### PR TITLE
Add unmodifiedImportedMemory pass option

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -107,6 +107,15 @@ struct PassOptions {
   // forth (which IEEE floats do not, strictly speaking). This is inspired by
   // gcc/clang's -ffast-math flag.
   bool fastMath = false;
+  // Whether to assume that an imported memory has not been modified. Without
+  // this, we can do fewer optimizations on memory segments, because if memory
+  // *was* modified then the wasm's segments may trample those previous
+  // modifications. If memory was not modified, we can assume it starts as zero,
+  // which allows us to remove zeros from wasm's segments.
+  // (This is not a problem if the memory is *not* imported, since then wasm
+  // creates it and we know it is all zeros right before the active segments are
+  // applied.)
+  bool unmodifiedImportedMemory = false;
   // Whether to try to preserve debug info through, which are special calls.
   bool debugInfo = false;
   // Arbitrary string arguments from the commandline, which we forward to

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -193,8 +193,8 @@ struct OptimizationOptions : public ToolOptions {
         "-ffm",
         "Optimize floats without handling corner cases of NaNs and rounding",
         Options::Arguments::Zero,
-        [this](Options*, const std::string&) { passOptions.fastMath = true; });
-    .add("--unmodified-imported-mem",
+        [this](Options*, const std::string&) { passOptions.fastMath = true; })
+      .add("--unmodified-imported-mem",
          "-uim",
          "Assume that an imported memory will not have been modified",
          Options::Arguments::Zero,

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -195,12 +195,12 @@ struct OptimizationOptions : public ToolOptions {
         Options::Arguments::Zero,
         [this](Options*, const std::string&) { passOptions.fastMath = true; })
       .add("--unmodified-imported-mem",
-         "-uim",
-         "Assume that an imported memory will not have been modified",
-         Options::Arguments::Zero,
-         [this](Options*, const std::string&) {
-           passOptions.unmodifiedImportedMemory = true;
-         });
+           "-uim",
+           "Assume that an imported memory will not have been modified",
+           Options::Arguments::Zero,
+           [this](Options*, const std::string&) {
+             passOptions.unmodifiedImportedMemory = true;
+           });
     // add passes in registry
     for (const auto& p : PassRegistry::get()->getRegisteredNames()) {
       (*this).add(

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -194,6 +194,13 @@ struct OptimizationOptions : public ToolOptions {
         "Optimize floats without handling corner cases of NaNs and rounding",
         Options::Arguments::Zero,
         [this](Options*, const std::string&) { passOptions.fastMath = true; });
+    .add("--unmodified-imported-mem",
+         "-uim",
+         "Assume that an imported memory will not have been modified",
+         Options::Arguments::Zero,
+         [this](Options*, const std::string&) {
+           passOptions.unmodifiedImportedMemory = true;
+         });
     // add passes in registry
     for (const auto& p : PassRegistry::get()->getRegisteredNames()) {
       (*this).add(


### PR DESCRIPTION
When set, we can assume an imported memory was not modified before us.
That lets us assume it is all zeros and so we can optimize out zeros from
memory segments.

This does not actually do anything with the flag, just adds it. This is to avoid
a rolling problem. Next emscripten can emit it without erroring, and then we
can start to use it.