### PR TITLE
Harden exnref literals

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -44,13 +44,15 @@ class Literal {
   };
 
 public:
-  Type type;
+  // Type of the literal. Immutable because the literal's payload depends on it.
+  const Type type;
 
-public:
   Literal() : v128(), type(Type::none) {}
   explicit Literal(Type type) : v128(), type(type) {
-    assert(type != Type::unreachable);
+    assert(type != Type::unreachable && type != Type::funcref &&
+           type != Type::exnref);
   }
+  explicit Literal(Type::BasicID typeId) : Literal(Type(typeId)) {}
   explicit Literal(int32_t init) : i32(init), type(Type::i32) {}
   explicit Literal(uint32_t init) : i32(init), type(Type::i32) {}
   explicit Literal(int64_t init) : i64(init), type(Type::i64) {}
@@ -67,7 +69,7 @@ public:
   explicit Literal(const std::array<Literal, 4>&);
   explicit Literal(const std::array<Literal, 2>&);
   explicit Literal(Name func) : func(func), type(Type::funcref) {}
-  explicit Literal(std::unique_ptr<ExceptionPackage> exn)
+  explicit Literal(std::unique_ptr<ExceptionPackage>&& exn)
     : exn(std::move(exn)), type(Type::exnref) {}
   Literal(const Literal& other);
   Literal& operator=(const Literal& other);
@@ -105,7 +107,7 @@ public:
 
   static Literal makeNullref() { return Literal(Type(Type::nullref)); }
   static Literal makeFuncref(Name func) { return Literal(func.c_str()); }
-  static Literal makeExnref(std::unique_ptr<ExceptionPackage> exn) {
+  static Literal makeExnref(std::unique_ptr<ExceptionPackage>&& exn) {
     return Literal(std::move(exn));
   }
 

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -299,12 +299,12 @@ struct DAE : public Pass {
               value = c->value;
             } else if (value != c->value) {
               // Not identical, give up
-              value.type = Type::none;
+              value = Literal(Type::none);
               break;
             }
           } else {
             // Not a constant, give up
-            value.type = Type::none;
+            value = Literal(Type::none);
             break;
           }
         }

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -38,8 +38,7 @@ struct RemoveImports : public WalkerPass<PostWalker<RemoveImports>> {
     if (type == Type::none) {
       replaceCurrent(getModule()->allocator.alloc<Nop>());
     } else {
-      Literal nopLiteral;
-      nopLiteral.type = type;
+      Literal nopLiteral(type);
       replaceCurrent(getModule()->allocator.alloc<Const>()->set(nopLiteral));
     }
   }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1273,7 +1273,7 @@ public:
     for (auto item : arguments) {
       exn->values.push_back(item);
     }
-    throwException(Literal(std::move(exn)));
+    throwException(Literal::makeExnref(std::move(exn)));
     WASM_UNREACHABLE("throw");
   }
   Flow visitRethrow(Rethrow* curr) {

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -136,29 +136,29 @@ ExceptionPackage Literal::getExceptionPackage() const {
 
 Literal Literal::castToF32() {
   assert(type == Type::i32);
-  Literal ret(i32);
-  ret.type = Type::f32;
+  Literal ret(Type::f32);
+  ret.i32 = i32;
   return ret;
 }
 
 Literal Literal::castToF64() {
   assert(type == Type::i64);
-  Literal ret(i64);
-  ret.type = Type::f64;
+  Literal ret(Type::f64);
+  ret.i64 = i64;
   return ret;
 }
 
 Literal Literal::castToI32() {
   assert(type == Type::f32);
-  Literal ret(i32);
-  ret.type = Type::i32;
+  Literal ret(Type::i32);
+  ret.i32 = i32;
   return ret;
 }
 
 Literal Literal::castToI64() {
   assert(type == Type::f64);
-  Literal ret(i64);
-  ret.type = Type::i64;
+  Literal ret(Type::i64);
+  ret.i64 = i64;
   return ret;
 }
 


### PR DESCRIPTION
Outsourced safety guards for `exnref` `Literal`s I came up with in https://github.com/WebAssembly/binaryen/pull/3084.

* Make `Literal::type` immutable to guarantee that we do not lose track of `Literal::exn` by changing the literal's type
* Add an assert to guarantee that we don't create `exnref` literals without an `ExceptionPackage` (for now)
* Enforce rvalue reference when creating an `exnref` Literal from a `std::unique_ptr<ExceptionPackage>`, avoiding a redundant copy by means of requiring `std::move`