### PR TITLE
Fuzz fix for DuplicateFunctionElimination

### DIFF
--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -97,7 +97,9 @@ inline void replaceFunctions(PassRunner* runner,
   }
   // replace in exports
   for (auto& exp : module.exports) {
-    maybeReplace(exp->value);
+    if (exp->kind == ExternalKind::Function) {
+      maybeReplace(exp->value);
+    }
   }
 }
 

--- a/test/passes/duplicate-function-elimination_all-features.txt
+++ b/test/passes/duplicate-function-elimination_all-features.txt
@@ -8,3 +8,13 @@
   (ref.func $0)
  )
 )
+(module
+ (type $none_=>_none (func))
+ (memory $foo 16 16)
+ (global $bar i32 (i32.const 0))
+ (export "memory" (memory $foo))
+ (export "global" (global $bar))
+ (func $bar
+  (nop)
+ )
+)

--- a/test/passes/duplicate-function-elimination_all-features.wast
+++ b/test/passes/duplicate-function-elimination_all-features.wast
@@ -1,4 +1,4 @@
-;; --dupliate-function-elimination should not remove functions used in ref.func.
+;; --duplicate-function-elimination should not remove functions used in ref.func.
 (module
   (func $0 (result i32)
     (i32.const 0)
@@ -9,4 +9,15 @@
   (func $test (result funcref)
     (ref.func $1)
   )
+)
+;; renaming after deduplication must only affect functions
+(module
+ (memory $foo 16 16)
+ (global $bar i32 (i32.const 0))
+ (export "memory" (memory $foo))
+ (export "global" (global $bar))
+ (func $bar ;; happens to share a name with the global
+ )
+ (func $foo ;; happens to share a name with the memory
+ )
 )


### PR DESCRIPTION
The `replaceFunctions` utility replaced exports by name, but did not check
the kind, so it could get confused when names happen to overlap (see
testcase).