### PR TITLE
Flatten fuzz fix with unreachable special-casing

### DIFF
--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -62,9 +62,8 @@ struct Flatten
     std::vector<Expression*> ourPreludes;
     Builder builder(*getModule());
 
-    // Nothing to do for constants, nop, and unreachable
-    if (Properties::isConstantExpression(curr) || curr->is<Nop>() ||
-        curr->is<Unreachable>()) {
+    // Nothing to do for constants and nop.
+    if (Properties::isConstantExpression(curr) || curr->is<Nop>()) {
       return;
     }
 

--- a/test/passes/flatten.bin.txt
+++ b/test/passes/flatten.bin.txt
@@ -103,6 +103,7 @@
   (block $label$1
    (nop)
    (unreachable)
+   (unreachable)
   )
   (unreachable)
  )

--- a/test/passes/flatten_all-features.txt
+++ b/test/passes/flatten_all-features.txt
@@ -540,9 +540,13 @@
    )
    (if
     (local.get $0)
-    (unreachable)
+    (block
+     (unreachable)
+     (unreachable)
+    )
     (block
      (block $label$3
+      (unreachable)
       (unreachable)
      )
      (local.set $2
@@ -651,6 +655,7 @@
   (local $0 i32)
   (local $1 i32)
   (block $label$1
+   (unreachable)
    (local.set $0
     (i32.const 1)
    )
@@ -676,6 +681,7 @@
  (func $a19 (result f32)
   (block $label$0
    (block $label$1
+    (unreachable)
     (return
      (f32.const 4289944320)
     )
@@ -727,6 +733,7 @@
    (block
     (block $out1
      (unreachable)
+     (unreachable)
      (drop
       (i32.const 0)
      )
@@ -773,6 +780,7 @@
       (block
        (block $out8
         (unreachable)
+        (unreachable)
         (drop
          (i32.const 0)
         )
@@ -781,6 +789,7 @@
       )
       (block
        (block $out9
+        (unreachable)
         (unreachable)
         (drop
          (i32.const 0)
@@ -803,9 +812,11 @@
     (block $out11
      (unreachable)
      (unreachable)
+     (unreachable)
      (drop
       (i32.const 0)
      )
+     (unreachable)
      (unreachable)
     )
     (local.set $2
@@ -822,9 +833,11 @@
     (block $out13
      (unreachable)
      (unreachable)
+     (unreachable)
      (drop
       (i32.const 0)
      )
+     (unreachable)
      (unreachable)
     )
     (local.set $4
@@ -841,9 +854,12 @@
     (block $out15
      (unreachable)
      (unreachable)
+     (unreachable)
+     (unreachable)
      (drop
       (i32.const 0)
      )
+     (unreachable)
      (unreachable)
     )
     (local.set $6
@@ -861,6 +877,7 @@
     )
    )
    (unreachable)
+   (unreachable)
   )
   (if
    (i32.const 0)
@@ -872,6 +889,7 @@
         (i32.const 1)
        )
       )
+      (unreachable)
       (unreachable)
      )
      (unreachable)
@@ -890,6 +908,7 @@
     (unreachable)
    )
    (unreachable)
+   (unreachable)
   )
   (block $out22
    (block $in23
@@ -898,6 +917,7 @@
     )
     (unreachable)
    )
+   (unreachable)
    (unreachable)
   )
   (if
@@ -911,6 +931,7 @@
        )
        (unreachable)
       )
+      (unreachable)
       (unreachable)
      )
      (unreachable)
@@ -932,9 +953,12 @@
       (i32.const 42)
      )
      (unreachable)
+     (unreachable)
+     (unreachable)
      (return
       (unreachable)
      )
+     (unreachable)
      (unreachable)
      (unreachable)
      (return)
@@ -948,6 +972,7 @@
    (block
     (loop $loop-in18
      (unreachable)
+     (unreachable)
     )
     (unreachable)
    )
@@ -958,6 +983,7 @@
      (br_if $out29
       (i32.const 1)
      )
+     (unreachable)
      (unreachable)
     )
     (unreachable)
@@ -974,6 +1000,7 @@
         (i32.const 1)
        )
        (unreachable)
+       (unreachable)
       )
       (unreachable)
      )
@@ -988,6 +1015,7 @@
   (if
    (i32.const 1)
    (block
+    (unreachable)
     (call $call-me
      (i32.const 123)
      (unreachable)
@@ -998,6 +1026,7 @@
   (if
    (i32.const 2)
    (block
+    (unreachable)
     (call $call-me
      (unreachable)
      (i32.const 0)
@@ -1008,6 +1037,8 @@
   (if
    (i32.const 3)
    (block
+    (unreachable)
+    (unreachable)
     (call $call-me
      (unreachable)
      (unreachable)
@@ -1018,6 +1049,7 @@
   (if
    (i32.const -1)
    (block
+    (unreachable)
     (call_indirect (type $i32_i32_=>_none)
      (i32.const 123)
      (i32.const 456)
@@ -1029,6 +1061,7 @@
   (if
    (i32.const -2)
    (block
+    (unreachable)
     (call_indirect (type $i32_i32_=>_none)
      (i32.const 139)
      (unreachable)
@@ -1040,6 +1073,8 @@
   (if
    (i32.const -3)
    (block
+    (unreachable)
+    (unreachable)
     (call_indirect (type $i32_i32_=>_none)
      (i32.const 246)
      (unreachable)
@@ -1051,6 +1086,9 @@
   (if
    (i32.const -4)
    (block
+    (unreachable)
+    (unreachable)
+    (unreachable)
     (call_indirect (type $i32_i32_=>_none)
      (unreachable)
      (unreachable)
@@ -1064,11 +1102,13 @@
    (block
     (unreachable)
     (unreachable)
+    (unreachable)
    )
   )
   (if
    (i32.const 22)
    (block
+    (unreachable)
     (i32.load
      (unreachable)
     )
@@ -1081,6 +1121,7 @@
   (if
    (i32.const 33)
    (block
+    (unreachable)
     (i32.store
      (i32.const 0)
      (unreachable)
@@ -1091,6 +1132,7 @@
   (if
    (i32.const 44)
    (block
+    (unreachable)
     (i32.store
      (unreachable)
      (i32.const 0)
@@ -1101,6 +1143,8 @@
   (if
    (i32.const 55)
    (block
+    (unreachable)
+    (unreachable)
     (i32.store
      (unreachable)
      (unreachable)
@@ -1111,6 +1155,7 @@
   (if
    (i32.const 66)
    (block
+    (unreachable)
     (i32.eqz
      (unreachable)
     )
@@ -1123,6 +1168,7 @@
   (if
    (i32.const 77)
    (block
+    (unreachable)
     (i32.add
      (unreachable)
      (i32.const 0)
@@ -1136,6 +1182,7 @@
   (if
    (i32.const 88)
    (block
+    (unreachable)
     (i32.add
      (i32.const 0)
      (unreachable)
@@ -1149,6 +1196,8 @@
   (if
    (i32.const 99)
    (block
+    (unreachable)
+    (unreachable)
     (i32.add
      (unreachable)
      (unreachable)
@@ -1159,6 +1208,7 @@
   (if
    (i32.const 100)
    (block
+    (unreachable)
     (select
      (i32.const 123)
      (i32.const 456)
@@ -1173,6 +1223,7 @@
   (if
    (i32.const 101)
    (block
+    (unreachable)
     (select
      (i32.const 123)
      (unreachable)
@@ -1187,6 +1238,7 @@
   (if
    (i32.const 102)
    (block
+    (unreachable)
     (select
      (unreachable)
      (i32.const 123)
@@ -1204,6 +1256,7 @@
  )
  (func $killer
   (block
+   (unreachable)
    (unreachable)
    (drop
     (i32.const 1000)
@@ -1290,6 +1343,7 @@
   (local $0 i32)
   (block
    (unreachable)
+   (unreachable)
    (local.set $0
     (global.get $x)
    )
@@ -1353,9 +1407,11 @@
   (block $label$0
    (block $label$3
     (nop)
+    (unreachable)
     (br_table $label$3
      (unreachable)
     )
+    (unreachable)
     (unreachable)
     (unreachable)
    )
@@ -1376,9 +1432,11 @@
   (block $label$0
    (block $label$2
     (nop)
+    (unreachable)
     (br_if $label$2
      (unreachable)
     )
+    (unreachable)
     (unreachable)
     (unreachable)
    )
@@ -1425,6 +1483,7 @@
   (local $5 i32)
   (block $label$0
    (block $label$1
+    (unreachable)
     (local.set $1
      (i32.const 4104)
     )
@@ -1538,6 +1597,7 @@
       (local.set $13
        (local.get $12)
       )
+      (unreachable)
       (i64.mul
        (local.get $13)
        (unreachable)
@@ -1897,6 +1957,7 @@
     (unreachable)
    )
    (unreachable)
+   (unreachable)
    (i32.add
     (i32.const 1)
     (unreachable)
@@ -2196,6 +2257,7 @@
  )
  (func $switch-unreachable
   (block $label$3
+   (unreachable)
    (br_table $label$3
     (unreachable)
    )
@@ -2278,6 +2340,7 @@
     (local.get $2)
    )
    (unreachable)
+   (unreachable)
    (drop
     (unreachable)
    )
@@ -2359,5 +2422,24 @@
   (return
    (local.get $7)
   )
+ )
+)
+(module
+ (type $i64_f32_=>_none (func (param i64 f32)))
+ (type $none_=>_i32 (func (result i32)))
+ (export "test" (func $1))
+ (func $0 (param $0 i64) (param $1 f32)
+  (nop)
+ )
+ (func $1 (result i32)
+  (unreachable)
+  (return
+   (i32.const -111)
+  )
+  (call $0
+   (unreachable)
+   (unreachable)
+  )
+  (unreachable)
  )
 )

--- a/test/passes/flatten_all-features.wast
+++ b/test/passes/flatten_all-features.wast
@@ -1040,3 +1040,17 @@
     )
   )
 )
+(module
+ (func $0 (param $0 i64) (param $1 f32)
+  (nop)
+ )
+ (func "test" (result i32)
+  (call $0
+   (unreachable) ;; the unreachable should be handled properly, and not be
+                 ;; reordered with the return
+   (return
+    (i32.const -111)
+   )
+  )
+ )
+)

--- a/test/passes/flatten_i64-to-i32-lowering.txt
+++ b/test/passes/flatten_i64-to-i32-lowering.txt
@@ -83,6 +83,7 @@
  )
  (func $unreachable-select-i64 (result i32)
   (local $i64toi32_i32$0 i32)
+  (unreachable)
   (block
    (drop
     (block (result i32)
@@ -101,6 +102,7 @@
  )
  (func $unreachable-select-i64-b (result i32)
   (local $i64toi32_i32$0 i32)
+  (unreachable)
   (block
    (unreachable)
    (drop
@@ -120,6 +122,7 @@
  (func $unreachable-select-i64-c (result i32)
   (local $i64toi32_i32$0 i32)
   (local $i64toi32_i32$1 i32)
+  (unreachable)
   (block
    (drop
     (block (result i32)
@@ -462,6 +465,7 @@
   (local $1$hi i32)
   (local $i64toi32_i32$0 i32)
   (block $label$1
+   (unreachable)
    (unreachable)
   )
   (block

--- a/test/passes/flatten_local-cse_all-features.txt
+++ b/test/passes/flatten_local-cse_all-features.txt
@@ -646,7 +646,10 @@
     )
     (if
      (local.get $2)
-     (unreachable)
+     (block
+      (unreachable)
+      (unreachable)
+     )
     )
    )
    (local.set $3

--- a/test/passes/flatten_rereloop.txt
+++ b/test/passes/flatten_rereloop.txt
@@ -517,7 +517,7 @@
   (local $8 i32)
   (local $9 i32)
   (local $10 i32)
-  (block $block$18$break
+  (block $block$21$break
    (block
     (local.set $4
      (local.get $x)
@@ -537,11 +537,11 @@
       (br $shape$2$continue)
      )
     )
-    (br $block$18$break)
+    (br $block$21$break)
    )
   )
   (block
-   (block $block$21$break
+   (block $block$24$break
     (loop $shape$4$continue
      (block
       (call $trivial)
@@ -558,7 +558,7 @@
      (if
       (local.get $7)
       (br $shape$4$continue)
-      (br $block$21$break)
+      (br $block$24$break)
      )
     )
    )
@@ -972,7 +972,7 @@
    )
   )
   (block
-   (block $block$8$break
+   (block $block$9$break
     (block
      (call $switch
       (i32.const 1)
@@ -989,13 +989,13 @@
     )
     (block $switch$3$leave
      (block $switch$3$default
-      (block $switch$3$case$8
-       (br_table $switch$3$case$8 $switch$3$case$8 $switch$3$case$8 $switch$3$default
+      (block $switch$3$case$9
+       (br_table $switch$3$case$9 $switch$3$case$9 $switch$3$case$9 $switch$3$default
         (local.get $6)
        )
       )
       (block
-       (br $block$8$break)
+       (br $block$9$break)
       )
      )
      (block
@@ -1004,7 +1004,7 @@
         (i32.const 2)
        )
        (block
-        (br $block$8$break)
+        (br $block$9$break)
        )
       )
      )

--- a/test/passes/flatten_simplify-locals-nonesting_souperify-single-use_enable-threads.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify-single-use_enable-threads.txt
@@ -1567,7 +1567,10 @@ infer %4
      )
      (unreachable)
     )
-    (unreachable)
+    (block
+     (unreachable)
+     (unreachable)
+    )
    )
   )
   (unreachable)
@@ -1756,15 +1759,18 @@ infer %4
  (func $various-conditions-4 (param $x i32)
   (local $1 i32)
   (local $2 i32)
-  (if
+  (block
    (unreachable)
-   (block
-    (nop)
-    (nop)
-    (local.set $x
-     (i32.add
-      (local.get $x)
-      (i32.const 3)
+   (if
+    (unreachable)
+    (block
+     (nop)
+     (nop)
+     (local.set $x
+      (i32.add
+       (local.get $x)
+       (i32.const 3)
+      )
      )
     )
    )
@@ -2393,6 +2399,7 @@ infer %4
         (i32.const 1)
        )
        (unreachable)
+       (unreachable)
       )
       (unreachable)
      )
@@ -2609,6 +2616,7 @@ infer %4
     (local.get $1)
    )
    (unreachable)
+   (unreachable)
   )
   (i32.store16
    (i32.const 0)
@@ -2619,6 +2627,7 @@ infer %4
   (local $2 i32)
   (local $3 i32)
   (block $block
+   (unreachable)
    (unreachable)
    (block
     (nop)
@@ -2664,6 +2673,7 @@ infer %4
         (unreachable)
        )
        (unreachable)
+       (unreachable)
       )
       (br $label$1)
       (unreachable)
@@ -2684,6 +2694,7 @@ infer %4
      (br $label$1)
      (unreachable)
     )
+    (unreachable)
     (unreachable)
    )
    (nop)
@@ -3945,7 +3956,10 @@ infer %4
        (block $label$3
         (if
          (i32.const 0)
-         (unreachable)
+         (block
+          (unreachable)
+          (unreachable)
+         )
         )
         (nop)
         (nop)
@@ -3955,7 +3969,10 @@ infer %4
        )
        (if
         (local.get $6)
-        (unreachable)
+        (block
+         (unreachable)
+         (unreachable)
+        )
        )
       )
       (nop)
@@ -3998,7 +4015,10 @@ infer %4
       (block $label$4
        (if
         (i32.const 1337)
-        (unreachable)
+        (block
+         (unreachable)
+         (unreachable)
+        )
        )
        (nop)
        (nop)
@@ -4029,6 +4049,7 @@ infer %4
         (drop
          (local.get $6)
         )
+        (unreachable)
         (unreachable)
        )
        (nop)
@@ -4080,7 +4101,10 @@ infer %4
     (nop)
     (if
      (local.get $var$0)
-     (unreachable)
+     (block
+      (unreachable)
+      (unreachable)
+     )
      (block
       (block $block
        (block
@@ -4121,6 +4145,7 @@ infer %4
    )
    (nop)
    (nop)
+   (unreachable)
    (unreachable)
   )
   (nop)
@@ -4286,6 +4311,7 @@ infer %4
       (local.get $8)
      )
      (unreachable)
+     (unreachable)
     )
     (nop)
     (local.set $10
@@ -4311,9 +4337,13 @@ infer %4
      )
      (if
       (local.get $13)
-      (unreachable)
+      (block
+       (unreachable)
+       (unreachable)
+      )
      )
     )
+    (unreachable)
     (unreachable)
    )
   )
@@ -4383,6 +4413,7 @@ infer %4
          (unreachable)
         )
         (unreachable)
+        (unreachable)
        )
        (br $label$1)
        (unreachable)
@@ -4408,6 +4439,7 @@ infer %4
       (local.get $6)
      )
     )
+    (unreachable)
     (unreachable)
    )
    (nop)
@@ -4468,7 +4500,10 @@ infer %4
   )
   (if
    (local.get $8)
-   (unreachable)
+   (block
+    (unreachable)
+    (unreachable)
+   )
   )
  )
  (func $zext-numGets-hasAnotherUse (param $var$0 i32) (param $var$1 i32)
@@ -4526,7 +4561,10 @@ infer %4
   )
   (if
    (local.get $11)
-   (unreachable)
+   (block
+    (unreachable)
+    (unreachable)
+   )
   )
  )
  (func $flipped-needs-right-origin (param $var$0 i32) (result i32)
@@ -4567,7 +4605,10 @@ infer %4
     )
     (if
      (local.get $5)
-     (unreachable)
+     (block
+      (unreachable)
+      (unreachable)
+     )
     )
    )
    (nop)
@@ -4612,6 +4653,7 @@ infer %4
     (i32.const 3)
     (local.get $7)
    )
+   (unreachable)
    (unreachable)
   )
   (nop)
@@ -4722,6 +4764,7 @@ infer %4
     (i32.const 8)
     (i32.const 64)
    )
+   (unreachable)
    (unreachable)
   )
   (nop)

--- a/test/passes/flatten_simplify-locals-nonesting_souperify_enable-threads.txt
+++ b/test/passes/flatten_simplify-locals-nonesting_souperify_enable-threads.txt
@@ -1608,7 +1608,10 @@ infer %4
      )
      (unreachable)
     )
-    (unreachable)
+    (block
+     (unreachable)
+     (unreachable)
+    )
    )
   )
   (unreachable)
@@ -1858,15 +1861,18 @@ infer %4
  (func $various-conditions-4 (param $x i32)
   (local $1 i32)
   (local $2 i32)
-  (if
+  (block
    (unreachable)
-   (block
-    (nop)
-    (nop)
-    (local.set $x
-     (i32.add
-      (local.get $x)
-      (i32.const 3)
+   (if
+    (unreachable)
+    (block
+     (nop)
+     (nop)
+     (local.set $x
+      (i32.add
+       (local.get $x)
+       (i32.const 3)
+      )
      )
     )
    )
@@ -2495,6 +2501,7 @@ infer %4
         (i32.const 1)
        )
        (unreachable)
+       (unreachable)
       )
       (unreachable)
      )
@@ -2711,6 +2718,7 @@ infer %4
     (local.get $1)
    )
    (unreachable)
+   (unreachable)
   )
   (i32.store16
    (i32.const 0)
@@ -2721,6 +2729,7 @@ infer %4
   (local $2 i32)
   (local $3 i32)
   (block $block
+   (unreachable)
    (unreachable)
    (block
     (nop)
@@ -2766,6 +2775,7 @@ infer %4
         (unreachable)
        )
        (unreachable)
+       (unreachable)
       )
       (br $label$1)
       (unreachable)
@@ -2786,6 +2796,7 @@ infer %4
      (br $label$1)
      (unreachable)
     )
+    (unreachable)
     (unreachable)
    )
    (nop)
@@ -4047,7 +4058,10 @@ infer %4
        (block $label$3
         (if
          (i32.const 0)
-         (unreachable)
+         (block
+          (unreachable)
+          (unreachable)
+         )
         )
         (nop)
         (nop)
@@ -4057,7 +4071,10 @@ infer %4
        )
        (if
         (local.get $6)
-        (unreachable)
+        (block
+         (unreachable)
+         (unreachable)
+        )
        )
       )
       (nop)
@@ -4100,7 +4117,10 @@ infer %4
       (block $label$4
        (if
         (i32.const 1337)
-        (unreachable)
+        (block
+         (unreachable)
+         (unreachable)
+        )
        )
        (nop)
        (nop)
@@ -4131,6 +4151,7 @@ infer %4
         (drop
          (local.get $6)
         )
+        (unreachable)
         (unreachable)
        )
        (nop)
@@ -4182,7 +4203,10 @@ infer %4
     (nop)
     (if
      (local.get $var$0)
-     (unreachable)
+     (block
+      (unreachable)
+      (unreachable)
+     )
      (block
       (block $block
        (block
@@ -4223,6 +4247,7 @@ infer %4
    )
    (nop)
    (nop)
+   (unreachable)
    (unreachable)
   )
   (nop)
@@ -4388,6 +4413,7 @@ infer %4
       (local.get $8)
      )
      (unreachable)
+     (unreachable)
     )
     (nop)
     (local.set $10
@@ -4413,9 +4439,13 @@ infer %4
      )
      (if
       (local.get $13)
-      (unreachable)
+      (block
+       (unreachable)
+       (unreachable)
+      )
      )
     )
+    (unreachable)
     (unreachable)
    )
   )
@@ -4485,6 +4515,7 @@ infer %4
          (unreachable)
         )
         (unreachable)
+        (unreachable)
        )
        (br $label$1)
        (unreachable)
@@ -4510,6 +4541,7 @@ infer %4
       (local.get $6)
      )
     )
+    (unreachable)
     (unreachable)
    )
    (nop)
@@ -4570,7 +4602,10 @@ infer %4
   )
   (if
    (local.get $8)
-   (unreachable)
+   (block
+    (unreachable)
+    (unreachable)
+   )
   )
  )
  (func $zext-numGets-hasAnotherUse (param $var$0 i32) (param $var$1 i32)
@@ -4628,7 +4663,10 @@ infer %4
   )
   (if
    (local.get $11)
-   (unreachable)
+   (block
+    (unreachable)
+    (unreachable)
+   )
   )
  )
  (func $flipped-needs-right-origin (param $var$0 i32) (result i32)
@@ -4669,7 +4707,10 @@ infer %4
     )
     (if
      (local.get $5)
-     (unreachable)
+     (block
+      (unreachable)
+      (unreachable)
+     )
     )
    )
    (nop)
@@ -4714,6 +4755,7 @@ infer %4
     (i32.const 3)
     (local.get $7)
    )
+   (unreachable)
    (unreachable)
   )
   (nop)
@@ -4824,6 +4866,7 @@ infer %4
     (i32.const 8)
     (i32.const 64)
    )
+   (unreachable)
    (unreachable)
   )
   (nop)


### PR DESCRIPTION
The special-casing of `unreachable` there could lead to bad
behavior, where we did nothing to the unreachable and ended
up moving something with side effects before it, see testcase
in `test/passes/flatten_all-features.wast`.

This emits less efficient code, but only if `--dce` was not run
earlier, so probably not worth optimizing.