### PR TITLE
disable nodejs warnings

### DIFF
--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -80,7 +80,7 @@ def test_wasm2js_output():
                 # `spectest` and `env` modules in our tests.
                 if shared.NODEJS:
                     loader = os.path.join(shared.options.binaryen_root, 'scripts', 'test', 'node-esm-loader.mjs')
-                    node = [shared.NODEJS, '--experimental-modules', '--loader', loader]
+                    node = [shared.NODEJS, '--experimental-modules', '--no-warnings', '--loader', loader]
                     cmd = node[:]
                     cmd.append('a.2asm.mjs')
                     out = support.run_command(cmd)


### PR DESCRIPTION
Fixes issue #2970

Exception: 'run_command unexpected stderr' when running wasm2js tests with nodejs-14.5.0