### PR TITLE
Add v128 support to instrument locals

### DIFF
--- a/src/passes/InstrumentLocals.cpp
+++ b/src/passes/InstrumentLocals.cpp
@@ -60,6 +60,7 @@ Name get_funcref("get_funcref");
 Name get_externref("get_externref");
 Name get_nullref("get_nullref");
 Name get_exnref("get_exnref");
+Name get_v128("get_v128");
 
 Name set_i32("set_i32");
 Name set_i64("set_i64");
@@ -69,6 +70,7 @@ Name set_funcref("set_funcref");
 Name set_externref("set_externref");
 Name set_nullref("set_nullref");
 Name set_exnref("set_exnref");
+Name set_v128("set_v128");
 
 struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
   void visitLocalGet(LocalGet* curr) {
@@ -87,7 +89,8 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
         import = get_f64;
         break;
       case Type::v128:
-        assert(false && "v128 not implemented yet");
+        import = get_v128;
+        break;
       case Type::funcref:
         import = get_funcref;
         break;
@@ -135,7 +138,8 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
         import = set_f64;
         break;
       case Type::v128:
-        assert(false && "v128 not implemented yet");
+        import = set_v128;
+        break;
       case Type::funcref:
         import = set_funcref;
         break;
@@ -202,6 +206,10 @@ struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
         curr, get_exnref, {Type::i32, Type::i32, Type::exnref}, Type::exnref);
       addImport(
         curr, set_exnref, {Type::i32, Type::i32, Type::exnref}, Type::exnref);
+    }
+    if (curr->features.hasSIMD()) {
+      addImport(curr, get_v128, {Type::i32, Type::i32, Type::v128}, Type::v128);
+      addImport(curr, set_v128, {Type::i32, Type::i32, Type::v128}, Type::v128);
     }
   }
 

--- a/test/passes/instrument-locals_all-features.txt
+++ b/test/passes/instrument-locals_all-features.txt
@@ -3,6 +3,7 @@
  (type $i32_i32_i64_=>_i64 (func (param i32 i32 i64) (result i64)))
  (type $i32_i32_f32_=>_f32 (func (param i32 i32 f32) (result f32)))
  (type $i32_i32_f64_=>_f64 (func (param i32 i32 f64) (result f64)))
+ (type $i32_i32_v128_=>_v128 (func (param i32 i32 v128) (result v128)))
  (type $i32_i32_funcref_=>_funcref (func (param i32 i32 funcref) (result funcref)))
  (type $i32_i32_externref_=>_externref (func (param i32 i32 externref) (result externref)))
  (type $i32_i32_nullref_=>_nullref (func (param i32 i32 nullref) (result nullref)))
@@ -24,6 +25,8 @@
  (import "env" "set_nullref" (func $set_nullref (param i32 i32 nullref) (result nullref)))
  (import "env" "get_exnref" (func $get_exnref (param i32 i32 exnref) (result exnref)))
  (import "env" "set_exnref" (func $set_exnref (param i32 i32 exnref) (result exnref)))
+ (import "env" "get_v128" (func $get_v128 (param i32 i32 v128) (result v128)))
+ (import "env" "set_v128" (func $set_v128 (param i32 i32 v128) (result v128)))
  (func $test
   (local $x i32)
   (local $y i64)
@@ -33,6 +36,7 @@
   (local $X externref)
   (local $N nullref)
   (local $E exnref)
+  (local $S v128)
   (drop
    (call $get_i32
     (i32.const 0)
@@ -276,6 +280,20 @@
   )
   (local.set $E
    (exnref.pop)
+  )
+  (drop
+   (call $get_v128
+    (i32.const 34)
+    (i32.const 8)
+    (local.get $S)
+   )
+  )
+  (local.set $S
+   (call $set_v128
+    (i32.const 35)
+    (i32.const 8)
+    (v128.const i32x4 0x00000000 0x00000001 0x00000002 0x00000003)
+   )
   )
  )
 )

--- a/test/passes/instrument-locals_all-features.wast
+++ b/test/passes/instrument-locals_all-features.wast
@@ -8,6 +8,7 @@
     (local $X externref)
     (local $N nullref)
     (local $E exnref)
+    (local $S v128)
 
     (drop (local.get $x))
     (drop (local.get $y))
@@ -50,6 +51,11 @@
     (local.set $X (externref.pop))
     (local.set $N (nullref.pop))
     (local.set $E (exnref.pop))
+
+    ;; Add new instructions here so expected output doesn't change too much, it
+    ;; depends on order of instructions in this file.
+    (drop (local.get $S))
+    (local.set $S (v128.const i32x4 0x00000000 0x00000001 0x00000002 0x00000003))
   )
 )
 


### PR DESCRIPTION
In instrument-locals_all-features.wast I added the tests to the end of
the file so that the diff of expected output is smaller and easier to
read. Otherwise the constants will have to all change since they are
order dependent.