### PR TITLE
Fix 64-bit UB in BinaryenLiteral

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -223,7 +223,7 @@ BINARYEN_API void BinaryenModuleDispose(BinaryenModuleRef module);
 // Literals. These are passed by value.
 
 struct BinaryenLiteral {
-  int32_t type;
+  uintptr_t type;
   union {
     int32_t i32;
     int64_t i64;
@@ -231,6 +231,7 @@ struct BinaryenLiteral {
     double f64;
     uint8_t v128[16];
     const char* func;
+    // TODO: exn
   };
 };
 


### PR DESCRIPTION
Changes the storage type of type ids in `BinaryenLiteral` from `int32_t` to `uintptr_t`, matching `Literal`. The maximum storage size of type ids changed with the introduction of tuples, with their type id being the memory address of the canonicalized type vector.

Interestingly, the related check

https://github.com/WebAssembly/binaryen/blob/bced89d2986bde990bf9bf52306e55772b02707e/src/binaryen-c.cpp#L48-L49

did not catch this due to implicit struct alignment, and other tests did not notice because type ids typically do not grow to values larger than 32 bits.