### PR TITLE
fix i64 type checking in getMaxBitsForLocal of DummyLocalInfoProvider

### DIFF
--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -113,8 +113,7 @@ struct DummyLocalInfoProvider {
   Index getMaxBitsForLocal(LocalGet* get) {
     if (get->type == Type::i32) {
       return 32;
-    }
-    if (get->type == Type::i32) {
+    } else if (get->type == Type::i64) {
       return 64;
     }
     WASM_UNREACHABLE("type has no integer bit size");


### PR DESCRIPTION
It looks like it existed for a very long time, but since the DummyLocalInfoProvider is never practically used, this did not create problems.