### PR TITLE
Stop renaming longjmp in wasm-emscripten-finalize

### DIFF
--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -130,11 +130,27 @@ struct PostEmscripten : public Pass {
       }
     }
 
+    // Optimize imports
+    optimizeImports(runner, module);
+
     // Optimize calls
     OptimizeCalls().run(runner, module);
 
     // Optimize exceptions
     optimizeExceptions(runner, module);
+  }
+
+  void optimizeImports(PassRunner* runner, Module* module) {
+    // Calling emscripten_longjmp_jmpbuf is the same as emscripten_longjmp.
+    Name EMSCRIPTEN_LONGJMP("emscripten_longjmp");
+    Name EMSCRIPTEN_LONGJMP_JMPBUF("emscripten_longjmp_jmpbuf");
+    ImportInfo info(*module);
+    auto* emscripten_longjmp = info.getImportedFunction(ENV, EMSCRIPTEN_LONGJMP);
+    auto* emscripten_longjmp_jmpbuf = info.getImportedFunction(ENV, EMSCRIPTEN_LONGJMP_JMPBUF);
+    if (emscripten_longjmp && emscripten_longjmp_jmpbuf) {
+      // Both exist, so it is worth renaming so that we have only one.
+      emscripten_longjmp_jmpbuf->base = EMSCRIPTEN_LONGJMP;
+    }
   }
 
   // Optimize exceptions (and setjmp) by removing unnecessary invoke* calls.

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -145,8 +145,10 @@ struct PostEmscripten : public Pass {
     Name EMSCRIPTEN_LONGJMP("emscripten_longjmp");
     Name EMSCRIPTEN_LONGJMP_JMPBUF("emscripten_longjmp_jmpbuf");
     ImportInfo info(*module);
-    auto* emscripten_longjmp = info.getImportedFunction(ENV, EMSCRIPTEN_LONGJMP);
-    auto* emscripten_longjmp_jmpbuf = info.getImportedFunction(ENV, EMSCRIPTEN_LONGJMP_JMPBUF);
+    auto* emscripten_longjmp =
+      info.getImportedFunction(ENV, EMSCRIPTEN_LONGJMP);
+    auto* emscripten_longjmp_jmpbuf =
+      info.getImportedFunction(ENV, EMSCRIPTEN_LONGJMP_JMPBUF);
     if (emscripten_longjmp && emscripten_longjmp_jmpbuf) {
       // Both exist, so it is worth renaming so that we have only one.
       emscripten_longjmp_jmpbuf->base = EMSCRIPTEN_LONGJMP;

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -633,16 +633,12 @@ struct FixInvokeFunctionNamesWalker
                 getSig(sigWoOrigFunc.results, sigWoOrigFunc.params));
   }
 
-  Name fixEmEHSjLjNames(const Name& name, Signature sig) {
-    return fixEmExceptionInvoke(name, sig);
-  }
-
   void visitFunction(Function* curr) {
     if (!curr->imported()) {
       return;
     }
 
-    Name newname = fixEmEHSjLjNames(curr->base, curr->sig);
+    Name newname = fixEmExceptionInvoke(curr->base, curr->sig);
     if (newname == curr->base) {
       return;
     }

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -634,9 +634,6 @@ struct FixInvokeFunctionNamesWalker
   }
 
   Name fixEmEHSjLjNames(const Name& name, Signature sig) {
-    if (name == "emscripten_longjmp_jmpbuf") {
-      return "emscripten_longjmp";
-    }
     return fixEmExceptionInvoke(name, sig);
   }
 

--- a/test/lld/longjmp.wat.out
+++ b/test/lld/longjmp.wat.out
@@ -1,6 +1,6 @@
 (module
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -11,14 +11,15 @@
  (import "env" "malloc" (func $fimport$0 (param i32) (result i32)))
  (import "env" "saveSetjmp" (func $fimport$1 (param i32 i32 i32 i32) (result i32)))
  (import "env" "getTempRet0" (func $fimport$2 (result i32)))
+ (import "env" "emscripten_longjmp_jmpbuf" (func $fimport$3 (param i32 i32)))
  (import "env" "invoke_vii" (func $invoke_vii (param i32 i32 i32)))
  (import "env" "testSetjmp" (func $fimport$5 (param i32 i32 i32) (result i32)))
  (import "env" "setTempRet0" (func $fimport$6 (param i32)))
  (import "env" "free" (func $fimport$7 (param i32)))
- (import "env" "emscripten_longjmp" (func $emscripten_longjmp (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $fimport$8 (param i32 i32)))
  (memory $0 2)
  (table $0 2 2 funcref)
- (elem (i32.const 1) $emscripten_longjmp)
+ (elem (i32.const 1) $fimport$3)
  (global $global$0 (mut i32) (i32.const 66112))
  (global $global$1 i32 (i32.const 576))
  (export "memory" (memory $0))
@@ -124,7 +125,7 @@
     (i32.const 0)
    )
   )
