### PR TITLE
Partial evaluation improvments

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1591,7 +1591,7 @@ private:
     // detect overflow during signed multiplication
     auto willOverflowSignedMul = [](auto a, auto b) {
       using T = decltype(a);
-      if (b == T(0)) {
+      if (a == T(0) || b == T(0)) {
         return false;
       }
       auto minDivB = std::numeric_limits<T>::min() / b;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1594,16 +1594,10 @@ private:
       if (a == T(0) || b == T(0)) {
         return false;
       }
-      if (b == T(-1)) {
-        return false;
-      }
-      auto minDivB = std::numeric_limits<T>::min() / b;
-      auto maxDivB = std::numeric_limits<T>::max() / b;
-      if ((b > T(0) && a > maxDivB) || (b < T(0) && a < maxDivB) ||
-          (b > T(0) && a < minDivB) || (b < T(-1) && a > minDivB)) {
-        return true;
-      }
-      return false;
+      auto min = std::numeric_limits<T>::min();
+      auto max = std::numeric_limits<T>::max();
+      return ((b > T(0) && a > max / b) || (b < T(0) && a < max / b) ||
+              (b > T(0) && a < min / b) || (b < T(-1) && a > min / b));
     };
 
     // detect overflow or zero during signed multiplication

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1587,6 +1587,7 @@ private:
 
   Expression* partialEvaluation(Binary* binary) {
     assert(binary->right->is<Const>());
+    Const* right = binary->right->cast<Const>();
 
     // detect overflow or zero during signed multiplication
     auto hasSignedMulOverflow = [](auto a, auto b) {
@@ -1604,7 +1605,6 @@ private:
       return a != T(0) && b != T(0) && a > std::numeric_limits<T>::max() / b;
     };
 
-    Const* right = binary->right->cast<Const>();
     // the square of some operations can be merged
     // (x op C1) op C2  ==>  (x op (C1 op C2))
     if (auto* left = binary->left->dynCast<Binary>()) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1589,7 +1589,7 @@ private:
     assert(binary->right->is<Const>());
 
     // detect overflow during signed multiplication
-    auto willOverflowSignedMul = [](auto a, auto b) {
+    auto hasSignedMulOverflow = [](auto a, auto b) {
       using T = decltype(a);
       if (a == T(0) || b == T(0)) {
         return false;
@@ -1604,7 +1604,7 @@ private:
     };
 
     // detect overflow during signed multiplication
-    auto willOverflowUnsignedMul = [](auto a, auto b) {
+    auto hasUnsignedMulOverflow = [](auto a, auto b) {
       using T = decltype(a);
       return a != T(0) && b != T(0) && a > std::numeric_limits<T>::max() / b;
     };
@@ -1632,11 +1632,11 @@ private:
             // owerflow just fold final constant as zero
             if (leftRight->value.isZero() || right->value.isZero() ||
                 (leftRight->value.type == Type::i32 &&
-                 willOverflowSignedMul(leftRight->value.geti32(),
-                                       right->value.geti32())) ||
+                 hasSignedMulOverflow(leftRight->value.geti32(),
+                                      right->value.geti32())) ||
                 (leftRight->value.type == Type::i64 &&
-                 willOverflowSignedMul(leftRight->value.geti64(),
-                                       right->value.geti64()))) {
+                 hasSignedMulOverflow(leftRight->value.geti64(),
+                                      right->value.geti64()))) {
               leftRight->value = Literal::makeZero(right->type);
               return left;
             } else {
@@ -1651,11 +1651,11 @@ private:
           } else if (left->op == DivUInt32 || left->op == DivUInt64) {
             if (leftRight->value.isZero() || right->value.isZero() ||
                 (leftRight->value.type == Type::i32 &&
-                 willOverflowUnsignedMul((uint32_t)leftRight->value.geti32(),
-                                         (uint32_t)right->value.geti32())) ||
+                 hasUnsignedMulOverflow((uint32_t)leftRight->value.geti32(),
+                                        (uint32_t)right->value.geti32())) ||
                 (leftRight->value.type == Type::i64 &&
-                 willOverflowUnsignedMul((uint64_t)leftRight->value.geti64(),
-                                         (uint64_t)right->value.geti64()))) {
+                 hasUnsignedMulOverflow((uint64_t)leftRight->value.geti64(),
+                                        (uint64_t)right->value.geti64()))) {
               leftRight->value = Literal::makeZero(right->type);
             } else {
               auto prod = leftRight->value.mul(right->value);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -538,7 +538,7 @@ struct OptimizeInstructions
                 auto effective = Bits::getEffectiveShifts(total, right->type);
                 if (left->op == RotLInt32 || left->op == RotLInt64 ||
                     left->op == RotRInt32 || left->op == RotRInt64) {
-                  // for cyclic rotations overflowing is legit
+                  // for cyclic shift rotations overflow is legit
                   leftRight->value =
                     Literal::makeFromInt32(effective, right->type);
                   return left;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1590,7 +1590,14 @@ private:
 
     // detect overflow during signed and unsigned multiplication
     auto willOverflowMul = [](auto a, auto b) {
-      return a != 0 && a * b / a != b;
+      if (b == 0) return false;
+      auto minDivB = std::numeric_limits<decltype(a)>::min() / b;
+      auto maxDivB = std::numeric_limits<decltype(a)>::max() / b;
+      if ((b > decltype(a)(0) && a > maxDivB) || (b < decltype(a)(0) && a < maxDivB) ||
+          (b > decltype(a)(0) && a < minDivB) || (b < decltype(a)(-1) && a > minDivB)) {
+        return true;
+      }
+      return false;
     };
 
     Const* right = binary->right->cast<Const>();

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1591,13 +1591,11 @@ private:
     // detect overflow or zero during signed multiplication
     auto hasSignedMulOverflow = [](auto a, auto b) {
       using T = decltype(a);
-      if (a == T(0) || b == T(0)) {
-        return false;
-      }
       auto min = std::numeric_limits<T>::min();
       auto max = std::numeric_limits<T>::max();
-      return ((b > T(0) && a > max / b) || (b < T(0) && a < max / b) ||
-              (b > T(0) && a < min / b) || (b < T(-1) && a > min / b));
+      return (a != T(0) && b != T(0) &&
+              ((b > T(0) && a > max / b) || (b < T(0) && a < max / b) ||
+               (b > T(0) && a < min / b) || (b < T(-1) && a > min / b)));
     };
 
     // detect overflow or zero during signed multiplication

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -535,13 +535,14 @@ struct OptimizeInstructions
                 // adding must be done carefully
                 auto total = Bits::getEffectiveShifts(leftRight) +
                              Bits::getEffectiveShifts(right);
+                auto actual = Bits::getEffectiveShifts(total, right->type);
                 if (left->op == RotLInt32 || left->op == RotLInt64 ||
                     left->op == RotRInt32 || left->op == RotRInt64) {
-                  leftRight->value = Literal::makeFromInt32(
-                    Bits::getEffectiveShifts(total, right->type), right->type);
+                  leftRight->value =
+                    Literal::makeFromInt32(actual, right->type);
                   return left;
                 } else {
-                  if (total == Bits::getEffectiveShifts(total, right->type)) {
+                  if (total == actual) {
                     // no overflow, we can do this
                     leftRight->value =
                       Literal::makeFromInt32(total, right->type);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -532,17 +532,42 @@ struct OptimizeInstructions
                 // if any of constants is zero or product of them produce
                 // owerflow just fold final constant as zero
                 auto prod = leftRight->value.mul(right->value);
-                auto hasMultiplyOwerflow = [&](Literal* x, Literal* y) {
-                  // from hacker's delight
-                  int32_t m = (int32_t)x->countLeadingZeroes().getInteger();
-                  int32_t n = (int32_t)y->countLeadingZeroes().getInteger();
-                  if (m + n <= 30) return true;
-                  t = x * (y >> 1);
-                  if ((int)t < 0) return true;
-                  z = t * 2;
-                  if (y & 1) {
-                    z = z + x;
-                    if (z < x) return true;
+                // auto hasMultiplyOwerflow = [&](Literal* x, Literal* y) {
+                //   // from hacker's delight
+                //   int32_t m = (int32_t)x->countLeadingZeroes().getInteger();
+                //   int32_t n = (int32_t)y->countLeadingZeroes().getInteger();
+                //   if (m + n <= 30) return true;
+                //   t = x * (y >> 1);
+                //   if ((int)t < 0) return true;
+                //   z = t * 2;
+                //   if (y & 1) {
+                //     z = z + x;
+                //     if (z < x) return true;
+                //   }
+                //   return false;
+                // };
+                auto hasMultiplyOwerflow = [&](Literal* a, Literal* b) {
+                  signed int result;
+                  if (si_a > 0) {  /* si_a is positive */
+                    if (si_b > 0) {  /* si_a and si_b are positive */
+                      if (si_a > (INT_MAX / si_b)) {
+                        return true;
+                      }
+                    } else { /* si_a positive, si_b nonpositive */
+                      if (si_b < (INT_MIN / si_a)) {
+                        return true;
+                      }
+                    } /* si_a positive, si_b nonpositive */
+                  } else { /* si_a is nonpositive */
+                    if (si_b > 0) { /* si_a is nonpositive, si_b is positive */
+                      if (si_a < (INT_MIN / si_b)) {
+                        return true;
+                      }
+                    } else { /* si_a and si_b are nonpositive */
+                      if ( (si_a != 0) && (si_b < (INT_MAX / si_a))) {
+                        return true;
+                      }
+                    }
                   }
                   return false;
                 };

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1682,7 +1682,7 @@ private:
                 (leftRight->value.type == Type::i64 &&
                  hasUnsignedMulOverflow((uint64_t)leftRight->value.geti64(),
                                         (uint64_t)right->value.geti64()))) {
-              leftRight->value = Literal::makeZero(right->type);
+              right->value = Literal::makeZero(right->type);
               return right;
             }
             leftRight->value = prod;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1590,11 +1590,15 @@ private:
 
     // detect overflow during signed and unsigned multiplication
     auto willOverflowMul = [](auto a, auto b) {
-      if (b == 0) return false;
-      auto minDivB = std::numeric_limits<decltype(a)>::min() / b;
-      auto maxDivB = std::numeric_limits<decltype(a)>::max() / b;
-      if ((b > decltype(a)(0) && a > maxDivB) || (b < decltype(a)(0) && a < maxDivB) ||
-          (b > decltype(a)(0) && a < minDivB) || (b < decltype(a)(-1) && a > minDivB)) {
+      using T = decltype(a);
+
+      if (b == T(0)) {
+        return false;
+      }
+      auto minDivB = std::numeric_limits<T>::min() / b;
+      auto maxDivB = std::numeric_limits<T>::max() / b;
+      if ((b > T(0) && a > maxDivB) || (b < T(0) && a < maxDivB) ||
+          (b > T(0) && a < minDivB) || (b < T(-1) && a > minDivB)) {
         return true;
       }
       return false;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -535,14 +535,15 @@ struct OptimizeInstructions
                 // adding must be done carefully
                 auto total = Bits::getEffectiveShifts(leftRight) +
                              Bits::getEffectiveShifts(right);
-                auto actual = Bits::getEffectiveShifts(total, right->type);
+                auto effective = Bits::getEffectiveShifts(total, right->type);
                 if (left->op == RotLInt32 || left->op == RotLInt64 ||
                     left->op == RotRInt32 || left->op == RotRInt64) {
+                  // for cyclic rotations overflowing is legit
                   leftRight->value =
-                    Literal::makeFromInt32(actual, right->type);
+                    Literal::makeFromInt32(effective, right->type);
                   return left;
                 } else {
-                  if (total == actual) {
+                  if (total == effective) {
                     // no overflow, we can do this
                     leftRight->value =
                       Literal::makeFromInt32(total, right->type);

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -54,6 +54,39 @@
    )
   )
   (drop
+   (i32.shl
+    (i32.shl
+     (local.get $i1)
+     (i32.const 31)
+    )
+    (i32.const 1)
+   )
+  )
+  (drop
+   (i32.mul
+    (i32.shl
+     (local.get $i1)
+     (i32.const 31)
+    )
+    (i32.const 3)
+   )
+  )
+  (drop
+   (i32.shl
+    (local.get $i1)
+    (i32.const 31)
+   )
+  )
+  (drop
+   (i32.shl
+    (i32.shl
+     (local.get $i1)
+     (i32.const 31)
+    )
+    (i32.const 31)
+   )
+  )
+  (drop
    (i32.rotl
     (local.get $i1)
     (i32.const 3)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -87,6 +87,33 @@
    )
   )
   (drop
+   (i32.div_s
+    (local.get $i1)
+    (i32.const -2300)
+   )
+  )
+  (drop
+   (i32.div_s
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
+    (i32.div_s
+     (local.get $i1)
+     (i32.const 65536)
+    )
+    (i32.const 32768)
+   )
+  )
+  (drop
    (i32.rotl
     (local.get $i1)
     (i32.const 3)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -95,6 +95,12 @@
   (drop
    (i32.div_s
     (local.get $i1)
+    (i32.const -45)
+   )
+  )
+  (drop
+   (i32.div_s
+    (local.get $i1)
     (i32.const 0)
    )
   )
@@ -106,11 +112,20 @@
   )
   (drop
    (i32.div_s
-    (i32.div_s
-     (local.get $i1)
-     (i32.const 65536)
-    )
-    (i32.const 32768)
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
+    (local.get $i1)
+    (i32.const 0)
    )
   )
   (drop

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -53,6 +53,27 @@
     (i32.const -133169153)
    )
   )
+  (drop
+   (i32.rotl
+    (local.get $i1)
+    (i32.const 3)
+   )
+  )
+  (drop
+   (i64.rotl
+    (local.get $i2)
+    (i64.const 10)
+   )
+  )
+  (drop
+   (i32.rotr
+    (local.get $i1)
+    (i32.const 3)
+   )
+  )
+  (drop
+   (local.get $i1)
+  )
   (if
    (i32.eqz
     (local.get $i1)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -54,22 +54,7 @@
    )
   )
   (drop
-   (i32.shl
-    (i32.shl
-     (local.get $i1)
-     (i32.const 31)
-    )
-    (i32.const 1)
-   )
-  )
-  (drop
-   (i32.mul
-    (i32.shl
-     (local.get $i1)
-     (i32.const 31)
-    )
-    (i32.const 3)
-   )
+   (i32.const 0)
   )
   (drop
    (i32.shl
@@ -79,12 +64,12 @@
   )
   (drop
    (i32.shl
-    (i32.shl
-     (local.get $i1)
-     (i32.const 31)
-    )
+    (local.get $i1)
     (i32.const 31)
    )
+  )
+  (drop
+   (i32.const 0)
   )
   (drop
    (i32.div_s

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -156,6 +156,21 @@
    )
   )
   (drop
+   (i32.ge_u
+    (local.get $i1)
+    (i32.const -8255)
+   )
+  )
+  (drop
+   (i32.eq
+    (local.get $i1)
+    (i32.const -1)
+   )
+  )
+  (drop
+   (i32.const 0)
+  )
+  (drop
    (i32.div_u
     (i32.eq
      (local.get $i1)
@@ -165,7 +180,25 @@
    )
   )
   (drop
+   (i32.div_u
+    (local.get $i1)
+    (i32.const 15)
+   )
+  )
+  (drop
    (i32.const 0)
+  )
+  (drop
+   (i32.div_u
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_u
+    (local.get $i1)
+    (i32.const 0)
+   )
   )
   (drop
    (i32.rotl

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -99,9 +99,30 @@
    )
   )
   (drop
+   (local.get $i1)
+  )
+  (drop
    (i32.div_s
     (local.get $i1)
     (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
+    (i32.div_s
+     (local.get $i1)
+     (i32.const -2147483648)
+    )
+    (i32.const -1)
+   )
+  )
+  (drop
+   (i32.div_s
+    (i32.div_s
+     (local.get $i1)
+     (i32.const -1)
+    )
+    (i32.const -2147483648)
    )
   )
   (drop
@@ -124,8 +145,11 @@
   )
   (drop
    (i32.div_s
-    (local.get $i1)
-    (i32.const 0)
+    (i32.div_s
+     (local.get $i1)
+     (i32.const 65536)
+    )
+    (i32.const 32768)
    )
   )
   (drop

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -106,6 +106,18 @@
   )
   (drop
    (i32.div_s
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
+    (local.get $i1)
+    (i32.const 0)
+   )
+  )
+  (drop
+   (i32.div_s
     (i32.div_s
      (local.get $i1)
      (i32.const -2147483648)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -150,6 +150,24 @@
    )
   )
   (drop
+   (i32.div_u
+    (local.get $i1)
+    (i32.const 75)
+   )
+  )
+  (drop
+   (i32.div_u
+    (i32.eq
+     (local.get $i1)
+     (i32.const -1)
+    )
+    (i32.const 3)
+   )
+  )
+  (drop
+   (i32.const 0)
+  )
+  (drop
    (i32.rotl
     (local.get $i1)
     (i32.const 3)

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -102,10 +102,7 @@
    (local.get $i1)
   )
   (drop
-   (i32.div_s
-    (local.get $i1)
-    (i32.const 0)
-   )
+   (i32.const 0)
   )
   (drop
    (i32.div_s

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -105,6 +105,9 @@
    (i32.const 0)
   )
   (drop
+   (i32.const 0)
+  )
+  (drop
    (i32.div_s
     (local.get $i1)
     (i32.const 0)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -111,6 +111,16 @@
         (i32.const -15)
       )
     )
+    ;; -> x / 1 -> x
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const -1)
+        )
+        (i32.const -1)
+      )
+    )
     ;; -> x / 0 (overflow)
     (drop
       (i32.div_s
@@ -119,6 +129,26 @@
           (i32.const -0xFFFF)
         )
         (i32.const -0xFFFF)
+      )
+    )
+    ;; -> skip (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const -1)
+      )
+    )
+    ;; -> skip (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const -1)
+        )
+        (i32.const 0x80000000)
       )
     )
     ;; -> x / 0

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -89,6 +89,47 @@
         (i32.const 0x80000000)
       )
     )
+
+    ;; signed division
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const -100)
+        )
+        (i32.const 23)
+      )
+    )
+    ;; -> x / 0
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0x10000)
+        )
+        (i32.const 0)
+      )
+    )
+    ;; -> x / 0
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0)
+        )
+        (i32.const 0x80000000)
+      )
+    )
+    ;; skip
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0x10000)
+        )
+        (i32.const 0x8000)
+      )
+    )
     (drop
       (i32.rotl
         (i32.rotl

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -131,6 +131,26 @@
         (i32.const -0xFFFF)
       )
     )
+    ;; -> 0 (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const 2)
+      )
+    )
+    ;; -> 0 (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 2)
+        )
+        (i32.const 0x80000000)
+      )
+    )
     ;; -> skip (overflow)
     (drop
       (i32.div_s

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -48,6 +48,47 @@
         (i32.const 0x8000001)
       )
     )
