### PR TITLE
Revert some changes from #3193

### DIFF
--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -2745,15 +2745,15 @@
    (i64.const 0)
   )
   (drop
-   (i32.and
+   (i32.rem_s
     (local.get $x)
-    (i32.const 2147483647)
+    (i32.const -2147483648)
    )
   )
   (drop
-   (i64.and
+   (i64.rem_s
     (local.get $y)
-    (i64.const 9223372036854775807)
+    (i64.const -9223372036854775808)
    )
   )
  )


### PR DESCRIPTION
Fuzzed found `(seed 17400736677355043573)` invalid transform which introduced in #3193.

`(signed)x % (i32|i64).min_s`   ==>  `(x & (i32|i64).max_s)`

This not valid without equal / unequal with zero unfortunately. So this PR fix that.

cc @tlively 
