### PR TITLE
Match and fold cyclic shift patterns to rotr / rotl

### DIFF
--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -40,6 +40,8 @@ enum Op {
   Shl,
   ShrU,
   ShrS,
+  RotL,
+  RotR,
   And,
   Or,
   Xor,
@@ -137,6 +139,10 @@ inline BinaryOp getBinary(Type type, Op op) {
           return ShrUInt32;
         case ShrS:
           return ShrSInt32;
+        case RotL:
+          return RotLInt32;
+        case RotR:
+          return RotRInt32;
         case And:
           return AndInt32;
         case Or:
@@ -190,6 +196,10 @@ inline BinaryOp getBinary(Type type, Op op) {
           return ShrUInt64;
         case ShrS:
           return ShrSInt64;
+        case RotL:
+          return RotLInt64;
+        case RotR:
+          return RotRInt64;
         case And:
           return AndInt64;
         case Or:

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -11,6 +11,7 @@
  (type $i32_i64_f32_=>_none (func (param i32 i64 f32)))
  (type $i32_i64_f32_f64_=>_none (func (param i32 i64 f32 f64)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $i32_i32_i64_i64_=>_none (func (param i32 i32 i64 i64)))
  (type $i32_i32_f64_f64_=>_none (func (param i32 i32 f64 f64)))
  (type $i32_i64_f64_i32_=>_none (func (param i32 i64 f64 i32)))
  (type $none_=>_f64 (func (result f64)))
@@ -3699,6 +3700,56 @@
    (i32.ge_s
     (local.get $x)
     (local.get $y)
+   )
+  )
+ )
+ (func $combine-rot (param $x i32) (param $y i32) (param $z i64) (param $w i64)
+  (drop
+   (i32.rotl
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (drop
+   (i32.rotl
+    (local.get $x)
+    (local.get $y)
+   )
+  )
+  (drop
+   (i32.rotl
+    (local.get $x)
+    (i32.const 31)
+   )
+  )
+  (drop
+   (i32.rotl
+    (local.get $x)
+    (i32.const 1)
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $z)
+    (local.get $w)
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $z)
+    (local.get $w)
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $w)
+    (i64.const 63)
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $w)
+    (i64.const 1)
    )
   )
  )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3752,6 +3752,96 @@
     (i64.const 1)
    )
   )
+  (drop
+   (i32.or
+    (i32.shl
+     (local.get $x)
+     (i32.and
+      (i32.sub
+       (i32.const 0)
+       (local.get $y)
+      )
+      (i32.const 31)
+     )
+    )
+    (i32.shr_u
+     (local.get $x)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.or
+    (i32.shl
+     (local.get $x)
+     (i32.sub
+      (i32.const 32)
+      (local.get $y)
+     )
+    )
+    (i32.shr_u
+     (local.get $x)
+     (local.get $y)
+    )
+   )
+  )
+  (drop
+   (i32.rotl
+    (local.get $x)
+    (i32.const 1)
+   )
+  )
+  (drop
+   (i32.rotl
+    (local.get $x)
+    (i32.const 31)
+   )
+  )
+  (drop
+   (i64.or
+    (i64.shl
+     (local.get $z)
+     (i64.and
+      (i64.sub
+       (i64.const 0)
+       (local.get $w)
+      )
+      (i64.const 63)
+     )
+    )
+    (i64.shr_u
+     (local.get $z)
+     (local.get $w)
+    )
+   )
+  )
+  (drop
+   (i64.or
+    (i64.shl
+     (local.get $z)
+     (i64.sub
+      (i64.const 64)
+      (local.get $w)
+     )
+    )
+    (i64.shr_u
+     (local.get $z)
+     (local.get $w)
+    )
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $w)
+    (i64.const 1)
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $w)
+    (i64.const 63)
+   )
+  )
  )
  (func $select-into-arms (param $x i32) (param $y i32)
   (if

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4197,6 +4197,120 @@
     ))
     ;; TODO: more stuff here
   )
