### PR TITLE
New Dealign pass: reduce load/store alignment to 1

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -18,6 +18,7 @@ set(passes_SOURCES
   DataFlowOpts.cpp
   DeadArgumentElimination.cpp
   DeadCodeElimination.cpp
+  DeAlign.cpp
   DeNaN.cpp
   Directize.cpp
   DuplicateImportElimination.cpp

--- a/src/passes/DeAlign.cpp
+++ b/src/passes/DeAlign.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// Forces all loads and stores to be completely unaligned, that is, to have
+// alignment 1.
+//
+
+#include "pass.h"
+#include "wasm.h"
+
+namespace wasm {
+
+struct DeAlign : public WalkerPass<PostWalker<DeAlign>> {
+  bool isFunctionParallel() override { return true; }
+
+  Pass* create() override { return new DeAlign(); }
+
+  void visitLoad(Load* curr) {
+    curr->align = 1;
+  }
+
+  void visitStore(Store* curr) {
+    curr->align = 1;
+  }
+
+  void visitSIMDLoad(SIMDLoad* curr) {
+    curr->align = 1;
+  }
+};
+
+Pass* createDeAlignPass() { return new DeAlign(); }
+
+} // namespace wasm

--- a/src/passes/DeAlign.cpp
+++ b/src/passes/DeAlign.cpp
@@ -29,17 +29,11 @@ struct DeAlign : public WalkerPass<PostWalker<DeAlign>> {
 
   Pass* create() override { return new DeAlign(); }
 
-  void visitLoad(Load* curr) {
-    curr->align = 1;
-  }
+  void visitLoad(Load* curr) { curr->align = 1; }
 
-  void visitStore(Store* curr) {
-    curr->align = 1;
-  }
+  void visitStore(Store* curr) { curr->align = 1; }
 
-  void visitSIMDLoad(SIMDLoad* curr) {
-    curr->align = 1;
-  }
+  void visitSIMDLoad(SIMDLoad* curr) { curr->align = 1; }
 };
 
 Pass* createDeAlignPass() { return new DeAlign(); }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -104,6 +104,9 @@ void PassRegistry::registerPasses() {
                createConstHoistingPass);
   registerPass(
     "dce", "removes unreachable code", createDeadCodeEliminationPass);
+  registerPass("dealign",
+               "forces all loads and stores to have alignment 1",
+               createDeAlignPass);
   registerPass("denan",
                "instrument the wasm to convert NaNs into 0 at runtime",
                createDeNaNPass);

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -35,6 +35,7 @@ Pass* createDAEOptimizingPass();
 Pass* createDataFlowOptsPass();
 Pass* createDeadCodeEliminationPass();
 Pass* createDeNaNPass();
+Pass* createDeAlignPass();
 Pass* createDirectizePass();
 Pass* createDWARFDumpPass();
 Pass* createDuplicateImportEliminationPass();

--- a/test/passes/dealign.txt
+++ b/test/passes/dealign.txt
@@ -1,0 +1,33 @@
+(module
+ (type $none_=>_none (func))
+ (memory $0 1 1)
+ (func $test
+  (drop
+   (i32.load align=1
+    (i32.const 4)
+   )
+  )
+  (drop
+   (i32.load align=1
+    (i32.const 8)
+   )
+  )
+  (drop
+   (i32.load align=1
+    (i32.const 12)
+   )
+  )
+  (i32.store align=1
+   (i32.const 16)
+   (i32.const 28)
+  )
+  (i32.store align=1
+   (i32.const 20)
+   (i32.const 32)
+  )
+  (i32.store align=1
+   (i32.const 24)
+   (i32.const 36)
+  )
+ )
+)

--- a/test/passes/dealign.wast
+++ b/test/passes/dealign.wast
@@ -1,0 +1,11 @@
+(module
+ (memory $0 1 1)
+ (func $test
+  (drop (i32.load         (i32.const 4)))
+  (drop (i32.load align=1 (i32.const 8)))
+  (drop (i32.load align=2 (i32.const 12)))
+  (i32.store         (i32.const 16) (i32.const 28))
+  (i32.store align=1 (i32.const 20) (i32.const 32))
+  (i32.store align=2 (i32.const 24) (i32.const 36))
+ )
+)


### PR DESCRIPTION
Pretty trivial, but will be useful in wasm2js testing, where we
can't assume an incorrectly-aligned load/store will still work,
so we'll need to be pessimistic about alignment there.