### PR TITLE
Optimize MergeBlocks by caching branch results

### DIFF
--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -236,6 +236,8 @@ struct BranchAccumulator : public PostWalker<BranchAccumulator, UnifiedExpressio
 
   void visitExpression(Expression* curr) {
     auto& branches = allBranches[curr];
+    // We may be re-run if part of the IR changes, so clear any previous data.
+    branches.clear();
     for (auto child : ChildIterator(curr)) {
       auto& childBranches = allBranches[child];
       branches.insert(childBranches.begin(), childBranches.end());

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -257,17 +257,14 @@ public:
     if (iter != branches.end()) {
       return iter->second;
     }
-    static int fast = 0, slow = 0, fast1 = 0, slow1 = 0;
     NameSet currBranches;
     auto add = [&](NameSet& moreBranches) {
       // Make sure to do a fast swap for the first set of branches to arrive.
       // This helps the case of the first child being a block with a very large
       // set of names.
       if (currBranches.empty()) {
-      fast1++;
         currBranches.swap(moreBranches);
       } else {
-      slow1++;
         currBranches.insert(moreBranches.begin(), moreBranches.end());
       }
     };
@@ -279,7 +276,6 @@ public:
         // We are scanning the parent, which means we assume the child will
         // never be visited again.
         branches.erase(iter);
-if (child->is<Block>())        fast++;
       } else {
         // The child was not cached. Scan it manually.
         BranchAccumulator childBranches;
@@ -287,9 +283,7 @@ if (child->is<Block>())        fast++;
         add(childBranches.branches);
         // Don't bother caching anything - we are scanning the parent, so the
         // child will presumably not be scanned again.
-if (child->is<Block>())        slow++;
       }
-if (child->is<Block>())            std::cout << "bu fast / slow: " << fast << " / " << slow << "    :    " << fast1 << " : " << slow1 << '\n';
     }
     // Finish with the parent's own branches.
     auto selfBranches = getUniqueTargets(curr);

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -229,19 +229,10 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
   }
 };
 
