### PR TITLE
Optimize booleans when argument is negative integer

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -982,6 +982,14 @@ private:
         }
       }
     } else if (auto* binary = boolean->dynCast<Binary>()) {
+      if (binary->op == SubInt32) {
+        if (auto* num = binary->left->dynCast<Const>()) {
+          if (num->value.geti32() == 0) {
+            // 0 - x   ==>   x
+            return binary->right;
+          }
+        }
+      }
       if (binary->op == OrInt32) {
         // an or flowing into a boolean context can consider each input as
         // boolean

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -985,7 +985,7 @@ private:
       if (binary->op == SubInt32) {
         if (auto* num = binary->left->dynCast<Const>()) {
           if (num->value.geti32() == 0) {
-            // 0 - x   ==>   x
+            // bool(0 - x)   ==>   bool(x)
             return binary->right;
           }
         }

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3,9 +3,9 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i64_=>_none (func (param i32 i64)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $none_=>_i64 (func (result i64)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
  (type $i32_i64_f32_=>_none (func (param i32 i64 f32)))
@@ -3262,6 +3262,15 @@
   (drop
    (local.tee $x
     (i32.const 6)
+   )
+  )
+ )
+ (func $optimize-boolean (param $x i32)
+  (drop
+   (select
+    (i32.const 1)
+    (i32.const 2)
+    (local.get $x)
    )
   )
  )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3766,6 +3766,18 @@
       )
     )
   )
+  (func $optimize-boolean (param $x i32)
+    (drop
+      (select
+        (i32.const 1)
+        (i32.const 2)
+        (i32.sub        ;; bool(-x) -> bool(x)
+          (i32.const 0)
+          (local.get $x)
+        )
+      )
+    )
+  )
   (func $getFallthrough ;; unit tests for Properties::getFallthrough
     (local $x0 i32)
     (local $x1 i32)


### PR DESCRIPTION
`bool(-x)` ==> `bool(x)`