### PR TITLE
Fix br_on_exn handling in ReFinalize

### DIFF
--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -130,8 +130,9 @@ void ReFinalize::visitBrOnExn(BrOnExn* curr) {
   curr->finalize();
   if (curr->exnref->type == Type::unreachable) {
     replaceUntaken(curr->exnref, nullptr);
+  } else {
+    updateBreakValueType(curr->name, curr->sent);
   }
-  updateBreakValueType(curr->name, curr->sent);
 }
 void ReFinalize::visitNop(Nop* curr) { curr->finalize(); }
 void ReFinalize::visitUnreachable(Unreachable* curr) { curr->finalize(); }

--- a/test/passes/precompute_all-features.txt
+++ b/test/passes/precompute_all-features.txt
@@ -10,6 +10,7 @@
  (data (i32.const 0) "passive")
  (global $global i32 (i32.const 1))
  (global $global-mut (mut i32) (i32.const 2))
+ (event $event$0 (attr 0) (param))
  (func $x (param $x i32)
   (call $x
    (i32.const 2300)
@@ -311,6 +312,15 @@
      )
     )
     (ref.null)
+   )
+  )
+ )
+ (func $unreachable-br_on_exn
+  (block $label$1
+   (drop
+    (loop $label$2
+     (br $label$2)
+    )
    )
   )
  )

--- a/test/passes/precompute_all-features.wast
+++ b/test/passes/precompute_all-features.wast
@@ -461,4 +461,19 @@
     )
    )
   )
+
+  ;; br_on_exn's argument becomes unreachable, so br_on_exn itself is replaced
+  ;; with its argument in ReFinalize process after precompute.
+  (event $event$0 (attr 0) (param))
+  (func $unreachable-br_on_exn
+    (block $label$1
+      (drop
+        (br_on_exn $label$1 $event$0
+          (loop $label$2 (result nullref)
+            (br $label$2)
+          )
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
In `ReFinalize`'s branch handling, `updateBreakValueType` is supposed to
be executed only when the branch itself is not replaced with its
argument (because it is guaranteed not to be taken).

Also this moves `visitBrOnExn` from `RuntimeExpressionRunner` to its
base class `ExpressionRunner`, because it does not depend on anything on
the runtime instance to work. This is effectively NFC for now because
`visitTry` is still only implemented only in `RuntimeExpressionRunner`
because it relies on multivalue handling of it, and without it we cannot
create a valid exception `Literal`.