### PR TITLE
Fuzzer: Don't keep doing `--denan` etc. in testcase handlers

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -637,7 +637,7 @@ def test_one(random_input, opts, given_wasm):
 
         # let the testcase handler handle this testcase however it wants. in this case we give it
         # the input and both wasms.
-        testcase_handler.handle_pair(input=random_input, before_wasm='a.wasm', after_wasm='b.wasm', opts=opts + FUZZ_OPTS + FEATURE_OPTS)
+        testcase_handler.handle_pair(input=random_input, before_wasm='a.wasm', after_wasm='b.wasm', opts=opts + FEATURE_OPTS)
         print('')
 
     return bytes


### PR DESCRIPTION
`FUZZ_OPTS` are things like `--denan` which affect generation of
the original wasm. We were passing those to testcase handlers,
which meant that in addition to the random optimizations we picked
they were also running `--denan` etc. again. That can be confusing,
so remove it.