### PR TITLE
Asyncify: Instrument indirect calls from functions in add-list or only-list

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -700,9 +700,7 @@ public:
           canChangeState = true;
         }
       }
-      void visitCallIndirect(CallIndirect* curr) {
-        hasIndirectCall = true;
-      }
+      void visitCallIndirect(CallIndirect* curr) { hasIndirectCall = true; }
       Module* module;
       ModuleAnalyzer* analyzer;
       Map* map;
@@ -724,7 +722,8 @@ public:
     // state. This allows adding functions to actually let some indirect calls
     // work (as the support needs to be on both sides, the caller and the
     // callee).
-    if (walker.hasIndirectCall && (canIndirectChangeState || map[func].addedFromList)) {
+    if (walker.hasIndirectCall &&
+        (canIndirectChangeState || map[func].addedFromList)) {
       walker.canChangeState = true;
     }
     return walker.canChangeState;
@@ -883,7 +882,8 @@ private:
           i++;
         } else {
           Index end = i + 1;
-          while (end < list.size() && !analyzer->canChangeState(list[end], func)) {
+          while (end < list.size() &&
+                 !analyzer->canChangeState(list[end], func)) {
             end++;
           }
           // We have a range of [i, end) in which the state cannot change,

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -725,9 +725,6 @@ public:
     walker.analyzer = this;
     walker.map = &map;
     walker.walk(curr);
-    if (walker.isBottomMostRuntime) {
-      walker.canChangeState = false;
-    }
     // An indirect call is normally ignored if we are ignoring indirect calls.
     // However, see the docs at the top: if the function we are inside was
     // specifically added by the user (in the only-list or the add-list) then we
@@ -737,7 +734,8 @@ public:
         (canIndirectChangeState || map[func].addedFromList)) {
       walker.canChangeState = true;
     }
-    return walker.canChangeState;
+    // The bottom-most runtime can never change the state.
+    return walker.canChangeState && !walker.isBottomMostRuntime;
   }
 
   FakeGlobalHelper fakeGlobals;

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -729,11 +729,10 @@ public:
       walker.canChangeState = false;
     }
     // An indirect call is normally ignored if we are ignoring indirect calls.
-    // However, if the function we are inside was specifically added by the user
-    // (in the only-list or the add-list) then we assume it may change the
-    // state. This allows adding functions to actually let some indirect calls
-    // work (as the support needs to be on both sides, the caller and the
-    // callee).
+    // However, see the docs at the top: if the function we are inside was
+    // specifically added by the user (in the only-list or the add-list) then we
+    // instrument indirect calls from it (this allows specifically allowing some
+    // indirect calls but not others).
     if (walker.hasIndirectCall &&
         (canIndirectChangeState || map[func].addedFromList)) {
       walker.canChangeState = true;

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -269,7 +269,7 @@
 // function: if foo() can be part of a pause/resume operation, then we need to
 // instrument code inside it to support pausing and resuming, but also, we need
 // callers of the function to instrument calls to it. Normally this is already
-// taken care of, as the callers need to instrumented as well anyhow. However,
+// taken care of as the callers need to be instrumented as well anyhow. However,
 // the ignore-indirect option makes things more complicated, since we can't tell
 // where all the calls to foo() are - all we see a indirect calls, that do not
 // refer to foo() by name. To make it possible for you to use the add-list or

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -271,7 +271,7 @@
 // callers of the function to instrument calls to it. Normally this is already
 // taken care of as the callers need to be instrumented as well anyhow. However,
 // the ignore-indirect option makes things more complicated, since we can't tell
-// where all the calls to foo() are - all we see a indirect calls, that do not
+// where all the calls to foo() are - all we see are indirect calls that do not
 // refer to foo() by name. To make it possible for you to use the add-list or
 // only-list with ignore-indirect, those lists affect *both* kinds of
 // instrumentation. That is, if parent() calls foo() indirectly, and you add

--- a/test/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.txt
@@ -1,0 +1,171 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "env" "import" (func $import))
+ (memory $0 1 2)
+ (table $0 1 funcref)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (export "asyncify_get_state" (func $asyncify_get_state))
+ (func $foo
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.tee $0
+   (block $__asyncify_unwind
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 0)
+       )
+       (block
+        (call $nothing)
+        (call_indirect (type $none_=>_none)
+         (i32.const 0)
+        )
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $bar
+  (call $nothing)
+  (call_indirect (type $none_=>_none)
+   (i32.const 0)
+  )
+ )
+ (func $nothing
+  (nop)
+ )
+ (func $asyncify_start_unwind (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_get_state (result i32)
+  (global.get $__asyncify_state)
+ )
+)

--- a/test/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.txt
@@ -22,8 +22,8 @@
    )
    (nop)
   )
-  (local.tee $0
-   (block $__asyncify_unwind
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
     (block
      (block
       (if
@@ -50,15 +50,39 @@
         )
        )
       )
-      (if
-       (i32.eq
-        (global.get $__asyncify_state)
-        (i32.const 0)
-       )
-       (block
-        (call $nothing)
-        (call_indirect (type $none_=>_none)
+      (block
+       (if
+        (i32.eq
+         (global.get $__asyncify_state)
          (i32.const 0)
+        )
+        (call $nothing)
+       )
+       (if
+        (if (result i32)
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 0)
+         )
+         (i32.const 1)
+         (i32.eq
+          (local.get $1)
+          (i32.const 0)
+         )
+        )
+        (block
+         (call_indirect (type $none_=>_none)
+          (i32.const 0)
+         )
+         (if
+          (i32.eq
+           (global.get $__asyncify_state)
+           (i32.const 1)
+          )
+          (br $__asyncify_unwind
+           (i32.const 0)
+          )
+         )
         )
        )
       )

--- a/test/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.wast
+++ b/test/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.wast
@@ -1,0 +1,18 @@
+(module
+  (type $t (func))
+  (memory 1 2)
+  (table 1 funcref)
+  (elem (i32.const 0))
+  (import "env" "import" (func $import))
+  (func $foo ;; doesn't look like it needs instrumentation, but in add list
+    (call $nothing)
+    (call_indirect (type $t) (i32.const 0))
+  )
+  (func $bar ;; doesn't look like it needs instrumentation, and not in add list
+    (call $nothing)
+    (call_indirect (type $t) (i32.const 0))
+  )
+  (func $nothing
+  )
+)
+


### PR DESCRIPTION
When doing manual tuning of calls using asyncify lists, we want it to
be possible to write out all the functions that can be on the stack when
pausing, and for that to work. This did not quite work right with the
`ignore-indirect` option: that would ignore all indirect calls all the
time, so that if `foo()` calls `bar()` indirectly, that indirect call was
not instrumented (we didn't check for a pause around it), even if
both `foo()` and `bar()` were listed. There was no way to make that
work (except for not ignoring indirect calls at all).

This PR makes the add-list and only-lists fully instrument the functions
mentioned in them: both themselves, and indirect calls from them.
(Note that direct calls need no special handling - we can just add
the direct call target to the add-list or only-list.)

This may add some overhead to existing users, but only in a function
that is instrumented anyhow, and also indirect calls are slow anyhow,
so it's probably fine. And it is simpler to do it this way instead of
adding another list for indirect call handling.