### PR TITLE
wasm2js fuzzing: properly ignore trapping code

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -514,11 +514,13 @@ class Wasm2JS(TestCaseHandler):
     frequency = 0.6
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):
-        # always check for compiler crashes. without NaNs we can also compare
-        # before and after (with NaNs, a reinterpret through memory might end up
-        # different in JS than wasm)
+        # always check for compiler crashes
         before = self.run(before_wasm)
         after = self.run(after_wasm)
+        if NANS:
+            # with NaNs we can't compare the output, as a reinterpret through
+            # memory might end up different in JS than wasm
+            return
         # we also cannot compare if the wasm hits a trap, as wasm2js does not
         # trap on many things wasm would, and in those cases it can do weird
         # undefined things. in such a case, at least compare up until before
@@ -552,11 +554,12 @@ class Wasm2JS(TestCaseHandler):
         main = run(cmd + FEATURE_OPTS)
         with open(os.path.join(shared.options.binaryen_root, 'scripts', 'wasm2js.js')) as f:
             glue = f.read()
-        with open('js.js', 'w') as f:
+        js_file = wasm + '.js'
+        with open(js_file, 'w') as f:
             f.write(glue)
             f.write(main)
             f.write(wrapper)
-        return fix_output(run_vm([shared.NODEJS, 'js.js', 'a.wasm']))
+        return fix_output(run_vm([shared.NODEJS, js_file, 'a.wasm']))
 
     def can_run_on_feature_opts(self, feature_opts):
         return all([x in feature_opts for x in ['--disable-exception-handling', '--disable-simd', '--disable-threads', '--disable-bulk-memory', '--disable-nontrapping-float-to-int', '--disable-tail-call', '--disable-sign-ext', '--disable-reference-types', '--disable-multivalue']])
@@ -618,11 +621,11 @@ class Asyncify(TestCaseHandler):
 
 # The global list of all test case handlers
 testcase_handlers = [
-    FuzzExec(),
-    CompareVMs(),
-    CheckDeterminism(),
+    #FuzzExec(),
+    #CompareVMs(),
+    #CheckDeterminism(),
     Wasm2JS(),
-    Asyncify(),
+    #Asyncify(),
 ]
 
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -528,7 +528,9 @@ class Wasm2JS(TestCaseHandler):
         interpreter_output = run([in_bin('wasm-opt'), before_wasm, '--fuzz-exec-before'])
         if TRAP_PREFIX in interpreter_output:
             trap_index = interpreter_output.index(TRAP_PREFIX)
-            # we can't test this function, which the trap is in the middle of
+            # we can't test this function, which the trap is in the middle of.
+            # erase everything from this function's output and onward, so we
+            # only compare the previous trap-free code
             call_start = interpreter_output.rindex(FUZZ_EXEC_CALL_PREFIX, 0, trap_index)
             call_end = interpreter_output.index('\n', call_start)
             call_line = interpreter_output[call_start:call_end]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -161,6 +161,12 @@ def randomize_fuzz_settings():
 # Test outputs we want to ignore are marked this way.
 IGNORE = '[binaryen-fuzzer-ignore]'
 
+# Traps are reported as [trap REASON]
+TRAP_PREFIX = '[trap '
+
+# --fuzz-exec reports calls as [fuzz-exec] calling foo
+FUZZ_EXEC_CALL_PREFIX = '[fuzz-exec] calling'
+
 
 # compare two strings, strictly
 def compare(x, y, context):
@@ -239,7 +245,7 @@ def fix_output(out):
         return 'f64.const ' + x
     out = re.sub(r'f64\.const (-?[nanN:abcdefxIity\d+-.]+)', fix_double, out)
     # mark traps from wasm-opt as exceptions, even though they didn't run in a vm
-    out = out.replace('[trap ', 'exception: [trap ')
+    out = out.replace(TRAP_PREFIX, 'exception: ' + TRAP_PREFIX)
     lines = out.splitlines()
     for i in range(len(lines)):
         line = lines[i]
@@ -503,11 +509,6 @@ class CheckDeterminism(TestCaseHandler):
         run([in_bin('wasm-opt'), before_wasm, '-o', 'b1.wasm'] + opts)
         run([in_bin('wasm-opt'), before_wasm, '-o', 'b2.wasm'] + opts)
         assert open('b1.wasm', 'rb').read() == open('b2.wasm', 'rb').read(), 'output must be deterministic'
-
-
-# interpreter logging notation
-TRAP_PREFIX = '[trap'
-FUZZ_EXEC_CALL_PREFIX = '[fuzz-exec] calling'
 
 
 class Wasm2JS(TestCaseHandler):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -623,11 +623,11 @@ class Asyncify(TestCaseHandler):
 
 # The global list of all test case handlers
 testcase_handlers = [
-    #FuzzExec(),
-    #CompareVMs(),
-    #CheckDeterminism(),
+    FuzzExec(),
+    CompareVMs(),
+    CheckDeterminism(),
     Wasm2JS(),
-    #Asyncify(),
+    Asyncify(),
 ]
 
 


### PR DESCRIPTION
wasm2js fuzzing should not compare outputs if the wasm would
trap. wasm2js traps on far fewer things, and if wasm would trap
(like an indirect call with the wrong type) it can just do weird undefined
things. Previously, if running wasm2js trapped then we ignored
the output, but that't not good enough, as we need to check if
wasm would, exactly for the cases just mentioned where wasm
would trap but wasm2js wouldn't. So run the wasm interpreter
to see if that happens.

When we see such a trap, ignore everything from that function
call onwards. This at least lets us compare the results of
previous calls, which adds some amount of coverage (before
we just ignored the entire output completely, so only if there
was no trap at all did we do any comparisons at all).

Also give better names than "js.js" to the JS files wasm2js
fuzzing creates.