### PR TITLE
Only ignore the root `config.h` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ CMakeFiles
 /.ninja_log
 /bin/
 /lib/
-config.h
+/config.h
 *.o
 *.obj
 


### PR DESCRIPTION
I'm trying to include binaryen in an archive that the Grain team needs to publish, and I ran into this problem with the `.gitignore`. Basically, the publishing tool filters things based on the gitignore file and https://github.com/WebAssembly/binaryen/blob/master/third_party/llvm-project/include/llvm/Config/config.h was removed from the archive because of the `config.h` reference.

By prefixing it with `/`, only the root `config.h` file is excluded from the archive.