### PR TITLE
Checkout python scripts with LF to keep shebangs intact in mixed setups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+*.py text eol=lf
 *.sh text eol=lf
 test/binaryen.js/*.txt text eol=lf


### PR DESCRIPTION
Python scripts were previously checked out with CRLF line endings by default on Windows (unless configured otherwise globally), leading to problems with the shebang not being correctly recognized when mounted into WSL and trying to run `./thescript.py` without prepending `python3` (just like `*.sh` files and `bash` that have already been addressed). NFC except that it helps in mixed setups.