### PR TITLE
SAFE_HEAP: remove fastcomp, prepare for new emscripten approach

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -69,10 +69,15 @@ struct AccessInstrumenter : public WalkerPass<PostWalker<AccessInstrumenter>> {
 
   bool isFunctionParallel() override { return true; }
 
-  AccessInstrumenter* create(Name funcToIgnore) override { return new AccessInstrumenter(funcToIgnore); }
+  AccessInstrumenter* create() override {
+    return new AccessInstrumenter(funcToIgnore);
+  }
+
+  AccessInstrumenter(Name funcToIgnore) : funcToIgnore(funcToIgnore) {}
 
   void visitLoad(Load* curr) {
-    if (getFunction()->name == funcToIgnore || curr->type == Type::unreachable) {
+    if (getFunction()->name == funcToIgnore ||
+        curr->type == Type::unreachable) {
       return;
     }
     Builder builder(*getModule());
@@ -86,7 +91,8 @@ struct AccessInstrumenter : public WalkerPass<PostWalker<AccessInstrumenter>> {
   }
 
   void visitStore(Store* curr) {
-    if (getFunction()->name == funcToIgnore || curr->type == Type::unreachable) {
+    if (getFunction()->name == funcToIgnore ||
+        curr->type == Type::unreachable) {
       return;
     }
     Builder builder(*getModule());
@@ -123,8 +129,7 @@ struct SafeHeap : public Pass {
     // Newer emscripten imports or exports emscripten_get_sbrk_ptr().
     if (auto* existing = info.getImportedGlobal(ENV, DYNAMICTOP_PTR_IMPORT)) {
       dynamicTopPtr = existing->name;
-    } else if (auto* existing =
-                 info.getImportedFunction(ENV, GET_SBRK_PTR)) {
+    } else if (auto* existing = info.getImportedFunction(ENV, GET_SBRK_PTR)) {
       getSbrkPtr = existing->name;
     } else if (auto* existing = module->getExportOrNull(GET_SBRK_PTR)) {
       getSbrkPtr = existing->value;

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -5753,8 +5753,7 @@
  (export "emscripten_get_sbrk_ptr" (func $foo))
  (func $foo (result i32)
   (drop
-   (call $SAFE_HEAP_LOAD_i32_4_4
-    (i32.const 0)
+   (i32.load
     (i32.const 0)
    )
   )

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -5750,8 +5750,14 @@
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 1 1)
- (export "_emscripten_get_sbrk_ptr" (func $foo))
+ (export "emscripten_get_sbrk_ptr" (func $foo))
  (func $foo (result i32)
+  (drop
+   (call $SAFE_HEAP_LOAD_i32_4_4
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
   (i32.const 1234)
  )
  (func $SAFE_HEAP_LOAD_i32_1_1 (param $0 i32) (param $1 i32) (result i32)

--- a/test/passes/safe-heap_disable-simd.wast
+++ b/test/passes/safe-heap_disable-simd.wast
@@ -11,8 +11,9 @@
 )
 (module
   (memory 1 1)
-  (export "_emscripten_get_sbrk_ptr" (func $foo))
+  (export "emscripten_get_sbrk_ptr" (func $foo))
   (func $foo (result i32)
+   (drop (i32.load (i32.const 0))) ;; should not be modified!
    (i32.const 1234)
   )
 )


### PR DESCRIPTION
In fastcomp we implemented `emscripten_get_sbrk_ptr` in wasm, and
exported `_emscripten_get_sbrk_ptr`. We don't need that anymore and
can remove it.

However I want to switch us to implementing `emscripten_get_sbrk_ptr`
in wasm in upstream too, as part of removing `DYNAMICTOP_PTR` and
other silliness that we have around link (https://github.com/WebAssembly/binaryen/issues/3043).

This makes us support an export of `emscripten_get_sbrk_ptr` (no
prefix), and also it makes sure not to instrument that function, which
may contain some memory operations itself, but if we SAFE_HEAP-ify
them we'd get infinite recursion, as the SAFE_HEAP methods need to
call that.