### PR TITLE
finalize: move more functionality behind legacyPIC

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -332,15 +332,17 @@ int main(int argc, const char* argv[]) {
     generator.generatePostInstantiateFunction();
   } else {
     BYN_TRACE("finalizing as regular module\n");
-    generator.internalizeStackPointerGlobal();
-    // For side modules these gets called via __post_instantiate
-    if (Function* F = wasm.getFunctionOrNull(ASSIGN_GOT_ENTRIES)) {
-      auto* ex = new Export();
-      ex->value = F->name;
-      ex->name = F->name;
-      ex->kind = ExternalKind::Function;
-      wasm.addExport(ex);
-      initializerFunctions.push_back(F->name);
+    if (legacyPIC) {
+      generator.internalizeStackPointerGlobal();
+      // For side modules these gets called via __post_instantiate
+      if (Function* F = wasm.getFunctionOrNull(ASSIGN_GOT_ENTRIES)) {
+        auto* ex = new Export();
+        ex->value = F->name;
+        ex->name = F->name;
+        ex->kind = ExternalKind::Function;
+        wasm.addExport(ex);
+        initializerFunctions.push_back(F->name);
+      }
     }
     // Costructors get called from crt1 in wasm standalone mode.
     // Unless there is no entry point.


### PR DESCRIPTION
Internalizing of the stack pointer is only needed in legacy
PIC mode, since in the new PIC mode we support mutable globals.

Also the additional ASSIGN_GOT_ENTRIES function only exists
in support of the legacy mode.