### PR TITLE
[WIP] Complemented shift bitwise patterns

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -630,7 +630,7 @@ struct OptimizeInstructions
           return ret;
         }
       }
-      if (binary->op == XorInt32) {
+      if (binary->op == XorInt32 || binary->op == XorInt64) {
         if (auto* ret = complementaryShift(binary)) {
           return ret;
         }
@@ -1215,8 +1215,44 @@ private:
   }
 
   // We try detect and simplify patterns like:
-  // ~(1 << shift)   ==>   rot(-2, shift)
+  // ~(1 << shift)
   Expression* complementaryShift(Binary* binary) {
+    assert(binary->op == XorInt32 || binary->op == XorInt64);
+    //   (1 << shift) ^ -1    ==>    rotl(-2, shift)
+    if (binary->type == Type::i32) {
+      if (auto* constRigth = binary->right->dynCast<Const>()) {
+        if (constRigth->value.geti32() == -1) {
+          if (auto* left = binary->left->dynCast<Binary>()) {
+            if (left->op == ShlInt32) {
+              if (auto* constLeft = left->left->dynCast<Const>()) {
+                if (constLeft->value.geti32() == 1) {
+                  left->op = RotLInt32;
+                  constLeft->value = Literal(int32_t(-2));
+                  return left;
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+      if (auto* constRigth = binary->right->dynCast<Const>()) {
+        if (constRigth->value.geti64() == -1LL) {
+          if (auto* left = binary->left->dynCast<Binary>()) {
+            if (left->op == ShlInt64) {
+              if (auto* constLeft = left->left->dynCast<Const>()) {
+                if (constLeft->value.geti64() == 1LL) {
+                  left->op = RotLInt64;
+                  constLeft->value = Literal(int64_t(-2));
+                  return left;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    return nullptr;
   }
 
   // We can combine `or` operations, e.g.

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -630,6 +630,11 @@ struct OptimizeInstructions
           return ret;
         }
       }
+      if (binary->op == XorInt32) {
+        if (auto* ret = complementaryShift(binary)) {
+          return ret;
+        }
+      }
       // relation/comparisons allow for math optimizations
       if (binary->isRelational()) {
         if (auto* ret = optimizeRelational(binary)) {
@@ -1207,6 +1212,11 @@ private:
       return builder.makeIf(
         left, right, builder.makeConst(Literal(int32_t(0))));
     }
+  }
+
+  // We try detect and simplify patterns like:
+  // ~(1 << shift)   ==>   rot(-2, shift)
+  Expression* complementaryShift(Binary* binary) {
   }
 
   // We can combine `or` operations, e.g.

--- a/test/emcc_O2_hello_world.fromasm
+++ b/test/emcc_O2_hello_world.fromasm
@@ -209,12 +209,9 @@
        (i32.store
         (i32.const 176)
         (i32.and
-         (i32.xor
-          (i32.shl
-           (i32.const 1)
-           (local.get $3)
-          )
-          (i32.const -1)
+         (i32.rotl
+          (i32.const -2)
+          (local.get $3)
          )
          (local.get $18)
         )
@@ -444,12 +441,9 @@
           (i32.store
            (i32.const 176)
            (i32.and
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $2)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $2)
             )
             (local.get $18)
            )
@@ -993,12 +987,9 @@
                 (i32.load
                  (i32.const 180)
                 )
-                (i32.xor
-                 (i32.shl
-                  (i32.const 1)
-                  (local.get $0)
-                 )
-                 (i32.const -1)
+                (i32.rotl
+                 (i32.const -2)
+                 (local.get $0)
                 )
                )
               )
@@ -2035,12 +2026,9 @@
                   (i32.load
                    (i32.const 180)
                   )
-                  (i32.xor
-                   (i32.shl
-                    (i32.const 1)
-                    (local.get $0)
-                   )
-                   (i32.const -1)
+                  (i32.rotl
+                   (i32.const -2)
+                   (local.get $0)
                   )
                  )
                 )
@@ -3991,12 +3979,9 @@
                        (i32.load
                         (i32.const 180)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $0)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $0)
                        )
                       )
                      )
@@ -4125,12 +4110,9 @@
                        (i32.load
                         (i32.const 176)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $3)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $3)
                        )
                       )
                      )
@@ -5829,12 +5811,9 @@
           (i32.load
            (i32.const 176)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $10)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $10)
           )
          )
         )
