### PR TITLE
DWARF: Fix sequence_end emitting

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -241,9 +241,10 @@ struct LineState {
   }
 
   bool needToEmit() {
-    // Zero values imply we can ignore this line.
+    // Zero values imply we can ignore this line, unless it has something
+    // special we must emit.
     // https://github.com/WebAssembly/debugging/issues/9#issuecomment-567720872
-    return line != 0 && addr != 0;
+    return (line != 0 && addr != 0) || endSequence;
   }
 
   // Given an old state, emit the diff from it to this state into a new line

--- a/test/passes/fannkuch0.bin.txt
+++ b/test/passes/fannkuch0.bin.txt
@@ -2301,7 +2301,7 @@ DWARF debug info
 Contains section .debug_info (640 bytes)
 Contains section .debug_ranges (32 bytes)
 Contains section .debug_abbrev (222 bytes)
-Contains section .debug_line (3965 bytes)
+Contains section .debug_line (3976 bytes)
 Contains section .debug_str (409 bytes)
 
 .debug_abbrev contents:
@@ -2750,7 +2750,7 @@ Abbrev table for offset: 0x00000000
 .debug_line contents:
 debug_line[0x00000000]
 Line table prologue:
-    total_length: 0x00000f79
+    total_length: 0x00000f84
          version: 4
  prologue_length: 0x00000059
  min_inst_length: 1
@@ -4012,1142 +4012,1147 @@ file_names[  3]:
             0x000000000000086e     43      4      1   0             0  is_stmt
 
 
-0x00000832: 00 DW_LNE_set_address (0x0000000000000874)
-0x00000839: 03 DW_LNS_advance_line (152)
-0x0000083c: 05 DW_LNS_set_column (0)
-0x0000083e: 01 DW_LNS_copy
+0x00000832: 00 DW_LNE_set_address (0x0000000000000872)
+0x00000839: 03 DW_LNS_advance_line (0)
+0x0000083b: 06 DW_LNS_negate_stmt
+0x0000083c: 00 DW_LNE_end_sequence
+            0x0000000000000872      0      4      1   0             0  end_sequence
+
+0x0000083f: 00 DW_LNE_set_address (0x0000000000000874)
+0x00000846: 03 DW_LNS_advance_line (152)
+0x00000849: 01 DW_LNS_copy
             0x0000000000000874    152      0      1   0             0  is_stmt
 
 
-0x0000083f: 00 DW_LNE_set_address (0x00000000000008a7)
-0x00000846: 03 DW_LNS_advance_line (153)
-0x00000848: 05 DW_LNS_set_column (12)
-0x0000084a: 0a DW_LNS_set_prologue_end
-0x0000084b: 01 DW_LNS_copy
+0x0000084a: 00 DW_LNE_set_address (0x00000000000008a7)
+0x00000851: 03 DW_LNS_advance_line (153)
+0x00000853: 05 DW_LNS_set_column (12)
+0x00000855: 0a DW_LNS_set_prologue_end
+0x00000856: 01 DW_LNS_copy
             0x00000000000008a7    153     12      1   0             0  is_stmt prologue_end
 
 
-0x0000084c: 00 DW_LNE_set_address (0x00000000000008ae)
-0x00000853: 05 DW_LNS_set_column (17)
-0x00000855: 06 DW_LNS_negate_stmt
-0x00000856: 01 DW_LNS_copy
+0x00000857: 00 DW_LNE_set_address (0x00000000000008ae)
+0x0000085e: 05 DW_LNS_set_column (17)
+0x00000860: 06 DW_LNS_negate_stmt
+0x00000861: 01 DW_LNS_copy
             0x00000000000008ae    153     17      1   0             0 
 
 
-0x00000857: 00 DW_LNE_set_address (0x00000000000008bd)
-0x0000085e: 05 DW_LNS_set_column (12)
-0x00000860: 01 DW_LNS_copy
+0x00000862: 00 DW_LNE_set_address (0x00000000000008bd)
+0x00000869: 05 DW_LNS_set_column (12)
+0x0000086b: 01 DW_LNS_copy
             0x00000000000008bd    153     12      1   0             0 
 
 
-0x00000861: 00 DW_LNE_set_address (0x00000000000008d1)
-0x00000868: 05 DW_LNS_set_column (28)
-0x0000086a: 01 DW_LNS_copy
+0x0000086c: 00 DW_LNE_set_address (0x00000000000008d1)
+0x00000873: 05 DW_LNS_set_column (28)
+0x00000875: 01 DW_LNS_copy
             0x00000000000008d1    153     28      1   0             0 
 
 
-0x0000086b: 00 DW_LNE_set_address (0x00000000000008df)
-0x00000872: 05 DW_LNS_set_column (23)
-0x00000874: 01 DW_LNS_copy
+0x00000876: 00 DW_LNE_set_address (0x00000000000008df)
+0x0000087d: 05 DW_LNS_set_column (23)
+0x0000087f: 01 DW_LNS_copy
             0x00000000000008df    153     23      1   0             0 
 
 
-0x00000875: 00 DW_LNE_set_address (0x00000000000008e5)
-0x0000087c: 05 DW_LNS_set_column (12)
-0x0000087e: 01 DW_LNS_copy
+0x00000880: 00 DW_LNE_set_address (0x00000000000008e5)
+0x00000887: 05 DW_LNS_set_column (12)
+0x00000889: 01 DW_LNS_copy
             0x00000000000008e5    153     12      1   0             0 
 
 
-0x0000087f: 00 DW_LNE_set_address (0x00000000000008f0)
-0x00000886: 01 DW_LNS_copy
+0x0000088a: 00 DW_LNE_set_address (0x00000000000008f0)
+0x00000891: 01 DW_LNS_copy
             0x00000000000008f0    153     12      1   0             0 
 
 
-0x00000887: 00 DW_LNE_set_address (0x00000000000008f5)
-0x0000088e: 01 DW_LNS_copy
+0x00000892: 00 DW_LNE_set_address (0x00000000000008f5)
+0x00000899: 01 DW_LNS_copy
             0x00000000000008f5    153     12      1   0             0 
 
 
-0x0000088f: 00 DW_LNE_set_address (0x00000000000008fd)
-0x00000896: 05 DW_LNS_set_column (8)
-0x00000898: 01 DW_LNS_copy
+0x0000089a: 00 DW_LNE_set_address (0x00000000000008fd)
+0x000008a1: 05 DW_LNS_set_column (8)
+0x000008a3: 01 DW_LNS_copy
             0x00000000000008fd    153      8      1   0             0 
 
 
-0x00000899: 00 DW_LNE_set_address (0x0000000000000904)
-0x000008a0: 03 DW_LNS_advance_line (155)
-0x000008a2: 06 DW_LNS_negate_stmt
-0x000008a3: 01 DW_LNS_copy
+0x000008a4: 00 DW_LNE_set_address (0x0000000000000904)
+0x000008ab: 03 DW_LNS_advance_line (155)
+0x000008ad: 06 DW_LNS_negate_stmt
+0x000008ae: 01 DW_LNS_copy
             0x0000000000000904    155      8      1   0             0  is_stmt
 
 
-0x000008a4: 00 DW_LNE_set_address (0x000000000000090b)
-0x000008ab: 05 DW_LNS_set_column (10)
-0x000008ad: 06 DW_LNS_negate_stmt
-0x000008ae: 01 DW_LNS_copy
+0x000008af: 00 DW_LNE_set_address (0x000000000000090b)
+0x000008b6: 05 DW_LNS_set_column (10)
+0x000008b8: 06 DW_LNS_negate_stmt
+0x000008b9: 01 DW_LNS_copy
             0x000000000000090b    155     10      1   0             0 
 
 
-0x000008af: 00 DW_LNE_set_address (0x000000000000091a)
-0x000008b6: 05 DW_LNS_set_column (8)
-0x000008b8: 01 DW_LNS_copy
+0x000008ba: 00 DW_LNE_set_address (0x000000000000091a)
+0x000008c1: 05 DW_LNS_set_column (8)
+0x000008c3: 01 DW_LNS_copy
             0x000000000000091a    155      8      1   0             0 
 
 
-0x000008b9: 00 DW_LNE_set_address (0x000000000000092e)
-0x000008c0: 03 DW_LNS_advance_line (156)
-0x000008c2: 05 DW_LNS_set_column (7)
-0x000008c4: 06 DW_LNS_negate_stmt
-0x000008c5: 01 DW_LNS_copy
+0x000008c4: 00 DW_LNE_set_address (0x000000000000092e)
+0x000008cb: 03 DW_LNS_advance_line (156)
+0x000008cd: 05 DW_LNS_set_column (7)
+0x000008cf: 06 DW_LNS_negate_stmt
+0x000008d0: 01 DW_LNS_copy
             0x000000000000092e    156      7      1   0             0  is_stmt
 
 
-0x000008c6: 00 DW_LNE_set_address (0x0000000000000942)
-0x000008cd: 03 DW_LNS_advance_line (157)
-0x000008cf: 01 DW_LNS_copy
+0x000008d1: 00 DW_LNE_set_address (0x0000000000000942)
+0x000008d8: 03 DW_LNS_advance_line (157)
+0x000008da: 01 DW_LNS_copy
             0x0000000000000942    157      7      1   0             0  is_stmt
 
 
-0x000008d0: 00 DW_LNE_set_address (0x000000000000094c)
-0x000008d7: 03 DW_LNS_advance_line (159)
-0x000008d9: 05 DW_LNS_set_column (38)
-0x000008db: 01 DW_LNS_copy
+0x000008db: 00 DW_LNE_set_address (0x000000000000094c)
+0x000008e2: 03 DW_LNS_advance_line (159)
+0x000008e4: 05 DW_LNS_set_column (38)
+0x000008e6: 01 DW_LNS_copy
             0x000000000000094c    159     38      1   0             0  is_stmt
 
 
-0x000008dc: 00 DW_LNE_set_address (0x0000000000000953)
-0x000008e3: 05 DW_LNS_set_column (50)
-0x000008e5: 06 DW_LNS_negate_stmt
-0x000008e6: 01 DW_LNS_copy
+0x000008e7: 00 DW_LNE_set_address (0x0000000000000953)
+0x000008ee: 05 DW_LNS_set_column (50)
+0x000008f0: 06 DW_LNS_negate_stmt
+0x000008f1: 01 DW_LNS_copy
             0x0000000000000953    159     50      1   0             0 
 
 
-0x000008e7: 00 DW_LNE_set_address (0x000000000000095a)
-0x000008ee: 05 DW_LNS_set_column (41)
-0x000008f0: 01 DW_LNS_copy
+0x000008f2: 00 DW_LNE_set_address (0x000000000000095a)
+0x000008f9: 05 DW_LNS_set_column (41)
+0x000008fb: 01 DW_LNS_copy
             0x000000000000095a    159     41      1   0             0 
 
 
-0x000008f1: 00 DW_LNE_set_address (0x0000000000000960)
-0x000008f8: 05 DW_LNS_set_column (4)
-0x000008fa: 01 DW_LNS_copy
+0x000008fc: 00 DW_LNE_set_address (0x0000000000000960)
+0x00000903: 05 DW_LNS_set_column (4)
+0x00000905: 01 DW_LNS_copy
             0x0000000000000960    159      4      1   0             0 
 
 
-0x000008fb: 00 DW_LNE_set_address (0x000000000000097e)
-0x00000902: 03 DW_LNS_advance_line (160)
-0x00000904: 06 DW_LNS_negate_stmt
-0x00000905: 01 DW_LNS_copy
+0x00000906: 00 DW_LNE_set_address (0x000000000000097e)
+0x0000090d: 03 DW_LNS_advance_line (160)
+0x0000090f: 06 DW_LNS_negate_stmt
+0x00000910: 01 DW_LNS_copy
             0x000000000000097e    160      4      1   0             0  is_stmt
 
 
-0x00000906: 00 DW_LNE_set_address (0x0000000000000986)
-0x0000090d: 03 DW_LNS_advance_line (161)
-0x0000090f: 05 DW_LNS_set_column (1)
-0x00000911: 01 DW_LNS_copy
+0x00000911: 00 DW_LNE_set_address (0x0000000000000986)
+0x00000918: 03 DW_LNS_advance_line (161)
+0x0000091a: 05 DW_LNS_set_column (1)
+0x0000091c: 01 DW_LNS_copy
             0x0000000000000986    161      1      1   0             0  is_stmt
 
 
