### PR TITLE
Update JS API function wrapper

### DIFF
--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -17,7 +17,6 @@ console.log("# Expression");
   assert(typeof binaryen.Block.getName === "function"); // own
   assert(typeof theExpression.getId === "function"); // proto
   assert(typeof theExpression.getName === "function"); // own
-  assert(theExpression.expr === 42);
   assert((theExpression | 0) === 42); // via valueOf
 })();
 

--- a/test/binaryen.js/functions.js
+++ b/test/binaryen.js/functions.js
@@ -32,3 +32,44 @@ module.removeFunction("a-function");
 assert(module.validate());
 
 console.log(module.emitText());
+
+// Test wrapper
+
+func = module.addFunction("b-function",
+  binaryen.createType([binaryen.i32, binaryen.i32]),
+  binaryen.i32,
+  [ binaryen.i32, binaryen.f64 ],
+  module.local.tee(2,
+    module.i32.add(
+      module.local.get(0, binaryen.i32),
+      module.local.get(1, binaryen.i32)
+    ),
+    binaryen.i32
+  )
+);
+binaryen.Function.setLocalName(func, 0, "a");
+binaryen.Function.setLocalName(func, 1, "b");
+binaryen.Function.setLocalName(func, 2, "ret");
+binaryen.Function.setLocalName(func, 3, "unused");
+
+var theFunc = binaryen.Function(func);
+assert(theFunc.name === "b-function");
+assert(theFunc.params === binaryen.createType([binaryen.i32, binaryen.i32]));
+assert(theFunc.results === binaryen.i32);
+assert(theFunc.numVars === 2);
+assert(theFunc.getVar(0) === binaryen.i32);
+assert(theFunc.getVar(1) === binaryen.f64);
+assert(theFunc.numLocals === 4);
+assert(theFunc.getLocalName(0) === "a");
+assert(theFunc.getLocalName(1) === "b");
+assert(theFunc.getLocalName(2) === "ret");
+assert(theFunc.getLocalName(3) === "unused");
+theFunc.setLocalName(2, "res");
+assert(theFunc.getLocalName(2) === "res");
+assert((theFunc | 0) === func);
+
+assert(module.validate());
+
+console.log(module.emitText());
+
+module.dispose();

--- a/test/binaryen.js/functions.js.txt
+++ b/test/binaryen.js/functions.js.txt
@@ -6,3 +6,17 @@ getExpressionInfo(body)={"id":14,"value":3}
 (module
 )
 
+(module
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (func $b-function (param $a i32) (param $b i32) (result i32)
+  (local $res i32)
+  (local $unused f64)
+  (local.tee $res
+   (i32.add
+    (local.get $a)
+    (local.get $b)
+   )
+  )
+ )
+)
+


### PR DESCRIPTION
Follow-up on https://github.com/WebAssembly/binaryen/pull/3115#discussion_r487205710.

Updates the JS API `Function` wrapper introduced in #3115 with bindings for more C API functions (unrelated to #3115). Also adds additional comments to describe the inner workings of wrappers in more detail.