### PR TITLE
Add EH support for SimplifyLocals

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -446,8 +446,16 @@ struct EffectAnalyzer
     if (tryDepth == 0) {
       throws = true;
     }
+    if (!ignoreImplicitTraps) { // rethrow traps when the arg is null
+      implicitTrap = true;
+    }
   }
-  void visitBrOnExn(BrOnExn* curr) { breakNames.insert(curr->name); }
+  void visitBrOnExn(BrOnExn* curr) {
+    breakNames.insert(curr->name);
+    if (!ignoreImplicitTraps) { // br_on_exn traps when the arg is null
+      implicitTrap = true;
+    }
+  }
   void visitNop(Nop* curr) {}
   void visitUnreachable(Unreachable* curr) { branches = true; }
   void visitPush(Push* curr) { calls = true; }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -126,7 +126,7 @@ struct SimplifyLocals
                   Expression** currp) {
     // Main processing.
     auto* curr = *currp;
-    if (auto *br = curr->dynCast<Break>()) {
+    if (auto* br = curr->dynCast<Break>()) {
       if (br->value) {
         // value means the block already has a return value
         self->unoptimizableBlocks.insert(br->name);
@@ -146,7 +146,7 @@ struct SimplifyLocals
         self->unoptimizableBlocks.insert(target);
       }
       // TODO: we could use this info to stop gathering data on these blocks
-    } else if (auto *br = curr->dynCast<BrOnExn>()) {
+    } else if (auto* br = curr->dynCast<BrOnExn>()) {
       // We cannot sink br_on_exn out of its targeting block
       self->unoptimizableBlocks.insert(br->name);
     }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -147,7 +147,8 @@ struct SimplifyLocals
       }
       // TODO: we could use this info to stop gathering data on these blocks
     } else if (auto* br = curr->dynCast<BrOnExn>()) {
-      // We cannot sink br_on_exn out of its targeting block
+      // We cannot optimize the block this targets to have a return value, as
+      // the br_on_exn doesn't support a change to the block's type
       self->unoptimizableBlocks.insert(br->name);
     }
     self->sinkables.clear();

--- a/test/passes/simplify-locals_all-features.txt
+++ b/test/passes/simplify-locals_all-features.txt
@@ -1898,7 +1898,7 @@
  (type $none_=>_exnref (func (result exnref)))
  (event $event$0 (attr 0) (param))
  (event $event$1 (attr 0) (param exnref))
- (func $br_on_exn-cannot-sink (result exnref)
+ (func $unoptimizable-br_on_exn-block (result exnref)
   (local $0 exnref)
   (block $label$0
    (local.set $0

--- a/test/passes/simplify-locals_all-features.txt
+++ b/test/passes/simplify-locals_all-features.txt
@@ -1892,3 +1892,19 @@
   (local.get $0)
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_exnref (func (result exnref)))
+ (event $event$0 (attr 0) (param))
+ (func $br_on_exn-test (result exnref)
+  (local $0 exnref)
+  (block $label$0
+   (local.set $0
+    (br_on_exn $label$0 $event$0
+     (ref.null)
+    )
+   )
+  )
+  (local.get $0)
+ )
+)

--- a/test/passes/simplify-locals_all-features.txt
+++ b/test/passes/simplify-locals_all-features.txt
@@ -1894,9 +1894,11 @@
 )
 (module
  (type $none_=>_none (func))
+ (type $exnref_=>_none (func (param exnref)))
  (type $none_=>_exnref (func (result exnref)))
  (event $event$0 (attr 0) (param))
- (func $br_on_exn-test (result exnref)
+ (event $event$1 (attr 0) (param exnref))
+ (func $br_on_exn-cannot-sink (result exnref)
   (local $0 exnref)
   (block $label$0
    (local.set $0
@@ -1906,5 +1908,33 @@
    )
   )
   (local.get $0)
+ )
+ (func $br_on_exn-trap
+  (local $0 exnref)
+  (drop
+   (block $label$1 (result exnref)
+    (br_on_exn $label$1 $event$1
+     (ref.null)
+    )
+   )
+  )
+ )
+ (func $rethrow-trap
+  (local $0 i32)
+  (drop
+   (block $label$1 (result i32)
+    (try
+     (do
+      (rethrow
+       (ref.null)
+      )
+     )
+     (catch
+      (nop)
+     )
+    )
+    (i32.const 0)
+   )
+  )
  )
 )

--- a/test/passes/simplify-locals_all-features.wast
+++ b/test/passes/simplify-locals_all-features.wast
@@ -1673,7 +1673,7 @@
 )
 (module
   (event $event$0 (attr 0) (param))
-  (func $br_on_exn-test (result exnref) (local $0 exnref)
+  (func $br_on_exn-cannot-sink (result exnref) (local $0 exnref)
     (block $label$0
       (local.set $0
         ;; br_on_exn cannot be sinked out of its targeting block
@@ -1683,5 +1683,32 @@
       )
     )
     (local.get $0)
+  )
+
+  (event $event$1 (attr 0) (param exnref))
+  (func $br_on_exn-trap (local $0 exnref)
+    ;; This dead local.set cannot be replaced with a nop because br_on_exn can
+    ;; trap.
+    (local.set $0
+      (block $label$1 (result exnref)
+        (br_on_exn $label$1 $event$1
+          (ref.null)
+        )
+      )
+    )
+  )
+
+  (func $rethrow-trap (local $0 i32)
+    ;; This dead local.set cannot be replaced with a nop because rethrow can
+    ;; trap.
+    (local.set $0
+      (block $label$1 (result i32)
+        (try
+          (do (rethrow (ref.null)))
+          (catch)
+        )
+        (i32.const 0)
+      )
+    )
   )
 )

--- a/test/passes/simplify-locals_all-features.wast
+++ b/test/passes/simplify-locals_all-features.wast
@@ -1671,3 +1671,17 @@
   (local.get $1)
  )
 )
+(module
+  (event $event$0 (attr 0) (param))
+  (func $br_on_exn-test (result exnref) (local $0 exnref)
+    (block $label$0
+      (local.set $0
+        ;; br_on_exn cannot be sinked out of its targeting block
+        (br_on_exn $label$0 $event$0
+          (ref.null)
+        )
+      )
+    )
+    (local.get $0)
+  )
+)

--- a/test/passes/simplify-locals_all-features.wast
+++ b/test/passes/simplify-locals_all-features.wast
@@ -1673,10 +1673,10 @@
 )
 (module
   (event $event$0 (attr 0) (param))
-  (func $br_on_exn-cannot-sink (result exnref) (local $0 exnref)
+  (func $unoptimizable-br_on_exn-block (result exnref) (local $0 exnref)
     (block $label$0
       (local.set $0
-        ;; br_on_exn cannot be sinked out of its targeting block
+        ;; br_on_exn's target block cannot be optimized to have a return value
         (br_on_exn $label$0 $event$0
           (ref.null)
         )


### PR DESCRIPTION
- `br_on_exn`'s target block cannot be optimized to have a separate
  return value. This handles that in `SimplifyLocals`.
- `br_on_exn` and `rethrow` can trap (when the arg is null). This
  handles that in `EffectAnalyzer`.
- Fix a few nits