-0x00000912: 00 DW_LNE_set_address (0x00000000000009a0)
-0x00000919: 00 DW_LNE_end_sequence
+0x0000091d: 00 DW_LNE_set_address (0x00000000000009a0)
+0x00000924: 00 DW_LNE_end_sequence
             0x00000000000009a0    161      1      1   0             0  is_stmt end_sequence
 
-0x0000091c: 00 DW_LNE_set_address (0x00000000000009a2)
-0x00000923: 03 DW_LNS_advance_line (88)
-0x00000926: 01 DW_LNS_copy
+0x00000927: 00 DW_LNE_set_address (0x00000000000009a2)
+0x0000092e: 03 DW_LNS_advance_line (88)
+0x00000931: 01 DW_LNS_copy
             0x00000000000009a2     88      0      1   0             0  is_stmt
 
 
-0x00000927: 00 DW_LNE_set_address (0x00000000000009c8)
-0x0000092e: 03 DW_LNS_advance_line (90)
-0x00000930: 05 DW_LNS_set_column (8)
-0x00000932: 0a DW_LNS_set_prologue_end
-0x00000933: 01 DW_LNS_copy
+0x00000932: 00 DW_LNE_set_address (0x00000000000009c8)
+0x00000939: 03 DW_LNS_advance_line (90)
+0x0000093b: 05 DW_LNS_set_column (8)
+0x0000093d: 0a DW_LNS_set_prologue_end
+0x0000093e: 01 DW_LNS_copy
             0x00000000000009c8     90      8      1   0             0  is_stmt prologue_end
 
 
-0x00000934: 00 DW_LNE_set_address (0x00000000000009cf)
-0x0000093b: 03 DW_LNS_advance_line (93)
-0x0000093d: 05 DW_LNS_set_column (9)
-0x0000093f: 01 DW_LNS_copy
+0x0000093f: 00 DW_LNE_set_address (0x00000000000009cf)
+0x00000946: 03 DW_LNS_advance_line (93)
+0x00000948: 05 DW_LNS_set_column (9)
+0x0000094a: 01 DW_LNS_copy
             0x00000000000009cf     93      9      1   0             0  is_stmt
 
 
-0x00000940: 00 DW_LNE_set_address (0x00000000000009d6)
-0x00000947: 03 DW_LNS_advance_line (94)
-0x00000949: 05 DW_LNS_set_column (11)
-0x0000094b: 01 DW_LNS_copy
+0x0000094b: 00 DW_LNE_set_address (0x00000000000009d6)
+0x00000952: 03 DW_LNS_advance_line (94)
+0x00000954: 05 DW_LNS_set_column (11)
+0x00000956: 01 DW_LNS_copy
             0x00000000000009d6     94     11      1   0             0  is_stmt
 
 
-0x0000094c: 00 DW_LNE_set_address (0x00000000000009dd)
-0x00000953: 05 DW_LNS_set_column (16)
-0x00000955: 06 DW_LNS_negate_stmt
-0x00000956: 01 DW_LNS_copy
+0x00000957: 00 DW_LNE_set_address (0x00000000000009dd)
+0x0000095e: 05 DW_LNS_set_column (16)
+0x00000960: 06 DW_LNS_negate_stmt
+0x00000961: 01 DW_LNS_copy
             0x00000000000009dd     94     16      1   0             0 
 
 
-0x00000957: 00 DW_LNE_set_address (0x00000000000009e8)
-0x0000095e: 05 DW_LNS_set_column (20)
-0x00000960: 01 DW_LNS_copy
+0x00000962: 00 DW_LNE_set_address (0x00000000000009e8)
+0x00000969: 05 DW_LNS_set_column (20)
+0x0000096b: 01 DW_LNS_copy
             0x00000000000009e8     94     20      1   0             0 
 
 
-0x00000961: 00 DW_LNE_set_address (0x00000000000009ef)
-0x00000968: 05 DW_LNS_set_column (22)
-0x0000096a: 01 DW_LNS_copy
+0x0000096c: 00 DW_LNE_set_address (0x00000000000009ef)
+0x00000973: 05 DW_LNS_set_column (22)
+0x00000975: 01 DW_LNS_copy
             0x00000000000009ef     94     22      1   0             0 
 
 
-0x0000096b: 00 DW_LNE_set_address (0x00000000000009fa)
-0x00000972: 05 DW_LNS_set_column (18)
-0x00000974: 01 DW_LNS_copy
+0x00000976: 00 DW_LNE_set_address (0x00000000000009fa)
+0x0000097d: 05 DW_LNS_set_column (18)
+0x0000097f: 01 DW_LNS_copy
             0x00000000000009fa     94     18      1   0             0 
 
 
-0x00000975: 00 DW_LNE_set_address (0x0000000000000a09)
-0x0000097c: 05 DW_LNS_set_column (4)
-0x0000097e: 01 DW_LNS_copy
+0x00000980: 00 DW_LNE_set_address (0x0000000000000a09)
+0x00000987: 05 DW_LNS_set_column (4)
+0x00000989: 01 DW_LNS_copy
             0x0000000000000a09     94      4      1   0             0 
 
 
-0x0000097f: 00 DW_LNE_set_address (0x0000000000000a1d)
-0x00000986: 03 DW_LNS_advance_line (95)
-0x00000988: 05 DW_LNS_set_column (29)
-0x0000098a: 06 DW_LNS_negate_stmt
-0x0000098b: 01 DW_LNS_copy
+0x0000098a: 00 DW_LNE_set_address (0x0000000000000a1d)
+0x00000991: 03 DW_LNS_advance_line (95)
+0x00000993: 05 DW_LNS_set_column (29)
+0x00000995: 06 DW_LNS_negate_stmt
+0x00000996: 01 DW_LNS_copy
             0x0000000000000a1d     95     29      1   0             0  is_stmt
 
 
-0x0000098c: 00 DW_LNE_set_address (0x0000000000000a23)
-0x00000993: 05 DW_LNS_set_column (13)
-0x00000995: 06 DW_LNS_negate_stmt
-0x00000996: 01 DW_LNS_copy
+0x00000997: 00 DW_LNE_set_address (0x0000000000000a23)
+0x0000099e: 05 DW_LNS_set_column (13)
+0x000009a0: 06 DW_LNS_negate_stmt
+0x000009a1: 01 DW_LNS_copy
             0x0000000000000a23     95     13      1   0             0 
 
 
-0x00000997: 00 DW_LNE_set_address (0x0000000000000a2a)
-0x0000099e: 03 DW_LNS_advance_line (96)
-0x000009a0: 05 DW_LNS_set_column (18)
-0x000009a2: 06 DW_LNS_negate_stmt
-0x000009a3: 01 DW_LNS_copy
+0x000009a2: 00 DW_LNE_set_address (0x0000000000000a2a)
+0x000009a9: 03 DW_LNS_advance_line (96)
+0x000009ab: 05 DW_LNS_set_column (18)
+0x000009ad: 06 DW_LNS_negate_stmt
+0x000009ae: 01 DW_LNS_copy
             0x0000000000000a2a     96     18      1   0             0  is_stmt
 
 
-0x000009a4: 00 DW_LNE_set_address (0x0000000000000a31)
-0x000009ab: 05 DW_LNS_set_column (7)
-0x000009ad: 06 DW_LNS_negate_stmt
-0x000009ae: 01 DW_LNS_copy
+0x000009af: 00 DW_LNE_set_address (0x0000000000000a31)
+0x000009b6: 05 DW_LNS_set_column (7)
+0x000009b8: 06 DW_LNS_negate_stmt
+0x000009b9: 01 DW_LNS_copy
             0x0000000000000a31     96      7      1   0             0 
 
 
-0x000009af: 00 DW_LNE_set_address (0x0000000000000a38)
-0x000009b6: 05 DW_LNS_set_column (16)
-0x000009b8: 01 DW_LNS_copy
+0x000009ba: 00 DW_LNE_set_address (0x0000000000000a38)
+0x000009c1: 05 DW_LNS_set_column (16)
+0x000009c3: 01 DW_LNS_copy
             0x0000000000000a38     96     16      1   0             0 
 
 
-0x000009b9: 00 DW_LNE_set_address (0x0000000000000a3f)
-0x000009c0: 03 DW_LNS_advance_line (97)
-0x000009c2: 05 DW_LNS_set_column (18)
-0x000009c4: 06 DW_LNS_negate_stmt
-0x000009c5: 01 DW_LNS_copy
+0x000009c4: 00 DW_LNE_set_address (0x0000000000000a3f)
+0x000009cb: 03 DW_LNS_advance_line (97)
+0x000009cd: 05 DW_LNS_set_column (18)
+0x000009cf: 06 DW_LNS_negate_stmt
+0x000009d0: 01 DW_LNS_copy
             0x0000000000000a3f     97     18      1   0             0  is_stmt
 
 
-0x000009c6: 00 DW_LNE_set_address (0x0000000000000a46)
-0x000009cd: 05 DW_LNS_set_column (7)
-0x000009cf: 06 DW_LNS_negate_stmt
-0x000009d0: 01 DW_LNS_copy
+0x000009d1: 00 DW_LNE_set_address (0x0000000000000a46)
+0x000009d8: 05 DW_LNS_set_column (7)
+0x000009da: 06 DW_LNS_negate_stmt
+0x000009db: 01 DW_LNS_copy
             0x0000000000000a46     97      7      1   0             0 
 
 
-0x000009d1: 00 DW_LNE_set_address (0x0000000000000a4d)
-0x000009d8: 05 DW_LNS_set_column (16)
-0x000009da: 01 DW_LNS_copy
+0x000009dc: 00 DW_LNE_set_address (0x0000000000000a4d)
+0x000009e3: 05 DW_LNS_set_column (16)
+0x000009e5: 01 DW_LNS_copy
             0x0000000000000a4d     97     16      1   0             0 
 
 
-0x000009db: 00 DW_LNE_set_address (0x0000000000000a54)
-0x000009e2: 03 DW_LNS_advance_line (98)
-0x000009e4: 05 DW_LNS_set_column (21)
-0x000009e6: 06 DW_LNS_negate_stmt
-0x000009e7: 01 DW_LNS_copy
+0x000009e6: 00 DW_LNE_set_address (0x0000000000000a54)
+0x000009ed: 03 DW_LNS_advance_line (98)
+0x000009ef: 05 DW_LNS_set_column (21)
+0x000009f1: 06 DW_LNS_negate_stmt
+0x000009f2: 01 DW_LNS_copy
             0x0000000000000a54     98     21      1   0             0  is_stmt
 
 
-0x000009e8: 00 DW_LNE_set_address (0x0000000000000a5b)
-0x000009ef: 05 DW_LNS_set_column (7)
-0x000009f1: 06 DW_LNS_negate_stmt
-0x000009f2: 01 DW_LNS_copy
+0x000009f3: 00 DW_LNE_set_address (0x0000000000000a5b)
+0x000009fa: 05 DW_LNS_set_column (7)
+0x000009fc: 06 DW_LNS_negate_stmt
+0x000009fd: 01 DW_LNS_copy
             0x0000000000000a5b     98      7      1   0             0 
 
 
-0x000009f3: 00 DW_LNE_set_address (0x0000000000000a62)
-0x000009fa: 05 DW_LNS_set_column (19)
-0x000009fc: 01 DW_LNS_copy
+0x000009fe: 00 DW_LNE_set_address (0x0000000000000a62)
+0x00000a05: 05 DW_LNS_set_column (19)
+0x00000a07: 01 DW_LNS_copy
             0x0000000000000a62     98     19      1   0             0 
 
 
