### PR TITLE
Use const modifier when dealing with types

### DIFF
--- a/src/asmjs/asm_v_wasm.cpp
+++ b/src/asmjs/asm_v_wasm.cpp
@@ -104,7 +104,7 @@ std::string getSig(Type results, Type params) {
   assert(!results.isMulti());
   std::string sig;
   sig += getSig(results);
-  for (auto& param : params) {
+  for (const auto& param : params) {
     sig += getSig(param);
   }
   return sig;

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -152,7 +152,7 @@ uint32_t BinaryenTypeArity(BinaryenType t) { return Type(t).size(); }
 void BinaryenTypeExpand(BinaryenType t, BinaryenType* buf) {
   Type types(t);
   size_t i = 0;
-  for (auto& type : types) {
+  for (const auto& type : types) {
     buf[i++] = type.getID();
   }
 }

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1306,7 +1306,7 @@ private:
       }
       auto localType = func->getLocalType(i);
       SmallVector<Expression*, 1> loads;
-      for (auto& type : localType) {
+      for (const auto& type : localType) {
         auto size = type.getByteSize();
         assert(size % STACK_ALIGN == 0);
         // TODO: higher alignment?
@@ -1350,7 +1350,7 @@ private:
       }
       auto localType = func->getLocalType(i);
       size_t j = 0;
-      for (auto& type : localType) {
+      for (const auto& type : localType) {
         auto size = type.getByteSize();
         Expression* localGet = builder->makeLocalGet(i, localType);
         if (localType.size() > 1) {

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -197,7 +197,7 @@ private:
     Builder builder(*module);
     std::vector<Expression*> callOperands;
     Index i = 0;
-    for (auto& param : func->sig.params) {
+    for (const auto& param : func->sig.params) {
       callOperands.push_back(
         fromABI(builder.makeLocalGet(i++, Type::i64), param, module));
     }

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -272,7 +272,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     visitGenericCall<CallIndirect>(
       curr, [&](std::vector<Expression*>& args, Type results) {
         std::vector<Type> params;
-        for (auto& param : curr->sig.params) {
+        for (const auto& param : curr->sig.params) {
           if (param == Type::i64) {
             params.push_back(Type::i32);
             params.push_back(Type::i32);

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -183,7 +183,7 @@ private:
   std::map<Name, Name> illegalImportsToLegal;
 
   template<typename T> bool isIllegal(T* t) {
-    for (auto& param : t->sig.params) {
+    for (const auto& param : t->sig.params) {
       if (param == Type::i64) {
         return true;
       }
@@ -223,7 +223,7 @@ private:
     call->type = func->sig.results;
 
     std::vector<Type> legalParams;
-    for (auto& param : func->sig.params) {
+    for (const auto& param : func->sig.params) {
       if (param == Type::i64) {
         call->operands.push_back(I64Utilities::recreateI64(
           builder, legalParams.size(), legalParams.size() + 1));
@@ -278,7 +278,7 @@ private:
 
     std::vector<Type> params;
     Index i = 0;
-    for (auto& param : im->sig.params) {
+    for (const auto& param : im->sig.params) {
       if (param == Type::i64) {
         call->operands.push_back(I64Utilities::getI64Low(builder, i));
         call->operands.push_back(I64Utilities::getI64High(builder, i));

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -69,7 +69,7 @@ static std::ostream& operator<<(std::ostream& o, const SExprType& localType) {
   if (type.isMulti()) {
     o << '(';
     auto sep = "";
-    for (auto& t : type) {
+    for (const auto& t : type) {
       o << sep << t;
       sep = " ";
     }
@@ -92,7 +92,7 @@ std::ostream& operator<<(std::ostream& os, SigName sigName) {
       os << "none";
     } else {
       auto sep = "";
-      for (auto& t : type) {
+      for (const auto& t : type) {
         os << sep << t;
         sep = "_";
       }
@@ -2170,7 +2170,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     }
     if (curr->sig.params.size() > 0) {
       Index i = 0;
-      for (auto& param : curr->sig.params) {
+      for (const auto& param : curr->sig.params) {
         o << maybeSpace;
         o << '(';
         printMinor(o, "param ");

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -169,7 +169,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
       trap("callIndirect: bad # of arguments");
     }
     size_t i = 0;
-    for (auto& param : func->sig.params) {
+    for (const auto& param : func->sig.params) {
       if (!Type::isSubType(arguments[i++].type, param)) {
         trap("callIndirect: bad argument type");
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -144,7 +144,7 @@ struct ExecutionResults {
         instance.callFunction(ex->value, arguments);
       }
       // call the method
-      for (auto& param : func->sig.params) {
+      for (const auto& param : func->sig.params) {
         // zeros in arguments TODO: more?
         arguments.push_back(Literal::makeSingleZero(param));
       }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -308,7 +308,7 @@ private:
   Type getSubType(Type type) {
     if (type.isMulti()) {
       std::vector<Type> types;
-      for (auto& t : type) {
+      for (const auto& t : type) {
         types.push_back(getSubType(t));
       }
       return Type(types);
@@ -770,7 +770,7 @@ private:
     std::vector<Expression*> invocations;
     while (oneIn(2) && !finishedInput) {
       std::vector<Expression*> args;
-      for (auto& type : func->sig.params) {
+      for (const auto& type : func->sig.params) {
         args.push_back(makeConst(type));
       }
       Expression* invoke =
@@ -1166,7 +1166,7 @@ private:
       }
       // we found one!
       std::vector<Expression*> args;
-      for (auto& argType : target->sig.params) {
+      for (const auto& argType : target->sig.params) {
         args.push_back(make(argType));
       }
       return builder.makeCall(target->name, args, type, isReturn);
@@ -1210,7 +1210,7 @@ private:
       target = make(Type::i32);
     }
     std::vector<Expression*> args;
-    for (auto& type : targetFn->sig.params) {
+    for (const auto& type : targetFn->sig.params) {
       args.push_back(make(type));
     }
     return builder.makeCallIndirect(target, args, targetFn->sig, isReturn);
@@ -1267,7 +1267,7 @@ private:
     assert(wasm.features.hasMultivalue());
     assert(type.isMulti());
     std::vector<Expression*> elements;
-    for (auto& t : type) {
+    for (const auto& t : type) {
       elements.push_back(make(t));
     }
     return builder.makeTupleMake(std::move(elements));
@@ -1281,7 +1281,7 @@ private:
     // Find indices from which we can extract `type`
     std::vector<size_t> extractIndices;
     size_t i = 0;
-    for (auto& t : tupleType) {
+    for (const auto& t : tupleType) {
       if (t == type) {
         extractIndices.push_back(i);
       }
@@ -1767,7 +1767,7 @@ private:
     }
     if (type.isMulti()) {
       std::vector<Expression*> operands;
-      for (auto& t : type) {
+      for (const auto& t : type) {
         operands.push_back(makeConst(t));
       }
       return builder.makeTupleMake(std::move(operands));

--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -99,7 +99,7 @@ static std::string generateJSWrapper(Module& wasm) {
     }
     ret += std::string("instance.exports.") + exp->name.str + "(";
     bool first = true;
-    for (auto& param : func->sig.params) {
+    for (const auto& param : func->sig.params) {
       // zeros in arguments TODO more?
       if (first) {
         first = false;

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -30,7 +30,7 @@ static std::string generateSpecWrapper(Module& wasm) {
     }
     ret += std::string("(invoke \"hangLimitInitializer\") (invoke \"") +
            exp->name.str + "\" ";
-    for (auto& param : func->sig.params) {
+    for (const auto& param : func->sig.params) {
       // zeros in arguments TODO more?
       TODO_SINGLE_COMPOUND(param);
       switch (param.getBasic()) {

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -111,7 +111,7 @@ static void run_asserts(Name moduleName,
         std::cerr << "Unknown entry " << entry << std::endl;
       } else {
         LiteralList arguments;
-        for (auto& param : function->sig.params) {
+        for (const auto& param : function->sig.params) {
           arguments.push_back(Literal(param));
         }
         try {

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -165,7 +165,7 @@ int main(int argc, char** argv) {
 
     ret += wasm2cSignature(result);
     if (func->sig.params.isMulti()) {
-      for (auto& param : func->sig.params) {
+      for (const auto& param : func->sig.params) {
         ret += wasm2cSignature(param);
       }
     } else {
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
 
     // Emit the parameters (all 0s, like the other wrappers).
     bool first = true;
-    for (auto& param : func->sig.params) {
+    for (const auto& param : func->sig.params) {
       WASM_UNUSED(param);
       if (!first) {
         ret += ", ";

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -112,7 +112,7 @@ public:
 
 private:
   template<bool (Type::*pred)() const> bool hasPredicate() {
-    for (auto& type : *this) {
+    for (const auto& type : *this) {
       if ((type.*pred)()) {
         return true;
       }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -102,7 +102,7 @@ Literal::Literal(const LaneArray<2>& lanes) : type(Type::v128) {
 Literals Literal::makeZero(Type type) {
   assert(type.isConcrete());
   Literals zeroes;
-  for (auto& t : type) {
+  for (const auto& t : type) {
     zeroes.push_back(makeSingleZero(t));
   }
   return zeroes;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -220,7 +220,7 @@ void WasmBinaryWriter::writeTypes() {
     o << S32LEB(BinaryConsts::EncodedType::Func);
     for (auto& sigType : {sig.params, sig.results}) {
       o << U32LEB(sigType.size());
-      for (auto& type : sigType) {
+      for (const auto& type : sigType) {
         o << binaryType(type);
       }
     }
@@ -386,7 +386,7 @@ void WasmBinaryWriter::writeGlobals() {
   ModuleUtils::iterDefinedGlobals(*wasm, [&](Global* global) {
     BYN_TRACE("write one\n");
     size_t i = 0;
-    for (auto& t : global->type) {
+    for (const auto& t : global->type) {
       o << binaryType(t);
       o << U32LEB(global->mutable_);
       if (global->type.size() == 1) {

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -154,14 +154,14 @@ void EmscriptenGlueGenerator::generateDynCallThunk(Signature sig) {
   std::vector<NameType> params;
   params.emplace_back("fptr", Type::i32); // function pointer param
   int p = 0;
-  for (auto& param : sig.params) {
+  for (const auto& param : sig.params) {
     params.emplace_back(std::to_string(p++), param);
   }
   Function* f = builder.makeFunction(name, std::move(params), sig.results, {});
   Expression* fptr = builder.makeLocalGet(0, Type::i32);
   std::vector<Expression*> args;
   Index i = 0;
-  for (auto& param : sig.params) {
+  for (const auto& param : sig.params) {
     args.push_back(builder.makeLocalGet(++i, param));
   }
   Expression* call = builder.makeCallIndirect(fptr, args, sig);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -641,7 +641,7 @@ SExpressionWasmBuilder::parseTypeUse(Element& s,
   // If only (type) is specified, populate `namedParams`
   if (!paramsOrResultsExist) {
     size_t index = 0;
-    for (auto& param : functionSignature.params) {
+    for (const auto& param : functionSignature.params) {
       namedParams.emplace_back(Name::fromInt(index++), param);
     }
   }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1808,7 +1808,7 @@ void BinaryInstWriter::mapLocalsAndEmitHeader() {
     return;
   }
   for (auto type : func->vars) {
-    for (auto& t : type) {
+    for (const auto& t : type) {
       numLocalsByType[t]++;
     }
   }
@@ -1816,7 +1816,7 @@ void BinaryInstWriter::mapLocalsAndEmitHeader() {
   std::map<Type, size_t> currLocalsByType;
   for (Index i = func->getVarIndexBase(); i < func->getNumLocals(); i++) {
     Index j = 0;
-    for (auto& type : func->getLocalType(i)) {
+    for (const auto& type : func->getLocalType(i)) {
       auto fullIndex = std::make_pair(i, j++);
       Index index = func->getVarIndexBase();
       for (auto& typeCount : numLocalsByType) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -147,7 +147,7 @@ unsigned Type::getByteSize() const {
 
   if (isMulti()) {
     unsigned size = 0;
-    for (auto& t : *this) {
+    for (const auto& t : *this) {
       size += getSingleByteSize(t);
     }
     return size;
@@ -197,7 +197,7 @@ FeatureSet Type::getFeatures() const {
 
   if (isMulti()) {
     FeatureSet feats = FeatureSet::Multivalue;
-    for (auto& t : *this) {
+    for (const auto& t : *this) {
       feats |= getSingleFeatures(t);
     }
     return feats;
@@ -284,7 +284,7 @@ namespace {
 std::ostream&
 printPrefixedTypes(std::ostream& os, const char* prefix, Type type) {
   os << '(' << prefix;
-  for (auto& t : type) {
+  for (const auto& t : type) {
     os << " " << t;
   }
   os << ')';
@@ -319,7 +319,7 @@ std::ostream& operator<<(std::ostream& os, Type type) {
   if (type.isMulti()) {
     os << '(';
     auto sep = "";
-    for (auto& t : type) {
+    for (const auto& t : type) {
       os << sep << t;
       sep = ", ";
     }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -647,7 +647,7 @@ void FunctionValidator::visitCall(Call* curr) {
     return;
   }
   size_t i = 0;
-  for (auto& param : target->sig.params) {
+  for (const auto& param : target->sig.params) {
     if (!shouldBeSubTypeOrFirstIsUnreachable(curr->operands[i]->type,
                                              param,
                                              curr,
@@ -703,7 +703,7 @@ void FunctionValidator::visitCallIndirect(CallIndirect* curr) {
     return;
   }
   size_t i = 0;
-  for (auto& param : curr->sig.params) {
+  for (const auto& param : curr->sig.params) {
     if (!shouldBeSubTypeOrFirstIsUnreachable(curr->operands[i]->type,
                                              param,
                                              curr,
@@ -1874,7 +1874,7 @@ void FunctionValidator::visitThrow(Throw* curr) {
     return;
   }
   size_t i = 0;
-  for (auto& param : event->sig.params) {
+  for (const auto& param : event->sig.params) {
     if (!shouldBeSubTypeOrFirstIsUnreachable(curr->operands[i]->type,
                                              param,
                                              curr->operands[i],
@@ -1975,15 +1975,15 @@ void FunctionValidator::visitFunction(Function* curr) {
                  "Multivalue function results (multivalue is not enabled)");
   }
   FeatureSet features;
-  for (auto& param : curr->sig.params) {
+  for (const auto& param : curr->sig.params) {
     features |= param.getFeatures();
     shouldBeTrue(param.isConcrete(), curr, "params must be concretely typed");
   }
-  for (auto& result : curr->sig.results) {
+  for (const auto& result : curr->sig.results) {
     features |= result.getFeatures();
     shouldBeTrue(result.isConcrete(), curr, "results must be concretely typed");
   }
-  for (auto& var : curr->vars) {
+  for (const auto& var : curr->vars) {
     features |= var.getFeatures();
     shouldBeTrue(var.isConcrete(), curr, "vars must be concretely typed");
   }
@@ -2144,13 +2144,13 @@ static void validateImports(Module& module, ValidationInfo& info) {
                         "(multivalue is not enabled)");
     }
     if (info.validateWeb) {
-      for (auto& param : curr->sig.params) {
+      for (const auto& param : curr->sig.params) {
         info.shouldBeUnequal(param,
                              Type(Type::i64),
                              curr->name,
                              "Imported function must not have i64 parameters");
       }
-      for (auto& result : curr->sig.results) {
+      for (const auto& result : curr->sig.results) {
         info.shouldBeUnequal(result,
                              Type(Type::i64),
                              curr->name,
@@ -2173,14 +2173,14 @@ static void validateExports(Module& module, ValidationInfo& info) {
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
         Function* f = module.getFunction(curr->value);
-        for (auto& param : f->sig.params) {
+        for (const auto& param : f->sig.params) {
           info.shouldBeUnequal(
             param,
             Type(Type::i64),
             f->name,
             "Exported function must not have i64 parameters");
         }
-        for (auto& result : f->sig.results) {
+        for (const auto& result : f->sig.results) {
           info.shouldBeUnequal(result,
                                Type(Type::i64),
                                f->name,
@@ -2352,7 +2352,7 @@ static void validateEvents(Module& module, ValidationInfo& info) {
                         curr->name,
                         "Multivalue event type (multivalue is not enabled)");
     }
-    for (auto& param : curr->sig.params) {
+    for (const auto& param : curr->sig.params) {
       info.shouldBeTrue(param.isConcrete(),
                         curr->name,
                         "Values in an event should have concrete types");


### PR DESCRIPTION
As a follow-up to https://github.com/WebAssembly/binaryen/pull/3012#discussion_r473756121, this PR

* Changes the use of `auto&`  introduced in https://github.com/WebAssembly/binaryen/pull/3061 to `const auto&` for clarity when dealing with `Type`s