### PR TITLE
memory.copy: use nop reductions only for ignoreImplicitTraps

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1405,11 +1405,6 @@ private:
       Builder builder(*getModule());
 
       switch (bytes) {
-        case 0: {
-          return builder.makeBlock({builder.makeDrop(memCopy->dest),
-                                    builder.makeDrop(memCopy->source)});
-          break;
-        }
         case 1:
         case 2:
         case 4: {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1399,12 +1399,29 @@ private:
   }
 
   Expression* optimizeMemoryCopy(MemoryCopy* memCopy) {
+    PassOptions options = getPassOptions();
+
+    if (options.ignoreImplicitTraps) {
+      if (ExpressionAnalyzer::equal(memCopy->dest, memCopy->source)) {
+        Builder builder(*getModule());
+        return builder.makeBlock(
+          {builder.makeDrop(memCopy->dest), builder.makeDrop(memCopy->source)});
+      }
+    }
+
     // memory.copy(dst, src, C)  ==>  store(dst, load(src))
     if (auto* csize = memCopy->size->dynCast<Const>()) {
       auto bytes = csize->value.geti32();
       Builder builder(*getModule());
 
       switch (bytes) {
+        case 0: {
+          if (options.ignoreImplicitTraps) {
+            return builder.makeBlock({builder.makeDrop(memCopy->dest),
+                                      builder.makeDrop(memCopy->source)});
+          }
+          break;
+        }
         case 1:
         case 2:
         case 4: {
@@ -1426,7 +1443,7 @@ private:
             Type::i64);
         }
         case 16: {
-          if (getPassOptions().shrinkLevel == 0) {
+          if (options.shrinkLevel == 0) {
             // This adds an extra 2 bytes so apply it only for
             // minimal shrink level
             if (getModule()->features.hasSIMD()) {

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3734,13 +3734,10 @@
    (local.get $dst)
    (local.get $sz)
   )
-  (block
-   (drop
-    (local.get $dst)
-   )
-   (drop
-    (local.get $src)
-   )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (i32.const 0)
   )
   (i32.store8
    (local.get $dst)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4240,7 +4240,7 @@
       (local.get $sz)
     )
 
-    (memory.copy  ;; nop
+    (memory.copy  ;; skip
       (local.get $dst)
       (local.get $src)
       (i32.const 0)

--- a/test/passes/optimize-instructions_optimize-level=2_all-features_ignore-implicit-traps.txt
+++ b/test/passes/optimize-instructions_optimize-level=2_all-features_ignore-implicit-traps.txt
@@ -1,5 +1,6 @@
 (module
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_f64 (func (result f64)))
  (memory $0 0)
  (func $conditionals (param $0 i32) (param $1 i32) (result i32)
@@ -358,5 +359,23 @@
    )
   )
   (f64.const -nan:0xfffffffffffff)
+ )
+ (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
+  (block
+   (drop
+    (local.get $dst)
+   )
+   (drop
+    (local.get $dst)
+   )
+  )
+  (block
+   (drop
+    (local.get $dst)
+   )
+   (drop
+    (local.get $src)
+   )
+  )
  )
 )

--- a/test/passes/optimize-instructions_optimize-level=2_all-features_ignore-implicit-traps.wast
+++ b/test/passes/optimize-instructions_optimize-level=2_all-features_ignore-implicit-traps.wast
@@ -361,5 +361,18 @@
   )
   (f64.const -nan:0xfffffffffffff)
  )
+ (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
+  (memory.copy  ;; nop
+    (local.get $dst)
+    (local.get $dst)
+    (local.get $sz)
+  )
+
+  (memory.copy  ;; nop
+    (local.get $dst)
+    (local.get $src)
+    (i32.const 0)
+  )
+ )
 )
 


### PR DESCRIPTION
According to changes in spec:
https://github.com/WebAssembly/bulk-memory-operations/issues/124
https://github.com/WebAssembly/bulk-memory-operations/issues/145

we unfortunately can't fold to `nop` even for `memory.copy(x, y, 0)`.

So this PR revert all reductions to `nop` but do this only under `ignoreImplicitTraps` flag