@@ -6087,12 +6066,9 @@
             (i32.load
              (i32.const 180)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -6589,12 +6565,9 @@
                (i32.load
                 (i32.const 180)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $0)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $0)
                )
               )
              )
@@ -6759,12 +6732,9 @@
            (i32.load
             (i32.const 176)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $4)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $4)
            )
           )
          )

--- a/test/emcc_O2_hello_world.fromasm.clamp
+++ b/test/emcc_O2_hello_world.fromasm.clamp
@@ -209,12 +209,9 @@
        (i32.store
         (i32.const 176)
         (i32.and
-         (i32.xor
-          (i32.shl
-           (i32.const 1)
-           (local.get $3)
-          )
-          (i32.const -1)
+         (i32.rotl
+          (i32.const -2)
+          (local.get $3)
          )
          (local.get $18)
         )
@@ -444,12 +441,9 @@
           (i32.store
            (i32.const 176)
            (i32.and
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $2)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $2)
             )
             (local.get $18)
            )
@@ -993,12 +987,9 @@
                 (i32.load
                  (i32.const 180)
                 )
-                (i32.xor
-                 (i32.shl
-                  (i32.const 1)
-                  (local.get $0)
-                 )
-                 (i32.const -1)
+                (i32.rotl
+                 (i32.const -2)
+                 (local.get $0)
                 )
                )
               )
@@ -2035,12 +2026,9 @@
                   (i32.load
                    (i32.const 180)
                   )
-                  (i32.xor
-                   (i32.shl
-                    (i32.const 1)
-                    (local.get $0)
-                   )
-                   (i32.const -1)
+                  (i32.rotl
+                   (i32.const -2)
+                   (local.get $0)
                   )
                  )
                 )
@@ -3991,12 +3979,9 @@
                        (i32.load
                         (i32.const 180)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $0)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $0)
                        )
                       )
                      )
@@ -4125,12 +4110,9 @@
                        (i32.load
                         (i32.const 176)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $3)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $3)
                        )
                       )
                      )
@@ -5829,12 +5811,9 @@
           (i32.load
            (i32.const 176)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $10)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $10)
           )
          )
         )
@@ -6087,12 +6066,9 @@
             (i32.load
              (i32.const 180)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -6589,12 +6565,9 @@
                (i32.load
                 (i32.const 180)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $0)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $0)
                )
               )
              )
@@ -6759,12 +6732,9 @@
            (i32.load
             (i32.const 176)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $4)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $4)
            )
           )
          )

--- a/test/emcc_O2_hello_world.fromasm.imprecise
+++ b/test/emcc_O2_hello_world.fromasm.imprecise
@@ -208,12 +208,9 @@
        (i32.store
         (i32.const 176)
         (i32.and
-         (i32.xor
-          (i32.shl
-           (i32.const 1)
-           (local.get $3)
-          )
-          (i32.const -1)
+         (i32.rotl
+          (i32.const -2)
+          (local.get $3)
          )
          (local.get $18)
         )
@@ -443,12 +440,9 @@
           (i32.store
            (i32.const 176)
            (i32.and
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $2)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $2)
             )
             (local.get $18)
            )
@@ -992,12 +986,9 @@
                 (i32.load
                  (i32.const 180)
                 )
-                (i32.xor
-                 (i32.shl
-                  (i32.const 1)
-                  (local.get $0)
-                 )
-                 (i32.const -1)
+                (i32.rotl
+                 (i32.const -2)
+                 (local.get $0)
                 )
                )
               )
@@ -2036,12 +2027,9 @@
                   (i32.load
                    (i32.const 180)
                   )
-                  (i32.xor
-                   (i32.shl
-                    (i32.const 1)
-                    (local.get $0)
-                   )
-                   (i32.const -1)
+                  (i32.rotl
+                   (i32.const -2)
+                   (local.get $0)
                   )
                  )
                 )
@@ -3992,12 +3980,9 @@
                        (i32.load
                         (i32.const 180)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $0)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $0)
                        )
                       )
                      )
