### PR TITLE
When looking for node binary, search for 'node' first

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -191,7 +191,7 @@ NATIVECC = (os.environ.get('CC') or which('mingw32-gcc') or
             which('gcc') or which('clang'))
 NATIVEXX = (os.environ.get('CXX') or which('mingw32-g++') or
             which('g++') or which('clang++'))
-NODEJS = os.getenv('NODE', which('nodejs') or which('node'))
+NODEJS = os.getenv('NODE', which('node') or which('nodejs'))
 MOZJS = which('mozjs') or which('spidermonkey')
 V8 = which('v8') or which('d8')
 


### PR DESCRIPTION
`node` is the name used by the upstream project.  `nodejs` is a legacy
name used on older debian/ubunru systems.

Searching for `nodejs` first meant it was finding my local (old)
`nodejs` package even those I have a more recent `node` in my $PATH.