### PR TITLE
RemoveUnusedBrs fuzz fix

### DIFF
--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -2502,4 +2502,30 @@
    )
   )
  )
+ (func $unswitch-reordering (param $x i32) (result i32)
+  (block $label$1 (result i32)
+   (block
+    (drop
+     (block $block (result i32)
+      (if
+       (local.get $x)
+       (return
+        (i32.const 5)
+       )
+      )
+      (i32.const 6)
+     )
+    )
+    (br $label$1
+     (block $label$2 (result i32)
+      (i32.store
+       (i32.const 1)
+       (i32.const 2)
+      )
+      (i32.const 3)
+     )
+    )
+   )
+  )
+ )
 )

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -2504,26 +2504,22 @@
  )
  (func $unswitch-reordering (param $x i32) (result i32)
   (block $label$1 (result i32)
-   (block
-    (drop
-     (block $block (result i32)
-      (if
-       (local.get $x)
-       (return
-        (i32.const 5)
-       )
-      )
-      (i32.const 6)
+   (br_table $label$1
+    (block $label$2 (result i32)
+     (i32.store
+      (i32.const 1)
+      (i32.const 2)
      )
+     (i32.const 3)
     )
-    (br $label$1
-     (block $label$2 (result i32)
-      (i32.store
-       (i32.const 1)
-       (i32.const 2)
+    (block $block (result i32)
+     (if
+      (local.get $x)
+      (return
+       (i32.const 5)
       )
-      (i32.const 3)
      )
+     (i32.const 6)
     )
    )
   )

--- a/test/passes/remove-unused-brs_enable-multivalue.wast
+++ b/test/passes/remove-unused-brs_enable-multivalue.wast
@@ -2106,4 +2106,26 @@
    )
   )
  )
+ (func $unswitch-reordering (param $x i32) (result i32)
+  (block $label$1 (result i32)
+   (br_table $label$1
+    (block $label$2 (result i32)
+     (i32.store ;; has a possible side effect
+      (i32.const 1)
+      (i32.const 2)
+     )
+     (i32.const 3)
+    )
+    (block (result i32)
+     (if
+      (local.get $x)
+      (return
+       (i32.const 5)
+      )
+     )
+     (i32.const 6)
+    )
+   )
+  )
+ )
 )


### PR DESCRIPTION
We turn a `br_table` with a single target into a `br`, but we reverse the order of the
condition and the value when doing so, which we forgot to take into account.