### PR TITLE
Dwarfdump: Always use unix-style separators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: test
       run: python check.py --binaryen-bin=out/install/bin
-      # Currently disabled on windows due to a single test failure.
+      # Currently disabled on windows due to tests failures, including
       # https://github.com/WebAssembly/binaryen/issues/2781
       if: matrix.os != 'windows-latest'
 

--- a/third_party/llvm-project/Path.cpp
+++ b/third_party/llvm-project/Path.cpp
@@ -51,8 +51,7 @@ namespace {
   }
 
   inline char preferred_separator(Style style) {
-    if (real_style(style) == Style::windows)
-      return '\\';
+    // XXX BINARYEN: always use unix-style separators for consistency
     return '/';
   }
 


### PR DESCRIPTION
This should fix #2781 and then allow windows testing on CI.

I think it is ok to always use unix slashes since DWARF will be parsed
by browsers in a way that accepts them. However, I'm not 100% sure,
we should verify on a windows machine (I am not sure of the current
status of DWARF debugging on windows, though, it may be too early
to see).