### PR TITLE
finalize: remove legacy support for "table" import

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -261,13 +261,6 @@ int main(int argc, const char* argv[]) {
 
   std::vector<Name> initializerFunctions;
 
-  // The wasm backend emits "__indirect_function_table" as the import name for
-  // the table, while older emscripten expects "table"
-  if (wasm.table.imported() && !minimizeWasmChanges) {
-    wasm.table.base = Name("table");
-  }
-  wasm.updateMaps();
-
   if (!standaloneWasm) {
     // This is also not needed in standalone mode since standalone mode uses
     // crt1.c to invoke the main and is aware of __main_argc_argv mangling.

--- a/test/lld/em_asm_shared.wat.out
+++ b/test/lld/em_asm_shared.wat.out
@@ -6,7 +6,7 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
  (data (global.get $gimport$3) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
- (import "env" "table" (table $timport$1 0 funcref))
+ (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
  (import "env" "__memory_base" (global $gimport$3 i32))
  (import "env" "__table_base" (global $gimport$4 i32))
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))

--- a/test/lld/main_module.wat.out
+++ b/test/lld/main_module.wat.out
@@ -4,7 +4,7 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "memory" (memory $0 0))
  (data (global.get $gimport$2) "Hello, world\00\00\00\00\00\00\00\00\00\00\00\00")
- (import "env" "table" (table $timport$1 0 funcref))
+ (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
  (import "env" "__stack_pointer" (global $sp_import i32))
  (import "env" "__memory_base" (global $gimport$2 i32))
  (import "env" "__table_base" (global $gimport$3 i32))

--- a/test/lld/shared.wat.out
+++ b/test/lld/shared.wat.out
@@ -4,7 +4,7 @@
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
  (data (global.get $gimport$2) "Hello, world\00\00\00\00\00\00\00\00\00\00\00\00")
- (import "env" "table" (table $timport$1 0 funcref))
+ (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
  (import "env" "__memory_base" (global $gimport$2 i32))
  (import "env" "__table_base" (global $gimport$3 i32))
  (import "env" "puts" (func $puts (param i32) (result i32)))

--- a/test/lld/shared_add_to_table.wasm.out
+++ b/test/lld/shared_add_to_table.wasm.out
@@ -5,7 +5,7 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
  (data (global.get $gimport$1) "*\00\00\00")
- (import "env" "table" (table $timport$0 0 funcref))
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
  (import "env" "__memory_base" (global $gimport$1 i32))
  (import "env" "__table_base" (global $gimport$2 i32))
  (import "env" "_Z16waka_func_theirsi" (func $waka_func_theirs\28int\29 (param i32) (result i32)))

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -9,7 +9,7 @@
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
  (data (global.get $gimport$2) "\00\00\00\00\00\00\00\00")
- (import "env" "table" (table $timport$1 0 funcref))
+ (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
  (import "env" "__memory_base" (global $gimport$2 i32))
  (import "env" "__table_base" (global $gimport$3 i32))
  (import "env" "malloc" (func $fimport$4 (param i32) (result i32)))


### PR DESCRIPTION
These days we always export the table, except in the
case of dynamic linking, and even then we use the name
`__indirect_function_table`.