### PR TITLE
DWARF: Always update .debug_loc base offsets

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -960,9 +960,13 @@ static void updateLoc(llvm::DWARFYAML::Data& yaml,
           smallest = std::min(smallest, updatedStart);
         }
       }
-      if (smallest != BinaryLocation(-1)) {
-        newBase = newEnd = smallest;
+      // If we found no valid values that will be relativized here, just use 0
+      // as the new (never-to-be-used) base, which is less confusing (otherwise
+      // the value looks like it means something).
+      if (smallest == BinaryLocation(-1)) {
+        smallest = 0;
       }
+      newBase = newEnd = smallest;
     } else if (isEndMarkerLoc(loc)) {
       // This is an end marker, this list is done; reset the base.
       atStart = true;

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -931,7 +931,8 @@ static void updateLoc(llvm::DWARFYAML::Data& yaml,
   for (size_t i = 0; i < locs.size(); i++) {
     auto& loc = locs[i];
     if (atStart) {
-      oldBase = newBase = locationUpdater.getLocationBaseAddress(loc.CompileUnitOffset);
+      oldBase = newBase =
+        locationUpdater.getLocationBaseAddress(loc.CompileUnitOffset);
       atStart = false;
     }
     // By default we copy values over, unless we modify them below.
@@ -952,7 +953,8 @@ static void updateLoc(llvm::DWARFYAML::Data& yaml,
         if (isNewBaseLoc(futureLoc) || isEndMarkerLoc(futureLoc)) {
           break;
         }
-        auto updatedStart = locationUpdater.getNewStart(futureLoc.Start + oldBase);
+        auto updatedStart =
+          locationUpdater.getNewStart(futureLoc.Start + oldBase);
         // If we found a valid mapping, this is a relevant value for us. If the
         // optimizer removed it, it's a 0, and we can ignore it here - we will
         // emit IGNOREABLE_LOCATION for it later anyhow.

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -791,7 +791,8 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
           newValue = locationUpdater.getNewFuncStart(oldValue);
           // Per the DWARF spec, "The base address of a compile unit is
           // defined as the value of the DW_AT_low_pc attribute, if present."
-          locationUpdater.compileUnitBases[compileUnitIndex] = LocationUpdater::OldToNew{oldValue, newValue};
+          locationUpdater.compileUnitBases[compileUnitIndex] =
+            LocationUpdater::OldToNew{oldValue, newValue};
         } else if (tag == llvm::dwarf::DW_TAG_subprogram) {
           newValue = locationUpdater.getNewFuncStart(oldValue);
         } else {
@@ -869,11 +870,8 @@ static void updateCompileUnits(const BinaryenDWARFInfo& info,
           auto abbrevDecl = DIE.getAbbreviationDeclarationPtr();
           if (abbrevDecl) {
             // This is relevant; look for things to update.
-            updateDIE(DIE,
-                      yamlEntry,
-                      abbrevDecl,
-                      locationUpdater,
-                      compileUnitIndex);
+            updateDIE(
+              DIE, yamlEntry, abbrevDecl, locationUpdater, compileUnitIndex);
           }
         });
       compileUnitIndex++;
@@ -945,7 +943,8 @@ static void updateLoc(llvm::DWARFYAML::Data& yaml,
   for (size_t i = 0; i < locs.size(); i++) {
     auto& loc = locs[i];
     if (atStart) {
-      std::tie(oldBase, newBase) = locationUpdater.getCompileUnitBasesForLoc(loc.CompileUnitOffset);
+      std::tie(oldBase, newBase) =
+        locationUpdater.getCompileUnitBasesForLoc(loc.CompileUnitOffset);
       atStart = false;
     }
     // By default we copy values over, unless we modify them below.

--- a/test/passes/fannkuch3.bin.txt
+++ b/test/passes/fannkuch3.bin.txt
@@ -2567,16 +2567,16 @@ Abbrev table for offset: 0x00000000
 
 0x000000c3:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000001d: 
-                     [0xffffffff,  0x00000006): 
-                     [0x00000007,  0x00000030): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000046,  0x0000004b): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x000000dc,  0x000000e5): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000121,  0x0000012b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x00000169,  0x00000176): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000258,  0x00000263): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000269,  0x00000272): DW_OP_consts +1, DW_OP_stack_value
-                     [0x000002ae,  0x000002b8): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x000002f6,  0x00000303): DW_OP_consts +0, DW_OP_stack_value)
+                     [0xffffffff,  0x0000000d): 
+                     [0x00000000,  0x00000029): DW_OP_consts +0, DW_OP_stack_value
+                     [0x0000003f,  0x00000044): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x000000d5,  0x000000de): DW_OP_consts +1, DW_OP_stack_value
+                     [0x0000011a,  0x00000124): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000162,  0x0000016f): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000251,  0x0000025c): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000262,  0x0000026b): DW_OP_consts +1, DW_OP_stack_value
+                     [0x000002a7,  0x000002b1): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x000002ef,  0x000002fc): DW_OP_consts +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000d6] = "i")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2584,8 +2584,8 @@ Abbrev table for offset: 0x00000000
 
 0x000000d2:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000a5: 
-                     [0xffffffff,  0x00000006): 
-                     [0x0000000e,  0x00000030): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
+                     [0xffffffff,  0x00000014): 
+                     [0x00000000,  0x00000022): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000dc] = "n")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2593,8 +2593,8 @@ Abbrev table for offset: 0x00000000
 
 0x000000e1:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000c3: 
