### PR TITLE
Add Memory64 feature flag to the C and JS APIs

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -343,6 +343,9 @@ BinaryenFeatures BinaryenFeatureMultivalue(void) {
 BinaryenFeatures BinaryenFeatureGC(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::GC);
 }
+BinaryenFeatures BinaryenFeatureMemory64(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::Memory64);
+}
 BinaryenFeatures BinaryenFeatureAll(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::All);
 }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -201,6 +201,7 @@ BINARYEN_API BinaryenFeatures BinaryenFeatureTailCall(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureReferenceTypes(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureMultivalue(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureGC(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureMemory64(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureAll(void);
 
 // Modules

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -125,6 +125,7 @@ function initializeConstants() {
     'ReferenceTypes',
     'Multivalue',
     'GC',
+    'Memory64',
     'All'
   ].forEach(name => {
     Module['Features'][name] = Module['_BinaryenFeature' + name]();

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -113,6 +113,7 @@ function test_features() {
   console.log("Features.ReferenceTypes: " + binaryen.Features.ReferenceTypes);
   console.log("Features.Multivalue: " + binaryen.Features.Multivalue);
   console.log("Features.GC: " + binaryen.Features.GC);
+  console.log("Features.Memory64: " + binaryen.Features.Memory64);
   console.log("Features.All: " + binaryen.Features.All);
 }
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -40,6 +40,7 @@ Features.TailCall: 128
 Features.ReferenceTypes: 256
 Features.Multivalue: 512
 Features.GC: 1024
+Features.Memory64: 2048
 Features.All: 4095
 InvalidId: 0
 BlockId: 1

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -260,6 +260,7 @@ void test_features() {
   printf("BinaryenFeatureReferenceTypes: %d\n", BinaryenFeatureReferenceTypes());
   printf("BinaryenFeatureMultivalue: %d\n", BinaryenFeatureMultivalue());
   printf("BinaryenFeatureGC: %d\n", BinaryenFeatureGC());
+  printf("BinaryenFeatureMemory64: %d\n", BinaryenFeatureMemory64());
   printf("BinaryenFeatureAll: %d\n", BinaryenFeatureAll());
 }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -24,6 +24,7 @@ BinaryenFeatureTailCall: 128
 BinaryenFeatureReferenceTypes: 256
 BinaryenFeatureMultivalue: 512
 BinaryenFeatureGC: 1024
+BinaryenFeatureMemory64: 2048
 BinaryenFeatureAll: 4095
 (f32.neg
  (f32.const -33.61199951171875)


### PR DESCRIPTION
Noticed that these are missing while updating our custom bindings. Sorry for not noticing earlier.