### PR TITLE
Add float operations for isSymmetric util

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -51,6 +51,16 @@ inline bool isSymmetric(Binary* binary) {
     case XorInt64:
     case EqInt64:
     case NeInt64:
+
+    case AddFloat32:
+    case MulFloat32:
+    case EqFloat32:
+    case NeFloat32:
+
+    case AddFloat64:
+    case MulFloat64:
+    case EqFloat64:
+    case NeFloat64:
       return true;
 
     default:

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -58,19 +58,6 @@ inline bool isSymmetric(Binary* binary) {
     case NeFloat64:
       return true;
 
-    case AddFloat32:
-    case MulFloat32:
-    case AddFloat64:
-    case MulFloat64: {
-      // We should be more careful with different forrm of NaNs so
-      // check if LHS is non-NaN constant. We are not interested in RHS
-      // in term of canonization which prefer constant on right side.
-      if (auto* c = binary->left->dynCast<Const>()) {
-        return !c->value.isNaN();
-      }
-      return false;
-    }
-
     default:
       return false;
   }

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -63,7 +63,7 @@ inline bool isSymmetric(Binary* binary) {
     case AddFloat64:
     case MulFloat64: {
       // We should be more careful with different forrm of NaNs so
-      // check if lhs is non-NaN constant. We don't interesting rhs
+      // check if LHS is non-NaN constant. We are not interested in RHS
       // in term of canonization which prefer constant on right side.
       if (auto* c = binary->left->dynCast<Const>()) {
         return !c->value.isNaN();

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -52,16 +52,24 @@ inline bool isSymmetric(Binary* binary) {
     case EqInt64:
     case NeInt64:
 
-    case AddFloat32:
-    case MulFloat32:
     case EqFloat32:
     case NeFloat32:
-
-    case AddFloat64:
-    case MulFloat64:
     case EqFloat64:
     case NeFloat64:
       return true;
+
+    case AddFloat32:
+    case MulFloat32:
+    case AddFloat64:
+    case MulFloat64: {
+      if (auto* c = binary->left->dynCast<Const>()) {
+        return !c->value.isNaN();
+      }
+      if (auto* c = binary->right->dynCast<Const>()) {
+        return !c->value.isNaN();
+      }
+      return false;
+    }
 
     default:
       return false;

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -62,6 +62,9 @@ inline bool isSymmetric(Binary* binary) {
     case MulFloat32:
     case AddFloat64:
     case MulFloat64: {
+      // We should be more careful with different forrm of NaNs so
+      // check if lhs is non-NaN constant. We don't interesting rhs
+      // in term of canonization which prefer constant on right side.
       if (auto* c = binary->left->dynCast<Const>()) {
         return !c->value.isNaN();
       }

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -65,9 +65,6 @@ inline bool isSymmetric(Binary* binary) {
       if (auto* c = binary->left->dynCast<Const>()) {
         return !c->value.isNaN();
       }
-      if (auto* c = binary->right->dynCast<Const>()) {
-        return !c->value.isNaN();
-      }
       return false;
     }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -202,7 +202,7 @@ struct OptimizeInstructions
       return nullptr;
     }
     if (auto* binary = curr->dynCast<Binary>()) {
-      if (Properties::isSymmetric(binary) || isSpecialSymmetric(binary)) {
+      if (isSymmetric(binary)) {
         canonicalize(binary);
       }
       if (auto* ext = Properties::getAlmostSignExt(binary)) {
@@ -731,7 +731,7 @@ private:
   // Canonicalizing the order of a symmetric binary helps us
   // write more concise pattern matching code elsewhere.
   void canonicalize(Binary* binary) {
-    assert(Properties::isSymmetric(binary) || isSpecialSymmetric(binary));
+    assert(isSymmetric(binary));
     FeatureSet features = getModule()->features;
     auto swap = [&]() {
       assert(EffectAnalyzer::canReorder(
@@ -1571,7 +1571,10 @@ private:
     }
   }
 
-  bool isSpecialSymmetric(Binary* binary) {
+  bool isSymmetric(Binary* binary) {
+    if (Properties::isSymmetric(binary)) {
+      return true;
+    }
     switch (binary->op) {
       case AddFloat32:
       case MulFloat32:

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -202,7 +202,7 @@ struct OptimizeInstructions
       return nullptr;
     }
     if (auto* binary = curr->dynCast<Binary>()) {
-      if (Properties::isSymmetric(binary)) {
+      if (Properties::isSymmetric(binary) || isSpecialSymmetric(binary)) {
         canonicalize(binary);
       }
       if (auto* ext = Properties::getAlmostSignExt(binary)) {
@@ -731,7 +731,7 @@ private:
   // Canonicalizing the order of a symmetric binary helps us
   // write more concise pattern matching code elsewhere.
   void canonicalize(Binary* binary) {
-    assert(Properties::isSymmetric(binary));
+    assert(Properties::isSymmetric(binary) || isSpecialSymmetric(binary));
     FeatureSet features = getModule()->features;
     auto swap = [&]() {
       assert(EffectAnalyzer::canReorder(
@@ -1568,6 +1568,26 @@ private:
 
       default:
         return InvalidBinary;
+    }
+  }
+
+  bool isSpecialSymmetric(Binary* binary) {
+    switch (binary->op) {
+      case AddFloat32:
+      case MulFloat32:
+      case AddFloat64:
+      case MulFloat64: {
+        // If the LHS is known to be non-NaN, the operands can commute.
+        // We don't care about the RHS because right now we only know if
+        // an expression is non-NaN if it is constant, but if the RHS is
+        // constant, then this expression is already canonicalized.
+        if (auto* c = binary->left->dynCast<Const>()) {
+          return !c->value.isNaN();
+        }
+        return false;
+      }
+      default:
+        return false;
     }
   }
 };

--- a/test/passes/O4_disable-bulk-memory.txt
+++ b/test/passes/O4_disable-bulk-memory.txt
@@ -134,52 +134,53 @@
     )
     (block
      (local.set $3
-      (f64.add
-       (f64.mul
-        (local.tee $4
-         (f64.load offset=48
-          (local.tee $2
-           (i32.load offset=8
-            (i32.add
-             (i32.load
-              (local.get $0)
-             )
-             (i32.shl
-              (local.get $1)
-              (i32.const 2)
-             )
-            )
-           )
+      (f64.load offset=48
+       (local.tee $2
+        (i32.load offset=8
+         (i32.add
+          (i32.load
+           (local.get $0)
+          )
+          (i32.shl
+           (local.get $1)
+           (i32.const 2)
           )
          )
         )
+       )
+      )
+     )
+     (local.set $4
+      (f64.add
+       (local.get $4)
+       (f64.mul
         (f64.load offset=24
          (local.get $2)
         )
+        (local.get $3)
        )
-       (local.get $3)
       )
      )
      (local.set $5
       (f64.add
+       (local.get $5)
        (f64.mul
         (f64.load offset=32
          (local.get $2)
         )
-        (local.get $4)
+        (local.get $3)
        )
-       (local.get $5)
       )
      )
      (local.set $6
       (f64.add
+       (local.get $6)
        (f64.mul
         (f64.load offset=40
          (local.get $2)
         )
-        (local.get $4)
+        (local.get $3)
        )
-       (local.get $6)
       )
      )
      (local.set $1
@@ -216,7 +217,7 @@
    )
    (f64.div
     (f64.neg
-     (local.get $3)
+     (local.get $4)
     )
     (f64.const 39.47841760435743)
    )
@@ -859,8 +860,12 @@
          (f64.sub
           (local.get $4)
           (f64.mul
+           (local.get $2)
            (local.tee $8
             (f64.mul
+             (f64.load offset=48
+              (local.get $1)
+             )
              (local.tee $11
               (f64.div
                (f64.const 0.01)
@@ -870,12 +875,8 @@
                )
               )
              )
-             (f64.load offset=48
-              (local.get $1)
-             )
             )
            )
-           (local.get $2)
           )
          )
         )
@@ -883,8 +884,8 @@
          (f64.sub
           (local.get $5)
           (f64.mul
-           (local.get $8)
            (local.get $9)
+           (local.get $8)
           )
          )
         )
@@ -892,8 +893,8 @@
          (f64.sub
           (local.get $6)
           (f64.mul
-           (local.get $8)
            (local.get $10)
+           (local.get $8)
           )
          )
         )
@@ -907,8 +908,8 @@
            (local.get $2)
            (local.tee $2
             (f64.mul
-             (local.get $11)
              (local.get $17)
+             (local.get $11)
             )
            )
           )
@@ -921,8 +922,8 @@
            (local.get $1)
           )
           (f64.mul
-           (local.get $2)
            (local.get $9)
+           (local.get $2)
           )
          )
         )
@@ -933,8 +934,8 @@
            (local.get $1)
           )
           (f64.mul
-           (local.get $2)
            (local.get $10)
+           (local.get $2)
           )
          )
         )
@@ -1065,6 +1066,14 @@
       (f64.add
        (local.get $1)
        (f64.mul
+        (f64.mul
+         (local.tee $10
+          (f64.load offset=48
+           (local.get $0)
+          )
+         )
+         (f64.const 0.5)
+        )
         (f64.add
          (f64.add
           (f64.mul
@@ -1092,14 +1101,6 @@
           )
           (local.get $1)
          )
-        )
-        (f64.mul
-         (local.tee $10
-          (f64.load offset=48
-           (local.get $0)
-          )
-         )
-         (f64.const 0.5)
         )
        )
       )
@@ -1142,10 +1143,10 @@
           (local.get $1)
           (f64.div
            (f64.mul
+            (local.get $10)
             (f64.load offset=48
              (local.get $3)
             )
-            (local.get $10)
            )
            (f64.sqrt
             (f64.add

--- a/test/passes/O4_disable-bulk-memory.txt
+++ b/test/passes/O4_disable-bulk-memory.txt
@@ -134,53 +134,52 @@
     )
     (block
      (local.set $3
-      (f64.load offset=48
-       (local.tee $2
-        (i32.load offset=8
-         (i32.add
-          (i32.load
-           (local.get $0)
-          )
-          (i32.shl
-           (local.get $1)
-           (i32.const 2)
+      (f64.add
+       (f64.mul
+        (local.tee $4
+         (f64.load offset=48
+          (local.tee $2
+           (i32.load offset=8
+            (i32.add
+             (i32.load
+              (local.get $0)
+             )
+             (i32.shl
+              (local.get $1)
+              (i32.const 2)
+             )
+            )
+           )
           )
          )
         )
-       )
-      )
-     )
-     (local.set $4
-      (f64.add
-       (local.get $4)
-       (f64.mul
         (f64.load offset=24
          (local.get $2)
         )
-        (local.get $3)
        )
+       (local.get $3)
       )
      )
      (local.set $5
       (f64.add
-       (local.get $5)
        (f64.mul
         (f64.load offset=32
          (local.get $2)
         )
-        (local.get $3)
+        (local.get $4)
        )
+       (local.get $5)
       )
      )
      (local.set $6
       (f64.add
-       (local.get $6)
        (f64.mul
         (f64.load offset=40
          (local.get $2)
         )
-        (local.get $3)
+        (local.get $4)
        )
+       (local.get $6)
       )
      )
      (local.set $1
@@ -217,7 +216,7 @@
    )
    (f64.div
     (f64.neg
-     (local.get $4)
+     (local.get $3)
     )
     (f64.const 39.47841760435743)
    )
@@ -860,12 +859,8 @@
          (f64.sub
           (local.get $4)
           (f64.mul
-           (local.get $2)
            (local.tee $8
             (f64.mul
-             (f64.load offset=48
-              (local.get $1)
-             )
              (local.tee $11
               (f64.div
                (f64.const 0.01)
@@ -875,8 +870,12 @@
                )
               )
              )
+             (f64.load offset=48
+              (local.get $1)
+             )
             )
            )
+           (local.get $2)
           )
          )
         )
@@ -884,8 +883,8 @@
          (f64.sub
           (local.get $5)
           (f64.mul
-           (local.get $9)
            (local.get $8)
+           (local.get $9)
           )
          )
         )
@@ -893,8 +892,8 @@
          (f64.sub
           (local.get $6)
           (f64.mul
-           (local.get $10)
            (local.get $8)
+           (local.get $10)
           )
          )
         )
@@ -908,8 +907,8 @@
            (local.get $2)
            (local.tee $2
             (f64.mul
-             (local.get $17)
              (local.get $11)
+             (local.get $17)
             )
            )
           )
@@ -922,8 +921,8 @@
            (local.get $1)
           )
           (f64.mul
-           (local.get $9)
            (local.get $2)
+           (local.get $9)
           )
          )
         )
@@ -934,8 +933,8 @@
            (local.get $1)
           )
           (f64.mul
-           (local.get $10)
            (local.get $2)
+           (local.get $10)
           )
          )
         )
@@ -968,8 +967,8 @@
         (local.get $0)
        )
        (f64.mul
-        (f64.const 0.01)
         (local.get $4)
+        (f64.const 0.01)
        )
       )
      )
@@ -980,8 +979,8 @@
         (local.get $0)
        )
        (f64.mul
-        (f64.const 0.01)
         (local.get $5)
+        (f64.const 0.01)
        )
       )
      )
@@ -992,8 +991,8 @@
         (local.get $0)
        )
        (f64.mul
-        (f64.const 0.01)
         (local.get $6)
+        (f64.const 0.01)
        )
       )
      )
