### PR TITLE
Fuzzer: Fix wasm2c name mangling

### DIFF
--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -43,7 +43,7 @@ static std::string wasm2cMangle(Name name) {
       mangled += ss.str();
     }
   }
-  return std::string("(*Z_") + mangled + "Z_";
+  return std::string("(*Z_") + mangled;
 }
 
 static std::string generateWasm2CWrapper(Module& wasm) {


### PR DESCRIPTION
This is necessary for cases where the input has an export name that
needs mangling, like a name with `-` (common in the spec test suite).