### PR TITLE
wasm-emscripten-finalize: remove exportWasiStart

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -277,10 +277,7 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  if (standaloneWasm) {
-    // Export a standard wasi "_start" method.
-    generator.exportWasiStart();
-  } else {
+  if (!standaloneWasm) {
     // If not standalone wasm then JS is relevant and we need dynCalls.
     generator.generateDynCallThunks();
     // This is also not needed in standalone mode since standalone mode uses

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -62,8 +62,6 @@ public:
   // as expected by emscripten.
   void renameMainArgcArgv();
 
-  void exportWasiStart();
-
   // Emits the data segments to a file. The file contains data from address base
   // onwards (we must pass in base, as we can't tell it from the wasm - the
   // first segment may start after a run of zeros, but we need those zeros in

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -1059,29 +1059,4 @@ void EmscriptenGlueGenerator::renameMainArgcArgv() {
   ModuleUtils::renameFunction(wasm, "__main_argc_argv", "main");
 }
 
-void EmscriptenGlueGenerator::exportWasiStart() {
-  // If main exists, export a function to call it per the wasi standard.
-  Name main = "main";
-  if (!wasm.getFunctionOrNull(main)) {
-    BYN_TRACE("exportWasiStart: main not found\n");
-    return;
-  }
-  Name _start = "_start";
-  if (wasm.getExportOrNull(_start)) {
-    BYN_TRACE("exportWasiStart: _start already present\n");
-    return;
-  }
-  BYN_TRACE("exportWasiStart\n");
-  Builder builder(wasm);
-  auto* body =
-    builder.makeDrop(builder.makeCall(main,
-                                      {LiteralUtils::makeZero(Type::i32, wasm),
-                                       LiteralUtils::makeZero(Type::i32, wasm)},
-                                      Type::i32));
-  auto* func =
-    builder.makeFunction(_start, Signature(Type::none, Type::none), {}, body);
-  wasm.addFunction(func);
-  wasm.addExport(builder.makeExport(_start, _start, ExternalKind::Function));
-}
-
 } // namespace wasm

--- a/test/lld/safe_stack_standalone-wasm.wat.out
+++ b/test/lld/safe_stack_standalone-wasm.wat.out
@@ -19,7 +19,6 @@
  (export "main" (func $main))
  (export "__set_stack_limit" (func $__set_stack_limit))
  (export "__growWasmMemory" (func $__growWasmMemory))
- (export "_start" (func $_start))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -150,14 +149,6 @@
    (local.get $newSize)
   )
  )
- (func $_start
-  (drop
-   (call $main
-    (i32.const 0)
-    (i32.const 0)
-   )
-  )
- )
 )
 (;
 --BEGIN METADATA --
@@ -176,8 +167,7 @@
     "__wasm_call_ctors",
     "main",
     "__set_stack_limit",
-    "__growWasmMemory",
-    "_start"
+    "__growWasmMemory"
   ],
   "namedGlobals": {
     "__heap_base" : "66128",

--- a/test/lld/standalone-wasm.wat.out
+++ b/test/lld/standalone-wasm.wat.out
@@ -1,6 +1,5 @@
 (module
  (type $none_=>_i32 (func (result i32)))
- (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (memory $0 2)
@@ -14,7 +13,6 @@
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
  (export "__growWasmMemory" (func $__growWasmMemory))
- (export "_start" (func $_start))
  (func $__original_main (result i32)
   (nop)
  )
@@ -29,14 +27,6 @@
    (local.get $newSize)
   )
  )
- (func $_start
-  (drop
-   (call $main
-    (i32.const 0)
-    (i32.const 0)
-   )
-  )
- )
 )
 (;
 --BEGIN METADATA --
@@ -49,8 +39,7 @@
   ],
   "exports": [
     "main",
-    "__growWasmMemory",
-    "_start"
+    "__growWasmMemory"
   ],
   "namedGlobals": {
     "__heap_base" : "66112",

--- a/test/lld/standalone-wasm2.wat.out
+++ b/test/lld/standalone-wasm2.wat.out
@@ -1,6 +1,5 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (memory $0 2)
  (global $global$0 (mut i32) (i32.const 66112))
@@ -11,7 +10,6 @@
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
  (export "__growWasmMemory" (func $__growWasmMemory))
- (export "_start" (func $_start))
  (func $__original_main (param $0 i32) (param $1 i32) (result i32)
   (nop)
  )
@@ -26,14 +24,6 @@
    (local.get $newSize)
   )
  )
- (func $_start
-  (drop
-   (call $main
-    (i32.const 0)
-    (i32.const 0)
-   )
-  )
- )
 )
 (;
 --BEGIN METADATA --
@@ -46,8 +36,7 @@
   ],
   "exports": [
     "main",
-    "__growWasmMemory",
-    "_start"
+    "__growWasmMemory"
   ],
   "namedGlobals": {
     "__heap_base" : "66112",


### PR DESCRIPTION
This should not be needed since in emscripten standalone mode we
always include a crt1.o that includes _start.