### PR TITLE
Asyncify verbose option

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -349,9 +349,15 @@ template<typename T> struct CallGraphPropertyAnalysis {
   enum IndirectCalls { IgnoreIndirectCalls, IndirectCallsHaveProperty };
 
   // Propagate a property from a function to those that call it.
+  //
+  // hasProperty() - Check if the property is present.
+  // canHaveProperty() - Check if the property could be present. This is checked
+  //                     before adding it.
+  // addProperty() - Adds the property. This receives a second parameter which
+  //                 is the function due to which we are adding the property.
   void propagateBack(std::function<bool(const T&)> hasProperty,
                      std::function<bool(const T&)> canHaveProperty,
-                     std::function<void(T&)> addProperty,
+                     std::function<void(T&), Function*> addProperty,
                      IndirectCalls indirectCalls) {
     // The work queue contains items we just learned can change the state.
     UniqueDeferredQueue<Function*> work;
@@ -369,7 +375,7 @@ template<typename T> struct CallGraphPropertyAnalysis {
         // If we don't already have the property, and we are not forbidden
         // from getting it, then it propagates back to us now.
         if (!hasProperty(map[caller]) && canHaveProperty(map[caller])) {
-          addProperty(map[caller]);
+          addProperty(map[caller], func);
           work.push(caller);
         }
       }

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -354,9 +354,6 @@ template<typename T> struct CallGraphPropertyAnalysis {
   // canHaveProperty() - Check if the property could be present.
   // addProperty() - Adds the property. This receives a second parameter which
   //                 is the function due to which we are adding the property.
-  //                 The second parameter is null if the change is not due to
-  //                 propagation (that is, it is null during the initial setup
-  //                 before propagation).
   void propagateBack(std::function<bool(const T&)> hasProperty,
                      std::function<bool(const T&)> canHaveProperty,
                      std::function<void(T&, Function*)> addProperty,
@@ -367,7 +364,7 @@ template<typename T> struct CallGraphPropertyAnalysis {
       if (hasProperty(map[func.get()]) ||
           (indirectCalls == IndirectCallsHaveProperty &&
            map[func.get()].hasIndirectCall)) {
-        addProperty(map[func.get()], nullptr);
+        addProperty(map[func.get()], func.get());
         work.push(func.get());
       }
     }

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -351,13 +351,15 @@ template<typename T> struct CallGraphPropertyAnalysis {
   // Propagate a property from a function to those that call it.
   //
   // hasProperty() - Check if the property is present.
-  // canHaveProperty() - Check if the property could be present. This is checked
-  //                     before adding it.
+  // canHaveProperty() - Check if the property could be present.
   // addProperty() - Adds the property. This receives a second parameter which
   //                 is the function due to which we are adding the property.
+  //                 The second parameter is null if the change is not due to
+  //                 propagation (that is, it is null during the initial setup
+  //                 before propagation).
   void propagateBack(std::function<bool(const T&)> hasProperty,
                      std::function<bool(const T&)> canHaveProperty,
-                     std::function<void(T&), Function*> addProperty,
+                     std::function<void(T&, Function*)> addProperty,
                      IndirectCalls indirectCalls) {
     // The work queue contains items we just learned can change the state.
     UniqueDeferredQueue<Function*> work;
@@ -365,7 +367,7 @@ template<typename T> struct CallGraphPropertyAnalysis {
       if (hasProperty(map[func.get()]) ||
           (indirectCalls == IndirectCallsHaveProperty &&
            map[func.get()].hasIndirectCall)) {
-        addProperty(map[func.get()]);
+        addProperty(map[func.get()], nullptr);
         work.push(func.get());
       }
     }

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -672,7 +672,7 @@ public:
       [verbose](Info& info, Function* reason) {
         if (verbose && !info.canChangeState) {
           std::cout << "[asyncify] " << info.name
-                    << " can change the state due to propagation from "
+                    << " can change the state due to "
                     << reason->name << "\n";
         }
         info.canChangeState = true;

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -233,7 +233,8 @@
 //
 //   --pass-arg=asyncify-verbose
 //
-//      This logs out instrumentation decisions to the console.
+//      Logs out instrumentation decisions to the console. This can help figure
+//      out why a certain function was instrumented.
 //
 // For manual fine-tuning of the list of instrumented functions, there are lists
 // that you can set. These must be used carefully, as misuse can break your
@@ -668,11 +669,12 @@ public:
                             return !info.isBottomMostRuntime &&
                                    !info.inRemoveList;
                           },
-                          [verbose](Info& info) {
+                          [verbose](Info& info, Function* reason) {
                             if (verbose && !info.canChangeState) {
                               std::cout
                                 << "[asyncify] " << info.name
-                                << " can change the state due to propagation\n";
+                                << " can change the state due to propagation from "
+                                << reason->name << "\n";
                             }
                             info.canChangeState = true;
                           },

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -664,21 +664,20 @@ public:
       module.removeFunction(name);
     }
 
-    scanner.propagateBack([](const Info& info) { return info.canChangeState; },
-                          [](const Info& info) {
-                            return !info.isBottomMostRuntime &&
-                                   !info.inRemoveList;
-                          },
-                          [verbose](Info& info, Function* reason) {
-                            if (verbose && !info.canChangeState) {
-                              std::cout
-                                << "[asyncify] " << info.name
-                                << " can change the state due to propagation from "
-                                << reason->name << "\n";
-                            }
-                            info.canChangeState = true;
-                          },
-                          scanner.IgnoreIndirectCalls);
+    scanner.propagateBack(
+      [](const Info& info) { return info.canChangeState; },
+      [](const Info& info) {
+        return !info.isBottomMostRuntime && !info.inRemoveList;
+      },
+      [verbose](Info& info, Function* reason) {
+        if (verbose && !info.canChangeState) {
+          std::cout << "[asyncify] " << info.name
+                    << " can change the state due to propagation from "
+                    << reason->name << "\n";
+        }
+        info.canChangeState = true;
+      },
+      scanner.IgnoreIndirectCalls);
 
     map.swap(scanner.map);
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -231,6 +231,10 @@
 //      an unwind/rewind in an invalid place (this can be helpful for manual
 //      tweaking of the only-list / remove-list, see later).
 //
+//   --pass-arg=asyncify-verbose
+//
+//      This logs out instrumentation decisions to the console.
+//
 // For manual fine-tuning of the list of instrumented functions, there are lists
 // that you can set. These must be used carefully, as misuse can break your
 // application - for example, if a function is called that should be
@@ -486,6 +490,8 @@ class ModuleAnalyzer {
 
   struct Info
     : public ModuleUtils::CallGraphPropertyAnalysis<Info>::FunctionInfo {
+    // The function name.
+    Name name;
     // If this function can start an unwind/rewind.
     bool canChangeState = false;
     // If this function is part of the runtime that receives an unwinding
@@ -513,9 +519,10 @@ public:
                  const String::Split& removeListInput,
                  const String::Split& addListInput,
                  const String::Split& onlyListInput,
-                 bool asserts)
+                 bool asserts,
+                 bool verbose)
     : module(module), canIndirectChangeState(canIndirectChangeState),
-      fakeGlobals(module), asserts(asserts) {
+      fakeGlobals(module), asserts(asserts), verbose(verbose) {
 
     PatternMatcher removeList("remove", module, removeListInput);
     PatternMatcher addList("add", module, addListInput);
@@ -548,6 +555,7 @@ public:
     // name.
     ModuleUtils::CallGraphPropertyAnalysis<Info> scanner(
       module, [&](Function* func, Info& info) {
+        info.name = func->name;
         if (func->imported()) {
           // The relevant asyncify imports can definitely change the state.
           if (func->module == ASYNCIFY &&
@@ -556,6 +564,10 @@ public:
           } else {
             info.canChangeState =
               canImportChangeState(func->module, func->base);
+            if (verbose && info.canChangeState) {
+              std::cout << "[asyncify] " << func->name
+                        << " is an import that can change the state\n";
+            }
           }
           return;
         }
@@ -609,6 +621,10 @@ public:
           //       the bottom-most runtime also doing top-most runtime stuff
           //       like starting and unwinding.
         }
+        if (verbose && info.canChangeState) {
+          std::cout << "[asyncify] " << func->name
+                    << " can change the state due to initial scan\n";
+        }
       });
 
     // Functions in the remove-list are assumed to not change the state.
@@ -617,6 +633,10 @@ public:
       auto& info = pair.second;
       if (removeList.match(func->name)) {
         info.inRemoveList = true;
+        if (verbose && info.canChangeState) {
+          std::cout << "[asyncify] " << func->name
+                    << " is in the remove-list, ignore\n";
+        }
         info.canChangeState = false;
       }
     }
@@ -648,7 +668,14 @@ public:
                             return !info.isBottomMostRuntime &&
                                    !info.inRemoveList;
                           },
-                          [](Info& info) { info.canChangeState = true; },
+                          [verbose](Info& info) {
+                            if (verbose && !info.canChangeState) {
+                              std::cout
+                                << "[asyncify] " << info.name
+                                << " can change the state due to propagation\n";
+                            }
+                            info.canChangeState = true;
+                          },
                           scanner.IgnoreIndirectCalls);
 
     map.swap(scanner.map);
@@ -663,6 +690,11 @@ public:
           if (matched) {
             info.addedFromList = true;
           }
+          if (verbose) {
+            std::cout << "[asyncify] " << func->name
+                      << "'s state is set based on the only-list to " << matched
+                      << '\n';
+          }
         }
       }
     }
@@ -671,6 +703,10 @@ public:
       for (auto& func : module.functions) {
         if (!func->imported() && addList.match(func->name)) {
           auto& info = map[func.get()];
+          if (verbose && !info.canChangeState) {
+            std::cout << "[asyncify] " << func->name
+                      << " is in the add-list, add\n";
+          }
           info.canChangeState = true;
           info.addedFromList = true;
         }
@@ -741,6 +777,7 @@ public:
 
   FakeGlobalHelper fakeGlobals;
   bool asserts;
+  bool verbose;
 };
 
 // Checks if something performs a call: either a direct or indirect call,
@@ -1397,6 +1434,8 @@ struct Asyncify : public Pass {
       String::trim(read_possible_response_file(onlyListInput)), ",");
     auto asserts =
       runner->options.getArgumentOrDefault("asyncify-asserts", "") != "";
+    auto verbose =
+      runner->options.getArgumentOrDefault("asyncify-verbose", "") != "";
 
     removeList = handleBracketingOperators(removeList);
     addList = handleBracketingOperators(addList);
@@ -1427,7 +1466,8 @@ struct Asyncify : public Pass {
                             removeList,
                             addList,
                             onlyList,
-                            asserts);
+                            asserts,
+                            verbose);
 
     // Add necessary globals before we emit code to use them.
     addGlobals(module);

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -664,20 +664,20 @@ public:
       module.removeFunction(name);
     }
 
