### PR TITLE
bits.h cleanups after #2879

### DIFF
--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -177,7 +177,7 @@ Index getMaxBits(Expression* curr,
       case RemSInt32: {
         if (auto* c = binary->right->dynCast<Const>()) {
           auto maxBitsLeft = getMaxBits(binary->left, localInfoProvider);
-          // if maxBitsLeft is negative
+          // if left may be negative, the result may be negative
           if (maxBitsLeft == 32) {
             return 32;
           }
@@ -200,12 +200,7 @@ Index getMaxBits(Expression* curr,
       }
       case OrInt32:
       case XorInt32: {
-        auto maxBits = getMaxBits(binary->right, localInfoProvider);
-        // if maxBits is negative
-        if (maxBits == 32) {
-          return 32;
-        }
-        return std::max(getMaxBits(binary->left, localInfoProvider), maxBits);
+        return std::max(getMaxBits(binary->left, localInfoProvider), getMaxBits(binary->right, localInfoProvider));
       }
       case ShlInt32: {
         if (auto* shifts = binary->right->dynCast<Const>()) {
@@ -228,7 +223,7 @@ Index getMaxBits(Expression* curr,
       case ShrSInt32: {
         if (auto* shift = binary->right->dynCast<Const>()) {
           auto maxBits = getMaxBits(binary->left, localInfoProvider);
-          // if maxBits is negative
+          // if left may be negative, the result may be negative
           if (maxBits == 32) {
             return 32;
           }
@@ -256,7 +251,7 @@ Index getMaxBits(Expression* curr,
       case DivSInt64: {
         if (auto* c = binary->right->dynCast<Const>()) {
           int32_t maxBitsLeft = getMaxBits(binary->left, localInfoProvider);
-          // if maxBitsLeft or right const value is negative
+          // if left or right const value is negative
           if (maxBitsLeft == 64 || c->value.geti64() < 0) {
             return 64;
           }
@@ -276,7 +271,7 @@ Index getMaxBits(Expression* curr,
       case RemSInt64: {
         if (auto* c = binary->right->dynCast<Const>()) {
           auto maxBitsLeft = getMaxBits(binary->left, localInfoProvider);
-          // if maxBitsLeft is negative
+          // if left may be negative, the result may be negative
           if (maxBitsLeft == 64) {
             return 64;
           }
@@ -294,17 +289,11 @@ Index getMaxBits(Expression* curr,
         return 64;
       }
       case AndInt64: {
-        auto maxBits = getMaxBits(binary->right, localInfoProvider);
-        return std::min(getMaxBits(binary->left, localInfoProvider), maxBits);
+        return std::min(getMaxBits(binary->left, localInfoProvider), getMaxBits(binary->right, localInfoProvider));
       }
       case OrInt64:
       case XorInt64: {
-        auto maxBits = getMaxBits(binary->right, localInfoProvider);
-        // if maxBits is negative
-        if (maxBits == 64) {
-          return 64;
-        }
-        return std::max(getMaxBits(binary->left, localInfoProvider), maxBits);
+        return std::max(getMaxBits(binary->left, localInfoProvider), getMaxBits(binary->right, localInfoProvider));
       }
       case ShlInt64: {
         if (auto* shifts = binary->right->dynCast<Const>()) {
@@ -327,7 +316,7 @@ Index getMaxBits(Expression* curr,
       case ShrSInt64: {
         if (auto* shift = binary->right->dynCast<Const>()) {
           auto maxBits = getMaxBits(binary->left, localInfoProvider);
-          // if maxBits is negative
+          // if left may be negative, the result may be negative
           if (maxBits == 64) {
             return 64;
           }

--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -200,7 +200,8 @@ Index getMaxBits(Expression* curr,
       }
       case OrInt32:
       case XorInt32: {
-        return std::max(getMaxBits(binary->left, localInfoProvider), getMaxBits(binary->right, localInfoProvider));
+        return std::max(getMaxBits(binary->left, localInfoProvider),
+                        getMaxBits(binary->right, localInfoProvider));
       }
       case ShlInt32: {
         if (auto* shifts = binary->right->dynCast<Const>()) {
@@ -289,11 +290,13 @@ Index getMaxBits(Expression* curr,
         return 64;
       }
       case AndInt64: {
-        return std::min(getMaxBits(binary->left, localInfoProvider), getMaxBits(binary->right, localInfoProvider));
+        return std::min(getMaxBits(binary->left, localInfoProvider),
+                        getMaxBits(binary->right, localInfoProvider));
       }
       case OrInt64:
       case XorInt64: {
-        return std::max(getMaxBits(binary->left, localInfoProvider), getMaxBits(binary->right, localInfoProvider));
+        return std::max(getMaxBits(binary->left, localInfoProvider),
+                        getMaxBits(binary->right, localInfoProvider));
       }
       case ShlInt64: {
         if (auto* shifts = binary->right->dynCast<Const>()) {


### PR DESCRIPTION
Improve some comments, and remove fast paths that are just optimizations for
compile time.

About the fast paths, is there a previous discussion I missed? They seem
unnecessary unless I'm not seeing something. A minor speedup from them
doesn't seem worth more complicated code - this code is pretty complex as
it is.

cc @MaxGraey 