### PR TITLE
Don't change NaN bits on trivial add/sub in the interpreter

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -759,10 +759,35 @@ Literal Literal::add(const Literal& other) const {
       return Literal(uint32_t(i32) + uint32_t(other.i32));
     case Type::i64:
       return Literal(uint64_t(i64) + uint64_t(other.i64));
-    case Type::f32:
-      return Literal(getf32() + other.getf32());
-    case Type::f64:
-      return Literal(getf64() + other.getf64());
+    case Type::f32: {
+      // Special-case addition of 1. nan + 1 can change nan bits per the
+      // wasm spec, but it is ok to just return that original nan, and we
+      // do that here so that we are consistent with the optimization of
+      // removing the * 1 and leaving just the nan. That is, if we just
+      // do a normal multiply and the CPU decides to change the bits, we'd
+      // give a different result on optimized code, which would look like
+      // it was a bad optimization. So out of all the valid results to
+      // return here, return the simplest one that is consistent with
+      // our optimization for the case of 1.
+      float lhs = getf32(), rhs = other.getf32();
+      if (lhs == 1) {
+        return Literal(rhs);
+      }
+      if (rhs == 1) {
+        return Literal(lhs);
+      }
+      return Literal(lhs + rhs);
+    }
+    case Type::f64: {
+      double lhs = getf64(), rhs = other.getf64();
+      if (lhs == 1) {
+        return Literal(rhs);
+      }
+      if (rhs == 1) {
+        return Literal(lhs);
+      }
+      return Literal(lhs + rhs);
+    }
     case Type::v128:
     case Type::funcref:
     case Type::externref:
@@ -781,10 +806,22 @@ Literal Literal::sub(const Literal& other) const {
       return Literal(uint32_t(i32) - uint32_t(other.i32));
     case Type::i64:
       return Literal(uint64_t(i64) - uint64_t(other.i64));
-    case Type::f32:
-      return Literal(getf32() - other.getf32());
-    case Type::f64:
-      return Literal(getf64() - other.getf64());
+    case Type::f32: {
+      float lhs = getf32(), rhs = other.getf32();
+      // As with addition, make sure to not change NaN bits in trivial
+      // operations.
+      if (rhs == 0) {
+        return Literal(lhs);
+      }
+      return Literal(lhs - rhs);
+    }
+    case Type::f64: {
+      double lhs = getf64(), rhs = other.getf64();
+      if (rhs == 0) {
+        return Literal(lhs);
+      }
+      return Literal(lhs - rhs);
+    }
     case Type::v128:
     case Type::funcref:
     case Type::externref:
@@ -875,16 +912,9 @@ Literal Literal::mul(const Literal& other) const {
     case Type::i64:
       return Literal(uint64_t(i64) * uint64_t(other.i64));
     case Type::f32: {
-      // Special-case multiplication by 1. nan * 1 can change nan bits per the
-      // wasm spec, but it is ok to just return that original nan, and we
-      // do that here so that we are consistent with the optimization of
-      // removing the * 1 and leaving just the nan. That is, if we just
-      // do a normal multiply and the CPU decides to change the bits, we'd
-      // give a different result on optimized code, which would look like
-      // it was a bad optimization. So out of all the valid results to
-      // return here, return the simplest one that is consistent with
-      // our optimization for the case of 1.
       float lhs = getf32(), rhs = other.getf32();
+      // As with addition, make sure to not change NaN bits in trivial
+      // operations.
       if (rhs == 1) {
         return Literal(lhs);
       }
@@ -940,7 +970,8 @@ Literal Literal::div(const Literal& other) const {
         case FP_INFINITE: // fallthrough
         case FP_NORMAL:   // fallthrough
         case FP_SUBNORMAL:
-          // Special-case division by 1, similar to multiply from earlier.
+          // As with addition, make sure to not change NaN bits in trivial
+          // operations.
           if (rhs == 1) {
             return Literal(lhs);
           }
@@ -972,7 +1003,6 @@ Literal Literal::div(const Literal& other) const {
         case FP_INFINITE: // fallthrough
         case FP_NORMAL:   // fallthrough
         case FP_SUBNORMAL:
-          // See above comment on f32.
           if (rhs == 1) {
             return Literal(lhs);
           }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -759,10 +759,35 @@ Literal Literal::add(const Literal& other) const {
       return Literal(uint32_t(i32) + uint32_t(other.i32));
     case Type::i64:
       return Literal(uint64_t(i64) + uint64_t(other.i64));
-    case Type::f32:
-      return Literal(getf32() + other.getf32());
-    case Type::f64:
-      return Literal(getf64() + other.getf64());
+    case Type::f32: {
+      // Special-case addition of -0. nan + -0 can change nan bits per the
+      // wasm spec, but it is ok to just return that original nan, and we
+      // do that here so that we are consistent with the optimization of
+      // removing the + -0 and leaving just the nan. That is, if we just
+      // do a normal add and the CPU decides to change the bits, we'd
+      // give a different result on optimized code, which would look like
+      // it was a bad optimization. So out of all the valid results to
+      // return here, return the simplest one that is consistent with
+      // our optimization for the case of 1.
+      float lhs = getf32(), rhs = other.getf32();
+      if (lhs == 0 && std::signbit(lhs)) {
+        return Literal(rhs);
+      }
+      if (rhs == 0 && std::signbit(rhs)) {
+        return Literal(lhs);
+      }
+      return Literal(lhs + rhs);
+    }
+    case Type::f64: {
+      double lhs = getf64(), rhs = other.getf64();
+      if (lhs == 0 && std::signbit(lhs)) {
+        return Literal(rhs);
+      }
+      if (rhs == 0 && std::signbit(rhs)) {
+        return Literal(lhs);
+      }
+      return Literal(lhs + rhs);
+    }
     case Type::v128:
     case Type::funcref:
     case Type::externref:
@@ -783,15 +808,8 @@ Literal Literal::sub(const Literal& other) const {
       return Literal(uint64_t(i64) - uint64_t(other.i64));
     case Type::f32: {
       float lhs = getf32(), rhs = other.getf32();
-      // Special-case subtraction of 0. nan - 0 can change nan bits per the
-      // wasm spec, but it is ok to just return that original nan, and we
-      // do that here so that we are consistent with the optimization of
-      // removing the - 0 and leaving just the nan. That is, if we just
-      // do a normal add and the CPU decides to change the bits, we'd
-      // give a different result on optimized code, which would look like
-      // it was a bad optimization. So out of all the valid results to
-      // return here, return the simplest one that is consistent with
-      // our optimization for the case of 1.
+      // As with addition, make sure to not change NaN bits in trivial
+      // operations.
       if (rhs == 0 && !std::signbit(rhs)) {
         return Literal(lhs);
       }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -760,7 +760,7 @@ Literal Literal::add(const Literal& other) const {
     case Type::i64:
       return Literal(uint64_t(i64) + uint64_t(other.i64));
     case Type::f32: {
-      // Special-case addition of 1. nan + 1 can change nan bits per the
+      // Special-case addition of 0. nan + 0 can change nan bits per the
       // wasm spec, but it is ok to just return that original nan, and we
       // do that here so that we are consistent with the optimization of
       // removing the * 1 and leaving just the nan. That is, if we just

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -759,35 +759,10 @@ Literal Literal::add(const Literal& other) const {
       return Literal(uint32_t(i32) + uint32_t(other.i32));
     case Type::i64:
       return Literal(uint64_t(i64) + uint64_t(other.i64));
-    case Type::f32: {
-      // Special-case addition of 0. nan + 0 can change nan bits per the
-      // wasm spec, but it is ok to just return that original nan, and we
-      // do that here so that we are consistent with the optimization of
-      // removing the + 0 and leaving just the nan. That is, if we just
-      // do a normal add and the CPU decides to change the bits, we'd
-      // give a different result on optimized code, which would look like
-      // it was a bad optimization. So out of all the valid results to
-      // return here, return the simplest one that is consistent with
-      // our optimization for the case of 1.
-      float lhs = getf32(), rhs = other.getf32();
-      if (lhs == 1) {
-        return Literal(rhs);
-      }
-      if (rhs == 1) {
-        return Literal(lhs);
-      }
-      return Literal(lhs + rhs);
-    }
-    case Type::f64: {
-      double lhs = getf64(), rhs = other.getf64();
-      if (lhs == 1) {
-        return Literal(rhs);
-      }
-      if (rhs == 1) {
-        return Literal(lhs);
-      }
-      return Literal(lhs + rhs);
-    }
+    case Type::f32:
+      return Literal(getf32() + other.getf32());
+    case Type::f64:
+      return Literal(getf64() + other.getf64());
     case Type::v128:
     case Type::funcref:
     case Type::externref:
@@ -808,16 +783,23 @@ Literal Literal::sub(const Literal& other) const {
       return Literal(uint64_t(i64) - uint64_t(other.i64));
     case Type::f32: {
       float lhs = getf32(), rhs = other.getf32();
-      // As with addition, make sure to not change NaN bits in trivial
-      // operations.
-      if (rhs == 0) {
+      // Special-case subtraction of 0. nan - 0 can change nan bits per the
+      // wasm spec, but it is ok to just return that original nan, and we
+      // do that here so that we are consistent with the optimization of
+      // removing the - 0 and leaving just the nan. That is, if we just
+      // do a normal add and the CPU decides to change the bits, we'd
+      // give a different result on optimized code, which would look like
+      // it was a bad optimization. So out of all the valid results to
+      // return here, return the simplest one that is consistent with
+      // our optimization for the case of 1.
+      if (rhs == 0 && !std::signbit(rhs)) {
         return Literal(lhs);
       }
       return Literal(lhs - rhs);
     }
     case Type::f64: {
       double lhs = getf64(), rhs = other.getf64();
-      if (rhs == 0) {
+      if (rhs == 0 && !std::signbit(rhs)) {
         return Literal(lhs);
       }
       return Literal(lhs - rhs);

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -763,8 +763,8 @@ Literal Literal::add(const Literal& other) const {
       // Special-case addition of 0. nan + 0 can change nan bits per the
       // wasm spec, but it is ok to just return that original nan, and we
       // do that here so that we are consistent with the optimization of
-      // removing the * 1 and leaving just the nan. That is, if we just
-      // do a normal multiply and the CPU decides to change the bits, we'd
+      // removing the + 0 and leaving just the nan. That is, if we just
+      // do a normal add and the CPU decides to change the bits, we'd
       // give a different result on optimized code, which would look like
       // it was a bad optimization. So out of all the valid results to
       // return here, return the simplest one that is consistent with

--- a/test/passes/fuzz-exec_O.txt
+++ b/test/passes/fuzz-exec_O.txt
@@ -36,16 +36,28 @@
 [fuzz-exec] note result: mul1 => -nan:0x34546d
 [fuzz-exec] calling mul2
 [fuzz-exec] note result: mul2 => -nan:0x34546d
+[fuzz-exec] calling add1
+[fuzz-exec] note result: add1 => -nan:0x74546d
+[fuzz-exec] calling add2
+[fuzz-exec] note result: add2 => -nan:0x74546d
+[fuzz-exec] calling sub
+[fuzz-exec] note result: sub => -nan:0x34546d
 (module
  (type $none_=>_f32 (func (result f32)))
  (export "div" (func $0))
  (export "mul1" (func $1))
  (export "mul2" (func $1))
+ (export "add1" (func $3))
+ (export "add2" (func $3))
+ (export "sub" (func $1))
  (func $0 (; has Stack IR ;) (result f32)
   (f32.const -nan:0x23017a)
  )
  (func $1 (; has Stack IR ;) (result f32)
   (f32.const -nan:0x34546d)
+ )
+ (func $3 (; has Stack IR ;) (result f32)
+  (f32.const -nan:0x74546d)
  )
 )
 [fuzz-exec] calling div
@@ -54,6 +66,15 @@
 [fuzz-exec] note result: mul1 => -nan:0x34546d
 [fuzz-exec] calling mul2
 [fuzz-exec] note result: mul2 => -nan:0x34546d
+[fuzz-exec] calling add1
+[fuzz-exec] note result: add1 => -nan:0x74546d
+[fuzz-exec] calling add2
+[fuzz-exec] note result: add2 => -nan:0x74546d
+[fuzz-exec] calling sub
+[fuzz-exec] note result: sub => -nan:0x34546d
+[fuzz-exec] comparing add1
+[fuzz-exec] comparing add2
 [fuzz-exec] comparing div
 [fuzz-exec] comparing mul1
 [fuzz-exec] comparing mul2
+[fuzz-exec] comparing sub

--- a/test/passes/fuzz-exec_O.txt
+++ b/test/passes/fuzz-exec_O.txt
@@ -37,26 +37,35 @@
 [fuzz-exec] calling mul2
 [fuzz-exec] note result: mul2 => -nan:0x34546d
 [fuzz-exec] calling add1
-[fuzz-exec] note result: add1 => -nan:0x74546d
+[fuzz-exec] note result: add1 => -nan:0x34546d
 [fuzz-exec] calling add2
-[fuzz-exec] note result: add2 => -nan:0x74546d
-[fuzz-exec] calling sub
-[fuzz-exec] note result: sub => -nan:0x34546d
+[fuzz-exec] note result: add2 => -nan:0x34546d
+[fuzz-exec] calling add3
+[fuzz-exec] note result: add3 => -nan:0x74546d
+[fuzz-exec] calling add4
+[fuzz-exec] note result: add4 => -nan:0x74546d
+[fuzz-exec] calling sub1
+[fuzz-exec] note result: sub1 => -nan:0x34546d
+[fuzz-exec] calling sub2
+[fuzz-exec] note result: sub2 => -nan:0x74546d
 (module
  (type $none_=>_f32 (func (result f32)))
  (export "div" (func $0))
  (export "mul1" (func $1))
  (export "mul2" (func $1))
- (export "add1" (func $3))
- (export "add2" (func $3))
- (export "sub" (func $1))
+ (export "add1" (func $1))
+ (export "add2" (func $1))
+ (export "add3" (func $5))
+ (export "add4" (func $5))
+ (export "sub1" (func $1))
+ (export "sub2" (func $5))
  (func $0 (; has Stack IR ;) (result f32)
   (f32.const -nan:0x23017a)
  )
  (func $1 (; has Stack IR ;) (result f32)
   (f32.const -nan:0x34546d)
  )
- (func $3 (; has Stack IR ;) (result f32)
+ (func $5 (; has Stack IR ;) (result f32)
   (f32.const -nan:0x74546d)
  )
 )
@@ -67,14 +76,23 @@
 [fuzz-exec] calling mul2
 [fuzz-exec] note result: mul2 => -nan:0x34546d
 [fuzz-exec] calling add1
-[fuzz-exec] note result: add1 => -nan:0x74546d
+[fuzz-exec] note result: add1 => -nan:0x34546d
 [fuzz-exec] calling add2
-[fuzz-exec] note result: add2 => -nan:0x74546d
-[fuzz-exec] calling sub
-[fuzz-exec] note result: sub => -nan:0x34546d
+[fuzz-exec] note result: add2 => -nan:0x34546d
+[fuzz-exec] calling add3
+[fuzz-exec] note result: add3 => -nan:0x74546d
+[fuzz-exec] calling add4
+[fuzz-exec] note result: add4 => -nan:0x74546d
+[fuzz-exec] calling sub1
+[fuzz-exec] note result: sub1 => -nan:0x34546d
+[fuzz-exec] calling sub2
+[fuzz-exec] note result: sub2 => -nan:0x74546d
 [fuzz-exec] comparing add1
 [fuzz-exec] comparing add2
+[fuzz-exec] comparing add3
+[fuzz-exec] comparing add4
 [fuzz-exec] comparing div
 [fuzz-exec] comparing mul1
 [fuzz-exec] comparing mul2
-[fuzz-exec] comparing sub
+[fuzz-exec] comparing sub1
+[fuzz-exec] comparing sub2

--- a/test/passes/fuzz-exec_O.wast
+++ b/test/passes/fuzz-exec_O.wast
@@ -57,13 +57,19 @@
    (f32.const 0)
   )
  )
- (func "sub" (result f32)
+ (func "add4" (result f32)
+  (f32.add
+   (f32.const 0)
+   (f32.const -nan:0x34546d)
+  )
+ )
+ (func "sub1" (result f32)
   (f32.sub
    (f32.const -nan:0x34546d)
    (f32.const 0)
   )
  )
- (func "sub" (result f32)
+ (func "sub2" (result f32)
   (f32.sub
    (f32.const -nan:0x34546d)
    (f32.const -0)

--- a/test/passes/fuzz-exec_O.wast
+++ b/test/passes/fuzz-exec_O.wast
@@ -39,5 +39,22 @@
    (f32.const -nan:0x34546d)
   )
  )
+ (func "add1" (result f32)
+  (f32.add
+   (f32.const -nan:0x34546d)
+   (f32.const 0)
+  )
+ )
+ (func "add2" (result f32)
+  (f32.add
+   (f32.const 0)
+   (f32.const -nan:0x34546d)
+  )
+ )
+ (func "sub" (result f32)
+  (f32.sub
+   (f32.const -nan:0x34546d)
+   (f32.const 0)
+  )
+ )
 )
-

--- a/test/passes/fuzz-exec_O.wast
+++ b/test/passes/fuzz-exec_O.wast
@@ -42,19 +42,31 @@
  (func "add1" (result f32)
   (f32.add
    (f32.const -nan:0x34546d)
-   (f32.const 0)
+   (f32.const -0)
   )
  )
  (func "add2" (result f32)
   (f32.add
-   (f32.const 0)
+   (f32.const -0)
    (f32.const -nan:0x34546d)
+  )
+ )
+ (func "add3" (result f32)
+  (f32.add
+   (f32.const -nan:0x34546d)
+   (f32.const 0)
   )
  )
  (func "sub" (result f32)
   (f32.sub
    (f32.const -nan:0x34546d)
    (f32.const 0)
+  )
+ )
+ (func "sub" (result f32)
+  (f32.sub
+   (f32.const -nan:0x34546d)
+   (f32.const -0)
   )
  )
 )

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -402,7 +402,7 @@
                   (block $label$6
                    (call $log-f32
                     (f32.min
-                     (f32.const -1)
+                     (f32.const -1.1754943508222875e-38)
                      (f32.demote_f64
                       (f64.copysign
                        (f64.const 28)
@@ -523,7 +523,7 @@
                      (call $log-v128
                       (i32x4.ne
                        (local.get $4)
-                       (v128.const i32x4 0xffe3e76d 0x41dfffff 0xd70a3d70 0x3ffb70a3)
+                       (v128.const i32x4 0xffe3e76d 0x41dfffff 0xae147ae1 0x3fe6e147)
                       )
                      )
                      (br $label$3)

--- a/test/passes/translate-to-fuzz_all-features.txt
+++ b/test/passes/translate-to-fuzz_all-features.txt
@@ -402,7 +402,7 @@
                   (block $label$6
                    (call $log-f32
                     (f32.min
-                     (f32.const -1.1754943508222875e-38)
+                     (f32.const -1)
                      (f32.demote_f64
                       (f64.copysign
                        (f64.const 28)
@@ -523,7 +523,7 @@
                      (call $log-v128
                       (i32x4.ne
                        (local.get $4)
-                       (v128.const i32x4 0xffe3e76d 0x41dfffff 0xae147ae1 0x3fe6e147)
+                       (v128.const i32x4 0xffe3e76d 0x41dfffff 0xd70a3d70 0x3ffb70a3)
                       )
                      )
                      (br $label$3)

--- a/test/spec/old_float_exprs.wast
+++ b/test/spec/old_float_exprs.wast
@@ -72,8 +72,10 @@
     (f64.sub (local.get $x) (f64.const 0.0)))
 )
 
-(assert_return (invoke "f32.no_fold_sub_zero" (f32.const nan:0x200000)) (f32.const nan:0x600000))
-(assert_return (invoke "f64.no_fold_sub_zero" (f64.const nan:0x4000000000000)) (f64.const nan:0xc000000000000))
+;; XXX BINARYEN: pick the same NaN pattern as the input here, to match the
+;; interpreter
+(assert_return (invoke "f32.no_fold_sub_zero" (f32.const nan:0x200000)) (f32.const nan:0x200000))
+(assert_return (invoke "f64.no_fold_sub_zero" (f64.const nan:0x4000000000000)) (f64.const nan:0x4000000000000))
 
 ;; Test that x*0.0 is not folded to 0.0.
 


### PR DESCRIPTION
Similar to https://github.com/WebAssembly/binaryen/pull/3096 but for add and sub: if we optimize a pattern, we want
the interpreter to match it even when there are various valid NaN patterns, we want
to emit the pattern the fuzzer recognizes (and, it's simpler).

Fixes #3138, replaces #3139