### PR TITLE
Move Stack IR out of default passes

### DIFF
--- a/src/asm2wasm.h
+++ b/src/asm2wasm.h
@@ -1719,6 +1719,7 @@ void Asm2WasmBuilder::processAsm(Ref ast) {
     // do final global optimizations after all function work is done
     // (e.g. duplicate funcs may appear thanks to that work)
     passRunner.addDefaultGlobalOptimizationPostPasses();
+    passRunner.addDefaultPreWritingPasses();
   }
   passRunner.run();
 

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -2458,6 +2458,7 @@ void BinaryenModuleOptimize(BinaryenModuleRef module) {
   PassRunner passRunner((Module*)module);
   passRunner.options = globalPassOptions;
   passRunner.addDefaultOptimizationPasses();
+  passRunner.addDefaultPreWritingPasses();
   passRunner.run();
 }
 
@@ -2705,6 +2706,7 @@ void BinaryenFunctionOptimize(BinaryenFunctionRef func,
   PassRunner passRunner((Module*)module);
   passRunner.options = globalPassOptions;
   passRunner.addDefaultOptimizationPasses();
+  passRunner.addDefaultPreWritingPasses();
   passRunner.runOnFunction((Function*)func);
 }
 void BinaryenFunctionRunPasses(BinaryenFunctionRef func,

--- a/src/pass.h
+++ b/src/pass.h
@@ -199,6 +199,11 @@ struct PassRunner {
   // afterwards.
   void addDefaultGlobalOptimizationPostPasses();
 
+  // Adds optimizations that should only be run immediately prior to module
+  // writing. After these passes the module may be in Poppy IR. This is not
+  // called as part of `addDefaultOptimizationPasses`.
+  void addDefaultPreWritingPasses();
+
   // Run the passes on the module
   void run();
 

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -489,6 +489,9 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   add("remove-unused-module-elements");
   // may allow more inlining/dae/etc., need --converge for that
   add("directize");
+}
+
+void PassRunner::addDefaultPreWritingPasses() {
   // perform Stack IR optimizations here, at the very end of the
   // optimization pipeline
   if (options.optimizeLevel >= 2 || options.shrinkLevel >= 1) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -329,6 +329,7 @@ int main(int argc, const char* argv[]) {
       }
     };
     runPasses();
+    // TODO: Fix this to read the binary at the beginning of every round.
     if (converge) {
       // Keep on running passes to convergence, defined as binary
       // size no longer decreasing.

--- a/test/passes/O2_precompute-propagate_print-stack-ir.txt
+++ b/test/passes/O2_precompute-propagate_print-stack-ir.txt
@@ -3,17 +3,16 @@
  (export "func" (func $0))
  (func $0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i64) (result i64)
   (local $4 i32)
-  (local.set $3
-   (i64.const 2147483647)
-  )
-  (nop)
-  (i64.const 2147483647)
+  i64.const 2147483647
+  local.set $3
+  nop
+  i64.const 2147483647
  )
 )
 (module
  (type $i32_i32_i32_i64_=>_i64 (func (param i32 i32 i32 i64) (result i64)))
  (export "func" (func $0))
- (func $0 (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i64) (result i64)
+ (func $0 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i64) (result i64)
   (local $4 i32)
   (local.set $3
    (i64.const 2147483647)

--- a/test/passes/O3_inlining.txt
+++ b/test/passes/O3_inlining.txt
@@ -3,7 +3,7 @@
  (memory $0 1 1)
  (global $global$1 (mut i32) (i32.const 100))
  (export "func_217" (func $1))
- (func $1 (param $0 i32)
+ (func $1 (; has Stack IR ;) (param $0 i32)
   (if
    (global.get $global$1)
    (unreachable)

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2303,7 +2303,7 @@ Contains section .debug_info (851 bytes)
 Contains section .debug_loc (1073 bytes)
 Contains section .debug_ranges (88 bytes)
 Contains section .debug_abbrev (333 bytes)
-Contains section .debug_line (2662 bytes)
+Contains section .debug_line (2702 bytes)
 Contains section .debug_str (434 bytes)
 
 .debug_abbrev contents:
@@ -2469,8 +2469,8 @@ Abbrev table for offset: 0x00000000
               DW_AT_comp_dir [DW_FORM_strp]	( .debug_str[0x000000a9] = "/usr/local/google/home/azakai/Dev/2-binaryen")
               DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
               DW_AT_ranges [DW_FORM_sec_offset]	(0x00000040
-                 [0x00000007, 0x00000364)
-                 [0x00000366, 0x00000639))
+                 [0x00000007, 0x00000370)
+                 [0x00000372, 0x0000064d))
 
 0x00000026:   DW_TAG_pointer_type [2]  
                 DW_AT_type [DW_FORM_ref4]	(cu + 0x002b => {0x0000002b} "worker_args")
@@ -2534,7 +2534,7 @@ Abbrev table for offset: 0x00000000
 
 0x00000082:   DW_TAG_subprogram [10] *
                 DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000007)
-                DW_AT_high_pc [DW_FORM_data4]	(0x0000035d)
+                DW_AT_high_pc [DW_FORM_data4]	(0x00000369)
                 DW_AT_frame_base [DW_FORM_exprloc]	(DW_OP_WASM_location 0x1 +0, DW_OP_stack_value)
                 DW_AT_GNU_all_call_sites [DW_FORM_flag_present]	(true)
                 DW_AT_linkage_name [DW_FORM_strp]	( .debug_str[0x00000166] = "_Z15fannkuch_workerPv")
@@ -2571,11 +2571,11 @@ Abbrev table for offset: 0x00000000
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000041,  0x00000046): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000110,  0x0000011a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000114,  0x0000011e): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000243,  0x0000024e): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x0000028d,  0x00000297): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000297,  0x000002a1): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000d6] = "i")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2621,8 +2621,8 @@ Abbrev table for offset: 0x00000000
 0x0000010e:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000011d: 
                      [0xffffffff,  0x00000006): 
-                     [0x000001bf,  0x000001c4): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-                     [0x0000033c,  0x00000341): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
+                     [0x000001c3,  0x000001c8): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+                     [0x00000346,  0x0000034b): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000014a] = "r")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2631,12 +2631,12 @@ Abbrev table for offset: 0x00000000
 0x0000011d:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000149: 
                      [0xffffffff,  0x00000006): 
-                     [0x000000b4,  0x000000c7): DW_OP_consts +0, DW_OP_stack_value
+                     [0x000000b8,  0x000000cb): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-                     [0x00000139,  0x00000141): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+                     [0x0000013d,  0x00000145): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000243,  0x0000024e): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-                     [0x000002b6,  0x000002be): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                     [0x000002c0,  0x000002c8): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000155] = "flips")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2645,8 +2645,8 @@ Abbrev table for offset: 0x00000000
 0x0000012c:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001ab: 
                      [0xffffffff,  0x00000006): 
-                     [0x000000c3,  0x000000c7): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-                     [0x00000240,  0x00000244): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
+                     [0x000000c7,  0x000000cb): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
+                     [0x0000024a,  0x0000024e): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019b] = "k")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2655,10 +2655,10 @@ Abbrev table for offset: 0x00000000
 0x0000013b:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001d7: 
                      [0xffffffff,  0x00000006): 
-                     [0x000000db,  0x000000df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000117,  0x0000011a): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000258,  0x0000025c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000294,  0x00000297): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0x000000df,  0x000000e3): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000011b,  0x0000011e): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x00000262,  0x00000266): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000029e,  0x000002a1): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019d] = "j")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2667,10 +2667,10 @@ Abbrev table for offset: 0x00000000
 0x0000014a:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000021f: 
                      [0xffffffff,  0x00000006): 
-                     [0x000000f0,  0x0000011a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-                     [0x0000012b,  0x00000141): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x0000026d,  0x00000297): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-                     [0x000002a8,  0x000002be): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0x000000f4,  0x0000011e): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+                     [0x0000012f,  0x00000145): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x00000277,  0x000002a1): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+                     [0x000002b2,  0x000002c8): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019f] = "tmp")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2678,10 +2678,10 @@ Abbrev table for offset: 0x00000000
 
 0x00000159:     DW_TAG_lexical_block [14] *
                   DW_AT_ranges [DW_FORM_sec_offset]	(0x00000000
-                     [0x00000162, 0x000001a0)
-                     [0x000001ca, 0x000001d3)
-                     [0x000002df, 0x0000031d)
-                     [0x00000347, 0x00000350))
+                     [0x00000166, 0x000001a4)
+                     [0x000001ce, 0x000001d7)
+                     [0x000002e9, 0x00000327)
+                     [0x00000351, 0x0000035a))
 
 0x0000015e:       DW_TAG_variable [12]  
                     DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000163] = "p0")
@@ -2701,19 +2701,19 @@ Abbrev table for offset: 0x00000000
                   DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000024)
 
 0x00000179:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000000c2)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000000c6)
 
 0x0000017e:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000359)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000365)
 
 0x00000187:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000035d)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000369)
 
 0x00000190:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000361)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000036d)
 
 0x00000199:     NULL
 
@@ -2817,8 +2817,8 @@ Abbrev table for offset: 0x00000000
 0x0000023a:     NULL
 
 0x0000023b:   DW_TAG_subprogram [23] *
-                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000366)
-                DW_AT_high_pc [DW_FORM_data4]	(0x000002d3)
+                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000372)
+                DW_AT_high_pc [DW_FORM_data4]	(0x000002db)
                 DW_AT_frame_base [DW_FORM_exprloc]	(DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                 DW_AT_GNU_all_call_sites [DW_FORM_flag_present]	(true)
                 DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000018c] = "main")
@@ -2850,8 +2850,8 @@ Abbrev table for offset: 0x00000000
 
 0x00000278:     DW_TAG_inlined_subroutine [24] *
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01a8 => {0x000001a8} "_ZL8fannkuchi")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000399)
-                  DW_AT_high_pc [DW_FORM_data4]	(0xfffffc67)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003a5)
+                  DW_AT_high_pc [DW_FORM_data4]	(0xfffffc5b)
                   DW_AT_call_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_call_line [DW_FORM_data1]	(159)
                   DW_AT_call_column [DW_FORM_data1]	(0x29)
@@ -2869,18 +2869,18 @@ Abbrev table for offset: 0x00000000
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002a2: 
                        [0xffffffff,  0x0000039f): 
                        [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-                       [0x0000025f,  0x00000277): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0x00000273,  0x0000028b): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ce => {0x000001ce} "args")
 
 0x0000029f:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002cc: 
                        [0xffffffff,  0x0000039f): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000036,  0x0000003b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000042,  0x00000047): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000075,  0x0000007a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x00000093,  0x00000097): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000000be,  0x000000c3): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000081,  0x00000086): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x0000009f,  0x000000a3): DW_OP_consts +0, DW_OP_stack_value
+                       [0x000000ca,  0x000000cf): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
@@ -2904,31 +2904,31 @@ Abbrev table for offset: 0x00000000
 0x000002bf:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000390: 
                        [0xffffffff,  0x0000039f): 
-                       [0x0000016f,  0x00000176): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-                       [0x0000022d,  0x00000234): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0x0000017f,  0x00000186): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+                       [0x00000241,  0x00000248): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0205 => {0x00000205} "r")
 
 0x000002c8:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000003e8: 
                        [0xffffffff,  0x0000039f): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x0000026f,  0x00000277): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                       [0x00000283,  0x0000028b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0210 => {0x00000210} "maxflips")
 
 0x000002d1:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000413: 
                        [0xffffffff,  0x0000039f): 
-                       [0x00000258,  0x00000277): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                       [0x0000026c,  0x0000028b): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x021b => {0x0000021b} "flips")
 
 0x000002da:       DW_TAG_label [28]  
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0226 => {0x00000226} "cleanup")
-                    DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005db)
+                    DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005ef)
 
 0x000002e3:       DW_TAG_lexical_block [14] *
                     DW_AT_ranges [DW_FORM_sec_offset]	(0x00000028
-                       [0x000004a4, 0x000004e9)
-                       [0x0000055c, 0x000005a7))
+                       [0x000004b4, 0x000004f9)
+                       [0x00000570, 0x000005bb))
 
 0x000002e8:         DW_TAG_variable [26]  
                       DW_AT_location [DW_FORM_sec_offset]	(0x000003bc: 
@@ -2942,46 +2942,46 @@ Abbrev table for offset: 0x00000000
 0x000002f2:       NULL
 
 0x000002f3:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000384)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000390)
 
 0x000002f8:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000391)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000039d)
 
 0x000002fd:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003b5)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003c1)
 
 0x00000302:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003e9)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003f5)
 
 0x00000307:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003ef)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003fb)
 
 0x0000030c:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000455)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000461)
 
 0x00000311:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000467)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000473)
 
 0x00000316:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000525)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000535)
 
 0x0000031b:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005df)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005f3)
 
 0x00000324:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005e3)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005f7)
 
 0x0000032d:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000000005f5)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000609)
 
 0x00000332:     DW_TAG_GNU_call_site [16]  
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x019a => {0x0000019a} "free")
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000602)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000616)
 
 0x0000033b:     DW_TAG_GNU_call_site [15]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x000000000000062d)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000641)
 
 0x00000340:     NULL
 
@@ -3008,11 +3008,11 @@ Abbrev table for offset: 0x00000000
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000041,  0x00000046): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000110,  0x0000011a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000114,  0x0000011e): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000243,  0x0000024e): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x0000028d,  0x00000297): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000297,  0x000002a1): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x000000a5: 
@@ -3033,36 +3033,36 @@ Abbrev table for offset: 0x00000000
 
 0x0000011d: 
             [0xffffffff,  0x00000006): 
-            [0x000001bf,  0x000001c4): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-            [0x0000033c,  0x00000341): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0x000001c3,  0x000001c8): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0x00000346,  0x0000034b): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x00000149: 
             [0xffffffff,  0x00000006): 
-            [0x000000b4,  0x000000c7): DW_OP_consts +0, DW_OP_stack_value
+            [0x000000b8,  0x000000cb): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-            [0x00000139,  0x00000141): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000013d,  0x00000145): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000243,  0x0000024e): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-            [0x000002b6,  0x000002be): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x000002c0,  0x000002c8): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x000001ab: 
             [0xffffffff,  0x00000006): 
-            [0x000000c3,  0x000000c7): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-            [0x00000240,  0x00000244): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
+            [0x000000c7,  0x000000cb): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
+            [0x0000024a,  0x0000024e): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
 
 0x000001d7: 
             [0xffffffff,  0x00000006): 
-            [0x000000db,  0x000000df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000117,  0x0000011a): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000258,  0x0000025c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000294,  0x00000297): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x000000df,  0x000000e3): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000011b,  0x0000011e): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000262,  0x00000266): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000029e,  0x000002a1): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x0000021f: 
             [0xffffffff,  0x00000006): 
-            [0x000000f0,  0x0000011a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-            [0x0000012b,  0x00000141): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x0000026d,  0x00000297): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-            [0x000002a8,  0x000002be): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x000000f4,  0x0000011e): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+            [0x0000012f,  0x00000145): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000277,  0x000002a1): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+            [0x000002b2,  0x000002c8): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000267: 
             [0xffffffff,  0x0000039f): 
@@ -3075,16 +3075,16 @@ Abbrev table for offset: 0x00000000
 0x000002a2: 
             [0xffffffff,  0x0000039f): 
             [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-            [0x0000025f,  0x00000277): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x00000273,  0x0000028b): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000002cc: 
             [0xffffffff,  0x0000039f): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000036,  0x0000003b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000042,  0x00000047): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000075,  0x0000007a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000093,  0x00000097): DW_OP_consts +0, DW_OP_stack_value
-            [0x000000be,  0x000000c3): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000081,  0x00000086): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000009f,  0x000000a3): DW_OP_consts +0, DW_OP_stack_value
+            [0x000000ca,  0x000000cf): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
@@ -3099,8 +3099,8 @@ Abbrev table for offset: 0x00000000
 
 0x00000390: 
             [0xffffffff,  0x0000039f): 
-            [0x0000016f,  0x00000176): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-            [0x0000022d,  0x00000234): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x0000017f,  0x00000186): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x00000241,  0x00000248): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000003bc: 
             [0xffffffff,  0x0000039f): 
@@ -3110,16 +3110,16 @@ Abbrev table for offset: 0x00000000
 0x000003e8: 
             [0xffffffff,  0x0000039f): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x0000026f,  0x00000277): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000283,  0x0000028b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x00000413: 
             [0xffffffff,  0x0000039f): 
-            [0x00000258,  0x00000277): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000026c,  0x0000028b): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x00000a62
+    total_length: 0x00000a8a
          version: 4
  prologue_length: 0x000000dd
  min_inst_length: 1
@@ -3348,1290 +3348,1316 @@ file_names[  4]:
             0x0000000000000097     44     16      1   0             0  is_stmt
 
 
-0x0000021a: 00 DW_LNE_set_address (0x00000000000000a4)
-0x00000221: 03 DW_LNS_advance_line (46)
-0x00000223: 05 DW_LNS_set_column (11)
-0x00000225: 01 DW_LNS_copy
-            0x00000000000000a4     46     11      1   0             0  is_stmt
+0x0000021a: 00 DW_LNE_set_address (0x00000000000000a2)
+0x00000221: 05 DW_LNS_set_column (7)
+0x00000223: 06 DW_LNS_negate_stmt
+0x00000224: 01 DW_LNS_copy
+            0x00000000000000a2     44      7      1   0             0 
 
 
-0x00000226: 00 DW_LNE_set_address (0x00000000000000b0)
-0x0000022d: 05 DW_LNS_set_column (28)
-0x0000022f: 06 DW_LNS_negate_stmt
-0x00000230: 01 DW_LNS_copy
-            0x00000000000000b0     46     28      1   0             0 
+0x00000225: 00 DW_LNE_set_address (0x00000000000000a8)
+0x0000022c: 03 DW_LNS_advance_line (46)
+0x0000022e: 05 DW_LNS_set_column (11)
+0x00000230: 06 DW_LNS_negate_stmt
+0x00000231: 01 DW_LNS_copy
+            0x00000000000000a8     46     11      1   0             0  is_stmt
 
 
-0x00000231: 00 DW_LNE_set_address (0x00000000000000b5)
-0x00000238: 05 DW_LNS_set_column (41)
-0x0000023a: 01 DW_LNS_copy
-            0x00000000000000b5     46     41      1   0             0 
+0x00000232: 00 DW_LNE_set_address (0x00000000000000b4)
+0x00000239: 05 DW_LNS_set_column (28)
+0x0000023b: 06 DW_LNS_negate_stmt
+0x0000023c: 01 DW_LNS_copy
+            0x00000000000000b4     46     28      1   0             0 
 
 
-0x0000023b: 00 DW_LNE_set_address (0x00000000000000ba)
-0x00000242: 03 DW_LNS_advance_line (48)
-0x00000244: 05 DW_LNS_set_column (21)
-0x00000246: 06 DW_LNS_negate_stmt
-0x00000247: 01 DW_LNS_copy
-            0x00000000000000ba     48     21      1   0             0  is_stmt
+0x0000023d: 00 DW_LNE_set_address (0x00000000000000b9)
+0x00000244: 05 DW_LNS_set_column (41)
+0x00000246: 01 DW_LNS_copy
+            0x00000000000000b9     46     41      1   0             0 
 
 
-0x00000248: 00 DW_LNE_set_address (0x00000000000000c2)
-0x0000024f: 03 DW_LNS_advance_line (50)
-0x00000251: 05 DW_LNS_set_column (14)
+0x00000247: 00 DW_LNE_set_address (0x00000000000000be)
+0x0000024e: 03 DW_LNS_advance_line (48)
+0x00000250: 05 DW_LNS_set_column (21)
+0x00000252: 06 DW_LNS_negate_stmt
 0x00000253: 01 DW_LNS_copy
-            0x00000000000000c2     50     14      1   0             0  is_stmt
+            0x00000000000000be     48     21      1   0             0  is_stmt
 
 
-0x00000254: 00 DW_LNE_set_address (0x00000000000000d3)
-0x0000025b: 03 DW_LNS_advance_line (52)
-0x0000025d: 05 DW_LNS_set_column (38)
+0x00000254: 00 DW_LNE_set_address (0x00000000000000c6)
+0x0000025b: 03 DW_LNS_advance_line (50)
+0x0000025d: 05 DW_LNS_set_column (14)
 0x0000025f: 01 DW_LNS_copy
-            0x00000000000000d3     52     38      1   0             0  is_stmt
+            0x00000000000000c6     50     14      1   0             0  is_stmt
 
 
-0x00000260: 00 DW_LNE_set_address (0x00000000000000e7)
-0x00000267: 03 DW_LNS_advance_line (53)
-0x00000269: 05 DW_LNS_set_column (22)
+0x00000260: 00 DW_LNE_set_address (0x00000000000000d7)
+0x00000267: 03 DW_LNS_advance_line (52)
+0x00000269: 05 DW_LNS_set_column (38)
 0x0000026b: 01 DW_LNS_copy
-            0x00000000000000e7     53     22      1   0             0  is_stmt
+            0x00000000000000d7     52     38      1   0             0  is_stmt
 
 
-0x0000026c: 00 DW_LNE_set_address (0x00000000000000f6)
-0x00000273: 03 DW_LNS_advance_line (54)
-0x00000275: 05 DW_LNS_set_column (24)
+0x0000026c: 00 DW_LNE_set_address (0x00000000000000eb)
+0x00000273: 03 DW_LNS_advance_line (53)
+0x00000275: 05 DW_LNS_set_column (22)
 0x00000277: 01 DW_LNS_copy
-            0x00000000000000f6     54     24      1   0             0  is_stmt
+            0x00000000000000eb     53     22      1   0             0  is_stmt
 
 
-0x00000278: 00 DW_LNE_set_address (0x00000000000000f8)
-0x0000027f: 05 DW_LNS_set_column (26)
-0x00000281: 06 DW_LNS_negate_stmt
-0x00000282: 01 DW_LNS_copy
-            0x00000000000000f8     54     26      1   0             0 
+0x00000278: 00 DW_LNE_set_address (0x00000000000000fa)
+0x0000027f: 03 DW_LNS_advance_line (54)
+0x00000281: 05 DW_LNS_set_column (24)
+0x00000283: 01 DW_LNS_copy
+            0x00000000000000fa     54     24      1   0             0  is_stmt
 
 
-0x00000283: 00 DW_LNE_set_address (0x0000000000000105)
-0x0000028a: 05 DW_LNS_set_column (24)
-0x0000028c: 01 DW_LNS_copy
-            0x0000000000000105     54     24      1   0             0 
+0x00000284: 00 DW_LNE_set_address (0x00000000000000fc)
+0x0000028b: 05 DW_LNS_set_column (26)
+0x0000028d: 06 DW_LNS_negate_stmt
+0x0000028e: 01 DW_LNS_copy
+            0x00000000000000fc     54     26      1   0             0 
 
 
-0x0000028d: 00 DW_LNE_set_address (0x0000000000000108)
-0x00000294: 03 DW_LNS_advance_line (55)
-0x00000296: 06 DW_LNS_negate_stmt
-0x00000297: 01 DW_LNS_copy
-            0x0000000000000108     55     24      1   0             0  is_stmt
+0x0000028f: 00 DW_LNE_set_address (0x0000000000000109)
+0x00000296: 05 DW_LNS_set_column (24)
+0x00000298: 01 DW_LNS_copy
+            0x0000000000000109     54     24      1   0             0 
 
 
-0x00000298: 00 DW_LNE_set_address (0x000000000000010f)
-0x0000029f: 03 DW_LNS_advance_line (52)
-0x000002a1: 05 DW_LNS_set_column (44)
+0x00000299: 00 DW_LNE_set_address (0x000000000000010c)
+0x000002a0: 03 DW_LNS_advance_line (55)
+0x000002a2: 06 DW_LNS_negate_stmt
 0x000002a3: 01 DW_LNS_copy
-            0x000000000000010f     52     44      1   0             0  is_stmt
+            0x000000000000010c     55     24      1   0             0  is_stmt
 
 
-0x000002a4: 00 DW_LNE_set_address (0x000000000000011b)
-0x000002ab: 05 DW_LNS_set_column (38)
-0x000002ad: 06 DW_LNS_negate_stmt
-0x000002ae: 01 DW_LNS_copy
-            0x000000000000011b     52     38      1   0             0 
+0x000002a4: 00 DW_LNE_set_address (0x0000000000000113)
+0x000002ab: 03 DW_LNS_advance_line (52)
+0x000002ad: 05 DW_LNS_set_column (44)
+0x000002af: 01 DW_LNS_copy
+            0x0000000000000113     52     44      1   0             0  is_stmt
 
 
-0x000002af: 00 DW_LNE_set_address (0x000000000000011e)
-0x000002b6: 05 DW_LNS_set_column (13)
-0x000002b8: 01 DW_LNS_copy
-            0x000000000000011e     52     13      1   0             0 
+0x000002b0: 00 DW_LNE_set_address (0x000000000000011f)
+0x000002b7: 05 DW_LNS_set_column (38)
+0x000002b9: 06 DW_LNS_negate_stmt
+0x000002ba: 01 DW_LNS_copy
+            0x000000000000011f     52     38      1   0             0 
 
 
-0x000002b9: 00 DW_LNE_set_address (0x0000000000000122)
-0x000002c0: 03 DW_LNS_advance_line (58)
-0x000002c2: 05 DW_LNS_set_column (19)
-0x000002c4: 06 DW_LNS_negate_stmt
-0x000002c5: 01 DW_LNS_copy
-            0x0000000000000122     58     19      1   0             0  is_stmt
+0x000002bb: 00 DW_LNE_set_address (0x0000000000000122)
+0x000002c2: 05 DW_LNS_set_column (13)
+0x000002c4: 01 DW_LNS_copy
+            0x0000000000000122     52     13      1   0             0 
 
 
-0x000002c6: 00 DW_LNE_set_address (0x0000000000000131)
-0x000002cd: 03 DW_LNS_advance_line (59)
-0x000002cf: 05 DW_LNS_set_column (21)
+0x000002c5: 00 DW_LNE_set_address (0x0000000000000126)
+0x000002cc: 03 DW_LNS_advance_line (58)
+0x000002ce: 05 DW_LNS_set_column (19)
+0x000002d0: 06 DW_LNS_negate_stmt
 0x000002d1: 01 DW_LNS_copy
