### PR TITLE
Fix github actions for releases

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -48,7 +48,7 @@ jobs:
       run: cmake --build out --config Release
 
     - name: strip
-      run: find bin/ -type f -perm -u=x -exec strip {} +
+      run: find out/bin/ -type f -perm -u=x -exec strip -x {} +
       if: matrix.os != 'windows-latest'
 
     - name: archive
@@ -115,7 +115,7 @@ jobs:
 
     - name: cmake
       run: |
-        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release
+        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON
 
     - name: build
       run: |
@@ -131,7 +131,7 @@ jobs:
         PKGNAME="binaryen-$VERSION-x86_64-linux"
         TARBALL=$PKGNAME.tar.gz
         SHASUM=$PKGNAME.tar.gz.sha256
-        ./alpine find bin/ -type f -perm -u=x -exec strip {} +
+        ./alpine.sh find bin/ -type f -perm -u=x -exec strip {} +
         mv bin binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
         shasum -a 256 $TARBALL > $SHASUM

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,36 +62,39 @@ jobs:
       run: mkdir -p out
 
     - name: cmake (linux)
-      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release
+      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install
       if: matrix.os == 'ubuntu-latest'
 
     - name: cmake (osx)
-      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release
+      run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install
       if: matrix.os == 'macos-latest'
 
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
-      run: cmake -S . -B out
+      run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out/install
       if: matrix.os == 'windows-latest'
 
     - name: build
       run: cmake --build out --config Release
 
-    - name: strip
-      run: find out/bin/ -type f -perm -u=x -exec strip {} +
-      if: matrix.os != 'windows-latest'
+    - name: install
+      run: cmake --install out --config Release
 
-    - name: test
-      run: python check.py --binaryen-bin=out/bin
-      # Currently disabled on windows due to a single test failure.
-      # https://github.com/WebAssembly/binaryen/issues/2781
+    - name: strip
+      run: find out/install/ -type f -perm -u=x -exec strip -x {} +
       if: matrix.os != 'windows-latest'
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v1
       with:
         name: build-${{ matrix.os }}
-        path: out/bin
+        path: out/install
+
+    - name: test
+      run: python check.py --binaryen-bin=out/install/bin
+      # Currently disabled on windows due to a single test failure.
+      # https://github.com/WebAssembly/binaryen/issues/2781
+      if: matrix.os != 'windows-latest'
 
   build-clang:
     name: clang


### PR DESCRIPTION
Also, perform cmake --install before archive assets during
normal CI builds.  This means we include the binaryen shared
library on platforms that use it.

Fixes: #2946 #2962