-    scanner.propagateBack(
-      [](const Info& info) { return info.canChangeState; },
-      [](const Info& info) {
-        return !info.isBottomMostRuntime && !info.inRemoveList;
-      },
-      [verbose](Info& info, Function* reason) {
-        if (verbose && !info.canChangeState) {
-          std::cout << "[asyncify] " << info.name
-                    << " can change the state due to "
-                    << reason->name << "\n";
-        }
-        info.canChangeState = true;
-      },
-      scanner.IgnoreIndirectCalls);
+    scanner.propagateBack([](const Info& info) { return info.canChangeState; },
+                          [](const Info& info) {
+                            return !info.isBottomMostRuntime &&
+                                   !info.inRemoveList;
+                          },
+                          [verbose](Info& info, Function* reason) {
+                            if (verbose && !info.canChangeState) {
+                              std::cout << "[asyncify] " << info.name
+                                        << " can change the state due to "
+                                        << reason->name << "\n";
+                            }
+                            info.canChangeState = true;
+                          },
+                          scanner.IgnoreIndirectCalls);
 
     map.swap(scanner.map);
 

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -177,7 +177,7 @@ struct PostEmscripten : public Pass {
     // Assume an indirect call might throw.
     analyzer.propagateBack([](const Info& info) { return info.canThrow; },
                            [](const Info& info) { return true; },
-                           [](Info& info) { info.canThrow = true; },
+                           [](Info& info, Function* reason) { info.canThrow = true; },
                            analyzer.IndirectCallsHaveProperty);
 
     // Apply the information.

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -175,10 +175,11 @@ struct PostEmscripten : public Pass {
       });
 
     // Assume an indirect call might throw.
