### PR TITLE
StubUnsupportedJSOps: Remove CallIndirects

### DIFF
--- a/src/passes/RemoveNonJSOps.cpp
+++ b/src/passes/RemoveNonJSOps.cpp
@@ -357,6 +357,7 @@ struct StubUnsupportedJSOpsPass
     for (auto* operand : curr->operands) {
       items.push_back(builder.makeDrop(operand));
     }
+    items.push_back(builder.makeDrop(curr->target));
     stubOut(builder.makeBlock(items), curr->type);
   }
 

--- a/src/passes/RemoveNonJSOps.cpp
+++ b/src/passes/RemoveNonJSOps.cpp
@@ -374,9 +374,8 @@ struct StubUnsupportedJSOpsPass
         value = builder.makeDrop(value);
       }
       // Return something with the right output type.
-      replacement =
-        builder.makeSequence(value,
-                             LiteralUtils::makeZero(outputType, *getModule()));
+      replacement = builder.makeSequence(
+        value, LiteralUtils::makeZero(outputType, *getModule()));
     }
     replaceCurrent(replacement);
   }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -1741,7 +1741,7 @@ private:
         }
         return tweak(value);
       }
-//      reinterpreted floats/ints
+        //      reinterpreted floats/ints
     }
     WASM_UNREACHABLE("invalid value");
   }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -1741,6 +1741,7 @@ private:
         }
         return tweak(value);
       }
+//      reinterpreted floats/ints
     }
     WASM_UNREACHABLE("invalid value");
   }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -1741,7 +1741,6 @@ private:
         }
         return tweak(value);
       }
-        //      reinterpreted floats/ints
     }
     WASM_UNREACHABLE("invalid value");
   }

--- a/test/passes/stub-unsupported-js.txt
+++ b/test/passes/stub-unsupported-js.txt
@@ -26,17 +26,23 @@
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_f32 (func (result f32)))
- (table $0 1 1 funcref)
- (elem (i32.const 0) $return-f32)
+ (table $0 2 2 funcref)
+ (elem (i32.const 1) $return-f32)
  (func $return-f32 (result f32)
-  (f32.const 1)
+  (f32.const 3.141590118408203)
  )
  (func $bad-indirect-call
+  (drop
+   (i32.const 1)
+  )
  )
  (func $bad-indirect-call-2 (result i32)
   (block
    (drop
     (i64.const 1234)
+   )
+   (drop
+    (i32.const 1)
    )
   )
   (i32.const 0)

--- a/test/passes/stub-unsupported-js.txt
+++ b/test/passes/stub-unsupported-js.txt
@@ -22,3 +22,23 @@
   )
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_f32 (func (result f32)))
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $return-f32)
+ (func $return-f32 (result f32)
+  (f32.const 1)
+ )
+ (func $bad-indirect-call
+ )
+ (func $bad-indirect-call-2 (result i32)
+  (block
+   (drop
+    (i64.const 1234)
+   )
+  )
+  (i32.const 0)
+ )
+)

--- a/test/passes/stub-unsupported-js.wast
+++ b/test/passes/stub-unsupported-js.wast
@@ -15,20 +15,20 @@
 (module
  (type $none_=>_none (func))
  (type $i64_=>_i32 (func (param $foo i64) (result i32)))
- (table $0 1 1 funcref)
- (elem (i32.const 0) $return-f32)
+ (table $0 2 2 funcref)
+ (elem (i32.const 1) $return-f32)
  (func $return-f32 (result f32)
-  (f32.const 1)
+  (f32.const 3.14159)
  )
  (func $bad-indirect-call
   (call_indirect (type $none_=>_none) ;; note how it's the wrong type
-   (i32.const 0)
+   (i32.const 1)
   )
  )
  (func $bad-indirect-call-2 (result i32)
   (call_indirect (type $i64_=>_i32) ;; note how it's the wrong type
    (i64.const 1234)
-   (i32.const 0)
+   (i32.const 1)
   )
  )
 )

--- a/test/passes/stub-unsupported-js.wast
+++ b/test/passes/stub-unsupported-js.wast
@@ -12,3 +12,24 @@
   (f32.convert_i32_u (unreachable))
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $i64_=>_i32 (func (param $foo i64) (result i32)))
+ (table $0 1 1 funcref)
+ (elem (i32.const 0) $return-f32)
+ (func $return-f32 (result f32)
+  (f32.const 1)
+ )
+ (func $bad-indirect-call
+  (call_indirect (type $none_=>_none) ;; note how it's the wrong type
+   (i32.const 0)
+  )
+ )
+ (func $bad-indirect-call-2 (result i32)
+  (call_indirect (type $i64_=>_i32) ;; note how it's the wrong type
+   (i64.const 1234)
+   (i32.const 0)
+  )
+ )
+)
+


### PR DESCRIPTION
wasm2js does not have full `call_indirect` support as we don't trap if
the type is incorrect, which wasm does. Therefore the StubUnsupportedJSOps
pass needs to remove those operations so that the fuzzer doesn't find
spurious issues.