### PR TITLE
Fix issues with cleanup dSYM in scripts for MacOS

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -150,9 +150,6 @@ def update_example_tests():
                 o.write(actual)
         finally:
             os.remove(output_file)
-            if sys.platform == 'darwin':
-                # Also removes debug directory produced on Mac OS
-                shutil.rmtree(output_file + '.dSYM', ignore_errors=True)
 
 
 def update_wasm_dis_tests():

--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -152,7 +152,7 @@ def update_example_tests():
             os.remove(output_file)
             if sys.platform == 'darwin':
                 # Also removes debug directory produced on Mac OS
-                shutil.rmtree(output_file + '.dSYM')
+                shutil.rmtree(output_file + '.dSYM', ignore_errors=True)
 
 
 def update_wasm_dis_tests():

--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import os
-import shutil
 import subprocess
 import sys
 from collections import OrderedDict

--- a/check.py
+++ b/check.py
@@ -329,10 +329,6 @@ def run_gcc_tests():
         print('run...', output_file)
         actual = subprocess.check_output([os.path.abspath(output_file)]).decode('utf-8')
         os.remove(output_file)
-        if sys.platform == 'darwin' and os.path.exists(output_file + '.dSYM'):
-            # Also removes debug directory produced on Mac OS
-            shutil.rmtree(output_file + '.dSYM')
-
         shared.fail_if_not_identical_to_file(actual, expected)
 
 

--- a/check.py
+++ b/check.py
@@ -16,7 +16,6 @@
 
 import glob
 import os
-import shutil
 import subprocess
 import sys
 import unittest


### PR DESCRIPTION
Without this I always catch an error during auto-update tests on Mac
```
FileNotFoundError: [Errno 2] No such file or directory: .../Github/binaryen/bin/example.dSYM'
```