### PR TITLE
Generalize transforms for #3153

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -96,6 +96,46 @@ public:
     }
     return false;
   }
+  bool isSignedMin() const {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return i32 == std::numeric_limits<int32_t>::min();
+      case Type::i64:
+        return i64 == std::numeric_limits<int64_t>::min();
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
+  bool isSignedMax() const {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return i32 == std::numeric_limits<int32_t>::max();
+      case Type::i64:
+        return i64 == std::numeric_limits<int64_t>::max();
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
+  bool isUnsignedMin() const {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return uint32_t(i32) == std::numeric_limits<uint32_t>::min();
+      case Type::i64:
+        return uint64_t(i64) == std::numeric_limits<uint64_t>::min();
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
+  bool isUnsignedMax() const {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return uint32_t(i32) == std::numeric_limits<uint32_t>::max();
+      case Type::i64:
+        return uint64_t(i64) == std::numeric_limits<uint64_t>::max();
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
 
   static Literal makeFromInt32(int32_t x, Type type) {
     switch (type.getBasic()) {
@@ -134,6 +174,26 @@ public:
 
   static Literals makeZero(Type type);
   static Literal makeSingleZero(Type type);
+  static Literal makeSignedMin(Type type) {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return Literal(std::numeric_limits<int32_t>::min());
+      case Type::i64:
+        return Literal(std::numeric_limits<int64_t>::min());
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
+  static Literal makeSignedMax(Type type) {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return Literal(std::numeric_limits<int32_t>::max());
+      case Type::i64:
+        return Literal(std::numeric_limits<int64_t>::max());
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
 
   static Literal makeNull(Type type) {
     assert(type.isNullable());

--- a/src/literal.h
+++ b/src/literal.h
@@ -97,6 +97,13 @@ public:
     return false;
   }
   bool isZero() const {
+    if (type.isVector()) {
+      uint8_t zeros[16] = {0};
+      return memcmp(&v128, zeros, 16) == 0;
+    }
+    return isSignleZero();
+  }
+  bool isSignleZero() const {
     switch (type.getBasic()) {
       case Type::i32:
         return i32 == 0;
@@ -106,10 +113,6 @@ public:
         return bit_cast<float>(i32) == 0.0f;
       case Type::f64:
         return bit_cast<double>(i64) == 0.0;
-      case Type::v128: {
-        uint8_t zeros[16] = {0};
-        return memcmp(&v128, zeros, 16) == 0;
-      }
       default:
         WASM_UNREACHABLE("unexpected type");
     }

--- a/src/literal.h
+++ b/src/literal.h
@@ -97,13 +97,6 @@ public:
     return false;
   }
   bool isZero() const {
-    if (type.isVector()) {
-      uint8_t zeros[16] = {0};
-      return memcmp(&v128, zeros, 16) == 0;
-    }
-    return isSingleZero();
-  }
-  bool isSingleZero() const {
     switch (type.getBasic()) {
       case Type::i32:
         return i32 == 0;
@@ -113,6 +106,10 @@ public:
         return bit_cast<float>(i32) == 0.0f;
       case Type::f64:
         return bit_cast<double>(i64) == 0.0;
+      case Type::v128: {
+        uint8_t zeros[16] = {0};
+        return memcmp(&v128, zeros, 16) == 0;
+      }
       default:
         WASM_UNREACHABLE("unexpected type");
     }

--- a/src/literal.h
+++ b/src/literal.h
@@ -137,16 +137,6 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-  bool isUnsignedMin() const {
-    switch (type.getBasic()) {
-      case Type::i32:
-        return uint32_t(i32) == std::numeric_limits<uint32_t>::min();
-      case Type::i64:
-        return uint64_t(i64) == std::numeric_limits<uint64_t>::min();
-      default:
-        WASM_UNREACHABLE("unexpected type");
-    }
-  }
   bool isUnsignedMax() const {
     switch (type.getBasic()) {
       case Type::i32:
@@ -213,7 +203,6 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-  static Literal makeUnsignedMin(Type type) { return makeSingleZero(type); }
   static Literal makeUnsignedMax(Type type) {
     switch (type.getBasic()) {
       case Type::i32:

--- a/src/literal.h
+++ b/src/literal.h
@@ -96,6 +96,24 @@ public:
     }
     return false;
   }
+  bool isZero() const {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return i32 == 0;
+      case Type::i64:
+        return i64 == 0LL;
+      case Type::f32:
+        return bit_cast<float>(i32) == 0.0f;
+      case Type::f64:
+        return bit_cast<double>(i64) == 0.0;
+      case Type::v128: {
+        uint8_t zeros[16] = {0};
+        return memcmp(&v128, zeros, 16) == 0;
+      }
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
   bool isSignedMin() const {
     switch (type.getBasic()) {
       case Type::i32:

--- a/src/literal.h
+++ b/src/literal.h
@@ -155,6 +155,8 @@ public:
     }
   }
 
+  static Literals makeZero(Type type);
+  static Literal makeSingleZero(Type type);
   static Literal makeFromInt32(int32_t x, Type type) {
     switch (type.getBasic()) {
       case Type::i32:
@@ -174,7 +176,6 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-
   static Literal makeFromUInt64(uint64_t x, Type type) {
     switch (type.getBasic()) {
       case Type::i32:
@@ -189,9 +190,6 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-
-  static Literals makeZero(Type type);
-  static Literal makeSingleZero(Type type);
   static Literal makeSignedMin(Type type) {
     switch (type.getBasic()) {
       case Type::i32:
@@ -212,7 +210,17 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-
+  static Literal makeUnsignedMin(Type type) { return makeSingleZero(type); }
+  static Literal makeUnsignedMax(Type type) {
+    switch (type.getBasic()) {
+      case Type::i32:
+        return Literal(std::numeric_limits<uint32_t>::max());
+      case Type::i64:
+        return Literal(std::numeric_limits<uint64_t>::max());
+      default:
+        WASM_UNREACHABLE("unexpected type");
+    }
+  }
   static Literal makeNull(Type type) {
     assert(type.isNullable());
     return Literal(type);

--- a/src/literal.h
+++ b/src/literal.h
@@ -101,9 +101,9 @@ public:
       uint8_t zeros[16] = {0};
       return memcmp(&v128, zeros, 16) == 0;
     }
-    return isSignleZero();
+    return isSingleZero();
   }
-  bool isSignleZero() const {
+  bool isSingleZero() const {
     switch (type.getBasic()) {
       case Type::i32:
         return i32 == 0;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -305,8 +305,8 @@ struct OptimizeInstructions
         if (matches(curr,
                     unary(Abstract::EqZ,
                           binary(&inner, Abstract::RemS, any(), ival(&c)))) &&
-            (Bits::isPowerOf2(c->value.abs().getInteger()) ||
-             c->value.isSignedMin())) {
+            (c->value.isSignedMin() ||
+             Bits::isPowerOf2(c->value.abs().getInteger()))) {
           inner->op = Abstract::getBinary(c->type, Abstract::And);
           if (c->value.isSignedMin()) {
             c->value = Literal::makeSignedMax(c->type);
@@ -1322,8 +1322,8 @@ private:
                   binary(Abstract::Ne,
                          binary(&inner, Abstract::RemS, any(), ival(&c)),
                          ival(0))) &&
-          (Bits::isPowerOf2(c->value.abs().getInteger()) ||
-           c->value.isSignedMin())) {
+          (c->value.isSignedMin() ||
+           Bits::isPowerOf2(c->value.abs().getInteger()))) {
         inner->op = Abstract::getBinary(c->type, Abstract::And);
         if (c->value.isSignedMin()) {
           c->value = Literal::makeSignedMax(c->type);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1310,9 +1310,8 @@ private:
     }
     {
       // (signed)x % (i32|i64).min_s   ==>  (x & (i32|i64).max_s)
-      Const* c;
-      if (matches(curr, binary(Abstract::RemS, any(&left), ival(&c))) &&
-          c->value.isSignedMin()) {
+      if (matches(curr, binary(Abstract::RemS, any(&left), ival())) &&
+          right->value.isSignedMin()) {
         curr->op = Abstract::getBinary(type, Abstract::And);
         right->value = Literal::makeSignedMax(type);
         return curr;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -306,10 +306,13 @@ struct OptimizeInstructions
                     unary(Abstract::EqZ,
                           binary(&inner, Abstract::RemS, any(), ival(&c)))) &&
             (Bits::isPowerOf2(c->value.abs().getInteger()) ||
-             c->value.getUnsigned() ==
-               (1ULL << (c->type.getByteSize() * 8 - 1)))) {
+             c->value.isSignedMin())) {
           inner->op = Abstract::getBinary(c->type, Abstract::And);
-          c->value = c->value.abs().sub(Literal::makeFromInt32(1, c->type));
+          if (c->value.isSignedMin()) {
+            c->value = Literal::makeSignedMax(c->type);
+          } else {
+            c->value = c->value.abs().sub(Literal::makeFromInt32(1, c->type));
+          }
           return curr;
         }
       }
@@ -1320,10 +1323,13 @@ private:
                          binary(&inner, Abstract::RemS, any(), ival(&c)),
                          ival(0))) &&
           (Bits::isPowerOf2(c->value.abs().getInteger()) ||
-           c->value.getUnsigned() ==
-             (1ULL << (c->type.getByteSize() * 8 - 1)))) {
+           c->value.isSignedMin())) {
         inner->op = Abstract::getBinary(c->type, Abstract::And);
-        c->value = c->value.abs().sub(Literal::makeFromInt32(1, c->type));
+        if (c->value.isSignedMin()) {
+          c->value = Literal::makeSignedMax(c->type);
+        } else {
+          c->value = c->value.abs().sub(Literal::makeFromInt32(1, c->type));
+        }
         return curr;
       }
     }

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -2858,14 +2858,6 @@
    )
   )
   (drop
-   (i32.eqz
-    (i32.and
-     (local.get $x)
-     (i32.const 3)
-    )
-   )
-  )
-  (drop
    (i64.eqz
     (i64.rem_s
      (local.get $y)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -2737,12 +2737,24 @@
   )
   (unreachable)
  )
- (func $srem-by-1 (param $x i32) (param $y i64)
+ (func $srem-by-const (param $x i32) (param $y i64)
   (drop
    (i32.const 0)
   )
   (drop
    (i64.const 0)
+  )
+  (drop
+   (i32.and
+    (local.get $x)
+    (i32.const 2147483647)
+   )
+  )
+  (drop
+   (i64.and
+    (local.get $y)
+    (i64.const 9223372036854775807)
+   )
   )
  )
  (func $srem-by-pot-eq-ne-zero (param $x i32) (param $y i64)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -2764,17 +2764,17 @@
   )
   (drop
    (i32.eqz
-    (i32.rem_s
+    (i32.and
      (local.get $x)
-     (i32.const -4)
+     (i32.const 3)
     )
    )
   )
   (drop
    (i64.eqz
-    (i64.rem_s
+    (i64.and
      (local.get $y)
-     (i64.const -4)
+     (i64.const 3)
     )
    )
   )
@@ -2796,17 +2796,17 @@
   )
   (drop
    (i32.eqz
-    (i32.rem_s
+    (i32.and
      (local.get $x)
-     (i32.const -4)
+     (i32.const 3)
     )
    )
   )
   (drop
    (i64.eqz
-    (i64.rem_s
+    (i64.and
      (local.get $y)
-     (i64.const -4)
+     (i64.const 3)
     )
    )
   )
@@ -2829,10 +2829,24 @@
   )
   (drop
    (i32.eqz
-    (i32.rem_s
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.eqz
+    (i32.and
      (local.get $x)
-     (i32.const -2147483648)
+     (i32.const 2147483647)
     )
+   )
+  )
+  (drop
+   (i32.ne
+    (i32.and
+     (local.get $x)
+     (i32.const 2147483647)
+    )
+    (i32.const 0)
    )
   )
   (drop
@@ -2845,9 +2859,9 @@
   )
   (drop
    (i32.eqz
-    (i32.rem_s
+    (i32.and
      (local.get $x)
-     (i32.const -4)
+     (i32.const 3)
     )
    )
   )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -2764,6 +2764,22 @@
   )
   (drop
    (i32.eqz
+    (i32.rem_s
+     (local.get $x)
+     (i32.const -4)
+    )
+   )
+  )
+  (drop
+   (i64.eqz
+    (i64.rem_s
+     (local.get $y)
+     (i64.const -4)
+    )
+   )
+  )
+  (drop
+   (i32.eqz
     (i32.and
      (local.get $x)
      (i32.const 3)
@@ -2775,6 +2791,22 @@
     (i64.and
      (local.get $y)
      (i64.const 1)
+    )
+   )
+  )
+  (drop
+   (i32.eqz
+    (i32.rem_s
+     (local.get $x)
+     (i32.const -4)
+    )
+   )
+  )
+  (drop
+   (i64.eqz
+    (i64.rem_s
+     (local.get $y)
+     (i64.const -4)
     )
    )
   )
@@ -2792,6 +2824,14 @@
     (i64.and
      (local.get $y)
      (i64.const 1)
+    )
+   )
+  )
+  (drop
+   (i32.eqz
+    (i32.rem_s
+     (local.get $x)
+     (i32.const -2147483648)
     )
    )
   )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -2850,6 +2850,23 @@
    )
   )
   (drop
+   (i64.eqz
+    (i64.and
+     (local.get $y)
+     (i64.const 9223372036854775807)
+    )
+   )
+  )
+  (drop
+   (i64.ne
+    (i64.and
+     (local.get $y)
+     (i64.const 9223372036854775807)
+    )
+    (i64.const 0)
+   )
+  )
+  (drop
    (i32.eqz
     (i32.rem_s
      (local.get $x)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3176,8 +3176,24 @@
       )
       (i64.const 0)
     ))
-    ;; (signed)x % 0x80000000
+    ;; (signed)x % -1 == 0  ->  0 == 0
     (drop (i32.eq
+      (i32.rem_s
+        (local.get $x)
+        (i32.const -1)
+      )
+      (i32.const 0)
+    ))
+    ;; (signed)x % 0x80000000 == 0
+    (drop (i32.eq
+      (i32.rem_s
+        (local.get $x)
+        (i32.const 0x80000000)
+      )
+      (i32.const 0)
+    ))
+    ;; (signed)x % 0x80000000 != 0
+    (drop (i32.ne
       (i32.rem_s
         (local.get $x)
         (i32.const 0x80000000)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3200,6 +3200,22 @@
       )
       (i32.const 0)
     ))
+    ;; (signed)x % 0x8000000000000000 == 0
+    (drop (i64.eq
+      (i64.rem_s
+        (local.get $y)
+        (i64.const 0x8000000000000000)
+      )
+      (i64.const 0)
+    ))
+    ;; (signed)x % 0x8000000000000000 != 0
+    (drop (i64.ne
+      (i64.rem_s
+        (local.get $y)
+        (i64.const 0x8000000000000000)
+      )
+      (i64.const 0)
+    ))
     ;;
     (drop (i32.eq
       (i32.rem_s

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3208,13 +3208,6 @@
       )
       (i32.const 0)
     ))
-    (drop (i32.eq
-      (i32.rem_s
-        (local.get $x)
-        (i32.const -4) ;; skip
-      )
-      (i32.const 0)
-    ))
     (drop (i64.eq
       (i64.rem_s
         (local.get $y)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3093,7 +3093,7 @@
     )
     (unreachable)
   )
-  (func $srem-by-1 (param $x i32) (param $y i64)
+  (func $srem-by-const (param $x i32) (param $y i64)
     ;; (signed)x % 1
     (drop (i32.rem_s
       (local.get $x)
@@ -3102,6 +3102,16 @@
     (drop (i64.rem_s
       (local.get $y)
       (i64.const 1)
+    ))
+    ;; (signed)x % 0x80000000 -> x & 0x7FFFFFFF
+    (drop (i32.rem_s
+      (local.get $x)
+      (i32.const 0x80000000)
+    ))
+    ;; (signed)x % 0x8000000000000000 -> x & 0x7FFFFFFFFFFFFFFF
+    (drop (i64.rem_s
+      (local.get $y)
+      (i64.const 0x8000000000000000)
     ))
   )
   (func $srem-by-pot-eq-ne-zero (param $x i32) (param $y i64)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -3118,6 +3118,19 @@
         (i64.const 4)
       )
     ))
+    ;; eqz((signed)x % -4)
+    (drop (i32.eqz
+      (i32.rem_s
+        (local.get $x)
+        (i32.const -4)
+      )
+    ))
+    (drop (i64.eqz
+      (i64.rem_s
+        (local.get $y)
+        (i64.const -4)
+      )
+    ))
     ;; (signed)x % 4 == 0
     (drop (i32.eq
       (i32.rem_s
@@ -3133,7 +3146,22 @@
       )
       (i64.const 0)
     ))
-    ;; ;; (signed)x % 2 != 0
+    ;; (signed)x % -4 == 0
+    (drop (i32.eq
+      (i32.rem_s
+        (local.get $x)
+        (i32.const -4)
+      )
+      (i32.const 0)
+    ))
+    (drop (i64.eq
+      (i64.rem_s
+        (local.get $y)
+        (i64.const -4)
+      )
+      (i64.const 0)
+    ))
+    ;; (signed)x % 2 != 0
     (drop (i32.ne
       (i32.rem_s
         (local.get $x)
@@ -3148,7 +3176,15 @@
       )
       (i64.const 0)
     ))
-    ;; ;;
+    ;; (signed)x % 0x80000000
+    (drop (i32.eq
+      (i32.rem_s
+        (local.get $x)
+        (i32.const 0x80000000)
+      )
+      (i32.const 0)
+    ))
+    ;;
     (drop (i32.eq
       (i32.rem_s
         (local.get $x)


### PR DESCRIPTION
It's more general (additional) version of #3153 which also handle negative constant dividers:
`(int32)x % -4 == 0` --> `(x & 3) == 0`
`x % -C_pot == 0` --> `(x & (abs(C_pot) - 1)) == 0`

and special two-complement values as well:
`(int32)x % 0x80000000 == 0` --> `(x & 0x7fffffff) == 0`
`(int64)x % 0x8000000000000000 == 0` --> `(x & 0x7fffffffffffffff) == 0`
as separete rules:
`(int32)x % 0x80000000` --> `x & 0x7fffffff`
`(int64)x % 0x8000000000000000` --> `x & 0x7fffffffffffffff`

The [previous pr](https://github.com/WebAssembly/binaryen/pull/3153) didn't use these possibilities.

cc @kripken @tlively 