### PR TITLE
Make try body start with 'do'

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1930,9 +1930,11 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   }
   // try-catch-end is written in the folded wat format as
   // (try
+  //  (do
   //   ...
+  //  )
   //  (catch
-  //    ...
+  //   ...
   //  )
   // )
   // The parenthesis wrapping 'catch' is just a syntax and does not affect
@@ -1941,7 +1943,12 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
     incIndent();
-    maybePrintImplicitBlock(curr->body, false);
+    doIndent(o, indent);
+    o << "(do";
+    incIndent();
+    maybePrintImplicitBlock(curr->body, true);
+    decIndent();
+    o << "\n";
     doIndent(o, indent);
     o << "(catch";
     incIndent();

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -232,7 +232,7 @@ private:
   Expression* makeRefIsNull(Element& s);
   Expression* makeRefFunc(Element& s);
   Expression* makeTry(Element& s);
-  Expression* makeCatch(Element& s, Type type);
+  Expression* makeTryOrCatchBody(Element& s, Type type, bool isTry);
   Expression* makeThrow(Element& s);
   Expression* makeRethrow(Element& s);
   Expression* makeBrOnExn(Element& s);

--- a/test/binaryen.js/exception-handling.js
+++ b/test/binaryen.js/exception-handling.js
@@ -19,7 +19,9 @@ module.setFeatures(binaryen.Features.ReferenceTypes |
 var event_ = module.addEvent("e", 0, binaryen.i32, binaryen.none);
 
 // (try
-//   (throw $e (i32.const 0))
+//   (do
+//     (throw $e (i32.const 0))
+//   )
 //   (catch
 //     ;; We don't support multi-value yet. Use locals instead.
 //     (local.set 0 (exnref.pop))

--- a/test/binaryen.js/exception-handling.js.txt
+++ b/test/binaryen.js/exception-handling.js.txt
@@ -5,8 +5,10 @@
  (func $test
   (local $0 exnref)
   (try
-   (throw $e
-    (i32.const 0)
+   (do
+    (throw $e
+     (i32.const 0)
+    )
    )
    (catch
     (local.set $0

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -1758,8 +1758,10 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        )
       )
       (try
-       (throw $a-event
-        (i32.const 0)
+       (do
+        (throw $a-event
+         (i32.const 0)
+        )
        )
        (catch
         (local.set $5
@@ -3524,8 +3526,10 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        )
       )
       (try
-       (throw $a-event
-        (i32.const 0)
+       (do
+        (throw $a-event
+         (i32.const 0)
+        )
        )
        (catch
         (local.set $5

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -305,7 +305,9 @@ void test_core() {
   // Exception handling
 
   // (try
-  //   (throw $a-event (i32.const 0))
+  //   (do
+  //     (throw $a-event (i32.const 0))
+  //   )
   //   (catch
   //     ;; We don't support multi-value yet. Use locals instead.
   //     (local.set 0 (exnref.pop))

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1691,8 +1691,10 @@ BinaryenFeatureAll: 1023
        )
       )
       (try
-       (throw $a-event
-        (i32.const 0)
+       (do
+        (throw $a-event
+         (i32.const 0)
+        )
        )
        (catch
         (local.set $5

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -11,7 +11,9 @@
 
   (func $eh_test (local $exn exnref)
     (try
-      (throw $e0 (i32.const 0))
+      (do
+        (throw $e0 (i32.const 0))
+      )
       (catch
         ;; Multi-value is not available yet, so block can't take a value from
         ;; stack. So this uses locals for now.
@@ -28,7 +30,9 @@
 
     ;; Try with a block label
     (try $l1
-      (br $l1)
+      (do
+        (br $l1)
+      )
       (catch
         (br $l1)
       )
@@ -43,7 +47,7 @@
 
     ;; Multiple instructions within try and catch bodies
     (try
-      (block
+      (do
         (call $foo)
         (call $bar)
       )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -17,8 +17,10 @@
  (func $eh_test
   (local $exn exnref)
   (try
-   (throw $e0
-    (i32.const 0)
+   (do
+    (throw $e0
+     (i32.const 0)
+    )
    )
    (catch
     (local.set $exn
@@ -37,14 +39,18 @@
   )
   (block $l1
    (try
-    (br $l1)
+    (do
+     (br $l1)
+    )
     (catch
      (br $l1)
     )
    )
   )
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)
@@ -52,7 +58,7 @@
    )
   )
   (try
-   (block $block
+   (do
     (call $foo)
     (call $bar)
    )
@@ -67,7 +73,9 @@
  )
  (func $subtype_test
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -17,8 +17,10 @@
  (func $eh_test
   (local $0 exnref)
   (try
-   (throw $event$0
-    (i32.const 0)
+   (do
+    (throw $event$0
+     (i32.const 0)
+    )
    )
    (catch
     (local.set $0
@@ -37,7 +39,9 @@
   )
   (block $label$4
    (try
-    (br $label$4)
+    (do
+     (br $label$4)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -47,7 +51,9 @@
    )
   )
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)
@@ -55,7 +61,7 @@
    )
   )
   (try
-   (block
+   (do
     (call $foo)
     (call $bar)
    )
@@ -70,7 +76,9 @@
  )
  (func $subtype_test
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -17,8 +17,10 @@
  (func $3
   (local $0 exnref)
   (try
-   (throw $event$0
-    (i32.const 0)
+   (do
+    (throw $event$0
+     (i32.const 0)
+    )
    )
    (catch
     (local.set $0
@@ -37,7 +39,9 @@
   )
   (block $label$4
    (try
-    (br $label$4)
+    (do
+     (br $label$4)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -47,7 +51,9 @@
    )
   )
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)
@@ -55,7 +61,7 @@
    )
   )
   (try
-   (block
+   (do
     (call $1)
     (call $2)
    )
@@ -70,7 +76,9 @@
  )
  (func $4
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)

--- a/test/extra-unreachable.wast
+++ b/test/extra-unreachable.wast
@@ -43,7 +43,9 @@
     ;; If a try is unreachable, i.e., both the 'try' and 'catch' bodies are
     ;; unreachable, we emit an extra unreachable after the try.
     (try
-      (unreachable)
+      (do
+        (unreachable)
+      )
       (catch
         (unreachable)
       )

--- a/test/extra-unreachable.wast.from-wast
+++ b/test/extra-unreachable.wast.from-wast
@@ -32,7 +32,9 @@
    (unreachable)
   )
   (try
-   (unreachable)
+   (do
+    (unreachable)
+   )
    (catch
     (unreachable)
    )

--- a/test/passes/code-pushing_all-features.txt
+++ b/test/passes/code-pushing_all-features.txt
@@ -44,8 +44,10 @@
   (local $x i32)
   (block $out
    (try
-    (throw $e
-     (i32.const 0)
+    (do
+     (throw $e
+      (i32.const 0)
+     )
     )
     (catch
      (drop
@@ -74,8 +76,10 @@
     (i32.const 1)
    )
    (try
-    (throw $e
-     (i32.const 0)
+    (do
+     (throw $e
+      (i32.const 0)
+     )
     )
     (catch
      (rethrow

--- a/test/passes/code-pushing_all-features.wast
+++ b/test/passes/code-pushing_all-features.wast
@@ -32,7 +32,9 @@
       ;; to be caught by the inner catch
       (local.set $x (i32.const 1))
       (try
-        (throw $e (i32.const 0))
+        (do
+          (throw $e (i32.const 0))
+        )
         (catch
           (drop (exnref.pop))
         )
@@ -50,7 +52,9 @@
       ;; the inner catch
       (local.set $x (i32.const 1))
       (try
-        (throw $e (i32.const 0))
+        (do
+          (throw $e (i32.const 0))
+        )
         (catch
           (rethrow (exnref.pop))
         )

--- a/test/passes/dce_all-features.txt
+++ b/test/passes/dce_all-features.txt
@@ -508,7 +508,9 @@
  )
  (func $try_unreachable
   (try
-   (unreachable)
+   (do
+    (unreachable)
+   )
    (catch
    )
   )
@@ -516,7 +518,9 @@
  )
  (func $catch_unreachable
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (unreachable)
    )
@@ -525,7 +529,9 @@
  )
  (func $both_unreachable
   (try
-   (unreachable)
+   (do
+    (unreachable)
+   )
    (catch
     (unreachable)
    )

--- a/test/passes/dce_all-features.wast
+++ b/test/passes/dce_all-features.wast
@@ -742,9 +742,10 @@
 
   (func $try_unreachable
     (try
-      (unreachable)
-      (catch
+      (do
+        (unreachable)
       )
+      (catch)
     )
     (call $foo) ;; shouldn't be dce'd
   )
@@ -760,7 +761,9 @@
 
   (func $both_unreachable
     (try
-      (unreachable)
+      (do
+        (unreachable)
+      )
       (catch
         (unreachable)
       )

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
@@ -26,8 +26,10 @@
  (func $eh (; has Stack IR ;)
   (local $exn exnref)
   (try
-   (throw $e0
-    (i32.const 0)
+   (do
+    (throw $e0
+     (i32.const 0)
+    )
    )
    (catch
     (local.set $exn

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.wast
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.wast
@@ -3,7 +3,9 @@
 
   (func $eh (local $exn exnref)
     (try
-      (throw $e0 (i32.const 0))
+      (do
+        (throw $e0 (i32.const 0))
+      )
       (catch
         (local.set $exn (exnref.pop))
         (drop

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -219,7 +219,9 @@
   )
   (if
    (try (result i32)
-    (i32.const 123)
+    (do
+     (i32.const 123)
+    )
     (catch
      (drop
       (exnref.pop)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -240,9 +240,11 @@
     )
     (if
       (try (result i32)
-        (i32.eqz
+        (do
           (i32.eqz
-            (i32.const 123)
+            (i32.eqz
+              (i32.const 123)
+            )
           )
         )
         (catch

--- a/test/passes/remove-unused-module-elements_all-features.txt
+++ b/test/passes/remove-unused-module-elements_all-features.txt
@@ -290,8 +290,10 @@
  (func $start
   (local $exn exnref)
   (try
-   (throw $e-throw
-    (i32.const 0)
+   (do
+    (throw $e-throw
+     (i32.const 0)
+    )
    )
    (catch
     (local.set $exn

--- a/test/passes/remove-unused-module-elements_all-features.wast
+++ b/test/passes/remove-unused-module-elements_all-features.wast
@@ -272,7 +272,9 @@
  (start $start)
  (func $start (local $exn exnref) (; 0 ;)
   (try
-   (throw $e-throw (i32.const 0))
+   (do
+    (throw $e-throw (i32.const 0))
+   )
    (catch
     (local.set $exn (exnref.pop))
     (drop

--- a/test/passes/remove-unused-names_code-folding_all-features.txt
+++ b/test/passes/remove-unused-names_code-folding_all-features.txt
@@ -1713,13 +1713,17 @@
   (local $exn exnref)
   (block $folding-inner0
    (try
-    (try
-     (nop)
-     (catch
-      (local.set $exn
-       (exnref.pop)
+    (do
+     (try
+      (do
+       (nop)
       )
-      (br $folding-inner0)
+      (catch
+       (local.set $exn
+        (exnref.pop)
+       )
+       (br $folding-inner0)
+      )
      )
     )
     (catch

--- a/test/passes/remove-unused-names_code-folding_all-features.wast
+++ b/test/passes/remove-unused-names_code-folding_all-features.wast
@@ -1194,15 +1194,17 @@
 
   (func $exnref_pop_test (local $exn exnref)
     (try
-      (try
-        (catch
-          ;; Expressions containing exnref.pop should NOT be taken out and
-          ;; folded.
-          (local.set $exn (exnref.pop))
-          (drop (i32.const 111))
-          (drop (i32.const 222))
-          (drop (i32.const 333))
-          (unreachable)
+      (do
+        (try
+          (catch
+            ;; Expressions containing exnref.pop should NOT be taken out and
+            ;; folded.
+            (local.set $exn (exnref.pop))
+            (drop (i32.const 111))
+            (drop (i32.const 222))
+            (drop (i32.const 333))
+            (unreachable)
+          )
         )
       )
       (catch

--- a/test/passes/remove-unused-names_optimize-instructions_all-features.txt
+++ b/test/passes/remove-unused-names_optimize-instructions_all-features.txt
@@ -12,7 +12,9 @@
   (local $x3 i32)
   (local.set $x0
    (try (result i32)
-    (i32.const 1)
+    (do
+     (i32.const 1)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -26,7 +28,7 @@
   )
   (local.set $x1
    (try (result i32)
-    (block (result i32)
+    (do
      (call $dummy)
      (i32.const 1)
     )
@@ -46,10 +48,12 @@
   )
   (local.set $x2
    (try (result i32)
-    (block (result i32)
+    (do
      (try
-      (throw $e
-       (i32.const 0)
+      (do
+       (throw $e
+        (i32.const 0)
+       )
       )
       (catch
        (drop
@@ -72,9 +76,11 @@
   )
   (local.set $x3
    (try (result i32)
-    (block (result i32)
+    (do
      (try
-      (nop)
+      (do
+       (nop)
+      )
       (catch
        (drop
         (exnref.pop)

--- a/test/passes/remove-unused-names_optimize-instructions_all-features.wast
+++ b/test/passes/remove-unused-names_optimize-instructions_all-features.wast
@@ -11,7 +11,9 @@
     ;; try - try body does not throw, can
     (local.set $x0
       (try (result i32)
-        (i32.const 1)
+        (do
+          (i32.const 1)
+        )
         (catch
           (drop (exnref.pop))
           (i32.const 3)
@@ -23,7 +25,7 @@
     ;; try - try body may throw, can't
     (local.set $x1
       (try (result i32)
-        (block (result i32)
+        (do
           (call $dummy)
           (i32.const 1)
         )
@@ -38,9 +40,11 @@
     ;; nested try - inner try may throw but will be caught by inner catch, can
     (local.set $x2
       (try (result i32)
-        (block (result i32)
+        (do
           (try
-            (throw $e (i32.const 0))
+            (do
+              (throw $e (i32.const 0))
+            )
             (catch
               (drop (exnref.pop))
             )
@@ -58,7 +62,7 @@
     ;; nested try - inner catch may throw, can't
     (local.set $x3
       (try (result i32)
-        (block (result i32)
+        (do
           (try
             (catch
               (drop (exnref.pop))

--- a/test/passes/rse_all-features.txt
+++ b/test/passes/rse_all-features.txt
@@ -478,7 +478,9 @@
  (func $try1
   (local $x i32)
   (try
-   (nop)
+   (do
+    (nop)
+   )
    (catch
     (drop
      (exnref.pop)
@@ -495,7 +497,7 @@
  (func $try2
   (local $x i32)
   (try
-   (block $block
+   (do
     (throw $e
      (i32.const 0)
     )
@@ -516,8 +518,10 @@
  (func $try3
   (local $x i32)
   (try
-   (throw $e
-    (i32.const 0)
+   (do
+    (throw $e
+     (i32.const 0)
+    )
    )
    (catch
     (drop
@@ -538,7 +542,7 @@
  (func $try4
   (local $x i32)
   (try
-   (block $block
+   (do
     (call $foo)
     (local.set $x
      (i32.const 1)
@@ -557,7 +561,7 @@
  (func $try5
   (local $x i32)
   (try
-   (block $block
+   (do
     (local.set $x
      (i32.const 1)
     )
@@ -576,13 +580,17 @@
  (func $nested-try
   (local $x i32)
   (try
-   (try
-    (throw $e
-     (i32.const 0)
-    )
-    (catch
-     (rethrow
-      (exnref.pop)
+   (do
+    (try
+     (do
+      (throw $e
+       (i32.const 0)
+      )
+     )
+     (catch
+      (rethrow
+       (exnref.pop)
+      )
      )
     )
    )

--- a/test/passes/rse_all-features.wast
+++ b/test/passes/rse_all-features.wast
@@ -301,7 +301,7 @@
   (func $try2
     (local $x i32)
     (try
-      (block
+      (do
         (throw $e (i32.const 0))
         (local.set $x (i32.const 1))
       )
@@ -314,7 +314,9 @@
   (func $try3
     (local $x i32)
     (try
-      (throw $e (i32.const 0))
+      (do
+        (throw $e (i32.const 0))
+      )
       (catch
         (drop (exnref.pop))
         (local.set $x (i32.const 1))
@@ -326,7 +328,7 @@
   (func $try4
     (local $x i32)
     (try
-      (block
+      (do
         (call $foo)
         (local.set $x (i32.const 1))
       )
@@ -339,7 +341,7 @@
   (func $try5
     (local $x i32)
     (try
-      (block
+      (do
         (local.set $x (i32.const 1))
         (call $foo)
       )
@@ -352,10 +354,14 @@
   (func $nested-try
     (local $x i32)
     (try
-      (try
-        (throw $e (i32.const 0))
-        (catch
-          (rethrow (exnref.pop))
+      (do
+        (try
+          (do
+            (throw $e (i32.const 0))
+          )
+          (catch
+            (rethrow (exnref.pop))
+          )
         )
       )
       (catch

--- a/test/passes/vacuum_all-features.txt
+++ b/test/passes/vacuum_all-features.txt
@@ -450,8 +450,10 @@
  (func $inner-try-test
   (local $0 i32)
   (try
-   (throw $e
-    (i32.const 0)
+   (do
+    (throw $e
+     (i32.const 0)
+    )
    )
    (catch
     (drop

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -801,7 +801,9 @@
   ;; When try body does not throw, try-body can be replaced with the try body
   (func $try-test
     (try
-      (drop (i32.const 0))
+      (do
+        (drop (i32.const 0))
+      )
       (catch
         (drop (exnref.pop))
       )
@@ -812,11 +814,15 @@
   ;; outer try body does not throw and the outer try-catch can be removed
   (func $inner-try-test (local $0 i32)
     (try
-      (try
-        (throw $e (i32.const 0))
-        (catch
-          (drop (exnref.pop))
-          (local.set $0 (i32.const 1))
+      (do
+        (try
+          (do
+            (throw $e (i32.const 0))
+          )
+          (catch
+            (drop (exnref.pop))
+            (local.set $0 (i32.const 1))
+          )
         )
       )
       (catch
@@ -831,7 +837,9 @@
   (func $br-in-catch
     (block $label$1
       (try
-        (unreachable)
+        (do
+          (unreachable)
+        )
         (catch
           (drop (exnref.pop))
           (br $label$1)

--- a/test/reference-types.wast
+++ b/test/reference-types.wast
@@ -202,7 +202,9 @@
     ;; Test subtype relationship for try return type
     (drop
       (try (result anyref)
-        (local.get $local_anyref)
+        (do
+          (local.get $local_anyref)
+        )
         (catch
           (exnref.pop)
         )
@@ -210,7 +212,9 @@
     )
     (drop
       (try (result anyref)
-        (ref.func $foo)
+        (do
+          (ref.func $foo)
+        )
         (catch
           (drop (exnref.pop))
           (ref.null)
@@ -219,7 +223,9 @@
     )
     (drop
       (try (result funcref)
-        (ref.func $foo)
+        (do
+          (ref.func $foo)
+        )
         (catch
           (drop (exnref.pop))
           (ref.null)
@@ -228,7 +234,9 @@
     )
     (drop
       (try (result exnref)
-        (ref.null)
+        (do
+          (ref.null)
+        )
         (catch
           (exnref.pop)
         )
@@ -236,7 +244,9 @@
     )
     (drop
       (try (result nullref)
-        (ref.null)
+        (do
+          (ref.null)
+        )
         (catch
           (drop (exnref.pop))
           (ref.null)

--- a/test/reference-types.wast.from-wast
+++ b/test/reference-types.wast.from-wast
@@ -309,7 +309,9 @@
   )
   (drop
    (try (result anyref)
-    (local.get $local_anyref)
+    (do
+     (local.get $local_anyref)
+    )
     (catch
      (exnref.pop)
     )
@@ -317,7 +319,9 @@
   )
   (drop
    (try (result anyref)
-    (ref.func $foo)
+    (do
+     (ref.func $foo)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -328,7 +332,9 @@
   )
   (drop
    (try (result funcref)
-    (ref.func $foo)
+    (do
+     (ref.func $foo)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -339,7 +345,9 @@
   )
   (drop
    (try (result exnref)
-    (ref.null)
+    (do
+     (ref.null)
+    )
     (catch
      (exnref.pop)
     )
@@ -347,7 +355,9 @@
   )
   (drop
    (try (result nullref)
-    (ref.null)
+    (do
+     (ref.null)
+    )
     (catch
      (drop
       (exnref.pop)

--- a/test/reference-types.wast.fromBinary
+++ b/test/reference-types.wast.fromBinary
@@ -309,7 +309,9 @@
   )
   (drop
    (try (result anyref)
-    (local.get $1)
+    (do
+     (local.get $1)
+    )
     (catch
      (exnref.pop)
     )
@@ -317,7 +319,9 @@
   )
   (drop
    (try (result anyref)
-    (ref.func $foo)
+    (do
+     (ref.func $foo)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -328,7 +332,9 @@
   )
   (drop
    (try (result funcref)
-    (ref.func $foo)
+    (do
+     (ref.func $foo)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -339,7 +345,9 @@
   )
   (drop
    (try (result exnref)
-    (ref.null)
+    (do
+     (ref.null)
+    )
     (catch
      (exnref.pop)
     )
@@ -347,7 +355,9 @@
   )
   (drop
    (try (result nullref)
-    (ref.null)
+    (do
+     (ref.null)
+    )
     (catch
      (drop
       (exnref.pop)

--- a/test/reference-types.wast.fromBinary.noDebugInfo
+++ b/test/reference-types.wast.fromBinary.noDebugInfo
@@ -309,7 +309,9 @@
   )
   (drop
    (try (result anyref)
-    (local.get $1)
+    (do
+     (local.get $1)
+    )
     (catch
      (exnref.pop)
     )
@@ -317,7 +319,9 @@
   )
   (drop
    (try (result anyref)
-    (ref.func $4)
+    (do
+     (ref.func $4)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -328,7 +332,9 @@
   )
   (drop
    (try (result funcref)
-    (ref.func $4)
+    (do
+     (ref.func $4)
+    )
     (catch
      (drop
       (exnref.pop)
@@ -339,7 +345,9 @@
   )
   (drop
    (try (result exnref)
-    (ref.null)
+    (do
+     (ref.null)
+    )
     (catch
      (exnref.pop)
     )
@@ -347,7 +355,9 @@
   )
   (drop
    (try (result nullref)
-    (ref.null)
+    (do
+     (ref.null)
+    )
     (catch
      (drop
       (exnref.pop)

--- a/test/spec/exception-handling.wast
+++ b/test/spec/exception-handling.wast
@@ -17,7 +17,9 @@
 
   (func (export "try_nothrow") (result i32)
     (try (result i32)
-      (i32.const 3)
+      (do
+        (i32.const 3)
+      )
       (catch
         (drop (exnref.pop))
         (i32.const 0)
@@ -27,7 +29,9 @@
 
   (func (export "try_throw_catch") (result i32)
     (try (result i32)
-      (throw $e-i32 (i32.const 5))
+      (do
+        (throw $e-i32 (i32.const 5))
+      )
       (catch
         (drop (exnref.pop))
         (i32.const 3)
@@ -37,7 +41,7 @@
 
   (func (export "try_call_catch") (result i32)
     (try (result i32)
-      (block
+      (do
         (call $throw_single_value)
         (unreachable)
       )
@@ -50,7 +54,9 @@
 
   (func (export "try_throw_rethrow")
     (try
-      (throw $e-i32 (i32.const 5))
+      (do
+        (throw $e-i32 (i32.const 5))
+      )
       (catch
         (rethrow (exnref.pop))
       )
@@ -59,7 +65,9 @@
 
   (func $try_call_rethrow (export "try_call_rethrow")
     (try
-      (call $throw_single_value)
+      (do
+        (call $throw_single_value)
+      )
       (catch
         (rethrow (exnref.pop))
       )
@@ -77,7 +85,9 @@
 
   (func (export "br_on_exn_match_no_value") (local $exn exnref)
     (try
-      (throw $e-v)
+      (do
+        (throw $e-v)
+      )
       (catch
         (local.set $exn (exnref.pop))
         (block $l0
@@ -91,7 +101,9 @@
 
   (func (export "br_on_exn_match_single_value") (result i32) (local $exn exnref)
     (try (result i32)
-      (throw $e-i32 (i32.const 5))
+      (do
+        (throw $e-i32 (i32.const 5))
+      )
       (catch
         (local.set $exn (exnref.pop))
         (block $l0 (result i32)
@@ -106,7 +118,9 @@
   (func (export "br_on_exn_match_multiple_values") (result i32 f32)
         (local $exn exnref)
     (try (result i32 f32)
-      (throw $e-i32-f32 (i32.const 3) (f32.const 3.5))
+      (do
+        (throw $e-i32-f32 (i32.const 3) (f32.const 3.5))
+      )
       (catch
         (local.set $exn (exnref.pop))
         (block $l0 (result i32 f32)
@@ -120,7 +134,9 @@
 
   (func (export "br_on_exn_dont_match") (local $exn exnref)
     (try
-      (throw $e-i32 (i32.const 5))
+      (do
+        (throw $e-i32 (i32.const 5))
+      )
       (catch
         (local.set $exn (exnref.pop))
         (block $l0
@@ -134,7 +150,7 @@
 
   (func (export "call_br_on_exn") (result i32) (local $exn exnref)
     (try (result i32)
-      (block
+      (do
         (call $throw_single_value)
         (unreachable)
       )
@@ -151,7 +167,7 @@
 
   (func (export "call_rethrow_br_on_exn") (result i32) (local $exn exnref)
     (try (result i32)
-      (block
+      (do
         (call $try_call_rethrow)
         (unreachable)
       )
@@ -186,7 +202,7 @@
   (module
     (func $f0
       (try
-        (nop)
+        (do (nop))
         (catch (i32.const 0))
       )
     )
@@ -198,7 +214,7 @@
   (module
     (func $f0
       (try
-        (i32.const 0)
+        (do (i32.const 0))
         (catch (i32.const 0))
       )
     )

--- a/test/try-body-multiple-insts.wasm.fromBinary
+++ b/test/try-body-multiple-insts.wasm.fromBinary
@@ -9,7 +9,7 @@
  (func $2
   (local $0 exnref)
   (try
-   (block
+   (do
     (call $0)
     (call $1)
    )


### PR DESCRIPTION
In WebAssembly/exception-handling#52, We decided to put `try` bodies in
a `do` clause to be more consistent with `catch`.

- Before
```wast
(try
  ...
  (catch
    ...
  )
)
```

- After
```wast
(try
  (do
    ...
  )
  (catch
    ...
  )
)
```

Another upside of this change is when there are multiple instructions
within a `try` body, we no longer need to wrap them in a `block`.