### PR TITLE
wasm2js: Fix a bug with adjacent reinterprets

### DIFF
--- a/src/passes/wasm-intrinsics.wat
+++ b/src/passes/wasm-intrinsics.wat
@@ -10,6 +10,7 @@
 ;;    add $wasm-intrinsics-temp-i64 global for that.
 ;;  * Fix function type of __wasm_ctz_i64, which was wrong somehow,
 ;;    i32, i32 => i32 instead of i64 => i64
+;;  * Remove unnecessary memory import.
 ;;
 ;; [1]: https://gist.github.com/alexcrichton/e7ea67bcdd17ce4b6254e66f77165690
 
@@ -20,7 +21,6 @@
  (type $3 (func (param i32) (result i32)))
  (type $4 (func (param i32 i32) (result i32)))
  (type $5 (func (param i64) (result i64)))
- (import "env" "memory" (memory $0 17))
  (export "__wasm_i64_sdiv" (func $__wasm_i64_sdiv))
  (export "__wasm_i64_udiv" (func $__wasm_i64_udiv))
  (export "__wasm_i64_srem" (func $__wasm_i64_srem))

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1437,8 +1437,9 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
               Ref store =
                 ValueBuilder::makeCall(ABI::wasm2js::SCRATCH_STORE_F32,
                                        visit(curr->value, EXPRESSION_RESULT));
-              // 32-bit scratch memory uses index 3, so that it does not
-              // conflict with indexes 0, 1 which are used for 64-bit.
+              // 32-bit scratch memory uses index 2, so that it does not
+              // conflict with indexes 0, 1 which are used for 64-bit, see
+              // comment where |scratchBuffer| is defined.
               Ref load = ValueBuilder::makeCall(ABI::wasm2js::SCRATCH_LOAD_I32,
                                                 ValueBuilder::makeInt(2));
               return ValueBuilder::makeSeq(store, load);
@@ -1530,8 +1531,9 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
               ABI::wasm2js::ensureHelpers(module,
                                           ABI::wasm2js::SCRATCH_LOAD_F32);
 
-              // 32-bit scratch memory uses index 3, so that it does not
-              // conflict with indexes 0, 1 which are used for 64-bit.
+              // 32-bit scratch memory uses index 2, so that it does not
+              // conflict with indexes 0, 1 which are used for 64-bit, see
+              // comment where |scratchBuffer| is defined.
               Ref store =
                 ValueBuilder::makeCall(ABI::wasm2js::SCRATCH_STORE_I32,
                                        ValueBuilder::makeNum(2),

--- a/test/wasm2js/atomics_32.2asm.js
+++ b/test/wasm2js/atomics_32.2asm.js
@@ -1,6 +1,6 @@
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);

--- a/test/wasm2js/atomics_32.2asm.js.opt
+++ b/test/wasm2js/atomics_32.2asm.js.opt
@@ -1,6 +1,6 @@
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);

--- a/test/wasm2js/bulk-memory.2asm.js
+++ b/test/wasm2js/bulk-memory.2asm.js
@@ -30,7 +30,7 @@ var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -115,7 +115,7 @@ export var fill = retasmFunc.fill;
 export var load8_u = retasmFunc.load8_u;
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -196,7 +196,7 @@ export var copy = retasmFunc.copy;
 export var load8_u = retasmFunc.load8_u;
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -301,7 +301,7 @@ export var init = retasmFunc.init;
 export var load8_u = retasmFunc.load8_u;
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);

--- a/test/wasm2js/bulk-memory.2asm.js.opt
+++ b/test/wasm2js/bulk-memory.2asm.js.opt
@@ -30,7 +30,7 @@ var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -115,7 +115,7 @@ export var fill = retasmFunc.fill;
 export var load8_u = retasmFunc.load8_u;
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -196,7 +196,7 @@ export var copy = retasmFunc.copy;
 export var load8_u = retasmFunc.load8_u;
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);