@@ -4126,12 +4111,9 @@
                        (i32.load
                         (i32.const 176)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $3)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $3)
                        )
                       )
                      )
@@ -5829,12 +5811,9 @@
           (i32.load
            (i32.const 176)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $11)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $11)
           )
          )
         )
@@ -6087,12 +6066,9 @@
             (i32.load
              (i32.const 180)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -6589,12 +6565,9 @@
                (i32.load
                 (i32.const 180)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $0)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $0)
                )
               )
              )
@@ -6759,12 +6732,9 @@
            (i32.load
             (i32.const 176)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $4)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $4)
            )
           )
          )

--- a/test/emcc_hello_world.fromasm
+++ b/test/emcc_hello_world.fromasm
@@ -7478,12 +7478,9 @@
          (i32.const 176)
          (i32.and
           (local.get $6)
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $0)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $0)
           )
          )
         )
@@ -7703,12 +7700,9 @@
             (i32.const 176)
             (i32.and
              (local.get $6)
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (local.get $2)
-              )
-              (i32.const -1)
+             (i32.rotl
+              (i32.const -2)
+              (local.get $2)
              )
             )
            )
@@ -8285,12 +8279,9 @@
                  (i32.load
                   (i32.const 180)
                  )
-                 (i32.xor
-                  (i32.shl
-                   (i32.const 1)
-                   (local.get $1)
-                  )
-                  (i32.const -1)
+                 (i32.rotl
+                  (i32.const -2)
+                  (local.get $1)
                  )
                 )
                )
@@ -9294,12 +9285,9 @@
                    (i32.load
                     (i32.const 180)
                    )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (local.get $1)
-                    )
-                    (i32.const -1)
+                   (i32.rotl
+                    (i32.const -2)
+                    (local.get $1)
                    )
                   )
                  )
@@ -10981,12 +10969,9 @@
                        (i32.load
                         (i32.const 176)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $1)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $1)
                        )
                       )
                      )
@@ -11233,12 +11218,9 @@
                        (i32.load
                         (i32.const 180)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $1)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $1)
                        )
                       )
                      )
@@ -12903,12 +12885,9 @@
           (i32.load
            (i32.const 176)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $4)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $4)
           )
          )
         )
@@ -13165,12 +13144,9 @@
             (i32.load
              (i32.const 180)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -13533,12 +13509,9 @@
            (i32.load
             (i32.const 176)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $2)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $2)
            )
           )
          )
@@ -13788,12 +13761,9 @@
                (i32.load
                 (i32.const 180)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $2)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $2)
                )
               )
              )

--- a/test/emcc_hello_world.fromasm.clamp
+++ b/test/emcc_hello_world.fromasm.clamp
@@ -7529,12 +7529,9 @@
          (i32.const 176)
          (i32.and
           (local.get $6)
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $0)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $0)
           )
          )
         )
@@ -7754,12 +7751,9 @@
             (i32.const 176)
             (i32.and
              (local.get $6)
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (local.get $2)
-              )
-              (i32.const -1)
+             (i32.rotl
+              (i32.const -2)
+              (local.get $2)
              )
             )
            )
@@ -8336,12 +8330,9 @@
                  (i32.load
                   (i32.const 180)
                  )
-                 (i32.xor
-                  (i32.shl
-                   (i32.const 1)
-                   (local.get $1)
-                  )
-                  (i32.const -1)
+                 (i32.rotl
+                  (i32.const -2)
+                  (local.get $1)
                  )
                 )
                )
@@ -9345,12 +9336,9 @@
                    (i32.load
                     (i32.const 180)
                    )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (local.get $1)
-                    )
-                    (i32.const -1)
+                   (i32.rotl
+                    (i32.const -2)
+                    (local.get $1)
                    )
                   )
                  )
@@ -11032,12 +11020,9 @@
                        (i32.load
                         (i32.const 176)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $1)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $1)
                        )
                       )
                      )
@@ -11284,12 +11269,9 @@
                        (i32.load
                         (i32.const 180)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $1)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $1)
                        )
                       )
                      )
@@ -12954,12 +12936,9 @@
           (i32.load
            (i32.const 176)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $4)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $4)
           )
          )
         )
