### PR TITLE
Enable LeakSanitizer on CI again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,7 @@ jobs:
     name: asan
     runs-on: ubuntu-latest
     env:
-      # FIXME we currently must disable LSAN entirely, see #1351
-      ASAN_OPTIONS: "detect_leaks=0 symbolize=1"
+      ASAN_OPTIONS: "symbolize=1"
       COMPILER_FLAGS: "-fsanitize=address"
     steps:
     - uses: actions/setup-python@v1

--- a/check.py
+++ b/check.py
@@ -292,9 +292,6 @@ def run_gcc_tests():
     for t in sorted(os.listdir(shared.get_test_dir('example'))):
         output_file = 'example'
         cmd = ['-I' + os.path.join(shared.options.binaryen_root, 'src'), '-g', '-pthread', '-o', output_file]
-        # build with ASan if enabled on CI
-        if ('COMPILER_FLAGS' in os.environ and 'fsanitize=address' in str(os.environ['COMPILER_FLAGS'])):
-            cmd.insert(0, '-fsanitize=address')
         if t.endswith('.txt'):
             # check if there is a trace in the file, if so, we should build it
             out = subprocess.check_output([os.path.join(shared.options.binaryen_root, 'scripts', 'clean_c_api_trace.py'), os.path.join(shared.get_test_dir('example'), t)])

--- a/check.py
+++ b/check.py
@@ -292,6 +292,9 @@ def run_gcc_tests():
     for t in sorted(os.listdir(shared.get_test_dir('example'))):
         output_file = 'example'
         cmd = ['-I' + os.path.join(shared.options.binaryen_root, 'src'), '-g', '-pthread', '-o', output_file]
+        # build with ASan if enabled on CI
+        if ('COMPILER_FLAGS' in os.environ and 'fsanitize=address' in str(os.environ['COMPILER_FLAGS'])):
+            cmd.insert(0, '-fsanitize=address')
         if t.endswith('.txt'):
             # check if there is a trace in the file, if so, we should build it
             out = subprocess.check_output([os.path.join(shared.options.binaryen_root, 'scripts', 'clean_c_api_trace.py'), os.path.join(shared.get_test_dir('example'), t)])


### PR DESCRIPTION
With the respective fixes

* https://github.com/WebAssembly/binaryen/pull/3088
* https://github.com/WebAssembly/binaryen/pull/3093
* https://github.com/WebAssembly/binaryen/pull/3095
* https://github.com/WebAssembly/binaryen/pull/3098
* https://github.com/WebAssembly/binaryen/pull/3097

merged, it should now be possible to enable LSan on CI again.