-            0x0000000000000131     59     21      1   0             0  is_stmt
+            0x0000000000000126     58     19      1   0             0  is_stmt
 
 
-0x000002d2: 00 DW_LNE_set_address (0x0000000000000138)
-0x000002d9: 03 DW_LNS_advance_line (57)
-0x000002db: 05 DW_LNS_set_column (18)
+0x000002d2: 00 DW_LNE_set_address (0x0000000000000135)
+0x000002d9: 03 DW_LNS_advance_line (59)
+0x000002db: 05 DW_LNS_set_column (21)
 0x000002dd: 01 DW_LNS_copy
-            0x0000000000000138     57     18      1   0             0  is_stmt
+            0x0000000000000135     59     21      1   0             0  is_stmt
 
 
-0x000002de: 00 DW_LNE_set_address (0x0000000000000148)
-0x000002e5: 03 DW_LNS_advance_line (62)
-0x000002e7: 05 DW_LNS_set_column (14)
+0x000002de: 00 DW_LNE_set_address (0x000000000000013c)
+0x000002e5: 03 DW_LNS_advance_line (57)
+0x000002e7: 05 DW_LNS_set_column (18)
 0x000002e9: 01 DW_LNS_copy
-            0x0000000000000148     62     14      1   0             0  is_stmt
+            0x000000000000013c     57     18      1   0             0  is_stmt
 
 
 0x000002ea: 00 DW_LNE_set_address (0x000000000000014c)
-0x000002f1: 05 DW_LNS_set_column (23)
-0x000002f3: 06 DW_LNS_negate_stmt
-0x000002f4: 01 DW_LNS_copy
-            0x000000000000014c     62     23      1   0             0 
+0x000002f1: 03 DW_LNS_advance_line (62)
+0x000002f3: 05 DW_LNS_set_column (14)
+0x000002f5: 01 DW_LNS_copy
+            0x000000000000014c     62     14      1   0             0  is_stmt
 
 
-0x000002f5: 00 DW_LNE_set_address (0x0000000000000151)
-0x000002fc: 05 DW_LNS_set_column (14)
-0x000002fe: 01 DW_LNS_copy
-            0x0000000000000151     62     14      1   0             0 
+0x000002f6: 00 DW_LNE_set_address (0x0000000000000150)
+0x000002fd: 05 DW_LNS_set_column (23)
+0x000002ff: 06 DW_LNS_negate_stmt
+0x00000300: 01 DW_LNS_copy
+            0x0000000000000150     62     23      1   0             0 
 
 
-0x000002ff: 00 DW_LNE_set_address (0x0000000000000155)
-0x00000306: 03 DW_LNS_advance_line (66)
-0x00000308: 05 DW_LNS_set_column (16)
-0x0000030a: 06 DW_LNS_negate_stmt
-0x0000030b: 01 DW_LNS_copy
-            0x0000000000000155     66     16      1   0             0  is_stmt
+0x00000301: 00 DW_LNE_set_address (0x0000000000000155)
+0x00000308: 05 DW_LNS_set_column (14)
+0x0000030a: 01 DW_LNS_copy
+            0x0000000000000155     62     14      1   0             0 
 
 
-0x0000030c: 00 DW_LNE_set_address (0x0000000000000162)
-0x00000313: 03 DW_LNS_advance_line (75)
-0x00000315: 05 DW_LNS_set_column (27)
+0x0000030b: 00 DW_LNE_set_address (0x0000000000000159)
+0x00000312: 03 DW_LNS_advance_line (66)
+0x00000314: 05 DW_LNS_set_column (16)
+0x00000316: 06 DW_LNS_negate_stmt
 0x00000317: 01 DW_LNS_copy
-            0x0000000000000162     75     27      1   0             0  is_stmt
+            0x0000000000000159     66     16      1   0             0  is_stmt
 
 
-0x00000318: 00 DW_LNE_set_address (0x000000000000016b)
-0x0000031f: 03 DW_LNS_advance_line (76)
-0x00000321: 05 DW_LNS_set_column (16)
+0x00000318: 00 DW_LNE_set_address (0x0000000000000166)
+0x0000031f: 03 DW_LNS_advance_line (75)
+0x00000321: 05 DW_LNS_set_column (27)
 0x00000323: 01 DW_LNS_copy
-            0x000000000000016b     76     16      1   0             0  is_stmt
+            0x0000000000000166     75     27      1   0             0  is_stmt
 
 
-0x00000324: 00 DW_LNE_set_address (0x0000000000000173)
-0x0000032b: 05 DW_LNS_set_column (27)
-0x0000032d: 06 DW_LNS_negate_stmt
-0x0000032e: 01 DW_LNS_copy
-            0x0000000000000173     76     27      1   0             0 
+0x00000324: 00 DW_LNE_set_address (0x000000000000016f)
+0x0000032b: 03 DW_LNS_advance_line (76)
+0x0000032d: 05 DW_LNS_set_column (16)
+0x0000032f: 01 DW_LNS_copy
+            0x000000000000016f     76     16      1   0             0  is_stmt
 
 
-0x0000032f: 00 DW_LNE_set_address (0x0000000000000175)
-0x00000336: 05 DW_LNS_set_column (35)
-0x00000338: 01 DW_LNS_copy
-            0x0000000000000175     76     35      1   0             0 
+0x00000330: 00 DW_LNE_set_address (0x0000000000000177)
+0x00000337: 05 DW_LNS_set_column (27)
+0x00000339: 06 DW_LNS_negate_stmt
+0x0000033a: 01 DW_LNS_copy
+            0x0000000000000177     76     27      1   0             0 
 
 
-0x00000339: 00 DW_LNE_set_address (0x000000000000017e)
-0x00000340: 05 DW_LNS_set_column (27)
-0x00000342: 01 DW_LNS_copy
-            0x000000000000017e     76     27      1   0             0 
+0x0000033b: 00 DW_LNE_set_address (0x0000000000000179)
+0x00000342: 05 DW_LNS_set_column (35)
+0x00000344: 01 DW_LNS_copy
+            0x0000000000000179     76     35      1   0             0 
 
 
-0x00000343: 00 DW_LNE_set_address (0x0000000000000183)
-0x0000034a: 05 DW_LNS_set_column (25)
-0x0000034c: 01 DW_LNS_copy
-            0x0000000000000183     76     25      1   0             0 
+0x00000345: 00 DW_LNE_set_address (0x0000000000000182)
+0x0000034c: 05 DW_LNS_set_column (27)
+0x0000034e: 01 DW_LNS_copy
+            0x0000000000000182     76     27      1   0             0 
 
 
-0x0000034d: 00 DW_LNE_set_address (0x0000000000000186)
-0x00000354: 03 DW_LNS_advance_line (75)
-0x00000356: 05 DW_LNS_set_column (27)
-0x00000358: 06 DW_LNS_negate_stmt
-0x00000359: 01 DW_LNS_copy
-            0x0000000000000186     75     27      1   0             0  is_stmt
+0x0000034f: 00 DW_LNE_set_address (0x0000000000000187)
+0x00000356: 05 DW_LNS_set_column (25)
+0x00000358: 01 DW_LNS_copy
+            0x0000000000000187     76     25      1   0             0 
 
 
-0x0000035a: 00 DW_LNE_set_address (0x000000000000018b)
-0x00000361: 05 DW_LNS_set_column (13)
-0x00000363: 06 DW_LNS_negate_stmt
-0x00000364: 01 DW_LNS_copy
-            0x000000000000018b     75     13      1   0             0 
+0x00000359: 00 DW_LNE_set_address (0x000000000000018a)
+0x00000360: 03 DW_LNS_advance_line (75)
+0x00000362: 05 DW_LNS_set_column (27)
+0x00000364: 06 DW_LNS_negate_stmt
+0x00000365: 01 DW_LNS_copy
+            0x000000000000018a     75     27      1   0             0  is_stmt
 
 
-0x00000365: 00 DW_LNE_set_address (0x0000000000000193)
-0x0000036c: 03 DW_LNS_advance_line (77)
-0x0000036e: 06 DW_LNS_negate_stmt
-0x0000036f: 01 DW_LNS_copy
-            0x0000000000000193     77     13      1   0             0  is_stmt
+0x00000366: 00 DW_LNE_set_address (0x000000000000018f)
+0x0000036d: 05 DW_LNS_set_column (13)
+0x0000036f: 06 DW_LNS_negate_stmt
+0x00000370: 01 DW_LNS_copy
+            0x000000000000018f     75     13      1   0             0 
 
 
-0x00000370: 00 DW_LNE_set_address (0x000000000000019b)
-0x00000377: 05 DW_LNS_set_column (22)
-0x00000379: 06 DW_LNS_negate_stmt
-0x0000037a: 01 DW_LNS_copy
-            0x000000000000019b     77     22      1   0             0 
+0x00000371: 00 DW_LNE_set_address (0x0000000000000197)
+0x00000378: 03 DW_LNS_advance_line (77)
+0x0000037a: 06 DW_LNS_negate_stmt
+0x0000037b: 01 DW_LNS_copy
+            0x0000000000000197     77     13      1   0             0  is_stmt
 
 
-0x0000037b: 00 DW_LNE_set_address (0x00000000000001a0)
-0x00000382: 03 DW_LNS_advance_line (79)
-0x00000384: 05 DW_LNS_set_column (16)
-0x00000386: 06 DW_LNS_negate_stmt
-0x00000387: 01 DW_LNS_copy
-            0x00000000000001a0     79     16      1   0             0  is_stmt
+0x0000037c: 00 DW_LNE_set_address (0x000000000000019f)
+0x00000383: 05 DW_LNS_set_column (22)
+0x00000385: 06 DW_LNS_negate_stmt
+0x00000386: 01 DW_LNS_copy
+            0x000000000000019f     77     22      1   0             0 
 
 
-0x00000388: 00 DW_LNE_set_address (0x00000000000001a8)
-0x0000038f: 05 DW_LNS_set_column (14)
-0x00000391: 06 DW_LNS_negate_stmt
-0x00000392: 01 DW_LNS_copy
-            0x00000000000001a8     79     14      1   0             0 
+0x00000387: 00 DW_LNE_set_address (0x00000000000001a4)
+0x0000038e: 03 DW_LNS_advance_line (79)
+0x00000390: 05 DW_LNS_set_column (16)
+0x00000392: 06 DW_LNS_negate_stmt
+0x00000393: 01 DW_LNS_copy
+            0x00000000000001a4     79     16      1   0             0  is_stmt
 
 
-0x00000393: 00 DW_LNE_set_address (0x00000000000001b7)
-0x0000039a: 05 DW_LNS_set_column (25)
-0x0000039c: 01 DW_LNS_copy
-            0x00000000000001b7     79     25      1   0             0 
+0x00000394: 00 DW_LNE_set_address (0x00000000000001ac)
+0x0000039b: 05 DW_LNS_set_column (14)
+0x0000039d: 06 DW_LNS_negate_stmt
+0x0000039e: 01 DW_LNS_copy
+            0x00000000000001ac     79     14      1   0             0 
 
 
-0x0000039d: 00 DW_LNE_set_address (0x00000000000001be)
-0x000003a4: 03 DW_LNS_advance_line (81)
-0x000003a6: 05 DW_LNS_set_column (11)
-0x000003a8: 06 DW_LNS_negate_stmt
-0x000003a9: 01 DW_LNS_copy
-            0x00000000000001be     81     11      1   0             0  is_stmt
+0x0000039f: 00 DW_LNE_set_address (0x00000000000001bb)
+0x000003a6: 05 DW_LNS_set_column (25)
+0x000003a8: 01 DW_LNS_copy
+            0x00000000000001bb     79     25      1   0             0 
 
 
-0x000003aa: 00 DW_LNE_set_address (0x00000000000001c3)
-0x000003b1: 03 DW_LNS_advance_line (66)
-0x000003b3: 05 DW_LNS_set_column (16)
+0x000003a9: 00 DW_LNE_set_address (0x00000000000001c2)
+0x000003b0: 03 DW_LNS_advance_line (81)
+0x000003b2: 05 DW_LNS_set_column (11)
+0x000003b4: 06 DW_LNS_negate_stmt
 0x000003b5: 01 DW_LNS_copy
-            0x00000000000001c3     66     16      1   0             0  is_stmt
+            0x00000000000001c2     81     11      1   0             0  is_stmt
 
 
-0x000003b6: 00 DW_LNE_set_address (0x00000000000001ca)
-0x000003bd: 03 DW_LNS_advance_line (74)
-0x000003bf: 05 DW_LNS_set_column (22)
+0x000003b6: 00 DW_LNE_set_address (0x00000000000001c7)
+0x000003bd: 03 DW_LNS_advance_line (66)
+0x000003bf: 05 DW_LNS_set_column (16)
 0x000003c1: 01 DW_LNS_copy
-            0x00000000000001ca     74     22      1   0             0  is_stmt
+            0x00000000000001c7     66     16      1   0             0  is_stmt
 
 
-0x000003c2: 00 DW_LNE_set_address (0x00000000000001d3)
-0x000003c9: 03 DW_LNS_advance_line (37)
-0x000003cb: 05 DW_LNS_set_column (4)
+0x000003c2: 00 DW_LNE_set_address (0x00000000000001ce)
+0x000003c9: 03 DW_LNS_advance_line (74)
+0x000003cb: 05 DW_LNS_set_column (22)
 0x000003cd: 01 DW_LNS_copy
-            0x00000000000001d3     37      4      1   0             0  is_stmt
+            0x00000000000001ce     74     22      1   0             0  is_stmt
 
 
 0x000003ce: 00 DW_LNE_set_address (0x00000000000001d8)
-0x000003d5: 03 DW_LNS_advance_line (39)
-0x000003d7: 01 DW_LNS_copy
-            0x00000000000001d8     39      4      1   0             0  is_stmt
+0x000003d5: 03 DW_LNS_advance_line (37)
+0x000003d7: 05 DW_LNS_set_column (4)
+0x000003d9: 01 DW_LNS_copy
+            0x00000000000001d8     37      4      1   0             0  is_stmt
 
 
-0x000003d8: 00 DW_LNE_set_address (0x00000000000001da)
-0x000003df: 05 DW_LNS_set_column (16)
-0x000003e1: 06 DW_LNS_negate_stmt
-0x000003e2: 01 DW_LNS_copy
-            0x00000000000001da     39     16      1   0             0 
+0x000003da: 00 DW_LNE_set_address (0x00000000000001de)
+0x000003e1: 03 DW_LNS_advance_line (39)
+0x000003e3: 01 DW_LNS_copy
+            0x00000000000001de     39      4      1   0             0  is_stmt
 
 
-0x000003e3: 00 DW_LNE_set_address (0x00000000000001e3)
-0x000003ea: 05 DW_LNS_set_column (4)
-0x000003ec: 01 DW_LNS_copy
-            0x00000000000001e3     39      4      1   0             0 
+0x000003e4: 00 DW_LNE_set_address (0x00000000000001e0)
+0x000003eb: 05 DW_LNS_set_column (16)
+0x000003ed: 06 DW_LNS_negate_stmt
+0x000003ee: 01 DW_LNS_copy
+            0x00000000000001e0     39     16      1   0             0 
 
 
-0x000003ed: 00 DW_LNE_set_address (0x00000000000001e5)
-0x000003f4: 05 DW_LNS_set_column (23)
-0x000003f6: 01 DW_LNS_copy
-            0x00000000000001e5     39     23      1   0             0 
+0x000003ef: 00 DW_LNE_set_address (0x00000000000001e9)
+0x000003f6: 05 DW_LNS_set_column (4)
+0x000003f8: 01 DW_LNS_copy
+            0x00000000000001e9     39      4      1   0             0 
 
 
-0x000003f7: 00 DW_LNE_set_address (0x00000000000001ea)
-0x000003fe: 05 DW_LNS_set_column (19)
-0x00000400: 01 DW_LNS_copy
-            0x00000000000001ea     39     19      1   0             0 
+0x000003f9: 00 DW_LNE_set_address (0x00000000000001eb)
+0x00000400: 05 DW_LNS_set_column (23)
+0x00000402: 01 DW_LNS_copy
+            0x00000000000001eb     39     23      1   0             0 
 
 
-0x00000401: 00 DW_LNE_set_address (0x00000000000001ef)
-0x00000408: 03 DW_LNS_advance_line (40)
-0x0000040a: 05 DW_LNS_set_column (4)
-0x0000040c: 06 DW_LNS_negate_stmt
-0x0000040d: 01 DW_LNS_copy
-            0x00000000000001ef     40      4      1   0             0  is_stmt
+0x00000403: 00 DW_LNE_set_address (0x00000000000001f0)
+0x0000040a: 05 DW_LNS_set_column (19)
+0x0000040c: 01 DW_LNS_copy
+            0x00000000000001f0     39     19      1   0             0 
 
 
-0x0000040e: 00 DW_LNE_set_address (0x00000000000001f7)
-0x00000415: 05 DW_LNS_set_column (17)
-0x00000417: 06 DW_LNS_negate_stmt
-0x00000418: 01 DW_LNS_copy
-            0x00000000000001f7     40     17      1   0             0 
+0x0000040d: 00 DW_LNE_set_address (0x00000000000001f5)
+0x00000414: 03 DW_LNS_advance_line (40)
+0x00000416: 05 DW_LNS_set_column (4)
+0x00000418: 06 DW_LNS_negate_stmt
+0x00000419: 01 DW_LNS_copy
+            0x00000000000001f5     40      4      1   0             0  is_stmt
 
 
-0x00000419: 00 DW_LNE_set_address (0x0000000000000201)
-0x00000420: 03 DW_LNS_advance_line (44)
-0x00000422: 05 DW_LNS_set_column (16)
-0x00000424: 06 DW_LNS_negate_stmt
-0x00000425: 01 DW_LNS_copy
-            0x0000000000000201     44     16      1   0             0  is_stmt
+0x0000041a: 00 DW_LNE_set_address (0x00000000000001fd)
+0x00000421: 05 DW_LNS_set_column (17)
+0x00000423: 06 DW_LNS_negate_stmt
+0x00000424: 01 DW_LNS_copy
+            0x00000000000001fd     40     17      1   0             0 
 
 
-0x00000426: 00 DW_LNE_set_address (0x000000000000020a)
-0x0000042d: 03 DW_LNS_advance_line (45)
-0x0000042f: 05 DW_LNS_set_column (10)
+0x00000425: 00 DW_LNE_set_address (0x0000000000000207)
+0x0000042c: 03 DW_LNS_advance_line (44)
+0x0000042e: 05 DW_LNS_set_column (16)
+0x00000430: 06 DW_LNS_negate_stmt
 0x00000431: 01 DW_LNS_copy
-            0x000000000000020a     45     10      1   0             0  is_stmt
+            0x0000000000000207     44     16      1   0             0  is_stmt
 
 
-0x00000432: 00 DW_LNE_set_address (0x000000000000020c)
-0x00000439: 05 DW_LNS_set_column (18)
-0x0000043b: 06 DW_LNS_negate_stmt
-0x0000043c: 01 DW_LNS_copy
-            0x000000000000020c     45     18      1   0             0 
+0x00000432: 00 DW_LNE_set_address (0x0000000000000210)
+0x00000439: 03 DW_LNS_advance_line (45)
+0x0000043b: 05 DW_LNS_set_column (10)
+0x0000043d: 01 DW_LNS_copy
+            0x0000000000000210     45     10      1   0             0  is_stmt
 
 
-0x0000043d: 00 DW_LNE_set_address (0x0000000000000215)
-0x00000444: 05 DW_LNS_set_column (10)
-0x00000446: 01 DW_LNS_copy
-            0x0000000000000215     45     10      1   0             0 
+0x0000043e: 00 DW_LNE_set_address (0x0000000000000212)
+0x00000445: 05 DW_LNS_set_column (18)
+0x00000447: 06 DW_LNS_negate_stmt
+0x00000448: 01 DW_LNS_copy
+            0x0000000000000212     45     18      1   0             0 
 
 
-0x00000447: 00 DW_LNE_set_address (0x0000000000000217)
-0x0000044e: 05 DW_LNS_set_column (23)
-0x00000450: 01 DW_LNS_copy
-            0x0000000000000217     45     23      1   0             0 
+0x00000449: 00 DW_LNE_set_address (0x000000000000021b)
+0x00000450: 05 DW_LNS_set_column (10)
+0x00000452: 01 DW_LNS_copy
+            0x000000000000021b     45     10      1   0             0 
 
 
-0x00000451: 00 DW_LNE_set_address (0x000000000000021c)
-0x00000458: 03 DW_LNS_advance_line (44)
-0x0000045a: 05 DW_LNS_set_column (16)
-0x0000045c: 06 DW_LNS_negate_stmt
-0x0000045d: 01 DW_LNS_copy
-            0x000000000000021c     44     16      1   0             0  is_stmt
+0x00000453: 00 DW_LNE_set_address (0x000000000000021d)
+0x0000045a: 05 DW_LNS_set_column (23)
+0x0000045c: 01 DW_LNS_copy
+            0x000000000000021d     45     23      1   0             0 
 
 
-0x0000045e: 00 DW_LNE_set_address (0x0000000000000229)
-0x00000465: 03 DW_LNS_advance_line (46)
-0x00000467: 05 DW_LNS_set_column (11)
+0x0000045d: 00 DW_LNE_set_address (0x0000000000000222)
+0x00000464: 03 DW_LNS_advance_line (44)
+0x00000466: 05 DW_LNS_set_column (16)
+0x00000468: 06 DW_LNS_negate_stmt
 0x00000469: 01 DW_LNS_copy
-            0x0000000000000229     46     11      1   0             0  is_stmt
+            0x0000000000000222     44     16      1   0             0  is_stmt
 
 
-0x0000046a: 00 DW_LNE_set_address (0x0000000000000235)
-0x00000471: 05 DW_LNS_set_column (28)
-0x00000473: 06 DW_LNS_negate_stmt
-0x00000474: 01 DW_LNS_copy
-            0x0000000000000235     46     28      1   0             0 
+0x0000046a: 00 DW_LNE_set_address (0x0000000000000233)
+0x00000471: 03 DW_LNS_advance_line (46)
+0x00000473: 05 DW_LNS_set_column (11)
+0x00000475: 01 DW_LNS_copy
+            0x0000000000000233     46     11      1   0             0  is_stmt
 
 
-0x00000475: 00 DW_LNE_set_address (0x000000000000023a)
-0x0000047c: 05 DW_LNS_set_column (41)
-0x0000047e: 01 DW_LNS_copy
-            0x000000000000023a     46     41      1   0             0 
+0x00000476: 00 DW_LNE_set_address (0x000000000000023f)
+0x0000047d: 05 DW_LNS_set_column (28)
+0x0000047f: 06 DW_LNS_negate_stmt
+0x00000480: 01 DW_LNS_copy
+            0x000000000000023f     46     28      1   0             0 
 
 
-0x0000047f: 00 DW_LNE_set_address (0x000000000000023f)
-0x00000486: 03 DW_LNS_advance_line (50)
-0x00000488: 05 DW_LNS_set_column (14)
-0x0000048a: 06 DW_LNS_negate_stmt
-0x0000048b: 01 DW_LNS_copy
-            0x000000000000023f     50     14      1   0             0  is_stmt
+0x00000481: 00 DW_LNE_set_address (0x0000000000000244)
+0x00000488: 05 DW_LNS_set_column (41)
+0x0000048a: 01 DW_LNS_copy
+            0x0000000000000244     46     41      1   0             0 
 
 
-0x0000048c: 00 DW_LNE_set_address (0x0000000000000250)
-0x00000493: 03 DW_LNS_advance_line (52)
-0x00000495: 05 DW_LNS_set_column (38)
+0x0000048b: 00 DW_LNE_set_address (0x0000000000000249)
+0x00000492: 03 DW_LNS_advance_line (50)
+0x00000494: 05 DW_LNS_set_column (14)
+0x00000496: 06 DW_LNS_negate_stmt
 0x00000497: 01 DW_LNS_copy
-            0x0000000000000250     52     38      1   0             0  is_stmt
+            0x0000000000000249     50     14      1   0             0  is_stmt
 
 
-0x00000498: 00 DW_LNE_set_address (0x0000000000000264)
-0x0000049f: 03 DW_LNS_advance_line (53)
-0x000004a1: 05 DW_LNS_set_column (22)
+0x00000498: 00 DW_LNE_set_address (0x000000000000025a)
+0x0000049f: 03 DW_LNS_advance_line (52)
+0x000004a1: 05 DW_LNS_set_column (38)
 0x000004a3: 01 DW_LNS_copy
-            0x0000000000000264     53     22      1   0             0  is_stmt
+            0x000000000000025a     52     38      1   0             0  is_stmt
 
 
-0x000004a4: 00 DW_LNE_set_address (0x0000000000000273)
-0x000004ab: 03 DW_LNS_advance_line (54)
-0x000004ad: 05 DW_LNS_set_column (24)
+0x000004a4: 00 DW_LNE_set_address (0x000000000000026e)
+0x000004ab: 03 DW_LNS_advance_line (53)
+0x000004ad: 05 DW_LNS_set_column (22)
 0x000004af: 01 DW_LNS_copy
