### PR TITLE
Added headers to CMake files

### DIFF
--- a/src/asmjs/CMakeLists.txt
+++ b/src/asmjs/CMakeLists.txt
@@ -1,6 +1,8 @@
+FILE(GLOB asmjs_HEADERS *.h)
 set(asmjs_SOURCES
   asm_v_wasm.cpp
   asmangle.cpp
   shared-constants.cpp
+  ${asmjs_HEADERS}
 )
 add_library(asmjs OBJECT ${asmjs_SOURCES})

--- a/src/cfg/CMakeLists.txt
+++ b/src/cfg/CMakeLists.txt
@@ -1,4 +1,6 @@
+FILE(GLOB cfg_HEADERS *.h)
 set(cfg_SOURCES
   Relooper.cpp
+  ${cfg_HEADERS}
 )
 add_library(cfg OBJECT ${cfg_SOURCES})

--- a/src/emscripten-optimizer/CMakeLists.txt
+++ b/src/emscripten-optimizer/CMakeLists.txt
@@ -1,6 +1,8 @@
+FILE(GLOB emscripten-optimizer_HEADERS *.h)
 set(emscripten-optimizer_SOURCES
   optimizer-shared.cpp
   parser.cpp
   simple_ast.cpp
+  ${emscripten-optimizer_HEADERS}
 )
 add_library(emscripten-optimizer OBJECT ${emscripten-optimizer_SOURCES})

--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -1,7 +1,9 @@
+FILE(GLOB ir_HEADERS *.h)
 set(ir_SOURCES
   ExpressionAnalyzer.cpp
   ExpressionManipulator.cpp
   LocalGraph.cpp
   ReFinalize.cpp
+  ${ir_HEADERS}
 )
 add_library(ir OBJECT ${ir_SOURCES})

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_command(
   COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/embedwat.py ${PROJECT_SOURCE_DIR}/src/passes/wasm-intrinsics.wat ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
   DEPENDS ${PROJECT_SOURCE_DIR}/scripts/embedwat.py wasm-intrinsics.wat)
 
+FILE(GLOB passes_HEADERS *.h)
 set(passes_SOURCES
   pass.cpp
   AlignmentLowering.cpp
@@ -82,5 +83,6 @@ set(passes_SOURCES
   Untee.cpp
   Vacuum.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
+  ${passes_HEADERS}
 )
 add_library(passes OBJECT ${passes_SOURCES})

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -1,3 +1,4 @@
+FILE(GLOB support_HEADERS *.h)
 set(support_SOURCES
   archive.cpp
   bits.cpp
@@ -9,5 +10,6 @@ set(support_SOURCES
   safe_integer.cpp
   threads.cpp
   utilities.cpp
+  ${support_HEADERS}
 )
 add_library(support OBJECT ${support_SOURCES})

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -1,3 +1,4 @@
+FILE(GLOB wasm_HEADERS *.h)
 set(wasm_SOURCES
   literal.cpp
   wasm.cpp
@@ -11,5 +12,6 @@ set(wasm_SOURCES
   wasm-stack.cpp
   wasm-type.cpp
   wasm-validator.cpp
+  ${wasm_HEADERS}
 )
 add_library(wasm OBJECT ${wasm_SOURCES})


### PR DESCRIPTION
This is needed for headers to show up in IDE projects, and has no other effect on the build.