### PR TITLE
Remove optimization for memory.copy(x, x, C)

### DIFF
--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3729,7 +3729,11 @@
   )
  )
  (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
-  (nop)
+  (memory.copy
+   (local.get $dst)
+   (local.get $dst)
+   (local.get $sz)
+  )
   (block
    (drop
     (local.get $dst)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4234,7 +4234,7 @@
     ))
   )
   (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
-    (memory.copy  ;; nop
+    (memory.copy  ;; skip
       (local.get $dst)
       (local.get $dst)
       (local.get $sz)


### PR DESCRIPTION
It seems we couldn't simply remove `memory.copy(x, x, C)` even if all arguments are side effect free due to `x` value could exceeds memory bounds.

See: https://github.com/WebAssembly/binaryen/pull/3038#issuecomment-678790358