### PR TITLE
memory.copy: Also drop size for memory.copy(x, x, y) case

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1403,9 +1403,11 @@ private:
 
     if (options.ignoreImplicitTraps) {
       if (ExpressionAnalyzer::equal(memCopy->dest, memCopy->source)) {
+        // memory.copy(x, x, sz)  ==>  {drop(x), drop(x), drop(sz)}
         Builder builder(*getModule());
-        return builder.makeBlock(
-          {builder.makeDrop(memCopy->dest), builder.makeDrop(memCopy->source)});
+        return builder.makeBlock({builder.makeDrop(memCopy->dest),
+                                  builder.makeDrop(memCopy->source),
+                                  builder.makeDrop(memCopy->size)});
       }
     }
 
@@ -1417,6 +1419,7 @@ private:
       switch (bytes) {
         case 0: {
           if (options.ignoreImplicitTraps) {
+            // memory.copy(dst, src, 0)  ==>  {drop(dst), drop(src)}
             return builder.makeBlock({builder.makeDrop(memCopy->dest),
                                       builder.makeDrop(memCopy->source)});
           }

--- a/test/passes/optimize-instructions_optimize-level=2_all-features_ignore-implicit-traps.txt
+++ b/test/passes/optimize-instructions_optimize-level=2_all-features_ignore-implicit-traps.txt
@@ -368,6 +368,9 @@
    (drop
     (local.get $dst)
    )
+   (drop
+    (local.get $sz)
+   )
   )
   (block
    (drop


### PR DESCRIPTION
Post addition for #3074  