### PR TITLE
Handle uncaught wasm exceptions in shell-interface and execution-results

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -226,7 +226,10 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     throw TrapException();
   }
 
-  void throwException(Literal exn) override { throw WasmException(exn); }
+  void throwException(Literal exn) override {
+    std::cout << "[trap (exception) " << exn << "]\n";
+    throw WasmException(exn);
+  }
 };
 
 } // namespace wasm

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -132,7 +132,8 @@ struct ExecutionResults {
       ModuleInstance instance(wasm, &interface);
       return run(func, wasm, instance);
     } catch (const TrapException&) {
-      // may throw in instance creation (init of offsets)
+      return {};
+    } catch (const WasmException&) {
       return {};
     }
   }
@@ -151,6 +152,8 @@ struct ExecutionResults {
       }
       return instance.callFunction(func->name, arguments);
     } catch (const TrapException&) {
+      return {};
+    } catch (const WasmException&) {
       return {};
     }
   }


### PR DESCRIPTION
Very similar to the existing handling of traps.

This is needed for fuzzing.