### PR TITLE
Make wasm-emscripten-finalize's output optional

### DIFF
--- a/test/unit/input/empty_lld.wat
+++ b/test/unit/input/empty_lld.wat
@@ -1,0 +1,9 @@
+(module
+ (global $global$0 (mut i32) (i32.const 66192))
+ (global $global$1 i32 (i32.const 652))
+ (export "__data_end" (global $global$1))
+ (export "main" (func $main))
+ (func $main (param $0 i32) (param $1 i32) (result i32)
+  (i32.const 0)
+ )
+)

--- a/test/unit/test_finalize.py
+++ b/test/unit/test_finalize.py
@@ -6,10 +6,30 @@ from . import utils
 
 class EmscriptenFinalizeTest(utils.BinaryenTestCase):
     def test_em_asm_mangled_string(self):
-        input_dir = os.path.dirname(__file__)
         p = shared.run_process(shared.WASM_EMSCRIPTEN_FINALIZE + [
-            os.path.join(input_dir, 'input', 'em_asm_mangled_string.wat'), '-o', os.devnull, '--global-base=1024'
+            self.input_path('em_asm_mangled_string.wat'), '-o', os.devnull, '--global-base=1024'
         ], check=False, capture_output=True)
         self.assertNotEqual(p.returncode, 0)
         self.assertIn('Fatal: local.get of unknown in arg0 of call to emscripten_asm_const_int (used by EM_ASM* macros) in function main.', p.stderr)
         self.assertIn('This might be caused by aggressive compiler transformations. Consider using EM_JS instead.', p.stderr)
+
+    def do_output_test(self, args):
+        # without any output file specified, don't error, don't write the wasm,
+        # but do emit metadata
+        p = shared.run_process(shared.WASM_EMSCRIPTEN_FINALIZE + [
+            self.input_path('empty_lld.wat'), '--global-base=1024'
+        ] + args, capture_output=True)
+        # metadata is always present
+        self.assertIn('{', p.stdout)
+        self.assertIn('}', p.stdout)
+        return p.stdout
+
+    def test_no_output(self):
+        stdout = self.do_output_test([])
+        # module is not present
+        self.assertNotIn('(module', stdout)
+
+    def test_text_output(self):
+        stdout = self.do_output_test(['-S'])
+        # module is present
+        self.assertIn('(module', stdout)


### PR DESCRIPTION
This helps towards the goal of allowing emscripten to not always modify
the wasm during link. Until now wasm-emscripten-finalize always wrote
an output, while with this PR it only does so if it was asked to, either by
giving it an output filename, or asking for text output.

The only noticeable change from this should be to make what was an
error before (not specify an output or ask for text) into a non-error (run
and print metadata, but do not write the wasm).