### PR TITLE
Fix Wasm2JSBuilder leaking temporary Function

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -424,13 +424,14 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
   });
   if (generateFetchHighBits) {
     Builder builder(allocator);
-    std::unique_ptr<Function> tempFunc(
-      builder.makeFunction(WASM_FETCH_HIGH_BITS,
-                           Signature(Type::none, Type::i32),
-                           {},
-                           builder.makeReturn(builder.makeGlobalGet(
-                             INT64_TO_32_HIGH_BITS, Type::i32))));
-    asmFunc[3]->push_back(processFunction(wasm, tempFunc.get()));
+    asmFunc[3]->push_back(
+      processFunction(wasm,
+                      wasm->addFunction(builder.makeFunction(
+                        WASM_FETCH_HIGH_BITS,
+                        Signature(Type::none, Type::i32),
+                        {},
+                        builder.makeReturn(builder.makeGlobalGet(
+                          INT64_TO_32_HIGH_BITS, Type::i32))))));
     auto e = new Export();
     e->name = WASM_FETCH_HIGH_BITS;
     e->value = WASM_FETCH_HIGH_BITS;

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -424,13 +424,13 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
   });
   if (generateFetchHighBits) {
     Builder builder(allocator);
-    asmFunc[3]->push_back(processFunction(
-      wasm,
+    std::unique_ptr<Function> tempFunc(
       builder.makeFunction(WASM_FETCH_HIGH_BITS,
                            Signature(Type::none, Type::i32),
                            {},
                            builder.makeReturn(builder.makeGlobalGet(
-                             INT64_TO_32_HIGH_BITS, Type::i32)))));
+                             INT64_TO_32_HIGH_BITS, Type::i32))));
+    asmFunc[3]->push_back(processFunction(wasm, tempFunc.get()));
     auto e = new Export();
     e->name = WASM_FETCH_HIGH_BITS;
     e->value = WASM_FETCH_HIGH_BITS;


### PR DESCRIPTION
Fixes `Wasm2JSBuilder` leaking a temporary `Function` (`WASM_FETCH_HIGH_BITS`) in `Wasm2JSBuilder::processWasm`. The function is created to be converted to JS, but is not actually part of the module, so it either needs to be cleaned up separately or be added to the module. This PR does the latter in case it is useful.