### PR TITLE
Create a Binaryen IR Matcher API for use in OptimizeInstructions

### DIFF
--- a/src/ir/match.h
+++ b/src/ir/match.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// match.h: Convenience structes for matching Binaryen IR patterns
+//
+
+#ifndef wasm_ir_match_h
+#define wasm_ir_match_h
+
+#include "wasm.h"
+
+namespace wasm {
+
+namespace Match {
+
+struct Matcher {
+  virtual bool matches(Expression*) const = 0;
+};
+
+using matcher_ptr = std::unique_ptr<Matcher>;
+
+struct AnyMatcher : Matcher {
+  Expression** e;
+  AnyMatcher(Expression** e) : e(e) {}
+  bool matches(Expression* expr) const override {
+    if (e) {
+      *e = expr;
+    }
+    return true;
+  }
+};
+
+matcher_ptr any(Expression** e = nullptr) {
+  return std::make_unique<AnyMatcher>(e);
+}
+
+struct UnaryMatcher : Matcher {
+  UnaryOp op;
+  matcher_ptr value;
+  Unary** curr;
+  UnaryMatcher(UnaryOp op, matcher_ptr value, Unary** curr)
+    : op(op), value(std::move(value)), curr(curr) {}
+  bool matches(Expression* expr) const override {
+    auto* unary = expr->dynCast<Unary>();
+    if (unary && unary->op == op) {
+      if (curr) {
+        *curr = unary;
+      }
+      return value->matches(unary->value);
+    }
+    return false;
+  }
+};
+
+matcher_ptr unary(UnaryOp op, matcher_ptr value, Unary** curr = nullptr) {
+  return std::make_unique<UnaryMatcher>(op, std::move(value), curr);
+}
+
+bool matches(Expression* expr, matcher_ptr&& matcher) {
+  return matcher->matches(expr);
+}
+
+} // namespace Match
+
+} // namespace wasm
+
+#endif // wasm_ir_match_h

--- a/src/ir/match.h
+++ b/src/ir/match.h
@@ -29,6 +29,7 @@ namespace Match {
 
 struct Matcher {
   virtual bool matches(Expression*) const = 0;
+  virtual ~Matcher(){};
 };
 
 using matcher_ptr = std::unique_ptr<Matcher>;
@@ -36,6 +37,7 @@ using matcher_ptr = std::unique_ptr<Matcher>;
 struct AnyMatcher : Matcher {
   Expression** e;
   AnyMatcher(Expression** e) : e(e) {}
+  ~AnyMatcher() = default;
   bool matches(Expression* expr) const override {
     if (e) {
       *e = expr;
@@ -54,6 +56,7 @@ struct UnaryMatcher : Matcher {
   Unary** curr;
   UnaryMatcher(UnaryOp op, matcher_ptr value, Unary** curr)
     : op(op), value(std::move(value)), curr(curr) {}
+  ~UnaryMatcher() = default;
   bool matches(Expression* expr) const override {
     auto* unary = expr->dynCast<Unary>();
     if (unary && unary->op == op) {


### PR DESCRIPTION
Implements an ergonomic API for matching IR expressions that allows for
extracting multiple subexpressions at once. This can dramatically reduce
nesting depth and increase readability when matching complex patterns.

@MaxGraey, @kripken what do you think? Is this a direction worth pursuing until we can invest more time in a proper matching DSL that can generate optimized code? I'm envisioning that we wouldn't use these matchers for every pattern, but we could at least use them for the leaf parts of patterns that are specific to a single optimization, like in the example. Is it worth doing enough work on this that we could measure the performance hit?