### PR TITLE
Add binaryen option --add-stack-limit-global

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -153,7 +153,8 @@ int main(int argc, const char* argv[]) {
          "Check for stack overflows every time the stack is extended."
          " Implies --add-stack-limit-global.",
          Options::Arguments::Zero,
-         [&checkStackOverflow, &addStackLimitGlobal](Options* o, const std::string&) {
+         [&checkStackOverflow, &addStackLimitGlobal](Options* o,
+                                                     const std::string&) {
            checkStackOverflow = true;
            addStackLimitGlobal = true;
          })

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -57,9 +57,13 @@ public:
   generateEmscriptenMetadata(Address staticBump,
                              std::vector<Name> const& initializerFunctions);
 
+  void fixStackGetFree();
   void fixInvokeFunctionNames();
 
-  void enforceStackLimit();
+  // Adds the __stack_limit variable and the __set_stack_limit() function,
+  // and if addStackLimitChecks==true, annotates all functions with stack
+  // overflow checks.
+  void generateStackLimit(bool addStackLimitChecks);
 
   void exportWasiStart();
 
@@ -86,6 +90,7 @@ private:
   void generateStackSaveFunction();
   void generateStackAllocFunction();
   void generateStackRestoreFunction();
+  void generateStackGetFreeFunction();
   void generateSetStackLimitFunction();
   Name importStackOverflowHandler();
 };


### PR DESCRIPTION
Add binaryen option --add-stack-limit-global to enable controlling when to emit the stack limit global variable to the wasm module.