-                     [0xffffffff,  0x00000006): 
-                     [0x00000017,  0x00000030): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
+                     [0xffffffff,  0x0000001d): 
+                     [0x00000000,  0x00000019): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000013e] = "perm1")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(29)
@@ -2602,8 +2602,8 @@ Abbrev table for offset: 0x00000000
 
 0x000000f0:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000e1: 
-                     [0xffffffff,  0x00000006): 
-                     [0x0000001d,  0x00000030): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value)
+                     [0xffffffff,  0x00000023): 
+                     [0x00000000,  0x00000013): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000196] = "perm")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(29)
@@ -2611,8 +2611,8 @@ Abbrev table for offset: 0x00000000
 
 0x000000ff:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000ff: 
-                     [0xffffffff,  0x00000006): 
-                     [0x00000023,  0x00000030): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                     [0xffffffff,  0x00000029): 
+                     [0x00000000,  0x0000000d): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000144] = "count")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(29)
@@ -2620,9 +2620,9 @@ Abbrev table for offset: 0x00000000
 
 0x0000010e:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000011d: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000001d2,  0x000001d7): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-                     [0x0000035f,  0x00000364): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
+                     [0xffffffff,  0x000001d8): 
+                     [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+                     [0x0000018d,  0x00000192): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000014a] = "r")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2630,13 +2630,13 @@ Abbrev table for offset: 0x00000000
 
 0x0000011d:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000149: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000c3,  0x000000d6): DW_OP_consts +0, DW_OP_stack_value
-                     [0x000000dc,  0x000000e5): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-                     [0x0000014a,  0x00000152): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x00000258,  0x00000263): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000269,  0x00000272): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-                     [0x000002d7,  0x000002df): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                     [0xffffffff,  0x000000c9): 
+                     [0x00000000,  0x00000013): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000019,  0x00000022): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
+                     [0x00000087,  0x0000008f): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000195,  0x000001a0): DW_OP_consts +0, DW_OP_stack_value
+                     [0x000001a6,  0x000001af): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
+                     [0x00000214,  0x0000021c): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000155] = "flips")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2644,9 +2644,9 @@ Abbrev table for offset: 0x00000000
 
 0x0000012c:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001ab: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000d2,  0x000000d6): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-                     [0x0000025f,  0x00000263): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
+                     [0xffffffff,  0x000000d8): 
+                     [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
+                     [0x0000018d,  0x00000191): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019b] = "k")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2654,11 +2654,11 @@ Abbrev table for offset: 0x00000000
 
 0x0000013b:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001d7: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000ec,  0x000000f0): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000128,  0x0000012b): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000279,  0x0000027d): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x000002b5,  0x000002b8): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0xffffffff,  0x000000f2): 
+                     [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000003c,  0x0000003f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000018d,  0x00000191): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x000001c9,  0x000001cc): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019d] = "j")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2666,11 +2666,11 @@ Abbrev table for offset: 0x00000000
 
 0x0000014a:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000021f: 
-                     [0xffffffff,  0x00000006): 
-                     [0x00000101,  0x0000012b): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-                     [0x0000013c,  0x00000152): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x0000028e,  0x000002b8): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-                     [0x000002c9,  0x000002df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0xffffffff,  0x00000107): 
+                     [0x00000000,  0x0000002a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+                     [0x0000003b,  0x00000051): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000018d,  0x000001b7): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+                     [0x000001c8,  0x000001de): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019f] = "tmp")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2841,8 +2841,8 @@ Abbrev table for offset: 0x00000000
 
 0x00000269:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000267: 
-                     [0xffffffff,  0x0000039f): 
-                     [0x00000012,  0x00000017): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
+                     [0xffffffff,  0x000003b1): 
+                     [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000dc] = "n")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(153)
@@ -2861,29 +2861,29 @@ Abbrev table for offset: 0x00000000
 
 0x0000028d:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000285: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x00000025,  0x0000002e): DW_OP_consts +30, DW_OP_stack_value)
+                       [0xffffffff,  0x000003c4): 
+                       [0x00000000,  0x00000009): DW_OP_consts +30, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01c3 => {0x000001c3} "showmax")
 
 0x00000296:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002a2: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x00000025,  0x0000002e): DW_OP_lit0, DW_OP_stack_value
-                       [0x000002ac,  0x000002c4): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0xffffffff,  0x000003c4): 
+                       [0x00000000,  0x00000009): DW_OP_lit0, DW_OP_stack_value
+                       [0x00000287,  0x0000029f): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ce => {0x000001ce} "args")
 
 0x0000029f:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002cc: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x00000025,  0x0000002e): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000063,  0x00000068): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x0000006e,  0x0000008e): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000000a4,  0x000000a9): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x000000c2,  0x000000c6): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000000ed,  0x000000f2): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x0000013a,  0x0000014a): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000001be,  0x000001cc): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000201,  0x00000215): DW_OP_consts +0, DW_OP_stack_value)