-0x000009fd: 00 DW_LNE_set_address (0x0000000000000a69)
-0x00000a04: 03 DW_LNS_advance_line (99)
-0x00000a06: 05 DW_LNS_set_column (14)
-0x00000a08: 06 DW_LNS_negate_stmt
-0x00000a09: 01 DW_LNS_copy
+0x00000a08: 00 DW_LNE_set_address (0x0000000000000a69)
+0x00000a0f: 03 DW_LNS_advance_line (99)
+0x00000a11: 05 DW_LNS_set_column (14)
+0x00000a13: 06 DW_LNS_negate_stmt
+0x00000a14: 01 DW_LNS_copy
             0x0000000000000a69     99     14      1   0             0  is_stmt
 
 
-0x00000a0a: 00 DW_LNE_set_address (0x0000000000000a70)
-0x00000a11: 05 DW_LNS_set_column (12)
-0x00000a13: 06 DW_LNS_negate_stmt
-0x00000a14: 01 DW_LNS_copy
+0x00000a15: 00 DW_LNE_set_address (0x0000000000000a70)
+0x00000a1c: 05 DW_LNS_set_column (12)
+0x00000a1e: 06 DW_LNS_negate_stmt
+0x00000a1f: 01 DW_LNS_copy
             0x0000000000000a70     99     12      1   0             0 
 
 
-0x00000a15: 00 DW_LNE_set_address (0x0000000000000a77)
-0x00000a1c: 03 DW_LNS_advance_line (94)
-0x00000a1e: 05 DW_LNS_set_column (28)
-0x00000a20: 06 DW_LNS_negate_stmt
-0x00000a21: 01 DW_LNS_copy
+0x00000a20: 00 DW_LNE_set_address (0x0000000000000a77)
+0x00000a27: 03 DW_LNS_advance_line (94)
+0x00000a29: 05 DW_LNS_set_column (28)
+0x00000a2b: 06 DW_LNS_negate_stmt
+0x00000a2c: 01 DW_LNS_copy
             0x0000000000000a77     94     28      1   0             0  is_stmt
 
 
-0x00000a22: 00 DW_LNE_set_address (0x0000000000000a90)
-0x00000a29: 05 DW_LNS_set_column (4)
-0x00000a2b: 06 DW_LNS_negate_stmt
-0x00000a2c: 01 DW_LNS_copy
+0x00000a2d: 00 DW_LNE_set_address (0x0000000000000a90)
+0x00000a34: 05 DW_LNS_set_column (4)
+0x00000a36: 06 DW_LNS_negate_stmt
+0x00000a37: 01 DW_LNS_copy
             0x0000000000000a90     94      4      1   0             0 
 
 
-0x00000a2d: 00 DW_LNE_set_address (0x0000000000000a93)
-0x00000a34: 01 DW_LNS_copy
+0x00000a38: 00 DW_LNE_set_address (0x0000000000000a93)
+0x00000a3f: 01 DW_LNS_copy
             0x0000000000000a93     94      4      1   0             0 
 
 
-0x00000a35: 00 DW_LNE_set_address (0x0000000000000a9a)
-0x00000a3c: 03 DW_LNS_advance_line (102)
-0x00000a3e: 05 DW_LNS_set_column (25)
-0x00000a40: 06 DW_LNS_negate_stmt
-0x00000a41: 01 DW_LNS_copy
+0x00000a40: 00 DW_LNE_set_address (0x0000000000000a9a)
+0x00000a47: 03 DW_LNS_advance_line (102)
+0x00000a49: 05 DW_LNS_set_column (25)
+0x00000a4b: 06 DW_LNS_negate_stmt
+0x00000a4c: 01 DW_LNS_copy
             0x0000000000000a9a    102     25      1   0             0  is_stmt
 
 
-0x00000a42: 00 DW_LNE_set_address (0x0000000000000aa1)
-0x00000a49: 05 DW_LNS_set_column (27)
-0x00000a4b: 06 DW_LNS_negate_stmt
-0x00000a4c: 01 DW_LNS_copy
+0x00000a4d: 00 DW_LNE_set_address (0x0000000000000aa1)
+0x00000a54: 05 DW_LNS_set_column (27)
+0x00000a56: 06 DW_LNS_negate_stmt
+0x00000a57: 01 DW_LNS_copy
             0x0000000000000aa1    102     27      1   0             0 
 
 
-0x00000a4d: 00 DW_LNE_set_address (0x0000000000000aac)
-0x00000a54: 05 DW_LNS_set_column (18)
-0x00000a56: 01 DW_LNS_copy
+0x00000a58: 00 DW_LNE_set_address (0x0000000000000aac)
+0x00000a5f: 05 DW_LNS_set_column (18)
+0x00000a61: 01 DW_LNS_copy
             0x0000000000000aac    102     18      1   0             0 
 
 
-0x00000a57: 00 DW_LNE_set_address (0x0000000000000ab2)
-0x00000a5e: 05 DW_LNS_set_column (10)
-0x00000a60: 01 DW_LNS_copy
+0x00000a62: 00 DW_LNE_set_address (0x0000000000000ab2)
+0x00000a69: 05 DW_LNS_set_column (10)
+0x00000a6b: 01 DW_LNS_copy
             0x0000000000000ab2    102     10      1   0             0 
 
 
-0x00000a61: 00 DW_LNE_set_address (0x0000000000000ab9)
-0x00000a68: 03 DW_LNS_advance_line (103)
-0x00000a6a: 05 DW_LNS_set_column (25)
-0x00000a6c: 06 DW_LNS_negate_stmt
-0x00000a6d: 01 DW_LNS_copy
+0x00000a6c: 00 DW_LNE_set_address (0x0000000000000ab9)
+0x00000a73: 03 DW_LNS_advance_line (103)
+0x00000a75: 05 DW_LNS_set_column (25)
+0x00000a77: 06 DW_LNS_negate_stmt
+0x00000a78: 01 DW_LNS_copy
             0x0000000000000ab9    103     25      1   0             0  is_stmt
 
 
-0x00000a6e: 00 DW_LNE_set_address (0x0000000000000ac0)
-0x00000a75: 05 DW_LNS_set_column (27)
-0x00000a77: 06 DW_LNS_negate_stmt
-0x00000a78: 01 DW_LNS_copy
+0x00000a79: 00 DW_LNE_set_address (0x0000000000000ac0)
+0x00000a80: 05 DW_LNS_set_column (27)
+0x00000a82: 06 DW_LNS_negate_stmt
+0x00000a83: 01 DW_LNS_copy
             0x0000000000000ac0    103     27      1   0             0 
 
 
-0x00000a79: 00 DW_LNE_set_address (0x0000000000000acb)
-0x00000a80: 05 DW_LNS_set_column (18)
-0x00000a82: 01 DW_LNS_copy
+0x00000a84: 00 DW_LNE_set_address (0x0000000000000acb)
+0x00000a8b: 05 DW_LNS_set_column (18)
+0x00000a8d: 01 DW_LNS_copy
             0x0000000000000acb    103     18      1   0             0 
 
 
-0x00000a83: 00 DW_LNE_set_address (0x0000000000000ad1)
-0x00000a8a: 05 DW_LNS_set_column (10)
-0x00000a8c: 01 DW_LNS_copy
+0x00000a8e: 00 DW_LNE_set_address (0x0000000000000ad1)
+0x00000a95: 05 DW_LNS_set_column (10)
+0x00000a97: 01 DW_LNS_copy
             0x0000000000000ad1    103     10      1   0             0 
 
 
-0x00000a8d: 00 DW_LNE_set_address (0x0000000000000ad8)
-0x00000a94: 03 DW_LNS_advance_line (105)
-0x00000a96: 05 DW_LNS_set_column (11)
-0x00000a98: 06 DW_LNS_negate_stmt
-0x00000a99: 01 DW_LNS_copy
+0x00000a98: 00 DW_LNE_set_address (0x0000000000000ad8)
+0x00000a9f: 03 DW_LNS_advance_line (105)
+0x00000aa1: 05 DW_LNS_set_column (11)
+0x00000aa3: 06 DW_LNS_negate_stmt
+0x00000aa4: 01 DW_LNS_copy
             0x0000000000000ad8    105     11      1   0             0  is_stmt
 
 
-0x00000a9a: 00 DW_LNE_set_address (0x0000000000000adf)
-0x00000aa1: 05 DW_LNS_set_column (16)
-0x00000aa3: 06 DW_LNS_negate_stmt
-0x00000aa4: 01 DW_LNS_copy
+0x00000aa5: 00 DW_LNE_set_address (0x0000000000000adf)
+0x00000aac: 05 DW_LNS_set_column (16)
+0x00000aae: 06 DW_LNS_negate_stmt
+0x00000aaf: 01 DW_LNS_copy
             0x0000000000000adf    105     16      1   0             0 
 
 
-0x00000aa5: 00 DW_LNE_set_address (0x0000000000000aea)
-0x00000aac: 05 DW_LNS_set_column (20)
-0x00000aae: 01 DW_LNS_copy
+0x00000ab0: 00 DW_LNE_set_address (0x0000000000000aea)
+0x00000ab7: 05 DW_LNS_set_column (20)
+0x00000ab9: 01 DW_LNS_copy
             0x0000000000000aea    105     20      1   0             0 
 
 
-0x00000aaf: 00 DW_LNE_set_address (0x0000000000000af1)
-0x00000ab6: 05 DW_LNS_set_column (18)
-0x00000ab8: 01 DW_LNS_copy
+0x00000aba: 00 DW_LNE_set_address (0x0000000000000af1)
+0x00000ac1: 05 DW_LNS_set_column (18)
+0x00000ac3: 01 DW_LNS_copy
             0x0000000000000af1    105     18      1   0             0 
 
 
-0x00000ab9: 00 DW_LNE_set_address (0x0000000000000b00)
-0x00000ac0: 05 DW_LNS_set_column (4)
-0x00000ac2: 01 DW_LNS_copy
+0x00000ac4: 00 DW_LNE_set_address (0x0000000000000b00)
+0x00000acb: 05 DW_LNS_set_column (4)
+0x00000acd: 01 DW_LNS_copy
             0x0000000000000b00    105      4      1   0             0 
 
 
-0x00000ac3: 00 DW_LNE_set_address (0x0000000000000b10)
-0x00000aca: 03 DW_LNS_advance_line (106)
-0x00000acc: 05 DW_LNS_set_column (18)
-0x00000ace: 06 DW_LNS_negate_stmt
-0x00000acf: 01 DW_LNS_copy
+0x00000ace: 00 DW_LNE_set_address (0x0000000000000b10)
+0x00000ad5: 03 DW_LNS_advance_line (106)
+0x00000ad7: 05 DW_LNS_set_column (18)
+0x00000ad9: 06 DW_LNS_negate_stmt
+0x00000ada: 01 DW_LNS_copy
             0x0000000000000b10    106     18      1   0             0  is_stmt
 
 
-0x00000ad0: 00 DW_LNE_set_address (0x0000000000000b17)
-0x00000ad7: 05 DW_LNS_set_column (7)
-0x00000ad9: 06 DW_LNS_negate_stmt
-0x00000ada: 01 DW_LNS_copy
+0x00000adb: 00 DW_LNE_set_address (0x0000000000000b17)
+0x00000ae2: 05 DW_LNS_set_column (7)
+0x00000ae4: 06 DW_LNS_negate_stmt
+0x00000ae5: 01 DW_LNS_copy
             0x0000000000000b17    106      7      1   0             0 
 
 
-0x00000adb: 00 DW_LNE_set_address (0x0000000000000b1e)
-0x00000ae2: 05 DW_LNS_set_column (13)
-0x00000ae4: 01 DW_LNS_copy
+0x00000ae6: 00 DW_LNE_set_address (0x0000000000000b1e)
+0x00000aed: 05 DW_LNS_set_column (13)
+0x00000aef: 01 DW_LNS_copy
             0x0000000000000b1e    106     13      1   0             0 
 
 
-0x00000ae5: 00 DW_LNE_set_address (0x0000000000000b25)
-0x00000aec: 05 DW_LNS_set_column (7)
-0x00000aee: 01 DW_LNS_copy
+0x00000af0: 00 DW_LNE_set_address (0x0000000000000b25)
+0x00000af7: 05 DW_LNS_set_column (7)
+0x00000af9: 01 DW_LNS_copy
             0x0000000000000b25    106      7      1   0             0 
 
 