-  (call $emscripten_longjmp
+  (call $fimport$8
    (local.get $0)
    (local.get $3)
   )
@@ -158,6 +159,7 @@
     "malloc",
     "saveSetjmp",
     "getTempRet0",
+    "emscripten_longjmp_jmpbuf",
     "testSetjmp",
     "setTempRet0",
     "free",

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -1,8 +1,8 @@
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -15,14 +15,15 @@
  (import "env" "malloc" (func $fimport$4 (param i32) (result i32)))
  (import "env" "saveSetjmp" (func $fimport$5 (param i32 i32 i32 i32) (result i32)))
  (import "env" "getTempRet0" (func $fimport$6 (result i32)))
+ (import "env" "emscripten_longjmp_jmpbuf" (func $fimport$7 (param i32 i32)))
  (import "env" "invoke_vii" (func $invoke_vii (param i32 i32 i32)))
  (import "env" "testSetjmp" (func $fimport$9 (param i32 i32 i32) (result i32)))
  (import "env" "setTempRet0" (func $fimport$10 (param i32)))
  (import "env" "free" (func $fimport$11 (param i32)))
- (import "env" "emscripten_longjmp" (func $emscripten_longjmp (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $fimport$12 (param i32 i32)))
  (import "env" "g$__THREW__" (func $g$__THREW__ (result i32)))
  (import "env" "g$__threwValue" (func $g$__threwValue (result i32)))
- (import "env" "fp$emscripten_longjmp$vii" (func $fp$emscripten_longjmp$vii (result i32)))
+ (import "env" "fp$emscripten_longjmp_jmpbuf$vii" (func $fp$emscripten_longjmp_jmpbuf$vii (result i32)))
  (global $gimport$13 (mut i32) (i32.const 0))
  (global $gimport$14 (mut i32) (i32.const 0))
  (global $gimport$15 (mut i32) (i32.const 0))
@@ -136,7 +137,7 @@
    )
    (return)
   )
-  (call $emscripten_longjmp
+  (call $fimport$12
    (local.get $3)
    (local.get $0)
   )
@@ -157,7 +158,7 @@
    (call $g$__threwValue)
   )
   (global.set $gimport$14
-   (call $fp$emscripten_longjmp$vii)
+   (call $fp$emscripten_longjmp_jmpbuf$vii)
   )
  )
  (func $__post_instantiate
@@ -174,13 +175,14 @@
     "malloc",
     "saveSetjmp",
     "getTempRet0",
+    "emscripten_longjmp_jmpbuf",
     "testSetjmp",
     "setTempRet0",
     "free",
     "emscripten_longjmp",
     "g$__THREW__",
     "g$__threwValue",
-    "fp$emscripten_longjmp$vii"
+    "fp$emscripten_longjmp_jmpbuf$vii"
   ],
   "externs": [
     "___memory_base",

--- a/test/passes/post-emscripten.txt
+++ b/test/passes/post-emscripten.txt
@@ -176,3 +176,16 @@
   )
  )
 )
+(module
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $a (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $b (param i32 i32)))
+)
+(module
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (import "env" "emscripten_longjmp_jmpbuf" (func $b (param i32 i32)))
+)
+(module
+ (type $i32_i32_=>_none (func (param i32 i32)))
+ (import "env" "emscripten_longjmp" (func $a (param i32 i32)))
+)

--- a/test/passes/post-emscripten.wast
+++ b/test/passes/post-emscripten.wast
@@ -148,3 +148,14 @@
    )
   )
 )
+;; longjmp renaming
+(module
+  (import "env" "emscripten_longjmp" (func $a (param i32 i32)))
+  (import "env" "emscripten_longjmp_jmpbuf" (func $b (param i32 i32)))
+)
+(module
+  (import "env" "emscripten_longjmp_jmpbuf" (func $b (param i32 i32)))
+)
+(module
+  (import "env" "emscripten_longjmp" (func $a (param i32 i32)))
+)


### PR DESCRIPTION
Instead of finalize renaming `emscripten_longjmp_jmpbuf` to `emscripten_longjmp`,
do nothing in finalize. But in the optional `--post-emscripten` pass, rename it there if
both exist, so that we don't end up using two imports (other optimization passes
can then remove an unneeded import).

Depends on https://github.com/emscripten-core/emscripten/pull/12157 to land first.