### PR TITLE
Fix optimize memory.copy: check size for side effect as well

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1404,6 +1404,8 @@ private:
     // memory.copy(x, x, sz)  ==>  nop
     if (!EffectAnalyzer(getPassOptions(), features, memCopy->dest)
            .hasSideEffects() &&
+        !EffectAnalyzer(getPassOptions(), features, memCopy->size)
+           .hasSideEffects() &&
         ExpressionAnalyzer::equal(memCopy->dest, memCopy->source)) {
       return ExpressionManipulator::nop(memCopy);
     }

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3793,6 +3793,13 @@
    (local.get $src)
    (local.get $sz)
   )
+  (memory.copy
+   (i32.const 0)
+   (i32.const 0)
+   (i32.load
+    (i32.const 3)
+   )
+  )
  )
 )
 (module

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4294,7 +4294,7 @@
       (i32.const 8)
     )
 
-     (memory.copy
+    (memory.copy
       (local.get $dst)
       (local.get $src)
       (i32.const 16)
@@ -4304,6 +4304,14 @@
       (local.get $dst)
       (local.get $src)
       (local.get $sz)
+    )
+
+    (memory.copy  ;; skip
+      (i32.const 0)
+      (i32.const 0)
+      (i32.load
+        (i32.const 3) ;; side effect
+      )
     )
   )
 )


### PR DESCRIPTION
Fix issue found by fuzzer: https://github.com/WebAssembly/binaryen/pull/3038#issuecomment-678780340