+                       [0xffffffff,  0x000003c4): 
+                       [0x00000000,  0x00000009): DW_OP_consts +0, DW_OP_stack_value
+                       [0x0000003e,  0x00000043): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000049,  0x00000069): DW_OP_consts +0, DW_OP_stack_value
+                       [0x0000007f,  0x00000084): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x0000009d,  0x000000a1): DW_OP_consts +0, DW_OP_stack_value
+                       [0x000000c8,  0x000000cd): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000115,  0x00000125): DW_OP_consts +0, DW_OP_stack_value
+                       [0x00000199,  0x000001a7): DW_OP_consts +0, DW_OP_stack_value
+                       [0x000001dc,  0x000001f0): DW_OP_consts +0, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01d9 => {0x000001d9} "i")
 
 0x000002a8:       DW_TAG_variable [27]  
@@ -2891,34 +2891,34 @@ Abbrev table for offset: 0x00000000
 
 0x000002ad:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000354: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x00000079,  0x0000008e): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                       [0xffffffff,  0x00000418): 
+                       [0x00000000,  0x00000015): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ef => {0x000001ef} "perm1")
 
 0x000002b6:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000372: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x0000007f,  0x0000008e): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value)
+                       [0xffffffff,  0x0000041e): 
+                       [0x00000000,  0x0000000f): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01fa => {0x000001fa} "count")
 
 0x000002bf:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000390: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x000001a8,  0x000001af): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-                       [0x00000273,  0x0000027a): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0xffffffff,  0x00000547): 
+                       [0x00000000,  0x00000007): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+                       [0x000000cb,  0x000000d2): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0205 => {0x00000205} "r")
 
 0x000002c8:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000003e8: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x0000028e,  0x00000299): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000002bc,  0x000002c4): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                       [0xffffffff,  0x0000062d): 
+                       [0x00000000,  0x0000000b): DW_OP_consts +0, DW_OP_stack_value
+                       [0x0000002e,  0x00000036): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0210 => {0x00000210} "maxflips")
 
 0x000002d1:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000413: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x000002a5,  0x000002c4): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                       [0xffffffff,  0x00000644): 
+                       [0x00000000,  0x0000001f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x021b => {0x0000021b} "flips")
 
 0x000002da:       DW_TAG_label [28]  
@@ -2932,9 +2932,9 @@ Abbrev table for offset: 0x00000000
 
 0x000002e8:         DW_TAG_variable [26]  
                       DW_AT_location [DW_FORM_sec_offset]	(0x000003bc: 
-                         [0xffffffff,  0x0000039f): 
-                         [0x00000141,  0x0000014a): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
-                         [0x00000208,  0x00000215): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value)
+                         [0xffffffff,  0x000004e0): 
+                         [0x00000000,  0x00000009): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
+                         [0x000000c7,  0x000000d4): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value)
                       DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x022e => {0x0000022e} "p0")
 
 0x000002f1:         NULL
@@ -3004,117 +3004,117 @@ Abbrev table for offset: 0x00000000
             [0x00000000,  0x00000030): DW_OP_consts +0, DW_OP_stack_value
 
 0x0000001d: 
-            [0xffffffff,  0x00000006): 
-            [0x00000007,  0x00000030): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000046,  0x0000004b): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x000000dc,  0x000000e5): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000121,  0x0000012b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000169,  0x00000176): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000258,  0x00000263): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000269,  0x00000272): DW_OP_consts +1, DW_OP_stack_value
-            [0x000002ae,  0x000002b8): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x000002f6,  0x00000303): DW_OP_consts +0, DW_OP_stack_value
+            [0xffffffff,  0x0000000d): 
+            [0x00000000,  0x00000029): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000003f,  0x00000044): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x000000d5,  0x000000de): DW_OP_consts +1, DW_OP_stack_value
+            [0x0000011a,  0x00000124): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000162,  0x0000016f): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000251,  0x0000025c): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000262,  0x0000026b): DW_OP_consts +1, DW_OP_stack_value
+            [0x000002a7,  0x000002b1): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x000002ef,  0x000002fc): DW_OP_consts +0, DW_OP_stack_value
 
 0x000000a5: 
-            [0xffffffff,  0x00000006): 
-            [0x0000000e,  0x00000030): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0xffffffff,  0x00000014): 
+            [0x00000000,  0x00000022): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x000000c3: 
-            [0xffffffff,  0x00000006): 
-            [0x00000017,  0x00000030): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+            [0xffffffff,  0x0000001d): 
+            [0x00000000,  0x00000019): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
 
 0x000000e1: 
-            [0xffffffff,  0x00000006): 
-            [0x0000001d,  0x00000030): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value
+            [0xffffffff,  0x00000023): 
+            [0x00000000,  0x00000013): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value
 
 0x000000ff: 
