### PR TITLE
Add static guards for cast and dynCast

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -592,10 +592,14 @@ public:
   }
 
   template<class T> const T* dynCast() const {
+    static_assert(std::is_base_of<Expression, T>::value,
+                  "Expression is not a base of destination type T");
     return int(_id) == int(T::SpecificId) ? (const T*)this : nullptr;
   }
 
   template<class T> T* cast() {
+    static_assert(std::is_base_of<Expression, T>::value,
+                  "Expression is not a base of destination type T");
     assert(int(_id) == int(T::SpecificId));
     return (T*)this;
   }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -585,9 +585,15 @@ public:
 
   void finalize() {}
 
-  template<class T> bool is() const { return int(_id) == int(T::SpecificId); }
+  template<class T> bool is() const {
+    static_assert(std::is_base_of<Expression, T>::value,
+                  "Expression is not a base of destination type T");
+    return int(_id) == int(T::SpecificId);
+  }
 
   template<class T> T* dynCast() {
+    static_assert(std::is_base_of<Expression, T>::value,
+                  "Expression is not a base of destination type T");
     return int(_id) == int(T::SpecificId) ? (T*)this : nullptr;
   }
 
@@ -605,6 +611,8 @@ public:
   }
 
   template<class T> const T* cast() const {
+    static_assert(std::is_base_of<Expression, T>::value,
+                  "Expression is not a base of destination type T");
     assert(int(_id) == int(T::SpecificId));
     return (const T*)this;
   }


### PR DESCRIPTION
This add compile time guards for `Expression::cast` and `Expression::dynCast` for making sure type `T` derived from `Expression`.