-0x00000aef: 00 DW_LNE_set_address (0x0000000000000b37)
-0x00000af6: 05 DW_LNS_set_column (16)
-0x00000af8: 01 DW_LNS_copy
+0x00000afa: 00 DW_LNE_set_address (0x0000000000000b37)
+0x00000b01: 05 DW_LNS_set_column (16)
+0x00000b03: 01 DW_LNS_copy
             0x0000000000000b37    106     16      1   0             0 
 
 
-0x00000af9: 00 DW_LNE_set_address (0x0000000000000b3e)
-0x00000b00: 03 DW_LNS_advance_line (105)
-0x00000b02: 05 DW_LNS_set_column (24)
-0x00000b04: 06 DW_LNS_negate_stmt
-0x00000b05: 01 DW_LNS_copy
+0x00000b04: 00 DW_LNE_set_address (0x0000000000000b3e)
+0x00000b0b: 03 DW_LNS_advance_line (105)
+0x00000b0d: 05 DW_LNS_set_column (24)
+0x00000b0f: 06 DW_LNS_negate_stmt
+0x00000b10: 01 DW_LNS_copy
             0x0000000000000b3e    105     24      1   0             0  is_stmt
 
 
-0x00000b06: 00 DW_LNE_set_address (0x0000000000000b57)
-0x00000b0d: 05 DW_LNS_set_column (4)
-0x00000b0f: 06 DW_LNS_negate_stmt
-0x00000b10: 01 DW_LNS_copy
+0x00000b11: 00 DW_LNE_set_address (0x0000000000000b57)
+0x00000b18: 05 DW_LNS_set_column (4)
+0x00000b1a: 06 DW_LNS_negate_stmt
+0x00000b1b: 01 DW_LNS_copy
             0x0000000000000b57    105      4      1   0             0 
 
 
-0x00000b11: 00 DW_LNE_set_address (0x0000000000000b5a)
-0x00000b18: 01 DW_LNS_copy
+0x00000b1c: 00 DW_LNE_set_address (0x0000000000000b5a)
+0x00000b23: 01 DW_LNS_copy
             0x0000000000000b5a    105      4      1   0             0 
 
 
-0x00000b19: 00 DW_LNE_set_address (0x0000000000000b5d)
-0x00000b20: 03 DW_LNS_advance_line (108)
-0x00000b22: 05 DW_LNS_set_column (8)
-0x00000b24: 06 DW_LNS_negate_stmt
-0x00000b25: 01 DW_LNS_copy
+0x00000b24: 00 DW_LNE_set_address (0x0000000000000b5d)
+0x00000b2b: 03 DW_LNS_advance_line (108)
+0x00000b2d: 05 DW_LNS_set_column (8)
+0x00000b2f: 06 DW_LNS_negate_stmt
+0x00000b30: 01 DW_LNS_copy
             0x0000000000000b5d    108      8      1   0             0  is_stmt
 
 
-0x00000b26: 00 DW_LNE_set_address (0x0000000000000b64)
-0x00000b2d: 05 DW_LNS_set_column (6)
-0x00000b2f: 06 DW_LNS_negate_stmt
-0x00000b30: 01 DW_LNS_copy
+0x00000b31: 00 DW_LNE_set_address (0x0000000000000b64)
+0x00000b38: 05 DW_LNS_set_column (6)
+0x00000b3a: 06 DW_LNS_negate_stmt
+0x00000b3b: 01 DW_LNS_copy
             0x0000000000000b64    108      6      1   0             0 
 
 
-0x00000b31: 00 DW_LNE_set_address (0x0000000000000b6b)
-0x00000b38: 03 DW_LNS_advance_line (110)
-0x00000b3a: 05 DW_LNS_set_column (11)
-0x00000b3c: 06 DW_LNS_negate_stmt
-0x00000b3d: 01 DW_LNS_copy
+0x00000b3c: 00 DW_LNE_set_address (0x0000000000000b6b)
+0x00000b43: 03 DW_LNS_advance_line (110)
+0x00000b45: 05 DW_LNS_set_column (11)
+0x00000b47: 06 DW_LNS_negate_stmt
+0x00000b48: 01 DW_LNS_copy
             0x0000000000000b6b    110     11      1   0             0  is_stmt
 
 
-0x00000b3e: 00 DW_LNE_set_address (0x0000000000000b76)
-0x00000b45: 06 DW_LNS_negate_stmt
-0x00000b46: 01 DW_LNS_copy
+0x00000b49: 00 DW_LNE_set_address (0x0000000000000b76)
+0x00000b50: 06 DW_LNS_negate_stmt
+0x00000b51: 01 DW_LNS_copy
             0x0000000000000b76    110     11      1   0             0 
 
 
-0x00000b47: 00 DW_LNE_set_address (0x0000000000000b83)
-0x00000b4e: 03 DW_LNS_advance_line (111)
-0x00000b50: 05 DW_LNS_set_column (17)
-0x00000b52: 06 DW_LNS_negate_stmt
-0x00000b53: 01 DW_LNS_copy
+0x00000b52: 00 DW_LNE_set_address (0x0000000000000b83)
+0x00000b59: 03 DW_LNS_advance_line (111)
+0x00000b5b: 05 DW_LNS_set_column (17)
+0x00000b5d: 06 DW_LNS_negate_stmt
+0x00000b5e: 01 DW_LNS_copy
             0x0000000000000b83    111     17      1   0             0  is_stmt
 
 
-0x00000b54: 00 DW_LNE_set_address (0x0000000000000b8a)
-0x00000b5b: 05 DW_LNS_set_column (22)
-0x00000b5d: 06 DW_LNS_negate_stmt
-0x00000b5e: 01 DW_LNS_copy
+0x00000b5f: 00 DW_LNE_set_address (0x0000000000000b8a)
+0x00000b66: 05 DW_LNS_set_column (22)
+0x00000b68: 06 DW_LNS_negate_stmt
+0x00000b69: 01 DW_LNS_copy
             0x0000000000000b8a    111     22      1   0             0 
 
 
-0x00000b5f: 00 DW_LNE_set_address (0x0000000000000b95)
-0x00000b66: 05 DW_LNS_set_column (26)
-0x00000b68: 01 DW_LNS_copy
+0x00000b6a: 00 DW_LNE_set_address (0x0000000000000b95)
+0x00000b71: 05 DW_LNS_set_column (26)
+0x00000b73: 01 DW_LNS_copy
             0x0000000000000b95    111     26      1   0             0 
 
 
-0x00000b69: 00 DW_LNE_set_address (0x0000000000000b9c)
-0x00000b70: 05 DW_LNS_set_column (24)
-0x00000b72: 01 DW_LNS_copy
+0x00000b74: 00 DW_LNE_set_address (0x0000000000000b9c)
+0x00000b7b: 05 DW_LNS_set_column (24)
+0x00000b7d: 01 DW_LNS_copy
             0x0000000000000b9c    111     24      1   0             0 
 
 
-0x00000b73: 00 DW_LNE_set_address (0x0000000000000bab)
-0x00000b7a: 05 DW_LNS_set_column (10)
-0x00000b7c: 01 DW_LNS_copy
+0x00000b7e: 00 DW_LNE_set_address (0x0000000000000bab)
+0x00000b85: 05 DW_LNS_set_column (10)
+0x00000b87: 01 DW_LNS_copy
             0x0000000000000bab    111     10      1   0             0 
 
 
-0x00000b7d: 00 DW_LNE_set_address (0x0000000000000bbb)
-0x00000b84: 03 DW_LNS_advance_line (112)
-0x00000b86: 05 DW_LNS_set_column (26)
-0x00000b88: 06 DW_LNS_negate_stmt
-0x00000b89: 01 DW_LNS_copy
+0x00000b88: 00 DW_LNE_set_address (0x0000000000000bbb)
+0x00000b8f: 03 DW_LNS_advance_line (112)
+0x00000b91: 05 DW_LNS_set_column (26)
+0x00000b93: 06 DW_LNS_negate_stmt
+0x00000b94: 01 DW_LNS_copy
             0x0000000000000bbb    112     26      1   0             0  is_stmt
 
 
-0x00000b8a: 00 DW_LNE_set_address (0x0000000000000bc2)
-0x00000b91: 05 DW_LNS_set_column (32)
-0x00000b93: 06 DW_LNS_negate_stmt
-0x00000b94: 01 DW_LNS_copy
+0x00000b95: 00 DW_LNE_set_address (0x0000000000000bc2)
+0x00000b9c: 05 DW_LNS_set_column (32)
+0x00000b9e: 06 DW_LNS_negate_stmt
+0x00000b9f: 01 DW_LNS_copy
             0x0000000000000bc2    112     32      1   0             0 
 
 
-0x00000b95: 00 DW_LNE_set_address (0x0000000000000bc9)
-0x00000b9c: 05 DW_LNS_set_column (26)
-0x00000b9e: 01 DW_LNS_copy
+0x00000ba0: 00 DW_LNE_set_address (0x0000000000000bc9)
+0x00000ba7: 05 DW_LNS_set_column (26)
+0x00000ba9: 01 DW_LNS_copy
             0x0000000000000bc9    112     26      1   0             0 
 
 
-0x00000b9f: 00 DW_LNE_set_address (0x0000000000000be2)
-0x00000ba6: 05 DW_LNS_set_column (35)
-0x00000ba8: 01 DW_LNS_copy
+0x00000baa: 00 DW_LNE_set_address (0x0000000000000be2)
+0x00000bb1: 05 DW_LNS_set_column (35)
+0x00000bb3: 01 DW_LNS_copy
             0x0000000000000be2    112     35      1   0             0 
 
 
-0x00000ba9: 00 DW_LNE_set_address (0x0000000000000bed)
-0x00000bb0: 05 DW_LNS_set_column (13)
-0x00000bb2: 01 DW_LNS_copy
+0x00000bb4: 00 DW_LNE_set_address (0x0000000000000bed)
+0x00000bbb: 05 DW_LNS_set_column (13)
+0x00000bbd: 01 DW_LNS_copy
             0x0000000000000bed    112     13      1   0             0 
 
 
-0x00000bb3: 00 DW_LNE_set_address (0x0000000000000c00)
-0x00000bba: 03 DW_LNS_advance_line (111)
-0x00000bbc: 05 DW_LNS_set_column (30)
-0x00000bbe: 06 DW_LNS_negate_stmt
-0x00000bbf: 01 DW_LNS_copy
+0x00000bbe: 00 DW_LNE_set_address (0x0000000000000c00)
+0x00000bc5: 03 DW_LNS_advance_line (111)
+0x00000bc7: 05 DW_LNS_set_column (30)
+0x00000bc9: 06 DW_LNS_negate_stmt
+0x00000bca: 01 DW_LNS_copy
             0x0000000000000c00    111     30      1   0             0  is_stmt
 
 
-0x00000bc0: 00 DW_LNE_set_address (0x0000000000000c19)
-0x00000bc7: 05 DW_LNS_set_column (10)
-0x00000bc9: 06 DW_LNS_negate_stmt
-0x00000bca: 01 DW_LNS_copy
+0x00000bcb: 00 DW_LNE_set_address (0x0000000000000c19)
+0x00000bd2: 05 DW_LNS_set_column (10)
+0x00000bd4: 06 DW_LNS_negate_stmt
+0x00000bd5: 01 DW_LNS_copy
             0x0000000000000c19    111     10      1   0             0 
 
 
-0x00000bcb: 00 DW_LNE_set_address (0x0000000000000c1c)
-0x00000bd2: 01 DW_LNS_copy
+0x00000bd6: 00 DW_LNE_set_address (0x0000000000000c1c)
+0x00000bdd: 01 DW_LNS_copy
             0x0000000000000c1c    111     10      1   0             0 
 
 
-0x00000bd3: 00 DW_LNE_set_address (0x0000000000000c1f)
-0x00000bda: 03 DW_LNS_advance_line (113)
-0x00000bdc: 06 DW_LNS_negate_stmt
-0x00000bdd: 01 DW_LNS_copy
+0x00000bde: 00 DW_LNE_set_address (0x0000000000000c1f)
+0x00000be5: 03 DW_LNS_advance_line (113)
+0x00000be7: 06 DW_LNS_negate_stmt
+0x00000be8: 01 DW_LNS_copy
             0x0000000000000c1f    113     10      1   0             0  is_stmt
 
 