--- a/test/wasm2js/conversions-modified.2asm.js
+++ b/test/wasm2js/conversions-modified.2asm.js
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -23,11 +23,11 @@ import { setTempRet0 } from 'env';
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
 function asmFunc(global, env, buffer) {
@@ -240,7 +240,7 @@ function asmFunc(global, env, buffer) {
  
  function $21(x) {
   x = x | 0;
-  return Math_fround((wasm2js_scratch_store_i32(0, x), wasm2js_scratch_load_f32()));
+  return Math_fround((wasm2js_scratch_store_i32(2, x), wasm2js_scratch_load_f32()));
  }
  
  function $22(x, x$hi) {
@@ -255,7 +255,7 @@ function asmFunc(global, env, buffer) {
  
  function $23(x) {
   x = Math_fround(x);
-  return (wasm2js_scratch_store_f32(x), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(x), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $24(x) {

--- a/test/wasm2js/conversions-modified.2asm.js.opt
+++ b/test/wasm2js/conversions-modified.2asm.js.opt
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -23,11 +23,11 @@ import { setTempRet0 } from 'env';
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
 function asmFunc(global, env, buffer) {
@@ -117,12 +117,12 @@ function asmFunc(global, env, buffer) {
  
  function $21($0) {
   $0 = $0 | 0;
-  return Math_fround((wasm2js_scratch_store_i32(0, $0), wasm2js_scratch_load_f32()));
+  return Math_fround((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32()));
  }
  
  function $23($0) {
   $0 = Math_fround($0);
-  return (wasm2js_scratch_store_f32($0), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32($0), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function legalstub$0($0) {

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -23,11 +23,11 @@ import { setTempRet0 } from 'env';
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
 function asmFunc(global, env, buffer) {
@@ -209,7 +209,7 @@ function asmFunc(global, env, buffer) {
  
  function $14(value) {
   value = Math_fround(value);
-  i32_store_little(0 | 0, (wasm2js_scratch_store_f32(value), wasm2js_scratch_load_i32(0)) | 0);
+  i32_store_little(0 | 0, (wasm2js_scratch_store_f32(value), wasm2js_scratch_load_i32(2)) | 0);
   return Math_fround(Math_fround(HEAPF32[0 >> 2]));
  }
  
@@ -275,7 +275,7 @@ function asmFunc(global, env, buffer) {
  function $21(value) {
   value = Math_fround(value);
   HEAPF32[0 >> 2] = value;
-  return Math_fround((wasm2js_scratch_store_i32(0, i32_load_little(0 | 0) | 0), wasm2js_scratch_load_f32()));
+  return Math_fround((wasm2js_scratch_store_i32(2, i32_load_little(0 | 0) | 0), wasm2js_scratch_load_f32()));
  }
  
  function $22(value) {

--- a/test/wasm2js/float_literals-modified.2asm.js
+++ b/test/wasm2js/float_literals-modified.2asm.js
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -15,7 +15,7 @@ import { setTempRet0 } from 'env';
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
 function asmFunc(global, env, buffer) {
@@ -42,123 +42,123 @@ function asmFunc(global, env, buffer) {
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $1() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $2() {
-  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $3() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $4() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $5() {
-  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $6() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $7() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $8() {
-  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $9() {
-  return (wasm2js_scratch_store_f32(Math_fround(infinity)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(infinity)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $10() {
-  return (wasm2js_scratch_store_f32(Math_fround(infinity)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(infinity)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $11() {
-  return (wasm2js_scratch_store_f32(Math_fround(-infinity)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-infinity)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $12() {
-  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $13() {
-  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $14() {
-  return (wasm2js_scratch_store_f32(Math_fround(-0.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-0.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $15() {
-  return (wasm2js_scratch_store_f32(Math_fround(6.2831854820251465)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(6.2831854820251465)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $16() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.401298464324817e-45)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.401298464324817e-45)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $17() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.1754943508222875e-38)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.1754943508222875e-38)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $18() {
-  return (wasm2js_scratch_store_f32(Math_fround(3402823466385288598117041.0e14)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(3402823466385288598117041.0e14)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $19() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.1754942106924411e-38)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.1754942106924411e-38)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $20() {
-  return (wasm2js_scratch_store_f32(Math_fround(1024.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1024.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $21() {
-  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $22() {
-  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $23() {
-  return (wasm2js_scratch_store_f32(Math_fround(-0.0)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-0.0)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $24() {
-  return (wasm2js_scratch_store_f32(Math_fround(6.2831854820251465)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(6.2831854820251465)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $25() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.401298464324817e-45)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.401298464324817e-45)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $26() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.1754943508222875e-38)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.1754943508222875e-38)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $27() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.1754942106924411e-38)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.1754942106924411e-38)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $28() {
-  return (wasm2js_scratch_store_f32(Math_fround(3402823466385288598117041.0e14)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(3402823466385288598117041.0e14)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $29() {
-  return (wasm2js_scratch_store_f32(Math_fround(1.0e10)), wasm2js_scratch_load_i32(0)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(1.0e10)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $30() {

--- a/test/wasm2js/float_literals-modified.2asm.js.opt
+++ b/test/wasm2js/float_literals-modified.2asm.js.opt
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);

--- a/test/wasm2js/float_misc.2asm.js
+++ b/test/wasm2js/float_misc.2asm.js
@@ -1,6 +1,6 @@
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -22,11 +22,11 @@
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
 function asmFunc(global, env, buffer) {
@@ -92,7 +92,7 @@ function asmFunc(global, env, buffer) {
  function $7(x, y) {
   x = Math_fround(x);
   y = Math_fround(y);
-  return Math_fround((wasm2js_scratch_store_i32(0, (wasm2js_scratch_store_f32(x), wasm2js_scratch_load_i32(0)) & 2147483647 | 0 | ((wasm2js_scratch_store_f32(y), wasm2js_scratch_load_i32(0)) & -2147483648 | 0) | 0), wasm2js_scratch_load_f32()));
+  return Math_fround((wasm2js_scratch_store_i32(2, (wasm2js_scratch_store_f32(x), wasm2js_scratch_load_i32(2)) & 2147483647 | 0 | ((wasm2js_scratch_store_f32(y), wasm2js_scratch_load_i32(2)) & -2147483648 | 0) | 0), wasm2js_scratch_load_f32()));
  }
  
  function $8(x) {

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -1,6 +1,6 @@
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -22,7 +22,7 @@
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
 function asmFunc(global, env, buffer) {
@@ -1019,7 +1019,7 @@ function asmFunc(global, env, buffer) {
  
  function $98() {
   reset();
-  (wasm2js_scratch_store_f32(Math_fround(f32_left())), wasm2js_scratch_load_i32(0)) & 2147483647 | 0 | ((wasm2js_scratch_store_f32(Math_fround(f32_right())), wasm2js_scratch_load_i32(0)) & -2147483648 | 0) | 0;
+  (wasm2js_scratch_store_f32(Math_fround(f32_left())), wasm2js_scratch_load_i32(2)) & 2147483647 | 0 | ((wasm2js_scratch_store_f32(Math_fround(f32_right())), wasm2js_scratch_load_i32(2)) & -2147483648 | 0) | 0;
   return get() | 0 | 0;
  }
  

--- a/test/wasm2js/reinterpret.2asm.js
+++ b/test/wasm2js/reinterpret.2asm.js
@@ -1,6 +1,6 @@
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -22,11 +22,11 @@
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
 function asmFunc(global, env, buffer) {
@@ -52,7 +52,7 @@ function asmFunc(global, env, buffer) {
  var infinity = global.Infinity;
  function $1($0) {
   $0 = $0 | 0;
-  return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(0, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(0)) | 0) == ($0 | 0) | 0;
+  return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(2)) | 0) == ($0 | 0) | 0;
  }
  
  function $2($0, $0$hi) {

--- a/test/wasm2js/reinterpret_scratch.2asm.js
+++ b/test/wasm2js/reinterpret_scratch.2asm.js
@@ -9,24 +9,12 @@
     return i32ScratchView[index];
   }
       
-  function wasm2js_scratch_store_i32(index, value) {
-    i32ScratchView[index] = value;
-  }
-      
-  function wasm2js_scratch_load_f64() {
-    return f64ScratchView[0];
-  }
-      
   function wasm2js_scratch_store_f64(value) {
     f64ScratchView[0] = value;
   }
       
   function wasm2js_scratch_store_f32(value) {
     f32ScratchView[2] = value;
-  }
-      
-  function wasm2js_scratch_load_f32() {
-    return f32ScratchView[2];
   }
       
 function asmFunc(global, env, buffer) {
@@ -50,34 +38,27 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- function $1($0) {
-  $0 = $0 | 0;
-  return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(2)) | 0) == ($0 | 0) | 0;
- }
- 
- function $2($0, $1_1) {
-  $0 = $0 | 0;
-  $1_1 = $1_1 | 0;
-  var $2_1 = 0;
-  wasm2js_scratch_store_i32(0, $0 | 0);
-  wasm2js_scratch_store_i32(1, $1_1 | 0);
-  wasm2js_scratch_store_f64(+wasm2js_scratch_load_f64());
-  $2_1 = wasm2js_scratch_load_i32(1) | 0;
-  return (wasm2js_scratch_load_i32(0) | 0) == ($0 | 0) & ($1_1 | 0) == ($2_1 | 0);
- }
- 
- function legalstub$2($0, $1_1) {
-  return $2($0, $1_1);
+ function $0() {
+  var i64toi32_i32$1 = 0, i64toi32_i32$0 = 0, $0_1 = Math_fround(0);
+  wasm2js_scratch_store_f64(+(305419896.0));
+  i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
+  i64toi32_i32$1 = (wasm2js_scratch_store_f32($0_1), wasm2js_scratch_load_i32(2));
+  HEAP32[i64toi32_i32$1 >> 2] = wasm2js_scratch_load_i32(0 | 0) | 0;
+  HEAP32[(i64toi32_i32$1 + 4 | 0) >> 2] = i64toi32_i32$0;
+  return HEAP32[0 >> 2] | 0 | 0;
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
-  "i32_roundtrip": $1, 
-  "i64_roundtrip": legalstub$2
+  "foo": $0
  };
 }
 
 var memasmFunc = new ArrayBuffer(65536);
+var bufferView = new Uint8Array(memasmFunc);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
-export var i32_roundtrip = retasmFunc.i32_roundtrip;
-export var i64_roundtrip = retasmFunc.i64_roundtrip;
+export var foo = retasmFunc.foo;

--- a/test/wasm2js/reinterpret_scratch.2asm.js.opt
+++ b/test/wasm2js/reinterpret_scratch.2asm.js.opt
@@ -9,24 +9,8 @@
     return i32ScratchView[index];
   }
       
-  function wasm2js_scratch_store_i32(index, value) {
-    i32ScratchView[index] = value;
-  }
-      
-  function wasm2js_scratch_load_f64() {
-    return f64ScratchView[0];
-  }
-      
   function wasm2js_scratch_store_f64(value) {
     f64ScratchView[0] = value;
-  }
-      
-  function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[2] = value;
-  }
-      
-  function wasm2js_scratch_load_f32() {
-    return f32ScratchView[2];
   }
       
 function asmFunc(global, env, buffer) {
@@ -50,34 +34,26 @@ function asmFunc(global, env, buffer) {
  var abort = env.abort;
  var nan = global.NaN;
  var infinity = global.Infinity;
- function $1($0) {
-  $0 = $0 | 0;
-  return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(2)) | 0) == ($0 | 0) | 0;
- }
- 
- function $2($0, $1_1) {
-  $0 = $0 | 0;
-  $1_1 = $1_1 | 0;
-  var $2_1 = 0;
-  wasm2js_scratch_store_i32(0, $0 | 0);
-  wasm2js_scratch_store_i32(1, $1_1 | 0);
-  wasm2js_scratch_store_f64(+wasm2js_scratch_load_f64());
-  $2_1 = wasm2js_scratch_load_i32(1) | 0;
-  return (wasm2js_scratch_load_i32(0) | 0) == ($0 | 0) & ($1_1 | 0) == ($2_1 | 0);
- }
- 
- function legalstub$2($0, $1_1) {
-  return $2($0, $1_1);
+ function $0() {
+  var $0_1 = 0;
+  wasm2js_scratch_store_f64(305419896.0);
+  $0_1 = wasm2js_scratch_load_i32(1) | 0;
+  HEAP32[0] = wasm2js_scratch_load_i32(0);
+  HEAP32[1] = $0_1;
+  return HEAP32[0];
  }
  
  var FUNCTION_TABLE = [];
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
  return {
-  "i32_roundtrip": $1, 
-  "i64_roundtrip": legalstub$2
+  "foo": $0
  };
 }
 
 var memasmFunc = new ArrayBuffer(65536);
+var bufferView = new Uint8Array(memasmFunc);
 var retasmFunc = asmFunc({Math,Int8Array,Uint8Array,Int16Array,Uint16Array,Int32Array,Uint32Array,Float32Array,Float64Array,NaN,Infinity}, {abort:function() { throw new Error('abort'); }},memasmFunc);
-export var i32_roundtrip = retasmFunc.i32_roundtrip;
-export var i64_roundtrip = retasmFunc.i64_roundtrip;
+export var foo = retasmFunc.foo;

--- a/test/wasm2js/reinterpret_scratch.wast
+++ b/test/wasm2js/reinterpret_scratch.wast
@@ -1,0 +1,17 @@
+(module
+ (memory $0 1 1)
+ (func "foo" (result i32)
+  (local $0 f32)
+  (i64.store align=4
+   (i32.reinterpret_f32 ;; i32 0
+    (local.get $0)      ;; f32 0
+   )
+   (i64.reinterpret_f64    ;; these two reinterprets must not interfere with
+    (f64.const 0x12345678) ;; each other, even though both use scratch memory
+   )
+  )
+  (i32.load
+   (i32.const 0)
+  )
+ )
+)

--- a/test/wasm2js/unaligned.2asm.js
+++ b/test/wasm2js/unaligned.2asm.js
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -23,11 +23,11 @@ import { setTempRet0 } from 'env';
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
   function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[0] = value;
+    f32ScratchView[2] = value;
   }
       
 function asmFunc(global, env, buffer) {
@@ -71,7 +71,7 @@ function asmFunc(global, env, buffer) {
  function $2() {
   var $0_1 = 0;
   $0_1 = 0;
-  return Math_fround((wasm2js_scratch_store_i32(0, HEAPU8[$0_1 >> 0] | 0 | ((HEAPU8[($0_1 + 1 | 0) >> 0] | 0) << 8 | 0) | 0 | ((HEAPU8[($0_1 + 2 | 0) >> 0] | 0) << 16 | 0 | ((HEAPU8[($0_1 + 3 | 0) >> 0] | 0) << 24 | 0) | 0) | 0), wasm2js_scratch_load_f32()));
+  return Math_fround((wasm2js_scratch_store_i32(2, HEAPU8[$0_1 >> 0] | 0 | ((HEAPU8[($0_1 + 1 | 0) >> 0] | 0) << 8 | 0) | 0 | ((HEAPU8[($0_1 + 2 | 0) >> 0] | 0) << 16 | 0 | ((HEAPU8[($0_1 + 3 | 0) >> 0] | 0) << 24 | 0) | 0) | 0), wasm2js_scratch_load_f32()));
  }
  
  function $3() {
@@ -111,7 +111,7 @@ function asmFunc(global, env, buffer) {
  function $6() {
   var $0_1 = 0, $1_1 = 0;
   $0_1 = 0;
-  $1_1 = (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(0));
+  $1_1 = (wasm2js_scratch_store_f32(Math_fround(0.0)), wasm2js_scratch_load_i32(2));
   HEAP8[$0_1 >> 0] = $1_1;
   HEAP8[($0_1 + 1 | 0) >> 0] = $1_1 >>> 8 | 0;
   HEAP8[($0_1 + 2 | 0) >> 0] = $1_1 >>> 16 | 0;

--- a/test/wasm2js/unaligned.2asm.js.opt
+++ b/test/wasm2js/unaligned.2asm.js.opt
@@ -1,7 +1,7 @@
 import { setTempRet0 } from 'env';
 
 
-  var scratchBuffer = new ArrayBuffer(8);
+  var scratchBuffer = new ArrayBuffer(16);
   var i32ScratchView = new Int32Array(scratchBuffer);
   var f32ScratchView = new Float32Array(scratchBuffer);
   var f64ScratchView = new Float64Array(scratchBuffer);
@@ -23,7 +23,7 @@ import { setTempRet0 } from 'env';
   }
       
   function wasm2js_scratch_load_f32() {
-    return f32ScratchView[0];
+    return f32ScratchView[2];
   }
       
 function asmFunc(global, env, buffer) {
@@ -59,7 +59,7 @@ function asmFunc(global, env, buffer) {
  }
  
  function $2() {
-  return Math_fround((wasm2js_scratch_store_i32(0, HEAPU8[0] | HEAPU8[1] << 8 | (HEAPU8[2] << 16 | HEAPU8[3] << 24)), wasm2js_scratch_load_f32()));
+  return Math_fround((wasm2js_scratch_store_i32(2, HEAPU8[0] | HEAPU8[1] << 8 | (HEAPU8[2] << 16 | HEAPU8[3] << 24)), wasm2js_scratch_load_f32()));
  }
  
  function $3() {


### PR DESCRIPTION
i64 reinterprets were lowered in the i64 pass, and i32s at the very end, in
wasm2js itself. This could break since in between the i64 pass and wasm2js
we run optimizations, and the optimizer was not aware of what we lower
the i32 reinterprets to - calls to use scratch memory. Those calls have a
side effect of altering scratch memory. The optimizer just saw an i32
reinterpret, and moved it across the i64 reinterpret's scratch memory calls.

To fix this, lower i32 reinterprets early on, just like i64 ones. Then the
optimizer sees them all as calls, and does not assume they have no side
effects.

Note that it's not really possible to remove the side effects from the
scratch memory helpers - we write to scratch memory in one, and read
from scratch memory in the other. The former has to have a side effect.
(If we merged them into a single function we could remove the side effect,
but only by saving the old state on a stack etc., which has a cost; also,
the i64 scratch memory operations separately fetch back 32-bit chunks,
so it can't be a single function.)

Fixes #2963 Thanks for filing it @MaxGraey !

Verified with emscripten test suite `wasm2js0 wasm2js1 wasm2js3 other`
locally.