### PR TITLE
wasm2js: Sign-extend support

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1466,25 +1466,19 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
             }
             case ExtendS8Int32: {
               return ValueBuilder::makeBinary(
-                ValueBuilder::makeBinary(
-                  visit(curr->value, EXPRESSION_RESULT),
-                  LSHIFT,
-                  ValueBuilder::makeNum(24)
-                ),
+                ValueBuilder::makeBinary(visit(curr->value, EXPRESSION_RESULT),
+                                         LSHIFT,
+                                         ValueBuilder::makeNum(24)),
                 RSHIFT,
-                ValueBuilder::makeNum(24)
-              );
+                ValueBuilder::makeNum(24));
             }
             case ExtendS16Int32: {
               return ValueBuilder::makeBinary(
-                ValueBuilder::makeBinary(
-                  visit(curr->value, EXPRESSION_RESULT),
-                  LSHIFT,
-                  ValueBuilder::makeNum(16)
-                ),
+                ValueBuilder::makeBinary(visit(curr->value, EXPRESSION_RESULT),
+                                         LSHIFT,
+                                         ValueBuilder::makeNum(16)),
                 RSHIFT,
-                ValueBuilder::makeNum(16)
-              );
+                ValueBuilder::makeNum(16));
             }
             default: {
               std::cerr << "Unhandled unary i32 operator: " << curr

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1464,6 +1464,28 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
                 TRSHIFT,
                 ValueBuilder::makeNum(0));
             }
+            case ExtendS8Int32: {
+              return ValueBuilder::makeBinary(
+                ValueBuilder::makeBinary(
+                  visit(curr->value, EXPRESSION_RESULT),
+                  LSHIFT,
+                  ValueBuilder::makeNum(24)
+                ),
+                RSHIFT,
+                ValueBuilder::makeNum(24)
+              );
+            }
+            case ExtendS16Int32: {
+              return ValueBuilder::makeBinary(
+                ValueBuilder::makeBinary(
+                  visit(curr->value, EXPRESSION_RESULT),
+                  LSHIFT,
+                  ValueBuilder::makeNum(16)
+                ),
+                RSHIFT,
+                ValueBuilder::makeNum(16)
+              );
+            }
             default: {
               std::cerr << "Unhandled unary i32 operator: " << curr
                         << std::endl;

--- a/test/wasm2js/sign_ext.2asm.js
+++ b/test/wasm2js/sign_ext.2asm.js
@@ -1,0 +1,30 @@
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var FUNCTION_TABLE = [];
+ return {
+  
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);

--- a/test/wasm2js/sign_ext.2asm.js
+++ b/test/wasm2js/sign_ext.2asm.js
@@ -20,11 +20,24 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
+ function $0(x) {
+  x = x | 0;
+  return x << 24 >> 24 | 0;
+ }
+ 
+ function $1(x) {
+  x = x | 0;
+  return x << 16 >> 16 | 0;
+ }
+ 
  var FUNCTION_TABLE = [];
  return {
-  
+  "test8": $0, 
+  "test16": $1
  };
 }
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export var test8 = retasmFunc.test8;
+export var test16 = retasmFunc.test16;

--- a/test/wasm2js/sign_ext.2asm.js.opt
+++ b/test/wasm2js/sign_ext.2asm.js.opt
@@ -20,11 +20,24 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
+ function $0($0_1) {
+  $0_1 = $0_1 | 0;
+  return $0_1 << 24 >> 24;
+ }
+ 
+ function $1($0_1) {
+  $0_1 = $0_1 | 0;
+  return $0_1 << 16 >> 16;
+ }
+ 
  var FUNCTION_TABLE = [];
  return {
-  
+  "test8": $0, 
+  "test16": $1
  };
 }
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
+export var test8 = retasmFunc.test8;
+export var test16 = retasmFunc.test16;

--- a/test/wasm2js/sign_ext.2asm.js.opt
+++ b/test/wasm2js/sign_ext.2asm.js.opt
@@ -1,0 +1,30 @@
+
+function asmFunc(global, env, buffer) {
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var FUNCTION_TABLE = [];
+ return {
+  
+ };
+}
+
+var memasmFunc = new ArrayBuffer(65536);
+var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);

--- a/test/wasm2js/sign_ext.wast
+++ b/test/wasm2js/sign_ext.wast
@@ -1,0 +1,8 @@
+(module
+  (func $test8 (param $x i32) (result i32)
+    (i32.extend8_s (local.get $x))
+  )
+  (func $test16 (param $x i32) (result i32)
+    (i32.extend16_s (local.get $x))
+  )
+)

--- a/test/wasm2js/sign_ext.wast
+++ b/test/wasm2js/sign_ext.wast
@@ -1,8 +1,8 @@
 (module
-  (func $test8 (param $x i32) (result i32)
+  (func "test8" (param $x i32) (result i32)
     (i32.extend8_s (local.get $x))
   )
-  (func $test16 (param $x i32) (result i32)
+  (func "test16" (param $x i32) (result i32)
     (i32.extend16_s (local.get $x))
   )
 )


### PR DESCRIPTION
The usual "trick" to extend: shift left so the sign bit in the small
integer is now the sign bit in a 32-bit integer, then shift right to
spread that sign bit out and return the lower bits to their
proper place, `(x << 24) >> 24`.