-    analyzer.propagateBack([](const Info& info) { return info.canThrow; },
-                           [](const Info& info) { return true; },
-                           [](Info& info, Function* reason) { info.canThrow = true; },
-                           analyzer.IndirectCallsHaveProperty);
+    analyzer.propagateBack(
+      [](const Info& info) { return info.canThrow; },
+      [](const Info& info) { return true; },
+      [](Info& info, Function* reason) { info.canThrow = true; },
+      analyzer.IndirectCallsHaveProperty);
 
     // Apply the information.
     struct OptimizeInvokes : public WalkerPass<PostWalker<OptimizeInvokes>> {

--- a/test/passes/asyncify_pass-arg=asyncify-verbose.txt
+++ b/test/passes/asyncify_pass-arg=asyncify-verbose.txt
@@ -1,0 +1,355 @@
+[asyncify] import is an import that can change the state
+[asyncify] calls-import can change the state due to import
+[asyncify] calls-calls-import can change the state due to calls-import
+[asyncify] calls-calls-calls-import can change the state due to calls-calls-import
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "env" "import" (func $import))
+ (memory $0 1 2)
+ (global $__asyncify_state (mut i32) (i32.const 0))
+ (global $__asyncify_data (mut i32) (i32.const 0))
+ (export "asyncify_start_unwind" (func $asyncify_start_unwind))
+ (export "asyncify_stop_unwind" (func $asyncify_stop_unwind))
+ (export "asyncify_start_rewind" (func $asyncify_start_rewind))
+ (export "asyncify_stop_rewind" (func $asyncify_stop_rewind))
+ (export "asyncify_get_state" (func $asyncify_get_state))
+ (func $calls-import
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (if
+       (if (result i32)
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $calls-calls-import
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (if
+       (if (result i32)
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $calls-import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $calls-calls-calls-import
+  (local $0 i32)
+  (local $1 i32)
+  (if
+   (i32.eq
+    (global.get $__asyncify_state)
+    (i32.const 2)
+   )
+   (nop)
+  )
+  (local.set $0
+   (block $__asyncify_unwind (result i32)
+    (block
+     (block
+      (if
+       (i32.eq
+        (global.get $__asyncify_state)
+        (i32.const 2)
+       )
+       (block
+        (i32.store
+         (global.get $__asyncify_data)
+         (i32.add
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+          (i32.const -4)
+         )
+        )
+        (local.set $1
+         (i32.load
+          (i32.load
+           (global.get $__asyncify_data)
+          )
+         )
+        )
+       )
+      )
+      (if
+       (if (result i32)
+        (i32.eq
+         (global.get $__asyncify_state)
+         (i32.const 0)
+        )
+        (i32.const 1)
+        (i32.eq
+         (local.get $1)
+         (i32.const 0)
+        )
+       )
+       (block
+        (call $calls-calls-import)
+        (if
+         (i32.eq
+          (global.get $__asyncify_state)
+          (i32.const 1)
+         )
+         (br $__asyncify_unwind
+          (i32.const 0)
+         )
+        )
+       )
+      )
+     )
+     (return)
+    )
+   )
+  )
+  (block
+   (i32.store
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (local.get $0)
+   )
+   (i32.store
+    (global.get $__asyncify_data)
+    (i32.add
+     (i32.load
+      (global.get $__asyncify_data)
+     )
+     (i32.const 4)
+    )
+   )
+  )
+  (nop)
+ )
+ (func $nothing
+  (nop)
+ )
+ (func $asyncify_start_unwind (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 1)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_unwind
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_start_rewind (param $0 i32)
+  (global.set $__asyncify_state
+   (i32.const 2)
+  )
+  (global.set $__asyncify_data
+   (local.get $0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_stop_rewind
+  (global.set $__asyncify_state
+   (i32.const 0)
+  )
+  (if
+   (i32.gt_u
+    (i32.load
+     (global.get $__asyncify_data)
+    )
+    (i32.load offset=4
+     (global.get $__asyncify_data)
+    )
+   )
+   (unreachable)
+  )
+ )
+ (func $asyncify_get_state (result i32)
+  (global.get $__asyncify_state)
+ )
+)

--- a/test/passes/asyncify_pass-arg=asyncify-verbose.wast
+++ b/test/passes/asyncify_pass-arg=asyncify-verbose.wast
@@ -1,0 +1,17 @@
+(module
+  (memory 1 2)
+  (import "env" "import" (func $import))
+  (func $calls-import
+    (call $import)
+  )
+  (func $calls-calls-import
+    (call $calls-import)
+  )
+  (func $calls-calls-calls-import
+    (call $calls-calls-import)
+  )
+  (func $nothing
+    (nop)
+  )
+)
+


### PR DESCRIPTION
This logs out the decisions made about instrumenting functions, which
can help figure out why a function is instrumented, or to get a list of
what might need to be.

As the test shows, it can print things like this:
```
[asyncify] import is an import that can change the state
[asyncify] calls-import can change the state due to import
[asyncify] calls-calls-import can change the state due to calls-import
[asyncify] calls-calls-calls-import can change the state due to calls-calls-import
```
(the test has `calls-calls-calls-import => calls-calls-import => calls-import -> import`).

Not sure how useful this might be, but it was easy to write up. Thoughts?

cc @curiousdannii @aardappel 