-            [0xffffffff,  0x00000006): 
-            [0x00000023,  0x00000030): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0xffffffff,  0x00000029): 
+            [0x00000000,  0x0000000d): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x0000011d: 
-            [0xffffffff,  0x00000006): 
-            [0x000001d2,  0x000001d7): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-            [0x0000035f,  0x00000364): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0xffffffff,  0x000001d8): 
+            [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0x0000018d,  0x00000192): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x00000149: 
-            [0xffffffff,  0x00000006): 
-            [0x000000c3,  0x000000d6): DW_OP_consts +0, DW_OP_stack_value
-            [0x000000dc,  0x000000e5): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-            [0x0000014a,  0x00000152): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000258,  0x00000263): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000269,  0x00000272): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-            [0x000002d7,  0x000002df): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0xffffffff,  0x000000c9): 
+            [0x00000000,  0x00000013): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000019,  0x00000022): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
+            [0x00000087,  0x0000008f): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000195,  0x000001a0): DW_OP_consts +0, DW_OP_stack_value
+            [0x000001a6,  0x000001af): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
+            [0x00000214,  0x0000021c): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x000001ab: 
-            [0xffffffff,  0x00000006): 
-            [0x000000d2,  0x000000d6): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-            [0x0000025f,  0x00000263): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
+            [0xffffffff,  0x000000d8): 
+            [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
+            [0x0000018d,  0x00000191): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
 
 0x000001d7: 
-            [0xffffffff,  0x00000006): 
-            [0x000000ec,  0x000000f0): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000128,  0x0000012b): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000279,  0x0000027d): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x000002b5,  0x000002b8): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x000000f2): 
+            [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000003c,  0x0000003f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000018d,  0x00000191): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x000001c9,  0x000001cc): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x0000021f: 
-            [0xffffffff,  0x00000006): 
-            [0x00000101,  0x0000012b): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-            [0x0000013c,  0x00000152): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x0000028e,  0x000002b8): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-            [0x000002c9,  0x000002df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x00000107): 
+            [0x00000000,  0x0000002a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+            [0x0000003b,  0x00000051): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000018d,  0x000001b7): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+            [0x000001c8,  0x000001de): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000267: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000012,  0x00000017): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+            [0xffffffff,  0x000003b1): 
+            [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
 
 0x00000285: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000025,  0x0000002e): DW_OP_consts +30, DW_OP_stack_value
+            [0xffffffff,  0x000003c4): 
+            [0x00000000,  0x00000009): DW_OP_consts +30, DW_OP_stack_value
 
 0x000002a2: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000025,  0x0000002e): DW_OP_lit0, DW_OP_stack_value
-            [0x000002ac,  0x000002c4): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0xffffffff,  0x000003c4): 
+            [0x00000000,  0x00000009): DW_OP_lit0, DW_OP_stack_value
+            [0x00000287,  0x0000029f): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000002cc: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000025,  0x0000002e): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000063,  0x00000068): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x0000006e,  0x0000008e): DW_OP_consts +0, DW_OP_stack_value
-            [0x000000a4,  0x000000a9): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x000000c2,  0x000000c6): DW_OP_consts +0, DW_OP_stack_value
-            [0x000000ed,  0x000000f2): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x0000013a,  0x0000014a): DW_OP_consts +0, DW_OP_stack_value
-            [0x000001be,  0x000001cc): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000201,  0x00000215): DW_OP_consts +0, DW_OP_stack_value
+            [0xffffffff,  0x000003c4): 
+            [0x00000000,  0x00000009): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000003e,  0x00000043): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000049,  0x00000069): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000007f,  0x00000084): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000009d,  0x000000a1): DW_OP_consts +0, DW_OP_stack_value
+            [0x000000c8,  0x000000cd): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000115,  0x00000125): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000199,  0x000001a7): DW_OP_consts +0, DW_OP_stack_value
+            [0x000001dc,  0x000001f0): DW_OP_consts +0, DW_OP_stack_value
 
 0x00000354: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000079,  0x0000008e): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x00000418): 
+            [0x00000000,  0x00000015): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000372: 
-            [0xffffffff,  0x0000039f): 
-            [0x0000007f,  0x0000008e): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value
+            [0xffffffff,  0x0000041e): 
+            [0x00000000,  0x0000000f): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value
 
 0x00000390: 
-            [0xffffffff,  0x0000039f): 
-            [0x000001a8,  0x000001af): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-            [0x00000273,  0x0000027a): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0xffffffff,  0x00000547): 
+            [0x00000000,  0x00000007): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x000000cb,  0x000000d2): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000003bc: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000141,  0x0000014a): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
-            [0x00000208,  0x00000215): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
+            [0xffffffff,  0x000004e0): 
+            [0x00000000,  0x00000009): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
+            [0x000000c7,  0x000000d4): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
 
 0x000003e8: 
-            [0xffffffff,  0x0000039f): 
-            [0x0000028e,  0x00000299): DW_OP_consts +0, DW_OP_stack_value
-            [0x000002bc,  0x000002c4): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0xffffffff,  0x0000062d): 
+            [0x00000000,  0x0000000b): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000002e,  0x00000036): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x00000413: 
-            [0xffffffff,  0x0000039f): 
-            [0x000002a5,  0x000002c4): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x00000644): 
+            [0x00000000,  0x0000001f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 .debug_line contents:
 debug_line[0x00000000]

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2558,7 +2558,7 @@ Abbrev table for offset: 0x00000000
 
 0x000000b4:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000000: 
-                     [0xffffffff,  0x00000006): 
+                     [0xffffffff,  0x00000007): 
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000014c] = "maxflips")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2567,15 +2567,15 @@ Abbrev table for offset: 0x00000000
 
 0x000000c3:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000001d: 
-                     [0xffffffff,  0x00000006): 
+                     [0xffffffff,  0x00000000): 
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000041,  0x00000046): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x00000047,  0x0000004c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000110,  0x0000011a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000116,  0x00000120): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+                     [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x0000028d,  0x00000297): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000293,  0x0000029d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000d6] = "i")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2584,7 +2584,7 @@ Abbrev table for offset: 0x00000000
 
 0x000000d2:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000a5: 
