### PR TITLE
Add also non-equal with zero  simplification for boolean context

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1275,7 +1275,6 @@ private:
     if ((matches(curr, binary(Abstract::Eq, any(&left), ival(0))))) {
       return builder.makeUnary(EqZInt64, left);
     }
-
     // Operations on one
     // (signed)x % 1   ==>   0
     if (matches(curr, binary(Abstract::RemS, pure(&left), ival(1)))) {
@@ -1298,7 +1297,9 @@ private:
       return left;
     }
     // i64(bool(x)) == 1  ==>  i32(bool(x))
-    if (matches(curr, binary(EqInt64, any(&left), i64(1))) &&
+    // i64(bool(x)) != 0  ==>  i32(bool(x))
+    if ((matches(curr, binary(EqInt64, any(&left), i64(1))) ||
+         matches(curr, binary(NeInt64, any(&left), i64(0)))) &&
         Bits::getMaxBits(left, this) == 1) {
       return builder.makeUnary(WrapInt64, left);
     }

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -13,6 +13,7 @@
  (type $none_=>_anyref (func (result anyref)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_f64_=>_none (func (param i32 i32 i32 f64)))
+ (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_f64_f64_=>_none (func (param i32 i32 f64 f64)))
  (type $i32_i64_f64_i32_=>_none (func (param i32 i64 f64 i32)))
  (type $f32_f64_=>_none (func (param f32 f64)))
@@ -3813,7 +3814,7 @@
    (ref.null func)
   )
  )
- (func $optimize-boolean-context (param $x i32) (param $y i32)
+ (func $optimize-boolean-context (param $x i32) (param $y i32) (param $z i64)
   (if
    (local.get $x)
    (unreachable)
@@ -3823,6 +3824,14 @@
     (local.get $x)
     (local.get $y)
     (local.get $x)
+   )
+  )
+  (drop
+   (i32.wrap_i64
+    (i64.shr_u
+     (local.get $z)
+     (i64.const 63)
+    )
    )
   )
  )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -13,7 +13,6 @@
  (type $none_=>_anyref (func (result anyref)))
  (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_f64_=>_none (func (param i32 i32 i32 f64)))
- (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_f64_f64_=>_none (func (param i32 i32 f64 f64)))
  (type $i32_i64_f64_i32_=>_none (func (param i32 i64 f64 i32)))
  (type $f32_f64_=>_none (func (param f32 f64)))
@@ -3420,6 +3419,14 @@
    )
   )
   (drop
+   (i32.wrap_i64
+    (i64.shr_u
+     (local.get $y)
+     (i64.const 63)
+    )
+   )
+  )
+  (drop
    (i32.and
     (local.get $x)
     (i32.const 1)
@@ -3814,7 +3821,7 @@
    (ref.null func)
   )
  )
- (func $optimize-boolean-context (param $x i32) (param $y i32) (param $z i64)
+ (func $optimize-boolean-context (param $x i32) (param $y i32)
   (if
    (local.get $x)
    (unreachable)
@@ -3824,14 +3831,6 @@
     (local.get $x)
     (local.get $y)
     (local.get $x)
-   )
-  )
-  (drop
-   (i32.wrap_i64
-    (i64.shr_u
-     (local.get $z)
-     (i64.const 63)
-    )
    )
   )
  )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -3419,14 +3419,6 @@
    )
   )
   (drop
-   (i32.wrap_i64
-    (i64.shr_u
-     (local.get $y)
-     (i64.const 63)
-    )
-   )
-  )
-  (drop
    (i32.and
     (local.get $x)
     (i32.const 1)
@@ -3437,6 +3429,14 @@
     (i32.and
      (local.get $x)
      (i32.const 1)
+    )
+   )
+  )
+  (drop
+   (i32.wrap_i64
+    (i64.shr_u
+     (local.get $y)
+     (i64.const 63)
     )
    )
   )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4336,7 +4336,7 @@
       (ref.null func)
     )
   )
-  (func $optimize-boolean-context (param $x i32) (param $y i32)
+  (func $optimize-boolean-context (param $x i32) (param $y i32) (param $z i64)
     ;; 0 - x   ==>   x
     (if
       (i32.sub
@@ -4352,6 +4352,14 @@
         (i32.const 0)
         (local.get $x)
       )
+    ))
+    ;; x >>> 63 != 0   ==>   i32.wrap_64(x >>> 63)
+    (drop (i64.ne
+      (i64.shr_u
+        (local.get $z)
+        (i64.const 63)
+      )
+      (i64.const 0)
     ))
   )
   (func $unsigned-context (param $x i32) (param $y i64)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3972,6 +3972,14 @@
         )
       )
     )
+    ;; x >>> 63 != 0   ==>   i32(x >>> 63)
+    (drop (i64.ne
+      (i64.shr_u
+        (local.get $y)
+        (i64.const 63)
+      )
+      (i64.const 0)
+    ))
     ;; i32(bool(expr)) == 1 -> bool(expr)
     (drop (i32.eq
       (i32.and
@@ -4336,7 +4344,7 @@
       (ref.null func)
     )
   )
-  (func $optimize-boolean-context (param $x i32) (param $y i32) (param $z i64)
+  (func $optimize-boolean-context (param $x i32) (param $y i32)
     ;; 0 - x   ==>   x
     (if
       (i32.sub
@@ -4352,14 +4360,6 @@
         (i32.const 0)
         (local.get $x)
       )
-    ))
-    ;; x >>> 63 != 0   ==>   i32.wrap_64(x >>> 63)
-    (drop (i64.ne
-      (i64.shr_u
-        (local.get $z)
-        (i64.const 63)
-      )
-      (i64.const 0)
     ))
   )
   (func $unsigned-context (param $x i32) (param $y i64)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3972,14 +3972,6 @@
         )
       )
     )
-    ;; x >>> 63 != 0   ==>   i32(x >>> 63)
-    (drop (i64.ne
-      (i64.shr_u
-        (local.get $y)
-        (i64.const 63)
-      )
-      (i64.const 0)
-    ))
     ;; i32(bool(expr)) == 1 -> bool(expr)
     (drop (i32.eq
       (i32.and
@@ -3996,7 +3988,15 @@
       )
       (i32.const 1)
     ))
-    ;; i64(bool(expr)) == 1 -> i64(bool(expr))
+    ;; i64(bool(expr)) != 0 -> i32(bool(expr))
+    (drop (i64.ne
+      (i64.shr_u
+        (local.get $y)
+        (i64.const 63)
+      )
+      (i64.const 0)
+    ))
+    ;; i64(bool(expr)) == 1 -> i32(bool(expr))
     (drop (i64.eq
       (i64.and
         (local.get $y)


### PR DESCRIPTION
`i64(bool(x)) != 0` -> `i32(bool(x))`