### PR TITLE
Add a C source for for test/lld/em_asm_O0

### DIFF
--- a/test/lld/em_asm.wat
+++ b/test/lld/em_asm.wat
@@ -65,6 +65,6 @@
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (call $__original_main)
  )
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/em_asm_O0.c
+++ b/test/lld/em_asm_O0.c
@@ -1,0 +1,7 @@
+#include <emscripten.h>
+
+int main() {
+  EM_ASM({ Module.print("Hello world"); });
+  EM_ASM({ Module.print("Got " + $0); }, 42);
+  return EM_ASM_INT({ return $0 + $1; }, 20, 30);
+}

--- a/test/lld/em_asm_O0.c
+++ b/test/lld/em_asm_O0.c
@@ -1,7 +1,8 @@
 #include <emscripten.h>
 
-int main() {
+int main(int argc, char **argv) {
   EM_ASM({ Module.print("Hello world"); });
+  int ret = EM_ASM_INT({ return $0 + $1; }, 20, 30);
   EM_ASM({ Module.print("Got " + $0); }, 42);
-  return EM_ASM_INT({ return $0 + $1; }, 20, 30);
+  return ret;
 }

--- a/test/lld/em_asm_O0.wat
+++ b/test/lld/em_asm_O0.wat
@@ -1,11 +1,10 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (memory $0 2)
- (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ Module.print(\"Got \" + $0); }\00{ return $0 + $1; }\00")
+ (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66192))
  (global $global$1 i32 (i32.const 652))
@@ -15,11 +14,11 @@
  (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
- (func $__original_main (result i32)
-  (local $0 i32)
-  (local $1 i32)
+ (func $main (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
   (global.set $global$0
-   (local.tee $0
+   (local.tee $2
     (i32.sub
      (global.get $global$0)
      (i32.const 32)
@@ -27,72 +26,69 @@
    )
   )
   (i32.store8 offset=31
-   (local.get $0)
+   (local.get $2)
    (i32.const 0)
   )
   (drop
    (call $emscripten_asm_const_int
     (i32.const 568)
     (i32.add
-     (local.get $0)
+     (local.get $2)
      (i32.const 31)
     )
     (i32.const 0)
    )
   )
-  (i32.store16 offset=29 align=1
-   (local.get $0)
-   (i32.const 105)
+  (i32.store8 offset=30
+   (local.get $2)
+   (i32.const 0)
   )
-  (i32.store offset=16
-   (local.get $0)
-   (i32.const 42)
+  (i32.store16 offset=28 align=1
+   (local.get $2)
+   (i32.const 26985)
   )
-  (drop
+  (i64.store offset=16
+   (local.get $2)
+   (i64.const 128849018900)
+  )
+  (local.set $3
    (call $emscripten_asm_const_int
     (i32.const 601)
     (i32.add
-     (local.get $0)
-     (i32.const 29)
+     (local.get $2)
+     (i32.const 28)
     )
     (i32.add
-     (local.get $0)
+     (local.get $2)
      (i32.const 16)
     )
    )
   )
-  (i32.store8 offset=28
-   (local.get $0)
-   (i32.const 0)
-  )
   (i32.store16 offset=26 align=1
-   (local.get $0)
-   (i32.const 26985)
+   (local.get $2)
+   (i32.const 105)
   )
-  (i64.store
-   (local.get $0)
-   (i64.const 128849018900)
+  (i32.store
+   (local.get $2)
+   (i32.const 42)
   )
-  (local.set $1
+  (drop
    (call $emscripten_asm_const_int
-    (i32.const 632)
+    (i32.const 621)
     (i32.add
-     (local.get $0)
+     (local.get $2)
      (i32.const 26)
     )
-    (local.get $0)
+    (local.get $2)
    )
   )
   (global.set $global$0
    (i32.add
-    (local.get $0)
+    (local.get $2)
     (i32.const 32)
    )
   )
-  (local.get $1)
- )
- (func $main (param $0 i32) (param $1 i32) (result i32)
-  (call $__original_main)
+  (local.get $3)
  )
  ;; custom section "producers", size 157
 )

--- a/test/lld/em_asm_O0.wat
+++ b/test/lld/em_asm_O0.wat
@@ -1,47 +1,99 @@
 (module
- (type $0 (func (param i32) (result i32)))
- (type $1 (func (param i32 i32 i32) (result i32)))
- (type $2 (func (param i32 i32) (result i32)))
- (type $3 (func (result i32)))
- (type $4 (func))
- (import "env" "_Z24emscripten_asm_const_intIJEEiPKcDpT_" (func $_Z24emscripten_asm_const_intIJEEiPKcDpT_ (param i32) (result i32)))
- (import "env" "_Z24emscripten_asm_const_intIJiiEEiPKcDpT_" (func $_Z24emscripten_asm_const_intIJiiEEiPKcDpT_ (param i32 i32 i32) (result i32)))
- (import "env" "_Z24emscripten_asm_const_intIJiEEiPKcDpT_" (func $_Z24emscripten_asm_const_intIJiEEiPKcDpT_ (param i32 i32) (result i32)))
- (global $global$0 (mut i32) (i32.const 66192))
- (global $global$1 i32 (i32.const 66192))
- (global $global$2 i32 (i32.const 652))
- (table 1 1 funcref)
+ (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
+ (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (memory $0 2)
- (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
+ (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ Module.print(\"Got \" + $0); }\00{ return $0 + $1; }\00")
+ (table $0 1 1 funcref)
+ (global $global$0 (mut i32) (i32.const 66192))
+ (global $global$1 i32 (i32.const 652))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__heap_base" (global $global$1))
- (export "__data_end" (global $global$2))
- (func $main (; 3 ;) (type $3) (result i32)
-  (local $t1 i32)
-  (local $t2 i32)
-  (drop
-   (call $_Z24emscripten_asm_const_intIJEEiPKcDpT_
-    (i32.const 568)
-   )
-  )
-  (local.set $t1 (i32.const 621))
-  (local.set $t2 (i32.const 601))
-  (drop
-   (call $_Z24emscripten_asm_const_intIJiEEiPKcDpT_
-    (local.get $t1)
-    (call $_Z24emscripten_asm_const_intIJiiEEiPKcDpT_
-     (local.get $t2)
-     (i32.const 13)
-     (i32.const 27)
+ (export "__data_end" (global $global$1))
+ (func $__wasm_call_ctors
+ )
+ (func $__original_main (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (global.set $global$0
+   (local.tee $0
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 32)
     )
    )
   )
-  (i32.const 0)
+  (i32.store8 offset=31
+   (local.get $0)
+   (i32.const 0)
+  )
+  (drop
+   (call $emscripten_asm_const_int
+    (i32.const 568)
+    (i32.add
+     (local.get $0)
+     (i32.const 31)
+    )
+    (i32.const 0)
+   )
+  )
+  (i32.store16 offset=29 align=1
+   (local.get $0)
+   (i32.const 105)
+  )
+  (i32.store offset=16
+   (local.get $0)
+   (i32.const 42)
+  )
+  (drop
+   (call $emscripten_asm_const_int
+    (i32.const 601)
+    (i32.add
+     (local.get $0)
+     (i32.const 29)
+    )
+    (i32.add
+     (local.get $0)
+     (i32.const 16)
+    )
+   )
+  )
+  (i32.store8 offset=28
+   (local.get $0)
+   (i32.const 0)
+  )
+  (i32.store16 offset=26 align=1
+   (local.get $0)
+   (i32.const 26985)
+  )
+  (i64.store
+   (local.get $0)
+   (i64.const 128849018900)
+  )
+  (local.set $1
+   (call $emscripten_asm_const_int
+    (i32.const 632)
+    (i32.add
+     (local.get $0)
+     (i32.const 26)
+    )
+    (local.get $0)
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $0)
+    (i32.const 32)
+   )
+  )
+  (local.get $1)
  )
- (func $__wasm_call_ctors (; 4 ;) (type $4)
+ (func $main (param $0 i32) (param $1 i32) (result i32)
+  (call $__original_main)
  )
- ;; custom section "linking", size 3
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -1,12 +1,11 @@
 (module
  (type $none_=>_none (func))
- (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "emscripten_asm_const_iii" (func $emscripten_asm_const_iii (param i32 i32 i32) (result i32)))
  (memory $0 2)
- (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ Module.print(\"Got \" + $0); }\00{ return $0 + $1; }\00")
+ (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66192))
  (global $global$1 i32 (i32.const 652))
@@ -18,11 +17,11 @@
  (func $__wasm_call_ctors
   (nop)
  )
- (func $__original_main (result i32)
-  (local $0 i32)
-  (local $1 i32)
+ (func $main (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local $3 i32)
   (global.set $global$0
-   (local.tee $0
+   (local.tee $2
     (i32.sub
      (global.get $global$0)
      (i32.const 32)
@@ -30,72 +29,69 @@
    )
   )
   (i32.store8 offset=31
-   (local.get $0)
+   (local.get $2)
    (i32.const 0)
   )
   (drop
    (call $emscripten_asm_const_iii
     (i32.const 568)
     (i32.add
-     (local.get $0)
+     (local.get $2)
      (i32.const 31)
     )
     (i32.const 0)
    )
   )
-  (i32.store16 offset=29 align=1
-   (local.get $0)
-   (i32.const 105)
+  (i32.store8 offset=30
+   (local.get $2)
+   (i32.const 0)
   )
-  (i32.store offset=16
-   (local.get $0)
-   (i32.const 42)
+  (i32.store16 offset=28 align=1
+   (local.get $2)
+   (i32.const 26985)
   )
-  (drop
+  (i64.store offset=16
+   (local.get $2)
+   (i64.const 128849018900)
+  )
+  (local.set $3
    (call $emscripten_asm_const_iii
     (i32.const 601)
     (i32.add
-     (local.get $0)
-     (i32.const 29)
+     (local.get $2)
+     (i32.const 28)
     )
     (i32.add
-     (local.get $0)
+     (local.get $2)
      (i32.const 16)
     )
    )
   )
-  (i32.store8 offset=28
-   (local.get $0)
-   (i32.const 0)
-  )
   (i32.store16 offset=26 align=1
-   (local.get $0)
-   (i32.const 26985)
+   (local.get $2)
+   (i32.const 105)
   )
-  (i64.store
-   (local.get $0)
-   (i64.const 128849018900)
+  (i32.store
+   (local.get $2)
+   (i32.const 42)
   )
-  (local.set $1
+  (drop
    (call $emscripten_asm_const_iii
-    (i32.const 632)
+    (i32.const 621)
     (i32.add
-     (local.get $0)
+     (local.get $2)
      (i32.const 26)
     )
-    (local.get $0)
+    (local.get $2)
    )
   )
   (global.set $global$0
    (i32.add
-    (local.get $0)
+    (local.get $2)
     (i32.const 32)
    )
   )
-  (local.get $1)
- )
- (func $main (param $0 i32) (param $1 i32) (result i32)
-  (call $__original_main)
+  (local.get $3)
  )
  (func $__growWasmMemory (param $newSize i32) (result i32)
   (memory.grow
@@ -108,8 +104,8 @@
 {
   "asmConsts": {
     "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "601": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
-    "632": ["{ return $0 + $1; }", ["iii"], [""]]
+    "601": ["{ return $0 + $1; }", ["iii"], [""]],
+    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,
@@ -130,7 +126,7 @@
   },
   "invokeFuncs": [
   ],
-  "mainReadsParams": 0,
+  "mainReadsParams": 1,
   "features": [
   ]
 }

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -1,52 +1,101 @@
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
- (import "env" "emscripten_asm_const_i" (func $emscripten_asm_const_i (param i32) (result i32)))
  (import "env" "emscripten_asm_const_iii" (func $emscripten_asm_const_iii (param i32 i32 i32) (result i32)))
- (import "env" "emscripten_asm_const_ii" (func $emscripten_asm_const_ii (param i32 i32) (result i32)))
  (memory $0 2)
- (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
+ (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ Module.print(\"Got \" + $0); }\00{ return $0 + $1; }\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66192))
- (global $global$1 i32 (i32.const 66192))
- (global $global$2 i32 (i32.const 652))
+ (global $global$1 i32 (i32.const 652))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__heap_base" (global $global$1))
- (export "__data_end" (global $global$2))
+ (export "__data_end" (global $global$1))
  (export "__growWasmMemory" (func $__growWasmMemory))
- (func $main (result i32)
-  (local $t1 i32)
-  (local $t2 i32)
-  (drop
-   (call $emscripten_asm_const_i
-    (i32.const 568)
-   )
-  )
-  (local.set $t1
-   (i32.const 621)
-  )
-  (local.set $t2
-   (i32.const 601)
-  )
-  (drop
-   (call $emscripten_asm_const_ii
-    (local.get $t1)
-    (call $emscripten_asm_const_iii
-     (local.get $t2)
-     (i32.const 13)
-     (i32.const 27)
+ (func $__wasm_call_ctors
+  (nop)
+ )
+ (func $__original_main (result i32)
+  (local $0 i32)
+  (local $1 i32)
+  (global.set $global$0
+   (local.tee $0
+    (i32.sub
+     (global.get $global$0)
+     (i32.const 32)
     )
    )
   )
-  (i32.const 0)
+  (i32.store8 offset=31
+   (local.get $0)
+   (i32.const 0)
+  )
+  (drop
+   (call $emscripten_asm_const_iii
+    (i32.const 568)
+    (i32.add
+     (local.get $0)
+     (i32.const 31)
+    )
+    (i32.const 0)
+   )
+  )
+  (i32.store16 offset=29 align=1
+   (local.get $0)
+   (i32.const 105)
+  )
+  (i32.store offset=16
+   (local.get $0)
+   (i32.const 42)
+  )
+  (drop
+   (call $emscripten_asm_const_iii
+    (i32.const 601)
+    (i32.add
+     (local.get $0)
+     (i32.const 29)
+    )
+    (i32.add
+     (local.get $0)
+     (i32.const 16)
+    )
+   )
+  )
+  (i32.store8 offset=28
+   (local.get $0)
+   (i32.const 0)
+  )
+  (i32.store16 offset=26 align=1
+   (local.get $0)
+   (i32.const 26985)
+  )
+  (i64.store
+   (local.get $0)
+   (i64.const 128849018900)
+  )
+  (local.set $1
+   (call $emscripten_asm_const_iii
+    (i32.const 632)
+    (i32.add
+     (local.get $0)
+     (i32.const 26)
+    )
+    (local.get $0)
+   )
+  )
+  (global.set $global$0
+   (i32.add
+    (local.get $0)
+    (i32.const 32)
+   )
+  )
+  (local.get $1)
  )
- (func $__wasm_call_ctors
-  (nop)
+ (func $main (param $0 i32) (param $1 i32) (result i32)
+  (call $__original_main)
  )
  (func $__growWasmMemory (param $newSize i32) (result i32)
   (memory.grow
@@ -58,9 +107,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "568": ["{ Module.print(\"Hello world\"); }", ["i"], [""]],
-    "601": ["{ return $0 + $1; }", ["iii"], [""]],
-    "621": ["{ Module.print(\"Got \" + $0); }", ["ii"], [""]]
+    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
+    "601": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]],
+    "632": ["{ return $0 + $1; }", ["iii"], [""]]
   },
   "staticBump": 84,
   "tableSize": 1,
@@ -77,12 +126,11 @@
     "__growWasmMemory"
   ],
   "namedGlobals": {
-    "__heap_base" : "66192",
     "__data_end" : "652"
   },
   "invokeFuncs": [
   ],
-  "mainReadsParams": 1,
+  "mainReadsParams": 0,
   "features": [
   ]
 }

--- a/test/lld/em_asm_shared.wat
+++ b/test/lld/em_asm_shared.wat
@@ -94,6 +94,6 @@
  ;;   memoryalignment: 0
  ;;   tablesize: 0
  ;;   tablealignment: 0
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/hello_world.wat
+++ b/test/lld/hello_world.wat
@@ -26,6 +26,6 @@
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (call $__original_main)
  )
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/init.wat
+++ b/test/lld/init.wat
@@ -39,6 +39,6 @@
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (call $__original_main)
  )
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/longjmp.wat
+++ b/test/lld/longjmp.wat
@@ -131,6 +131,6 @@
  (func $2 (param $0 i32) (param $1 i32) (result i32)
   (call $1)
  )
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/recursive.wat
+++ b/test/lld/recursive.wat
@@ -83,6 +83,6 @@
  (func $main (param $0 i32) (param $1 i32) (result i32)
   (call $__original_main)
  )
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/reserved_func_ptr.wat
+++ b/test/lld/reserved_func_ptr.wat
@@ -106,6 +106,6 @@
   )
   (i32.const 0)
  )
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/shared.wat
+++ b/test/lld/shared.wat
@@ -54,6 +54,6 @@
  ;;   memoryalignment: 2
  ;;   tablesize: 0
  ;;   tablealignment: 0
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 

--- a/test/lld/shared_longjmp.wat
+++ b/test/lld/shared_longjmp.wat
@@ -143,6 +143,6 @@
  ;;   memoryalignment: 2
  ;;   tablesize: 0
  ;;   tablealignment: 0
- ;; custom section "producers", size 112
+ ;; custom section "producers", size 157
 )
 


### PR DESCRIPTION
That had just a wat file, with no C. This adds a C file as best I
can guess - looks pretty close - and updates all the lld tests with
`scripts/test/generate_lld_tests.py` and `./auto_update_tests.py lld`

As the diff shows, the handwritten wat was very different than what
emcc+lld emit now. I think we must have switches EM_ASMs to
be variadic at some point? That is what they currently are, and
would explain the diff.

See the discussion that led to this in #3044
