### PR TITLE
Fuzzing: Run --denan etc. even on a given wasm

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -585,7 +585,11 @@ def test_one(random_input, opts, given_wasm):
     print()
 
     if given_wasm:
-        shutil.copyfile(given_wasm, 'a.wasm')
+        # if given a wasm file we want to use it as is, but we also want to
+        # apply properties like not having any NaNs, which the original fuzz
+        # wasm had applied. that is, we need to preserve properties like not
+        # having nans through reduction.
+        run([in_bin('wasm-opt'), given_wasm, '-o', 'a.wasm'] + FUZZ_OPTS)
     else:
         # emit the target features section so that reduction can work later,
         # without needing to specify the features


### PR DESCRIPTION
When the fuzzer script is given a wasm we don't create a new
one from scratch. But we should still apply `--denan` and other
things so that we preserve those properties while reducing.

Without this it's possible for reduction to start with a wasm with
no nans but to lose the property eventually, and end up with a
reduced testcase which is not quite what you want.