### PR TITLE
Drop RHS of shift expression if effective shift always equal to zero

### DIFF
--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -4510,11 +4510,17 @@
    )
   )
   (drop
-   (i32.shl
-    (local.get $x)
-    (i32.and
-     (local.get $y)
-     (i32.const 32)
+   (local.get $x)
+  )
+  (drop
+   (local.get $z)
+  )
+  (drop
+   (i64.shl
+    (local.get $z)
+    (i64.and
+     (local.get $w)
+     (i64.const 32)
     )
    )
   )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -5026,13 +5026,29 @@
         (i64.const 63)
       )
     ))
-
-    ;; skip
-    (drop (i32.shl
+    ;; i32(x) >> (y & 32)  ->  x
+    (drop (i32.shr_u
       (local.get $x)
       (i32.and
         (local.get $y)
         (i32.const 32)
+      )
+    ))
+    ;; i64(x) >> (y & 64)  ->  x
+    (drop (i64.shr_u
+      (local.get $z)
+      (i64.and
+        (local.get $w)
+        (i64.const 128)
+      )
+    ))
+
+    ;; skip
+    (drop (i64.shl
+      (local.get $z)
+      (i64.and
+        (local.get $w)
+        (i64.const 32)
       )
     ))
     ;; skip


### PR DESCRIPTION
`x <<>> (y & (32 | 64))` -> `x`