-// Accumulates a map of expression => all the branches in its children and
-// itself, in linear time.
 struct BranchAccumulator : public PostWalker<BranchAccumulator, UnifiedExpressionVisitor<BranchAccumulator>> {
-  std::unordered_map<Expression*, std::set<Name>> allBranches;
+  std::set<Name> branches;
 
   void visitExpression(Expression* curr) {
-    auto& branches = allBranches[curr];
-    // We may be re-run if part of the IR changes, so clear any previous data.
-    branches.clear();
-    for (auto child : ChildIterator(curr)) {
-      auto& childBranches = allBranches[child];
-      branches.insert(childBranches.begin(), childBranches.end());
-    }
     auto selfBranches = getUniqueTargets(curr);
     branches.insert(selfBranches.begin(), selfBranches.end());
   }

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -232,52 +232,18 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
 // Accumulates a map of expression => all the branches in its children and
 // itself, in linear time.
 struct BranchAccumulator : public PostWalker<BranchAccumulator, UnifiedExpressionVisitor<BranchAccumulator>> {
-  using NameSet = std::set<Name>;
-  // Sets of branch targets. We keep a unique index for each one because the
-  // same set may be reused a huge amount of times. In particular, a tower of
-  // blocks with a switch on top would have all the blocks with the same set.
-  std::unordered_map<Index, std::unique_ptr<NameSet>> indexToSet;
-  std::map<NameSet, Index> setToIndex;
-
-  std::unordered_map<Expression*, Index> exprToIndex;
+  std::unordered_map<Expression*, std::set<Name>> allBranches;
 
   void visitExpression(Expression* curr) {
-    // Find the branches, using the fact that children have already been
-    // computed.
-    NameSet branches;
+    auto& branches = allBranches[curr];
+    // We may be re-run if part of the IR changes, so clear any previous data.
+    branches.clear();
     for (auto child : ChildIterator(curr)) {
-      auto& childBranches = *indexToSet[exprToIndex[child]].get();
+      auto& childBranches = allBranches[child];
       branches.insert(childBranches.begin(), childBranches.end());
     }
     auto selfBranches = getUniqueTargets(curr);
     branches.insert(selfBranches.begin(), selfBranches.end());
-    // Update the data structures.
-    Index index;
-    if (setToIndex.count(branches)) {
-      index = setToIndex[branches];
-    } else {
-      // This is a new set.
-      index = indexToSet.size();
-      // The index must not be used yet.
-      assert(indexToSet.count(index) == 0);
-      setToIndex[branches] = index;
-      auto& set = indexToSet[index] = make_unique<NameSet>();
-      set->swap(branches);
-    }
-    exprToIndex[curr] = index;
-  }
-
-  bool hasInfoFor(Expression* expr) {
-    return exprToIndex.count(expr);
-  }
-
-  bool hasBranch(Expression* expr, Name target) {
-    auto iter = exprToIndex.find(expr);
-    if (iter == exprToIndex.end()) {
-      return false;
-    }
-    auto index = iter->second;
-    return indexToSet[index]->count(target);
   }
 };
 

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -71,9 +71,11 @@ inline NameSet getUniqueTargets(BrOnExn* br) { return {br->name}; }
 inline NameSet getUniqueTargets(Expression* expr) {
   if (auto* br = expr->dynCast<Break>()) {
     return getUniqueTargets(br);
-  } if (auto* br = expr->dynCast<Switch>()) {
+  }
+  if (auto* br = expr->dynCast<Switch>()) {
     return getUniqueTargets(br);
-  } if (auto* br = expr->dynCast<BrOnExn>()) {
+  }
+  if (auto* br = expr->dynCast<BrOnExn>()) {
     return getUniqueTargets(br);
   }
   return {};
@@ -232,7 +234,9 @@ struct BranchSeeker : public PostWalker<BranchSeeker> {
 };
 
 // Accumulates all the branches in an entire tree.
-struct BranchAccumulator : public PostWalker<BranchAccumulator, UnifiedExpressionVisitor<BranchAccumulator>> {
+struct BranchAccumulator
+  : public PostWalker<BranchAccumulator,
+                      UnifiedExpressionVisitor<BranchAccumulator>> {
   NameSet branches;
 
   void visitExpression(Expression* curr) {
@@ -295,9 +299,7 @@ public:
     return getBranches(curr).count(target);
   }
 
-  void forget(Expression* curr) {
-    branches.erase(curr);
-  }
+  void forget(Expression* curr) { branches.erase(curr); }
 };
 
 } // namespace BranchUtils

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -296,7 +296,11 @@ public:
   }
 
   bool hasBranch(Expression* curr, Name target) {
-    return getBranches(curr).count(target);
+    bool result = getBranches(curr).count(target);
+#ifdef BRANCH_UTILS_DEBUG
+    assert(bresult == BranchSeeker::has(curr, target));
+#endif
+    return result;
   }
 };
 

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -298,8 +298,6 @@ public:
   bool hasBranch(Expression* curr, Name target) {
     return getBranches(curr).count(target);
   }