-                     [0xffffffff,  0x00000006): 
+                     [0xffffffff,  0x00000011): 
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000dc] = "n")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2593,7 +2593,7 @@ Abbrev table for offset: 0x00000000
 
 0x000000e1:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000c3: 
-                     [0xffffffff,  0x00000006): 
+                     [0xffffffff,  0x0000001a): 
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000013e] = "perm1")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2602,7 +2602,7 @@ Abbrev table for offset: 0x00000000
 
 0x000000f0:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000e1: 
-                     [0xffffffff,  0x00000006): 
+                     [0xffffffff,  0x00000020): 
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000196] = "perm")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2611,7 +2611,7 @@ Abbrev table for offset: 0x00000000
 
 0x000000ff:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000000ff: 
-                     [0xffffffff,  0x00000006): 
+                     [0xffffffff,  0x00000026): 
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000144] = "count")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2620,9 +2620,9 @@ Abbrev table for offset: 0x00000000
 
 0x0000010e:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000011d: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000001bf,  0x000001c4): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-                     [0x0000033c,  0x00000341): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
+                     [0xffffffff,  0x000001c5): 
+                     [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+                     [0x0000017d,  0x00000182): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000014a] = "r")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2630,13 +2630,13 @@ Abbrev table for offset: 0x00000000
 
 0x0000011d:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000149: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000b4,  0x000000c7): DW_OP_consts +0, DW_OP_stack_value
+                     [0xffffffff,  0x00000000): 
+                     [0x000000ba,  0x000000cd): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-                     [0x00000139,  0x00000141): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+                     [0x0000013f,  0x00000147): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-                     [0x000002b6,  0x000002be): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                     [0x000002bc,  0x000002c4): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000155] = "flips")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2644,9 +2644,9 @@ Abbrev table for offset: 0x00000000
 
 0x0000012c:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001ab: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000c3,  0x000000c7): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-                     [0x00000240,  0x00000244): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
+                     [0xffffffff,  0x000000c9): 
+                     [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
+                     [0x0000017d,  0x00000181): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019b] = "k")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2654,11 +2654,11 @@ Abbrev table for offset: 0x00000000
 
 0x0000013b:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x000001d7: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000db,  0x000000df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000117,  0x0000011a): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000258,  0x0000025c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x00000294,  0x00000297): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0xffffffff,  0x000000e1): 
+                     [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000003c,  0x0000003f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000017d,  0x00000181): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x000001b9,  0x000001bc): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019d] = "j")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2666,11 +2666,11 @@ Abbrev table for offset: 0x00000000
 
 0x0000014a:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000021f: 
-                     [0xffffffff,  0x00000006): 
-                     [0x000000f0,  0x0000011a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-                     [0x0000012b,  0x00000141): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-                     [0x0000026d,  0x00000297): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-                     [0x000002a8,  0x000002be): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0xffffffff,  0x000000f6): 
+                     [0x00000000,  0x0000002a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+                     [0x0000003b,  0x00000051): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000017d,  0x000001a7): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+                     [0x000001b8,  0x000001ce): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x0000019f] = "tmp")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2841,8 +2841,8 @@ Abbrev table for offset: 0x00000000
 
 0x00000269:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000267: 
-                     [0xffffffff,  0x0000039f): 
-                     [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
+                     [0xffffffff,  0x00000386): 
+                     [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000dc] = "n")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(153)
@@ -2861,26 +2861,26 @@ Abbrev table for offset: 0x00000000
 
 0x0000028d:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000285: 
-                       [0xffffffff,  0x0000039f): 
+                       [0xffffffff,  0x00000000): 
                        [0x00000001,  0x00000001): DW_OP_consts +30, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01c3 => {0x000001c3} "showmax")
 
 0x00000296:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002a2: 
-                       [0xffffffff,  0x0000039f): 
+                       [0xffffffff,  0x00000000): 
                        [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-                       [0x0000025f,  0x00000277): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0x000005fe,  0x00000616): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ce => {0x000001ce} "args")
 
 0x0000029f:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002cc: 
-                       [0xffffffff,  0x0000039f): 
+                       [0xffffffff,  0x00000000): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000036,  0x0000003b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x000003d5,  0x000003da): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000075,  0x0000007a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x00000093,  0x00000097): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000000be,  0x000000c3): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000414,  0x00000419): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000432,  0x00000436): DW_OP_consts +0, DW_OP_stack_value
+                       [0x0000045d,  0x00000462): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
@@ -2891,34 +2891,34 @@ Abbrev table for offset: 0x00000000
 
 0x000002ad:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000354: 
-                       [0xffffffff,  0x0000039f): 
+                       [0xffffffff,  0x000003eb): 
                        [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ef => {0x000001ef} "perm1")
 
 0x000002b6:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000372: 
-                       [0xffffffff,  0x0000039f): 
+                       [0xffffffff,  0x000003f1): 
                        [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01fa => {0x000001fa} "count")
 
 0x000002bf:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000390: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x0000016f,  0x00000176): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-                       [0x0000022d,  0x00000234): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0xffffffff,  0x0000050e): 
+                       [0x00000000,  0x00000007): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+                       [0x000000be,  0x000000c5): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0205 => {0x00000205} "r")
 
 0x000002c8:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000003e8: 
