### PR TITLE
Add Expression::dump for use while debugging

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -589,7 +589,7 @@ public:
     return (const T*)this;
   }
 
-  // Print the expression to stderr. Meant for use from debuggers.
+  // Print the expression to stderr. Meant for use while debugging.
   void dump();
 };
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -588,6 +588,9 @@ public:
     assert(int(_id) == int(T::SpecificId));
     return (const T*)this;
   }
+
+  // Print the expression to stderr. Meant for use from debuggers.
+  void dump();
 };
 
 const char* getExpressionName(Expression* curr);

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -16,6 +16,7 @@
 
 #include "wasm.h"
 #include "ir/branch-utils.h"
+#include "wasm-printing.h"
 #include "wasm-traversal.h"
 
 namespace wasm {
@@ -92,6 +93,13 @@ Name EVENT("event");
 Name ATTR("attr");
 
 // Expressions
+
+void Expression::dump() {
+  WasmPrinter::printExpression(this,
+                               std::cerr,
+                               /*minify=*/false,
+                               /*full=*/true);
+}
 
 const char* getExpressionName(Expression* curr) {
   switch (curr->_id) {


### PR DESCRIPTION
I have found that similar dump functions have been extremely helpful
while debugging LLVM. Rather than re-implement this locally whenever I
need it, it would be better have this utility upstream.