### PR TITLE
Truncate constant values during store operation

### DIFF
--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -343,6 +343,58 @@
    (i32.const 11)
    (i64.const 3)
   )
+  (i32.store8
+   (i32.const 7)
+   (i32.const 255)
+  )
+  (i32.store8
+   (i32.const 8)
+   (i32.const 255)
+  )
+  (i32.store8
+   (i32.const 9)
+   (i32.const 0)
+  )
+  (i32.store16
+   (i32.const 10)
+   (i32.const 65535)
+  )
+  (i32.store16
+   (i32.const 11)
+   (i32.const 0)
+  )
+  (i32.store16
+   (i32.const 13)
+   (i32.const 65535)
+  )
+  (i64.store8
+   (i32.const 8)
+   (i64.const 255)
+  )
+  (i64.store8
+   (i32.const 9)
+   (i64.const 0)
+  )
+  (i64.store16
+   (i32.const 10)
+   (i64.const 65535)
+  )
+  (i64.store16
+   (i32.const 11)
+   (i64.const 0)
+  )
+  (i64.store16
+   (i32.const 12)
+   (i64.const 65535)
+  )
+  (i64.store32
+   (i32.const 13)
+   (i64.const 4294967295)
+  )
+  (i64.store32
+   (i32.const 14)
+   (i64.const 0)
+  )
  )
  (func $and-neg1
   (drop

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -312,6 +312,21 @@
     (i32.store8 (i32.const 11) (i32.wrap_i64 (i64.const 1)))
     (i32.store16 (i32.const 11) (i32.wrap_i64 (i64.const 2)))
     (i32.store (i32.const 11) (i32.wrap_i64 (i64.const 3)))
+    ;;
+    (i32.store8 (i32.const 7) (i32.const -1))           ;; 255
+    (i32.store8 (i32.const 8) (i32.const 255))
+    (i32.store8 (i32.const 9) (i32.const 256))          ;; 0
+    (i32.store16 (i32.const 10) (i32.const 65535))
+    (i32.store16 (i32.const 11) (i32.const 65536))      ;; 0
+    (i32.store16 (i32.const 13) (i32.const -1))         ;; 65535
+    ;;
+    (i64.store8 (i32.const 8) (i64.const 255))
+    (i64.store8 (i32.const 9) (i64.const 256))          ;; 0
+    (i64.store16 (i32.const 10) (i64.const 65535))
+    (i64.store16 (i32.const 11) (i64.const 65536))      ;; 0
+    (i64.store16 (i32.const 12) (i64.const 65535))
+    (i64.store32 (i32.const 13) (i64.const 4294967295))
+    (i64.store32 (i32.const 14) (i64.const 4294967296)) ;; 0
   )
   (func $and-neg1
     (drop (i32.and (i32.const 100) (i32.const -1)))


### PR DESCRIPTION
Implement truncation constant during store operations described in #3077

`i32.store8(dst, C)`   ->  ` i32.store8(dst, C & 0xFF)`
`i32.store16(dst, C)`  ->  ` i32.store16(dst, C & 0xFFFF)`

`i64.store8(dst, C)`   ->   `i64.store8(dst, C & 0xFF)`
`i64.store16(dst, C)`  ->  ` i64.store16(dst, C & 0xFFFF)`
`i64.store32(dst, C)`  ->   `i64.store32(dst, C & 0xFFFFFFFF)`
