### PR TITLE
Stop building with assertions by default even in release builds. Fixes #3058

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
-# We default to assertions enabled, even in release builds so that we get
-# more useful error reports from users.
-option(BYN_ENABLE_ASSERTIONS "Enable assertions" ON)
-
 # For git users, attempt to generate a more useful version string
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git QUIET REQUIRED)
@@ -152,11 +148,6 @@ if(MSVC)
   # Don't warn about using "strdup" as a reserved name.
   add_compile_flag("/D_CRT_NONSTDC_NO_DEPRECATE")
 
-  if(BYN_ENABLE_ASSERTIONS)
-    # On non-Debug builds cmake automatically defines NDEBUG, so we
-    # explicitly undefine it:
-    add_nondebug_compile_flag("/UNDEBUG") # Keep asserts.
-  endif()
   # Also remove /D NDEBUG to avoid MSVC warnings about conflicting defines.
   if( NOT CMAKE_BUILD_TYPE MATCHES "Debug" )
     foreach(flags_var_to_scrub
@@ -223,11 +214,6 @@ else()
     add_nondebug_compile_flag("-Oz")
   else()
     add_nondebug_compile_flag("-O2")
-  endif()
-  if(BYN_ENABLE_ASSERTIONS)
-    # On non-Debug builds cmake automatically defines NDEBUG, so we
-    # explicitly undefine it:
-    add_nondebug_compile_flag("-UNDEBUG")
   endif()
 endif()
 

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -44,12 +44,6 @@ void setDebugEnabled(const char* types);
 
 #else
 
-// We have an option to build with assertions disabled
-// BYN_ASSERTIONS_ENABLED=OFF, but we currently don't recommend using and we
-// don't test with it.
-#error "binaryen is currently designed to be built with assertions enabled."
-#error "remove these #errors if you want to build without them anyway."
-
 #define BYN_DEBUG_WITH_TYPE(...)                                               \
   do {                                                                         \
   } while (false)

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1432,8 +1432,7 @@ public:
     if (!(flags & FlagValues::PRESERVE_SIDEEFFECTS) && module != nullptr) {
       // If we are evaluating and not replacing the expression, remember the
       // constant value set, if any, for subsequent gets.
-      auto* global = module->getGlobal(curr->name);
-      assert(global->mutable_);
+      assert(module->getGlobal(curr->name)->mutable_);
       auto setFlow = ExpressionRunner<SubType>::visit(curr->value);
       if (!setFlow.breaking()) {
         setGlobalValue(curr->name, setFlow.values);

--- a/third_party/llvm-project/Twine.cpp
+++ b/third_party/llvm-project/Twine.cpp
@@ -173,7 +173,7 @@ void Twine::printRepr(raw_ostream &OS) const {
   OS << ")";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
+// XXX BINARYEN #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Twine::dump() const {
   print(dbgs());
 }
@@ -181,4 +181,4 @@ LLVM_DUMP_METHOD void Twine::dump() const {
 LLVM_DUMP_METHOD void Twine::dumpRepr() const {
   printRepr(dbgs());
 }
-#endif
+// XXX BINARYEN #endif


### PR DESCRIPTION
As mentioned in #3058 this made sense in the early days when bugs were
everywhere, but we probably don't need all our users doing this all the time.

Some numbers: Testing on two benchmarks, this makes us about 5% faster,
and builds are 8% smaller.

Maybe we should add a CI run with assertions though?