### PR TITLE
Replace Type::expand() with an iterator-based approach

### DIFF
--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -104,8 +104,8 @@ std::string getSig(Type results, Type params) {
   assert(!results.isMulti());
   std::string sig;
   sig += getSig(results);
-  for (Type t : params.expand()) {
-    sig += getSig(t);
+  for (auto& param : params) {
+    sig += getSig(param);
   }
   return sig;
 }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -150,9 +150,10 @@ BinaryenType BinaryenTypeCreate(BinaryenType* types, uint32_t numTypes) {
 uint32_t BinaryenTypeArity(BinaryenType t) { return Type(t).size(); }
 
 void BinaryenTypeExpand(BinaryenType t, BinaryenType* buf) {
-  const std::vector<Type>& types = Type(t).expand();
-  for (size_t i = 0; i < types.size(); ++i) {
-    buf[i] = types[i].getID();
+  Type types(t);
+  size_t i = 0;
+  for (auto& type : types) {
+    buf[i++] = type.getID();
   }
 }
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1306,7 +1306,7 @@ private:
       }
       auto localType = func->getLocalType(i);
       SmallVector<Expression*, 1> loads;
-      for (auto type : localType) {
+      for (auto& type : localType) {
         auto size = type.getByteSize();
         assert(size % STACK_ALIGN == 0);
         // TODO: higher alignment?
@@ -1350,7 +1350,7 @@ private:
       }
       auto localType = func->getLocalType(i);
       size_t j = 0;
-      for (auto type : localType) {
+      for (auto& type : localType) {
         auto size = type.getByteSize();
         Expression* localGet = builder->makeLocalGet(i, localType);
         if (localType.size() > 1) {

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1304,10 +1304,9 @@ private:
       if (!relevantLiveLocals.count(i)) {
         continue;
       }
-      const auto& types = func->getLocalType(i).expand();
+      auto localType = func->getLocalType(i);
       SmallVector<Expression*, 1> loads;
-      for (Index j = 0; j < types.size(); j++) {
-        auto type = types[j];
+      for (auto type : localType) {
         auto size = type.getByteSize();
         assert(size % STACK_ALIGN == 0);
         // TODO: higher alignment?
@@ -1323,7 +1322,7 @@ private:
       Expression* load;
       if (loads.size() == 1) {
         load = loads[0];
-      } else if (types.size() > 1) {
+      } else if (localType.size() > 1) {
         load = builder->makeTupleMake(std::move(loads));
       } else {
         WASM_UNREACHABLE("Unexpected empty type");
@@ -1350,12 +1349,11 @@ private:
         continue;
       }
       auto localType = func->getLocalType(i);
-      const auto& types = localType.expand();
-      for (Index j = 0; j < types.size(); j++) {
-        auto type = types[j];
+      size_t j = 0;
+      for (auto type : localType) {
         auto size = type.getByteSize();
         Expression* localGet = builder->makeLocalGet(i, localType);
-        if (types.size() > 1) {
+        if (localType.size() > 1) {
           localGet = builder->makeTupleExtract(localGet, j);
         }
         assert(size % STACK_ALIGN == 0);
@@ -1368,6 +1366,7 @@ private:
                              localGet,
                              type));
         offset += size;
+        ++j;
       }
     }
     block->list.push_back(builder->makeIncStackPos(offset));

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -409,7 +409,7 @@ private:
     // Remove the parameter from the function. We must add a new local
     // for uses of the parameter, but cannot make it use the same index
     // (in general).
-    std::vector<Type> params = func->sig.params.expand();
+    std::vector<Type> params(func->sig.params.begin(), func->sig.params.end());
     auto type = params[i];
     params.erase(params.begin() + i);
     func->sig.params = Type(params);

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -193,13 +193,13 @@ private:
     }
     // The item in the table may be a function or a function import.
     auto* func = module->getFunction(name);
-    const std::vector<Type>& params = func->sig.params.expand();
     Type type = func->sig.results;
     Builder builder(*module);
     std::vector<Expression*> callOperands;
-    for (Index i = 0; i < params.size(); i++) {
+    Index i = 0;
+    for (auto& param : func->sig.params) {
       callOperands.push_back(
-        fromABI(builder.makeLocalGet(i, Type::i64), params[i], module));
+        fromABI(builder.makeLocalGet(i++, Type::i64), param, module));
     }
     auto* call = builder.makeCall(name, callOperands, type);
     std::vector<Type> thunkParams;

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -272,7 +272,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     visitGenericCall<CallIndirect>(
       curr, [&](std::vector<Expression*>& args, Type results) {
         std::vector<Type> params;
-        for (auto param : curr->sig.params.expand()) {
+        for (auto& param : curr->sig.params) {
           if (param == Type::i64) {
             params.push_back(Type::i32);
             params.push_back(Type::i32);

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -183,7 +183,7 @@ private:
   std::map<Name, Name> illegalImportsToLegal;
 
   template<typename T> bool isIllegal(T* t) {
-    for (auto param : t->sig.params.expand()) {
+    for (auto& param : t->sig.params) {
       if (param == Type::i64) {
         return true;
       }
@@ -222,9 +222,8 @@ private:
     call->target = func->name;
     call->type = func->sig.results;
 
-    const std::vector<Type>& params = func->sig.params.expand();
     std::vector<Type> legalParams;
-    for (auto param : params) {
+    for (auto& param : func->sig.params) {
       if (param == Type::i64) {
         call->operands.push_back(I64Utilities::recreateI64(
           builder, legalParams.size(), legalParams.size() + 1));
@@ -277,18 +276,19 @@ private:
     auto* call = module->allocator.alloc<Call>();
     call->target = legalIm->name;
 
-    const std::vector<Type>& imParams = im->sig.params.expand();
     std::vector<Type> params;
-    for (size_t i = 0; i < imParams.size(); ++i) {
-      if (imParams[i] == Type::i64) {
+    Index i = 0;
+    for (auto& param : im->sig.params) {
+      if (param == Type::i64) {
         call->operands.push_back(I64Utilities::getI64Low(builder, i));
         call->operands.push_back(I64Utilities::getI64High(builder, i));
         params.push_back(Type::i32);
         params.push_back(Type::i32);
       } else {
-        call->operands.push_back(builder.makeLocalGet(i, imParams[i]));
-        params.push_back(imParams[i]);
+        call->operands.push_back(builder.makeLocalGet(i, param));
+        params.push_back(param);
       }
+      ++i;
     }
 
     if (im->sig.results == Type::i64) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -68,10 +68,10 @@ static std::ostream& operator<<(std::ostream& o, const SExprType& localType) {
   Type type = localType.type;
   if (type.isMulti()) {
     o << '(';
-    auto ws = "";
+    auto sep = "";
     for (auto& t : type) {
-      o << ws << t;
-      ws = " ";
+      o << sep << t;
+      sep = " ";
     }
     o << ')';
   } else {
@@ -91,10 +91,10 @@ std::ostream& operator<<(std::ostream& os, SigName sigName) {
     if (type == Type::none) {
       os << "none";
     } else {
-      auto us = "";
+      auto sep = "";
       for (auto& t : type) {
-        os << us << t;
-        us = "_";
+        os << sep << t;
+        sep = "_";
       }
     }
   };

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -67,15 +67,16 @@ struct SExprType {
 static std::ostream& operator<<(std::ostream& o, const SExprType& localType) {
   Type type = localType.type;
   if (type.isMulti()) {
-    const std::vector<Type>& types = type.expand();
-    o << '(' << types[0];
-    for (size_t i = 1; i < types.size(); ++i) {
-      o << ' ' << types[i];
+    o << '(';
+    auto ws = "";
+    for (auto& t : type) {
+      o << ws << t;
+      ws = " ";
     }
     o << ')';
-    return o;
+  } else {
+    o << type;
   }
-  o << type;
   return o;
 }
 
@@ -90,12 +91,10 @@ std::ostream& operator<<(std::ostream& os, SigName sigName) {
     if (type == Type::none) {
       os << "none";
     } else {
-      const std::vector<Type>& types = type.expand();
-      for (size_t i = 0; i < types.size(); ++i) {
-        if (i != 0) {
-          os << '_';
-        }
-        os << types[i];
+      auto us = "";
+      for (auto& t : type) {
+        os << us << t;
+        us = "_";
       }
     }
   };
@@ -2169,14 +2168,15 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     if (!printStackIR && curr->stackIR && !minify) {
       o << " (; has Stack IR ;)";
     }
-    const std::vector<Type>& params = curr->sig.params.expand();
-    if (params.size() > 0) {
-      for (size_t i = 0; i < params.size(); i++) {
+    if (curr->sig.params.size() > 0) {
+      Index i = 0;
+      for (auto& param : curr->sig.params) {
         o << maybeSpace;
         o << '(';
         printMinor(o, "param ");
         printLocal(i, currFunction, o);
-        o << ' ' << params[i] << ')';
+        o << ' ' << param << ')';
+        ++i;
       }
     }
     if (curr->sig.results != Type::none) {

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -165,12 +165,12 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     if (sig != func->sig) {
       trap("callIndirect: function signatures don't match");
     }
-    const std::vector<Type>& params = func->sig.params.expand();
-    if (params.size() != arguments.size()) {
+    if (func->sig.params.size() != arguments.size()) {
       trap("callIndirect: bad # of arguments");
     }
-    for (size_t i = 0; i < params.size(); i++) {
-      if (!Type::isSubType(arguments[i].type, params[i])) {
+    size_t i = 0;
+    for (auto& param : func->sig.params) {
+      if (!Type::isSubType(arguments[i++].type, param)) {
         trap("callIndirect: bad argument type");
       }
     }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -144,7 +144,7 @@ struct ExecutionResults {
         instance.callFunction(ex->value, arguments);
       }
       // call the method
-      for (Type param : func->sig.params.expand()) {
+      for (auto& param : func->sig.params) {
         // zeros in arguments TODO: more?
         arguments.push_back(Literal::makeSingleZero(param));
       }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -308,7 +308,7 @@ private:
   Type getSubType(Type type) {
     if (type.isMulti()) {
       std::vector<Type> types;
-      for (auto t : type.expand()) {
+      for (auto& t : type) {
         types.push_back(getSubType(t));
       }
       return Type(types);
@@ -770,7 +770,7 @@ private:
     std::vector<Expression*> invocations;
     while (oneIn(2) && !finishedInput) {
       std::vector<Expression*> args;
-      for (auto type : func->sig.params.expand()) {
+      for (auto& type : func->sig.params) {
         args.push_back(makeConst(type));
       }
       Expression* invoke =
@@ -1166,7 +1166,7 @@ private:
       }
       // we found one!
       std::vector<Expression*> args;
-      for (auto argType : target->sig.params.expand()) {
+      for (auto& argType : target->sig.params) {
         args.push_back(make(argType));
       }
       return builder.makeCall(target->name, args, type, isReturn);
@@ -1210,7 +1210,7 @@ private:
       target = make(Type::i32);
     }
     std::vector<Expression*> args;
-    for (auto type : targetFn->sig.params.expand()) {
+    for (auto& type : targetFn->sig.params) {
       args.push_back(make(type));
     }
     return builder.makeCallIndirect(target, args, targetFn->sig, isReturn);
@@ -1267,7 +1267,7 @@ private:
     assert(wasm.features.hasMultivalue());
     assert(type.isMulti());
     std::vector<Expression*> elements;
-    for (auto t : type.expand()) {
+    for (auto& t : type) {
       elements.push_back(make(t));
     }
     return builder.makeTupleMake(std::move(elements));
@@ -1277,20 +1277,21 @@ private:
     assert(wasm.features.hasMultivalue());
     assert(type.isSingle() && type.isConcrete());
     Type tupleType = getTupleType();
-    auto& elements = tupleType.expand();
 
     // Find indices from which we can extract `type`
     std::vector<size_t> extractIndices;
-    for (size_t i = 0; i < elements.size(); ++i) {
-      if (elements[i] == type) {
+    size_t i = 0;
+    for (auto& t : tupleType) {
+      if (t == type) {
         extractIndices.push_back(i);
       }
+      ++i;
     }
 
     // If there are none, inject one
     if (extractIndices.size() == 0) {
-      auto newElements = elements;
-      size_t injected = upTo(elements.size());
+      std::vector<Type> newElements(tupleType.begin(), tupleType.end());
+      size_t injected = upTo(newElements.size());
       newElements[injected] = type;
       tupleType = Type(newElements);
       extractIndices.push_back(injected);
@@ -1766,7 +1767,7 @@ private:
     }
     if (type.isMulti()) {
       std::vector<Expression*> operands;
-      for (auto t : type.expand()) {
+      for (auto& t : type) {
         operands.push_back(makeConst(t));
       }
       return builder.makeTupleMake(std::move(operands));

--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -99,7 +99,7 @@ static std::string generateJSWrapper(Module& wasm) {
     }
     ret += std::string("instance.exports.") + exp->name.str + "(";
     bool first = true;
-    for (Type param : func->sig.params.expand()) {
+    for (auto& param : func->sig.params) {
       // zeros in arguments TODO more?
       if (first) {
         first = false;

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -30,7 +30,7 @@ static std::string generateSpecWrapper(Module& wasm) {
     }
     ret += std::string("(invoke \"hangLimitInitializer\") (invoke \"") +
            exp->name.str + "\" ";
-    for (Type param : func->sig.params.expand()) {
+    for (auto& param : func->sig.params) {
       // zeros in arguments TODO more?
       TODO_SINGLE_COMPOUND(param);
       switch (param.getBasic()) {

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -111,7 +111,7 @@ static void run_asserts(Name moduleName,
         std::cerr << "Unknown entry " << entry << std::endl;
       } else {
         LiteralList arguments;
-        for (Type param : function->sig.params.expand()) {
+        for (auto& param : function->sig.params) {
           arguments.push_back(Literal(param));
         }
         try {

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
 
     // Emit the parameters (all 0s, like the other wrappers).
     bool first = true;
-    for (auto param : func->sig.params) {
+    for (auto& param : func->sig.params) {
       WASM_UNUSED(param);
       if (!first) {
         ret += ", ";

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -144,7 +144,6 @@ int main(int argc, char** argv) {
 
     // Emit the callee's name with wasm2c name mangling.
     ret += std::string("(*Z_") + exp->name.str + "Z_";
-    auto params = func->sig.params.expand();
 
     auto wasm2cSignature = [](Type type) {
       TODO_SINGLE_COMPOUND(type);
@@ -165,18 +164,18 @@ int main(int argc, char** argv) {
     };
 
     ret += wasm2cSignature(result);
-    if (params.empty()) {
-      ret += wasm2cSignature(Type::none);
-    } else {
-      for (auto param : params) {
+    if (func->sig.params.isMulti()) {
+      for (auto& param : func->sig.params) {
         ret += wasm2cSignature(param);
       }
+    } else {
+      ret += wasm2cSignature(func->sig.params);
     }
     ret += ")(";
 
     // Emit the parameters (all 0s, like the other wrappers).
     bool first = true;
-    for (auto param : params) {
+    for (auto param : func->sig.params) {
       WASM_UNUSED(param);
       if (!first) {
         ret += ", ";

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -657,7 +657,7 @@ public:
     // only ok to add a param if no vars, otherwise indices are invalidated
     assert(func->localIndices.size() == func->sig.params.size());
     assert(name.is());
-    std::vector<Type> params = func->sig.params.expand();
+    std::vector<Type> params(func->sig.params.begin(), func->sig.params.end());
     params.push_back(type);
     func->sig.params = Type(params);
     Index index = func->localNames.size();

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1890,14 +1890,12 @@ private:
         WASM_UNREACHABLE("invalid param count");
       }
       locals.resize(function->getNumLocals());
-      const std::vector<Type>& params = function->sig.params.expand();
       for (size_t i = 0; i < function->getNumLocals(); i++) {
         if (i < arguments.size()) {
-          assert(i < params.size());
-          if (!Type::isSubType(arguments[i].type, params[i])) {
+          if (!Type::isSubType(arguments[i].type, function->sig.params[i])) {
             std::cerr << "Function `" << function->name << "` expects type "
-                      << params[i] << " for parameter " << i << ", got "
-                      << arguments[i].type << "." << std::endl;
+                      << function->sig.params[i] << " for parameter " << i
+                      << ", got " << arguments[i].type << "." << std::endl;
             WASM_UNREACHABLE("invalid param count");
           }
           locals[i] = {arguments[i]};

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -211,7 +211,8 @@ public:
     if (isMulti()) {
       return Iterator(this, (*(std::vector<Type>*)getID()).size());
     } else {
-      // TODO: unreachable expands to {unreachable} currently. change to {}?
+      // TODO: unreachable is special and expands to {unreachable} currently.
+      // see also: https://github.com/WebAssembly/binaryen/issues/3062
       return Iterator(this, size_t(id != Type::none));
     }
   }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -210,6 +210,7 @@ public:
       if (parent->isMulti()) {
         return (*(std::vector<Type>*)parent->getID())[index];
       }
+      assert(*parent != Type::none);
       return *parent;
     }
   };

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -210,7 +210,7 @@ public:
       if (parent->isMulti()) {
         return (*(std::vector<Type>*)parent->getID())[index];
       }
-      assert(*parent != Type::none);
+      assert(index == 0 && *parent != Type::none && "Index out of bounds");
       return *parent;
     }
   };

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -177,7 +177,7 @@ public:
 
   std::string toString() const;
 
-  Type& operator[](size_t i) {
+  const Type& operator[](size_t i) const {
     if (isMulti()) {
       return (*(std::vector<Type>*)getID())[i];
     }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -102,7 +102,7 @@ Literal::Literal(const LaneArray<2>& lanes) : type(Type::v128) {
 Literals Literal::makeZero(Type type) {
   assert(type.isConcrete());
   Literals zeroes;
-  for (auto t : type.expand()) {
+  for (auto& t : type) {
     zeroes.push_back(makeSingleZero(t));
   }
   return zeroes;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -220,7 +220,7 @@ void WasmBinaryWriter::writeTypes() {
     o << S32LEB(BinaryConsts::EncodedType::Func);
     for (auto& sigType : {sig.params, sig.results}) {
       o << U32LEB(sigType.size());
-      for (auto type : sigType.expand()) {
+      for (auto& type : sigType) {
         o << binaryType(type);
       }
     }
@@ -385,16 +385,17 @@ void WasmBinaryWriter::writeGlobals() {
   o << U32LEB(num);
   ModuleUtils::iterDefinedGlobals(*wasm, [&](Global* global) {
     BYN_TRACE("write one\n");
-    const auto& types = global->type.expand();
-    for (size_t i = 0; i < types.size(); ++i) {
-      o << binaryType(types[i]);
+    size_t i = 0;
+    for (auto& t : global->type) {
+      o << binaryType(t);
       o << U32LEB(global->mutable_);
-      if (types.size() == 1) {
+      if (global->type.size() == 1) {
         writeExpression(global->init);
       } else {
         writeExpression(global->init->cast<TupleMake>()->operands[i]);
       }
       o << int8_t(BinaryConsts::End);
+      ++i;
     }
   });
   finishSection(start);
@@ -1385,7 +1386,9 @@ void WasmBinaryBuilder::readImports() {
         wasm.addEvent(curr);
         break;
       }
-      default: { throwError("bad import kind"); }
+      default: {
+        throwError("bad import kind");
+      }
     }
   }
 }
@@ -1795,8 +1798,7 @@ void WasmBinaryBuilder::pushExpression(Expression* curr) {
     Builder builder(wasm);
     Index tuple = builder.addVar(currFunction, curr->type);
     expressionStack.push_back(builder.makeLocalSet(tuple, curr));
-    const std::vector<Type> types = curr->type.expand();
-    for (Index i = 0; i < types.size(); ++i) {
+    for (Index i = 0; i < curr->type.size(); ++i) {
       expressionStack.push_back(
         builder.makeTupleExtract(builder.makeLocalGet(tuple, curr->type), i));
     }

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -486,12 +486,12 @@ AsmConstWalker::AsmConst& AsmConstWalker::createAsmConst(uint32_t id,
 }
 
 Signature AsmConstWalker::asmConstSig(Signature baseSig) {
-  std::vector<Type> params(baseSig.params.begin(), baseSig.params.end());
-  assert(params.size() >= 1);
+  assert(baseSig.params.size() >= 1);
   // Omit the signature of the "code" parameter, taken as a string, as the
   // first argument
-  params.erase(params.begin());
-  return Signature(Type(params), baseSig.results);
+  return Signature(
+    Type(std::vector<Type>(baseSig.params.begin() + 1, baseSig.params.end())),
+    baseSig.results);
 }
 
 Name AsmConstWalker::nameForImportWithSig(Signature sig, Proxying proxy) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -641,7 +641,7 @@ SExpressionWasmBuilder::parseTypeUse(Element& s,
   // If only (type) is specified, populate `namedParams`
   if (!paramsOrResultsExist) {
     size_t index = 0;
-    for (auto param : functionSignature.params) {
+    for (auto& param : functionSignature.params) {
       namedParams.emplace_back(Name::fromInt(index++), param);
     }
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -640,9 +640,9 @@ SExpressionWasmBuilder::parseTypeUse(Element& s,
 
   // If only (type) is specified, populate `namedParams`
   if (!paramsOrResultsExist) {
-    const std::vector<Type>& funcParams = functionSignature.params.expand();
-    for (size_t index = 0, e = funcParams.size(); index < e; index++) {
-      namedParams.emplace_back(Name::fromInt(index), funcParams[index]);
+    size_t index = 0;
+    for (auto param : functionSignature.params) {
+      namedParams.emplace_back(Name::fromInt(index++), param);
     }
   }
 

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1808,17 +1808,16 @@ void BinaryInstWriter::mapLocalsAndEmitHeader() {
     return;
   }
   for (auto type : func->vars) {
-    for (auto t : type.expand()) {
+    for (auto& t : type) {
       numLocalsByType[t]++;
     }
   }
   countScratchLocals();
   std::map<Type, size_t> currLocalsByType;
   for (Index i = func->getVarIndexBase(); i < func->getNumLocals(); i++) {
-    const std::vector<Type> types = func->getLocalType(i).expand();
-    for (Index j = 0; j < types.size(); j++) {
-      Type type = types[j];
-      auto fullIndex = std::make_pair(i, j);
+    Index j = 0;
+    for (auto& type : func->getLocalType(i)) {
+      auto fullIndex = std::make_pair(i, j++);
       Index index = func->getVarIndexBase();
       for (auto& typeCount : numLocalsByType) {
         if (type == typeCount.first) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -56,19 +56,6 @@ namespace {
 
 std::mutex mutex;
 
-std::array<std::vector<Type>, Type::_last_value_type + 1> basicTypes = {
-  {{},
-   {Type::unreachable},
-   {Type::i32},
-   {Type::i64},
-   {Type::f32},
-   {Type::f64},
-   {Type::v128},
-   {Type::funcref},
-   {Type::externref},
-   {Type::nullref},
-   {Type::exnref}}};
-
 // Track unique_ptrs for constructed types to avoid leaks
 std::vector<std::unique_ptr<std::vector<Type>>> constructedTypes;
 
@@ -122,13 +109,6 @@ void Type::init(const std::vector<Type>& types) {
 Type::Type(std::initializer_list<Type> types) { init(types); }
 
 Type::Type(const std::vector<Type>& types) { init(types); }
-
-size_t Type::size() const {
-  if (isMulti()) {
-    return (*(std::vector<Type>*)getID()).size();
-  }
-  return size_t(getID() != Type::none);
-}
 
 bool Type::operator<(const Type& other) const {
   return std::lexicographical_compare((*this).begin(),

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -948,7 +948,7 @@ void TupleExtract::finalize() {
   if (tuple->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
-    type = tuple->type.expand()[index];
+    type = tuple->type[index];
   }
 }
 
@@ -1006,7 +1006,7 @@ Index Function::getVarIndexBase() { return sig.params.size(); }
 Type Function::getLocalType(Index index) {
   auto numParams = sig.params.size();
   if (index < numParams) {
-    return sig.params.expand()[index];
+    return sig.params[index];
   } else if (isVar(index)) {
     return vars[index - numParams];
   } else {


### PR DESCRIPTION
As a follow-up to https://github.com/WebAssembly/binaryen/pull/3012#discussion_r471842763, this PR replaces `Type::expand()` incl. its usages with an iterator-based approach.