+    ;; more cases
+    ;; (x * 0x80000000) * 2  -->  0
+    (drop
+      (i32.mul
+        (i32.mul
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const 2)
+      )
+    )
+    ;; (x * 0x80000000) * 3  -->  x * 0x80000000
+    (drop
+      (i32.mul
+        (i32.mul
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const 3)
+      )
+    )
+    ;; (x * -3) * 0x80000000  -->  x * 0x80000000
+    (drop
+      (i32.mul
+        (i32.mul
+          (local.get $i1)
+          (i32.const -3)
+        )
+        (i32.const 0x80000000)
+      )
+    )
+    ;; (x * 0x80000000) * 0x80000000 -->  x * 0
+    (drop
+      (i32.mul
+        (i32.mul
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const 0x80000000)
+      )
+    )
     (drop
       (i32.rotl
         (i32.rotl

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -121,7 +121,7 @@
         (i32.const -1)
       )
     )
-    ;; -> x / 0 (overflow)
+    ;; -> 0 (overflow)
     (drop
       (i32.div_s
         (i32.div_s
@@ -171,7 +171,7 @@
         (i32.const 0x80000000)
       )
     )
-    ;; -> x / 0
+    ;; -> 0
     (drop
       (i32.div_s
         (i32.div_s

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -141,6 +141,16 @@
       (i32.div_s
         (i32.div_s
           (local.get $i1)
+          (i32.const 0x7FFFFFFF)
+        )
+        (i32.const 2)
+      )
+    )
+    ;; -> 0 (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
           (i32.const 0x80000000)
         )
         (i32.const 2)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -48,6 +48,43 @@
         (i32.const 0x8000001)
       )
     )
+    (drop
+      (i32.rotl
+        (i32.rotl
+          (local.get $i1)
+          (i32.const 5)
+        )
+        (i32.const 30)
+      )
+    )
+    (drop
+      (i64.rotl
+        (i64.rotl
+          (local.get $i2)
+          (i64.const 4)
+        )
+        (i64.const 6)
+      )
+    )
+    (drop
+      (i32.rotr
+        (i32.rotr
+          (local.get $i1)
+          (i32.const 16)
+        )
+        (i32.const 19)
+      )
+    )
+    ;; rotl(rotl(x, 16), 16) -> x
+    (drop
+      (i32.rotl
+        (i32.rotl
+          (local.get $i1)
+          (i32.const 16)
+        )
+        (i32.const 16)
+      )
+    )
     (if
       (i32.eqz
         (local.get $i1)

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -94,7 +94,7 @@
       )
     )
 
-    ;; signed division
+    ;; signed divisions
 
     ;; -> x / -2300
     (drop
@@ -224,6 +224,39 @@
           (i32.const 0x10000)
         )
         (i32.const 0x8000)
+      )
+    )
+
+    ;; unsigned divisions
+
+    ;; -> x / 75
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 15)
+        )
+        (i32.const 5)
+      )
+    )
+    ;; -> 0 (overflow) ;; skipped now
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const -1)
+        )
+        (i32.const 3)
+      )
+    )
+    ;; -> 0 (overflow) ;; skipped now
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 0x7FFFFFFF)
+        )
+        (i32.const 3)
       )
     )
 

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -91,6 +91,7 @@
     )
 
     ;; signed division
