### PR TITLE
Default mainReadsParams to true in standalone mode

### DIFF
--- a/test/lld/safe_stack_standalone-wasm.wat.out
+++ b/test/lld/safe_stack_standalone-wasm.wat.out
@@ -187,7 +187,6 @@
   ],
   "features": [
   ],
-  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/standalone-wasm-with-start.wat.out
+++ b/test/lld/standalone-wasm-with-start.wat.out
@@ -45,7 +45,6 @@
   ],
   "features": [
   ],
-  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/standalone-wasm.wat.out
+++ b/test/lld/standalone-wasm.wat.out
@@ -60,7 +60,6 @@
   ],
   "features": [
   ],
-  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)

--- a/test/lld/standalone-wasm2.wat.out
+++ b/test/lld/standalone-wasm2.wat.out
@@ -57,7 +57,6 @@
   ],
   "features": [
   ],
-  "mainReadsParams": 1
 }
 -- END METADATA --
 ;)

--- a/test/lld/standalone-wasm3.wat.out
+++ b/test/lld/standalone-wasm3.wat.out
@@ -38,7 +38,6 @@
   ],
   "features": [
   ],
-  "mainReadsParams": 0
 }
 -- END METADATA --
 ;)


### PR DESCRIPTION
The process of DCE'ing the argument handling is already handled in
a different way in standalone more.   In standalone mode the entry
point is `_start` which takes no args, and argv code is included
on-demand via the presence or absence the wasi syscalls for argument
processing (__wasi_args_get/__wasi_args_sizes_get).