+  (func $combine-rot (param $x i32) (param $y i32) (param $z i64) (param $w i64)
+    ;; i32.rotl
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (local.get $y))
+      (i32.shr_u
+        (local.get $x)
+        (i32.and
+          (i32.sub
+            (i32.const 0)
+            (local.get $y)
+          )
+          (i32.const 31)
+        )
+      )
+    ))
+
+    ;; i32.rotl
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (local.get $y)
+      )
+      (i32.shr_u
+        (local.get $x)
+        (i32.sub
+          (i32.const 32)
+          (local.get $y)
+        )
+      )
+    ))
+
+    ;; i32.rotl
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (i32.const 31)
+      )
+      (i32.shr_u
+        (local.get $x)
+        (i32.const 1)
+      )
+    ))
+
+    ;; i32.rotl
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (i32.const 1)
+      )
+      (i32.shr_u
+        (local.get $x)
+        (i32.const 31)
+      )
+    ))
+
+
+    ;; i64.rotl
+    (drop (i64.or
+      (i64.shl
+        (local.get $z)
+        (local.get $w))
+      (i64.shr_u
+        (local.get $z)
+        (i64.and
+          (i64.sub
+            (i64.const 0)
+            (local.get $w)
+          )
+          (i64.const 63)
+        )
+      )
+    ))
+
+    ;; i64.rotl
+    (drop (i64.or
+      (i64.shl
+        (local.get $z)
+        (local.get $w)
+      )
+      (i64.shr_u
+        (local.get $z)
+        (i64.sub
+          (i64.const 64)
+          (local.get $w)
+        )
+      )
+    ))
+
+    ;; i64.rotl
+    (drop (i64.or
+      (i64.shl
+        (local.get $w)
+        (i64.const 63)
+      )
+      (i64.shr_u
+        (local.get $w)
+        (i64.const 1)
+      )
+    ))
+
+    ;; i64.rotl
+    (drop (i64.or
+      (i64.shl
+        (local.get $w)
+        (i64.const 1)
+      )
+      (i64.shr_u
+        (local.get $w)
+        (i64.const 63)
+      )
+    ))
+  )
   (func $select-into-arms (param $x i32) (param $y i32)
     (if
       (select

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4198,6 +4198,10 @@
     ;; TODO: more stuff here
   )
   (func $combine-rot (param $x i32) (param $y i32) (param $z i64) (param $w i64)
+    ;;
+    ;;  rotate left
+    ;;
+
     ;; i32.rotl
     (drop (i32.or
       (i32.shl
@@ -4308,6 +4312,125 @@
       (i64.shr_u
         (local.get $w)
         (i64.const 63)
+      )
+    ))
+
+    ;;
+    ;;  rotate right
+    ;;
+
+    ;; i32.rotr
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (i32.and
+          (i32.sub
+            (i32.const 0)
+            (local.get $y)
+          )
+          (i32.const 31)
+        )
+      )
+      (i32.shr_u
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+
+    ;; i32.rotr
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (i32.sub
+          (i32.const 32)
+          (local.get $y)
+        )
+      )
+      (i32.shr_u
+        (local.get $x)
+        (local.get $y)
+      )
+    ))
+
+    ;; i32.rotr
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (i32.const 1)
+      )
+      (i32.shr_u
+        (local.get $x)
+        (i32.const 31)
+      )
+    ))
+
+    ;; i32.rotr
+    (drop (i32.or
+      (i32.shl
+        (local.get $x)
+        (i32.const 31)
+      )
+      (i32.shr_u
+        (local.get $x)
+        (i32.const 1)
+      )
+    ))
+
+
+    ;; i64.rotr
+    (drop (i64.or
+      (i64.shl
+        (local.get $z)
+        (i64.and
+          (i64.sub
+            (i64.const 0)
+            (local.get $w)
+          )
+          (i64.const 63)
+        )
+      )
+      (i64.shr_u
+        (local.get $z)
+        (local.get $w)
+      )
+    ))
+
+    ;; i64.rotr
+    (drop (i64.or
+      (i64.shl
+        (local.get $z)
+        (i64.sub
+          (i64.const 64)
+          (local.get $w)
+        )
+      )
+      (i64.shr_u
+        (local.get $z)
+        (local.get $w)
+      )
+    ))
+
+    ;; i64.rotr
+    (drop (i64.or
+      (i64.shl
+        (local.get $w)
+        (i64.const 1)
+      )
+      (i64.shr_u
+        (local.get $w)
+        (i64.const 63)
+      )
+    ))
+
+    ;; i64.rotr
+    (drop (i64.or
+      (i64.shl
+        (local.get $w)
+        (i64.const 63)
+      )
+      (i64.shr_u
+        (local.get $w)
+        (i64.const 1)
       )
     ))
   )


### PR DESCRIPTION
`(x <<  y) | (x >>> ((-y) & (31|63)))`  ->  `(i32|i64).rotl(x, y)`
`(x >>> y) | (x  << ((-y) & (31|63)))`  ->  `(i32|i64).rotr(x, y)`

`(x <<  y) | (x >>> ((32|64) - y))`  ->  `(i32|i64).rotl(x, y)`
`(x >>> y) | (x  << ((32|64) - y))`  ->  `(i32|i64).rotr(x, y)`

`(x <<  C) | (x >>> ((32|64) - C))` ->  `(i32|i64).rotl(x, C)`
`(x >>> C) | (x  << ((32|64) - C))` ->  `(i32|i64).rotr(x, C)`