### PR TITLE
Prevent calls from sinking into 'try'

### DIFF
--- a/test/passes/simplify-locals_all-features.txt
+++ b/test/passes/simplify-locals_all-features.txt
@@ -1896,6 +1896,7 @@
  (type $none_=>_none (func))
  (type $i32_exnref_=>_none (func (param i32 exnref)))
  (type $exnref_=>_none (func (param exnref)))
+ (type $none_=>_i32 (func (result i32)))
  (type $none_=>_exnref (func (result exnref)))
  (event $event$0 (attr 0) (param))
  (event $event$1 (attr 0) (param exnref))
@@ -1976,6 +1977,43 @@
        (exnref.pop)
       )
      )
+    )
+   )
+  )
+ )
+ (func $bar (result i32)
+  (i32.const 3)
+ )
+ (func $call-cannot-be-sinked-into-try
+  (local $0 i32)
+  (local.set $0
+   (call $bar)
+  )
+  (try
+   (do
+    (drop
+     (local.get $0)
+    )
+   )
+   (catch
+    (drop
+     (exnref.pop)
+    )
+   )
+  )
+ )
+ (func $non-call-can-be-sinked-into-try
+  (local $0 i32)
+  (nop)
+  (try
+   (do
+    (drop
+     (i32.const 3)
+    )
+   )
+   (catch
+    (drop
+     (exnref.pop)
     )
    )
   )

--- a/test/passes/simplify-locals_all-features.wast
+++ b/test/passes/simplify-locals_all-features.wast
@@ -1749,4 +1749,36 @@
       )
     )
   )
+
+  (func $bar (result i32) (i32.const 3))
+  (func $call-cannot-be-sinked-into-try (local $0 i32)
+    (drop
+      ;; This local.tee should NOT be sinked into 'try' below, because it may
+      ;; throw
+      (local.tee $0 (call $bar))
+    )
+    (try
+      (do
+        (drop (local.get $0))
+      )
+      (catch
+        (drop (exnref.pop))
+      )
+    )
+  )
+
+  (func $non-call-can-be-sinked-into-try (local $0 i32)
+    (drop
+      ;; This local.tee can be sinked into 'try' below, because it cannot throw
+      (local.tee $0 (i32.const 3))
+    )
+    (try
+      (do
+        (drop (local.get $0))
+      )
+      (catch
+        (drop (exnref.pop))
+      )
+    )
+  )
 )


### PR DESCRIPTION
Expressions that may throw cannot be sinked into 'try'. At the start of
'try', we drop all sinkables that may throw.