### PR TITLE
Ordering correction fix in OptimizeInstructions for #3047

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1599,8 +1599,8 @@ private:
 
               // x & (y & x)  ==>   y & x
               // x | (y | x)  ==>   y | x
-              if (canReorder(outer->left, inner->left) && (
-                   outer->op == Abstract::getBinary(type, Abstract::And) ||
+              if (canReorder(outer->left, inner->left) &&
+                  (outer->op == Abstract::getBinary(type, Abstract::And) ||
                    outer->op == Abstract::getBinary(type, Abstract::Or))) {
                 return inner;
               }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1605,8 +1605,8 @@ private:
               // x | (y | x)  ==>   y | x
               // (here we need the check for reordering for the more obvious
               // reason that previously x appeared before y, and now y appears
-              // first; or, if we tried to emit x * y here, reversing the order,
-              // we'd be in the same situation as the previous comment)
+              // first; or, if we tried to emit x [&|] y here, reversing the
+              // order, we'd be in the same situation as the previous comment)
               if (outer->op == Abstract::getBinary(type, Abstract::And) ||
                   outer->op == Abstract::getBinary(type, Abstract::Or)) {
                 return inner;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1599,8 +1599,9 @@ private:
 
               // x & (y & x)  ==>   y & x
               // x | (y | x)  ==>   y | x
-              if (outer->op == Abstract::getBinary(type, Abstract::And) ||
-                  outer->op == Abstract::getBinary(type, Abstract::Or)) {
+              if (canReorder(outer->left, inner->left) && (
+                   outer->op == Abstract::getBinary(type, Abstract::And) ||
+                   outer->op == Abstract::getBinary(type, Abstract::Or))) {
                 return inner;
               }
             }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1635,7 +1635,9 @@ private:
                 return inner;
               }
             }
-            if (ExpressionAnalyzer::equal(inner->left, outer->right)) {
+            // See comments in the parallel code earlier about ordering here.
+            if (ExpressionAnalyzer::equal(inner->left, outer->right) &&
+                canReorder(inner->left, inner->right)) {
               // (x ^ y) ^ x  ==>   y
               if (outer->op == Abstract::getBinary(type, Abstract::Xor)) {
                 return inner->right;

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -4331,6 +4331,14 @@
    )
   )
   (drop
+   (i32.or
+    (local.get $x)
+    (local.tee $x
+     (i32.const 1)
+    )
+   )
+  )
+  (drop
    (i32.xor
     (local.get $x)
     (i32.xor
@@ -4339,6 +4347,11 @@
      )
      (local.get $x)
     )
+   )
+  )
+  (drop
+   (local.tee $x
+    (i32.const 1)
    )
   )
  )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -4319,6 +4319,17 @@
     )
    )
   )
+  (drop
+   (i32.or
+    (local.get $x)
+    (i32.or
+     (local.tee $x
+      (i32.const 1)
+     )
+     (local.get $x)
+    )
+   )
+  )
  )
  (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
   (memory.copy

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -4332,10 +4332,13 @@
   )
   (drop
    (i32.or
-    (local.get $x)
-    (local.tee $x
-     (i32.const 1)
+    (i32.or
+     (local.get $x)
+     (local.tee $x
+      (i32.const 1)
+     )
     )
+    (local.get $x)
    )
   )
   (drop
@@ -4350,8 +4353,14 @@
    )
   )
   (drop
-   (local.tee $x
-    (i32.const 1)
+   (i32.xor
+    (i32.xor
+     (local.get $x)
+     (local.tee $x
+      (i32.const 1)
+     )
+    )
+    (local.get $x)
    )
   )
  )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -4330,6 +4330,17 @@
     )
    )
   )
+  (drop
+   (i32.xor
+    (local.get $x)
+    (i32.xor
+     (local.tee $x
+      (i32.const 1)
+     )
+     (local.get $x)
+    )
+   )
+  )
  )
  (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
   (memory.copy

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4809,12 +4809,12 @@
     ;; x | (y | x)   where x and y cannot be reordered  -  skip
     (drop
       (i32.or
-        (local.get $0)
+        (local.get $x)
         (i32.or
-          (local.tee $0
+          (local.tee $x
             (i32.const 1)
           )
-          (local.get $0)
+          (local.get $x)
         )
       )
     )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4805,7 +4805,19 @@
         (local.get $x)
         (local.get $y)
       )
-    ))
+     ))
+    ;; x | (y | x)   where x and y cannot be reordered  -  skip
+    (drop
+      (i32.or
+        (local.get $0)
+        (i32.or
+          (local.tee $0
+            (i32.const 1)
+          )
+          (local.get $0)
+        )
+      )
+    )
   )
   (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
     (memory.copy  ;; skip

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4818,6 +4818,17 @@
         )
       )
     )
+    (drop
+      (i32.or
+        (i32.or
+          (local.get $x)
+          (local.tee $x
+            (i32.const 1)
+          )
+        )
+        (local.get $x)
+      )
+    )
     ;; x ^ (y ^ x)   where x and y cannot be reordered  -  skip
     (drop
       (i32.xor
@@ -4828,6 +4839,17 @@
           )
           (local.get $x)
         )
+      )
+    )
+    (drop
+      (i32.xor
+        (i32.xor
+          (local.get $x)
+          (local.tee $x
+            (i32.const 1)
+          )
+        )
+        (local.get $x)
       )
     )
   )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -4818,6 +4818,18 @@
         )
       )
     )
+    ;; x ^ (y ^ x)   where x and y cannot be reordered  -  skip
+    (drop
+      (i32.xor
+        (local.get $x)
+        (i32.xor
+          (local.tee $x
+            (i32.const 1)
+          )
+          (local.get $x)
+        )
+      )
+    )
   )
   (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
     (memory.copy  ;; skip


### PR DESCRIPTION
(found by the fuzzer)

It is not valid to replace `x | (y | x)  ==>  y | x`, if `x, y` cannot be reordered.

It is also not valid to replace `x ^ (y ^ x)  ==>  y`, if `x, y` cannot be reordered,
for a more subtle reason: if they cannot be reordered then `y` can affect the
value of `x` (the opposite is not possible as we checked `x` for side effects so
that we could remove one copy). If so, then the second appearance of `x`
could be different, if e.g. it reads a local `y` writes to. Whereas, if it's ok to
reorder, then it's ok to do `x ^ (y ^ x)  ==>  x ^ (x ^ y)  ==>  y`.

PTAL @MaxGraey @tlively , and also please check for similar things in
other code - I think I fixed up all of `deduplicateBinary` but maybe there are
similar patterns elsewhere?