### PR TITLE
wasm2js: Remove an incorrect optimization

### DIFF
--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -255,12 +255,6 @@ static void optimizeJS(Ref ast, Wasm2JSBuilder::Flags flags) {
   };
 
   auto optimizeBoolean = [&](Ref node) {
-    if (isConstantBinary(node, XOR, 1)) {
-      // x ^ 1  =>  !x
-      node[0]->setString(UNARY_PREFIX);
-      node[1]->setString(L_NOT);
-      node[3]->setNull();
-    }
     // TODO: in some cases it may be possible to turn
     //
     //   if (x | 0)

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -254,6 +254,7 @@ static void optimizeJS(Ref ast, Wasm2JSBuilder::Flags flags) {
     return false;
   };
 
+  // Optimize given that the expression is flowing into a boolean context
   auto optimizeBoolean = [&](Ref node) {
     // TODO: in some cases it may be possible to turn
     //

--- a/test/wasm2js/emscripten.2asm.js.opt
+++ b/test/wasm2js/emscripten.2asm.js.opt
@@ -155,13 +155,13 @@ function asmFunc(global, env, buffer) {
   bools(HEAP32[0] & 1);
   bools(HEAPU8[0] & 2);
   bools($0 ^ 1);
-  if (!$0) {
+  if ($0 ^ 1) {
    bools(2)
   }
   if ($0 ^ 2) {
    bools(2)
   }
-  bools(!!$0);
+  bools(!($0 ^ 1));
   abort();
  }
  


### PR DESCRIPTION
optimizeBoolean does not receive a boolean, it is done when the
output flows into a boolean context.

(found by the fuzzer)