-0x00000bde: 00 DW_LNE_set_address (0x0000000000000c2f)
-0x00000be5: 03 DW_LNS_advance_line (114)
-0x00000be7: 05 DW_LNS_set_column (17)
-0x00000be9: 01 DW_LNS_copy
+0x00000be9: 00 DW_LNE_set_address (0x0000000000000c2f)
+0x00000bf0: 03 DW_LNS_advance_line (114)
+0x00000bf2: 05 DW_LNS_set_column (17)
+0x00000bf4: 01 DW_LNS_copy
             0x0000000000000c2f    114     17      1   0             0  is_stmt
 
 
-0x00000bea: 00 DW_LNE_set_address (0x0000000000000c48)
-0x00000bf1: 03 DW_LNS_advance_line (115)
-0x00000bf3: 05 DW_LNS_set_column (7)
-0x00000bf5: 01 DW_LNS_copy
+0x00000bf5: 00 DW_LNE_set_address (0x0000000000000c48)
+0x00000bfc: 03 DW_LNS_advance_line (115)
+0x00000bfe: 05 DW_LNS_set_column (7)
+0x00000c00: 01 DW_LNS_copy
             0x0000000000000c48    115      7      1   0             0  is_stmt
 
 
-0x00000bf6: 00 DW_LNE_set_address (0x0000000000000c4b)
-0x00000bfd: 03 DW_LNS_advance_line (116)
-0x00000bff: 05 DW_LNS_set_column (10)
-0x00000c01: 01 DW_LNS_copy
+0x00000c01: 00 DW_LNE_set_address (0x0000000000000c4b)
+0x00000c08: 03 DW_LNS_advance_line (116)
+0x00000c0a: 05 DW_LNS_set_column (10)
+0x00000c0c: 01 DW_LNS_copy
             0x0000000000000c4b    116     10      1   0             0  is_stmt
 
 
-0x00000c02: 00 DW_LNE_set_address (0x0000000000000c56)
-0x00000c09: 03 DW_LNS_advance_line (118)
-0x00000c0b: 05 DW_LNS_set_column (14)
-0x00000c0d: 01 DW_LNS_copy
+0x00000c0d: 00 DW_LNE_set_address (0x0000000000000c56)
+0x00000c14: 03 DW_LNS_advance_line (118)
+0x00000c16: 05 DW_LNS_set_column (14)
+0x00000c18: 01 DW_LNS_copy
             0x0000000000000c56    118     14      1   0             0  is_stmt
 
 
-0x00000c0e: 00 DW_LNE_set_address (0x0000000000000c5d)
-0x00000c15: 05 DW_LNS_set_column (16)
-0x00000c17: 06 DW_LNS_negate_stmt
-0x00000c18: 01 DW_LNS_copy
+0x00000c19: 00 DW_LNE_set_address (0x0000000000000c5d)
+0x00000c20: 05 DW_LNS_set_column (16)
+0x00000c22: 06 DW_LNS_negate_stmt
+0x00000c23: 01 DW_LNS_copy
             0x0000000000000c5d    118     16      1   0             0 
 
 
-0x00000c19: 00 DW_LNE_set_address (0x0000000000000c6c)
-0x00000c20: 05 DW_LNS_set_column (7)
-0x00000c22: 01 DW_LNS_copy
+0x00000c24: 00 DW_LNE_set_address (0x0000000000000c6c)
+0x00000c2b: 05 DW_LNS_set_column (7)
+0x00000c2d: 01 DW_LNS_copy
             0x0000000000000c6c    118      7      1   0             0 
 
 
-0x00000c23: 00 DW_LNE_set_address (0x0000000000000c7c)
-0x00000c2a: 03 DW_LNS_advance_line (119)
-0x00000c2c: 05 DW_LNS_set_column (25)
-0x00000c2e: 06 DW_LNS_negate_stmt
-0x00000c2f: 01 DW_LNS_copy
+0x00000c2e: 00 DW_LNE_set_address (0x0000000000000c7c)
+0x00000c35: 03 DW_LNS_advance_line (119)
+0x00000c37: 05 DW_LNS_set_column (25)
+0x00000c39: 06 DW_LNS_negate_stmt
+0x00000c3a: 01 DW_LNS_copy
             0x0000000000000c7c    119     25      1   0             0  is_stmt
 
 
-0x00000c30: 00 DW_LNE_set_address (0x0000000000000c83)
-0x00000c37: 05 DW_LNS_set_column (10)
-0x00000c39: 06 DW_LNS_negate_stmt
-0x00000c3a: 01 DW_LNS_copy
+0x00000c3b: 00 DW_LNE_set_address (0x0000000000000c83)
+0x00000c42: 05 DW_LNS_set_column (10)
+0x00000c44: 06 DW_LNS_negate_stmt
+0x00000c45: 01 DW_LNS_copy
             0x0000000000000c83    119     10      1   0             0 
 
 
-0x00000c3b: 00 DW_LNE_set_address (0x0000000000000c8a)
-0x00000c42: 05 DW_LNS_set_column (16)
-0x00000c44: 01 DW_LNS_copy
+0x00000c46: 00 DW_LNE_set_address (0x0000000000000c8a)
+0x00000c4d: 05 DW_LNS_set_column (16)
+0x00000c4f: 01 DW_LNS_copy
             0x0000000000000c8a    119     16      1   0             0 
 
 
-0x00000c45: 00 DW_LNE_set_address (0x0000000000000c91)
-0x00000c4c: 05 DW_LNS_set_column (18)
-0x00000c4e: 01 DW_LNS_copy
+0x00000c50: 00 DW_LNE_set_address (0x0000000000000c91)
+0x00000c57: 05 DW_LNS_set_column (18)
+0x00000c59: 01 DW_LNS_copy
             0x0000000000000c91    119     18      1   0             0 
 
 
-0x00000c4f: 00 DW_LNE_set_address (0x0000000000000c9c)
-0x00000c56: 05 DW_LNS_set_column (10)
-0x00000c58: 01 DW_LNS_copy
+0x00000c5a: 00 DW_LNE_set_address (0x0000000000000c9c)
+0x00000c61: 05 DW_LNS_set_column (10)
+0x00000c63: 01 DW_LNS_copy
             0x0000000000000c9c    119     10      1   0             0 
 
 
-0x00000c59: 00 DW_LNE_set_address (0x0000000000000cae)
-0x00000c60: 05 DW_LNS_set_column (23)
-0x00000c62: 01 DW_LNS_copy
+0x00000c64: 00 DW_LNE_set_address (0x0000000000000cae)
+0x00000c6b: 05 DW_LNS_set_column (23)
+0x00000c6d: 01 DW_LNS_copy
             0x0000000000000cae    119     23      1   0             0 
 
 
-0x00000c63: 00 DW_LNE_set_address (0x0000000000000cb5)
-0x00000c6a: 03 DW_LNS_advance_line (118)
-0x00000c6c: 05 DW_LNS_set_column (22)
-0x00000c6e: 06 DW_LNS_negate_stmt
-0x00000c6f: 01 DW_LNS_copy
+0x00000c6e: 00 DW_LNE_set_address (0x0000000000000cb5)
+0x00000c75: 03 DW_LNS_advance_line (118)
+0x00000c77: 05 DW_LNS_set_column (22)
+0x00000c79: 06 DW_LNS_negate_stmt
+0x00000c7a: 01 DW_LNS_copy
             0x0000000000000cb5    118     22      1   0             0  is_stmt
 
 
-0x00000c70: 00 DW_LNE_set_address (0x0000000000000cce)
-0x00000c77: 05 DW_LNS_set_column (7)
-0x00000c79: 06 DW_LNS_negate_stmt
-0x00000c7a: 01 DW_LNS_copy
+0x00000c7b: 00 DW_LNE_set_address (0x0000000000000cce)
+0x00000c82: 05 DW_LNS_set_column (7)
+0x00000c84: 06 DW_LNS_negate_stmt
+0x00000c85: 01 DW_LNS_copy
             0x0000000000000cce    118      7      1   0             0 
 
 
-0x00000c7b: 00 DW_LNE_set_address (0x0000000000000cd1)
-0x00000c82: 01 DW_LNS_copy
+0x00000c86: 00 DW_LNE_set_address (0x0000000000000cd1)
+0x00000c8d: 01 DW_LNS_copy
             0x0000000000000cd1    118      7      1   0             0 
 
 
-0x00000c83: 00 DW_LNE_set_address (0x0000000000000cd4)
-0x00000c8a: 03 DW_LNS_advance_line (122)
-0x00000c8c: 05 DW_LNS_set_column (14)
-0x00000c8e: 06 DW_LNS_negate_stmt
-0x00000c8f: 01 DW_LNS_copy
+0x00000c8e: 00 DW_LNE_set_address (0x0000000000000cd4)
+0x00000c95: 03 DW_LNS_advance_line (122)
+0x00000c97: 05 DW_LNS_set_column (14)
+0x00000c99: 06 DW_LNS_negate_stmt
+0x00000c9a: 01 DW_LNS_copy
             0x0000000000000cd4    122     14      1   0             0  is_stmt
 
 
-0x00000c90: 00 DW_LNE_set_address (0x0000000000000cdd)
-0x00000c97: 05 DW_LNS_set_column (19)
-0x00000c99: 06 DW_LNS_negate_stmt
-0x00000c9a: 01 DW_LNS_copy
+0x00000c9b: 00 DW_LNE_set_address (0x0000000000000cdd)
+0x00000ca2: 05 DW_LNS_set_column (19)
+0x00000ca4: 06 DW_LNS_negate_stmt
+0x00000ca5: 01 DW_LNS_copy
             0x0000000000000cdd    122     19      1   0             0 
 
 
-0x00000c9b: 00 DW_LNE_set_address (0x0000000000000ce4)
-0x00000ca2: 05 DW_LNS_set_column (16)
-0x00000ca4: 01 DW_LNS_copy
+0x00000ca6: 00 DW_LNE_set_address (0x0000000000000ce4)
+0x00000cad: 05 DW_LNS_set_column (16)
+0x00000caf: 01 DW_LNS_copy
             0x0000000000000ce4    122     16      1   0             0 
 
 
-0x00000ca5: 00 DW_LNE_set_address (0x0000000000000cf3)
-0x00000cac: 05 DW_LNS_set_column (14)
-0x00000cae: 01 DW_LNS_copy
+0x00000cb0: 00 DW_LNE_set_address (0x0000000000000cf3)
+0x00000cb7: 05 DW_LNS_set_column (14)
+0x00000cb9: 01 DW_LNS_copy
             0x0000000000000cf3    122     14      1   0             0 
 
 
-0x00000caf: 00 DW_LNE_set_address (0x0000000000000d05)
-0x00000cb6: 03 DW_LNS_advance_line (123)
-0x00000cb8: 05 DW_LNS_set_column (13)
-0x00000cba: 06 DW_LNS_negate_stmt
-0x00000cbb: 01 DW_LNS_copy
+0x00000cba: 00 DW_LNE_set_address (0x0000000000000d05)
+0x00000cc1: 03 DW_LNS_advance_line (123)
+0x00000cc3: 05 DW_LNS_set_column (13)
+0x00000cc5: 06 DW_LNS_negate_stmt
+0x00000cc6: 01 DW_LNS_copy
             0x0000000000000d05    123     13      1   0             0  is_stmt
 
 
-0x00000cbc: 00 DW_LNE_set_address (0x0000000000000d0c)
-0x00000cc3: 03 DW_LNS_advance_line (125)
-0x00000cc5: 05 DW_LNS_set_column (22)
-0x00000cc7: 01 DW_LNS_copy
+0x00000cc7: 00 DW_LNE_set_address (0x0000000000000d0c)
+0x00000cce: 03 DW_LNS_advance_line (125)
+0x00000cd0: 05 DW_LNS_set_column (22)
+0x00000cd2: 01 DW_LNS_copy
             0x0000000000000d0c    125     22      1   0             0  is_stmt
 
 
