### PR TITLE
Improve support for new llvm's new `main` name mangling

### DIFF
--- a/test/lld/basic_safe_stack.wat.out
+++ b/test/lld/basic_safe_stack.wat.out
@@ -102,7 +102,7 @@
   },
   "invokeFuncs": [
   ],
-  "mainReadsParams": 1,
+  "mainReadsParams": 0,
   "features": [
   ]
 }

--- a/test/lld/duplicate_imports.wat.out
+++ b/test/lld/duplicate_imports.wat.out
@@ -77,7 +77,7 @@
   "invokeFuncs": [
     "invoke_ffd"
   ],
-  "mainReadsParams": 1,
+  "mainReadsParams": 0,
   "features": [
   ]
 }

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -82,7 +82,7 @@
   },
   "invokeFuncs": [
   ],
-  "mainReadsParams": 1,
+  "mainReadsParams": 0,
   "features": [
   ]
 }


### PR DESCRIPTION
This is precursor to landing the change on the llvm side
to switch to the new name mangling scheme.

The code refactor actually caught a few cases in the test
code where the wrong answer was being reported.

See https://reviews.llvm.org/D70700