### PR TITLE
Fix ExceptionPackage memory errors

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -135,10 +135,7 @@ public:
     assert(type == Type::funcref);
     return func;
   }
-  const ExceptionPackage& getExceptionPackage() const {
-    assert(type == Type::exnref);
-    return *exn.get();
-  }
+  ExceptionPackage getExceptionPackage() const;
 
   // careful!
   int32_t* geti32Ptr() {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1297,7 +1297,7 @@ public:
     if (flow.getType() == Type::nullref) {
       trap("br_on_exn: argument is null");
     }
-    const ExceptionPackage& ex = flow.getSingleValue().getExceptionPackage();
+    auto ex = flow.getSingleValue().getExceptionPackage();
     if (curr->event != ex.event) { // Not taken
       return flow;
     }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -58,8 +58,7 @@ Literal& Literal::operator=(const Literal& other) {
       break;
     case Type::exnref:
       // Avoid calling the destructor, which may not be correct
-      new (&exn) auto(
-        std::move(std::make_unique<ExceptionPackage>(*other.exn)));
+      new (&exn) auto(std::make_unique<ExceptionPackage>(*other.exn));
       break;
     case Type::none:
     case Type::nullref:


### PR DESCRIPTION
First, adds an explicit destructor call to fix a memory leak in
`Literal::operator=` in which existing `ExceptionPackage`s would be
silently dropped. Next, changes `Literal::getExceptionPackage` to
return the `ExceptionPackage` by value to avoid a use-after-free bug
in the interpreter that was surfaced by the new destructor call.

Fixes #3087.