-
-  void forget(Expression* curr) { branches.erase(curr); }
 };
 
 } // namespace BranchUtils

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -370,7 +370,7 @@ static void optimizeBlock(Block* curr,
         // already forgotten the child's info, so there is nothing to do here
         // for the child.
         // (We also don't need to do anything for the parent - we move code
-        // from a child into the parent, but that doens't change the total
+        // from a child into the parent, but that doesn't change the total
         // branches in the parent.)
       }
       // Add the rest of the parent block after the child.

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -299,10 +299,10 @@ optimizeBlock(Block* curr,
           auto* item = childList[j];
           bool hasBranchToChild;
           if (branchInfo) {
-            //#ifdef MERGE_BLOCKS_DEBUG
+//#ifdef MERGE_BLOCKS_DEBUG
             assert(branchInfo->hasBranch(item, childName) ==
                    BranchUtils::BranchSeeker::has(item, childName));
-            //#endif
+//#endif
             hasBranchToChild = branchInfo->hasBranch(item, childName);
           } else {
             hasBranchToChild = BranchUtils::BranchSeeker::has(item, childName);
@@ -373,12 +373,10 @@ optimizeBlock(Block* curr,
         if (loop) {
           loop->finalize();
         }
-        if (branchInfo) {
-          // Some items from the child were moved out; update the child's
-          // branch info. (If we merge all the child's items, the child won't
-          // exist anyhow.)
-          branchInfo->forget(child);
-        }
+        // Note that we modify the child block here, which invalidates info
+        // in branchInfo. However, as we have scanned the parent, we have
+        // already forgotten the child's info, so there is nothing to do here
+        // for the child.
       }
       // Add the rest of the parent block after the child.
       for (size_t j = i + 1; j < list.size(); j++) {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -299,10 +299,6 @@ static void optimizeBlock(Block* curr,
         auto childName = childBlock->name;
         for (size_t j = 0; j < childSize; j++) {
           auto* item = childList[j];
-#ifdef MERGE_BLOCKS_DEBUG
-          assert(branchInfo.hasBranch(item, childName) ==
-                 BranchUtils::BranchSeeker::has(item, childName));
-#endif
           if (branchInfo.hasBranch(item, childName)) {
             // We can't remove this from the child.
             keepStart = j;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -373,6 +373,9 @@ static void optimizeBlock(Block* curr,
         // in branchInfo. However, as we have scanned the parent, we have
         // already forgotten the child's info, so there is nothing to do here
         // for the child.
+        // (We also don't need to do anything for the parent - we move code
+        // from a child into the parent, but that doens't change the total
+        // branches in the parent.)
       }
       // Add the rest of the parent block after the child.
       for (size_t j = i + 1; j < list.size(); j++) {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -299,10 +299,10 @@ static void optimizeBlock(Block* curr,
         auto childName = childBlock->name;
         for (size_t j = 0; j < childSize; j++) {
           auto* item = childList[j];
-//#ifdef MERGE_BLOCKS_DEBUG
+#ifdef MERGE_BLOCKS_DEBUG
           assert(branchInfo.hasBranch(item, childName) ==
                  BranchUtils::BranchSeeker::has(item, childName));
-//#endif
+#endif
           if (branchInfo.hasBranch(item, childName)) {
             // We can't remove this from the child.
             keepStart = j;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -199,7 +199,10 @@ static bool hasDeadCode(Block* block) {
 
 // core block optimizer routine
 static void
-optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils::BranchSeekerCache* branchInfo=nullptr) {
+optimizeBlock(Block* curr,
+              Module* module,
+              PassOptions& passOptions,
+              BranchUtils::BranchSeekerCache* branchInfo = nullptr) {
   auto& list = curr->list;
   // Main merging loop.
   bool more = true;
@@ -296,9 +299,10 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils
           auto* item = childList[j];
           bool hasBranchToChild;
           if (branchInfo) {
-//#ifdef MERGE_BLOCKS_DEBUG
-            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
-//#endif
+            //#ifdef MERGE_BLOCKS_DEBUG
+            assert(branchInfo->hasBranch(item, childName) ==
+                   BranchUtils::BranchSeeker::has(item, childName));
+            //#endif
             hasBranchToChild = branchInfo->hasBranch(item, childName);
           } else {
             hasBranchToChild = BranchUtils::BranchSeeker::has(item, childName);

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -297,7 +297,7 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils
           bool hasBranchToChild;
           if (branchInfo) {
 #ifdef MERGE_BLOCKS_DEBUG
-            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
+//            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
 #endif
             hasBranchToChild = branchInfo->hasBranch(item, childName);
           } else {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -295,11 +295,11 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils
         for (size_t j = 0; j < childSize; j++) {
           auto* item = childList[j];
           bool hasBranchToChild;
-          if (branchInfo && branchInfo->hasInfoFor(item)) {
+          if (branchInfo && branchInfo->allBranches.count(item)) {
 #ifdef MERGE_BLOCKS_DEBUG
-            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
+            assert(branchInfo->allBranches[item].count(childName) == BranchUtils::BranchSeeker::has(item, childName));
 #endif
-            hasBranchToChild = branchInfo->hasBranch(item, childName);
+            hasBranchToChild = branchInfo->allBranches[item].count(childName);
           } else {
             hasBranchToChild = BranchUtils::BranchSeeker::has(item, childName);
           }

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -197,9 +197,38 @@ static bool hasDeadCode(Block* block) {
   return false;
 }
 
+struct BranchInfo {
+  // Tracks branches we've seen in an expression. This is used to avoid
+  // re-querying the same things again and again. Note that this does not take
+  // into account IR changes: an expression may have a branch under it somewhere
+  // but have it moved outside. Therefore this data only says that at some point
+  // the branch existed there. That is enough for the common
+  std::unordered_map<Expression*, std::set<Name>> knownBranches;
+
+  // Checks if an expression has a branch to a particular target underneath it
+  // somewhere.
+  bool hasBranch(Expression* expr, Name target) {
+    // Check if we know the answer already.
+    if (knownBranches.count(expr)) {
+      return knownBranches[expr].count(target);
+    }
+    // Check the children.
+    for (auto child : ChildIterator(curr)) {
+      if (hasBranch(child, target)) {
+        return true;
+      }
+    }
+    return BranchUtils::getUniqueTargets(expr).count(target);
+  }
+
+  void forget(Expression* expr) {
+    knownBranches.erase(expr);
+  }
+};
+
 // core block optimizer routine
 static void
-optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils::BranchAccumulator* branchInfo=nullptr) {
+optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchInfo* branchInfo=nullptr) {
   auto& list = curr->list;
   // Main merging loop.
   bool more = true;
@@ -295,11 +324,11 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils
         for (size_t j = 0; j < childSize; j++) {
           auto* item = childList[j];
           bool hasBranchToChild;
-          if (branchInfo && branchInfo->allBranches.count(item)) {
+          if (branchInfo && branchInfo->hasInfoFor(item)) {
 #ifdef MERGE_BLOCKS_DEBUG
-            assert(branchInfo->allBranches[item].count(childName) == BranchUtils::BranchSeeker::has(item, childName));
+            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
 #endif
-            hasBranchToChild = branchInfo->allBranches[item].count(childName);
+            hasBranchToChild = branchInfo->hasBranch(item, childName);
           } else {
             hasBranchToChild = BranchUtils::BranchSeeker::has(item, childName);
           }
@@ -410,12 +439,7 @@ struct MergeBlocks : public WalkerPass<PostWalker<MergeBlocks>> {
 
   Pass* create() override { return new MergeBlocks; }
 
-  BranchUtils::BranchAccumulator branchInfo;
-
-  void doWalkFunction(Function* func) {
-    branchInfo.walk(func->body);
-    walk(func->body);
-  }
+  BranchInfo branchInfo;
 
   void visitBlock(Block* curr) {
     optimizeBlock(curr, getModule(), getPassOptions(), &branchInfo);

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -296,9 +296,9 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils
           auto* item = childList[j];
           bool hasBranchToChild;
           if (branchInfo) {
-#ifdef MERGE_BLOCKS_DEBUG
-//            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
-#endif
+//#ifdef MERGE_BLOCKS_DEBUG
+            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
+//#endif
             hasBranchToChild = branchInfo->hasBranch(item, childName);
           } else {
             hasBranchToChild = BranchUtils::BranchSeeker::has(item, childName);

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -295,11 +295,11 @@ optimizeBlock(Block* curr, Module* module, PassOptions& passOptions, BranchUtils
         for (size_t j = 0; j < childSize; j++) {
           auto* item = childList[j];
           bool hasBranchToChild;
-          if (branchInfo && branchInfo->allBranches.count(item)) {
+          if (branchInfo && branchInfo->hasInfoFor(item)) {
 #ifdef MERGE_BLOCKS_DEBUG
-            assert(branchInfo->allBranches[item].count(childName) == BranchUtils::BranchSeeker::has(item, childName));
+            assert(branchInfo->hasBranch(item, childName) == BranchUtils::BranchSeeker::has(item, childName));
 #endif
-            hasBranchToChild = branchInfo->allBranches[item].count(childName);
+            hasBranchToChild = branchInfo->hasBranch(item, childName);
           } else {
             hasBranchToChild = BranchUtils::BranchSeeker::has(item, childName);
           }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -19,7 +19,6 @@
 #include <sstream>
 #include <unordered_set>
 
-#include "ir/branch-utils.h"
 #include "ir/features.h"
 #include "ir/global-utils.h"
 #include "ir/module-utils.h"


### PR DESCRIPTION
`BranchSeekerCache` caches the set of branches in a node +
its children, and helps compute new results by looking in the cache
and using data for the children. This avoids quadratic time in the
common case of a post-walk on a tower of nested blocks which is
common in a switch.

Fixes https://github.com/WebAssembly/binaryen/issues/3090 . On the testcase there this pass goes from
over a minute to less than a second.

I haven't looked at the validator yet which may also be helped by this,
but as this ended up more work than I thought I didn't want to do too
much in one PR.

Fuzzed for a few thousand iterations + random50 on emscripten test suite.