-                       [0xffffffff,  0x0000039f): 
+                       [0xffffffff,  0x000005e7): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x0000026f,  0x00000277): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                       [0x00000027,  0x0000002f): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x0210 => {0x00000210} "maxflips")
 
 0x000002d1:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000413: 
-                       [0xffffffff,  0x0000039f): 
-                       [0x00000258,  0x00000277): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                       [0xffffffff,  0x000005f7): 
+                       [0x00000000,  0x0000001f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x021b => {0x0000021b} "flips")
 
 0x000002da:       DW_TAG_label [28]  
@@ -2932,7 +2932,7 @@ Abbrev table for offset: 0x00000000
 
 0x000002e8:         DW_TAG_variable [26]  
                       DW_AT_location [DW_FORM_sec_offset]	(0x000003bc: 
-                         [0xffffffff,  0x0000039f): 
+                         [0xffffffff,  0x00000000): 
                          [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
                          [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value)
                       DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x022e => {0x0000022e} "p0")
@@ -3000,121 +3000,121 @@ Abbrev table for offset: 0x00000000
 
 .debug_loc contents:
 0x00000000: 
-            [0xffffffff,  0x00000006): 
+            [0xffffffff,  0x00000007): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x0000001d: 
-            [0xffffffff,  0x00000006): 
+            [0xffffffff,  0x00000000): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000041,  0x00000046): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x00000047,  0x0000004c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000110,  0x0000011a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000116,  0x00000120): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x0000028d,  0x00000297): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000293,  0x0000029d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x000000a5: 
-            [0xffffffff,  0x00000006): 
+            [0xffffffff,  0x00000011): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x000000c3: 
-            [0xffffffff,  0x00000006): 
+            [0xffffffff,  0x0000001a): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
 
 0x000000e1: 
-            [0xffffffff,  0x00000006): 
+            [0xffffffff,  0x00000020): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value
 
 0x000000ff: 
-            [0xffffffff,  0x00000006): 
+            [0xffffffff,  0x00000026): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x0000011d: 
-            [0xffffffff,  0x00000006): 
-            [0x000001bf,  0x000001c4): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
-            [0x0000033c,  0x00000341): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0xffffffff,  0x000001c5): 
+            [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
+            [0x0000017d,  0x00000182): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x00000149: 
-            [0xffffffff,  0x00000006): 
-            [0x000000b4,  0x000000c7): DW_OP_consts +0, DW_OP_stack_value
+            [0xffffffff,  0x00000000): 
+            [0x000000ba,  0x000000cd): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-            [0x00000139,  0x00000141): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000239,  0x00000244): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000013f,  0x00000147): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-            [0x000002b6,  0x000002be): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x000002bc,  0x000002c4): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x000001ab: 
-            [0xffffffff,  0x00000006): 
-            [0x000000c3,  0x000000c7): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
-            [0x00000240,  0x00000244): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
+            [0xffffffff,  0x000000c9): 
+            [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +12, DW_OP_stack_value
+            [0x0000017d,  0x00000181): DW_OP_WASM_location 0x0 +16, DW_OP_stack_value
 
 0x000001d7: 
-            [0xffffffff,  0x00000006): 
-            [0x000000db,  0x000000df): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000117,  0x0000011a): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000258,  0x0000025c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x00000294,  0x00000297): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x000000e1): 
+            [0x00000000,  0x00000004): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000003c,  0x0000003f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000017d,  0x00000181): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x000001b9,  0x000001bc): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x0000021f: 
-            [0xffffffff,  0x00000006): 
-            [0x000000f0,  0x0000011a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
-            [0x0000012b,  0x00000141): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
-            [0x0000026d,  0x00000297): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
-            [0x000002a8,  0x000002be): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x000000f6): 
+            [0x00000000,  0x0000002a): DW_OP_WASM_location 0x0 +15, DW_OP_stack_value
+            [0x0000003b,  0x00000051): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000017d,  0x000001a7): DW_OP_WASM_location 0x0 +14, DW_OP_stack_value
+            [0x000001b8,  0x000001ce): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000267: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+            [0xffffffff,  0x00000386): 
+            [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
 
 0x00000285: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x00000000): 
             [0x00000001,  0x00000001): DW_OP_consts +30, DW_OP_stack_value
 
 0x000002a2: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x00000000): 
             [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-            [0x0000025f,  0x00000277): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x000005fe,  0x00000616): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000002cc: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x00000000): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000036,  0x0000003b): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x000003d5,  0x000003da): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000075,  0x0000007a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000093,  0x00000097): DW_OP_consts +0, DW_OP_stack_value
-            [0x000000be,  0x000000c3): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000414,  0x00000419): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000432,  0x00000436): DW_OP_consts +0, DW_OP_stack_value
+            [0x0000045d,  0x00000462): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x00000354: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x000003eb): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000372: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x000003f1): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +5, DW_OP_stack_value
 
 0x00000390: 
-            [0xffffffff,  0x0000039f): 
-            [0x0000016f,  0x00000176): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
-            [0x0000022d,  0x00000234): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0xffffffff,  0x0000050e): 
+            [0x00000000,  0x00000007): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x000000be,  0x000000c5): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000003bc: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x00000000): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
 
 0x000003e8: 
-            [0xffffffff,  0x0000039f): 
+            [0xffffffff,  0x000005e7): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x0000026f,  0x00000277): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000027,  0x0000002f): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x00000413: 
-            [0xffffffff,  0x0000039f): 
-            [0x00000258,  0x00000277): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x000005f7): 
+            [0x00000000,  0x0000001f): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 .debug_line contents:
 debug_line[0x00000000]

