### PR TITLE
Remove old EM_ASM handling method

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -56,6 +56,7 @@ int main(int argc, const char* argv[]) {
   bool checkStackOverflow = false;
   uint64_t globalBase = INVALID_BASE;
   bool standaloneWasm = false;
+  // TODO: remove after https://github.com/WebAssembly/binaryen/issues/3043
   bool minimizeWasmChanges = false;
 
   ToolOptions options("wasm-emscripten-finalize",

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -445,9 +445,9 @@ void AsmConstWalker::process() {
 }
 
 void AsmConstWalker::createAsmConst(uint32_t id,
-                                                         std::string code,
-                                                         Signature sig,
-                                                         Name name) {
+                                    std::string code,
+                                    Signature sig,
+                                    Name name) {
   AsmConst asmConst;
   asmConst.id = id;
   asmConst.code = code;

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -343,14 +343,11 @@ struct AsmConstWalker : public LinearExecutionWalker<AsmConstWalker> {
 
   void visitLocalSet(LocalSet* curr);
   void visitCall(Call* curr);
-  void visitTable(Table* curr);
 
   void process();
 
 private:
-  Signature fixupName(Name& name, Signature baseSig, Proxying proxy);
-  AsmConst&
-  createAsmConst(uint32_t id, std::string code, Signature sig, Name name);
+  void createAsmConst(uint32_t id, std::string code, Signature sig, Name name);
   Signature asmConstSig(Signature baseSig);
   Name nameForImportWithSig(Signature sig, Proxying proxy);
   void queueImport(Name importName, Signature baseSig);
@@ -427,10 +424,7 @@ void AsmConstWalker::visitCall(Call* curr) {
   auto* value = arg->cast<Const>();
   int32_t address = value->value.geti32();
   auto code = codeForConstAddr(wasm, segmentOffsets, address);
-  auto& asmConst = createAsmConst(address, code, sig, importName);
-  if (!minimizeWasmChanges) {
-    fixupName(curr->target, baseSig, asmConst.proxy);
-  }
+  createAsmConst(address, code, sig, importName);
 }
 
 Proxying AsmConstWalker::proxyType(Name name) {
@@ -442,21 +436,6 @@ Proxying AsmConstWalker::proxyType(Name name) {
   return Proxying::None;
 }
 
-void AsmConstWalker::visitTable(Table* curr) {
-  if (minimizeWasmChanges) {
-    return;
-  }
-  for (auto& segment : curr->segments) {
-    for (auto& name : segment.data) {
-      auto* func = wasm.getFunction(name);
-      if (func->imported() && func->base.hasSubstring(EM_ASM_PREFIX)) {
-        auto proxy = proxyType(func->base);
-        fixupName(name, func->sig, proxy);
-      }
-    }
-  }
-}
-
 void AsmConstWalker::process() {
   // Find and queue necessary imports
   walkModule(&wasm);
@@ -465,21 +444,7 @@ void AsmConstWalker::process() {
   addImports();
 }
 
-Signature
-AsmConstWalker::fixupName(Name& name, Signature baseSig, Proxying proxy) {
-  auto sig = asmConstSig(baseSig);
-  auto importName = nameForImportWithSig(sig, proxy);
-  name = importName;
-
-  auto pair = std::make_pair(sig, proxy);
-  if (allSigs.count(pair) == 0) {
-    allSigs.insert(pair);
-    queueImport(importName, baseSig);
-  }
-  return sig;
-}
-
-AsmConstWalker::AsmConst& AsmConstWalker::createAsmConst(uint32_t id,
+void AsmConstWalker::createAsmConst(uint32_t id,
                                                          std::string code,
                                                          Signature sig,
                                                          Name name) {
@@ -489,7 +454,6 @@ AsmConstWalker::AsmConst& AsmConstWalker::createAsmConst(uint32_t id,
   asmConst.sigs.insert(sig);
   asmConst.proxy = proxyType(name);
   asmConsts.push_back(asmConst);
-  return asmConsts.back();
 }
 
 Signature AsmConstWalker::asmConstSig(Signature baseSig) {
@@ -524,28 +488,8 @@ void AsmConstWalker::addImports() {
 
 static AsmConstWalker fixEmAsmConstsAndReturnWalker(Module& wasm,
                                                     bool minimizeWasmChanges) {
-  // Collect imports to remove
-  // This would find our generated functions if we ran it later
-  std::vector<Name> toRemove;
-  if (!minimizeWasmChanges) {
-    for (auto& import : wasm.functions) {
-      if (import->imported() && import->base.hasSubstring(EM_ASM_PREFIX)) {
-        toRemove.push_back(import->name);
-      }
-    }
-  }
-
-  // Walk the module, generate _sig versions of EM_ASM functions
   AsmConstWalker walker(wasm, minimizeWasmChanges);
   walker.process();
-
-  if (!minimizeWasmChanges) {
-    // Remove the base functions that we didn't generate
-    for (auto importName : toRemove) {
-      wasm.removeFunction(importName);
-    }
-  }
-
   return walker;
 }
 
@@ -823,7 +767,6 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
   commaFirst = true;
   ModuleUtils::iterImportedFunctions(wasm, [&](Function* import) {
     if (emJsWalker.codeByName.count(import->base.str) == 0 &&
-        (minimizeWasmChanges || !import->base.startsWith(EM_ASM_PREFIX.str)) &&
         !import->base.startsWith("invoke_")) {
       if (declares.insert(import->base.str).second) {
         meta << nextElement() << '"' << import->base.str << '"';


### PR DESCRIPTION
The `minimizeWasmChanges` flag now does nothing (but new changes are
coming, so keep it around).

See #3043