### PR TITLE
finalize: add --mutable-sp flag

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -113,7 +113,7 @@ int main(int argc, const char* argv[]) {
          })
     .add("--mutable-sp",
          "",
-         "Import SP as a mutable global",
+         "Allow the import of __stack_pointer as a mutable global",
          Options::Arguments::Zero,
          [&mutableSP](Options* o, const std::string& argument) {
            mutableSP = true;


### PR DESCRIPTION
This flag disables the features of wasm-emscripten-finalize
the replace the mutable global import of `__stack_pointer`.

See the corresponding emscripten change that depends on this
one: https://github.com/emscripten-core/emscripten/pull/12536