### PR TITLE
wasm2c signal handler fixes

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -402,6 +402,9 @@ class CompareVMs(TestCaseHandler):
                 run([in_bin('wasm-opt'), wasm, '--emit-wasm2c-wrapper=main.c'] + FEATURE_OPTS)
                 run(['wasm2c', wasm, '-o', 'wasm.c'])
                 compile_cmd = ['emcc', 'main.c', 'wasm.c', os.path.join(self.wasm2c_dir, 'wasm-rt-impl.c'), '-I' + self.wasm2c_dir, '-lm']
+                # disable the signal handler: emcc looks like unix, but wasm has
+                # no signals
+                compile_cmd += ['-DWASM_RT_MEMCHECK_SIGNAL_HANDLER=0']
                 if random.random() < 0.5:
                     compile_cmd += ['-O' + str(random.randint(1, 3))]
                 elif random.random() < 0.5:

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
     (*Z_hangLimitInitializerZ_vv)();
 
     // Prepare to call the export, so we can catch traps.
-    if (setjmp(g_jmp_buf) != 0) {
+    if (WASM_RT_SETJMP(g_jmp_buf) != 0) {
       puts("exception!");
     } else {
       // Call the proper export.


### PR DESCRIPTION
Use `WASM_RT_SETJMP` so we use `sigsetjmp` when we need to.

Also disable signals in emcc+wasm2c in the fuzzer. emcc looks like
unix, so it enters the ifdef to use signals, but wasm has no signals...
This might also be done in the ifdef on the wabt side perhaps? I'm
ok either way.