### PR TITLE
Prevent calls from escaping try in CodeFolding

### DIFF
--- a/test/passes/remove-unused-names_code-folding_all-features.txt
+++ b/test/passes/remove-unused-names_code-folding_all-features.txt
@@ -3,6 +3,7 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $none_=>_exnref (func (result exnref)))
  (event $e (attr 0) (param))
  (func $ifs
   (if
@@ -1709,7 +1710,7 @@
    (i32.const 2)
   )
  )
- (func $exnref_pop_test
+ (func $exnref_pop-test
   (local $exn exnref)
   (block $folding-inner0
    (try
@@ -1746,7 +1747,7 @@
   )
   (unreachable)
  )
- (func $br_on_exn_target_block
+ (func $br_on_exn-target-block
   (local $exn exnref)
   (block $x
    (if
@@ -1785,6 +1786,61 @@
     (i32.const 2)
    )
    (br $x)
+  )
+ )
+ (func $foo
+  (nop)
+ )
+ (func $try-call-optimize-terminating-tails (result exnref)
+  (try
+   (do
+    (call $foo)
+    (call $foo)
+    (call $foo)
+    (call $foo)
+    (return
+     (ref.null)
+    )
+   )
+   (catch
+    (drop
+     (exnref.pop)
+    )
+    (call $foo)
+    (call $foo)
+    (call $foo)
+    (call $foo)
+    (return
+     (ref.null)
+    )
+   )
+  )
+  (ref.null)
+ )
+ (func $try-call-optimize-expression-tails
+  (local $exn exnref)
+  (block $x
+   (try
+    (do
+     (local.set $exn
+      (exnref.pop)
+     )
+     (call $foo)
+     (call $foo)
+     (call $foo)
+     (br $x)
+    )
+    (catch
+     (local.set $exn
+      (exnref.pop)
+     )
+     (call $foo)
+     (call $foo)
+     (call $foo)
+     (br $x)
+    )
+   )
+   (unreachable)
   )
  )
 )

--- a/test/passes/remove-unused-names_code-folding_all-features.wast
+++ b/test/passes/remove-unused-names_code-folding_all-features.wast
@@ -1192,7 +1192,7 @@
     )
   )
 
-  (func $exnref_pop_test (local $exn exnref)
+  (func $exnref_pop-test (local $exn exnref)
     (try
       (do
         (try
@@ -1219,7 +1219,7 @@
   )
 
   (event $e (attr 0)) ;; exception with no param
-  (func $br_on_exn_target_block (local $exn exnref)
+  (func $br_on_exn-target-block (local $exn exnref)
     ;; Here this block $x is targeted by br_on_exn, so code folding out of this
     ;; block should NOT happen.
     (block $x
@@ -1242,6 +1242,52 @@
       (drop (i32.const 1))
       (drop (i32.const 2))
       (br $x)
+    )
+  )
+
+  (func $foo)
+  (func $try-call-optimize-terminating-tails (result exnref)
+    (try
+      (do
+        ;; Expressions that can throw should NOT be taken out of 'try' scope.
+        (call $foo)
+        (call $foo)
+        (call $foo)
+        (call $foo)
+        (return (ref.null))
+      )
+      (catch
+        (drop (exnref.pop))
+        (call $foo)
+        (call $foo)
+        (call $foo)
+        (call $foo)
+        (return (ref.null))
+      )
+    )
+    (ref.null)
+  )
+
+  (func $try-call-optimize-expression-tails (local $exn exnref)
+    (block $x
+      (try
+        (do
+          ;; Expressions that can throw should NOT be taken out of 'try' scope.
+          (local.set $exn (exnref.pop))
+          (call $foo)
+          (call $foo)
+          (call $foo)
+          (br $x)
+        )
+        (catch
+          (local.set $exn (exnref.pop))
+          (call $foo)
+          (call $foo)
+          (call $foo)
+          (br $x)
+        )
+      )
+      (unreachable)
     )
   )
 )


### PR DESCRIPTION
In CodeFolding, we should not take an expression that may throw out of a
`try` scope. This patch adds this restriction in `canMove`.