--- a/test/passes/fannkuch3_manyopts.bin.txt
+++ b/test/passes/fannkuch3_manyopts.bin.txt
@@ -2567,15 +2567,15 @@ Abbrev table for offset: 0x00000000
 
 0x000000c3:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000001d: 
-                     [0xffffffff,  0x00000000): 
+                     [0xffffffff,  0x0000000a): 
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x00000047,  0x0000004c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+                     [0x0000003d,  0x00000042): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000116,  0x00000120): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x0000010c,  0x00000116): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                     [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000235,  0x00000240): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-                     [0x00000293,  0x0000029d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000289,  0x00000293): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000d6] = "i")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
@@ -2630,13 +2630,13 @@ Abbrev table for offset: 0x00000000
 
 0x0000011d:     DW_TAG_variable [13]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000149: 
-                     [0xffffffff,  0x00000000): 
-                     [0x000000ba,  0x000000cd): DW_OP_consts +0, DW_OP_stack_value
+                     [0xffffffff,  0x000000ba): 
+                     [0x00000000,  0x00000013): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-                     [0x0000013f,  0x00000147): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                     [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000085,  0x0000008d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                     [0x00000185,  0x00000190): DW_OP_consts +0, DW_OP_stack_value
                      [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-                     [0x000002bc,  0x000002c4): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
+                     [0x00000202,  0x0000020a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x00000155] = "flips")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_decl_line [DW_FORM_data1]	(30)
@@ -2867,20 +2867,20 @@ Abbrev table for offset: 0x00000000
 
 0x00000296:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002a2: 
-                       [0xffffffff,  0x00000000): 
+                       [0xffffffff,  0x000005fe): 
                        [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-                       [0x000005fe,  0x00000616): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
+                       [0x00000000,  0x00000018): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value)
                     DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01ce => {0x000001ce} "args")
 
 0x0000029f:       DW_TAG_variable [26]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x000002cc: 
-                       [0xffffffff,  0x00000000): 
+                       [0xffffffff,  0x000003d5): 
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x000003d5,  0x000003da): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-                       [0x00000414,  0x00000419): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-                       [0x00000432,  0x00000436): DW_OP_consts +0, DW_OP_stack_value
-                       [0x0000045d,  0x00000462): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x0000003f,  0x00000044): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+                       [0x0000005d,  0x00000061): DW_OP_consts +0, DW_OP_stack_value
+                       [0x00000088,  0x0000008d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
                        [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value)
@@ -2932,7 +2932,7 @@ Abbrev table for offset: 0x00000000
 
 0x000002e8:         DW_TAG_variable [26]  
                       DW_AT_location [DW_FORM_sec_offset]	(0x000003bc: 
-                         [0xffffffff,  0x00000000): 
+                         [0xffffffff,  0x00000565): 
                          [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
                          [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value)
                       DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x022e => {0x0000022e} "p0")
@@ -3004,15 +3004,15 @@ Abbrev table for offset: 0x00000000
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x0000001d: 
-            [0xffffffff,  0x00000000): 
+            [0xffffffff,  0x0000000a): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000047,  0x0000004c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0x0000003d,  0x00000042): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000116,  0x00000120): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000010c,  0x00000116): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000235,  0x00000240): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +1, DW_OP_stack_value
-            [0x00000293,  0x0000029d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000289,  0x00000293): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
 
 0x000000a5: 
@@ -3037,13 +3037,13 @@ Abbrev table for offset: 0x00000000
             [0x0000017d,  0x00000182): DW_OP_WASM_location 0x0 +2, DW_OP_stack_value
 
 0x00000149: 
-            [0xffffffff,  0x00000000): 
-            [0x000000ba,  0x000000cd): DW_OP_consts +0, DW_OP_stack_value
+            [0xffffffff,  0x000000ba): 
+            [0x00000000,  0x00000013): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +13, DW_OP_stack_value
-            [0x0000013f,  0x00000147): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x0000023f,  0x0000024a): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000085,  0x0000008d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000185,  0x00000190): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +10, DW_OP_stack_value
-            [0x000002bc,  0x000002c4): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000202,  0x0000020a): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
 
 0x000001ab: 
             [0xffffffff,  0x000000c9): 
@@ -3073,18 +3073,18 @@ Abbrev table for offset: 0x00000000
             [0x00000001,  0x00000001): DW_OP_consts +30, DW_OP_stack_value
 
 0x000002a2: 
-            [0xffffffff,  0x00000000): 
+            [0xffffffff,  0x000005fe): 
             [0x00000001,  0x00000001): DW_OP_lit0, DW_OP_stack_value
-            [0x000005fe,  0x00000616): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
+            [0x00000000,  0x00000018): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000002cc: 
-            [0xffffffff,  0x00000000): 
+            [0xffffffff,  0x000003d5): 
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x000003d5,  0x000003da): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x00000000,  0x00000005): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
-            [0x00000414,  0x00000419): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
-            [0x00000432,  0x00000436): DW_OP_consts +0, DW_OP_stack_value
-            [0x0000045d,  0x00000462): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000003f,  0x00000044): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
+            [0x0000005d,  0x00000061): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000088,  0x0000008d): DW_OP_WASM_location 0x0 +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_consts +0, DW_OP_stack_value
@@ -3103,7 +3103,7 @@ Abbrev table for offset: 0x00000000
             [0x000000be,  0x000000c5): DW_OP_WASM_location 0x0 +6, DW_OP_stack_value
 
 0x000003bc: 