-0x00000cc8: 00 DW_LNE_set_address (0x0000000000000d1a)
-0x00000ccf: 05 DW_LNS_set_column (17)
-0x00000cd1: 06 DW_LNS_negate_stmt
-0x00000cd2: 01 DW_LNS_copy
+0x00000cd3: 00 DW_LNE_set_address (0x0000000000000d1a)
+0x00000cda: 05 DW_LNS_set_column (17)
+0x00000cdc: 06 DW_LNS_negate_stmt
+0x00000cdd: 01 DW_LNS_copy
             0x0000000000000d1a    125     17      1   0             0 
 
 
-0x00000cd3: 00 DW_LNE_set_address (0x0000000000000d21)
-0x00000cda: 03 DW_LNS_advance_line (126)
-0x00000cdc: 05 DW_LNS_set_column (20)
-0x00000cde: 06 DW_LNS_negate_stmt
-0x00000cdf: 01 DW_LNS_copy
+0x00000cde: 00 DW_LNE_set_address (0x0000000000000d21)
+0x00000ce5: 03 DW_LNS_advance_line (126)
+0x00000ce7: 05 DW_LNS_set_column (20)
+0x00000ce9: 06 DW_LNS_negate_stmt
+0x00000cea: 01 DW_LNS_copy
             0x0000000000000d21    126     20      1   0             0  is_stmt
 
 
-0x00000ce0: 00 DW_LNE_set_address (0x0000000000000d28)
-0x00000ce7: 05 DW_LNS_set_column (25)
-0x00000ce9: 06 DW_LNS_negate_stmt
-0x00000cea: 01 DW_LNS_copy
+0x00000ceb: 00 DW_LNE_set_address (0x0000000000000d28)
+0x00000cf2: 05 DW_LNS_set_column (25)
+0x00000cf4: 06 DW_LNS_negate_stmt
+0x00000cf5: 01 DW_LNS_copy
             0x0000000000000d28    126     25      1   0             0 
 
 
-0x00000ceb: 00 DW_LNE_set_address (0x0000000000000d33)
-0x00000cf2: 05 DW_LNS_set_column (29)
-0x00000cf4: 01 DW_LNS_copy
+0x00000cf6: 00 DW_LNE_set_address (0x0000000000000d33)
+0x00000cfd: 05 DW_LNS_set_column (29)
+0x00000cff: 01 DW_LNS_copy
             0x0000000000000d33    126     29      1   0             0 
 
 
-0x00000cf5: 00 DW_LNE_set_address (0x0000000000000d3a)
-0x00000cfc: 05 DW_LNS_set_column (27)
-0x00000cfe: 01 DW_LNS_copy
+0x00000d00: 00 DW_LNE_set_address (0x0000000000000d3a)
+0x00000d07: 05 DW_LNS_set_column (27)
+0x00000d09: 01 DW_LNS_copy
             0x0000000000000d3a    126     27      1   0             0 
 
 
-0x00000cff: 00 DW_LNE_set_address (0x0000000000000d49)
-0x00000d06: 05 DW_LNS_set_column (13)
-0x00000d08: 01 DW_LNS_copy
+0x00000d0a: 00 DW_LNE_set_address (0x0000000000000d49)
+0x00000d11: 05 DW_LNS_set_column (13)
+0x00000d13: 01 DW_LNS_copy
             0x0000000000000d49    126     13      1   0             0 
 
 
-0x00000d09: 00 DW_LNE_set_address (0x0000000000000d59)
-0x00000d10: 03 DW_LNS_advance_line (127)
-0x00000d12: 05 DW_LNS_set_column (27)
-0x00000d14: 06 DW_LNS_negate_stmt
-0x00000d15: 01 DW_LNS_copy
+0x00000d14: 00 DW_LNE_set_address (0x0000000000000d59)
+0x00000d1b: 03 DW_LNS_advance_line (127)
+0x00000d1d: 05 DW_LNS_set_column (27)
+0x00000d1f: 06 DW_LNS_negate_stmt
+0x00000d20: 01 DW_LNS_copy
             0x0000000000000d59    127     27      1   0             0  is_stmt
 
 
-0x00000d16: 00 DW_LNE_set_address (0x0000000000000d60)
-0x00000d1d: 05 DW_LNS_set_column (33)
-0x00000d1f: 06 DW_LNS_negate_stmt
-0x00000d20: 01 DW_LNS_copy
+0x00000d21: 00 DW_LNE_set_address (0x0000000000000d60)
+0x00000d28: 05 DW_LNS_set_column (33)
+0x00000d2a: 06 DW_LNS_negate_stmt
+0x00000d2b: 01 DW_LNS_copy
             0x0000000000000d60    127     33      1   0             0 
 
 
-0x00000d21: 00 DW_LNE_set_address (0x0000000000000d67)
-0x00000d28: 05 DW_LNS_set_column (35)
-0x00000d2a: 01 DW_LNS_copy
+0x00000d2c: 00 DW_LNE_set_address (0x0000000000000d67)
+0x00000d33: 05 DW_LNS_set_column (35)
+0x00000d35: 01 DW_LNS_copy
             0x0000000000000d67    127     35      1   0             0 
 
 
-0x00000d2b: 00 DW_LNE_set_address (0x0000000000000d72)
-0x00000d32: 05 DW_LNS_set_column (27)
-0x00000d34: 01 DW_LNS_copy
+0x00000d36: 00 DW_LNE_set_address (0x0000000000000d72)
+0x00000d3d: 05 DW_LNS_set_column (27)
+0x00000d3f: 01 DW_LNS_copy
             0x0000000000000d72    127     27      1   0             0 
 
 
-0x00000d35: 00 DW_LNE_set_address (0x0000000000000d8b)
-0x00000d3c: 05 DW_LNS_set_column (16)
-0x00000d3e: 01 DW_LNS_copy
+0x00000d40: 00 DW_LNE_set_address (0x0000000000000d8b)
+0x00000d47: 05 DW_LNS_set_column (16)
+0x00000d49: 01 DW_LNS_copy
             0x0000000000000d8b    127     16      1   0             0 
 
 
-0x00000d3f: 00 DW_LNE_set_address (0x0000000000000d92)
-0x00000d46: 05 DW_LNS_set_column (22)
-0x00000d48: 01 DW_LNS_copy
+0x00000d4a: 00 DW_LNE_set_address (0x0000000000000d92)
+0x00000d51: 05 DW_LNS_set_column (22)
+0x00000d53: 01 DW_LNS_copy
             0x0000000000000d92    127     22      1   0             0 
 
 
-0x00000d49: 00 DW_LNE_set_address (0x0000000000000d99)
-0x00000d50: 05 DW_LNS_set_column (16)
-0x00000d52: 01 DW_LNS_copy
+0x00000d54: 00 DW_LNE_set_address (0x0000000000000d99)
+0x00000d5b: 05 DW_LNS_set_column (16)
+0x00000d5d: 01 DW_LNS_copy
             0x0000000000000d99    127     16      1   0             0 
 
 
-0x00000d53: 00 DW_LNE_set_address (0x0000000000000dab)
-0x00000d5a: 05 DW_LNS_set_column (25)
-0x00000d5c: 01 DW_LNS_copy
+0x00000d5e: 00 DW_LNE_set_address (0x0000000000000dab)
+0x00000d65: 05 DW_LNS_set_column (25)
+0x00000d67: 01 DW_LNS_copy
             0x0000000000000dab    127     25      1   0             0 
 
 
-0x00000d5d: 00 DW_LNE_set_address (0x0000000000000db2)
-0x00000d64: 03 DW_LNS_advance_line (126)
-0x00000d66: 05 DW_LNS_set_column (33)
-0x00000d68: 06 DW_LNS_negate_stmt
-0x00000d69: 01 DW_LNS_copy
+0x00000d68: 00 DW_LNE_set_address (0x0000000000000db2)
+0x00000d6f: 03 DW_LNS_advance_line (126)
+0x00000d71: 05 DW_LNS_set_column (33)
+0x00000d73: 06 DW_LNS_negate_stmt
+0x00000d74: 01 DW_LNS_copy
             0x0000000000000db2    126     33      1   0             0  is_stmt
 
 
-0x00000d6a: 00 DW_LNE_set_address (0x0000000000000dcf)
-0x00000d71: 05 DW_LNS_set_column (13)
-0x00000d73: 06 DW_LNS_negate_stmt
-0x00000d74: 01 DW_LNS_copy
+0x00000d75: 00 DW_LNE_set_address (0x0000000000000dcf)
+0x00000d7c: 05 DW_LNS_set_column (13)
+0x00000d7e: 06 DW_LNS_negate_stmt
+0x00000d7f: 01 DW_LNS_copy
             0x0000000000000dcf    126     13      1   0             0 
 
 
-0x00000d75: 00 DW_LNE_set_address (0x0000000000000dd2)
-0x00000d7c: 01 DW_LNS_copy
+0x00000d80: 00 DW_LNE_set_address (0x0000000000000dd2)
+0x00000d87: 01 DW_LNS_copy
             0x0000000000000dd2    126     13      1   0             0 
 
 
-0x00000d7d: 00 DW_LNE_set_address (0x0000000000000dda)
-0x00000d84: 03 DW_LNS_advance_line (128)
-0x00000d86: 05 DW_LNS_set_column (24)
-0x00000d88: 06 DW_LNS_negate_stmt
-0x00000d89: 01 DW_LNS_copy
+0x00000d88: 00 DW_LNE_set_address (0x0000000000000dda)
+0x00000d8f: 03 DW_LNS_advance_line (128)
+0x00000d91: 05 DW_LNS_set_column (24)
+0x00000d93: 06 DW_LNS_negate_stmt
+0x00000d94: 01 DW_LNS_copy
             0x0000000000000dda    128     24      1   0             0  is_stmt
 
 
-0x00000d8a: 00 DW_LNE_set_address (0x0000000000000de2)
-0x00000d91: 05 DW_LNS_set_column (13)
-0x00000d93: 06 DW_LNS_negate_stmt
-0x00000d94: 01 DW_LNS_copy
+0x00000d95: 00 DW_LNE_set_address (0x0000000000000de2)
+0x00000d9c: 05 DW_LNS_set_column (13)
+0x00000d9e: 06 DW_LNS_negate_stmt
+0x00000d9f: 01 DW_LNS_copy
             0x0000000000000de2    128     13      1   0             0 
 
 
-0x00000d95: 00 DW_LNE_set_address (0x0000000000000dea)
-0x00000d9c: 05 DW_LNS_set_column (19)
-0x00000d9e: 01 DW_LNS_copy
+0x00000da0: 00 DW_LNE_set_address (0x0000000000000dea)
+0x00000da7: 05 DW_LNS_set_column (19)
+0x00000da9: 01 DW_LNS_copy
             0x0000000000000dea    128     19      1   0             0 
 
 
-0x00000d9f: 00 DW_LNE_set_address (0x0000000000000df2)
-0x00000da6: 05 DW_LNS_set_column (13)
-0x00000da8: 01 DW_LNS_copy
+0x00000daa: 00 DW_LNE_set_address (0x0000000000000df2)
+0x00000db1: 05 DW_LNS_set_column (13)
+0x00000db3: 01 DW_LNS_copy
             0x0000000000000df2    128     13      1   0             0 
 
 
-0x00000da9: 00 DW_LNE_set_address (0x0000000000000e0b)
-0x00000db0: 05 DW_LNS_set_column (22)
-0x00000db2: 01 DW_LNS_copy
+0x00000db4: 00 DW_LNE_set_address (0x0000000000000e0b)
+0x00000dbb: 05 DW_LNS_set_column (22)
+0x00000dbd: 01 DW_LNS_copy
             0x0000000000000e0b    128     22      1   0             0 
 
 
-0x00000db3: 00 DW_LNE_set_address (0x0000000000000e14)
-0x00000dba: 03 DW_LNS_advance_line (130)
-0x00000dbc: 05 DW_LNS_set_column (16)
-0x00000dbe: 06 DW_LNS_negate_stmt
-0x00000dbf: 01 DW_LNS_copy
+0x00000dbe: 00 DW_LNE_set_address (0x0000000000000e14)
+0x00000dc5: 03 DW_LNS_advance_line (130)
+0x00000dc7: 05 DW_LNS_set_column (16)
+0x00000dc9: 06 DW_LNS_negate_stmt
+0x00000dca: 01 DW_LNS_copy
             0x0000000000000e14    130     16      1   0             0  is_stmt
 
 
