### PR TITLE
Remove unneeded old binary validation in test suite

### DIFF
--- a/check.py
+++ b/check.py
@@ -102,8 +102,6 @@ def run_wasm_dis_tests():
 
         shared.with_pass_debug(check)
 
-        shared.validate_binary(t)
-
 
 def run_crash_tests():
     print("\n[ checking we don't crash on tricky inputs... ]\n")

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -442,16 +442,6 @@ options.spec_tests = [t for t in options.spec_tests if os.path.basename(t) not
 
 # check utilities
 
-
-def validate_binary(wasm):
-    if V8:
-        cmd = [V8] + V8_OPTS + [in_binaryen('scripts', 'validation_shell.js'), '--', wasm]
-        print('            ', ' '.join(cmd))
-        subprocess.check_call(cmd, stdout=subprocess.PIPE)
-    else:
-        print('(skipping v8 binary validation)')
-
-
 def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'],
                         binary_suffix='.fromBinary', original_wast=None):
     # checks we can convert the wast to binary and back
@@ -463,13 +453,6 @@ def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'],
         os.unlink('a.wasm')
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
     assert os.path.exists('a.wasm')
-
-    # make sure it is a valid wasm, using a real wasm VM
-    if os.path.basename(original_wast or wast) not in [
-        'atomics.wast',    # https://bugs.chromium.org/p/v8/issues/detail?id=9425
-        'simd.wast',    # https://bugs.chromium.org/p/v8/issues/detail?id=8460
-    ]:
-        validate_binary('a.wasm')
 
     cmd = WASM_DIS + ['a.wasm', '-o', 'ab.wast']
     print('            ', ' '.join(cmd))


### PR DESCRIPTION
This was useful back when we didn't have many VMs to test in, and
we weren't confident in our binaries being valid wasm. Today we have
lots of testing on VMs, and in particular, this test tends to fail when we
do things like reorder SIMD opcode constants. (This doesn't fail on CI
as we don't have v8 installed there, so this path is never reached, but
it does happen locally.)