### PR TITLE
Fast reject expensive optimizations for passes with zero number of locals

### DIFF
--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -81,6 +81,7 @@ struct RedundantSetElimination
 
   void doWalkFunction(Function* func) {
     numLocals = func->getNumLocals();
+    if (numLocals == 0) return; // nothing to do
     // create the CFG by walking the IR
     CFGWalker<RedundantSetElimination, Visitor<RedundantSetElimination>, Info>::
       doWalkFunction(func);

--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -81,7 +81,9 @@ struct RedundantSetElimination
 
   void doWalkFunction(Function* func) {
     numLocals = func->getNumLocals();
-    if (numLocals == 0) return; // nothing to do
+    if (numLocals == 0) {
+      return; // nothing to do
+    }
     // create the CFG by walking the IR
     CFGWalker<RedundantSetElimination, Visitor<RedundantSetElimination>, Info>::
       doWalkFunction(func);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -57,7 +57,7 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     // Gather information about local usages.
     walk(curr->body);
     // Use the information about local usages.
-    std::vector<Index> newToOld((size_t)num);
+    std::vector<Index> newToOld(num);
     for (size_t i = 0; i < num; i++) {
       newToOld[i] = i;
     }

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -47,11 +47,8 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   enum { Unseen = 0 };
 
   void doWalkFunction(Function* curr) {
-    Index i = 0, num = curr->getNumLocals();
-    while (i < num && curr->isParam(i)) {
-      i++;
-    }
-    if (num == i) {
+    Index num = curr->getNumLocals();
+    if (num == curr->getNumParams()) {
       return; // nothing to do. All locals are parameters
     }
     counts.resize(num);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -47,15 +47,11 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   enum { Unseen = 0 };
 
   void doWalkFunction(Function* curr) {
-    Index num = curr->getNumLocals();
-    if (num == 0) {
-      return; // nothing to do
-    }
-    Index i = 0;
+    Index i = 0, num = curr->getNumLocals();
     while (i < num && curr->isParam(i)) {
       i++;
     }
-    if (i == num) {
+    if (num == i) {
       return; // nothing to do. All locals are parameters
     }
     counts.resize(num);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -51,6 +51,13 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     if (num == 0) {
       return; // nothing to do
     }
+    Index i = 0;
+    while (i < num && curr->isParam(i)) {
+      i++;
+    }
+    if (i == num) {
+      return; // nothing to do. All locals are parameters
+    }
     counts.resize(num);
     std::fill(counts.begin(), counts.end(), 0);
     firstUses.resize(num);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -23,7 +23,6 @@
 //
 
 #include <memory>
-#include <numeric>
 
 #include <pass.h>
 #include <wasm.h>
@@ -59,8 +58,9 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     walk(curr->body);
     // Use the information about local usages.
     std::vector<Index> newToOld((size_t)num);
-    // Fill newToOld from "0" to "num".
-    std::iota(newToOld.begin(), newToOld.end(), 0);
+    for (size_t i = 0; i < num; i++) {
+      newToOld[i] = i;
+    }
     // sort, keeping params in front (where they will not be moved)
     sort(
       newToOld.begin(), newToOld.end(), [this, curr](Index a, Index b) -> bool {
@@ -132,10 +132,9 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
     auto oldLocalIndices = curr->localIndices;
     curr->localNames.clear();
     curr->localIndices.clear();
-    auto end = oldLocalNames.end();
     for (size_t i = 0; i < newToOld.size(); i++) {
       auto iter = oldLocalNames.find(newToOld[i]);
-      if (iter != end) {
+      if (iter != oldLocalNames.end()) {
         auto old = iter->second;
         curr->localNames[i] = old;
         curr->localIndices[old] = i;

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -47,10 +47,10 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   enum { Unseen = 0 };
 
   void doWalkFunction(Function* curr) {
-    Index num = curr->getNumLocals();
-    if (num == curr->getNumParams()) {
+    if (curr->getNumVars() == 0) {
       return; // nothing to do. All locals are parameters
     }
+    Index num = curr->getNumLocals();
     counts.resize(num);
     std::fill(counts.begin(), counts.end(), 0);
     firstUses.resize(num);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -47,6 +47,7 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
 
   void doWalkFunction(Function* curr) {
     Index num = curr->getNumLocals();
+    if (num == 0) return; // nothing to do
     counts.resize(num);
     std::fill(counts.begin(), counts.end(), 0);
     firstUses.resize(num);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -47,7 +47,9 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
 
   void doWalkFunction(Function* curr) {
     Index num = curr->getNumLocals();
-    if (num == 0) return; // nothing to do
+    if (num == 0) {
+      return; // nothing to do
+    }
     counts.resize(num);
     std::fill(counts.begin(), counts.end(), 0);
     firstUses.resize(num);

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -811,6 +811,9 @@ struct SimplifyLocals
   }
 
   void doWalkFunction(Function* func) {
+    if (func->getNumLocals() == 0) {
+      return; // nothing to do
+    }
     // scan local.gets
     getCounter.analyze(func);
     // multiple passes may be required per function, consider this:


### PR DESCRIPTION
It seems some optimization passes which manipulate only locals could be early rejected when number of locals is zero