### PR TITLE
Fix split_wast on asserts before the first module

### DIFF
--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -146,7 +146,10 @@ def split_wast(wastFile):
         elif chunk.startswith('(assert_invalid'):
             continue
         elif chunk.startswith(('(assert', '(invoke')):
-            ret[-1][1].append(chunk)
+            # ret may be empty if there are some asserts before the first
+            # module
+            if ret:
+                ret[-1][1].append(chunk)
     return ret
 
 

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -147,9 +147,12 @@ def split_wast(wastFile):
             continue
         elif chunk.startswith(('(assert', '(invoke')):
             # ret may be empty if there are some asserts before the first
-            # module
-            if ret:
-                ret[-1][1].append(chunk)
+            # module. in that case these are asserts *without* a module, which
+            # are valid (they may check something that doesn't refer to a module
+            # in any way).
+            if not ret:
+                ret += [(None, [])]
+            ret[-1][1].append(chunk)
     return ret
 
 


### PR DESCRIPTION
Normally a wast file has a module and then asserts on it, but
some tests have just asserts without a module. Before this PR
we would break if such asserts happened before the first
module, as we didn't know what module to attach them to.