+    ;; -> x / -2300
     (drop
       (i32.div_s
         (i32.div_s
@@ -98,6 +99,26 @@
           (i32.const -100)
         )
         (i32.const 23)
+      )
+    )
+    ;; -> x / -45
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 3)
+        )
+        (i32.const -15)
+      )
+    )
+    ;; -> x / 0 (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const -0xFFFF)
+        )
+        (i32.const -0xFFFF)
       )
     )
     ;; -> x / 0
@@ -120,7 +141,17 @@
         (i32.const 0x80000000)
       )
     )
-    ;; skip
+    ;; -> x / 0
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const 0x80000000)
+      )
+    )
+    ;; skip due to C1 * C2 == 0x80000000
     (drop
       (i32.div_s
         (i32.div_s

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -29,6 +29,10 @@
         (i32.const -5)
       )
     )
+
+    ;; partial evaluation for
+    ;; multiplications
+
     (drop
       (i32.mul
         (i32.mul
@@ -91,6 +95,7 @@
     )
 
     ;; signed division
+
     ;; -> x / -2300
     (drop
       (i32.div_s
@@ -211,6 +216,9 @@
         (i32.const 0x8000)
       )
     )
+
+    ;; rotated shifts
+
     (drop
       (i32.rotl
         (i32.rotl

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -239,6 +239,36 @@
         (i32.const 5)
       )
     )
+    ;; -> x / -8255
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 0x1FFF)
+        )
+        (i32.const 0x8003F)
+      )
+    )
+    ;; -> x / -1 -> x == -1
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 0x10001)
+        )
+        (i32.const 0xFFFF)
+      )
+    )
+    ;; -> 0 (overflow)
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 0x10001)
+        )
+        (i32.const 0x10001)
+      )
+    )
     ;; -> 0 (overflow) ;; skipped now
     (drop
       (i32.div_u
@@ -249,12 +279,42 @@
         (i32.const 3)
       )
     )
