### PR TITLE
AvoidReinterpreters should not look at a reinterpret's value's fallthrough

### DIFF
--- a/src/passes/AvoidReinterprets.cpp
+++ b/src/passes/AvoidReinterprets.cpp
@@ -17,7 +17,8 @@
 // Avoids reinterprets by using more loads: if we load a value and
 // reinterpret it, we could have loaded it with the other type
 // anyhow. This uses more locals and loads, so it is not generally
-// beneficial, unless reinterprets are very costly.
+// beneficial, unless reinterprets are very costly (which is the case
+// with wasm2js).
 
 #include <ir/local-graph.h>
 #include <ir/properties.h>
@@ -147,8 +148,7 @@ struct AvoidReinterprets : public WalkerPass<PostWalker<AvoidReinterprets>> {
 
       void visitUnary(Unary* curr) {
         if (isReinterpret(curr)) {
-          auto* value = Properties::getFallthrough(
-            curr->value, passOptions, module->features);
+          auto* value = curr->value;
           if (auto* load = value->dynCast<Load>()) {
             // A reinterpret of a load - flip it right here if we can.
             if (canReplaceWithReinterpret(load)) {

--- a/test/passes/avoid-reinterprets.txt
+++ b/test/passes/avoid-reinterprets.txt
@@ -163,4 +163,20 @@
    )
   )
  )
+ (func $nofallthrough
+  (local $x i32)
+  (local.set $x
+   (i32.load
+    (i32.const 1024)
+   )
+  )
+  (drop
+   (f32.reinterpret_i32
+    (block $block (result i32)
+     (nop)
+     (local.get $x)
+    )
+   )
+  )
+ )
 )

--- a/test/passes/avoid-reinterprets.wast
+++ b/test/passes/avoid-reinterprets.wast
@@ -49,4 +49,21 @@
     )
    )
   )
+  (func $nofallthrough
+    (local $x i32)
+    (local.set $x
+     (i32.load
+      (i32.const 1024)
+     )
+    )
+    (drop
+     (f32.reinterpret_i32
+      (block (result i32)
+       (nop) ;; this would be removed by other opts, but in general, we can't
+             ;; just look at the fallthrough, as we can't just remove code here
+       (local.get $x)
+      )
+     )
+    )
+  )
 )


### PR DESCRIPTION
We can turn a reinterpret of a load into a different load, and so forth, but if
the reinterpret has a non-load child with a load fallthrough, that's not good
enough - we can't remove the extra code:

```wat
(reinterpret
  (block
    ..extra code..
    (load)
  )
)
```

That can't be turned into a load of the flipped type.

Not sure why I thought this made sense to do - seems obvious it's been wrong
all along. Fuzzer found an issue only now.