-0x00000dc0: 00 DW_LNE_set_address (0x0000000000000e1c)
-0x00000dc7: 05 DW_LNS_set_column (22)
-0x00000dc9: 06 DW_LNS_negate_stmt
-0x00000dca: 01 DW_LNS_copy
+0x00000dcb: 00 DW_LNE_set_address (0x0000000000000e1c)
+0x00000dd2: 05 DW_LNS_set_column (22)
+0x00000dd4: 06 DW_LNS_negate_stmt
+0x00000dd5: 01 DW_LNS_copy
             0x0000000000000e1c    130     22      1   0             0 
 
 
-0x00000dcb: 00 DW_LNE_set_address (0x0000000000000e24)
-0x00000dd2: 05 DW_LNS_set_column (16)
-0x00000dd4: 01 DW_LNS_copy
+0x00000dd6: 00 DW_LNE_set_address (0x0000000000000e24)
+0x00000ddd: 05 DW_LNS_set_column (16)
+0x00000ddf: 01 DW_LNS_copy
             0x0000000000000e24    130     16      1   0             0 
 
 
-0x00000dd5: 00 DW_LNE_set_address (0x0000000000000e3d)
-0x00000ddc: 05 DW_LNS_set_column (14)
-0x00000dde: 01 DW_LNS_copy
+0x00000de0: 00 DW_LNE_set_address (0x0000000000000e3d)
+0x00000de7: 05 DW_LNS_set_column (14)
+0x00000de9: 01 DW_LNS_copy
             0x0000000000000e3d    130     14      1   0             0 
 
 
-0x00000ddf: 00 DW_LNE_set_address (0x0000000000000e5e)
-0x00000de6: 05 DW_LNS_set_column (25)
-0x00000de8: 01 DW_LNS_copy
+0x00000dea: 00 DW_LNE_set_address (0x0000000000000e5e)
+0x00000df1: 05 DW_LNS_set_column (25)
+0x00000df3: 01 DW_LNS_copy
             0x0000000000000e5e    130     25      1   0             0 
 
 
-0x00000de9: 00 DW_LNE_set_address (0x0000000000000e74)
-0x00000df0: 05 DW_LNS_set_column (14)
-0x00000df2: 01 DW_LNS_copy
+0x00000df4: 00 DW_LNE_set_address (0x0000000000000e74)
+0x00000dfb: 05 DW_LNS_set_column (14)
+0x00000dfd: 01 DW_LNS_copy
             0x0000000000000e74    130     14      1   0             0 
 
 
-0x00000df3: 00 DW_LNE_set_address (0x0000000000000e8d)
-0x00000dfa: 03 DW_LNS_advance_line (131)
-0x00000dfc: 05 DW_LNS_set_column (13)
-0x00000dfe: 06 DW_LNS_negate_stmt
-0x00000dff: 01 DW_LNS_copy
+0x00000dfe: 00 DW_LNE_set_address (0x0000000000000e8d)
+0x00000e05: 03 DW_LNS_advance_line (131)
+0x00000e07: 05 DW_LNS_set_column (13)
+0x00000e09: 06 DW_LNS_negate_stmt
+0x00000e0a: 01 DW_LNS_copy
             0x0000000000000e8d    131     13      1   0             0  is_stmt
 
 
-0x00000e00: 00 DW_LNE_set_address (0x0000000000000e90)
-0x00000e07: 03 DW_LNS_advance_line (133)
-0x00000e09: 05 DW_LNS_set_column (11)
-0x00000e0b: 01 DW_LNS_copy
+0x00000e0b: 00 DW_LNE_set_address (0x0000000000000e90)
+0x00000e12: 03 DW_LNS_advance_line (133)
+0x00000e14: 05 DW_LNS_set_column (11)
+0x00000e16: 01 DW_LNS_copy
             0x0000000000000e90    133     11      1   0             0  is_stmt
 
 
-0x00000e0c: 00 DW_LNE_set_address (0x0000000000000eaf)
-0x00000e13: 03 DW_LNS_advance_line (121)
-0x00000e15: 05 DW_LNS_set_column (7)
-0x00000e17: 01 DW_LNS_copy
+0x00000e17: 00 DW_LNE_set_address (0x0000000000000eaf)
+0x00000e1e: 03 DW_LNS_advance_line (121)
+0x00000e20: 05 DW_LNS_set_column (7)
+0x00000e22: 01 DW_LNS_copy
             0x0000000000000eaf    121      7      1   0             0  is_stmt
 
 
-0x00000e18: 00 DW_LNE_set_address (0x0000000000000eb2)
-0x00000e1f: 03 DW_LNS_advance_line (131)
-0x00000e21: 05 DW_LNS_set_column (13)
-0x00000e23: 01 DW_LNS_copy
+0x00000e23: 00 DW_LNE_set_address (0x0000000000000eb2)
+0x00000e2a: 03 DW_LNS_advance_line (131)
+0x00000e2c: 05 DW_LNS_set_column (13)
+0x00000e2e: 01 DW_LNS_copy
             0x0000000000000eb2    131     13      1   0             0  is_stmt
 
 
-0x00000e24: 00 DW_LNE_set_address (0x0000000000000eb3)
-0x00000e2b: 03 DW_LNS_advance_line (109)
-0x00000e2d: 05 DW_LNS_set_column (4)
-0x00000e2f: 01 DW_LNS_copy
+0x00000e2f: 00 DW_LNE_set_address (0x0000000000000eb3)
+0x00000e36: 03 DW_LNS_advance_line (109)
+0x00000e38: 05 DW_LNS_set_column (4)
+0x00000e3a: 01 DW_LNS_copy
             0x0000000000000eb3    109      4      1   0             0  is_stmt
 
 
-0x00000e30: 00 DW_LNE_set_address (0x0000000000000eb6)
-0x00000e37: 03 DW_LNS_advance_line (123)
-0x00000e39: 05 DW_LNS_set_column (13)
-0x00000e3b: 01 DW_LNS_copy
+0x00000e3b: 00 DW_LNE_set_address (0x0000000000000eb6)
+0x00000e42: 03 DW_LNS_advance_line (123)
+0x00000e44: 05 DW_LNS_set_column (13)
+0x00000e46: 01 DW_LNS_copy
             0x0000000000000eb6    123     13      1   0             0  is_stmt
 
 
-0x00000e3c: 00 DW_LNE_set_address (0x0000000000000ebe)
-0x00000e43: 03 DW_LNS_advance_line (138)
-0x00000e45: 05 DW_LNS_set_column (9)
-0x00000e47: 01 DW_LNS_copy
+0x00000e47: 00 DW_LNE_set_address (0x0000000000000ebe)
+0x00000e4e: 03 DW_LNS_advance_line (138)
+0x00000e50: 05 DW_LNS_set_column (9)
+0x00000e52: 01 DW_LNS_copy
             0x0000000000000ebe    138      9      1   0             0  is_stmt
 
 
-0x00000e48: 00 DW_LNE_set_address (0x0000000000000ec6)
-0x00000e4f: 05 DW_LNS_set_column (4)
-0x00000e51: 06 DW_LNS_negate_stmt
-0x00000e52: 01 DW_LNS_copy
+0x00000e53: 00 DW_LNE_set_address (0x0000000000000ec6)
+0x00000e5a: 05 DW_LNS_set_column (4)
+0x00000e5c: 06 DW_LNS_negate_stmt
+0x00000e5d: 01 DW_LNS_copy
             0x0000000000000ec6    138      4      1   0             0 
 
 
-0x00000e53: 00 DW_LNE_set_address (0x0000000000000ecb)
-0x00000e5a: 03 DW_LNS_advance_line (139)
-0x00000e5c: 05 DW_LNS_set_column (9)
-0x00000e5e: 06 DW_LNS_negate_stmt
-0x00000e5f: 01 DW_LNS_copy
+0x00000e5e: 00 DW_LNE_set_address (0x0000000000000ecb)
+0x00000e65: 03 DW_LNS_advance_line (139)
+0x00000e67: 05 DW_LNS_set_column (9)
+0x00000e69: 06 DW_LNS_negate_stmt
+0x00000e6a: 01 DW_LNS_copy
             0x0000000000000ecb    139      9      1   0             0  is_stmt
 
 
-0x00000e60: 00 DW_LNE_set_address (0x0000000000000ed3)
-0x00000e67: 05 DW_LNS_set_column (4)
-0x00000e69: 06 DW_LNS_negate_stmt
-0x00000e6a: 01 DW_LNS_copy
+0x00000e6b: 00 DW_LNE_set_address (0x0000000000000ed3)
+0x00000e72: 05 DW_LNS_set_column (4)
+0x00000e74: 06 DW_LNS_negate_stmt
+0x00000e75: 01 DW_LNS_copy
             0x0000000000000ed3    139      4      1   0             0 
 
 
-0x00000e6b: 00 DW_LNE_set_address (0x0000000000000ed8)
-0x00000e72: 03 DW_LNS_advance_line (140)
-0x00000e74: 05 DW_LNS_set_column (13)
-0x00000e76: 06 DW_LNS_negate_stmt
-0x00000e77: 01 DW_LNS_copy
+0x00000e76: 00 DW_LNE_set_address (0x0000000000000ed8)
+0x00000e7d: 03 DW_LNS_advance_line (140)
+0x00000e7f: 05 DW_LNS_set_column (13)
+0x00000e81: 06 DW_LNS_negate_stmt
+0x00000e82: 01 DW_LNS_copy
             0x0000000000000ed8    140     13      1   0             0  is_stmt
 
 
-0x00000e78: 00 DW_LNE_set_address (0x0000000000000ee9)
-0x00000e7f: 03 DW_LNS_advance_line (141)
-0x00000e81: 05 DW_LNS_set_column (11)
-0x00000e83: 01 DW_LNS_copy
+0x00000e83: 00 DW_LNE_set_address (0x0000000000000ee9)
+0x00000e8a: 03 DW_LNS_advance_line (141)
+0x00000e8c: 05 DW_LNS_set_column (11)
+0x00000e8e: 01 DW_LNS_copy
             0x0000000000000ee9    141     11      1   0             0  is_stmt
 
 
-0x00000e84: 00 DW_LNE_set_address (0x0000000000000ef1)
-0x00000e8b: 05 DW_LNS_set_column (16)
-0x00000e8d: 06 DW_LNS_negate_stmt
-0x00000e8e: 01 DW_LNS_copy
+0x00000e8f: 00 DW_LNE_set_address (0x0000000000000ef1)
+0x00000e96: 05 DW_LNS_set_column (16)
+0x00000e98: 06 DW_LNS_negate_stmt
+0x00000e99: 01 DW_LNS_copy
             0x0000000000000ef1    141     16      1   0             0 
 
 
-0x00000e8f: 00 DW_LNE_set_address (0x0000000000000f07)
-0x00000e96: 05 DW_LNS_set_column (4)
-0x00000e98: 01 DW_LNS_copy
+0x00000e9a: 00 DW_LNE_set_address (0x0000000000000f07)
+0x00000ea1: 05 DW_LNS_set_column (4)
+0x00000ea3: 01 DW_LNS_copy
             0x0000000000000f07    141      4      1   0             0 
 
 
-0x00000e99: 00 DW_LNE_set_address (0x0000000000000f1c)
-0x00000ea0: 03 DW_LNS_advance_line (142)
-0x00000ea2: 05 DW_LNS_set_column (36)
-0x00000ea4: 06 DW_LNS_negate_stmt
-0x00000ea5: 01 DW_LNS_copy
+0x00000ea4: 00 DW_LNE_set_address (0x0000000000000f1c)
+0x00000eab: 03 DW_LNS_advance_line (142)
+0x00000ead: 05 DW_LNS_set_column (36)
+0x00000eaf: 06 DW_LNS_negate_stmt
+0x00000eb0: 01 DW_LNS_copy
             0x0000000000000f1c    142     36      1   0             0  is_stmt
 
 
