### PR TITLE
Move ReplaceStackPointer into a pass

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -61,6 +61,7 @@ set(passes_SOURCES
   RemoveImports.cpp
   RemoveMemory.cpp
   RemoveNonJSOps.cpp
+  ReplaceStackPointer.cpp
   RemoveUnusedBrs.cpp
   RemoveUnusedNames.cpp
   RemoveUnusedModuleElements.cpp

--- a/src/passes/ReplaceStackPointer.cpp
+++ b/src/passes/ReplaceStackPointer.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Convert llvm's stack pointer usage from from global.get/global.set into
+// cals to external stackSave/stackRestore.
+// This is needed to emscripten SIDE_MODULE code where motuble global imports
+// are not yet permitted by default.
+//
+
+#include "abi/js.h"
+#include "ir/import-utils.h"
+#include "pass.h"
+#include "support/debug.h"
+#include "wasm-emscripten.h"
+
+#define DEBUG_TYPE "binary"
+
+namespace wasm {
+
+static Name STACK_SAVE("stackSave");
+static Name STACK_RESTORE("stackRestore");
+
+struct ReplaceStackPointer : public WalkerPass<PostWalker<ReplaceStackPointer>> {
+  void visitGlobalGet(GlobalGet* curr) {
+    if (getModule()->getGlobalOrNull(curr->name) == stackPointer) {
+      needStackSave = true;
+      if (!builder) {
+        builder = make_unique<Builder>(*getModule());
+      }
+      replaceCurrent(builder->makeCall(STACK_SAVE, {}, Type::i32));
+    }
+  }
+
+  void visitGlobalSet(GlobalSet* curr) {
+    if (getModule()->getGlobalOrNull(curr->name) == stackPointer) {
+      needStackRestore = true;
+      if (!builder) {
+        builder = make_unique<Builder>(*getModule());
+      }
+      replaceCurrent(
+        builder->makeCall(STACK_RESTORE, {curr->value}, Type::none));
+    }
+  }
+
+  void doWalkModule(Module* module) {
+    stackPointer = getStackPointerGlobal(*module);
+    if (!stackPointer) {
+      BYN_DEBUG(std::cerr << "no stack pointer found\n");
+      return;
+    }
+    BYN_DEBUG(std::cerr << "stack pointer found\n");
+    super::doWalkModule(module);
+    if (needStackSave) {
+      ensureFunctionImport(module, STACK_SAVE, Signature(Type::none, Type::i32));
+    }
+    if (needStackRestore) {
+      ensureFunctionImport(
+        module, STACK_RESTORE, Signature(Type::i32, Type::none));
+    }
+    // Finally remove the stack pointer global itself. This avoids importing
+    // a mutable global.
+    module->removeGlobal(stackPointer->name);
+  }
+
+  void ensureFunctionImport(Module* module, Name name, Signature sig) {
+    ImportInfo info(*module);
+    if (info.getImportedFunction(ENV, name)) {
+      return;
+    }
+    auto import = new Function;
+    import->name = name;
+    import->module = ENV;
+    import->base = name;
+    import->sig = sig;
+    module->addFunction(import);
+  }
+
+private:
+  std::unique_ptr<Builder> builder;
+  Global* stackPointer = nullptr;
+  bool needStackSave = false;
+  bool needStackRestore = false;
+};
+
+
+Pass* createReplaceStackPointerPass() { return new ReplaceStackPointer; }
+
+} // namespace wasm

--- a/src/passes/ReplaceStackPointer.cpp
+++ b/src/passes/ReplaceStackPointer.cpp
@@ -17,7 +17,7 @@
 //
 // Convert llvm's stack pointer usage from from global.get/global.set into
 // cals to external stackSave/stackRestore.
-// This is needed to emscripten SIDE_MODULE code where motuble global imports
+// This is needed to emscripten SIDE_MODULE code where mutable global imports
 // are not yet permitted by default.
 //
 

--- a/src/passes/ReplaceStackPointer.cpp
+++ b/src/passes/ReplaceStackPointer.cpp
@@ -34,7 +34,8 @@ namespace wasm {
 static Name STACK_SAVE("stackSave");
 static Name STACK_RESTORE("stackRestore");
 
-struct ReplaceStackPointer : public WalkerPass<PostWalker<ReplaceStackPointer>> {
+struct ReplaceStackPointer
+  : public WalkerPass<PostWalker<ReplaceStackPointer>> {
   void visitGlobalGet(GlobalGet* curr) {
     if (getModule()->getGlobalOrNull(curr->name) == stackPointer) {
       needStackSave = true;
@@ -65,7 +66,8 @@ struct ReplaceStackPointer : public WalkerPass<PostWalker<ReplaceStackPointer>> 
     BYN_DEBUG(std::cerr << "stack pointer found\n");
     super::doWalkModule(module);
     if (needStackSave) {
-      ensureFunctionImport(module, STACK_SAVE, Signature(Type::none, Type::i32));
+      ensureFunctionImport(
+        module, STACK_SAVE, Signature(Type::none, Type::i32));
     }
     if (needStackRestore) {
       ensureFunctionImport(
@@ -95,7 +97,6 @@ private:
   bool needStackSave = false;
   bool needStackRestore = false;
 };
-
 
 Pass* createReplaceStackPointerPass() { return new ReplaceStackPointer; }
 

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -285,6 +285,10 @@ void PassRegistry::registerPasses() {
   registerPass("rereloop",
                "re-optimize control flow using the relooper algorithm",
                createReReloopPass);
+  registerPass("replace-stack-pointer",
+               "Replace llvm-generated stack pointer global with calls with "
+               "imported functions.",
+               createReplaceStackPointerPass);
   registerPass(
     "rse", "remove redundant local.sets", createRedundantSetEliminationPass);
   registerPass("roundtrip",

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -95,6 +95,7 @@ Pass* createRemoveUnusedNonFunctionModuleElementsPass();
 Pass* createRemoveUnusedNamesPass();
 Pass* createReorderFunctionsPass();
 Pass* createReorderLocalsPass();
+Pass* createReplaceStackPointerPass();
 Pass* createReReloopPass();
 Pass* createRedundantSetEliminationPass();
 Pass* createRoundTripPass();

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -247,7 +247,9 @@ int main(int argc, const char* argv[]) {
 
   if (sideModule) {
     BYN_TRACE("finalizing as side module\n");
-    generator.replaceStackPointerGlobal();
+    PassRunner passRunner(&wasm);
+    passRunner.add("replace-stack-pointer");
+    passRunner.run();
     generator.generatePostInstantiateFunction();
   } else {
     BYN_TRACE("finalizing as regular module\n");

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -44,10 +44,6 @@ public:
   // signature in the indirect function table.
   void generateDynCallThunks();
 
-  // Convert stack pointer access from global.get/global.set to calling save
-  // and restore functions.
-  void replaceStackPointerGlobal();
-
   // Remove the import of a mutable __stack_pointer and instead initialize the
   // stack pointer from an immutable import.
   void internalizeStackPointerGlobal();


### PR DESCRIPTION
First step in making wasm-emscripten-finalize use more passes.