### PR TITLE
Validator: Fix missing feature checks

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -328,6 +328,7 @@ public:
   void visitReturn(Return* curr);
   void visitMemorySize(MemorySize* curr);
   void visitMemoryGrow(MemoryGrow* curr);
+  void visitRefNull(RefNull* curr);
   void visitRefIsNull(RefIsNull* curr);
   void visitRefFunc(RefFunc* curr);
   void visitRefEq(RefEq* curr);
@@ -1948,7 +1949,16 @@ void FunctionValidator::visitMemoryGrow(MemoryGrow* curr) {
                                     "memory.grow must match memory index type");
 }
 
+void FunctionValidator::visitRefNull(RefNull* curr) {
+  shouldBeTrue(getModule()->features.hasReferenceTypes(),
+               curr,
+               "ref.null requires reference-types to be enabled");
+}
+
 void FunctionValidator::visitRefIsNull(RefIsNull* curr) {
+  shouldBeTrue(getModule()->features.hasReferenceTypes(),
+               curr,
+               "ref.is_null requires reference-types to be enabled");
   shouldBeTrue(curr->value->type == Type::unreachable ||
                  curr->value->type.isRef(),
                curr->value,
@@ -1956,6 +1966,9 @@ void FunctionValidator::visitRefIsNull(RefIsNull* curr) {
 }
 
 void FunctionValidator::visitRefFunc(RefFunc* curr) {
+  shouldBeTrue(getModule()->features.hasReferenceTypes(),
+               curr,
+               "ref.func requires reference-types to be enabled");
   auto* func = getModule()->getFunctionOrNull(curr->func);
   shouldBeTrue(!!func, curr, "function argument of ref.func must exist");
 }
@@ -1976,6 +1989,9 @@ void FunctionValidator::visitRefEq(RefEq* curr) {
 }
 
 void FunctionValidator::visitTry(Try* curr) {
+  shouldBeTrue(getModule()->features.hasExceptionHandling(),
+               curr,
+               "try requires exception-handling to be enabled");
   if (curr->type != Type::unreachable) {
     shouldBeSubTypeOrFirstIsUnreachable(
       curr->body->type,
@@ -2000,6 +2016,9 @@ void FunctionValidator::visitTry(Try* curr) {
 }
 
 void FunctionValidator::visitThrow(Throw* curr) {
+  shouldBeTrue(getModule()->features.hasExceptionHandling(),
+               curr,
+               "throw requires exception-handling to be enabled");
   if (!info.validateGlobally) {
     return;
   }
@@ -2030,6 +2049,9 @@ void FunctionValidator::visitThrow(Throw* curr) {
 }
 
 void FunctionValidator::visitRethrow(Rethrow* curr) {
+  shouldBeTrue(getModule()->features.hasExceptionHandling(),
+               curr,
+               "rethrow requires exception-handling to be enabled");
   shouldBeEqual(curr->type,
                 Type(Type::unreachable),
                 curr,
@@ -2042,6 +2064,9 @@ void FunctionValidator::visitRethrow(Rethrow* curr) {
 }
 
 void FunctionValidator::visitBrOnExn(BrOnExn* curr) {
+  shouldBeTrue(getModule()->features.hasExceptionHandling(),
+               curr,
+               "br_on_exn requires exception-handling to be enabled");
   Event* event = getModule()->getEventOrNull(curr->event);
   shouldBeTrue(event != nullptr, curr, "br_on_exn's event must exist");
   shouldBeTrue(event->sig.params == curr->sent,


### PR DESCRIPTION
Adds feature checks to `ref.null`, `ref.is_null`, `ref.func`, `try`, `throw`, `rethrow` and `br_on_exn` instructions.

fixes #3147