### PR TITLE
Add EH support in MergeBlocks

### DIFF
--- a/test/passes/remove-unused-names_merge-blocks_all-features.txt
+++ b/test/passes/remove-unused-names_merge-blocks_all-features.txt
@@ -1697,3 +1697,50 @@
   )
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (event $e (attr 0) (param i32))
+ (func $foo
+  (nop)
+ )
+ (func $throw
+  (nop)
+  (throw $e
+   (i32.const 3)
+  )
+ )
+ (func $rethrow
+  (local $0 exnref)
+  (call $foo)
+  (rethrow
+   (local.get $0)
+  )
+ )
+ (func $br_on_exn (result i32)
+  (local $0 exnref)
+  (block $label$0 (result i32)
+   (call $foo)
+   (drop
+    (br_on_exn $label$0 $e
+     (local.get $0)
+    )
+   )
+   (i32.const 3)
+  )
+ )
+ (func $cannot_extract_br_on_exn_exnref
+  (local $0 exnref)
+  (drop
+   (block $label$0 (result i32)
+    (drop
+     (br_on_exn $label$0 $e
+      (local.get $0)
+     )
+    )
+    (i32.const 5)
+   )
+  )
+ )
+)


### PR DESCRIPTION
This adds support for `throw`, `rethrow`, and `br_on_exn` in
MergeBlocks. While unrelated instructions within blocks can be hoisted
as in other instructions, `br_on_exn` requires a special handling in
`ProblemFinder`, because unlike `br_if`, its `exnref` argument itself
cannot be moved out of `br_on_exn`.