### PR TITLE
Implement more cases for "combine or" in OptimizeInstruction pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ config.h
 # files related to VS Code
 /.history
 /.vscode
+
+# py-env
+.python-version

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1255,14 +1255,6 @@ private:
 
               break;
             }
-            case GtUInt32:
-            case GtSInt32: {
-              //   (x < y) | (x > y)     ==>    x != y
-              if (right->op == LtSInt32 || right->op == LtUInt32) {
-                left->op = NeInt32;
-              }
-              break;
-            }
             case LtUInt32:
             case LtSInt32: {
               //   (x > y) | (x < y)     ==>    x != y

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3315,6 +3315,192 @@
     )
    )
   )
+  (drop
+   (i32.le_s
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (drop
+   (i32.le_s
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (drop
+   (i32.or
+    (i32.eq
+     (local.get $x)
+     (i32.const 1)
+    )
+    (i32.lt_s
+     (local.get $x)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.eq
+     (local.get $x)
+     (local.get $y)
+    )
+    (i32.lt_s
+     (local.get $x)
+     (i32.const 1)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (call $ne0)
+     (local.get $y)
+    )
+    (i32.eq
+     (call $ne0)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (local.get $y)
+     (call $ne0)
+    )
+    (i32.eq
+     (call $ne0)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.const 1)
+  )
+  (drop
+   (i32.const 1)
+  )
+  (drop
+   (i32.or
+    (i32.eq
+     (local.get $x)
+     (i32.const 1)
+    )
+    (i32.ne
+     (local.get $x)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.eq
+     (local.get $x)
+     (local.get $y)
+    )
+    (i32.ne
+     (local.get $x)
+     (i32.const 1)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.ne
+     (call $ne0)
+     (local.get $y)
+    )
+    (i32.eq
+     (call $ne0)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.ne
+     (call $ne0)
+     (local.get $y)
+    )
+    (i32.eq
+     (call $ne0)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (local.get $x)
+     (local.get $y)
+    )
+    (i32.gt_s
+     (local.get $y)
+     (local.get $x)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (local.get $x)
+     (local.get $y)
+    )
+    (i32.gt_s
+     (local.get $y)
+     (local.get $x)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (local.get $x)
+     (local.get $y)
+    )
+    (i32.gt_s
+     (local.get $x)
+     (i32.const 1)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (local.get $x)
+     (i32.const 1)
+    )
+    (i32.gt_s
+     (local.get $x)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (call $ne0)
+     (local.get $y)
+    )
+    (i32.gt_s
+     (call $ne0)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.lt_s
+     (local.get $y)
+     (call $ne0)
+    )
+    (i32.gt_s
+     (local.get $y)
+     (call $ne0)
+    )
+   )
+  )
  )
  (func $combine-or (param $x i32) (param $y i32)
   (drop

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3704,6 +3704,9 @@
    )
   )
   (func $pre-combine-or (param $x i32) (param $y i32)
+    ;;
+    ;; x > y | x == y --> pass
+    ;;
     (drop (i32.or
       (i32.gt_s
         (local.get $x)
@@ -3714,6 +3717,7 @@
         (local.get $x)
       )
     ))
+    ;; x == y | x > y --> pass
     (drop (i32.or
       (i32.eq ;; ordering should not stop us
         (local.get $y)
@@ -3724,6 +3728,7 @@
         (local.get $y)
       )
     ))
+    ;; x > y | x == 1 --> skip
     (drop (i32.or
       (i32.gt_s
         (local.get $x)
@@ -3734,6 +3739,7 @@
         (i32.const 1) ;; not equal
       )
     ))
+    ;; x > 1 | x == y --> skip
     (drop (i32.or
       (i32.gt_s
         (local.get $x)
@@ -3744,6 +3750,7 @@
         (local.get $y)
       )
     ))
+    ;; fn() > y | fn() == y --> skip
     (drop (i32.or
       (i32.gt_s
         (call $ne0) ;; side effects
@@ -3754,12 +3761,217 @@
         (local.get $y)
       )
     ))
+    ;; y > fn() | y == fn() --> skip
     (drop (i32.or
       (i32.gt_s
         (local.get $y)
         (call $ne0) ;; side effects
       )
       (i32.eq
+        (local.get $y)
+        (call $ne0)
+      )
+    ))
+    ;;
+    ;; x < y | x == y --> pass
+    ;;
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.eq
+        (local.get $y) ;; ordering should not stop us
+        (local.get $x)
+      )
+    ))
+    ;; x == y | x < y --> pass
+    (drop (i32.or
+      (i32.eq ;; ordering should not stop us
+        (local.get $y)
+        (local.get $x)
+      )
+      (i32.lt_s
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+    ;; x < y | x == 1 --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.eq
+        (local.get $x)
+        (i32.const 1) ;; not equal
+      )
+    ))
+    ;; x < 1 | x == y --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $x)
+        (i32.const 1) ;; not equal
+      )
+      (i32.eq
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+    ;; fn() < y | fn() == y --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (call $ne0) ;; side effects
+        (local.get $y)
+      )
+      (i32.eq
+        (call $ne0)
+        (local.get $y)
+      )
+    ))
+    ;; y < fn() | y == fn() --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $y)
+        (call $ne0) ;; side effects
+      )
+      (i32.eq
+        (local.get $y)
+        (call $ne0)
+      )
+    ))
+    ;;
+    ;; x != y | x == y --> pass
+    ;;
+    (drop (i32.or
+      (i32.ne
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.eq
+        (local.get $y) ;; ordering should not stop us
+        (local.get $x)
+      )
+    ))
+    ;; x == y | x != y --> pass
+    (drop (i32.or
+      (i32.eq ;; ordering should not stop us
+        (local.get $y)
+        (local.get $x)
+      )
+      (i32.ne
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+    ;; x != y | x == 1 --> skip
+    (drop (i32.or
+      (i32.ne
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.eq
+        (local.get $x)
+        (i32.const 1) ;; not equal
+      )
+    ))
+    ;; x != 1 | x == y --> skip
+    (drop (i32.or
+      (i32.ne
+        (local.get $x)
+        (i32.const 1) ;; not equal
+      )
+      (i32.eq
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+    ;; fn() != y | fn() == y --> skip
+    (drop (i32.or
+      (i32.ne
+        (call $ne0) ;; side effects
+        (local.get $y)
+      )
+      (i32.eq
+        (call $ne0)
+        (local.get $y)
+      )
+    ))
+    ;; y != fn() | y == fn() --> skip
+    (drop (i32.or
+      (i32.ne
+        (local.get $y)
+        (call $ne0) ;; side effects
+      )
+      (i32.eq
+        (local.get $y)
+        (call $ne0)
+      )
+    ))
+    ;;
+    ;; x < y | x > y --> pass
+    ;;
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.gt_s
+        (local.get $y) ;; ordering should not stop us
+        (local.get $x)
+      )
+    ))
+    ;; x > y | x < y --> pass
+    (drop (i32.or
+      (i32.gt_s ;; ordering should not stop us
+        (local.get $y)
+        (local.get $x)
+      )
+      (i32.lt_s
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+    ;; x < y | x > 1 --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.gt_s
+        (local.get $x)
+        (i32.const 1) ;; not equal
+      )
+    ))
+    ;; x < 1 | x > y --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $x)
+        (i32.const 1) ;; not equal
+      )
+      (i32.gt_s
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+    ;; fn() < y | fn() > y --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (call $ne0) ;; side effects
+        (local.get $y)
+      )
+      (i32.gt_s
+        (call $ne0)
+        (local.get $y)
+      )
+    ))
+    ;; y < fn() | y > fn() --> skip
+    (drop (i32.or
+      (i32.lt_s
+        (local.get $y)
+        (call $ne0) ;; side effects
+      )
+      (i32.gt_s
         (local.get $y)
         (call $ne0)
       )


### PR DESCRIPTION
Added more peephole optimizations for "combine or"
 -   `(x < y) | (x == y)`    -->    `x <= y`
 -   `(x < y) | (x > y)`     ==>    `x != y`
 -   `(x != y) | (x == y)`   ==>    `1`