### PR TITLE
Don't warn 'skipping debug location info'

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1652,10 +1652,6 @@ void WasmBinaryBuilder::readNextDebugLocation() {
   }
 
   while (nextDebugLocation.first && nextDebugLocation.first <= pos) {
-    if (nextDebugLocation.first < pos) {
-      std::cerr << "skipping debug location info for 0x";
-      std::cerr << std::hex << nextDebugLocation.first << std::dec << std::endl;
-    }
     debugLocation.clear();
     // use debugLocation only for function expressions
     if (currFunction) {


### PR DESCRIPTION
That is only for the old source maps logic, not DWARF, and it is
only useful to debug source maps (it's not actually useful for
users that see the message) which we do not plan to do
since DWARF is the future.