-            0x0000000000000273     54     24      1   0             0  is_stmt
+            0x000000000000026e     53     22      1   0             0  is_stmt
 
 
-0x000004b0: 00 DW_LNE_set_address (0x0000000000000275)
-0x000004b7: 05 DW_LNS_set_column (26)
-0x000004b9: 06 DW_LNS_negate_stmt
-0x000004ba: 01 DW_LNS_copy
-            0x0000000000000275     54     26      1   0             0 
+0x000004b0: 00 DW_LNE_set_address (0x000000000000027d)
+0x000004b7: 03 DW_LNS_advance_line (54)
+0x000004b9: 05 DW_LNS_set_column (24)
+0x000004bb: 01 DW_LNS_copy
+            0x000000000000027d     54     24      1   0             0  is_stmt
 
 
-0x000004bb: 00 DW_LNE_set_address (0x0000000000000282)
-0x000004c2: 05 DW_LNS_set_column (24)
-0x000004c4: 01 DW_LNS_copy
-            0x0000000000000282     54     24      1   0             0 
+0x000004bc: 00 DW_LNE_set_address (0x000000000000027f)
+0x000004c3: 05 DW_LNS_set_column (26)
+0x000004c5: 06 DW_LNS_negate_stmt
+0x000004c6: 01 DW_LNS_copy
+            0x000000000000027f     54     26      1   0             0 
 
 
-0x000004c5: 00 DW_LNE_set_address (0x0000000000000285)
-0x000004cc: 03 DW_LNS_advance_line (55)
-0x000004ce: 06 DW_LNS_negate_stmt
-0x000004cf: 01 DW_LNS_copy
-            0x0000000000000285     55     24      1   0             0  is_stmt
+0x000004c7: 00 DW_LNE_set_address (0x000000000000028c)
+0x000004ce: 05 DW_LNS_set_column (24)
+0x000004d0: 01 DW_LNS_copy
+            0x000000000000028c     54     24      1   0             0 
 
 
-0x000004d0: 00 DW_LNE_set_address (0x000000000000028c)
-0x000004d7: 03 DW_LNS_advance_line (52)
-0x000004d9: 05 DW_LNS_set_column (44)
+0x000004d1: 00 DW_LNE_set_address (0x000000000000028f)
+0x000004d8: 03 DW_LNS_advance_line (55)
+0x000004da: 06 DW_LNS_negate_stmt
 0x000004db: 01 DW_LNS_copy
-            0x000000000000028c     52     44      1   0             0  is_stmt
+            0x000000000000028f     55     24      1   0             0  is_stmt
 
 
-0x000004dc: 00 DW_LNE_set_address (0x0000000000000298)
-0x000004e3: 05 DW_LNS_set_column (38)
-0x000004e5: 06 DW_LNS_negate_stmt
-0x000004e6: 01 DW_LNS_copy
-            0x0000000000000298     52     38      1   0             0 
+0x000004dc: 00 DW_LNE_set_address (0x0000000000000296)
+0x000004e3: 03 DW_LNS_advance_line (52)
+0x000004e5: 05 DW_LNS_set_column (44)
+0x000004e7: 01 DW_LNS_copy
+            0x0000000000000296     52     44      1   0             0  is_stmt
 
 
-0x000004e7: 00 DW_LNE_set_address (0x000000000000029f)
-0x000004ee: 03 DW_LNS_advance_line (58)
-0x000004f0: 05 DW_LNS_set_column (19)
-0x000004f2: 06 DW_LNS_negate_stmt
-0x000004f3: 01 DW_LNS_copy
-            0x000000000000029f     58     19      1   0             0  is_stmt
+0x000004e8: 00 DW_LNE_set_address (0x00000000000002a2)
+0x000004ef: 05 DW_LNS_set_column (38)
+0x000004f1: 06 DW_LNS_negate_stmt
+0x000004f2: 01 DW_LNS_copy
+            0x00000000000002a2     52     38      1   0             0 
 
 
-0x000004f4: 00 DW_LNE_set_address (0x00000000000002ae)
-0x000004fb: 03 DW_LNS_advance_line (59)
-0x000004fd: 05 DW_LNS_set_column (21)
+0x000004f3: 00 DW_LNE_set_address (0x00000000000002a9)
+0x000004fa: 03 DW_LNS_advance_line (58)
+0x000004fc: 05 DW_LNS_set_column (19)
+0x000004fe: 06 DW_LNS_negate_stmt
 0x000004ff: 01 DW_LNS_copy
-            0x00000000000002ae     59     21      1   0             0  is_stmt
+            0x00000000000002a9     58     19      1   0             0  is_stmt
 
 
-0x00000500: 00 DW_LNE_set_address (0x00000000000002b5)
-0x00000507: 03 DW_LNS_advance_line (57)
-0x00000509: 05 DW_LNS_set_column (18)
+0x00000500: 00 DW_LNE_set_address (0x00000000000002b8)
+0x00000507: 03 DW_LNS_advance_line (59)
+0x00000509: 05 DW_LNS_set_column (21)
 0x0000050b: 01 DW_LNS_copy
-            0x00000000000002b5     57     18      1   0             0  is_stmt
+            0x00000000000002b8     59     21      1   0             0  is_stmt
 
 
-0x0000050c: 00 DW_LNE_set_address (0x00000000000002c5)
-0x00000513: 03 DW_LNS_advance_line (62)
-0x00000515: 05 DW_LNS_set_column (14)
+0x0000050c: 00 DW_LNE_set_address (0x00000000000002bf)
+0x00000513: 03 DW_LNS_advance_line (57)
+0x00000515: 05 DW_LNS_set_column (18)
 0x00000517: 01 DW_LNS_copy
-            0x00000000000002c5     62     14      1   0             0  is_stmt
+            0x00000000000002bf     57     18      1   0             0  is_stmt
 
 
-0x00000518: 00 DW_LNE_set_address (0x00000000000002c9)
-0x0000051f: 05 DW_LNS_set_column (23)
-0x00000521: 06 DW_LNS_negate_stmt
-0x00000522: 01 DW_LNS_copy
-            0x00000000000002c9     62     23      1   0             0 
+0x00000518: 00 DW_LNE_set_address (0x00000000000002cf)
+0x0000051f: 03 DW_LNS_advance_line (62)
+0x00000521: 05 DW_LNS_set_column (14)
+0x00000523: 01 DW_LNS_copy
+            0x00000000000002cf     62     14      1   0             0  is_stmt
 
 
-0x00000523: 00 DW_LNE_set_address (0x00000000000002ce)
-0x0000052a: 05 DW_LNS_set_column (14)
-0x0000052c: 01 DW_LNS_copy
-            0x00000000000002ce     62     14      1   0             0 
+0x00000524: 00 DW_LNE_set_address (0x00000000000002d3)
+0x0000052b: 05 DW_LNS_set_column (23)
+0x0000052d: 06 DW_LNS_negate_stmt
+0x0000052e: 01 DW_LNS_copy
+            0x00000000000002d3     62     23      1   0             0 
 
 
-0x0000052d: 00 DW_LNE_set_address (0x00000000000002d2)
-0x00000534: 03 DW_LNS_advance_line (66)
-0x00000536: 05 DW_LNS_set_column (16)
-0x00000538: 06 DW_LNS_negate_stmt
-0x00000539: 01 DW_LNS_copy
-            0x00000000000002d2     66     16      1   0             0  is_stmt
+0x0000052f: 00 DW_LNE_set_address (0x00000000000002d8)
+0x00000536: 05 DW_LNS_set_column (14)
+0x00000538: 01 DW_LNS_copy
+            0x00000000000002d8     62     14      1   0             0 
 
 
-0x0000053a: 00 DW_LNE_set_address (0x00000000000002df)
-0x00000541: 03 DW_LNS_advance_line (75)
-0x00000543: 05 DW_LNS_set_column (27)
+0x00000539: 00 DW_LNE_set_address (0x00000000000002dc)
+0x00000540: 03 DW_LNS_advance_line (66)
+0x00000542: 05 DW_LNS_set_column (16)
+0x00000544: 06 DW_LNS_negate_stmt
 0x00000545: 01 DW_LNS_copy
-            0x00000000000002df     75     27      1   0             0  is_stmt
+            0x00000000000002dc     66     16      1   0             0  is_stmt
 
 
-0x00000546: 00 DW_LNE_set_address (0x00000000000002e8)
-0x0000054d: 03 DW_LNS_advance_line (76)
-0x0000054f: 05 DW_LNS_set_column (16)
+0x00000546: 00 DW_LNE_set_address (0x00000000000002e9)
+0x0000054d: 03 DW_LNS_advance_line (75)
+0x0000054f: 05 DW_LNS_set_column (27)
 0x00000551: 01 DW_LNS_copy
-            0x00000000000002e8     76     16      1   0             0  is_stmt
+            0x00000000000002e9     75     27      1   0             0  is_stmt
 
 
-0x00000552: 00 DW_LNE_set_address (0x00000000000002f0)
-0x00000559: 05 DW_LNS_set_column (27)
-0x0000055b: 06 DW_LNS_negate_stmt
-0x0000055c: 01 DW_LNS_copy
-            0x00000000000002f0     76     27      1   0             0 
+0x00000552: 00 DW_LNE_set_address (0x00000000000002f2)
+0x00000559: 03 DW_LNS_advance_line (76)
+0x0000055b: 05 DW_LNS_set_column (16)
+0x0000055d: 01 DW_LNS_copy
+            0x00000000000002f2     76     16      1   0             0  is_stmt
 
 
-0x0000055d: 00 DW_LNE_set_address (0x00000000000002f2)
-0x00000564: 05 DW_LNS_set_column (35)
-0x00000566: 01 DW_LNS_copy
-            0x00000000000002f2     76     35      1   0             0 
+0x0000055e: 00 DW_LNE_set_address (0x00000000000002fa)
+0x00000565: 05 DW_LNS_set_column (27)
+0x00000567: 06 DW_LNS_negate_stmt
+0x00000568: 01 DW_LNS_copy
+            0x00000000000002fa     76     27      1   0             0 
 
 
-0x00000567: 00 DW_LNE_set_address (0x00000000000002fb)
-0x0000056e: 05 DW_LNS_set_column (27)
-0x00000570: 01 DW_LNS_copy
-            0x00000000000002fb     76     27      1   0             0 
+0x00000569: 00 DW_LNE_set_address (0x00000000000002fc)
+0x00000570: 05 DW_LNS_set_column (35)
+0x00000572: 01 DW_LNS_copy
+            0x00000000000002fc     76     35      1   0             0 
 
 
-0x00000571: 00 DW_LNE_set_address (0x0000000000000300)
-0x00000578: 05 DW_LNS_set_column (25)
-0x0000057a: 01 DW_LNS_copy
-            0x0000000000000300     76     25      1   0             0 
+0x00000573: 00 DW_LNE_set_address (0x0000000000000305)
+0x0000057a: 05 DW_LNS_set_column (27)
+0x0000057c: 01 DW_LNS_copy
+            0x0000000000000305     76     27      1   0             0 
 
 
-0x0000057b: 00 DW_LNE_set_address (0x0000000000000303)
-0x00000582: 03 DW_LNS_advance_line (75)
-0x00000584: 05 DW_LNS_set_column (27)
-0x00000586: 06 DW_LNS_negate_stmt
-0x00000587: 01 DW_LNS_copy
-            0x0000000000000303     75     27      1   0             0  is_stmt
+0x0000057d: 00 DW_LNE_set_address (0x000000000000030a)
+0x00000584: 05 DW_LNS_set_column (25)
+0x00000586: 01 DW_LNS_copy
+            0x000000000000030a     76     25      1   0             0 
 
 
-0x00000588: 00 DW_LNE_set_address (0x0000000000000310)
-0x0000058f: 03 DW_LNS_advance_line (77)
-0x00000591: 05 DW_LNS_set_column (13)
+0x00000587: 00 DW_LNE_set_address (0x000000000000030d)
+0x0000058e: 03 DW_LNS_advance_line (75)
+0x00000590: 05 DW_LNS_set_column (27)
+0x00000592: 06 DW_LNS_negate_stmt
 0x00000593: 01 DW_LNS_copy
-            0x0000000000000310     77     13      1   0             0  is_stmt
+            0x000000000000030d     75     27      1   0             0  is_stmt
 
 
-0x00000594: 00 DW_LNE_set_address (0x0000000000000318)
-0x0000059b: 05 DW_LNS_set_column (22)
-0x0000059d: 06 DW_LNS_negate_stmt
-0x0000059e: 01 DW_LNS_copy
-            0x0000000000000318     77     22      1   0             0 
+0x00000594: 00 DW_LNE_set_address (0x000000000000031a)
+0x0000059b: 03 DW_LNS_advance_line (77)
+0x0000059d: 05 DW_LNS_set_column (13)
+0x0000059f: 01 DW_LNS_copy
+            0x000000000000031a     77     13      1   0             0  is_stmt
 
 
-0x0000059f: 00 DW_LNE_set_address (0x000000000000031d)
-0x000005a6: 03 DW_LNS_advance_line (79)
-0x000005a8: 05 DW_LNS_set_column (16)
-0x000005aa: 06 DW_LNS_negate_stmt
-0x000005ab: 01 DW_LNS_copy
-            0x000000000000031d     79     16      1   0             0  is_stmt
+0x000005a0: 00 DW_LNE_set_address (0x0000000000000322)
+0x000005a7: 05 DW_LNS_set_column (22)
+0x000005a9: 06 DW_LNS_negate_stmt
+0x000005aa: 01 DW_LNS_copy
+            0x0000000000000322     77     22      1   0             0 
 
 
-0x000005ac: 00 DW_LNE_set_address (0x0000000000000325)
-0x000005b3: 05 DW_LNS_set_column (14)
-0x000005b5: 06 DW_LNS_negate_stmt
-0x000005b6: 01 DW_LNS_copy
-            0x0000000000000325     79     14      1   0             0 
+0x000005ab: 00 DW_LNE_set_address (0x0000000000000327)
+0x000005b2: 03 DW_LNS_advance_line (79)
+0x000005b4: 05 DW_LNS_set_column (16)
+0x000005b6: 06 DW_LNS_negate_stmt
+0x000005b7: 01 DW_LNS_copy
+            0x0000000000000327     79     16      1   0             0  is_stmt
 
 
-0x000005b7: 00 DW_LNE_set_address (0x0000000000000334)
-0x000005be: 05 DW_LNS_set_column (25)
-0x000005c0: 01 DW_LNS_copy
-            0x0000000000000334     79     25      1   0             0 
+0x000005b8: 00 DW_LNE_set_address (0x000000000000032f)
+0x000005bf: 05 DW_LNS_set_column (14)
+0x000005c1: 06 DW_LNS_negate_stmt
+0x000005c2: 01 DW_LNS_copy
+            0x000000000000032f     79     14      1   0             0 
 
 
-0x000005c1: 00 DW_LNE_set_address (0x000000000000033b)
-0x000005c8: 03 DW_LNS_advance_line (81)
-0x000005ca: 05 DW_LNS_set_column (11)
-0x000005cc: 06 DW_LNS_negate_stmt
-0x000005cd: 01 DW_LNS_copy
-            0x000000000000033b     81     11      1   0             0  is_stmt
+0x000005c3: 00 DW_LNE_set_address (0x000000000000033e)
+0x000005ca: 05 DW_LNS_set_column (25)
+0x000005cc: 01 DW_LNS_copy
+            0x000000000000033e     79     25      1   0             0 
 
 
-0x000005ce: 00 DW_LNE_set_address (0x0000000000000340)
-0x000005d5: 03 DW_LNS_advance_line (66)
-0x000005d7: 05 DW_LNS_set_column (16)
+0x000005cd: 00 DW_LNE_set_address (0x0000000000000345)
+0x000005d4: 03 DW_LNS_advance_line (81)
+0x000005d6: 05 DW_LNS_set_column (11)
+0x000005d8: 06 DW_LNS_negate_stmt
 0x000005d9: 01 DW_LNS_copy
-            0x0000000000000340     66     16      1   0             0  is_stmt
+            0x0000000000000345     81     11      1   0             0  is_stmt
 
 
-0x000005da: 00 DW_LNE_set_address (0x0000000000000347)
-0x000005e1: 03 DW_LNS_advance_line (74)
-0x000005e3: 05 DW_LNS_set_column (22)
+0x000005da: 00 DW_LNE_set_address (0x000000000000034a)
+0x000005e1: 03 DW_LNS_advance_line (66)
+0x000005e3: 05 DW_LNS_set_column (16)
 0x000005e5: 01 DW_LNS_copy
-            0x0000000000000347     74     22      1   0             0  is_stmt
+            0x000000000000034a     66     16      1   0             0  is_stmt
 
 
-0x000005e6: 00 DW_LNE_set_address (0x0000000000000355)
-0x000005ed: 03 DW_LNS_advance_line (67)
-0x000005ef: 05 DW_LNS_set_column (13)
+0x000005e6: 00 DW_LNE_set_address (0x0000000000000351)
+0x000005ed: 03 DW_LNS_advance_line (74)
+0x000005ef: 05 DW_LNS_set_column (22)
 0x000005f1: 01 DW_LNS_copy
-            0x0000000000000355     67     13      1   0             0  is_stmt
+            0x0000000000000351     74     22      1   0             0  is_stmt
 
 
-0x000005f2: 00 DW_LNE_set_address (0x0000000000000359)
-0x000005f9: 03 DW_LNS_advance_line (68)
-0x000005fb: 01 DW_LNS_copy
-            0x0000000000000359     68     13      1   0             0  is_stmt
+0x000005f2: 00 DW_LNE_set_address (0x0000000000000361)
+0x000005f9: 03 DW_LNS_advance_line (67)
+0x000005fb: 05 DW_LNS_set_column (13)
+0x000005fd: 01 DW_LNS_copy
+            0x0000000000000361     67     13      1   0             0  is_stmt
 
 
-0x000005fc: 00 DW_LNE_set_address (0x000000000000035d)
-0x00000603: 03 DW_LNS_advance_line (69)
-0x00000605: 01 DW_LNS_copy
-            0x000000000000035d     69     13      1   0             0  is_stmt
+0x000005fe: 00 DW_LNE_set_address (0x0000000000000365)
+0x00000605: 03 DW_LNS_advance_line (68)
+0x00000607: 01 DW_LNS_copy
+            0x0000000000000365     68     13      1   0             0  is_stmt
 
 
-0x00000606: 00 DW_LNE_set_address (0x0000000000000361)
-0x0000060d: 03 DW_LNS_advance_line (70)
-0x0000060f: 01 DW_LNS_copy
-            0x0000000000000361     70     13      1   0             0  is_stmt
+0x00000608: 00 DW_LNE_set_address (0x0000000000000369)
+0x0000060f: 03 DW_LNS_advance_line (69)
+0x00000611: 01 DW_LNS_copy
+            0x0000000000000369     69     13      1   0             0  is_stmt
 
 
-0x00000610: 00 DW_LNE_set_address (0x0000000000000364)
-0x00000617: 00 DW_LNE_end_sequence
-            0x0000000000000364     70     13      1   0             0  is_stmt end_sequence
-
-0x0000061a: 00 DW_LNE_set_address (0x0000000000000366)
-0x00000621: 03 DW_LNS_advance_line (152)
-0x00000624: 01 DW_LNS_copy
-            0x0000000000000366    152      0      1   0             0  is_stmt
+0x00000612: 00 DW_LNE_set_address (0x000000000000036d)
+0x00000619: 03 DW_LNS_advance_line (70)
+0x0000061b: 01 DW_LNS_copy
+            0x000000000000036d     70     13      1   0             0  is_stmt
 
 
-0x00000625: 00 DW_LNE_set_address (0x0000000000000376)
-0x0000062c: 03 DW_LNS_advance_line (153)
-0x0000062e: 05 DW_LNS_set_column (17)
-0x00000630: 0a DW_LNS_set_prologue_end
-0x00000631: 01 DW_LNS_copy
-            0x0000000000000376    153     17      1   0             0  is_stmt prologue_end
+0x0000061c: 00 DW_LNE_set_address (0x0000000000000370)
+0x00000623: 00 DW_LNE_end_sequence
+            0x0000000000000370     70     13      1   0             0  is_stmt end_sequence
+
+0x00000626: 00 DW_LNE_set_address (0x0000000000000372)
+0x0000062d: 03 DW_LNS_advance_line (152)
+0x00000630: 01 DW_LNS_copy
+            0x0000000000000372    152      0      1   0             0  is_stmt
 
 
-0x00000632: 00 DW_LNE_set_address (0x000000000000037d)
-0x00000639: 05 DW_LNS_set_column (28)
-0x0000063b: 06 DW_LNS_negate_stmt
-0x0000063c: 01 DW_LNS_copy
-            0x000000000000037d    153     28      1   0             0 
+0x00000631: 00 DW_LNE_set_address (0x0000000000000382)
+0x00000638: 03 DW_LNS_advance_line (153)
+0x0000063a: 05 DW_LNS_set_column (17)
+0x0000063c: 0a DW_LNS_set_prologue_end
+0x0000063d: 01 DW_LNS_copy
+            0x0000000000000382    153     17      1   0             0  is_stmt prologue_end
 
 
-0x0000063d: 00 DW_LNE_set_address (0x0000000000000382)
-0x00000644: 05 DW_LNS_set_column (23)
-0x00000646: 01 DW_LNS_copy
-            0x0000000000000382    153     23      1   0             0 
+0x0000063e: 00 DW_LNE_set_address (0x0000000000000389)
+0x00000645: 05 DW_LNS_set_column (28)
+0x00000647: 06 DW_LNS_negate_stmt
+0x00000648: 01 DW_LNS_copy
+            0x0000000000000389    153     28      1   0             0 
 
 
-0x00000647: 00 DW_LNE_set_address (0x0000000000000388)
-0x0000064e: 03 DW_LNS_advance_line (155)
-0x00000650: 05 DW_LNS_set_column (10)
-0x00000652: 06 DW_LNS_negate_stmt
-0x00000653: 01 DW_LNS_copy
-            0x0000000000000388    155     10      1   0             0  is_stmt
+0x00000649: 00 DW_LNE_set_address (0x000000000000038e)
+0x00000650: 05 DW_LNS_set_column (23)
+0x00000652: 01 DW_LNS_copy
+            0x000000000000038e    153     23      1   0             0 
 
 
-0x00000654: 00 DW_LNE_set_address (0x0000000000000389)
-0x0000065b: 05 DW_LNS_set_column (8)
-0x0000065d: 06 DW_LNS_negate_stmt
-0x0000065e: 01 DW_LNS_copy
-            0x0000000000000389    155      8      1   0             0 
+0x00000653: 00 DW_LNE_set_address (0x0000000000000394)
+0x0000065a: 03 DW_LNS_advance_line (155)
+0x0000065c: 05 DW_LNS_set_column (10)
+0x0000065e: 06 DW_LNS_negate_stmt
+0x0000065f: 01 DW_LNS_copy
+            0x0000000000000394    155     10      1   0             0  is_stmt
 
 
-0x0000065f: 00 DW_LNE_set_address (0x000000000000038c)
-0x00000666: 03 DW_LNS_advance_line (156)
-0x00000668: 05 DW_LNS_set_column (7)
-0x0000066a: 06 DW_LNS_negate_stmt
-0x0000066b: 01 DW_LNS_copy
-            0x000000000000038c    156      7      1   0             0  is_stmt
+0x00000660: 00 DW_LNE_set_address (0x0000000000000395)
+0x00000667: 05 DW_LNS_set_column (8)
+0x00000669: 06 DW_LNS_negate_stmt
+0x0000066a: 01 DW_LNS_copy
+            0x0000000000000395    155      8      1   0             0 
 
 
-0x0000066c: 00 DW_LNE_set_address (0x0000000000000399)
-0x00000673: 03 DW_LNS_advance_line (94)
-0x00000675: 05 DW_LNS_set_column (18)
+0x0000066b: 00 DW_LNE_set_address (0x0000000000000398)
+0x00000672: 03 DW_LNS_advance_line (156)
+0x00000674: 05 DW_LNS_set_column (7)
+0x00000676: 06 DW_LNS_negate_stmt
 0x00000677: 01 DW_LNS_copy
-            0x0000000000000399     94     18      1   0             0  is_stmt
+            0x0000000000000398    156      7      1   0             0  is_stmt
 
 
-0x00000678: 00 DW_LNE_set_address (0x00000000000003b3)
-0x0000067f: 03 DW_LNS_advance_line (95)
-0x00000681: 05 DW_LNS_set_column (29)
+0x00000678: 00 DW_LNE_set_address (0x00000000000003a5)
+0x0000067f: 03 DW_LNS_advance_line (94)
+0x00000681: 05 DW_LNS_set_column (18)
 0x00000683: 01 DW_LNS_copy
-            0x00000000000003b3     95     29      1   0             0  is_stmt
+            0x00000000000003a5     94     18      1   0             0  is_stmt
 
 
-0x00000684: 00 DW_LNE_set_address (0x00000000000003b5)
-0x0000068b: 03 DW_LNS_advance_line (98)
-0x0000068d: 05 DW_LNS_set_column (19)
+0x00000684: 00 DW_LNE_set_address (0x00000000000003bf)
+0x0000068b: 03 DW_LNS_advance_line (95)
+0x0000068d: 05 DW_LNS_set_column (29)
 0x0000068f: 01 DW_LNS_copy
-            0x00000000000003b5     98     19      1   0             0  is_stmt
+            0x00000000000003bf     95     29      1   0             0  is_stmt
 
 
-0x00000690: 00 DW_LNE_set_address (0x00000000000003bc)
-0x00000697: 03 DW_LNS_advance_line (97)
-0x00000699: 05 DW_LNS_set_column (16)
+0x00000690: 00 DW_LNE_set_address (0x00000000000003c1)
+0x00000697: 03 DW_LNS_advance_line (98)
+0x00000699: 05 DW_LNS_set_column (19)
 0x0000069b: 01 DW_LNS_copy
-            0x00000000000003bc     97     16      1   0             0  is_stmt
+            0x00000000000003c1     98     19      1   0             0  is_stmt
 
 
-0x0000069c: 00 DW_LNE_set_address (0x00000000000003c3)
-0x000006a3: 03 DW_LNS_advance_line (96)
-0x000006a5: 01 DW_LNS_copy
-            0x00000000000003c3     96     16      1   0             0  is_stmt
+0x0000069c: 00 DW_LNE_set_address (0x00000000000003c8)
+0x000006a3: 03 DW_LNS_advance_line (97)
+0x000006a5: 05 DW_LNS_set_column (16)
+0x000006a7: 01 DW_LNS_copy
+            0x00000000000003c8     97     16      1   0             0  is_stmt
 
 
-0x000006a6: 00 DW_LNE_set_address (0x00000000000003ce)
-0x000006ad: 03 DW_LNS_advance_line (94)
-0x000006af: 05 DW_LNS_set_column (28)
+0x000006a8: 00 DW_LNE_set_address (0x00000000000003cf)
+0x000006af: 03 DW_LNS_advance_line (96)
 0x000006b1: 01 DW_LNS_copy