+    ;; -> 0 (overflow)
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 3)
+        )
+        (i32.const 5)
+      )
+    )
     ;; -> 0 (overflow) ;; skipped now
     (drop
       (i32.div_u
         (i32.div_u
           (local.get $i1)
           (i32.const 0x7FFFFFFF)
+        )
+        (i32.const 3)
+      )
+    )
+    ;; -> x / 0
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 0x7FFFFFFF)
+        )
+        (i32.const 0)
+      )
+    )
+    ;; -> x / 0
+    (drop
+      (i32.div_u
+        (i32.div_u
+          (local.get $i1)
+          (i32.const 0)
         )
         (i32.const 3)
       )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -171,6 +171,16 @@
         (i32.const 0x80000000)
       )
     )
+    ;; -> 0 (overflow)
+    (drop
+      (i32.div_s
+        (i32.div_s
+          (local.get $i1)
+          (i32.const 0x80000000)
+        )
+        (i32.const 0x80000000)
+      )
+    )
     ;; -> x / 0
     (drop
       (i32.div_s
@@ -187,16 +197,6 @@
         (i32.div_s
           (local.get $i1)
           (i32.const 0)
-        )
-        (i32.const 0x80000000)
-      )
-    )
-    ;; -> 0
-    (drop
-      (i32.div_s
-        (i32.div_s
-          (local.get $i1)
-          (i32.const 0x80000000)
         )
         (i32.const 0x80000000)
       )


### PR DESCRIPTION
`((signed)x / C1) / C2` -> `(signed)x / (C1 * C2)`
`((unsigned)x / C1) / C2` -> `(unsigned)x / (C1 * C2)`

Also canonicalization for mul / left shift pairs. Now partial evaluation have separate routine.