-0x00000ea6: 00 DW_LNE_set_address (0x0000000000000f24)
-0x00000ead: 05 DW_LNS_set_column (20)
-0x00000eaf: 06 DW_LNS_negate_stmt
-0x00000eb0: 01 DW_LNS_copy
+0x00000eb1: 00 DW_LNE_set_address (0x0000000000000f24)
+0x00000eb8: 05 DW_LNS_set_column (20)
+0x00000eba: 06 DW_LNS_negate_stmt
+0x00000ebb: 01 DW_LNS_copy
             0x0000000000000f24    142     20      1   0             0 
 
 
-0x00000eb1: 00 DW_LNE_set_address (0x0000000000000f2c)
-0x00000eb8: 05 DW_LNS_set_column (13)
-0x00000eba: 01 DW_LNS_copy
+0x00000ebc: 00 DW_LNE_set_address (0x0000000000000f2c)
+0x00000ec3: 05 DW_LNS_set_column (13)
+0x00000ec5: 01 DW_LNS_copy
             0x0000000000000f2c    142     13      1   0             0 
 
 
-0x00000ebb: 00 DW_LNE_set_address (0x0000000000000f34)
-0x00000ec2: 03 DW_LNS_advance_line (143)
-0x00000ec4: 05 DW_LNS_set_column (11)
-0x00000ec6: 06 DW_LNS_negate_stmt
-0x00000ec7: 01 DW_LNS_copy
+0x00000ec6: 00 DW_LNE_set_address (0x0000000000000f34)
+0x00000ecd: 03 DW_LNS_advance_line (143)
+0x00000ecf: 05 DW_LNS_set_column (11)
+0x00000ed1: 06 DW_LNS_negate_stmt
+0x00000ed2: 01 DW_LNS_copy
             0x0000000000000f34    143     11      1   0             0  is_stmt
 
 
-0x00000ec8: 00 DW_LNE_set_address (0x0000000000000f3c)
-0x00000ecf: 05 DW_LNS_set_column (22)
-0x00000ed1: 06 DW_LNS_negate_stmt
-0x00000ed2: 01 DW_LNS_copy
+0x00000ed3: 00 DW_LNE_set_address (0x0000000000000f3c)
+0x00000eda: 05 DW_LNS_set_column (22)
+0x00000edc: 06 DW_LNS_negate_stmt
+0x00000edd: 01 DW_LNS_copy
             0x0000000000000f3c    143     22      1   0             0 
 
 
-0x00000ed3: 00 DW_LNE_set_address (0x0000000000000f44)
-0x00000eda: 05 DW_LNS_set_column (20)
-0x00000edc: 01 DW_LNS_copy
+0x00000ede: 00 DW_LNE_set_address (0x0000000000000f44)
+0x00000ee5: 05 DW_LNS_set_column (20)
+0x00000ee7: 01 DW_LNS_copy
             0x0000000000000f44    143     20      1   0             0 
 
 
-0x00000edd: 00 DW_LNE_set_address (0x0000000000000f5a)
-0x00000ee4: 05 DW_LNS_set_column (11)
-0x00000ee6: 01 DW_LNS_copy
+0x00000ee8: 00 DW_LNE_set_address (0x0000000000000f5a)
+0x00000eef: 05 DW_LNS_set_column (11)
+0x00000ef1: 01 DW_LNS_copy
             0x0000000000000f5a    143     11      1   0             0 
 
 
-0x00000ee7: 00 DW_LNE_set_address (0x0000000000000f71)
-0x00000eee: 03 DW_LNS_advance_line (144)
-0x00000ef0: 05 DW_LNS_set_column (21)
-0x00000ef2: 06 DW_LNS_negate_stmt
-0x00000ef3: 01 DW_LNS_copy
+0x00000ef2: 00 DW_LNE_set_address (0x0000000000000f71)
+0x00000ef9: 03 DW_LNS_advance_line (144)
+0x00000efb: 05 DW_LNS_set_column (21)
+0x00000efd: 06 DW_LNS_negate_stmt
+0x00000efe: 01 DW_LNS_copy
             0x0000000000000f71    144     21      1   0             0  is_stmt
 
 
-0x00000ef4: 00 DW_LNE_set_address (0x0000000000000f79)
-0x00000efb: 05 DW_LNS_set_column (19)
-0x00000efd: 06 DW_LNS_negate_stmt
-0x00000efe: 01 DW_LNS_copy
+0x00000eff: 00 DW_LNE_set_address (0x0000000000000f79)
+0x00000f06: 05 DW_LNS_set_column (19)
+0x00000f08: 06 DW_LNS_negate_stmt
+0x00000f09: 01 DW_LNS_copy
             0x0000000000000f79    144     19      1   0             0 
 
 
-0x00000eff: 00 DW_LNE_set_address (0x0000000000000f82)
-0x00000f06: 03 DW_LNS_advance_line (145)
-0x00000f08: 05 DW_LNS_set_column (15)
-0x00000f0a: 06 DW_LNS_negate_stmt
-0x00000f0b: 01 DW_LNS_copy
+0x00000f0a: 00 DW_LNE_set_address (0x0000000000000f82)
+0x00000f11: 03 DW_LNS_advance_line (145)
+0x00000f13: 05 DW_LNS_set_column (15)
+0x00000f15: 06 DW_LNS_negate_stmt
+0x00000f16: 01 DW_LNS_copy
             0x0000000000000f82    145     15      1   0             0  is_stmt
 
 
-0x00000f0c: 00 DW_LNE_set_address (0x0000000000000f8a)
-0x00000f13: 05 DW_LNS_set_column (13)
-0x00000f15: 06 DW_LNS_negate_stmt
-0x00000f16: 01 DW_LNS_copy
+0x00000f17: 00 DW_LNE_set_address (0x0000000000000f8a)
+0x00000f1e: 05 DW_LNS_set_column (13)
+0x00000f20: 06 DW_LNS_negate_stmt
+0x00000f21: 01 DW_LNS_copy
             0x0000000000000f8a    145     13      1   0             0 
 
 
-0x00000f17: 00 DW_LNE_set_address (0x0000000000000f92)
-0x00000f1e: 03 DW_LNS_advance_line (146)
-0x00000f20: 05 DW_LNS_set_column (14)
-0x00000f22: 06 DW_LNS_negate_stmt
-0x00000f23: 01 DW_LNS_copy
+0x00000f22: 00 DW_LNE_set_address (0x0000000000000f92)
+0x00000f29: 03 DW_LNS_advance_line (146)
+0x00000f2b: 05 DW_LNS_set_column (14)
+0x00000f2d: 06 DW_LNS_negate_stmt
+0x00000f2e: 01 DW_LNS_copy
             0x0000000000000f92    146     14      1   0             0  is_stmt
 
 
-0x00000f24: 00 DW_LNE_set_address (0x0000000000000f9a)
-0x00000f2b: 05 DW_LNS_set_column (20)
-0x00000f2d: 06 DW_LNS_negate_stmt
-0x00000f2e: 01 DW_LNS_copy
+0x00000f2f: 00 DW_LNE_set_address (0x0000000000000f9a)
+0x00000f36: 05 DW_LNS_set_column (20)
+0x00000f38: 06 DW_LNS_negate_stmt
+0x00000f39: 01 DW_LNS_copy
             0x0000000000000f9a    146     20      1   0             0 
 
 
-0x00000f2f: 00 DW_LNE_set_address (0x0000000000000fa3)
-0x00000f36: 05 DW_LNS_set_column (12)
-0x00000f38: 01 DW_LNS_copy
+0x00000f3a: 00 DW_LNE_set_address (0x0000000000000fa3)
+0x00000f41: 05 DW_LNS_set_column (12)
+0x00000f43: 01 DW_LNS_copy
             0x0000000000000fa3    146     12      1   0             0 
 
 
-0x00000f39: 00 DW_LNE_set_address (0x0000000000000fab)
-0x00000f40: 03 DW_LNS_advance_line (147)
-0x00000f42: 06 DW_LNS_negate_stmt
-0x00000f43: 01 DW_LNS_copy
+0x00000f44: 00 DW_LNE_set_address (0x0000000000000fab)
+0x00000f4b: 03 DW_LNS_advance_line (147)
+0x00000f4d: 06 DW_LNS_negate_stmt
+0x00000f4e: 01 DW_LNS_copy
             0x0000000000000fab    147     12      1   0             0  is_stmt
 
 
-0x00000f44: 00 DW_LNE_set_address (0x0000000000000fb3)
-0x00000f4b: 05 DW_LNS_set_column (7)
-0x00000f4d: 06 DW_LNS_negate_stmt
-0x00000f4e: 01 DW_LNS_copy
+0x00000f4f: 00 DW_LNE_set_address (0x0000000000000fb3)
+0x00000f56: 05 DW_LNS_set_column (7)
+0x00000f58: 06 DW_LNS_negate_stmt
+0x00000f59: 01 DW_LNS_copy
             0x0000000000000fb3    147      7      1   0             0 
 
 
-0x00000f4f: 00 DW_LNE_set_address (0x0000000000000fb8)
-0x00000f56: 03 DW_LNS_advance_line (141)
-0x00000f58: 05 DW_LNS_set_column (4)
-0x00000f5a: 06 DW_LNS_negate_stmt
-0x00000f5b: 01 DW_LNS_copy
+0x00000f5a: 00 DW_LNE_set_address (0x0000000000000fb8)
+0x00000f61: 03 DW_LNS_advance_line (141)
+0x00000f63: 05 DW_LNS_set_column (4)
+0x00000f65: 06 DW_LNS_negate_stmt
+0x00000f66: 01 DW_LNS_copy
             0x0000000000000fb8    141      4      1   0             0  is_stmt
 
 
-0x00000f5c: 00 DW_LNE_set_address (0x0000000000000fbe)
-0x00000f63: 03 DW_LNS_advance_line (149)
-0x00000f65: 05 DW_LNS_set_column (11)
-0x00000f67: 01 DW_LNS_copy
+0x00000f67: 00 DW_LNE_set_address (0x0000000000000fbe)
+0x00000f6e: 03 DW_LNS_advance_line (149)
+0x00000f70: 05 DW_LNS_set_column (11)
+0x00000f72: 01 DW_LNS_copy
             0x0000000000000fbe    149     11      1   0             0  is_stmt
 
 
-0x00000f68: 00 DW_LNE_set_address (0x0000000000000fc6)
-0x00000f6f: 05 DW_LNS_set_column (4)
-0x00000f71: 06 DW_LNS_negate_stmt
-0x00000f72: 01 DW_LNS_copy
+0x00000f73: 00 DW_LNE_set_address (0x0000000000000fc6)
+0x00000f7a: 05 DW_LNS_set_column (4)
+0x00000f7c: 06 DW_LNS_negate_stmt
+0x00000f7d: 01 DW_LNS_copy
             0x0000000000000fc6    149      4      1   0             0 
 
 
-0x00000f73: 00 DW_LNE_set_address (0x0000000000000fde)
-0x00000f7a: 00 DW_LNE_end_sequence
+0x00000f7e: 00 DW_LNE_set_address (0x0000000000000fde)
+0x00000f85: 00 DW_LNE_end_sequence
             0x0000000000000fde    149      4      1   0             0  end_sequence
 
 
@@ -10160,7 +10165,7 @@ file_names[  3]:
  ;; custom section ".debug_info", size 640
  ;; custom section ".debug_ranges", size 32
  ;; custom section ".debug_abbrev", size 222
- ;; custom section ".debug_line", size 3965
+ ;; custom section ".debug_line", size 3976
  ;; custom section ".debug_str", size 409
  ;; custom section "producers", size 180
 )


### PR DESCRIPTION
We must emit those, even if otherwise it looks like a line we can
omit, as the ends of sequences have important meaning and
dwarfdump will warn without them.

Looks like fannkuch0 in the test suite already had an example
of an incorrectly-omitted sequence_end, so no need for a new
testcase.

Verified that without this e.g. `wasm2.test_exceptions` with `-g`
added will lead to a wasm that warns, but with this PR the debug_line
section is reported as valid by dwarfdump.