### PR TITLE
wasm-emscripten-finalize: Don't rename the imported table

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -255,15 +255,10 @@ int main(int argc, const char* argv[]) {
 
   std::vector<Name> initializerFunctions;
 
-  if (wasm.table.imported()) {
-    if (wasm.table.base != "table") {
-      wasm.table.base = Name("table");
-    }
-  }
-  if (wasm.memory.imported()) {
-    if (wasm.table.base != "memory") {
-      wasm.memory.base = Name("memory");
-    }
+  // The wasm backend emits "__indirect_function_table" as the import name for
+  // the table, while older emscripten expects "table"
+  if (wasm.table.imported() && wasm.table.base != "table" && !minimizeWasmChanges) {
+    wasm.table.base = Name("table");
   }
   wasm.updateMaps();
 

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -257,7 +257,8 @@ int main(int argc, const char* argv[]) {
 
   // The wasm backend emits "__indirect_function_table" as the import name for
   // the table, while older emscripten expects "table"
-  if (wasm.table.imported() && wasm.table.base != "table" && !minimizeWasmChanges) {
+  if (wasm.table.imported() && wasm.table.base != "table" &&
+      !minimizeWasmChanges) {
     wasm.table.base = Name("table");
   }
   wasm.updateMaps();

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -257,8 +257,7 @@ int main(int argc, const char* argv[]) {
 
   // The wasm backend emits "__indirect_function_table" as the import name for
   // the table, while older emscripten expects "table"
-  if (wasm.table.imported() && wasm.table.base != "table" &&
-      !minimizeWasmChanges) {
+  if (wasm.table.imported() && !minimizeWasmChanges) {
     wasm.table.base = Name("table");
   }
   wasm.updateMaps();


### PR DESCRIPTION
When minimizing wasm changes, leave it as `__indirect_function_table`
which is what LLVM emits.

This also removes the renaming of the memory. That was never needed
as LLVM already emits "memory" there.

See https://github.com/WebAssembly/binaryen/issues/3043