-            0x00000000000003ce     94     28      1   0             0  is_stmt
+            0x00000000000003cf     96     16      1   0             0  is_stmt
 
 
-0x000006b2: 00 DW_LNE_set_address (0x00000000000003d3)
-0x000006b9: 05 DW_LNS_set_column (18)
-0x000006bb: 06 DW_LNS_negate_stmt
-0x000006bc: 01 DW_LNS_copy
-            0x00000000000003d3     94     18      1   0             0 
+0x000006b2: 00 DW_LNE_set_address (0x00000000000003da)
+0x000006b9: 03 DW_LNS_advance_line (94)
+0x000006bb: 05 DW_LNS_set_column (28)
+0x000006bd: 01 DW_LNS_copy
+            0x00000000000003da     94     28      1   0             0  is_stmt
 
 
-0x000006bd: 00 DW_LNE_set_address (0x00000000000003d8)
-0x000006c4: 05 DW_LNS_set_column (4)
-0x000006c6: 01 DW_LNS_copy
-            0x00000000000003d8     94      4      1   0             0 
+0x000006be: 00 DW_LNE_set_address (0x00000000000003df)
+0x000006c5: 05 DW_LNS_set_column (18)
+0x000006c7: 06 DW_LNS_negate_stmt
+0x000006c8: 01 DW_LNS_copy
+            0x00000000000003df     94     18      1   0             0 
 
 
-0x000006c7: 00 DW_LNE_set_address (0x00000000000003e0)
-0x000006ce: 03 DW_LNS_advance_line (102)
-0x000006d0: 05 DW_LNS_set_column (27)
-0x000006d2: 06 DW_LNS_negate_stmt
-0x000006d3: 01 DW_LNS_copy
-            0x00000000000003e0    102     27      1   0             0  is_stmt
+0x000006c9: 00 DW_LNE_set_address (0x00000000000003e4)
+0x000006d0: 05 DW_LNS_set_column (4)
+0x000006d2: 01 DW_LNS_copy
+            0x00000000000003e4     94      4      1   0             0 
 
 
-0x000006d4: 00 DW_LNE_set_address (0x00000000000003e5)
-0x000006db: 05 DW_LNS_set_column (18)
-0x000006dd: 06 DW_LNS_negate_stmt
-0x000006de: 01 DW_LNS_copy
-            0x00000000000003e5    102     18      1   0             0 
+0x000006d3: 00 DW_LNE_set_address (0x00000000000003ec)
+0x000006da: 03 DW_LNS_advance_line (102)
+0x000006dc: 05 DW_LNS_set_column (27)
+0x000006de: 06 DW_LNS_negate_stmt
+0x000006df: 01 DW_LNS_copy
+            0x00000000000003ec    102     27      1   0             0  is_stmt
 
 
-0x000006df: 00 DW_LNE_set_address (0x00000000000003eb)
-0x000006e6: 03 DW_LNS_advance_line (103)
-0x000006e8: 06 DW_LNS_negate_stmt
-0x000006e9: 01 DW_LNS_copy
-            0x00000000000003eb    103     18      1   0             0  is_stmt
+0x000006e0: 00 DW_LNE_set_address (0x00000000000003f1)
+0x000006e7: 05 DW_LNS_set_column (18)
+0x000006e9: 06 DW_LNS_negate_stmt
+0x000006ea: 01 DW_LNS_copy
+            0x00000000000003f1    102     18      1   0             0 
 
 
-0x000006ea: 00 DW_LNE_set_address (0x00000000000003f7)
-0x000006f1: 03 DW_LNS_advance_line (105)
-0x000006f3: 01 DW_LNS_copy
-            0x00000000000003f7    105     18      1   0             0  is_stmt
+0x000006eb: 00 DW_LNE_set_address (0x00000000000003f7)
+0x000006f2: 03 DW_LNS_advance_line (103)
+0x000006f4: 06 DW_LNS_negate_stmt
+0x000006f5: 01 DW_LNS_copy
+            0x00000000000003f7    103     18      1   0             0  is_stmt
 
 
-0x000006f4: 00 DW_LNE_set_address (0x0000000000000400)
-0x000006fb: 03 DW_LNS_advance_line (106)
-0x000006fd: 05 DW_LNS_set_column (7)
+0x000006f6: 00 DW_LNE_set_address (0x0000000000000403)
+0x000006fd: 03 DW_LNS_advance_line (105)
 0x000006ff: 01 DW_LNS_copy
-            0x0000000000000400    106      7      1   0             0  is_stmt
+            0x0000000000000403    105     18      1   0             0  is_stmt
 
 
-0x00000700: 00 DW_LNE_set_address (0x0000000000000408)
-0x00000707: 05 DW_LNS_set_column (16)
-0x00000709: 06 DW_LNS_negate_stmt
-0x0000070a: 01 DW_LNS_copy
-            0x0000000000000408    106     16      1   0             0 
+0x00000700: 00 DW_LNE_set_address (0x000000000000040c)
+0x00000707: 03 DW_LNS_advance_line (106)
+0x00000709: 05 DW_LNS_set_column (7)
+0x0000070b: 01 DW_LNS_copy
+            0x000000000000040c    106      7      1   0             0  is_stmt
 
 
-0x0000070b: 00 DW_LNE_set_address (0x000000000000040d)
-0x00000712: 03 DW_LNS_advance_line (105)
-0x00000714: 05 DW_LNS_set_column (24)
-0x00000716: 06 DW_LNS_negate_stmt
-0x00000717: 01 DW_LNS_copy
-            0x000000000000040d    105     24      1   0             0  is_stmt
+0x0000070c: 00 DW_LNE_set_address (0x0000000000000414)
+0x00000713: 05 DW_LNS_set_column (16)
+0x00000715: 06 DW_LNS_negate_stmt
+0x00000716: 01 DW_LNS_copy
+            0x0000000000000414    106     16      1   0             0 
 
 
-0x00000718: 00 DW_LNE_set_address (0x0000000000000412)
-0x0000071f: 05 DW_LNS_set_column (18)
-0x00000721: 06 DW_LNS_negate_stmt
-0x00000722: 01 DW_LNS_copy
-            0x0000000000000412    105     18      1   0             0 
+0x00000717: 00 DW_LNE_set_address (0x0000000000000419)
+0x0000071e: 03 DW_LNS_advance_line (105)
+0x00000720: 05 DW_LNS_set_column (24)
+0x00000722: 06 DW_LNS_negate_stmt
+0x00000723: 01 DW_LNS_copy
+            0x0000000000000419    105     24      1   0             0  is_stmt
 
 
-0x00000723: 00 DW_LNE_set_address (0x0000000000000438)
-0x0000072a: 03 DW_LNS_advance_line (112)
-0x0000072c: 05 DW_LNS_set_column (13)
-0x0000072e: 06 DW_LNS_negate_stmt
-0x0000072f: 01 DW_LNS_copy
-            0x0000000000000438    112     13      1   0             0  is_stmt
+0x00000724: 00 DW_LNE_set_address (0x000000000000041e)
+0x0000072b: 05 DW_LNS_set_column (18)
+0x0000072d: 06 DW_LNS_negate_stmt
+0x0000072e: 01 DW_LNS_copy
+            0x000000000000041e    105     18      1   0             0 
 
 
-0x00000730: 00 DW_LNE_set_address (0x000000000000043a)
-0x00000737: 05 DW_LNS_set_column (26)
-0x00000739: 06 DW_LNS_negate_stmt
-0x0000073a: 01 DW_LNS_copy
-            0x000000000000043a    112     26      1   0             0 
+0x0000072f: 00 DW_LNE_set_address (0x0000000000000444)
+0x00000736: 03 DW_LNS_advance_line (112)
+0x00000738: 05 DW_LNS_set_column (13)
+0x0000073a: 06 DW_LNS_negate_stmt
+0x0000073b: 01 DW_LNS_copy
+            0x0000000000000444    112     13      1   0             0  is_stmt
 
 
-0x0000073b: 00 DW_LNE_set_address (0x0000000000000447)
-0x00000742: 05 DW_LNS_set_column (35)
-0x00000744: 01 DW_LNS_copy
-            0x0000000000000447    112     35      1   0             0 
+0x0000073c: 00 DW_LNE_set_address (0x0000000000000446)
+0x00000743: 05 DW_LNS_set_column (26)
+0x00000745: 06 DW_LNS_negate_stmt
+0x00000746: 01 DW_LNS_copy
+            0x0000000000000446    112     26      1   0             0 
 
 
-0x00000745: 00 DW_LNE_set_address (0x0000000000000448)
-0x0000074c: 05 DW_LNS_set_column (13)
-0x0000074e: 01 DW_LNS_copy
-            0x0000000000000448    112     13      1   0             0 
+0x00000747: 00 DW_LNE_set_address (0x0000000000000453)
+0x0000074e: 05 DW_LNS_set_column (35)
+0x00000750: 01 DW_LNS_copy
+            0x0000000000000453    112     35      1   0             0 
 
 
-0x0000074f: 00 DW_LNE_set_address (0x0000000000000456)
-0x00000756: 03 DW_LNS_advance_line (111)
-0x00000758: 05 DW_LNS_set_column (30)
-0x0000075a: 06 DW_LNS_negate_stmt
-0x0000075b: 01 DW_LNS_copy
-            0x0000000000000456    111     30      1   0             0  is_stmt
+0x00000751: 00 DW_LNE_set_address (0x0000000000000454)
+0x00000758: 05 DW_LNS_set_column (13)
+0x0000075a: 01 DW_LNS_copy
+            0x0000000000000454    112     13      1   0             0 
 
 
-0x0000075c: 00 DW_LNE_set_address (0x000000000000045b)
-0x00000763: 05 DW_LNS_set_column (24)
-0x00000765: 06 DW_LNS_negate_stmt
-0x00000766: 01 DW_LNS_copy
-            0x000000000000045b    111     24      1   0             0 
+0x0000075b: 00 DW_LNE_set_address (0x0000000000000462)
+0x00000762: 03 DW_LNS_advance_line (111)
+0x00000764: 05 DW_LNS_set_column (30)
+0x00000766: 06 DW_LNS_negate_stmt
+0x00000767: 01 DW_LNS_copy
+            0x0000000000000462    111     30      1   0             0  is_stmt
 
 
-0x00000767: 00 DW_LNE_set_address (0x0000000000000460)
-0x0000076e: 05 DW_LNS_set_column (10)
-0x00000770: 01 DW_LNS_copy
-            0x0000000000000460    111     10      1   0             0 
+0x00000768: 00 DW_LNE_set_address (0x0000000000000467)
+0x0000076f: 05 DW_LNS_set_column (24)
+0x00000771: 06 DW_LNS_negate_stmt
+0x00000772: 01 DW_LNS_copy
+            0x0000000000000467    111     24      1   0             0 
 
 
-0x00000771: 00 DW_LNE_set_address (0x0000000000000465)
-0x00000778: 03 DW_LNS_advance_line (113)
-0x0000077a: 06 DW_LNS_negate_stmt
-0x0000077b: 01 DW_LNS_copy
-            0x0000000000000465    113     10      1   0             0  is_stmt
+0x00000773: 00 DW_LNE_set_address (0x000000000000046c)
+0x0000077a: 05 DW_LNS_set_column (10)
+0x0000077c: 01 DW_LNS_copy
+            0x000000000000046c    111     10      1   0             0 
 
 
-0x0000077c: 00 DW_LNE_set_address (0x0000000000000468)
-0x00000783: 03 DW_LNS_advance_line (118)
-0x00000785: 05 DW_LNS_set_column (16)
+0x0000077d: 00 DW_LNE_set_address (0x0000000000000471)
+0x00000784: 03 DW_LNS_advance_line (113)
+0x00000786: 06 DW_LNS_negate_stmt
 0x00000787: 01 DW_LNS_copy
-            0x0000000000000468    118     16      1   0             0  is_stmt
+            0x0000000000000471    113     10      1   0             0  is_stmt
 
 
-0x00000788: 00 DW_LNE_set_address (0x0000000000000471)
-0x0000078f: 03 DW_LNS_advance_line (119)
-0x00000791: 05 DW_LNS_set_column (10)
+0x00000788: 00 DW_LNE_set_address (0x0000000000000474)
+0x0000078f: 03 DW_LNS_advance_line (118)
+0x00000791: 05 DW_LNS_set_column (16)
 0x00000793: 01 DW_LNS_copy