@@ -1066,14 +1065,6 @@
       (f64.add
        (local.get $1)
        (f64.mul
-        (f64.mul
-         (f64.const 0.5)
-         (local.tee $10
-          (f64.load offset=48
-           (local.get $0)
-          )
-         )
-        )
         (f64.add
          (f64.add
           (f64.mul
@@ -1101,6 +1092,14 @@
           )
           (local.get $1)
          )
+        )
+        (f64.mul
+         (local.tee $10
+          (f64.load offset=48
+           (local.get $0)
+          )
+         )
+         (f64.const 0.5)
         )
        )
       )
@@ -1143,10 +1142,10 @@
           (local.get $1)
           (f64.div
            (f64.mul
-            (local.get $10)
             (f64.load offset=48
              (local.get $3)
             )
+            (local.get $10)
            )
            (f64.sqrt
             (f64.add

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -4017,8 +4017,8 @@
                                   )
                                   (f64.sub
                                    (f64.add
-                                    (local.get $24)
                                     (local.get $14)
+                                    (local.get $24)
                                    )
                                    (local.get $14)
                                   )
@@ -5139,8 +5139,8 @@
                                  (br_if $do-once81
                                   (f64.eq
                                    (f64.add
-                                    (local.get $24)
                                     (local.get $14)
+                                    (local.get $24)
                                    )
                                    (local.get $24)
                                   )

--- a/test/passes/inlining-optimizing_optimize-level=3.txt
+++ b/test/passes/inlining-optimizing_optimize-level=3.txt
@@ -4017,8 +4017,8 @@
                                   )
                                   (f64.sub
                                    (f64.add
-                                    (local.get $14)
                                     (local.get $24)
+                                    (local.get $14)
                                    )
                                    (local.get $14)
                                   )
@@ -5139,8 +5139,8 @@
                                  (br_if $do-once81
                                   (f64.eq
                                    (f64.add
-                                    (local.get $14)
                                     (local.get $24)
+                                    (local.get $14)
                                    )
                                    (local.get $24)
                                   )

--- a/test/wasm2js/conversions-modified.2asm.js.opt
+++ b/test/wasm2js/conversions-modified.2asm.js.opt
@@ -156,19 +156,19 @@ function asmFunc(global, env, buffer) {
  }
  
  function legalstub$12($0, $1) {
-  return Math_fround(+($0 >>> 0) + 4294967296.0 * +($1 | 0));
+  return Math_fround(+($0 >>> 0) + +($1 | 0) * 4294967296.0);
  }
  
  function legalstub$14($0, $1) {
-  return +($0 >>> 0) + 4294967296.0 * +($1 | 0);
+  return +($0 >>> 0) + +($1 | 0) * 4294967296.0;
  }
  
  function legalstub$16($0, $1) {
-  return Math_fround(+($0 >>> 0) + 4294967296.0 * +($1 >>> 0));
+  return Math_fround(+($0 >>> 0) + +($1 >>> 0) * 4294967296.0);
  }
  
  function legalstub$18($0, $1) {
-  return +($0 >>> 0) + 4294967296.0 * +($1 >>> 0);
+  return +($0 >>> 0) + +($1 >>> 0) * 4294967296.0;
  }
  
  function legalstub$22($0, $1) {

--- a/test/wasm2js/float-ops.2asm.js.opt
+++ b/test/wasm2js/float-ops.2asm.js.opt
@@ -255,19 +255,19 @@ function asmFunc(global, env, buffer) {
  }
  
  function legalstub$43($0, $1_1) {
-  return Math_fround(+($0 >>> 0) + 4294967296.0 * +($1_1 | 0));
+  return Math_fround(+($0 >>> 0) + +($1_1 | 0) * 4294967296.0);
  }
  
  function legalstub$44($0, $1_1) {
-  return +($0 >>> 0) + 4294967296.0 * +($1_1 | 0);
+  return +($0 >>> 0) + +($1_1 | 0) * 4294967296.0;
  }
  
  function legalstub$45($0, $1_1) {
-  return Math_fround(+($0 >>> 0) + 4294967296.0 * +($1_1 >>> 0));
+  return Math_fround(+($0 >>> 0) + +($1_1 >>> 0) * 4294967296.0);
  }
  
  function legalstub$46($0, $1_1) {
-  return +($0 >>> 0) + 4294967296.0 * +($1_1 >>> 0);
+  return +($0 >>> 0) + +($1_1 >>> 0) * 4294967296.0;
  }
  
  var FUNCTION_TABLE = [];


### PR DESCRIPTION
Implement #3126

Add float point ops to `isSymmetric`:

AddFloat(32|64)*
MulFloat(32|64)*
EqFloat(32|64)
NeFloat(32|64)

`*` - only if we know that LHS is constant and not NaN