### PR TITLE
Make 'do' clause mandatory in 'try'

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1825,15 +1825,11 @@ Expression* SExpressionWasmBuilder::makeTry(Element& s) {
   }
   auto label = nameMapper.pushLabelName(sName);
   Type type = parseOptionalResultType(s, i); // signature
-  if (elementStartsWith(*s[i], "catch")) {   // empty try body
-    ret->body = makeNop();
-  } else {
-    if (!elementStartsWith(*s[i], "do")) {
-      throw ParseException(
-        "try body should start with 'do'", s[i]->line, s[i]->col);
-    }
-    ret->body = makeTryOrCatchBody(*s[i++], type, true);
+  if (!elementStartsWith(*s[i], "do")) {
+    throw ParseException(
+      "try body should start with 'do'", s[i]->line, s[i]->col);
   }
+  ret->body = makeTryOrCatchBody(*s[i++], type, true);
   if (!elementStartsWith(*s[i], "catch")) {
     throw ParseException("catch clause does not exist", s[i]->line, s[i]->col);
   }
@@ -1858,6 +1854,9 @@ SExpressionWasmBuilder::makeTryOrCatchBody(Element& s, Type type, bool isTry) {
   }
   if (!isTry && !elementStartsWith(s, "catch")) {
     throw ParseException("invalid catch clause", s.line, s.col);
+  }
+  if (s.size() == 1) { // (do) or (catch) without instructions
+    return makeNop();
   }
   auto ret = allocator.alloc<Block>();
   for (size_t i = 1; i < s.size(); i++) {

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -40,6 +40,7 @@
 
     ;; Empty try body
     (try
+      (do)
       (catch
         (drop (exnref.pop))
       )
@@ -62,6 +63,7 @@
   ;; Test subtype relationship
   (func $subtype_test
     (try
+      (do)
       (catch
         (drop (exnref.pop))
         (drop

--- a/test/passes/dce_all-features.txt
+++ b/test/passes/dce_all-features.txt
@@ -513,6 +513,9 @@
     (unreachable)
    )
    (catch
+    (drop
+     (exnref.pop)
+    )
    )
   )
   (call $foo)

--- a/test/passes/dce_all-features.wast
+++ b/test/passes/dce_all-features.wast
@@ -746,13 +746,18 @@
       (do
         (unreachable)
       )
-      (catch)
+      (catch
+        (drop
+          (exnref.pop)
+        )
+      )
     )
     (call $foo) ;; shouldn't be dce'd
   )
 
   (func $catch_unreachable
     (try
+      (do)
       (catch
         (unreachable)
       )

--- a/test/passes/remove-unused-names_code-folding_all-features.wast
+++ b/test/passes/remove-unused-names_code-folding_all-features.wast
@@ -1196,6 +1196,7 @@
     (try
       (do
         (try
+          (do)
           (catch
             ;; Expressions containing exnref.pop should NOT be taken out and
             ;; folded.

--- a/test/passes/remove-unused-names_optimize-instructions_all-features.wast
+++ b/test/passes/remove-unused-names_optimize-instructions_all-features.wast
@@ -64,6 +64,7 @@
       (try (result i32)
         (do
           (try
+            (do)
             (catch
               (drop (exnref.pop))
               (throw $e (i32.const 0))

--- a/test/passes/rse_all-features.wast
+++ b/test/passes/rse_all-features.wast
@@ -291,6 +291,7 @@
   (func $try1
     (local $x i32)
     (try
+      (do)
       (catch
         (drop (exnref.pop))
         (local.set $x (i32.const 1))


### PR DESCRIPTION
Previously we were able to omit the new syntax `do` when `try` body is
empty. This makes `do` clause mandatory, so when a `try` body is empty,
the folded text format will be
```
(try
  (do)
  (catch
    ...
  )
```
Suggested in
https://github.com/WebAssembly/exception-handling/issues/52#issuecomment-626696720.