@@ -13216,12 +13195,9 @@
             (i32.load
              (i32.const 180)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -13584,12 +13560,9 @@
            (i32.load
             (i32.const 176)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $2)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $2)
            )
           )
          )
@@ -13839,12 +13812,9 @@
                (i32.load
                 (i32.const 180)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $2)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $2)
                )
               )
              )

--- a/test/emcc_hello_world.fromasm.imprecise
+++ b/test/emcc_hello_world.fromasm.imprecise
@@ -7374,12 +7374,9 @@
          (i32.const 176)
          (i32.and
           (local.get $6)
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $0)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $0)
           )
          )
         )
@@ -7599,12 +7596,9 @@
             (i32.const 176)
             (i32.and
              (local.get $6)
-             (i32.xor
-              (i32.shl
-               (i32.const 1)
-               (local.get $2)
-              )
-              (i32.const -1)
+             (i32.rotl
+              (i32.const -2)
+              (local.get $2)
              )
             )
            )
@@ -8181,12 +8175,9 @@
                  (i32.load
                   (i32.const 180)
                  )
-                 (i32.xor
-                  (i32.shl
-                   (i32.const 1)
-                   (local.get $1)
-                  )
-                  (i32.const -1)
+                 (i32.rotl
+                  (i32.const -2)
+                  (local.get $1)
                  )
                 )
                )
@@ -9190,12 +9181,9 @@
                    (i32.load
                     (i32.const 180)
                    )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (local.get $1)
-                    )
-                    (i32.const -1)
+                   (i32.rotl
+                    (i32.const -2)
+                    (local.get $1)
                    )
                   )
                  )
@@ -10877,12 +10865,9 @@
                        (i32.load
                         (i32.const 176)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $1)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $1)
                        )
                       )
                      )
@@ -11129,12 +11114,9 @@
                        (i32.load
                         (i32.const 180)
                        )
-                       (i32.xor
-                        (i32.shl
-                         (i32.const 1)
-                         (local.get $1)
-                        )
-                        (i32.const -1)
+                       (i32.rotl
+                        (i32.const -2)
+                        (local.get $1)
                        )
                       )
                      )
@@ -12798,12 +12780,9 @@
           (i32.load
            (i32.const 176)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $4)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $4)
           )
          )
         )
@@ -13060,12 +13039,9 @@
             (i32.load
              (i32.const 180)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -13428,12 +13404,9 @@
            (i32.load
             (i32.const 176)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $2)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $2)
            )
           )
          )
@@ -13683,12 +13656,9 @@
                (i32.load
                 (i32.const 180)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $2)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $2)
                )
               )
              )

--- a/test/memorygrowth.fromasm
+++ b/test/memorygrowth.fromasm
@@ -193,12 +193,9 @@
        (i32.store
         (i32.const 1208)
         (i32.and
-         (i32.xor
-          (i32.shl
-           (i32.const 1)
-           (local.get $3)
-          )
-          (i32.const -1)
+         (i32.rotl
+          (i32.const -2)
+          (local.get $3)
          )
          (local.get $12)
         )
@@ -426,12 +423,9 @@
           (i32.store
            (i32.const 1208)
            (i32.and
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $5)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $5)
             )
             (local.get $12)
            )
@@ -1019,12 +1013,9 @@
                 (i32.load
                  (i32.const 1212)
                 )
-                (i32.xor
-                 (i32.shl
-                  (i32.const 1)
-                  (local.get $0)
-                 )
-                 (i32.const -1)
+                (i32.rotl
+                 (i32.const -2)
+                 (local.get $0)
                 )
                )
               )
@@ -2074,12 +2065,9 @@
                    (i32.load
                     (i32.const 1212)
                    )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (local.get $0)
-                    )
-                    (i32.const -1)
+                   (i32.rotl
+                    (i32.const -2)
+                    (local.get $0)
                    )
                   )
                  )
@@ -3880,12 +3868,9 @@
                         (i32.load
                          (i32.const 1208)
                         )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (local.get $3)
-                         )
-                         (i32.const -1)
+                        (i32.rotl
+                         (i32.const -2)
+                         (local.get $3)
                         )
                        )
                       )
@@ -4131,12 +4116,9 @@
                         (i32.load
                          (i32.const 1212)
                         )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (local.get $0)
