### PR TITLE
Add link to Github Action tab for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/WebAssembly/binaryen/workflows/CI/badge.svg?branch=master&event=push)
+[![CI](https://github.com/WebAssembly/binaryen/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/WebAssembly/binaryen/actions?query=workflow%3ACI)
 
 # Binaryen
 


### PR DESCRIPTION
With this changes when you click to CI badge you redirect to Github Actions tab