### PR TITLE
Stay on C++14 for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Current Trunk
 -------------
 - Remove asm2wasm, which supported Emscripten's fastcomp backend, after fastcomp
   was removed.
-- Binaryen now requires C++17 (was C++14) to build.
 
 v96
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(GNUInstallDirs)
 
 # The C++ standard whose features are required to build Binaryen.
 # Keep in sync with scripts/test/shared.py cxx_standard
-set(CXX_STANDARD 17)
+set(CXX_STANDARD 14)
 
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to Release")

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Usage instructions for each are below.
 cmake . && make
 ```
 
-A C++17 compiler is required. Note that you can also use `ninja` as your generator: `cmake -G Ninja . && ninja`.
+A C++14 compiler is required. Note that you can also use `ninja` as your generator: `cmake -G Ninja . && ninja`.
 
 Binaryen.js can be built using Emscripten, which can be installed via [the SDK](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html)).
 

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -25,7 +25,7 @@ import sys
 
 # The C++ standard whose features are required to build Binaryen.
 # Keep in sync with CMakeLists.txt CXX_STANDARD
-cxx_standard = 17
+cxx_standard = 14
 
 
 def parse_args(args):


### PR DESCRIPTION
An alternative to https://github.com/WebAssembly/binaryen/pull/3107 just switching C++ standard support to `14` (for now), so we can easily upgrade again once the autoroller issues are resolved.