### PR TITLE
Release 96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+v96
+---
+- Fuzzing: Compare wasm2js to the interpreter (#3026)
+- Fix CountLeadingZeroes on MSVC, which lead to bad optimizations (#3028)
+- Asyncify verbose option (#3022)
+- wasm2js: Add an "Export" scope for name resolution, avoids annoying
+  warnings (#2998)
+- Extend the C- and JS-APIs (#2586)
+
 v95
 ---
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1.3)
-project(binaryen LANGUAGES C CXX VERSION 95)
+project(binaryen LANGUAGES C CXX VERSION 96)
 include(GNUInstallDirs)
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
Contains in particular the MSVC fix for clz.