### PR TITLE
Update flags used in generate_lld_tests

### DIFF
--- a/scripts/test/generate_lld_tests.py
+++ b/scripts/test/generate_lld_tests.py
@@ -69,7 +69,6 @@ def generate_wat_files(llvm_bin, emscripten_root):
             '--export', '__wasm_call_ctors',
             '--export', '__data_end',
             '--global-base=568',
-            '--no-gc-sections',
         ]
         # We had a regression where this test only worked if debug names
         # were included.
@@ -79,6 +78,7 @@ def generate_wat_files(llvm_bin, emscripten_root):
             compile_cmd.append('-fPIC')
             compile_cmd.append('-fvisibility=default')
             link_cmd.append('-shared')
+            link_cmd.append('--experimental-pic')
         else:
             link_cmd.append('--entry=main')
 


### PR DESCRIPTION
The `--no-gc-sections` was added as part of #2857 but is not
needed and in fact changes the output of some tests.

`--experimental-pic` is needed these days when building shared
libraries with emscripten's abi.

After these two changes I verfied that the following command
generated no local changes (i.e. is a no-op):

  ./scripts/test/generate_lld_tests.py --binaryen-bin=$PWD/../binaryen-out/bin/ $PWD/../llvm-build/bin/ $PWD/../emscripten