-                         )
-                         (i32.const -1)
+                        (i32.rotl
+                         (i32.const -2)
+                         (local.get $0)
                         )
                        )
                       )
@@ -5857,12 +5839,9 @@
           (i32.load
            (i32.const 1208)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $10)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $10)
           )
          )
         )
@@ -6118,12 +6097,9 @@
             (i32.load
              (i32.const 1212)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -6486,12 +6462,9 @@
            (i32.load
             (i32.const 1208)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $4)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $4)
            )
           )
          )
@@ -6740,12 +6713,9 @@
                (i32.load
                 (i32.const 1212)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $0)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $0)
                )
               )
              )

--- a/test/memorygrowth.fromasm.clamp
+++ b/test/memorygrowth.fromasm.clamp
@@ -193,12 +193,9 @@
        (i32.store
         (i32.const 1208)
         (i32.and
-         (i32.xor
-          (i32.shl
-           (i32.const 1)
-           (local.get $3)
-          )
-          (i32.const -1)
+         (i32.rotl
+          (i32.const -2)
+          (local.get $3)
          )
          (local.get $12)
         )
@@ -426,12 +423,9 @@
           (i32.store
            (i32.const 1208)
            (i32.and
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $5)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $5)
             )
             (local.get $12)
            )
@@ -1019,12 +1013,9 @@
                 (i32.load
                  (i32.const 1212)
                 )
-                (i32.xor
-                 (i32.shl
-                  (i32.const 1)
-                  (local.get $0)
-                 )
-                 (i32.const -1)
+                (i32.rotl
+                 (i32.const -2)
+                 (local.get $0)
                 )
                )
               )
@@ -2074,12 +2065,9 @@
                    (i32.load
                     (i32.const 1212)
                    )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (local.get $0)
-                    )
-                    (i32.const -1)
+                   (i32.rotl
+                    (i32.const -2)
+                    (local.get $0)
                    )
                   )
                  )
@@ -3880,12 +3868,9 @@
                         (i32.load
                          (i32.const 1208)
                         )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (local.get $3)
-                         )
-                         (i32.const -1)
+                        (i32.rotl
+                         (i32.const -2)
+                         (local.get $3)
                         )
                        )
                       )
@@ -4131,12 +4116,9 @@
                         (i32.load
                          (i32.const 1212)
                         )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (local.get $0)
-                         )
-                         (i32.const -1)
+                        (i32.rotl
+                         (i32.const -2)
+                         (local.get $0)
                         )
                        )
                       )
@@ -5857,12 +5839,9 @@
           (i32.load
            (i32.const 1208)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $10)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $10)
           )
          )
         )
@@ -6118,12 +6097,9 @@
             (i32.load
              (i32.const 1212)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -6486,12 +6462,9 @@
            (i32.load
             (i32.const 1208)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $4)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $4)
            )
           )
          )
@@ -6740,12 +6713,9 @@
                (i32.load
                 (i32.const 1212)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $0)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $0)
                )
               )
              )

--- a/test/memorygrowth.fromasm.imprecise
+++ b/test/memorygrowth.fromasm.imprecise
@@ -191,12 +191,9 @@
        (i32.store
         (i32.const 1208)
         (i32.and
-         (i32.xor
-          (i32.shl
-           (i32.const 1)
-           (local.get $3)
-          )
-          (i32.const -1)
+         (i32.rotl
+          (i32.const -2)
+          (local.get $3)
          )
          (local.get $12)
         )
@@ -424,12 +421,9 @@
           (i32.store
            (i32.const 1208)
            (i32.and
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $5)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $5)
             )
             (local.get $12)
            )
@@ -1017,12 +1011,9 @@
                 (i32.load
                  (i32.const 1212)
                 )
-                (i32.xor
-                 (i32.shl
-                  (i32.const 1)
-                  (local.get $0)
-                 )
-                 (i32.const -1)
+                (i32.rotl
+                 (i32.const -2)
+                 (local.get $0)
                 )
                )
               )
@@ -2072,12 +2063,9 @@
                    (i32.load
                     (i32.const 1212)
                    )
-                   (i32.xor
-                    (i32.shl
-                     (i32.const 1)
-                     (local.get $0)
-                    )
-                    (i32.const -1)
+                   (i32.rotl
+                    (i32.const -2)
+                    (local.get $0)
                    )
                   )
                  )
