### PR TITLE
Fix Relooper leaking Branches

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3942,7 +3942,7 @@ RelooperRef RelooperCreate(BinaryenModuleRef module) {
 RelooperBlockRef RelooperAddBlock(RelooperRef relooper,
                                   BinaryenExpressionRef code) {
   return RelooperBlockRef(
-    new CFG::Block((CFG::Relooper*)relooper, (Expression*)code));
+    ((CFG::Relooper*)relooper)->AddBlock((Expression*)code));
 }
 
 void RelooperAddBranch(RelooperBlockRef from,
@@ -3956,8 +3956,9 @@ void RelooperAddBranch(RelooperBlockRef from,
 RelooperBlockRef RelooperAddBlockWithSwitch(RelooperRef relooper,
                                             BinaryenExpressionRef code,
                                             BinaryenExpressionRef condition) {
-  return RelooperBlockRef(new CFG::Block(
-    (CFG::Relooper*)relooper, (Expression*)code, (Expression*)condition));
+  return RelooperBlockRef(
+    ((CFG::Relooper*)relooper)
+      ->AddBlock((Expression*)code, (Expression*)condition));
 }
 
 void RelooperAddBranchForSwitch(RelooperBlockRef from,

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3941,9 +3941,8 @@ RelooperRef RelooperCreate(BinaryenModuleRef module) {
 
 RelooperBlockRef RelooperAddBlock(RelooperRef relooper,
                                   BinaryenExpressionRef code) {
-  auto* ret = new CFG::Block((Expression*)code);
-  ((CFG::Relooper*)relooper)->AddBlock(ret);
-  return RelooperBlockRef(ret);
+  return RelooperBlockRef(
+    new CFG::Block((CFG::Relooper*)relooper, (Expression*)code));
 }
 
 void RelooperAddBranch(RelooperBlockRef from,
@@ -3957,9 +3956,8 @@ void RelooperAddBranch(RelooperBlockRef from,
 RelooperBlockRef RelooperAddBlockWithSwitch(RelooperRef relooper,
                                             BinaryenExpressionRef code,
                                             BinaryenExpressionRef condition) {
-  auto* ret = new CFG::Block((Expression*)code, (Expression*)condition);
-  ((CFG::Relooper*)relooper)->AddBlock(ret);
-  return RelooperBlockRef(ret);
+  return RelooperBlockRef(new CFG::Block(
+    (CFG::Relooper*)relooper, (Expression*)code, (Expression*)condition));
 }
 
 void RelooperAddBranchForSwitch(RelooperBlockRef from,

--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -382,7 +382,7 @@ struct LoopShape : public Shape {
 //  3. Call Render().
 //
 // Implementation details: The Relooper instance takes ownership of the blocks,
-// branches and shapes when created using the `addBlock` etc. methods, and frees
+// branches and shapes when created using the `AddBlock` etc. methods, and frees
 // them when done.
 struct Relooper {
   wasm::Module* Module;

--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -79,6 +79,7 @@ public:
   }
 };
 
+struct Relooper;
 struct Block;
 struct Shape;
 
@@ -244,8 +245,6 @@ template<typename Key, typename T> struct InsertOrderedMap {
 
 typedef InsertOrderedSet<Block*> BlockSet;
 typedef InsertOrderedMap<Block*, Branch*> BlockBranchMap;
-
-struct Relooper;
 
 // Represents a basic block of code - some instructions that end with a
 // control flow modifier (a branch, return or throw).

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -50,9 +50,7 @@ struct ReReloop final : public Pass {
   CFG::Block* currCFGBlock = nullptr;
 
   CFG::Block* makeCFGBlock() {
-    auto* ret = new CFG::Block(builder->makeBlock());
-    relooper->AddBlock(ret);
-    return ret;
+    return new CFG::Block(relooper.get(), builder->makeBlock());
   }
 
   CFG::Block* setCurrCFGBlock(CFG::Block* curr) {
@@ -321,7 +319,7 @@ struct ReReloop final : public Pass {
     // blocks that do not have any exits are dead ends in the relooper. we need
     // to make sure that are in fact dead ends, and do not flow control
     // anywhere. add a return as needed
-    for (auto* cfgBlock : relooper->Blocks) {
+    for (auto& cfgBlock : relooper->Blocks) {
       auto* block = cfgBlock->Code->cast<Block>();
       if (cfgBlock->BranchesOut.empty() && block->type != Type::unreachable) {
         block->list.push_back(function->sig.results == Type::none

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -50,7 +50,7 @@ struct ReReloop final : public Pass {
   CFG::Block* currCFGBlock = nullptr;
 
   CFG::Block* makeCFGBlock() {
-    return new CFG::Block(relooper.get(), builder->makeBlock());
+    return relooper->AddBlock(builder->makeBlock());
   }
 
   CFG::Block* setCurrCFGBlock(CFG::Block* curr) {


### PR DESCRIPTION
Fixes the `Relooper` leaking `Branch`es in `Optimizer::SkipEmptyBlocks` (and potentially elsewhere), by refactoring the API so a `std::unique_ptr` is ensured for each `Block`, `Branch` and `Shape` upon adding to the relooper.

Fixes https://github.com/WebAssembly/binaryen/issues/3094