### PR TITLE
Remove redundant allocator in Builder

### DIFF
--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -810,7 +810,7 @@ void AssertionEmitter::emit() {
     }
   )";
 
-  Builder wasmBuilder(sexpBuilder.getAllocator(), sexpBuilder.getModule());
+  Builder wasmBuilder(sexpBuilder.getModule());
   Name asmModule = std::string("ret") + ASM_FUNC.str;
   for (size_t i = 0; i < root.size(); ++i) {
     Element& e = *root[i];

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -34,13 +34,10 @@ struct NameType {
 // General AST node builder
 
 class Builder {
-  MixedArena& allocator;
   Module& wasm;
 
 public:
-  Builder(MixedArena& allocator, Module& wasm)
-    : allocator(allocator), wasm(wasm) {}
-  Builder(Module& wasm) : allocator(wasm.allocator), wasm(wasm) {}
+  Builder(Module& wasm) : wasm(wasm) {}
 
   // make* functions, other globals
 
@@ -91,9 +88,9 @@ public:
 
   // IR nodes
 
-  Nop* makeNop() { return allocator.alloc<Nop>(); }
+  Nop* makeNop() { return wasm.allocator.alloc<Nop>(); }
   Block* makeBlock(Expression* first = nullptr) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     if (first) {
       ret->list.push_back(first);
       ret->finalize();
@@ -107,38 +104,38 @@ public:
     return ret;
   }
   Block* makeBlock(const std::vector<Expression*>& items) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
     ret->finalize();
     return ret;
   }
   Block* makeBlock(const std::vector<Expression*>& items, Type type) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
     ret->finalize(type);
     return ret;
   }
   Block* makeBlock(const ExpressionList& items) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
     ret->finalize();
     return ret;
   }
   Block* makeBlock(const ExpressionList& items, Type type) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
     ret->finalize(type);
     return ret;
   }
   Block* makeBlock(Name name, const ExpressionList& items) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     ret->name = name;
     ret->list.set(items);
     ret->finalize();
     return ret;
   }
   Block* makeBlock(Name name, const ExpressionList& items, Type type) {
-    auto* ret = allocator.alloc<Block>();
+    auto* ret = wasm.allocator.alloc<Block>();
     ret->name = name;
     ret->list.set(items);
     ret->finalize(type);
@@ -147,7 +144,7 @@ public:
   If* makeIf(Expression* condition,
              Expression* ifTrue,
              Expression* ifFalse = nullptr) {
-    auto* ret = allocator.alloc<If>();
+    auto* ret = wasm.allocator.alloc<If>();
     ret->condition = condition;
     ret->ifTrue = ifTrue;
     ret->ifFalse = ifFalse;
@@ -158,7 +155,7 @@ public:
              Expression* ifTrue,
              Expression* ifFalse,
              Type type) {
-    auto* ret = allocator.alloc<If>();
+    auto* ret = wasm.allocator.alloc<If>();
     ret->condition = condition;
     ret->ifTrue = ifTrue;
     ret->ifFalse = ifFalse;
@@ -166,14 +163,14 @@ public:
     return ret;
   }
   Loop* makeLoop(Name name, Expression* body) {
-    auto* ret = allocator.alloc<Loop>();
+    auto* ret = wasm.allocator.alloc<Loop>();
     ret->name = name;
     ret->body = body;
     ret->finalize();
     return ret;
   }
   Loop* makeLoop(Name name, Expression* body, Type type) {
-    auto* ret = allocator.alloc<Loop>();
+    auto* ret = wasm.allocator.alloc<Loop>();
     ret->name = name;
     ret->body = body;
     ret->finalize(type);
@@ -182,7 +179,7 @@ public:
   Break* makeBreak(Name name,
                    Expression* value = nullptr,
                    Expression* condition = nullptr) {
-    auto* ret = allocator.alloc<Break>();
+    auto* ret = wasm.allocator.alloc<Break>();
     ret->name = name;
     ret->value = value;
     ret->condition = condition;
@@ -194,7 +191,7 @@ public:
                      Name default_,
                      Expression* condition,
                      Expression* value = nullptr) {
-    auto* ret = allocator.alloc<Switch>();
+    auto* ret = wasm.allocator.alloc<Switch>();
     ret->targets.set(list);
     ret->default_ = default_;
     ret->value = value;
@@ -205,7 +202,7 @@ public:
                  const std::vector<Expression*>& args,
                  Type type,
                  bool isReturn = false) {
-    auto* call = allocator.alloc<Call>();
+    auto* call = wasm.allocator.alloc<Call>();
     // not all functions may exist yet, so type must be provided
     call->type = type;
     call->target = target;
@@ -215,7 +212,7 @@ public:
   }
   template<typename T>
   Call* makeCall(Name target, const T& args, Type type, bool isReturn = false) {
-    auto* call = allocator.alloc<Call>();
+    auto* call = wasm.allocator.alloc<Call>();
     // not all functions may exist yet, so type must be provided
     call->type = type;
     call->target = target;
@@ -228,7 +225,7 @@ public:
                                  const std::vector<Expression*>& args,
                                  Signature sig,
                                  bool isReturn = false) {
-    auto* call = allocator.alloc<CallIndirect>();
+    auto* call = wasm.allocator.alloc<CallIndirect>();
     call->sig = sig;
     call->type = sig.results;
     call->target = target;
@@ -238,13 +235,13 @@ public:
     return call;
   }
   LocalGet* makeLocalGet(Index index, Type type) {
-    auto* ret = allocator.alloc<LocalGet>();
+    auto* ret = wasm.allocator.alloc<LocalGet>();
     ret->index = index;
     ret->type = type;
     return ret;
   }
   LocalSet* makeLocalSet(Index index, Expression* value) {
-    auto* ret = allocator.alloc<LocalSet>();
+    auto* ret = wasm.allocator.alloc<LocalSet>();
     ret->index = index;
     ret->value = value;
     ret->makeSet();
@@ -252,20 +249,20 @@ public:
     return ret;
   }
   LocalSet* makeLocalTee(Index index, Expression* value, Type type) {
-    auto* ret = allocator.alloc<LocalSet>();
+    auto* ret = wasm.allocator.alloc<LocalSet>();
     ret->index = index;
     ret->value = value;
     ret->makeTee(type);
     return ret;
   }
   GlobalGet* makeGlobalGet(Name name, Type type) {
-    auto* ret = allocator.alloc<GlobalGet>();
+    auto* ret = wasm.allocator.alloc<GlobalGet>();
     ret->name = name;
     ret->type = type;
     return ret;
   }
   GlobalSet* makeGlobalSet(Name name, Expression* value) {
-    auto* ret = allocator.alloc<GlobalSet>();
+    auto* ret = wasm.allocator.alloc<GlobalSet>();
     ret->name = name;
     ret->value = value;
     ret->finalize();
@@ -277,7 +274,7 @@ public:
                  unsigned align,
                  Expression* ptr,
                  Type type) {
-    auto* ret = allocator.alloc<Load>();
+    auto* ret = wasm.allocator.alloc<Load>();
     ret->isAtomic = false;
     ret->bytes = bytes;
     ret->signed_ = signed_;
@@ -298,7 +295,7 @@ public:
                              Expression* timeout,
                              Type expectedType,
                              Address offset) {
-    auto* wait = allocator.alloc<AtomicWait>();
+    auto* wait = wasm.allocator.alloc<AtomicWait>();
     wait->offset = offset;
     wait->ptr = ptr;
     wait->expected = expected;
@@ -309,21 +306,21 @@ public:
   }
   AtomicNotify*
   makeAtomicNotify(Expression* ptr, Expression* notifyCount, Address offset) {
-    auto* notify = allocator.alloc<AtomicNotify>();
+    auto* notify = wasm.allocator.alloc<AtomicNotify>();
     notify->offset = offset;
     notify->ptr = ptr;
     notify->notifyCount = notifyCount;
     notify->finalize();
     return notify;
   }
-  AtomicFence* makeAtomicFence() { return allocator.alloc<AtomicFence>(); }
+  AtomicFence* makeAtomicFence() { return wasm.allocator.alloc<AtomicFence>(); }
   Store* makeStore(unsigned bytes,
                    uint32_t offset,
                    unsigned align,
                    Expression* ptr,
                    Expression* value,
                    Type type) {
-    auto* ret = allocator.alloc<Store>();
+    auto* ret = wasm.allocator.alloc<Store>();
     ret->isAtomic = false;
     ret->bytes = bytes;
     ret->offset = offset;
@@ -350,7 +347,7 @@ public:
                            Expression* ptr,
                            Expression* value,
                            Type type) {
-    auto* ret = allocator.alloc<AtomicRMW>();
+    auto* ret = wasm.allocator.alloc<AtomicRMW>();
     ret->op = op;
     ret->bytes = bytes;
     ret->offset = offset;
@@ -366,7 +363,7 @@ public:
                                    Expression* expected,
                                    Expression* replacement,
                                    Type type) {
-    auto* ret = allocator.alloc<AtomicCmpxchg>();
+    auto* ret = wasm.allocator.alloc<AtomicCmpxchg>();
     ret->bytes = bytes;
     ret->offset = offset;
     ret->ptr = ptr;
@@ -378,7 +375,7 @@ public:
   }
   SIMDExtract*
   makeSIMDExtract(SIMDExtractOp op, Expression* vec, uint8_t index) {
-    auto* ret = allocator.alloc<SIMDExtract>();
+    auto* ret = wasm.allocator.alloc<SIMDExtract>();
     ret->op = op;
     ret->vec = vec;
     ret->index = index;
@@ -389,7 +386,7 @@ public:
                                Expression* vec,
                                uint8_t index,
                                Expression* value) {
-    auto* ret = allocator.alloc<SIMDReplace>();
+    auto* ret = wasm.allocator.alloc<SIMDReplace>();
     ret->op = op;
     ret->vec = vec;
     ret->index = index;
@@ -400,7 +397,7 @@ public:
   SIMDShuffle* makeSIMDShuffle(Expression* left,
                                Expression* right,
                                const std::array<uint8_t, 16>& mask) {
-    auto* ret = allocator.alloc<SIMDShuffle>();
+    auto* ret = wasm.allocator.alloc<SIMDShuffle>();
     ret->left = left;
     ret->right = right;
     ret->mask = mask;
@@ -411,7 +408,7 @@ public:
                                Expression* a,
                                Expression* b,
                                Expression* c) {
-    auto* ret = allocator.alloc<SIMDTernary>();
+    auto* ret = wasm.allocator.alloc<SIMDTernary>();
     ret->op = op;
     ret->a = a;
     ret->b = b;
@@ -420,7 +417,7 @@ public:
     return ret;
   }
   SIMDShift* makeSIMDShift(SIMDShiftOp op, Expression* vec, Expression* shift) {
-    auto* ret = allocator.alloc<SIMDShift>();
+    auto* ret = wasm.allocator.alloc<SIMDShift>();
     ret->op = op;
     ret->vec = vec;
     ret->shift = shift;
@@ -429,7 +426,7 @@ public:
   }
   SIMDLoad*
   makeSIMDLoad(SIMDLoadOp op, Address offset, Address align, Expression* ptr) {
-    auto* ret = allocator.alloc<SIMDLoad>();
+    auto* ret = wasm.allocator.alloc<SIMDLoad>();
     ret->op = op;
     ret->offset = offset;
     ret->align = align;
@@ -441,7 +438,7 @@ public:
                              Expression* dest,
                              Expression* offset,
                              Expression* size) {
-    auto* ret = allocator.alloc<MemoryInit>();
+    auto* ret = wasm.allocator.alloc<MemoryInit>();
     ret->segment = segment;
     ret->dest = dest;
     ret->offset = offset;
@@ -450,14 +447,14 @@ public:
     return ret;
   }
   DataDrop* makeDataDrop(uint32_t segment) {
-    auto* ret = allocator.alloc<DataDrop>();
+    auto* ret = wasm.allocator.alloc<DataDrop>();
     ret->segment = segment;
     ret->finalize();
     return ret;
   }
   MemoryCopy*
   makeMemoryCopy(Expression* dest, Expression* source, Expression* size) {
-    auto* ret = allocator.alloc<MemoryCopy>();
+    auto* ret = wasm.allocator.alloc<MemoryCopy>();
     ret->dest = dest;
     ret->source = source;
     ret->size = size;
@@ -466,7 +463,7 @@ public:
   }
   MemoryFill*
   makeMemoryFill(Expression* dest, Expression* value, Expression* size) {
-    auto* ret = allocator.alloc<MemoryFill>();
+    auto* ret = wasm.allocator.alloc<MemoryFill>();
     ret->dest = dest;
     ret->value = value;
     ret->size = size;
@@ -475,14 +472,14 @@ public:
   }
   Const* makeConst(Literal value) {
     assert(value.type.isNumber());
-    auto* ret = allocator.alloc<Const>();
+    auto* ret = wasm.allocator.alloc<Const>();
     ret->value = value;
     ret->type = value.type;
     return ret;
   }
   template<typename T> Const* makeConst(T x) { return makeConst(Literal(x)); }
   Unary* makeUnary(UnaryOp op, Expression* value) {
-    auto* ret = allocator.alloc<Unary>();
+    auto* ret = wasm.allocator.alloc<Unary>();
     ret->op = op;
     ret->value = value;
     ret->finalize();
@@ -492,7 +489,7 @@ public:
     return makeConst(Literal::makeFromUInt64(val, wasm.memory.indexType));
   }
   Binary* makeBinary(BinaryOp op, Expression* left, Expression* right) {
-    auto* ret = allocator.alloc<Binary>();
+    auto* ret = wasm.allocator.alloc<Binary>();
     ret->op = op;
     ret->left = left;
     ret->right = right;
@@ -501,7 +498,7 @@ public:
   }
   Select*
   makeSelect(Expression* condition, Expression* ifTrue, Expression* ifFalse) {
-    auto* ret = allocator.alloc<Select>();
+    auto* ret = wasm.allocator.alloc<Select>();
     ret->condition = condition;
     ret->ifTrue = ifTrue;
     ret->ifFalse = ifFalse;
@@ -512,7 +509,7 @@ public:
                      Expression* ifTrue,
                      Expression* ifFalse,
                      Type type) {
-    auto* ret = allocator.alloc<Select>();
+    auto* ret = wasm.allocator.alloc<Select>();
     ret->condition = condition;
     ret->ifTrue = ifTrue;
     ret->ifFalse = ifFalse;
@@ -520,12 +517,12 @@ public:
     return ret;
   }
   Return* makeReturn(Expression* value = nullptr) {
-    auto* ret = allocator.alloc<Return>();
+    auto* ret = wasm.allocator.alloc<Return>();
     ret->value = value;
     return ret;
   }
   MemorySize* makeMemorySize() {
-    auto* ret = allocator.alloc<MemorySize>();
+    auto* ret = wasm.allocator.alloc<MemorySize>();
     if (wasm.memory.is64()) {
       ret->make64();
     }
@@ -533,7 +530,7 @@ public:
     return ret;
   }
   MemoryGrow* makeMemoryGrow(Expression* delta) {
-    auto* ret = allocator.alloc<MemoryGrow>();
+    auto* ret = wasm.allocator.alloc<MemoryGrow>();
     if (wasm.memory.is64()) {
       ret->make64();
     }
@@ -542,31 +539,31 @@ public:
     return ret;
   }
   RefNull* makeRefNull(Type type) {
-    auto* ret = allocator.alloc<RefNull>();
+    auto* ret = wasm.allocator.alloc<RefNull>();
     ret->finalize(type);
     return ret;
   }
   RefIsNull* makeRefIsNull(Expression* value) {
-    auto* ret = allocator.alloc<RefIsNull>();
+    auto* ret = wasm.allocator.alloc<RefIsNull>();
     ret->value = value;
     ret->finalize();
     return ret;
   }
   RefFunc* makeRefFunc(Name func) {
-    auto* ret = allocator.alloc<RefFunc>();
+    auto* ret = wasm.allocator.alloc<RefFunc>();
     ret->func = func;
     ret->finalize();
     return ret;
   }
   Try* makeTry(Expression* body, Expression* catchBody) {
-    auto* ret = allocator.alloc<Try>();
+    auto* ret = wasm.allocator.alloc<Try>();
     ret->body = body;
     ret->catchBody = catchBody;
     ret->finalize();
     return ret;
   }
   Try* makeTry(Expression* body, Expression* catchBody, Type type) {
-    auto* ret = allocator.alloc<Try>();
+    auto* ret = wasm.allocator.alloc<Try>();
     ret->body = body;
     ret->catchBody = catchBody;
     ret->finalize(type);
@@ -576,14 +573,14 @@ public:
     return makeThrow(event->name, args);
   }
   Throw* makeThrow(Name event, const std::vector<Expression*>& args) {
-    auto* ret = allocator.alloc<Throw>();
+    auto* ret = wasm.allocator.alloc<Throw>();
     ret->event = event;
     ret->operands.set(args);
     ret->finalize();
     return ret;
   }
   Rethrow* makeRethrow(Expression* exnref) {
-    auto* ret = allocator.alloc<Rethrow>();
+    auto* ret = wasm.allocator.alloc<Rethrow>();
     ret->exnref = exnref;
     ret->finalize();
     return ret;
@@ -592,7 +589,7 @@ public:
     return makeBrOnExn(name, event->name, exnref, event->sig.params);
   }
   BrOnExn* makeBrOnExn(Name name, Name event, Expression* exnref, Type sent) {
-    auto* ret = allocator.alloc<BrOnExn>();
+    auto* ret = wasm.allocator.alloc<BrOnExn>();
     ret->name = name;
     ret->event = event;
     ret->exnref = exnref;
@@ -602,21 +599,21 @@ public:
     ret->finalize();
     return ret;
   }
-  Unreachable* makeUnreachable() { return allocator.alloc<Unreachable>(); }
+  Unreachable* makeUnreachable() { return wasm.allocator.alloc<Unreachable>(); }
   Pop* makePop(Type type) {
-    auto* ret = allocator.alloc<Pop>();
+    auto* ret = wasm.allocator.alloc<Pop>();
     ret->type = type;
     ret->finalize();
     return ret;
   }
   template<typename ListType> TupleMake* makeTupleMake(ListType&& operands) {
-    auto* ret = allocator.alloc<TupleMake>();
+    auto* ret = wasm.allocator.alloc<TupleMake>();
     ret->operands.set(operands);
     ret->finalize();
     return ret;
   }
   TupleExtract* makeTupleExtract(Expression* tuple, Index index) {
-    auto* ret = allocator.alloc<TupleExtract>();
+    auto* ret = wasm.allocator.alloc<TupleExtract>();
     ret->tuple = tuple;
     ret->index = index;
     ret->finalize();
@@ -626,7 +623,7 @@ public:
   // Additional helpers
 
   Drop* makeDrop(Expression* value) {
-    auto* ret = allocator.alloc<Drop>();
+    auto* ret = wasm.allocator.alloc<Drop>();
     ret->value = value;
     ret->finalize();
     return ret;
@@ -776,7 +773,7 @@ public:
       // just one
       ret = input->list[from];
     } else {
-      auto* block = allocator.alloc<Block>();
+      auto* block = wasm.allocator.alloc<Block>();
       for (Index i = from; i < to; i++) {
         block->list.push_back(input->list[i]);
       }
@@ -787,7 +784,7 @@ public:
       input->list.resize(from);
     } else {
       for (Index i = from; i < to; i++) {
-        input->list[i] = allocator.alloc<Nop>();
+        input->list[i] = wasm.allocator.alloc<Nop>();
       }
     }
     input->finalize();

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -173,7 +173,6 @@ public:
   Expression* parseExpression(Element* s) { return parseExpression(*s); }
   Expression* parseExpression(Element& s);
 
-  MixedArena& getAllocator() { return allocator; }
   Module& getModule() { return wasm; }
 
 private:

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -423,7 +423,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
     asmFunc[3]->push_back(processFunction(wasm, func));
   });
   if (generateFetchHighBits) {
-    Builder builder(allocator, *wasm);
+    Builder builder(*wasm);
     asmFunc[3]->push_back(
       processFunction(wasm,
                       wasm->addFunction(builder.makeFunction(


### PR DESCRIPTION
Builders gained a `Module` field in #3130 because they now require extra context
to properly finalize some Expressions. Since modules contain allocators, the old
allocator field on the builder became redundant after that change. This PR
removes the redundant allocator field.