@@ -3878,12 +3866,9 @@
                         (i32.load
                          (i32.const 1208)
                         )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (local.get $3)
-                         )
-                         (i32.const -1)
+                        (i32.rotl
+                         (i32.const -2)
+                         (local.get $3)
                         )
                        )
                       )
@@ -4129,12 +4114,9 @@
                         (i32.load
                          (i32.const 1212)
                         )
-                        (i32.xor
-                         (i32.shl
-                          (i32.const 1)
-                          (local.get $0)
-                         )
-                         (i32.const -1)
+                        (i32.rotl
+                         (i32.const -2)
+                         (local.get $0)
                         )
                        )
                       )
@@ -5854,12 +5836,9 @@
           (i32.load
            (i32.const 1208)
           )
-          (i32.xor
-           (i32.shl
-            (i32.const 1)
-            (local.get $11)
-           )
-           (i32.const -1)
+          (i32.rotl
+           (i32.const -2)
+           (local.get $11)
           )
          )
         )
@@ -6115,12 +6094,9 @@
             (i32.load
              (i32.const 1212)
             )
-            (i32.xor
-             (i32.shl
-              (i32.const 1)
-              (local.get $4)
-             )
-             (i32.const -1)
+            (i32.rotl
+             (i32.const -2)
+             (local.get $4)
             )
            )
           )
@@ -6483,12 +6459,9 @@
            (i32.load
             (i32.const 1208)
            )
-           (i32.xor
-            (i32.shl
-             (i32.const 1)
-             (local.get $4)
-            )
-            (i32.const -1)
+           (i32.rotl
+            (i32.const -2)
+            (local.get $4)
            )
           )
          )
@@ -6737,12 +6710,9 @@
                (i32.load
                 (i32.const 1212)
                )
-               (i32.xor
-                (i32.shl
-                 (i32.const 1)
-                 (local.get $0)
-                )
-                (i32.const -1)
+               (i32.rotl
+                (i32.const -2)
+                (local.get $0)
                )
               )
              )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3,9 +3,9 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_=>_none (func (param i32)))
- (type $i32_i64_=>_none (func (param i32 i64)))
  (type $none_=>_i64 (func (result i64)))
  (type $i32_i64_f32_=>_none (func (param i32 i64 f32)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
@@ -3320,6 +3320,32 @@
   (drop
    (i32.ge_s
     (local.get $x)
+    (local.get $y)
+   )
+  )
+ )
+ (func $complementary-shift (param $x i32) (param $y i64)
+  (drop
+   (i32.rotl
+    (i32.const -2)
+    (local.get $x)
+   )
+  )
+  (drop
+   (i32.rotl
+    (i32.const -2)
+    (local.get $x)
+   )
+  )
+  (drop
+   (i64.rotl
+    (i64.const -2)
+    (local.get $y)
+   )
+  )
+  (drop
+   (i64.rotl
+    (i64.const -2)
     (local.get $y)
    )
   )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3778,6 +3778,37 @@
     ))
     ;; TODO: more stuff here
   )
+  (func $complementary-shift (param $x i32) (param $y i64)
+    ;; ~(1 << x) patterns
+    (drop (i32.xor
+      (i32.shl
+        (i32.const 1)
+        (local.get $x)
+      )
+      (i32.const -1)
+    ))
+    (drop (i32.xor
+      (i32.const -1)
+      (i32.shl
+        (i32.const 1)
+        (local.get $x)
+      )
+    ))
+    (drop (i64.xor
+      (i64.shl
+        (i64.const 1)
+        (local.get $y)
+      )
+      (i64.const -1)
+    ))
+    (drop (i64.xor
+      (i64.const -1)
+      (i64.shl
+        (i64.const 1)
+        (local.get $y)
+      )
+    ))
+  )
   (func $select-into-arms (param $x i32) (param $y i32)
     (if
       (select


### PR DESCRIPTION
I mentioned in [this](https://github.com/WebAssembly/binaryen/issues/1764#issuecomment-619340439) comment.

Try find and simplify patterns like this

`~(1 << shift)`  ==> `rotl(-2, shift)`

Which is pretty common