-            0x0000000000000471    119     10      1   0             0  is_stmt
+            0x0000000000000474    118     16      1   0             0  is_stmt
 
 
-0x00000794: 00 DW_LNE_set_address (0x0000000000000473)
-0x0000079b: 05 DW_LNS_set_column (18)
-0x0000079d: 06 DW_LNS_negate_stmt
-0x0000079e: 01 DW_LNS_copy
-            0x0000000000000473    119     18      1   0             0 
+0x00000794: 00 DW_LNE_set_address (0x000000000000047d)
+0x0000079b: 03 DW_LNS_advance_line (119)
+0x0000079d: 05 DW_LNS_set_column (10)
+0x0000079f: 01 DW_LNS_copy
+            0x000000000000047d    119     10      1   0             0  is_stmt
 
 
-0x0000079f: 00 DW_LNE_set_address (0x000000000000047c)
-0x000007a6: 05 DW_LNS_set_column (10)
-0x000007a8: 01 DW_LNS_copy
-            0x000000000000047c    119     10      1   0             0 
+0x000007a0: 00 DW_LNE_set_address (0x000000000000047f)
+0x000007a7: 05 DW_LNS_set_column (18)
+0x000007a9: 06 DW_LNS_negate_stmt
+0x000007aa: 01 DW_LNS_copy
+            0x000000000000047f    119     18      1   0             0 
 
 
-0x000007a9: 00 DW_LNE_set_address (0x000000000000047e)
-0x000007b0: 05 DW_LNS_set_column (23)
-0x000007b2: 01 DW_LNS_copy
-            0x000000000000047e    119     23      1   0             0 
+0x000007ab: 00 DW_LNE_set_address (0x0000000000000488)
+0x000007b2: 05 DW_LNS_set_column (10)
+0x000007b4: 01 DW_LNS_copy
+            0x0000000000000488    119     10      1   0             0 
 
 
-0x000007b3: 00 DW_LNE_set_address (0x0000000000000483)
-0x000007ba: 03 DW_LNS_advance_line (118)
-0x000007bc: 05 DW_LNS_set_column (16)
-0x000007be: 06 DW_LNS_negate_stmt
-0x000007bf: 01 DW_LNS_copy
-            0x0000000000000483    118     16      1   0             0  is_stmt
+0x000007b5: 00 DW_LNE_set_address (0x000000000000048a)
+0x000007bc: 05 DW_LNS_set_column (23)
+0x000007be: 01 DW_LNS_copy
+            0x000000000000048a    119     23      1   0             0 
 
 
-0x000007c0: 00 DW_LNE_set_address (0x0000000000000490)
-0x000007c7: 03 DW_LNS_advance_line (122)
-0x000007c9: 01 DW_LNS_copy
-            0x0000000000000490    122     16      1   0             0  is_stmt
+0x000007bf: 00 DW_LNE_set_address (0x000000000000048f)
+0x000007c6: 03 DW_LNS_advance_line (118)
+0x000007c8: 05 DW_LNS_set_column (16)
+0x000007ca: 06 DW_LNS_negate_stmt
+0x000007cb: 01 DW_LNS_copy
+            0x000000000000048f    118     16      1   0             0  is_stmt
 
 
-0x000007ca: 00 DW_LNE_set_address (0x00000000000004a4)
-0x000007d1: 03 DW_LNS_advance_line (125)
-0x000007d3: 05 DW_LNS_set_column (22)
-0x000007d5: 01 DW_LNS_copy
-            0x00000000000004a4    125     22      1   0             0  is_stmt
+0x000007cc: 00 DW_LNE_set_address (0x000000000000049a)
+0x000007d3: 05 DW_LNS_set_column (7)
+0x000007d5: 06 DW_LNS_negate_stmt
+0x000007d6: 01 DW_LNS_copy
+            0x000000000000049a    118      7      1   0             0 
 
 
-0x000007d6: 00 DW_LNE_set_address (0x00000000000004ab)
-0x000007dd: 03 DW_LNS_advance_line (126)
-0x000007df: 05 DW_LNS_set_column (27)
-0x000007e1: 01 DW_LNS_copy
-            0x00000000000004ab    126     27      1   0             0  is_stmt
+0x000007d7: 00 DW_LNE_set_address (0x00000000000004a0)
+0x000007de: 03 DW_LNS_advance_line (122)
+0x000007e0: 05 DW_LNS_set_column (16)
+0x000007e2: 06 DW_LNS_negate_stmt
+0x000007e3: 01 DW_LNS_copy
+            0x00000000000004a0    122     16      1   0             0  is_stmt
 
 
-0x000007e2: 00 DW_LNE_set_address (0x00000000000004b4)
-0x000007e9: 03 DW_LNS_advance_line (127)
-0x000007eb: 05 DW_LNS_set_column (16)
-0x000007ed: 01 DW_LNS_copy
-            0x00000000000004b4    127     16      1   0             0  is_stmt
+0x000007e4: 00 DW_LNE_set_address (0x00000000000004b4)
+0x000007eb: 03 DW_LNS_advance_line (125)
+0x000007ed: 05 DW_LNS_set_column (22)
+0x000007ef: 01 DW_LNS_copy
+            0x00000000000004b4    125     22      1   0             0  is_stmt
 
 
-0x000007ee: 00 DW_LNE_set_address (0x00000000000004bc)
-0x000007f5: 05 DW_LNS_set_column (27)
-0x000007f7: 06 DW_LNS_negate_stmt
-0x000007f8: 01 DW_LNS_copy
-            0x00000000000004bc    127     27      1   0             0 
+0x000007f0: 00 DW_LNE_set_address (0x00000000000004bb)
+0x000007f7: 03 DW_LNS_advance_line (126)
+0x000007f9: 05 DW_LNS_set_column (27)
+0x000007fb: 01 DW_LNS_copy
+            0x00000000000004bb    126     27      1   0             0  is_stmt
 
 
-0x000007f9: 00 DW_LNE_set_address (0x00000000000004be)
-0x00000800: 05 DW_LNS_set_column (35)
-0x00000802: 01 DW_LNS_copy
-            0x00000000000004be    127     35      1   0             0 
+0x000007fc: 00 DW_LNE_set_address (0x00000000000004c4)
+0x00000803: 03 DW_LNS_advance_line (127)
+0x00000805: 05 DW_LNS_set_column (16)
+0x00000807: 01 DW_LNS_copy
+            0x00000000000004c4    127     16      1   0             0  is_stmt
 
 
-0x00000803: 00 DW_LNE_set_address (0x00000000000004c7)
-0x0000080a: 05 DW_LNS_set_column (27)
-0x0000080c: 01 DW_LNS_copy
-            0x00000000000004c7    127     27      1   0             0 
+0x00000808: 00 DW_LNE_set_address (0x00000000000004cc)
+0x0000080f: 05 DW_LNS_set_column (27)
+0x00000811: 06 DW_LNS_negate_stmt
+0x00000812: 01 DW_LNS_copy
+            0x00000000000004cc    127     27      1   0             0 
 
 
-0x0000080d: 00 DW_LNE_set_address (0x00000000000004cc)
-0x00000814: 05 DW_LNS_set_column (25)
-0x00000816: 01 DW_LNS_copy
-            0x00000000000004cc    127     25      1   0             0 
+0x00000813: 00 DW_LNE_set_address (0x00000000000004ce)
+0x0000081a: 05 DW_LNS_set_column (35)
+0x0000081c: 01 DW_LNS_copy
+            0x00000000000004ce    127     35      1   0             0 
 
 
-0x00000817: 00 DW_LNE_set_address (0x00000000000004cf)
-0x0000081e: 03 DW_LNS_advance_line (126)
-0x00000820: 05 DW_LNS_set_column (27)
-0x00000822: 06 DW_LNS_negate_stmt
-0x00000823: 01 DW_LNS_copy
-            0x00000000000004cf    126     27      1   0             0  is_stmt
+0x0000081d: 00 DW_LNE_set_address (0x00000000000004d7)
+0x00000824: 05 DW_LNS_set_column (27)
+0x00000826: 01 DW_LNS_copy
+            0x00000000000004d7    127     27      1   0             0 
 
 
-0x00000824: 00 DW_LNE_set_address (0x00000000000004d4)
-0x0000082b: 05 DW_LNS_set_column (13)
-0x0000082d: 06 DW_LNS_negate_stmt
-0x0000082e: 01 DW_LNS_copy
-            0x00000000000004d4    126     13      1   0             0 
+0x00000827: 00 DW_LNE_set_address (0x00000000000004dc)
+0x0000082e: 05 DW_LNS_set_column (25)
+0x00000830: 01 DW_LNS_copy
+            0x00000000000004dc    127     25      1   0             0 
 
 
-0x0000082f: 00 DW_LNE_set_address (0x00000000000004dc)
-0x00000836: 03 DW_LNS_advance_line (128)
-0x00000838: 06 DW_LNS_negate_stmt
-0x00000839: 01 DW_LNS_copy
-            0x00000000000004dc    128     13      1   0             0  is_stmt
+0x00000831: 00 DW_LNE_set_address (0x00000000000004df)
+0x00000838: 03 DW_LNS_advance_line (126)
+0x0000083a: 05 DW_LNS_set_column (27)
+0x0000083c: 06 DW_LNS_negate_stmt
+0x0000083d: 01 DW_LNS_copy
+            0x00000000000004df    126     27      1   0             0  is_stmt
 
 
-0x0000083a: 00 DW_LNE_set_address (0x00000000000004e4)
-0x00000841: 05 DW_LNS_set_column (22)
-0x00000843: 06 DW_LNS_negate_stmt
-0x00000844: 01 DW_LNS_copy
-            0x00000000000004e4    128     22      1   0             0 
+0x0000083e: 00 DW_LNE_set_address (0x00000000000004e4)
+0x00000845: 05 DW_LNS_set_column (13)
+0x00000847: 06 DW_LNS_negate_stmt
+0x00000848: 01 DW_LNS_copy
+            0x00000000000004e4    126     13      1   0             0 
 
 
-0x00000845: 00 DW_LNE_set_address (0x00000000000004e9)
-0x0000084c: 03 DW_LNS_advance_line (130)
-0x0000084e: 05 DW_LNS_set_column (16)
-0x00000850: 06 DW_LNS_negate_stmt
-0x00000851: 01 DW_LNS_copy
-            0x00000000000004e9    130     16      1   0             0  is_stmt
+0x00000849: 00 DW_LNE_set_address (0x00000000000004ec)
+0x00000850: 03 DW_LNS_advance_line (128)
+0x00000852: 06 DW_LNS_negate_stmt
+0x00000853: 01 DW_LNS_copy
+            0x00000000000004ec    128     13      1   0             0  is_stmt
 
 
-0x00000852: 00 DW_LNE_set_address (0x00000000000004f1)
-0x00000859: 05 DW_LNS_set_column (14)
-0x0000085b: 06 DW_LNS_negate_stmt
-0x0000085c: 01 DW_LNS_copy
-            0x00000000000004f1    130     14      1   0             0 
+0x00000854: 00 DW_LNE_set_address (0x00000000000004f4)
+0x0000085b: 05 DW_LNS_set_column (22)
+0x0000085d: 06 DW_LNS_negate_stmt
+0x0000085e: 01 DW_LNS_copy
+            0x00000000000004f4    128     22      1   0             0 
 
 
-0x0000085d: 00 DW_LNE_set_address (0x0000000000000500)
-0x00000864: 05 DW_LNS_set_column (25)
-0x00000866: 01 DW_LNS_copy
-            0x0000000000000500    130     25      1   0             0 
+0x0000085f: 00 DW_LNE_set_address (0x00000000000004f9)
+0x00000866: 03 DW_LNS_advance_line (130)
+0x00000868: 05 DW_LNS_set_column (16)
+0x0000086a: 06 DW_LNS_negate_stmt
+0x0000086b: 01 DW_LNS_copy
+            0x00000000000004f9    130     16      1   0             0  is_stmt
 
 
-0x00000867: 00 DW_LNE_set_address (0x0000000000000507)
-0x0000086e: 03 DW_LNS_advance_line (133)
-0x00000870: 05 DW_LNS_set_column (11)
-0x00000872: 06 DW_LNS_negate_stmt
-0x00000873: 01 DW_LNS_copy
-            0x0000000000000507    133     11      1   0             0  is_stmt
+0x0000086c: 00 DW_LNE_set_address (0x0000000000000501)
+0x00000873: 05 DW_LNS_set_column (14)
+0x00000875: 06 DW_LNS_negate_stmt
+0x00000876: 01 DW_LNS_copy
+            0x0000000000000501    130     14      1   0             0 
 
 
-0x00000874: 00 DW_LNE_set_address (0x000000000000050c)
-0x0000087b: 03 DW_LNS_advance_line (122)
-0x0000087d: 05 DW_LNS_set_column (16)
-0x0000087f: 01 DW_LNS_copy
-            0x000000000000050c    122     16      1   0             0  is_stmt
+0x00000877: 00 DW_LNE_set_address (0x0000000000000510)
+0x0000087e: 05 DW_LNS_set_column (25)
+0x00000880: 01 DW_LNS_copy
+            0x0000000000000510    130     25      1   0             0 
 
 
-0x00000880: 00 DW_LNE_set_address (0x0000000000000511)
-0x00000887: 05 DW_LNS_set_column (14)
-0x00000889: 06 DW_LNS_negate_stmt
-0x0000088a: 01 DW_LNS_copy
-            0x0000000000000511    122     14      1   0             0 
+0x00000881: 00 DW_LNE_set_address (0x0000000000000517)
+0x00000888: 03 DW_LNS_advance_line (133)
+0x0000088a: 05 DW_LNS_set_column (11)
+0x0000088c: 06 DW_LNS_negate_stmt
+0x0000088d: 01 DW_LNS_copy
+            0x0000000000000517    133     11      1   0             0  is_stmt
 
 
-0x0000088b: 00 DW_LNE_set_address (0x0000000000000516)
-0x00000892: 03 DW_LNS_advance_line (130)
-0x00000894: 06 DW_LNS_negate_stmt
-0x00000895: 01 DW_LNS_copy
-            0x0000000000000516    130     14      1   0             0  is_stmt
+0x0000088e: 00 DW_LNE_set_address (0x000000000000051c)
+0x00000895: 03 DW_LNS_advance_line (122)
+0x00000897: 05 DW_LNS_set_column (16)
+0x00000899: 01 DW_LNS_copy
+            0x000000000000051c    122     16      1   0             0  is_stmt
 
 
-0x00000896: 00 DW_LNE_set_address (0x0000000000000517)
-0x0000089d: 03 DW_LNS_advance_line (110)
-0x0000089f: 05 DW_LNS_set_column (11)
-0x000008a1: 01 DW_LNS_copy
-            0x0000000000000517    110     11      1   0             0  is_stmt
+0x0000089a: 00 DW_LNE_set_address (0x0000000000000521)
+0x000008a1: 05 DW_LNS_set_column (14)
+0x000008a3: 06 DW_LNS_negate_stmt
+0x000008a4: 01 DW_LNS_copy
+            0x0000000000000521    122     14      1   0             0 
 
 
-0x000008a2: 00 DW_LNE_set_address (0x0000000000000523)
-0x000008a9: 03 DW_LNS_advance_line (113)
-0x000008ab: 05 DW_LNS_set_column (10)
-0x000008ad: 01 DW_LNS_copy
-            0x0000000000000523    113     10      1   0             0  is_stmt
+0x000008a5: 00 DW_LNE_set_address (0x0000000000000526)
+0x000008ac: 03 DW_LNS_advance_line (130)
+0x000008ae: 06 DW_LNS_negate_stmt
+0x000008af: 01 DW_LNS_copy
+            0x0000000000000526    130     14      1   0             0  is_stmt
 
 
-0x000008ae: 00 DW_LNE_set_address (0x0000000000000526)
-0x000008b5: 03 DW_LNS_advance_line (118)
-0x000008b7: 05 DW_LNS_set_column (16)
-0x000008b9: 01 DW_LNS_copy
-            0x0000000000000526    118     16      1   0             0  is_stmt
+0x000008b0: 00 DW_LNE_set_address (0x0000000000000527)
+0x000008b7: 03 DW_LNS_advance_line (110)
+0x000008b9: 05 DW_LNS_set_column (11)
+0x000008bb: 01 DW_LNS_copy
+            0x0000000000000527    110     11      1   0             0  is_stmt
 
 
-0x000008ba: 00 DW_LNE_set_address (0x000000000000052f)
-0x000008c1: 03 DW_LNS_advance_line (119)
-0x000008c3: 05 DW_LNS_set_column (10)
-0x000008c5: 01 DW_LNS_copy
-            0x000000000000052f    119     10      1   0             0  is_stmt
+0x000008bc: 00 DW_LNE_set_address (0x0000000000000533)
+0x000008c3: 03 DW_LNS_advance_line (113)
+0x000008c5: 05 DW_LNS_set_column (10)
+0x000008c7: 01 DW_LNS_copy
+            0x0000000000000533    113     10      1   0             0  is_stmt
 
 
-0x000008c6: 00 DW_LNE_set_address (0x0000000000000531)
-0x000008cd: 05 DW_LNS_set_column (18)
-0x000008cf: 06 DW_LNS_negate_stmt
-0x000008d0: 01 DW_LNS_copy
-            0x0000000000000531    119     18      1   0             0 
+0x000008c8: 00 DW_LNE_set_address (0x0000000000000536)
+0x000008cf: 03 DW_LNS_advance_line (118)
+0x000008d1: 05 DW_LNS_set_column (16)
+0x000008d3: 01 DW_LNS_copy
+            0x0000000000000536    118     16      1   0             0  is_stmt
 
 
-0x000008d1: 00 DW_LNE_set_address (0x000000000000053a)
-0x000008d8: 05 DW_LNS_set_column (10)
-0x000008da: 01 DW_LNS_copy
-            0x000000000000053a    119     10      1   0             0 
+0x000008d4: 00 DW_LNE_set_address (0x000000000000053f)
+0x000008db: 03 DW_LNS_advance_line (119)
+0x000008dd: 05 DW_LNS_set_column (10)
+0x000008df: 01 DW_LNS_copy
+            0x000000000000053f    119     10      1   0             0  is_stmt
 
 
-0x000008db: 00 DW_LNE_set_address (0x000000000000053c)
-0x000008e2: 05 DW_LNS_set_column (23)
-0x000008e4: 01 DW_LNS_copy
-            0x000000000000053c    119     23      1   0             0 
+0x000008e0: 00 DW_LNE_set_address (0x0000000000000541)
+0x000008e7: 05 DW_LNS_set_column (18)
+0x000008e9: 06 DW_LNS_negate_stmt
+0x000008ea: 01 DW_LNS_copy
+            0x0000000000000541    119     18      1   0             0 
 
 
-0x000008e5: 00 DW_LNE_set_address (0x0000000000000541)
-0x000008ec: 03 DW_LNS_advance_line (118)
-0x000008ee: 05 DW_LNS_set_column (16)
-0x000008f0: 06 DW_LNS_negate_stmt
-0x000008f1: 01 DW_LNS_copy
-            0x0000000000000541    118     16      1   0             0  is_stmt
+0x000008eb: 00 DW_LNE_set_address (0x000000000000054a)
+0x000008f2: 05 DW_LNS_set_column (10)
+0x000008f4: 01 DW_LNS_copy
+            0x000000000000054a    119     10      1   0             0 
 
 
-0x000008f2: 00 DW_LNE_set_address (0x000000000000054e)
-0x000008f9: 03 DW_LNS_advance_line (122)
-0x000008fb: 01 DW_LNS_copy
-            0x000000000000054e    122     16      1   0             0  is_stmt
+0x000008f5: 00 DW_LNE_set_address (0x000000000000054c)
+0x000008fc: 05 DW_LNS_set_column (23)
+0x000008fe: 01 DW_LNS_copy
+            0x000000000000054c    119     23      1   0             0 
 
 
-0x000008fc: 00 DW_LNE_set_address (0x0000000000000553)
-0x00000903: 05 DW_LNS_set_column (14)
-0x00000905: 06 DW_LNS_negate_stmt
-0x00000906: 01 DW_LNS_copy
-            0x0000000000000553    122     14      1   0             0 
+0x000008ff: 00 DW_LNE_set_address (0x0000000000000551)
+0x00000906: 03 DW_LNS_advance_line (118)
+0x00000908: 05 DW_LNS_set_column (16)
+0x0000090a: 06 DW_LNS_negate_stmt
+0x0000090b: 01 DW_LNS_copy
+            0x0000000000000551    118     16      1   0             0  is_stmt
 
 
-0x00000907: 00 DW_LNE_set_address (0x000000000000055c)
-0x0000090e: 03 DW_LNS_advance_line (125)
-0x00000910: 05 DW_LNS_set_column (22)
-0x00000912: 06 DW_LNS_negate_stmt
-0x00000913: 01 DW_LNS_copy
-            0x000000000000055c    125     22      1   0             0  is_stmt
+0x0000090c: 00 DW_LNE_set_address (0x000000000000055c)
+0x00000913: 05 DW_LNS_set_column (7)
+0x00000915: 06 DW_LNS_negate_stmt
+0x00000916: 01 DW_LNS_copy
+            0x000000000000055c    118      7      1   0             0 
 
 
-0x00000914: 00 DW_LNE_set_address (0x0000000000000569)
-0x0000091b: 03 DW_LNS_advance_line (126)
-0x0000091d: 05 DW_LNS_set_column (27)
-0x0000091f: 01 DW_LNS_copy
-            0x0000000000000569    126     27      1   0             0  is_stmt
+0x00000917: 00 DW_LNE_set_address (0x0000000000000562)
+0x0000091e: 03 DW_LNS_advance_line (122)
+0x00000920: 05 DW_LNS_set_column (16)
+0x00000922: 06 DW_LNS_negate_stmt
+0x00000923: 01 DW_LNS_copy
+            0x0000000000000562    122     16      1   0             0  is_stmt
 
 
-0x00000920: 00 DW_LNE_set_address (0x0000000000000572)
-0x00000927: 03 DW_LNS_advance_line (127)
-0x00000929: 05 DW_LNS_set_column (16)
-0x0000092b: 01 DW_LNS_copy
-            0x0000000000000572    127     16      1   0             0  is_stmt
+0x00000924: 00 DW_LNE_set_address (0x0000000000000567)
+0x0000092b: 05 DW_LNS_set_column (14)
+0x0000092d: 06 DW_LNS_negate_stmt
+0x0000092e: 01 DW_LNS_copy
+            0x0000000000000567    122     14      1   0             0 
 
 
-0x0000092c: 00 DW_LNE_set_address (0x000000000000057a)
-0x00000933: 05 DW_LNS_set_column (27)
-0x00000935: 06 DW_LNS_negate_stmt
-0x00000936: 01 DW_LNS_copy
-            0x000000000000057a    127     27      1   0             0 
+0x0000092f: 00 DW_LNE_set_address (0x0000000000000570)
+0x00000936: 03 DW_LNS_advance_line (125)
+0x00000938: 05 DW_LNS_set_column (22)
+0x0000093a: 06 DW_LNS_negate_stmt
+0x0000093b: 01 DW_LNS_copy
+            0x0000000000000570    125     22      1   0             0  is_stmt
 
 
-0x00000937: 00 DW_LNE_set_address (0x000000000000057c)
-0x0000093e: 05 DW_LNS_set_column (35)
-0x00000940: 01 DW_LNS_copy
-            0x000000000000057c    127     35      1   0             0 
+0x0000093c: 00 DW_LNE_set_address (0x000000000000057d)
+0x00000943: 03 DW_LNS_advance_line (126)
+0x00000945: 05 DW_LNS_set_column (27)
+0x00000947: 01 DW_LNS_copy
+            0x000000000000057d    126     27      1   0             0  is_stmt
 
 
-0x00000941: 00 DW_LNE_set_address (0x0000000000000585)
-0x00000948: 05 DW_LNS_set_column (27)
-0x0000094a: 01 DW_LNS_copy
-            0x0000000000000585    127     27      1   0             0 
+0x00000948: 00 DW_LNE_set_address (0x0000000000000586)
+0x0000094f: 03 DW_LNS_advance_line (127)
+0x00000951: 05 DW_LNS_set_column (16)
+0x00000953: 01 DW_LNS_copy
+            0x0000000000000586    127     16      1   0             0  is_stmt
 
 
-0x0000094b: 00 DW_LNE_set_address (0x000000000000058a)
-0x00000952: 05 DW_LNS_set_column (25)
-0x00000954: 01 DW_LNS_copy
-            0x000000000000058a    127     25      1   0             0 
+0x00000954: 00 DW_LNE_set_address (0x000000000000058e)
+0x0000095b: 05 DW_LNS_set_column (27)
+0x0000095d: 06 DW_LNS_negate_stmt
+0x0000095e: 01 DW_LNS_copy
+            0x000000000000058e    127     27      1   0             0 
 
 
-0x00000955: 00 DW_LNE_set_address (0x000000000000058d)
-0x0000095c: 03 DW_LNS_advance_line (126)
-0x0000095e: 05 DW_LNS_set_column (27)
-0x00000960: 06 DW_LNS_negate_stmt
-0x00000961: 01 DW_LNS_copy
-            0x000000000000058d    126     27      1   0             0  is_stmt
+0x0000095f: 00 DW_LNE_set_address (0x0000000000000590)
+0x00000966: 05 DW_LNS_set_column (35)
+0x00000968: 01 DW_LNS_copy
+            0x0000000000000590    127     35      1   0             0 
 
 
-0x00000962: 00 DW_LNE_set_address (0x0000000000000592)
-0x00000969: 05 DW_LNS_set_column (13)
-0x0000096b: 06 DW_LNS_negate_stmt
-0x0000096c: 01 DW_LNS_copy
-            0x0000000000000592    126     13      1   0             0 
+0x00000969: 00 DW_LNE_set_address (0x0000000000000599)
+0x00000970: 05 DW_LNS_set_column (27)
+0x00000972: 01 DW_LNS_copy
+            0x0000000000000599    127     27      1   0             0 
 
 
-0x0000096d: 00 DW_LNE_set_address (0x000000000000059a)
-0x00000974: 03 DW_LNS_advance_line (128)
-0x00000976: 06 DW_LNS_negate_stmt
-0x00000977: 01 DW_LNS_copy
-            0x000000000000059a    128     13      1   0             0  is_stmt
+0x00000973: 00 DW_LNE_set_address (0x000000000000059e)
+0x0000097a: 05 DW_LNS_set_column (25)
+0x0000097c: 01 DW_LNS_copy
+            0x000000000000059e    127     25      1   0             0 
 
 
-0x00000978: 00 DW_LNE_set_address (0x00000000000005a2)
-0x0000097f: 05 DW_LNS_set_column (22)
-0x00000981: 06 DW_LNS_negate_stmt
-0x00000982: 01 DW_LNS_copy
-            0x00000000000005a2    128     22      1   0             0 
+0x0000097d: 00 DW_LNE_set_address (0x00000000000005a1)
+0x00000984: 03 DW_LNS_advance_line (126)
+0x00000986: 05 DW_LNS_set_column (27)
+0x00000988: 06 DW_LNS_negate_stmt
+0x00000989: 01 DW_LNS_copy
+            0x00000000000005a1    126     27      1   0             0  is_stmt
 
 
-0x00000983: 00 DW_LNE_set_address (0x00000000000005a7)
-0x0000098a: 03 DW_LNS_advance_line (130)
-0x0000098c: 05 DW_LNS_set_column (16)
-0x0000098e: 06 DW_LNS_negate_stmt
-0x0000098f: 01 DW_LNS_copy
-            0x00000000000005a7    130     16      1   0             0  is_stmt
+0x0000098a: 00 DW_LNE_set_address (0x00000000000005a6)
+0x00000991: 05 DW_LNS_set_column (13)
+0x00000993: 06 DW_LNS_negate_stmt
+0x00000994: 01 DW_LNS_copy
+            0x00000000000005a6    126     13      1   0             0 
 
 
-0x00000990: 00 DW_LNE_set_address (0x00000000000005af)
-0x00000997: 05 DW_LNS_set_column (14)
-0x00000999: 06 DW_LNS_negate_stmt
-0x0000099a: 01 DW_LNS_copy
-            0x00000000000005af    130     14      1   0             0 
+0x00000995: 00 DW_LNE_set_address (0x00000000000005ae)
+0x0000099c: 03 DW_LNS_advance_line (128)
+0x0000099e: 06 DW_LNS_negate_stmt
+0x0000099f: 01 DW_LNS_copy
+            0x00000000000005ae    128     13      1   0             0  is_stmt
 
 
-0x0000099b: 00 DW_LNE_set_address (0x00000000000005be)
-0x000009a2: 05 DW_LNS_set_column (25)
-0x000009a4: 01 DW_LNS_copy
-            0x00000000000005be    130     25      1   0             0 
+0x000009a0: 00 DW_LNE_set_address (0x00000000000005b6)
+0x000009a7: 05 DW_LNS_set_column (22)
+0x000009a9: 06 DW_LNS_negate_stmt
+0x000009aa: 01 DW_LNS_copy
+            0x00000000000005b6    128     22      1   0             0 
 
 
-0x000009a5: 00 DW_LNE_set_address (0x00000000000005c5)
-0x000009ac: 03 DW_LNS_advance_line (133)
-0x000009ae: 05 DW_LNS_set_column (11)
-0x000009b0: 06 DW_LNS_negate_stmt
-0x000009b1: 01 DW_LNS_copy
-            0x00000000000005c5    133     11      1   0             0  is_stmt
+0x000009ab: 00 DW_LNE_set_address (0x00000000000005bb)
+0x000009b2: 03 DW_LNS_advance_line (130)
+0x000009b4: 05 DW_LNS_set_column (16)
+0x000009b6: 06 DW_LNS_negate_stmt
+0x000009b7: 01 DW_LNS_copy
+            0x00000000000005bb    130     16      1   0             0  is_stmt
 
 
-0x000009b2: 00 DW_LNE_set_address (0x00000000000005ca)
-0x000009b9: 03 DW_LNS_advance_line (122)
-0x000009bb: 05 DW_LNS_set_column (16)
-0x000009bd: 01 DW_LNS_copy
-            0x00000000000005ca    122     16      1   0             0  is_stmt
+0x000009b8: 00 DW_LNE_set_address (0x00000000000005c3)
+0x000009bf: 05 DW_LNS_set_column (14)
+0x000009c1: 06 DW_LNS_negate_stmt
+0x000009c2: 01 DW_LNS_copy
+            0x00000000000005c3    130     14      1   0             0 
 
 
-0x000009be: 00 DW_LNE_set_address (0x00000000000005cf)
-0x000009c5: 05 DW_LNS_set_column (14)
-0x000009c7: 06 DW_LNS_negate_stmt
-0x000009c8: 01 DW_LNS_copy
-            0x00000000000005cf    122     14      1   0             0 
+0x000009c3: 00 DW_LNE_set_address (0x00000000000005d2)
+0x000009ca: 05 DW_LNS_set_column (25)
+0x000009cc: 01 DW_LNS_copy
+            0x00000000000005d2    130     25      1   0             0 
 
 
-0x000009c9: 00 DW_LNE_set_address (0x00000000000005d4)
-0x000009d0: 03 DW_LNS_advance_line (130)
-0x000009d2: 06 DW_LNS_negate_stmt
-0x000009d3: 01 DW_LNS_copy
-            0x00000000000005d4    130     14      1   0             0  is_stmt
+0x000009cd: 00 DW_LNE_set_address (0x00000000000005d9)
+0x000009d4: 03 DW_LNS_advance_line (133)
+0x000009d6: 05 DW_LNS_set_column (11)
+0x000009d8: 06 DW_LNS_negate_stmt
+0x000009d9: 01 DW_LNS_copy
+            0x00000000000005d9    133     11      1   0             0  is_stmt
 
 
-0x000009d4: 00 DW_LNE_set_address (0x00000000000005d5)
-0x000009db: 03 DW_LNS_advance_line (110)
-0x000009dd: 05 DW_LNS_set_column (11)
-0x000009df: 01 DW_LNS_copy
-            0x00000000000005d5    110     11      1   0             0  is_stmt
+0x000009da: 00 DW_LNE_set_address (0x00000000000005de)
+0x000009e1: 03 DW_LNS_advance_line (122)
+0x000009e3: 05 DW_LNS_set_column (16)
+0x000009e5: 01 DW_LNS_copy
+            0x00000000000005de    122     16      1   0             0  is_stmt
 
 
-0x000009e0: 00 DW_LNE_set_address (0x00000000000005db)
-0x000009e7: 03 DW_LNS_advance_line (138)
-0x000009e9: 05 DW_LNS_set_column (4)
-0x000009eb: 01 DW_LNS_copy
-            0x00000000000005db    138      4      1   0             0  is_stmt
+0x000009e6: 00 DW_LNE_set_address (0x00000000000005e3)
+0x000009ed: 05 DW_LNS_set_column (14)
+0x000009ef: 06 DW_LNS_negate_stmt
+0x000009f0: 01 DW_LNS_copy
+            0x00000000000005e3    122     14      1   0             0 
 
 
-0x000009ec: 00 DW_LNE_set_address (0x00000000000005df)
-0x000009f3: 03 DW_LNS_advance_line (139)
-0x000009f5: 01 DW_LNS_copy
-            0x00000000000005df    139      4      1   0             0  is_stmt
+0x000009f1: 00 DW_LNE_set_address (0x00000000000005e8)
+0x000009f8: 03 DW_LNS_advance_line (130)
+0x000009fa: 06 DW_LNS_negate_stmt
+0x000009fb: 01 DW_LNS_copy
+            0x00000000000005e8    130     14      1   0             0  is_stmt
 
 
-0x000009f6: 00 DW_LNE_set_address (0x00000000000005ef)
-0x000009fd: 03 DW_LNS_advance_line (142)
-0x000009ff: 05 DW_LNS_set_column (20)
-0x00000a01: 01 DW_LNS_copy
-            0x00000000000005ef    142     20      1   0             0  is_stmt
+0x000009fc: 00 DW_LNE_set_address (0x00000000000005e9)
+0x00000a03: 03 DW_LNS_advance_line (110)
+0x00000a05: 05 DW_LNS_set_column (11)
+0x00000a07: 01 DW_LNS_copy
+            0x00000000000005e9    110     11      1   0             0  is_stmt
 
 
-0x00000a02: 00 DW_LNE_set_address (0x00000000000005f7)
-0x00000a09: 03 DW_LNS_advance_line (146)
-0x00000a0b: 01 DW_LNS_copy
-            0x00000000000005f7    146     20      1   0             0  is_stmt
+0x00000a08: 00 DW_LNE_set_address (0x00000000000005ef)
+0x00000a0f: 03 DW_LNS_advance_line (138)
+0x00000a11: 05 DW_LNS_set_column (4)
+0x00000a13: 01 DW_LNS_copy
+            0x00000000000005ef    138      4      1   0             0  is_stmt
 
 
-0x00000a0c: 00 DW_LNE_set_address (0x00000000000005fe)
-0x00000a13: 03 DW_LNS_advance_line (147)
-0x00000a15: 05 DW_LNS_set_column (7)
-0x00000a17: 01 DW_LNS_copy
-            0x00000000000005fe    147      7      1   0             0  is_stmt
+0x00000a14: 00 DW_LNE_set_address (0x00000000000005f3)
+0x00000a1b: 03 DW_LNS_advance_line (139)
+0x00000a1d: 01 DW_LNS_copy
+            0x00000000000005f3    139      4      1   0             0  is_stmt
 
 
-0x00000a18: 00 DW_LNE_set_address (0x0000000000000602)
-0x00000a1f: 03 DW_LNS_advance_line (143)
-0x00000a21: 05 DW_LNS_set_column (11)
-0x00000a23: 01 DW_LNS_copy
-            0x0000000000000602    143     11      1   0             0  is_stmt
+0x00000a1e: 00 DW_LNE_set_address (0x0000000000000603)
+0x00000a25: 03 DW_LNS_advance_line (142)
+0x00000a27: 05 DW_LNS_set_column (20)
+0x00000a29: 01 DW_LNS_copy
+            0x0000000000000603    142     20      1   0             0  is_stmt
 
 
-0x00000a24: 00 DW_LNE_set_address (0x0000000000000606)
-0x00000a2b: 05 DW_LNS_set_column (20)
-0x00000a2d: 06 DW_LNS_negate_stmt
-0x00000a2e: 01 DW_LNS_copy
-            0x0000000000000606    143     20      1   0             0 
+0x00000a2a: 00 DW_LNE_set_address (0x000000000000060b)
+0x00000a31: 03 DW_LNS_advance_line (146)
+0x00000a33: 01 DW_LNS_copy
+            0x000000000000060b    146     20      1   0             0  is_stmt
 
 
-0x00000a2f: 00 DW_LNE_set_address (0x000000000000060b)
-0x00000a36: 05 DW_LNS_set_column (11)
-0x00000a38: 01 DW_LNS_copy
-            0x000000000000060b    143     11      1   0             0 
+0x00000a34: 00 DW_LNE_set_address (0x0000000000000612)
+0x00000a3b: 03 DW_LNS_advance_line (147)
+0x00000a3d: 05 DW_LNS_set_column (7)
+0x00000a3f: 01 DW_LNS_copy
+            0x0000000000000612    147      7      1   0             0  is_stmt
 
 
-0x00000a39: 00 DW_LNE_set_address (0x0000000000000612)
-0x00000a40: 03 DW_LNS_advance_line (141)
-0x00000a42: 05 DW_LNS_set_column (4)
-0x00000a44: 06 DW_LNS_negate_stmt
-0x00000a45: 01 DW_LNS_copy
-            0x0000000000000612    141      4      1   0             0  is_stmt
+0x00000a40: 00 DW_LNE_set_address (0x0000000000000616)
+0x00000a47: 03 DW_LNS_advance_line (143)
+0x00000a49: 05 DW_LNS_set_column (11)
+0x00000a4b: 01 DW_LNS_copy
+            0x0000000000000616    143     11      1   0             0  is_stmt
 
 
-0x00000a46: 00 DW_LNE_set_address (0x0000000000000618)
-0x00000a4d: 03 DW_LNS_advance_line (159)
-0x00000a4f: 01 DW_LNS_copy
-            0x0000000000000618    159      4      1   0             0  is_stmt
+0x00000a4c: 00 DW_LNE_set_address (0x000000000000061a)
+0x00000a53: 05 DW_LNS_set_column (20)
+0x00000a55: 06 DW_LNS_negate_stmt
+0x00000a56: 01 DW_LNS_copy
+            0x000000000000061a    143     20      1   0             0 
 
 
-0x00000a50: 00 DW_LNE_set_address (0x000000000000062f)
-0x00000a57: 03 DW_LNS_advance_line (161)
-0x00000a59: 05 DW_LNS_set_column (1)
-0x00000a5b: 01 DW_LNS_copy
-            0x000000000000062f    161      1      1   0             0  is_stmt
+0x00000a57: 00 DW_LNE_set_address (0x000000000000061f)
+0x00000a5e: 05 DW_LNS_set_column (11)
+0x00000a60: 01 DW_LNS_copy
+            0x000000000000061f    143     11      1   0             0 
 
 
-0x00000a5c: 00 DW_LNE_set_address (0x0000000000000639)
-0x00000a63: 00 DW_LNE_end_sequence
-            0x0000000000000639    161      1      1   0             0  is_stmt end_sequence
+0x00000a61: 00 DW_LNE_set_address (0x0000000000000626)
+0x00000a68: 03 DW_LNS_advance_line (141)
+0x00000a6a: 05 DW_LNS_set_column (4)
+0x00000a6c: 06 DW_LNS_negate_stmt
+0x00000a6d: 01 DW_LNS_copy
+            0x0000000000000626    141      4      1   0             0  is_stmt
+
+
+0x00000a6e: 00 DW_LNE_set_address (0x000000000000062c)
+0x00000a75: 03 DW_LNS_advance_line (159)
+0x00000a77: 01 DW_LNS_copy
+            0x000000000000062c    159      4      1   0             0  is_stmt
+
+
+0x00000a78: 00 DW_LNE_set_address (0x0000000000000643)
+0x00000a7f: 03 DW_LNS_advance_line (161)
+0x00000a81: 05 DW_LNS_set_column (1)
+0x00000a83: 01 DW_LNS_copy
+            0x0000000000000643    161      1      1   0             0  is_stmt
+
+
+0x00000a84: 00 DW_LNE_set_address (0x000000000000064d)
+0x00000a8b: 00 DW_LNE_end_sequence
+            0x000000000000064d    161      1      1   0             0  is_stmt end_sequence
 
 
 .debug_str contents:
@@ -4672,16 +4698,16 @@ file_names[  4]:
 0x000001ad: "char"
 
 .debug_ranges contents:
-00000000 00000162 000001a0
-00000000 000001ca 000001d3
-00000000 000002df 0000031d
-00000000 00000347 00000350
+00000000 00000166 000001a4
+00000000 000001ce 000001d7
+00000000 000002e9 00000327
+00000000 00000351 0000035a
 00000000 <End of list>
-00000028 000004a4 000004e9
-00000028 0000055c 000005a7
+00000028 000004b4 000004f9
+00000028 00000570 000005bb
 00000028 <End of list>
-00000040 00000007 00000364
-00000040 00000366 00000639
+00000040 00000007 00000370
+00000040 00000372 0000064d
 00000040 <End of list>
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -4703,11 +4729,11 @@ file_names[  4]:
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__data_end" (global $global$1))
- (func $__wasm_call_ctors
+ (func $__wasm_call_ctors (; has Stack IR ;)
   ;; code offset: 0x3
   (nop)
  )
- (func $fannkuch_worker\28void*\29 (param $0 i32) (result i32)
+ (func $fannkuch_worker\28void*\29 (; has Stack IR ;) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -4724,8 +4750,6 @@ file_names[  4]:
   (local $14 i32)
   (local $15 i32)
   (local $16 i32)
-  (local $17 i32)
-  (local $18 i32)
   ;; code offset: 0x18
   (local.set $3
    ;; code offset: 0x16
@@ -4914,186 +4938,186 @@ file_names[  4]:
           ;; code offset: 0x92
           (local.get $2)
          )
-         ;; code offset: 0xa0
-         (br_if $label$7
-          (block (result i32)
-           (local.set $17
-            ;; code offset: 0x9b
-            (i32.gt_s
-             ;; code offset: 0x97
-             (local.get $2)
-             ;; code offset: 0x99
-             (i32.const 2)
-            )
-           )
-           ;; code offset: 0x9e
-           (local.set $2
-            ;; code offset: 0x9c
-            (local.get $1)
-           )
-           (local.get $17)
+         ;; code offset: 0x9c
+         (local.set $0
+          ;; code offset: 0x9b
+          (i32.gt_s
+           ;; code offset: 0x97
+           (local.get $2)
+           ;; code offset: 0x99
+           (i32.const 2)
           )
+         )
+         ;; code offset: 0xa0
+         (local.set $2
+          ;; code offset: 0x9e
+          (local.get $1)
+         )
+         ;; code offset: 0xa4
+         (br_if $label$7
+          ;; code offset: 0xa2
+          (local.get $0)
          )
         )
        )
-       ;; code offset: 0xa4
+       ;; code offset: 0xa8
        (block $label$8
-        ;; code offset: 0xae
+        ;; code offset: 0xb2
         (br_if $label$8
-         ;; code offset: 0xad
+         ;; code offset: 0xb1
          (i32.eqz
-          ;; code offset: 0xab
+          ;; code offset: 0xaf
           (local.tee $10
-           ;; code offset: 0xa8
+           ;; code offset: 0xac
            (i32.load
-            ;; code offset: 0xa6
+            ;; code offset: 0xaa
             (local.get $3)
            )
           )
          )
         )
-        ;; code offset: 0xb8
+        ;; code offset: 0xbc
         (br_if $label$8
-         ;; code offset: 0xb7
+         ;; code offset: 0xbb
          (i32.eq
-          ;; code offset: 0xb2
+          ;; code offset: 0xb6
           (i32.load
-           ;; code offset: 0xb0
+           ;; code offset: 0xb4
            (local.get $13)
           )
-          ;; code offset: 0xb5
+          ;; code offset: 0xb9
           (local.get $4)
          )
         )
-        ;; code offset: 0xc7
+        ;; code offset: 0xcb
         (local.set $6
-         ;; code offset: 0xc4
+         ;; code offset: 0xc8
          (i32.load
-          ;; code offset: 0xc2
+          ;; code offset: 0xc6
           (local.tee $11
-           ;; code offset: 0xc0
+           ;; code offset: 0xc4
            (call $memcpy
-            ;; code offset: 0xba
-            (local.get $8)
-            ;; code offset: 0xbc
-            (local.get $3)
             ;; code offset: 0xbe
+            (local.get $8)
+            ;; code offset: 0xc0
+            (local.get $3)
+            ;; code offset: 0xc2
             (local.get $12)
            )
           )
          )
         )
-        ;; code offset: 0xcb
+        ;; code offset: 0xcf
         (local.set $0
-         ;; code offset: 0xc9
+         ;; code offset: 0xcd
          (i32.const 0)
         )
-        ;; code offset: 0xcd
+        ;; code offset: 0xd1
         (loop $label$9
-         ;; code offset: 0xd1
+         ;; code offset: 0xd5
          (local.set $16
-          ;; code offset: 0xcf
+          ;; code offset: 0xd3
           (local.get $0)
          )
-         ;; code offset: 0xd8
+         ;; code offset: 0xdc
          (if
-          ;; code offset: 0xd7
+          ;; code offset: 0xdb
           (i32.ge_s
-           ;; code offset: 0xd3
+           ;; code offset: 0xd7
            (local.get $6)
-           ;; code offset: 0xd5
+           ;; code offset: 0xd9
            (i32.const 3)
           )
           (block
-           ;; code offset: 0xdf
+           ;; code offset: 0xe3
            (local.set $1
-            ;; code offset: 0xde
+            ;; code offset: 0xe2
             (i32.add
-             ;; code offset: 0xda
+             ;; code offset: 0xde
              (local.get $6)
-             ;; code offset: 0xdc
+             ;; code offset: 0xe0
              (i32.const -1)
             )
            )
-           ;; code offset: 0xe3
+           ;; code offset: 0xe7
            (local.set $0
-            ;; code offset: 0xe1
+            ;; code offset: 0xe5
             (i32.const 1)
            )
-           ;; code offset: 0xe5
+           ;; code offset: 0xe9
            (loop $label$11
-            ;; code offset: 0xf4
+            ;; code offset: 0xf8
             (local.set $15
-             ;; code offset: 0xf1
+             ;; code offset: 0xf5
              (i32.load
-              ;; code offset: 0xef
+              ;; code offset: 0xf3
               (local.tee $14
-               ;; code offset: 0xee
+               ;; code offset: 0xf2
                (i32.add
-                ;; code offset: 0xe7
+                ;; code offset: 0xeb
                 (local.get $11)
-                ;; code offset: 0xed
+                ;; code offset: 0xf1
                 (i32.shl
-                 ;; code offset: 0xe9
+                 ;; code offset: 0xed
                  (local.get $0)
-                 ;; code offset: 0xeb
+                 ;; code offset: 0xef
                  (i32.const 2)
                 )
                )
               )
              )
             )
-            ;; code offset: 0x105
+            ;; code offset: 0x109
             (i32.store
-             ;; code offset: 0xf6
+             ;; code offset: 0xfa
              (local.get $14)
-             ;; code offset: 0x102
+             ;; code offset: 0x106
              (i32.load
-              ;; code offset: 0x100
+              ;; code offset: 0x104
               (local.tee $7
-               ;; code offset: 0xff
+               ;; code offset: 0x103
                (i32.add
-                ;; code offset: 0xf8
+                ;; code offset: 0xfc
                 (local.get $11)
-                ;; code offset: 0xfe
+                ;; code offset: 0x102
                 (i32.shl
-                 ;; code offset: 0xfa
+                 ;; code offset: 0xfe
                  (local.get $1)
-                 ;; code offset: 0xfc
+                 ;; code offset: 0x100
                  (i32.const 2)
                 )
                )
               )
              )
             )
-            ;; code offset: 0x10c
+            ;; code offset: 0x110
             (i32.store
-             ;; code offset: 0x108
+             ;; code offset: 0x10c
              (local.get $7)
-             ;; code offset: 0x10a
+             ;; code offset: 0x10e
              (local.get $15)
             )
-            ;; code offset: 0x11e
+            ;; code offset: 0x122
             (br_if $label$11
-             ;; code offset: 0x11d
+             ;; code offset: 0x121
              (i32.lt_s
-              ;; code offset: 0x114
+              ;; code offset: 0x118
               (local.tee $0
-               ;; code offset: 0x113
+               ;; code offset: 0x117
                (i32.add
-                ;; code offset: 0x10f
+                ;; code offset: 0x113
                 (local.get $0)
-                ;; code offset: 0x111
+                ;; code offset: 0x115
                 (i32.const 1)
                )
               )
-              ;; code offset: 0x11b
+              ;; code offset: 0x11f
               (local.tee $1
-               ;; code offset: 0x11a
+               ;; code offset: 0x11e
                (i32.add
-                ;; code offset: 0x116
+                ;; code offset: 0x11a
                 (local.get $1)
-                ;; code offset: 0x118
+                ;; code offset: 0x11c
                 (i32.const -1)
                )
               )
@@ -5102,508 +5126,508 @@ file_names[  4]:
            )
           )
          )
-         ;; code offset: 0x12f
+         ;; code offset: 0x133
          (local.set $1
-          ;; code offset: 0x12c
+          ;; code offset: 0x130
           (i32.load
-           ;; code offset: 0x12a
+           ;; code offset: 0x12e
            (local.tee $0
-            ;; code offset: 0x129
+            ;; code offset: 0x12d
             (i32.add
-             ;; code offset: 0x122
+             ;; code offset: 0x126
              (local.get $11)
-             ;; code offset: 0x128
+             ;; code offset: 0x12c
              (i32.shl
-              ;; code offset: 0x124
+              ;; code offset: 0x128
               (local.get $6)
-              ;; code offset: 0x126
+              ;; code offset: 0x12a
               (i32.const 2)
              )
             )
            )
           )
          )
-         ;; code offset: 0x135
+         ;; code offset: 0x139
          (i32.store
-          ;; code offset: 0x131
+          ;; code offset: 0x135
           (local.get $0)
-          ;; code offset: 0x133
+          ;; code offset: 0x137
           (local.get $6)
          )
-         ;; code offset: 0x13d
+         ;; code offset: 0x141
          (local.set $0
-          ;; code offset: 0x13c
+          ;; code offset: 0x140
           (i32.add
-           ;; code offset: 0x138
+           ;; code offset: 0x13c
            (local.get $16)
-           ;; code offset: 0x13a
+           ;; code offset: 0x13e
            (i32.const 1)
           )
          )
-         ;; code offset: 0x141
-         (local.set $6
-          ;; code offset: 0x13f
-          (local.get $1)
-         )
          ;; code offset: 0x145
-         (br_if $label$9
+         (local.set $6
           ;; code offset: 0x143
           (local.get $1)
          )
+         ;; code offset: 0x149
+         (br_if $label$9
+          ;; code offset: 0x147
+          (local.get $1)
+         )
         )
-        ;; code offset: 0x152
+        ;; code offset: 0x156
         (local.set $5
-         ;; code offset: 0x151
+         ;; code offset: 0x155
          (select
-          ;; code offset: 0x148
+          ;; code offset: 0x14c
           (local.get $5)
-          ;; code offset: 0x14a
+          ;; code offset: 0x14e
           (local.get $0)
-          ;; code offset: 0x150
+          ;; code offset: 0x154
           (i32.gt_s
-           ;; code offset: 0x14c
+           ;; code offset: 0x150
            (local.get $5)
-           ;; code offset: 0x14e
+           ;; code offset: 0x152
            (local.get $16)
           )
          )
         )
        )
-       ;; code offset: 0x15a
+       ;; code offset: 0x15e
        (br_if $label$1
-        ;; code offset: 0x159
+        ;; code offset: 0x15d
         (i32.ge_s
-         ;; code offset: 0x155
+         ;; code offset: 0x159
          (local.get $2)
-         ;; code offset: 0x157
+         ;; code offset: 0x15b
          (local.get $4)
         )
        )
-       ;; code offset: 0x15c
+       ;; code offset: 0x160
        (loop $label$12
-        ;; code offset: 0x160
+        ;; code offset: 0x164
         (local.set $1
-         ;; code offset: 0x15e
+         ;; code offset: 0x162
          (i32.const 0)
         )
-        ;; code offset: 0x167
+        ;; code offset: 0x16b
         (if
-         ;; code offset: 0x166
+         ;; code offset: 0x16a
          (i32.gt_s
-          ;; code offset: 0x162
+          ;; code offset: 0x166
           (local.get $2)
-          ;; code offset: 0x164
+          ;; code offset: 0x168
           (i32.const 0)
          )
          (block
-          ;; code offset: 0x169
+          ;; code offset: 0x16d
           (loop $label$14
-           ;; code offset: 0x183
+           ;; code offset: 0x187
            (i32.store
-            ;; code offset: 0x172
+            ;; code offset: 0x176
             (i32.add
-             ;; code offset: 0x16b
+             ;; code offset: 0x16f
              (local.get $3)
-             ;; code offset: 0x171
+             ;; code offset: 0x175
              (i32.shl
-              ;; code offset: 0x16d
+              ;; code offset: 0x171
               (local.get $1)
-              ;; code offset: 0x16f
+              ;; code offset: 0x173
               (i32.const 2)
              )
             )
-            ;; code offset: 0x180
+            ;; code offset: 0x184
             (i32.load
-             ;; code offset: 0x17f
+             ;; code offset: 0x183
              (i32.add
-              ;; code offset: 0x173
+              ;; code offset: 0x177
               (local.get $3)
-              ;; code offset: 0x17e
+              ;; code offset: 0x182
               (i32.shl
-               ;; code offset: 0x17a
+               ;; code offset: 0x17e
                (local.tee $1
-                ;; code offset: 0x179
+                ;; code offset: 0x17d
                 (i32.add
-                 ;; code offset: 0x175
+                 ;; code offset: 0x179
                  (local.get $1)
-                 ;; code offset: 0x177
+                 ;; code offset: 0x17b
                  (i32.const 1)
                 )
                )
-               ;; code offset: 0x17c
+               ;; code offset: 0x180
                (i32.const 2)
               )
              )
             )
            )
-           ;; code offset: 0x18b
+           ;; code offset: 0x18f
            (br_if $label$14
-            ;; code offset: 0x18a
+            ;; code offset: 0x18e
             (i32.ne
-             ;; code offset: 0x186
+             ;; code offset: 0x18a
              (local.get $1)
-             ;; code offset: 0x188
+             ;; code offset: 0x18c
              (local.get $2)
             )
            )
           )
-          ;; code offset: 0x190
+          ;; code offset: 0x194
           (local.set $1
-           ;; code offset: 0x18e
+           ;; code offset: 0x192
            (local.get $2)
           )
          )
         )
-        ;; code offset: 0x19d
+        ;; code offset: 0x1a1
         (i32.store
-         ;; code offset: 0x19a
+         ;; code offset: 0x19e
          (i32.add
-          ;; code offset: 0x193
+          ;; code offset: 0x197
           (local.get $3)
-          ;; code offset: 0x199
+          ;; code offset: 0x19d
           (i32.shl
-           ;; code offset: 0x195
+           ;; code offset: 0x199
            (local.get $1)
-           ;; code offset: 0x197
+           ;; code offset: 0x19b
            (i32.const 2)
           )
          )
-         ;; code offset: 0x19b
+         ;; code offset: 0x19f
          (local.get $10)
         )
-        ;; code offset: 0x1b4
+        ;; code offset: 0x1b8
         (i32.store
-         ;; code offset: 0x1a8
+         ;; code offset: 0x1ac
          (local.tee $1
-          ;; code offset: 0x1a7
+          ;; code offset: 0x1ab
           (i32.add
-           ;; code offset: 0x1a0
+           ;; code offset: 0x1a4
            (local.get $9)
-           ;; code offset: 0x1a6
+           ;; code offset: 0x1aa
            (i32.shl
-            ;; code offset: 0x1a2
+            ;; code offset: 0x1a6
             (local.get $2)
-            ;; code offset: 0x1a4
+            ;; code offset: 0x1a8
             (i32.const 2)
            )
           )
          )
-         ;; code offset: 0x1b3
+         ;; code offset: 0x1b7
          (i32.add
-          ;; code offset: 0x1af
+          ;; code offset: 0x1b3
           (local.tee $1
-           ;; code offset: 0x1ac
+           ;; code offset: 0x1b0
            (i32.load
-            ;; code offset: 0x1aa
+            ;; code offset: 0x1ae
             (local.get $1)
            )
           )
-          ;; code offset: 0x1b1
+          ;; code offset: 0x1b5
           (i32.const -1)
          )
         )
-        ;; code offset: 0x1bc
+        ;; code offset: 0x1c0
         (br_if $label$5
-         ;; code offset: 0x1bb
+         ;; code offset: 0x1bf
          (i32.gt_s
-          ;; code offset: 0x1b7
+          ;; code offset: 0x1bb
           (local.get $1)
-          ;; code offset: 0x1b9
+          ;; code offset: 0x1bd
           (i32.const 1)
          )
         )
-        ;; code offset: 0x1c8
+        ;; code offset: 0x1cc
         (br_if $label$1
-         ;; code offset: 0x1c7
+         ;; code offset: 0x1cb
          (i32.eq
-          ;; code offset: 0x1c3
+          ;; code offset: 0x1c7
           (local.tee $2
-           ;; code offset: 0x1c2
+           ;; code offset: 0x1c6
            (i32.add
-            ;; code offset: 0x1be
+            ;; code offset: 0x1c2
             (local.get $2)
-            ;; code offset: 0x1c0
+            ;; code offset: 0x1c4
             (i32.const 1)
            )
           )
-          ;; code offset: 0x1c5
+          ;; code offset: 0x1c9
           (local.get $4)
          )
         )
-        ;; code offset: 0x1cf
+        ;; code offset: 0x1d3
         (local.set $10
-         ;; code offset: 0x1cc
+         ;; code offset: 0x1d0
          (i32.load
-          ;; code offset: 0x1ca
+          ;; code offset: 0x1ce
           (local.get $3)
          )
         )
-        ;; code offset: 0x1d1
+        ;; code offset: 0x1d5
         (br $label$12)
        )
       )
      )
     )
-    ;; code offset: 0x1ec
+    ;; code offset: 0x1f2
     (i32.store
-     ;; code offset: 0x1e4
+     ;; code offset: 0x1ea
      (i32.add
-      ;; code offset: 0x1d8
+      ;; code offset: 0x1de
       (local.get $3)
-      ;; code offset: 0x1e3
+      ;; code offset: 0x1e9
       (i32.shl
-       ;; code offset: 0x1df
+       ;; code offset: 0x1e5
        (local.tee $1
-        ;; code offset: 0x1dc
+        ;; code offset: 0x1e2
         (i32.load
-         ;; code offset: 0x1da
+         ;; code offset: 0x1e0
          (local.get $0)
         )
        )
-       ;; code offset: 0x1e1
+       ;; code offset: 0x1e7
        (i32.const 2)
       )
      )
-     ;; code offset: 0x1ea
+     ;; code offset: 0x1f0
      (local.tee $4
-      ;; code offset: 0x1e9
+      ;; code offset: 0x1ef
       (i32.add
-       ;; code offset: 0x1e5
+       ;; code offset: 0x1eb
        (local.get $2)
-       ;; code offset: 0x1e7
+       ;; code offset: 0x1ed
        (i32.const -1)
       )
      )
     )
-    ;; code offset: 0x1fb
+    ;; code offset: 0x201
     (i32.store
-     ;; code offset: 0x1f7
+     ;; code offset: 0x1fd
      (local.tee $13
-      ;; code offset: 0x1f6
+      ;; code offset: 0x1fc
       (i32.add
-       ;; code offset: 0x1ef
-       (local.get $3)
        ;; code offset: 0x1f5
+       (local.get $3)
+       ;; code offset: 0x1fb
        (i32.shl
-        ;; code offset: 0x1f1
+        ;; code offset: 0x1f7
         (local.get $4)
-        ;; code offset: 0x1f3
+        ;; code offset: 0x1f9
         (i32.const 2)
        )
       )
      )
-     ;; code offset: 0x1f9
+     ;; code offset: 0x1ff
      (local.get $1)
     )
    )
-   ;; code offset: 0x1ff
+   ;; code offset: 0x205
    (loop $label$15
-    ;; code offset: 0x206
+    ;; code offset: 0x20c
     (if
-     ;; code offset: 0x205
+     ;; code offset: 0x20b
      (i32.ge_s
-      ;; code offset: 0x201
+      ;; code offset: 0x207
       (local.get $2)
-      ;; code offset: 0x203
+      ;; code offset: 0x209
       (i32.const 2)
      )
-     ;; code offset: 0x208
+     ;; code offset: 0x20e
      (loop $label$17
-      ;; code offset: 0x219
+      ;; code offset: 0x21f
       (i32.store
-       ;; code offset: 0x216
+       ;; code offset: 0x21c
        (i32.add
-        ;; code offset: 0x20a
+        ;; code offset: 0x210
         (local.get $9)
-        ;; code offset: 0x215
+        ;; code offset: 0x21b
         (i32.shl
-         ;; code offset: 0x211
+         ;; code offset: 0x217
          (local.tee $1
-          ;; code offset: 0x210
+          ;; code offset: 0x216
           (i32.add
-           ;; code offset: 0x20c
+           ;; code offset: 0x212
            (local.get $2)
-           ;; code offset: 0x20e
+           ;; code offset: 0x214
            (i32.const -1)
           )
          )
-         ;; code offset: 0x213
+         ;; code offset: 0x219
          (i32.const 2)
         )
        )
-       ;; code offset: 0x217
+       ;; code offset: 0x21d
        (local.get $2)
       )
-      ;; code offset: 0x225
-      (br_if $label$17
-       (block (result i32)
-        (local.set $18
-         ;; code offset: 0x220
-         (i32.gt_s
-          ;; code offset: 0x21c
-          (local.get $2)
-          ;; code offset: 0x21e
-          (i32.const 2)
-         )
-        )
-        ;; code offset: 0x223
-        (local.set $2
-         ;; code offset: 0x221
-         (local.get $1)
-        )
-        (local.get $18)
+      ;; code offset: 0x227
+      (local.set $0
+       ;; code offset: 0x226
+       (i32.gt_s
+        ;; code offset: 0x222
+        (local.get $2)
+        ;; code offset: 0x224
+        (i32.const 2)
        )
+      )
+      ;; code offset: 0x22b
+      (local.set $2
+       ;; code offset: 0x229
+       (local.get $1)
+      )
+      ;; code offset: 0x22f
+      (br_if $label$17
+       ;; code offset: 0x22d
+       (local.get $0)
       )
      )
     )
-    ;; code offset: 0x229
+    ;; code offset: 0x233
     (block $label$18
-     ;; code offset: 0x233
+     ;; code offset: 0x23d
      (br_if $label$18
-      ;; code offset: 0x232
+      ;; code offset: 0x23c
       (i32.eqz
-       ;; code offset: 0x230
+       ;; code offset: 0x23a
        (local.tee $6
-        ;; code offset: 0x22d
+        ;; code offset: 0x237
         (i32.load
-         ;; code offset: 0x22b
+         ;; code offset: 0x235
          (local.get $3)
         )
        )
       )
      )
-     ;; code offset: 0x23d
+     ;; code offset: 0x247
      (br_if $label$18
-      ;; code offset: 0x23c
+      ;; code offset: 0x246
       (i32.eq
-       ;; code offset: 0x237
+       ;; code offset: 0x241
        (i32.load
-        ;; code offset: 0x235
+        ;; code offset: 0x23f
         (local.get $13)
        )
-       ;; code offset: 0x23a
+       ;; code offset: 0x244
        (local.get $4)
       )
      )
-     ;; code offset: 0x244
+     ;; code offset: 0x24e
      (local.set $7
-      ;; code offset: 0x241
+      ;; code offset: 0x24b
       (i32.load
-       ;; code offset: 0x23f
+       ;; code offset: 0x249
        (local.get $8)
       )
      )
-     ;; code offset: 0x248
+     ;; code offset: 0x252
      (local.set $0
-      ;; code offset: 0x246
+      ;; code offset: 0x250
       (i32.const 0)
      )
-     ;; code offset: 0x24a
+     ;; code offset: 0x254
      (loop $label$19
-      ;; code offset: 0x24e
+      ;; code offset: 0x258
       (local.set $10
-       ;; code offset: 0x24c
+       ;; code offset: 0x256
        (local.get $0)
       )
-      ;; code offset: 0x255
+      ;; code offset: 0x25f
       (if
-       ;; code offset: 0x254
+       ;; code offset: 0x25e
        (i32.ge_s
-        ;; code offset: 0x250
+        ;; code offset: 0x25a
         (local.get $7)
-        ;; code offset: 0x252
+        ;; code offset: 0x25c
         (i32.const 3)
        )
        (block
-        ;; code offset: 0x25c
+        ;; code offset: 0x266
         (local.set $1
-         ;; code offset: 0x25b
+         ;; code offset: 0x265
          (i32.add
-          ;; code offset: 0x257
+          ;; code offset: 0x261
           (local.get $7)
-          ;; code offset: 0x259
+          ;; code offset: 0x263
           (i32.const -1)
          )
         )
-        ;; code offset: 0x260
+        ;; code offset: 0x26a
         (local.set $0
-         ;; code offset: 0x25e
+         ;; code offset: 0x268
          (i32.const 1)
         )
-        ;; code offset: 0x262
+        ;; code offset: 0x26c
         (loop $label$21
-         ;; code offset: 0x271
+         ;; code offset: 0x27b
          (local.set $14
-          ;; code offset: 0x26e
+          ;; code offset: 0x278
           (i32.load
-           ;; code offset: 0x26c
+           ;; code offset: 0x276
            (local.tee $11
-            ;; code offset: 0x26b
+            ;; code offset: 0x275
             (i32.add
-             ;; code offset: 0x264
+             ;; code offset: 0x26e
              (local.get $8)
-             ;; code offset: 0x26a
+             ;; code offset: 0x274
              (i32.shl
-              ;; code offset: 0x266
+              ;; code offset: 0x270
               (local.get $0)
-              ;; code offset: 0x268
+              ;; code offset: 0x272
               (i32.const 2)
              )
             )
            )
           )
          )
-         ;; code offset: 0x282
+         ;; code offset: 0x28c
          (i32.store
-          ;; code offset: 0x273
+          ;; code offset: 0x27d
           (local.get $11)
-          ;; code offset: 0x27f
+          ;; code offset: 0x289
           (i32.load
-           ;; code offset: 0x27d
+           ;; code offset: 0x287
            (local.tee $15
-            ;; code offset: 0x27c
+            ;; code offset: 0x286
             (i32.add
-             ;; code offset: 0x275
+             ;; code offset: 0x27f
              (local.get $8)
-             ;; code offset: 0x27b
+             ;; code offset: 0x285
              (i32.shl
-              ;; code offset: 0x277
+              ;; code offset: 0x281
               (local.get $1)
-              ;; code offset: 0x279
+              ;; code offset: 0x283
               (i32.const 2)
              )
             )
            )
           )
          )
-         ;; code offset: 0x289
+         ;; code offset: 0x293
          (i32.store
-          ;; code offset: 0x285
+          ;; code offset: 0x28f
           (local.get $15)
-          ;; code offset: 0x287
+          ;; code offset: 0x291
           (local.get $14)
          )
-         ;; code offset: 0x29b
+         ;; code offset: 0x2a5
          (br_if $label$21
-          ;; code offset: 0x29a
+          ;; code offset: 0x2a4
           (i32.lt_s
-           ;; code offset: 0x291
+           ;; code offset: 0x29b
            (local.tee $0
-            ;; code offset: 0x290
+            ;; code offset: 0x29a
             (i32.add
-             ;; code offset: 0x28c
+             ;; code offset: 0x296
              (local.get $0)
-             ;; code offset: 0x28e
+             ;; code offset: 0x298
              (i32.const 1)
             )
            )
-           ;; code offset: 0x298
+           ;; code offset: 0x2a2
            (local.tee $1
-            ;; code offset: 0x297
+            ;; code offset: 0x2a1
             (i32.add
-             ;; code offset: 0x293
+             ;; code offset: 0x29d
              (local.get $1)
-             ;; code offset: 0x295
+             ;; code offset: 0x29f
              (i32.const -1)
             )
            )
@@ -5612,266 +5636,266 @@ file_names[  4]:
         )
        )
       )
-      ;; code offset: 0x2ac
+      ;; code offset: 0x2b6
       (local.set $1
-       ;; code offset: 0x2a9
+       ;; code offset: 0x2b3
        (i32.load
-        ;; code offset: 0x2a7
+        ;; code offset: 0x2b1
         (local.tee $0
-         ;; code offset: 0x2a6
+         ;; code offset: 0x2b0
          (i32.add
-          ;; code offset: 0x29f
+          ;; code offset: 0x2a9
           (local.get $8)
-          ;; code offset: 0x2a5
+          ;; code offset: 0x2af
           (i32.shl
-           ;; code offset: 0x2a1
+           ;; code offset: 0x2ab
            (local.get $7)
-           ;; code offset: 0x2a3
+           ;; code offset: 0x2ad
            (i32.const 2)
           )
          )
         )
        )
       )
-      ;; code offset: 0x2b2
+      ;; code offset: 0x2bc
       (i32.store
-       ;; code offset: 0x2ae
+       ;; code offset: 0x2b8
        (local.get $0)
-       ;; code offset: 0x2b0
+       ;; code offset: 0x2ba
        (local.get $7)
       )
-      ;; code offset: 0x2ba
+      ;; code offset: 0x2c4
       (local.set $0
-       ;; code offset: 0x2b9
+       ;; code offset: 0x2c3
        (i32.add
-        ;; code offset: 0x2b5
+        ;; code offset: 0x2bf
         (local.get $10)
-        ;; code offset: 0x2b7
+        ;; code offset: 0x2c1
         (i32.const 1)
        )
       )
-      ;; code offset: 0x2be
+      ;; code offset: 0x2c8
       (local.set $7
-       ;; code offset: 0x2bc
+       ;; code offset: 0x2c6
        (local.get $1)
       )
-      ;; code offset: 0x2c2
+      ;; code offset: 0x2cc
       (br_if $label$19
-       ;; code offset: 0x2c0
+       ;; code offset: 0x2ca
        (local.get $1)
       )
      )
-     ;; code offset: 0x2cf
+     ;; code offset: 0x2d9
      (local.set $5
-      ;; code offset: 0x2ce
+      ;; code offset: 0x2d8
       (select
-       ;; code offset: 0x2c5
+       ;; code offset: 0x2cf
        (local.get $5)
-       ;; code offset: 0x2c7
+       ;; code offset: 0x2d1
        (local.get $0)
-       ;; code offset: 0x2cd
+       ;; code offset: 0x2d7
        (i32.gt_s
-        ;; code offset: 0x2c9
+        ;; code offset: 0x2d3
         (local.get $5)
-        ;; code offset: 0x2cb
+        ;; code offset: 0x2d5
         (local.get $10)
        )
       )
      )
     )
-    ;; code offset: 0x2d7
+    ;; code offset: 0x2e1
     (br_if $label$1
-     ;; code offset: 0x2d6
+     ;; code offset: 0x2e0
      (i32.ge_s
-      ;; code offset: 0x2d2
+      ;; code offset: 0x2dc
       (local.get $2)
-      ;; code offset: 0x2d4
+      ;; code offset: 0x2de
       (local.get $4)
      )
     )
-    ;; code offset: 0x2d9
+    ;; code offset: 0x2e3
     (loop $label$22
-     ;; code offset: 0x2dd
+     ;; code offset: 0x2e7
      (local.set $1
-      ;; code offset: 0x2db
+      ;; code offset: 0x2e5
       (i32.const 0)
      )
-     ;; code offset: 0x2e4
+     ;; code offset: 0x2ee
      (if
-      ;; code offset: 0x2e3
+      ;; code offset: 0x2ed
       (i32.ge_s
-       ;; code offset: 0x2df
+       ;; code offset: 0x2e9
        (local.get $2)
-       ;; code offset: 0x2e1
+       ;; code offset: 0x2eb
        (i32.const 1)
       )
       (block
-       ;; code offset: 0x2e6
+       ;; code offset: 0x2f0
        (loop $label$24
-        ;; code offset: 0x300
+        ;; code offset: 0x30a
         (i32.store
-         ;; code offset: 0x2ef
+         ;; code offset: 0x2f9
          (i32.add
-          ;; code offset: 0x2e8
+          ;; code offset: 0x2f2
           (local.get $3)
-          ;; code offset: 0x2ee
+          ;; code offset: 0x2f8
           (i32.shl
-           ;; code offset: 0x2ea
+           ;; code offset: 0x2f4
            (local.get $1)
-           ;; code offset: 0x2ec
+           ;; code offset: 0x2f6
            (i32.const 2)
           )
          )
-         ;; code offset: 0x2fd
+         ;; code offset: 0x307
          (i32.load
-          ;; code offset: 0x2fc
+          ;; code offset: 0x306
           (i32.add
-           ;; code offset: 0x2f0
+           ;; code offset: 0x2fa
            (local.get $3)
-           ;; code offset: 0x2fb
+           ;; code offset: 0x305
            (i32.shl
-            ;; code offset: 0x2f7
+            ;; code offset: 0x301
             (local.tee $1
-             ;; code offset: 0x2f6
+             ;; code offset: 0x300
              (i32.add
-              ;; code offset: 0x2f2
+              ;; code offset: 0x2fc
               (local.get $1)
-              ;; code offset: 0x2f4
+              ;; code offset: 0x2fe
               (i32.const 1)
              )
             )
-            ;; code offset: 0x2f9
+            ;; code offset: 0x303
             (i32.const 2)
            )
           )
          )
         )
-        ;; code offset: 0x308
+        ;; code offset: 0x312
         (br_if $label$24
-         ;; code offset: 0x307
+         ;; code offset: 0x311
          (i32.ne
-          ;; code offset: 0x303
+          ;; code offset: 0x30d
           (local.get $1)
-          ;; code offset: 0x305
+          ;; code offset: 0x30f
           (local.get $2)
          )
         )
        )
-       ;; code offset: 0x30d
+       ;; code offset: 0x317
        (local.set $1
-        ;; code offset: 0x30b
+        ;; code offset: 0x315
         (local.get $2)
        )
       )
      )
-     ;; code offset: 0x31a
+     ;; code offset: 0x324
      (i32.store
-      ;; code offset: 0x317
+      ;; code offset: 0x321
       (i32.add
-       ;; code offset: 0x310
+       ;; code offset: 0x31a
        (local.get $3)
-       ;; code offset: 0x316
+       ;; code offset: 0x320
        (i32.shl
-        ;; code offset: 0x312
+        ;; code offset: 0x31c
         (local.get $1)
-        ;; code offset: 0x314
+        ;; code offset: 0x31e
         (i32.const 2)
        )
       )
-      ;; code offset: 0x318
+      ;; code offset: 0x322
       (local.get $6)
      )
-     ;; code offset: 0x331
+     ;; code offset: 0x33b
      (i32.store
-      ;; code offset: 0x325
+      ;; code offset: 0x32f
       (local.tee $1
-       ;; code offset: 0x324
+       ;; code offset: 0x32e
        (i32.add
-        ;; code offset: 0x31d
+        ;; code offset: 0x327
         (local.get $9)
-        ;; code offset: 0x323
+        ;; code offset: 0x32d
         (i32.shl
-         ;; code offset: 0x31f
+         ;; code offset: 0x329
          (local.get $2)
-         ;; code offset: 0x321
+         ;; code offset: 0x32b
          (i32.const 2)
         )
        )
       )
-      ;; code offset: 0x330
+      ;; code offset: 0x33a
       (i32.add
-       ;; code offset: 0x32c
+       ;; code offset: 0x336
        (local.tee $1
-        ;; code offset: 0x329
+        ;; code offset: 0x333
         (i32.load
-         ;; code offset: 0x327
+         ;; code offset: 0x331
          (local.get $1)
         )
        )
-       ;; code offset: 0x32e
+       ;; code offset: 0x338
        (i32.const -1)
       )
      )
-     ;; code offset: 0x339
+     ;; code offset: 0x343
      (br_if $label$15
-      ;; code offset: 0x338
+      ;; code offset: 0x342
       (i32.gt_s
-       ;; code offset: 0x334
+       ;; code offset: 0x33e
        (local.get $1)
-       ;; code offset: 0x336
+       ;; code offset: 0x340
        (i32.const 1)
       )
      )
-     ;; code offset: 0x345
+     ;; code offset: 0x34f
      (br_if $label$1
-      ;; code offset: 0x344
+      ;; code offset: 0x34e
       (i32.eq
-       ;; code offset: 0x340
+       ;; code offset: 0x34a
        (local.tee $2
-        ;; code offset: 0x33f
+        ;; code offset: 0x349
         (i32.add
-         ;; code offset: 0x33b
+         ;; code offset: 0x345
          (local.get $2)
-         ;; code offset: 0x33d
+         ;; code offset: 0x347
          (i32.const 1)
         )
        )
-       ;; code offset: 0x342
+       ;; code offset: 0x34c
        (local.get $4)
       )
      )
-     ;; code offset: 0x34c
+     ;; code offset: 0x356
      (local.set $6
-      ;; code offset: 0x349
+      ;; code offset: 0x353
       (i32.load
-       ;; code offset: 0x347
+       ;; code offset: 0x351
        (local.get $3)
       )
      )
-     ;; code offset: 0x34e
+     ;; code offset: 0x358
      (br $label$22)
     )
    )
   )
-  ;; code offset: 0x357
+  ;; code offset: 0x363
   (call $free
-   ;; code offset: 0x355
+   ;; code offset: 0x361
    (local.get $3)
   )
-  ;; code offset: 0x35b
+  ;; code offset: 0x367
   (call $free
-   ;; code offset: 0x359
+   ;; code offset: 0x365
    (local.get $8)
   )
-  ;; code offset: 0x35f
+  ;; code offset: 0x36b
   (call $free
-   ;; code offset: 0x35d
+   ;; code offset: 0x369
    (local.get $9)
   )
-  ;; code offset: 0x361
+  ;; code offset: 0x36d
   (local.get $5)
  )
- (func $main (param $0 i32) (param $1 i32) (result i32)
+ (func $main (; has Stack IR ;) (param $0 i32) (param $1 i32) (result i32)
   (local $2 i32)
   (local $3 i32)
   (local $4 i32)
@@ -5879,967 +5903,965 @@ file_names[  4]:
   (local $6 i32)
   (local $7 i32)
   (local $8 i32)
-  (local $9 i32)
-  (local $10 i32)
-  ;; code offset: 0x370
+  ;; code offset: 0x37c
   (global.set $global$0
-   ;; code offset: 0x36e
+   ;; code offset: 0x37a
    (local.tee $8
-    ;; code offset: 0x36d
+    ;; code offset: 0x379
     (i32.sub
-     ;; code offset: 0x369
+     ;; code offset: 0x375
      (global.get $global$0)
-     ;; code offset: 0x36b
+     ;; code offset: 0x377
      (i32.const 32)
     )
    )
   )
-  ;; code offset: 0x372
+  ;; code offset: 0x37e
   (block $label$1
    (block $label$2
-    ;; code offset: 0x37b
+    ;; code offset: 0x387
     (if
-     ;; code offset: 0x37a
+     ;; code offset: 0x386
      (i32.ge_s
-      ;; code offset: 0x376
+      ;; code offset: 0x382
       (local.get $0)
-      ;; code offset: 0x378
+      ;; code offset: 0x384
       (i32.const 2)
      )
-     ;; code offset: 0x389
+     ;; code offset: 0x395
      (br_if $label$2
-      ;; code offset: 0x388
+      ;; code offset: 0x394
       (i32.gt_s
-       ;; code offset: 0x384
+       ;; code offset: 0x390
        (local.tee $3
-        ;; code offset: 0x382
+        ;; code offset: 0x38e
         (call $atoi
-         ;; code offset: 0x37f
+         ;; code offset: 0x38b
          (i32.load offset=4
-          ;; code offset: 0x37d
+          ;; code offset: 0x389
           (local.get $1)
          )
         )
        )
-       ;; code offset: 0x386
+       ;; code offset: 0x392
        (i32.const 0)
       )
      )
     )
-    ;; code offset: 0x391
+    ;; code offset: 0x39d
     (drop
-     ;; code offset: 0x38f
+     ;; code offset: 0x39b
      (call $puts
-      ;; code offset: 0x38c
+      ;; code offset: 0x398
       (i32.const 1050)
      )
     )
-    ;; code offset: 0x394
+    ;; code offset: 0x3a0
     (local.set $5
-     ;; code offset: 0x392
+     ;; code offset: 0x39e
      (i32.const 1)
     )
-    ;; code offset: 0x396
+    ;; code offset: 0x3a2
     (br $label$1)
    )
-   ;; code offset: 0x39e
+   ;; code offset: 0x3aa
    (if
-    ;; code offset: 0x39d
+    ;; code offset: 0x3a9
     (i32.ne
-     ;; code offset: 0x399
+     ;; code offset: 0x3a5
      (local.get $3)
-     ;; code offset: 0x39b
+     ;; code offset: 0x3a7
      (i32.const 1)
     )
     (block
-     ;; code offset: 0x3a5
+     ;; code offset: 0x3b1
      (local.set $2
-      ;; code offset: 0x3a4
+      ;; code offset: 0x3b0
       (i32.add
-       ;; code offset: 0x3a0
+       ;; code offset: 0x3ac
        (local.get $3)
-       ;; code offset: 0x3a2
+       ;; code offset: 0x3ae
        (i32.const -1)
       )
      )
-     ;; code offset: 0x3a9
+     ;; code offset: 0x3b5
      (local.set $1
-      ;; code offset: 0x3a7
+      ;; code offset: 0x3b3
       (i32.const 0)
      )
-     ;; code offset: 0x3ad
+     ;; code offset: 0x3b9
      (local.set $0
-      ;; code offset: 0x3ab
+      ;; code offset: 0x3b7
       (i32.const 0)
      )
-     ;; code offset: 0x3af
+     ;; code offset: 0x3bb
      (loop $label$5
-      ;; code offset: 0x3b9
+      ;; code offset: 0x3c5
       (i32.store offset=8
-       ;; code offset: 0x3b5
+       ;; code offset: 0x3c1
        (local.tee $4
-        ;; code offset: 0x3b3
+        ;; code offset: 0x3bf
         (call $malloc
-         ;; code offset: 0x3b1
+         ;; code offset: 0x3bd
          (i32.const 12)
         )
        )
-       ;; code offset: 0x3b7
+       ;; code offset: 0x3c3
        (local.get $1)
       )
-      ;; code offset: 0x3c0
+      ;; code offset: 0x3cc
       (i32.store offset=4
-       ;; code offset: 0x3bc
+       ;; code offset: 0x3c8
        (local.get $4)
-       ;; code offset: 0x3be
+       ;; code offset: 0x3ca
        (local.get $3)
       )
-      ;; code offset: 0x3c7
+      ;; code offset: 0x3d3
       (i32.store
-       ;; code offset: 0x3c3
+       ;; code offset: 0x3cf
        (local.get $4)
-       ;; code offset: 0x3c5
+       ;; code offset: 0x3d1
        (local.get $0)
       )
-      ;; code offset: 0x3cc
+      ;; code offset: 0x3d8
       (local.set $1
-       ;; code offset: 0x3ca
+       ;; code offset: 0x3d6
        (local.get $4)
       )
-      ;; code offset: 0x3d8
+      ;; code offset: 0x3e4
       (br_if $label$5
-       ;; code offset: 0x3d7
+       ;; code offset: 0x3e3
        (i32.ne
-        ;; code offset: 0x3d3
+        ;; code offset: 0x3df
         (local.tee $0
-         ;; code offset: 0x3d2
+         ;; code offset: 0x3de
          (i32.add
-          ;; code offset: 0x3ce
+          ;; code offset: 0x3da
           (local.get $0)
-          ;; code offset: 0x3d0
+          ;; code offset: 0x3dc
           (i32.const 1)
          )
         )
-        ;; code offset: 0x3d5
+        ;; code offset: 0x3e1
         (local.get $2)
        )
       )
      )
     )
    )
-   ;; code offset: 0x3de
+   ;; code offset: 0x3ea
    (local.set $0
-    ;; code offset: 0x3dc
+    ;; code offset: 0x3e8
     (i32.const 0)
    )
-   ;; code offset: 0x3e9
+   ;; code offset: 0x3f5
    (local.set $1
-    ;; code offset: 0x3e7
+    ;; code offset: 0x3f3
     (call $malloc
-     ;; code offset: 0x3e5
+     ;; code offset: 0x3f1
      (local.tee $2
-      ;; code offset: 0x3e4
+      ;; code offset: 0x3f0
       (i32.shl
-       ;; code offset: 0x3e0
+       ;; code offset: 0x3ec
        (local.get $3)
-       ;; code offset: 0x3e2
+       ;; code offset: 0x3ee
        (i32.const 2)
       )
      )
     )
    )
-   ;; code offset: 0x3ef
+   ;; code offset: 0x3fb
    (local.set $5
-    ;; code offset: 0x3ed
+    ;; code offset: 0x3f9
     (call $malloc
-     ;; code offset: 0x3eb
+     ;; code offset: 0x3f7
      (local.get $2)
     )
    )
-   ;; code offset: 0x3f1
+   ;; code offset: 0x3fd
    (block $label$6
     (block $label$7
      (block $label$8
-      ;; code offset: 0x3fc
+      ;; code offset: 0x408
       (if
-       ;; code offset: 0x3fb
+       ;; code offset: 0x407
        (i32.gt_s
-        ;; code offset: 0x3f7
+        ;; code offset: 0x403
         (local.get $3)
-        ;; code offset: 0x3f9
+        ;; code offset: 0x405
         (i32.const 0)
        )
        (block
-        ;; code offset: 0x3fe
+        ;; code offset: 0x40a
         (loop $label$10
-         ;; code offset: 0x40a
+         ;; code offset: 0x416
          (i32.store
-          ;; code offset: 0x407
+          ;; code offset: 0x413
           (i32.add
-           ;; code offset: 0x400
+           ;; code offset: 0x40c
            (local.get $1)
-           ;; code offset: 0x406
+           ;; code offset: 0x412
            (i32.shl
-            ;; code offset: 0x402
+            ;; code offset: 0x40e
             (local.get $0)
-            ;; code offset: 0x404
+            ;; code offset: 0x410
             (i32.const 2)
            )
           )
-          ;; code offset: 0x408
+          ;; code offset: 0x414
           (local.get $0)
          )
-         ;; code offset: 0x417
+         ;; code offset: 0x423
          (br_if $label$10
-          ;; code offset: 0x416
+          ;; code offset: 0x422
           (i32.ne
-           ;; code offset: 0x412
+           ;; code offset: 0x41e
            (local.tee $0
-            ;; code offset: 0x411
+            ;; code offset: 0x41d
             (i32.add
-             ;; code offset: 0x40d
+             ;; code offset: 0x419
              (local.get $0)
-             ;; code offset: 0x40f
+             ;; code offset: 0x41b
              (i32.const 1)
             )
            )
-           ;; code offset: 0x414
+           ;; code offset: 0x420
            (local.get $3)
           )
          )
         )
-        ;; code offset: 0x41c
+        ;; code offset: 0x428
         (local.set $6
-         ;; code offset: 0x41a
+         ;; code offset: 0x426
          (i32.const 30)
         )
-        ;; code offset: 0x420
+        ;; code offset: 0x42c
         (local.set $2
-         ;; code offset: 0x41e
+         ;; code offset: 0x42a
          (local.get $3)
         )
-        ;; code offset: 0x422
+        ;; code offset: 0x42e
         (br $label$8)
        )
       )
-      ;; code offset: 0x427
+      ;; code offset: 0x433
       (local.set $6
-       ;; code offset: 0x425
+       ;; code offset: 0x431
        (i32.const 30)
       )
-      ;; code offset: 0x42b
+      ;; code offset: 0x437
       (local.set $2
-       ;; code offset: 0x429
+       ;; code offset: 0x435
        (local.get $3)
       )
-      ;; code offset: 0x42d
+      ;; code offset: 0x439
       (br $label$7)
      )
-     ;; code offset: 0x430
+     ;; code offset: 0x43c
      (loop $label$11
-      ;; code offset: 0x434
+      ;; code offset: 0x440
       (local.set $0
-       ;; code offset: 0x432
+       ;; code offset: 0x43e
        (i32.const 0)
       )
-      ;; code offset: 0x436
+      ;; code offset: 0x442
       (loop $label$12
-       ;; code offset: 0x448
+       ;; code offset: 0x454
        (i32.store offset=16
-        ;; code offset: 0x438
+        ;; code offset: 0x444
         (local.get $8)
-        ;; code offset: 0x447
+        ;; code offset: 0x453
         (i32.add
-         ;; code offset: 0x442
+         ;; code offset: 0x44e
          (i32.load
-          ;; code offset: 0x441
+          ;; code offset: 0x44d
           (i32.add
-           ;; code offset: 0x43a
+           ;; code offset: 0x446
            (local.get $1)
-           ;; code offset: 0x440
+           ;; code offset: 0x44c
            (i32.shl
-            ;; code offset: 0x43c
+            ;; code offset: 0x448
             (local.get $0)
-            ;; code offset: 0x43e
+            ;; code offset: 0x44a
             (i32.const 2)
            )
           )
          )
-         ;; code offset: 0x445
+         ;; code offset: 0x451
          (i32.const 1)
         )
        )
-       ;; code offset: 0x455
+       ;; code offset: 0x461
        (drop
-        ;; code offset: 0x453
+        ;; code offset: 0x45f
         (call $iprintf
-         ;; code offset: 0x44b
+         ;; code offset: 0x457
          (i32.const 1047)
-         ;; code offset: 0x452
+         ;; code offset: 0x45e
          (i32.add
-          ;; code offset: 0x44e
+          ;; code offset: 0x45a
           (local.get $8)
-          ;; code offset: 0x450
+          ;; code offset: 0x45c
           (i32.const 16)
          )
         )
        )
-       ;; code offset: 0x460
+       ;; code offset: 0x46c
        (br_if $label$12
-        ;; code offset: 0x45f
+        ;; code offset: 0x46b
         (i32.ne
-         ;; code offset: 0x45b
+         ;; code offset: 0x467
          (local.tee $0
-          ;; code offset: 0x45a
+          ;; code offset: 0x466
           (i32.add
-           ;; code offset: 0x456
+           ;; code offset: 0x462
            (local.get $0)
-           ;; code offset: 0x458
+           ;; code offset: 0x464
            (i32.const 1)
           )
          )
-         ;; code offset: 0x45d
+         ;; code offset: 0x469
          (local.get $3)
         )
        )
       )
-      ;; code offset: 0x467
+      ;; code offset: 0x473
       (drop
-       ;; code offset: 0x465
+       ;; code offset: 0x471
        (call $putchar
-        ;; code offset: 0x463
+        ;; code offset: 0x46f
         (i32.const 10)
        )
       )
-      ;; code offset: 0x46d
+      ;; code offset: 0x479
       (if
-       ;; code offset: 0x46c
+       ;; code offset: 0x478
        (i32.gt_s
-        ;; code offset: 0x468
+        ;; code offset: 0x474
         (local.get $2)
-        ;; code offset: 0x46a
+        ;; code offset: 0x476
         (i32.const 1)
        )
-       ;; code offset: 0x46f
+       ;; code offset: 0x47b
        (loop $label$14
-        ;; code offset: 0x480
+        ;; code offset: 0x48c
         (i32.store
-         ;; code offset: 0x47d
+         ;; code offset: 0x489
          (i32.add
-          ;; code offset: 0x471
+          ;; code offset: 0x47d
           (local.get $5)
-          ;; code offset: 0x47c
+          ;; code offset: 0x488
           (i32.shl
-           ;; code offset: 0x478
+           ;; code offset: 0x484
            (local.tee $0
-            ;; code offset: 0x477
+            ;; code offset: 0x483
             (i32.add
-             ;; code offset: 0x473
+             ;; code offset: 0x47f
              (local.get $2)
-             ;; code offset: 0x475
+             ;; code offset: 0x481
              (i32.const -1)
             )
            )
-           ;; code offset: 0x47a
+           ;; code offset: 0x486
            (i32.const 2)
           )
          )
-         ;; code offset: 0x47e
+         ;; code offset: 0x48a
          (local.get $2)
         )
-        ;; code offset: 0x48c
-        (br_if $label$14
-         (block (result i32)
-          (local.set $9
-           ;; code offset: 0x487
-           (i32.gt_s
-            ;; code offset: 0x483
-            (local.get $2)
-            ;; code offset: 0x485
-            (i32.const 2)
-           )
-          )
-          ;; code offset: 0x48a
-          (local.set $2
-           ;; code offset: 0x488
-           (local.get $0)
-          )
-          (local.get $9)
+        ;; code offset: 0x494
+        (local.set $7
+         ;; code offset: 0x493
+         (i32.gt_s
+          ;; code offset: 0x48f
+          (local.get $2)
+          ;; code offset: 0x491
+          (i32.const 2)
          )
+        )
+        ;; code offset: 0x498
+        (local.set $2
+         ;; code offset: 0x496
+         (local.get $0)
+        )
+        ;; code offset: 0x49c
+        (br_if $label$14
+         ;; code offset: 0x49a
+         (local.get $7)
         )
        )
       )
-      ;; code offset: 0x495
+      ;; code offset: 0x4a5
       (br_if $label$6
-       ;; code offset: 0x494
+       ;; code offset: 0x4a4
        (i32.eq
-        ;; code offset: 0x490
+        ;; code offset: 0x4a0
         (local.get $2)
-        ;; code offset: 0x492
+        ;; code offset: 0x4a2
         (local.get $3)
        )
       )
-      ;; code offset: 0x49c
+      ;; code offset: 0x4ac
       (local.set $6
-       ;; code offset: 0x49b
+       ;; code offset: 0x4ab
        (i32.add
-        ;; code offset: 0x497
+        ;; code offset: 0x4a7
         (local.get $6)
-        ;; code offset: 0x499
+        ;; code offset: 0x4a9
         (i32.const -1)
        )
       )
-      ;; code offset: 0x49e
+      ;; code offset: 0x4ae
       (loop $label$15
-       ;; code offset: 0x4a2
+       ;; code offset: 0x4b2
        (local.set $0
-        ;; code offset: 0x4a0
+        ;; code offset: 0x4b0
         (i32.const 0)
        )
-       ;; code offset: 0x4a9
+       ;; code offset: 0x4b9
        (local.set $7
-        ;; code offset: 0x4a6
+        ;; code offset: 0x4b6
         (i32.load
-         ;; code offset: 0x4a4
+         ;; code offset: 0x4b4
          (local.get $1)
         )
        )
-       ;; code offset: 0x4b0
+       ;; code offset: 0x4c0
        (if
-        ;; code offset: 0x4af
+        ;; code offset: 0x4bf
         (i32.gt_s
-         ;; code offset: 0x4ab
+         ;; code offset: 0x4bb
          (local.get $2)
-         ;; code offset: 0x4ad
+         ;; code offset: 0x4bd
          (i32.const 0)
         )
         (block
-         ;; code offset: 0x4b2
+         ;; code offset: 0x4c2
          (loop $label$17
-          ;; code offset: 0x4cc
+          ;; code offset: 0x4dc
           (i32.store
-           ;; code offset: 0x4bb
+           ;; code offset: 0x4cb
            (i32.add
-            ;; code offset: 0x4b4
+            ;; code offset: 0x4c4
             (local.get $1)
-            ;; code offset: 0x4ba
+            ;; code offset: 0x4ca
             (i32.shl
-             ;; code offset: 0x4b6
+             ;; code offset: 0x4c6
              (local.get $0)
-             ;; code offset: 0x4b8
+             ;; code offset: 0x4c8
              (i32.const 2)
             )
            )
-           ;; code offset: 0x4c9
+           ;; code offset: 0x4d9
            (i32.load
-            ;; code offset: 0x4c8
+            ;; code offset: 0x4d8
             (i32.add
-             ;; code offset: 0x4bc
+             ;; code offset: 0x4cc
              (local.get $1)
-             ;; code offset: 0x4c7
+             ;; code offset: 0x4d7
              (i32.shl
-              ;; code offset: 0x4c3
+              ;; code offset: 0x4d3
               (local.tee $0
-               ;; code offset: 0x4c2
+               ;; code offset: 0x4d2
                (i32.add
-                ;; code offset: 0x4be
+                ;; code offset: 0x4ce
                 (local.get $0)
-                ;; code offset: 0x4c0
+                ;; code offset: 0x4d0
                 (i32.const 1)
                )
               )
-              ;; code offset: 0x4c5
+              ;; code offset: 0x4d5
               (i32.const 2)
              )
             )
            )
           )
-          ;; code offset: 0x4d4
+          ;; code offset: 0x4e4
           (br_if $label$17
-           ;; code offset: 0x4d3
+           ;; code offset: 0x4e3
            (i32.ne
-            ;; code offset: 0x4cf
+            ;; code offset: 0x4df
             (local.get $0)
-            ;; code offset: 0x4d1
+            ;; code offset: 0x4e1
             (local.get $2)
            )
           )
          )
-         ;; code offset: 0x4d9
+         ;; code offset: 0x4e9
          (local.set $0
-          ;; code offset: 0x4d7
+          ;; code offset: 0x4e7
           (local.get $2)
          )
         )
        )
-       ;; code offset: 0x4e6
+       ;; code offset: 0x4f6
        (i32.store
-        ;; code offset: 0x4e3
+        ;; code offset: 0x4f3
         (i32.add
-         ;; code offset: 0x4dc
+         ;; code offset: 0x4ec
          (local.get $1)
-         ;; code offset: 0x4e2
+         ;; code offset: 0x4f2
          (i32.shl
-          ;; code offset: 0x4de
+          ;; code offset: 0x4ee
           (local.get $0)
-          ;; code offset: 0x4e0
+          ;; code offset: 0x4f0
           (i32.const 2)
          )
         )
-        ;; code offset: 0x4e4
+        ;; code offset: 0x4f4
         (local.get $7)
        )
-       ;; code offset: 0x4fd
+       ;; code offset: 0x50d
        (i32.store
-        ;; code offset: 0x4f1
+        ;; code offset: 0x501
         (local.tee $0
-         ;; code offset: 0x4f0
+         ;; code offset: 0x500
          (i32.add
-          ;; code offset: 0x4e9
+          ;; code offset: 0x4f9
           (local.get $5)
-          ;; code offset: 0x4ef
+          ;; code offset: 0x4ff
           (i32.shl
-           ;; code offset: 0x4eb
+           ;; code offset: 0x4fb
            (local.get $2)
-           ;; code offset: 0x4ed
+           ;; code offset: 0x4fd
            (i32.const 2)
           )
          )
         )
-        ;; code offset: 0x4fc
+        ;; code offset: 0x50c
         (i32.add
-         ;; code offset: 0x4f8
+         ;; code offset: 0x508
          (local.tee $0
-          ;; code offset: 0x4f5
+          ;; code offset: 0x505
           (i32.load
-           ;; code offset: 0x4f3
+           ;; code offset: 0x503
            (local.get $0)
           )
          )
-         ;; code offset: 0x4fa
+         ;; code offset: 0x50a
          (i32.const -1)
         )
        )
-       ;; code offset: 0x505
+       ;; code offset: 0x515
        (if
-        ;; code offset: 0x504
+        ;; code offset: 0x514
         (i32.le_s
-         ;; code offset: 0x500
+         ;; code offset: 0x510
          (local.get $0)
-         ;; code offset: 0x502
+         ;; code offset: 0x512
          (i32.const 1)
         )
         (block
-         ;; code offset: 0x511
+         ;; code offset: 0x521
          (br_if $label$15
-          ;; code offset: 0x510
+          ;; code offset: 0x520
           (i32.ne
-           ;; code offset: 0x50c
+           ;; code offset: 0x51c
            (local.tee $2
-            ;; code offset: 0x50b
+            ;; code offset: 0x51b
             (i32.add
-             ;; code offset: 0x507
+             ;; code offset: 0x517
              (local.get $2)
-             ;; code offset: 0x509
+             ;; code offset: 0x519
              (i32.const 1)
             )
            )
-           ;; code offset: 0x50e
+           ;; code offset: 0x51e
            (local.get $3)
           )
          )
-         ;; code offset: 0x513
+         ;; code offset: 0x523
          (br $label$6)
         )
        )
       )
-      ;; code offset: 0x519
+      ;; code offset: 0x529
       (br_if $label$11
-       ;; code offset: 0x517
+       ;; code offset: 0x527
        (local.get $6)
       )
      )
-     ;; code offset: 0x51c
+     ;; code offset: 0x52c
      (br $label$6)
     )
-    ;; code offset: 0x51f
+    ;; code offset: 0x52f
     (loop $label$19
-     ;; code offset: 0x525
+     ;; code offset: 0x535
      (drop
-      ;; code offset: 0x523
+      ;; code offset: 0x533
       (call $putchar
-       ;; code offset: 0x521
+       ;; code offset: 0x531
        (i32.const 10)
       )
      )
-     ;; code offset: 0x52b
+     ;; code offset: 0x53b
      (if
-      ;; code offset: 0x52a
+      ;; code offset: 0x53a
       (i32.gt_s
-       ;; code offset: 0x526
+       ;; code offset: 0x536
        (local.get $2)
-       ;; code offset: 0x528
+       ;; code offset: 0x538
        (i32.const 1)
       )
-      ;; code offset: 0x52d
+      ;; code offset: 0x53d
       (loop $label$21
-       ;; code offset: 0x53e
+       ;; code offset: 0x54e
        (i32.store
-        ;; code offset: 0x53b
+        ;; code offset: 0x54b
         (i32.add
-         ;; code offset: 0x52f
+         ;; code offset: 0x53f
          (local.get $5)
-         ;; code offset: 0x53a
+         ;; code offset: 0x54a
          (i32.shl
-          ;; code offset: 0x536
+          ;; code offset: 0x546
           (local.tee $0
-           ;; code offset: 0x535
+           ;; code offset: 0x545
            (i32.add
-            ;; code offset: 0x531
+            ;; code offset: 0x541
             (local.get $2)
-            ;; code offset: 0x533
+            ;; code offset: 0x543
             (i32.const -1)
            )
           )
-          ;; code offset: 0x538
+          ;; code offset: 0x548
           (i32.const 2)
          )
         )
-        ;; code offset: 0x53c
+        ;; code offset: 0x54c
         (local.get $2)
        )
-       ;; code offset: 0x54a
-       (br_if $label$21
-        (block (result i32)
-         (local.set $10
-          ;; code offset: 0x545
-          (i32.gt_s
-           ;; code offset: 0x541
-           (local.get $2)
-           ;; code offset: 0x543
-           (i32.const 2)
-          )
-         )
-         ;; code offset: 0x548
-         (local.set $2
-          ;; code offset: 0x546
-          (local.get $0)
-         )
-         (local.get $10)
+       ;; code offset: 0x556
+       (local.set $7
+        ;; code offset: 0x555
+        (i32.gt_s
+         ;; code offset: 0x551
+         (local.get $2)
+         ;; code offset: 0x553
+         (i32.const 2)
         )
+       )
+       ;; code offset: 0x55a
+       (local.set $2
+        ;; code offset: 0x558
+        (local.get $0)
+       )
+       ;; code offset: 0x55e
+       (br_if $label$21
+        ;; code offset: 0x55c
+        (local.get $7)
        )
       )
      )
-     ;; code offset: 0x553
+     ;; code offset: 0x567
      (br_if $label$6
-      ;; code offset: 0x552
+      ;; code offset: 0x566
       (i32.eq
-       ;; code offset: 0x54e
+       ;; code offset: 0x562
        (local.get $2)
-       ;; code offset: 0x550
+       ;; code offset: 0x564
        (local.get $3)
       )
      )
-     ;; code offset: 0x55a
+     ;; code offset: 0x56e
      (local.set $6
-      ;; code offset: 0x559
+      ;; code offset: 0x56d
       (i32.add
-       ;; code offset: 0x555
+       ;; code offset: 0x569
        (local.get $6)
-       ;; code offset: 0x557
+       ;; code offset: 0x56b
        (i32.const -1)
       )
      )
-     ;; code offset: 0x55c
+     ;; code offset: 0x570
      (loop $label$22
-      ;; code offset: 0x563
+      ;; code offset: 0x577
       (local.set $7
-       ;; code offset: 0x560
+       ;; code offset: 0x574
        (i32.load
-        ;; code offset: 0x55e
+        ;; code offset: 0x572
         (local.get $1)
        )
       )
-      ;; code offset: 0x567
+      ;; code offset: 0x57b
       (local.set $0
-       ;; code offset: 0x565
+       ;; code offset: 0x579
        (i32.const 0)
       )
-      ;; code offset: 0x56e
+      ;; code offset: 0x582
       (if
-       ;; code offset: 0x56d
+       ;; code offset: 0x581
        (i32.ge_s
-        ;; code offset: 0x569
+        ;; code offset: 0x57d
         (local.get $2)
-        ;; code offset: 0x56b
+        ;; code offset: 0x57f
         (i32.const 1)
        )
        (block
-        ;; code offset: 0x570
+        ;; code offset: 0x584
         (loop $label$24
-         ;; code offset: 0x58a
+         ;; code offset: 0x59e
          (i32.store
-          ;; code offset: 0x579
+          ;; code offset: 0x58d
           (i32.add
-           ;; code offset: 0x572
+           ;; code offset: 0x586
            (local.get $1)
-           ;; code offset: 0x578
+           ;; code offset: 0x58c
            (i32.shl
-            ;; code offset: 0x574
+            ;; code offset: 0x588
             (local.get $0)
-            ;; code offset: 0x576
+            ;; code offset: 0x58a
             (i32.const 2)
            )
           )
-          ;; code offset: 0x587
+          ;; code offset: 0x59b
           (i32.load
-           ;; code offset: 0x586
+           ;; code offset: 0x59a
            (i32.add
-            ;; code offset: 0x57a
+            ;; code offset: 0x58e
             (local.get $1)
-            ;; code offset: 0x585
+            ;; code offset: 0x599
             (i32.shl
-             ;; code offset: 0x581
+             ;; code offset: 0x595
              (local.tee $0
-              ;; code offset: 0x580
+              ;; code offset: 0x594
               (i32.add
-               ;; code offset: 0x57c
+               ;; code offset: 0x590
                (local.get $0)
-               ;; code offset: 0x57e
+               ;; code offset: 0x592
                (i32.const 1)
               )
              )
-             ;; code offset: 0x583
+             ;; code offset: 0x597
              (i32.const 2)
             )
            )
           )
          )
-         ;; code offset: 0x592
+         ;; code offset: 0x5a6
          (br_if $label$24
-          ;; code offset: 0x591
+          ;; code offset: 0x5a5
           (i32.ne
-           ;; code offset: 0x58d
+           ;; code offset: 0x5a1
            (local.get $0)
-           ;; code offset: 0x58f
+           ;; code offset: 0x5a3
            (local.get $2)
           )
          )
         )
-        ;; code offset: 0x597
+        ;; code offset: 0x5ab
         (local.set $0
-         ;; code offset: 0x595
+         ;; code offset: 0x5a9
          (local.get $2)
         )
        )
       )
-      ;; code offset: 0x5a4
+      ;; code offset: 0x5b8
       (i32.store
-       ;; code offset: 0x5a1
+       ;; code offset: 0x5b5
        (i32.add
-        ;; code offset: 0x59a
+        ;; code offset: 0x5ae
         (local.get $1)
-        ;; code offset: 0x5a0
+        ;; code offset: 0x5b4
         (i32.shl
-         ;; code offset: 0x59c
+         ;; code offset: 0x5b0
          (local.get $0)
-         ;; code offset: 0x59e
+         ;; code offset: 0x5b2
          (i32.const 2)
         )
        )
-       ;; code offset: 0x5a2
+       ;; code offset: 0x5b6
        (local.get $7)
       )
-      ;; code offset: 0x5bb
+      ;; code offset: 0x5cf
       (i32.store
-       ;; code offset: 0x5af
+       ;; code offset: 0x5c3
        (local.tee $0
-        ;; code offset: 0x5ae
+        ;; code offset: 0x5c2
         (i32.add
-         ;; code offset: 0x5a7
+         ;; code offset: 0x5bb
          (local.get $5)
-         ;; code offset: 0x5ad
+         ;; code offset: 0x5c1
          (i32.shl
-          ;; code offset: 0x5a9
+          ;; code offset: 0x5bd
           (local.get $2)
-          ;; code offset: 0x5ab
+          ;; code offset: 0x5bf
           (i32.const 2)
          )
         )
        )
-       ;; code offset: 0x5ba
+       ;; code offset: 0x5ce
        (i32.add
-        ;; code offset: 0x5b6
+        ;; code offset: 0x5ca
         (local.tee $0
-         ;; code offset: 0x5b3
+         ;; code offset: 0x5c7
          (i32.load
-          ;; code offset: 0x5b1
+          ;; code offset: 0x5c5
           (local.get $0)
          )
         )
-        ;; code offset: 0x5b8
+        ;; code offset: 0x5cc
         (i32.const -1)
        )
       )
-      ;; code offset: 0x5c3
+      ;; code offset: 0x5d7
       (if
-       ;; code offset: 0x5c2
+       ;; code offset: 0x5d6
        (i32.le_s
-        ;; code offset: 0x5be
+        ;; code offset: 0x5d2
         (local.get $0)
-        ;; code offset: 0x5c0
+        ;; code offset: 0x5d4
         (i32.const 1)
        )
        (block
-        ;; code offset: 0x5cf
+        ;; code offset: 0x5e3
         (br_if $label$22
-         ;; code offset: 0x5ce
+         ;; code offset: 0x5e2
          (i32.ne
-          ;; code offset: 0x5ca
+          ;; code offset: 0x5de
           (local.tee $2
-           ;; code offset: 0x5c9
+           ;; code offset: 0x5dd
            (i32.add
-            ;; code offset: 0x5c5
+            ;; code offset: 0x5d9
             (local.get $2)
-            ;; code offset: 0x5c7
+            ;; code offset: 0x5db
             (i32.const 1)
            )
           )
-          ;; code offset: 0x5cc
+          ;; code offset: 0x5e0
           (local.get $3)
          )
         )
-        ;; code offset: 0x5d1
+        ;; code offset: 0x5e5
         (br $label$6)
        )
       )
      )
-     ;; code offset: 0x5d7
+     ;; code offset: 0x5eb
      (br_if $label$19
-      ;; code offset: 0x5d5
+      ;; code offset: 0x5e9
       (local.get $6)
      )
     )
    )
-   ;; code offset: 0x5dd
+   ;; code offset: 0x5f1
    (call $free
-    ;; code offset: 0x5db
+    ;; code offset: 0x5ef
     (local.get $1)
    )
-   ;; code offset: 0x5e1
+   ;; code offset: 0x5f5
    (call $free
-    ;; code offset: 0x5df
+    ;; code offset: 0x5f3
     (local.get $5)
    )
-   ;; code offset: 0x5e5
+   ;; code offset: 0x5f9
    (local.set $5
-    ;; code offset: 0x5e3
+    ;; code offset: 0x5f7
     (i32.const 0)
    )
-   ;; code offset: 0x5e9
+   ;; code offset: 0x5fd
    (local.set $0
-    ;; code offset: 0x5e7
+    ;; code offset: 0x5fb
     (i32.const 0)
    )
-   ;; code offset: 0x5ed
+   ;; code offset: 0x601
    (if
-    ;; code offset: 0x5eb
+    ;; code offset: 0x5ff
     (local.get $4)
-    ;; code offset: 0x5ef
+    ;; code offset: 0x603
     (loop $label$27
-     ;; code offset: 0x5f5
+     ;; code offset: 0x609
      (local.set $1
-      ;; code offset: 0x5f3
+      ;; code offset: 0x607
       (call $fannkuch_worker\28void*\29
-       ;; code offset: 0x5f1
+       ;; code offset: 0x605
        (local.get $4)
       )
      )
-     ;; code offset: 0x5fc
+     ;; code offset: 0x610
      (local.set $2
-      ;; code offset: 0x5f9
+      ;; code offset: 0x60d
       (i32.load offset=8
-       ;; code offset: 0x5f7
+       ;; code offset: 0x60b
        (local.get $4)
       )
      )
-     ;; code offset: 0x600
+     ;; code offset: 0x614
      (call $free
-      ;; code offset: 0x5fe
+      ;; code offset: 0x612
       (local.get $4)
      )
-     ;; code offset: 0x60c
+     ;; code offset: 0x620
      (local.set $0
-      ;; code offset: 0x60b
+      ;; code offset: 0x61f
       (select
-       ;; code offset: 0x602
+       ;; code offset: 0x616
        (local.get $1)
-       ;; code offset: 0x604
+       ;; code offset: 0x618
        (local.get $0)
-       ;; code offset: 0x60a
+       ;; code offset: 0x61e
        (i32.lt_s
-        ;; code offset: 0x606
+        ;; code offset: 0x61a
         (local.get $0)
-        ;; code offset: 0x608
+        ;; code offset: 0x61c
         (local.get $1)
        )
       )
      )
-     ;; code offset: 0x610
+     ;; code offset: 0x624
      (local.set $4
-      ;; code offset: 0x60e
+      ;; code offset: 0x622
       (local.get $2)
      )
-     ;; code offset: 0x614
+     ;; code offset: 0x628
      (br_if $label$27
-      ;; code offset: 0x612
+      ;; code offset: 0x626
       (local.get $2)
      )
     )
    )
-   ;; code offset: 0x61c
+   ;; code offset: 0x630
    (i32.store offset=4
-    ;; code offset: 0x618
+    ;; code offset: 0x62c
     (local.get $8)
-    ;; code offset: 0x61a
+    ;; code offset: 0x62e
     (local.get $0)
    )
-   ;; code offset: 0x623
+   ;; code offset: 0x637
    (i32.store
-    ;; code offset: 0x61f
+    ;; code offset: 0x633
     (local.get $8)
-    ;; code offset: 0x621
+    ;; code offset: 0x635
     (local.get $3)
    )
-   ;; code offset: 0x62d
+   ;; code offset: 0x641
    (drop
-    ;; code offset: 0x62b
+    ;; code offset: 0x63f
     (call $iprintf
-     ;; code offset: 0x626
+     ;; code offset: 0x63a
      (i32.const 1024)
-     ;; code offset: 0x629
+     ;; code offset: 0x63d
      (local.get $8)
     )
    )
   )
-  ;; code offset: 0x634
+  ;; code offset: 0x648
   (global.set $global$0
-   ;; code offset: 0x633
+   ;; code offset: 0x647
    (i32.add
-    ;; code offset: 0x62f
+    ;; code offset: 0x643
     (local.get $8)
-    ;; code offset: 0x631
+    ;; code offset: 0x645
     (i32.const 32)
    )
   )
-  ;; code offset: 0x636
+  ;; code offset: 0x64a
   (local.get $5)
  )
  ;; custom section ".debug_info", size 851
  ;; custom section ".debug_loc", size 1073
  ;; custom section ".debug_ranges", size 88
  ;; custom section ".debug_abbrev", size 333
- ;; custom section ".debug_line", size 2662
+ ;; custom section ".debug_line", size 2702
  ;; custom section ".debug_str", size 434
  ;; custom section "producers", size 135
 )

--- a/test/unit/test_stack_ir.py
+++ b/test/unit/test_stack_ir.py
@@ -7,8 +7,8 @@ class StackIRTest(utils.BinaryenTestCase):
     # test that stack IR opts make a difference.
     def test_stack_ir_opts(self):
         path = self.input_path('stack_ir.wat')
-        opt = shared.run_process(shared.WASM_OPT + [path, '-O', '--generate-stack-ir', '--optimize-stack-ir', '--print-stack-ir', '-o', 'a.wasm'], capture_output=True).stdout
-        nonopt = shared.run_process(shared.WASM_OPT + [path, '-O', '--generate-stack-ir', '--print-stack-ir', '-o', 'b.wasm'], capture_output=True).stdout
+        opt = shared.run_process(shared.WASM_OPT + [path, '--shrink-level=1', '--generate-stack-ir', '--optimize-stack-ir', '--print-stack-ir', '-o', 'a.wasm'], capture_output=True).stdout
+        nonopt = shared.run_process(shared.WASM_OPT + [path, '--shrink-level=1', '--generate-stack-ir', '--print-stack-ir', '-o', 'b.wasm'], capture_output=True).stdout
         # see a difference in the printed stack IR (the optimizations let us
         # remove a pair of local.set/get)
         self.assertNotEqual(opt, nonopt)


### PR DESCRIPTION
This avoids Stack IR from being generated and thrown away in the
middle of an optimization pipeline. This change is partially
preparation for a future in which tuple lowering is performed as a
part of lowering to Stack IR or something similar. In that case, the
lowering would add locals and trying to throw away the Stack IR (or
similar construct) would become an error.