-            [0xffffffff,  0x00000000): 
+            [0xffffffff,  0x00000565): 
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
             [0x00000001,  0x00000001): DW_OP_WASM_location 0x0 +8, DW_OP_stack_value
 

--- a/test/passes/fib2.bin.txt
+++ b/test/passes/fib2.bin.txt
@@ -404,9 +404,9 @@ Abbrev table for offset: 0x00000000
 
 0x00000049:     DW_TAG_variable [4]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000000: 
-                     [0xffffffff,  0x00000005): 
-                     [0x00000007,  0x00000010): DW_OP_consts +0, DW_OP_stack_value
-                     [0x0000001e,  0x00000033): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
+                     [0xffffffff,  0x0000000c): 
+                     [0x00000000,  0x00000009): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000017,  0x0000002c): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000ac] = "a")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/2-binaryen/fib2.c")
                   DW_AT_decl_line [DW_FORM_data1]	(2)
@@ -414,10 +414,10 @@ Abbrev table for offset: 0x00000000
 
 0x00000058:     DW_TAG_variable [4]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x0000002b: 
-                     [0xffffffff,  0x00000005): 
-                     [0x00000007,  0x00000010): DW_OP_consts +1, DW_OP_stack_value
-                     [0x0000001e,  0x00000023): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
-                     [0x00000023,  0x00000033): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
+                     [0xffffffff,  0x0000000c): 
+                     [0x00000000,  0x00000009): DW_OP_consts +1, DW_OP_stack_value
+                     [0x00000017,  0x0000001c): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+                     [0x0000001c,  0x0000002c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000ae] = "b")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/2-binaryen/fib2.c")
                   DW_AT_decl_line [DW_FORM_data1]	(2)
@@ -425,9 +425,9 @@ Abbrev table for offset: 0x00000000
 
 0x00000067:     DW_TAG_variable [4]  
                   DW_AT_location [DW_FORM_sec_offset]	(0x00000064: 
-                     [0xffffffff,  0x00000005): 
-                     [0x00000007,  0x00000010): DW_OP_consts +0, DW_OP_stack_value
-                     [0x0000002e,  0x00000033): DW_OP_WASM_location 0x0 +3, DW_OP_stack_value)
+                     [0xffffffff,  0x0000000c): 
+                     [0x00000000,  0x00000009): DW_OP_consts +0, DW_OP_stack_value
+                     [0x00000027,  0x0000002c): DW_OP_WASM_location 0x0 +3, DW_OP_stack_value)
                   DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000b0] = "i")
                   DW_AT_decl_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/2-binaryen/fib2.c")
                   DW_AT_decl_line [DW_FORM_data1]	(2)
@@ -466,20 +466,20 @@ Abbrev table for offset: 0x00000000
 
 .debug_loc contents:
 0x00000000: 
-            [0xffffffff,  0x00000005): 
-            [0x00000007,  0x00000010): DW_OP_consts +0, DW_OP_stack_value
-            [0x0000001e,  0x00000033): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+            [0xffffffff,  0x0000000c): 
+            [0x00000000,  0x00000009): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000017,  0x0000002c): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
 
 0x0000002b: 
-            [0xffffffff,  0x00000005): 
-            [0x00000007,  0x00000010): DW_OP_consts +1, DW_OP_stack_value
-            [0x0000001e,  0x00000023): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
-            [0x00000023,  0x00000033): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
+            [0xffffffff,  0x0000000c): 
+            [0x00000000,  0x00000009): DW_OP_consts +1, DW_OP_stack_value
+            [0x00000017,  0x0000001c): DW_OP_WASM_location 0x0 +4, DW_OP_stack_value
+            [0x0000001c,  0x0000002c): DW_OP_WASM_location 0x0 +1, DW_OP_stack_value
 
 0x00000064: 
-            [0xffffffff,  0x00000005): 
-            [0x00000007,  0x00000010): DW_OP_consts +0, DW_OP_stack_value
-            [0x0000002e,  0x00000033): DW_OP_WASM_location 0x0 +3, DW_OP_stack_value
+            [0xffffffff,  0x0000000c): 
+            [0x00000000,  0x00000009): DW_OP_consts +0, DW_OP_stack_value
+            [0x00000027,  0x0000002c): DW_OP_WASM_location 0x0 +3, DW_OP_stack_value
 
 .debug_line contents:
 debug_line[0x00000000]


### PR DESCRIPTION
`.debug_loc` entries can have bases: a value that all values after
it in the list are relative to. Previously we used to keep the base
value as it was, to keep things as similar to the original DWARF as
possible. However, if optimizations move code around so that the
values after the base are *before* the base, then the values could
no longer be emitted, and we skipped them in effect.

This PR makes us always pick a new base for each list. This
allows the base to always work for the values after it, but does
mean we change the lists quite a lot more. If there is any extra
meaning to the original bases here we may lose that, but the
DWARF spec doesn't seem to indicate anything like that
(however, it isn't clear to me why LLVM then doesn't always
choose the maximal base as the code here does - LLVM's values
seem oddly arbitrary).