### PR TITLE
Avoid name collisions in MemoryPacking

### DIFF
--- a/src/ir/names.h
+++ b/src/ir/names.h
@@ -46,6 +46,33 @@ inline void ensureNames(Function* func) {
   }
 }
 
+// Given a root of a name, finds a valid name with perhaps a number appended
+// to it, by calling a function to check if a name is valid.
+inline Name
+getValidName(Module& module, Name root, std::function<bool(Name)> check) {
+  if (check(root)) {
+    return root;
+  }
+  auto prefixed = std::string(root.str) + '_';
+  Index num = 0;
+  while (1) {
+    auto name = prefixed + std::to_string(num);
+    if (check(name)) {
+      return name;
+    }
+    num++;
+  }
+}
+
+inline Name getValidGlobalName(Module& module, Name root) {
+  return getValidName(
+    module, root, [&](Name test) { return !module.getGlobalOrNull(test); });
+}
+inline Name getValidFunctionName(Module& module, Name root) {
+  return getValidName(
+    module, root, [&](Name test) { return !module.getFunctionOrNull(test); });
+}
+
 } // namespace Names
 
 } // namespace wasm

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -90,8 +90,6 @@ makeGtShiftedMemorySize(Builder& builder, Module& module, MemoryInit* curr) {
 } // anonymous namespace
 
 struct MemoryPacking : public Pass {
-  size_t dropStateGlobalCount = 0;
-
   // FIXME: Chrome has a bug decoding section indices that prevents it from
   // using more than 63. Just use WebLimitations::MaxDataSegments once this is
   // fixed. See https://bugs.chromium.org/p/v8/issues/detail?id=10151.
@@ -557,8 +555,8 @@ void MemoryPacking::createReplacements(Module* module,
     if (dropStateGlobal != Name()) {
       return dropStateGlobal;
     }
-    dropStateGlobal = Name(std::string("__mem_segment_drop_state_") +
-                           std::to_string(dropStateGlobalCount++));
+    dropStateGlobal =
+      Names::getValidGlobalName(*module, "__mem_segment_drop_state_");
     module->addGlobal(builder.makeGlobal(dropStateGlobal,
                                          Type::i32,
                                          builder.makeConst(int32_t(0)),

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -30,6 +30,7 @@
 
 #include "ir/manipulation.h"
 #include "ir/module-utils.h"
+#include "ir/names.h"
 #include "ir/utils.h"
 #include "pass.h"
 #include "support/space.h"

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -557,7 +557,7 @@ void MemoryPacking::createReplacements(Module* module,
       return dropStateGlobal;
     }
     dropStateGlobal =
-      Names::getValidGlobalName(*module, "__mem_segment_drop_state_");
+      Names::getValidGlobalName(*module, "__mem_segment_drop_state");
     module->addGlobal(builder.makeGlobal(dropStateGlobal,
                                          Type::i32,
                                          builder.makeConst(int32_t(0)),

--- a/test/passes/memory-packing_all-features.txt
+++ b/test/passes/memory-packing_all-features.txt
@@ -85,13 +85,13 @@
  (data passive "more")
  (data passive "zeroes")
  (data passive "no zeroes")
+ (global $__mem_segment_drop_state (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_0 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_1 (mut i32) (i32.const 0))
- (global $__mem_segment_drop_state_2 (mut i32) (i32.const 0))
  (func $zeroes-at-start
   (block
    (if
-    (global.get $__mem_segment_drop_state_0)
+    (global.get $__mem_segment_drop_state)
     (unreachable)
    )
    (memory.fill
@@ -106,7 +106,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_0
+   (global.set $__mem_segment_drop_state
     (i32.const 1)
    )
    (data.drop 0)
@@ -270,7 +270,7 @@
  (func $even-more-zeroes
   (block
    (if
-    (global.get $__mem_segment_drop_state_1)
+    (global.get $__mem_segment_drop_state_0)
     (unreachable)
    )
    (memory.fill
@@ -310,7 +310,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_1
+   (global.set $__mem_segment_drop_state_0
     (i32.const 1)
    )
    (data.drop 13)
@@ -321,7 +321,7 @@
  (func $only-zeroes
   (block
    (if
-    (global.get $__mem_segment_drop_state_2)
+    (global.get $__mem_segment_drop_state_1)
     (unreachable)
    )
    (memory.fill
@@ -330,7 +330,7 @@
     (i32.const 30)
    )
   )
-  (global.set $__mem_segment_drop_state_2
+  (global.set $__mem_segment_drop_state_1
    (i32.const 1)
   )
  )
@@ -400,6 +400,7 @@
  (data passive "more")
  (data passive "zeroes")
  (import "env" "param" (global $param i32))
+ (global $__mem_segment_drop_state (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_0 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_1 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_2 (mut i32) (i32.const 0))
@@ -407,7 +408,6 @@
  (global $__mem_segment_drop_state_4 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_5 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_6 (mut i32) (i32.const 0))
- (global $__mem_segment_drop_state_7 (mut i32) (i32.const 0))
  (func $nonconst-dest
   (local $0 i32)
   (block
@@ -415,7 +415,7 @@
     (global.get $param)
    )
    (if
-    (global.get $__mem_segment_drop_state_0)
+    (global.get $__mem_segment_drop_state)
     (unreachable)
    )
    (memory.fill
@@ -473,7 +473,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_0
+   (global.set $__mem_segment_drop_state
     (i32.const 1)
    )
    (data.drop 0)
@@ -500,7 +500,7 @@
  (func $partial-skip-start
   (block
    (if
-    (global.get $__mem_segment_drop_state_1)
+    (global.get $__mem_segment_drop_state_0)
     (unreachable)
    )
    (memory.fill
@@ -540,7 +540,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_1
+   (global.set $__mem_segment_drop_state_0
     (i32.const 1)
    )
    (data.drop 5)
@@ -590,7 +590,7 @@
  (func $partial-skip-end
   (block
    (if
-    (global.get $__mem_segment_drop_state_2)
+    (global.get $__mem_segment_drop_state_1)
     (unreachable)
    )
    (memory.fill
@@ -630,7 +630,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_2
+   (global.set $__mem_segment_drop_state_1
     (i32.const 1)
    )
    (data.drop 11)
@@ -641,7 +641,7 @@
  (func $full-skip-end
   (block
    (if
-    (global.get $__mem_segment_drop_state_3)
+    (global.get $__mem_segment_drop_state_2)
     (unreachable)
    )
    (memory.fill
@@ -676,7 +676,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_3
+   (global.set $__mem_segment_drop_state_2
     (i32.const 1)
    )
    (data.drop 14)
@@ -687,7 +687,7 @@
  (func $slice-zeroes
   (block
    (if
-    (global.get $__mem_segment_drop_state_4)
+    (global.get $__mem_segment_drop_state_3)
     (unreachable)
    )
    (memory.fill
@@ -697,7 +697,7 @@
    )
   )
   (block
-   (global.set $__mem_segment_drop_state_4
+   (global.set $__mem_segment_drop_state_3
     (i32.const 1)
    )
    (data.drop 17)
@@ -727,12 +727,12 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_5)
+    (global.get $__mem_segment_drop_state_4)
    )
    (unreachable)
   )
   (block
-   (global.set $__mem_segment_drop_state_5
+   (global.set $__mem_segment_drop_state_4
     (i32.const 1)
    )
    (data.drop 23)
@@ -750,7 +750,7 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_6)
+    (global.get $__mem_segment_drop_state_5)
    )
    (unreachable)
   )
@@ -810,12 +810,12 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_7)
+    (global.get $__mem_segment_drop_state_6)
    )
    (unreachable)
   )
   (block
-   (global.set $__mem_segment_drop_state_7
+   (global.set $__mem_segment_drop_state_6
     (i32.const 1)
    )
    (data.drop 29)
@@ -837,10 +837,10 @@
  (data passive "hi")
  (data passive "even")
  (data passive "hi")
+ (global $__mem_segment_drop_state (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_0 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_1 (mut i32) (i32.const 0))
  (global $__mem_segment_drop_state_2 (mut i32) (i32.const 0))
- (global $__mem_segment_drop_state_3 (mut i32) (i32.const 0))
  (func $zero-length-init-zeroes
   (if
    (i32.or
@@ -851,12 +851,12 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_0)
+    (global.get $__mem_segment_drop_state)
    )
    (unreachable)
   )
   (block
-   (global.set $__mem_segment_drop_state_0
+   (global.set $__mem_segment_drop_state
     (i32.const 1)
    )
    (data.drop 0)
@@ -874,12 +874,12 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_1)
+    (global.get $__mem_segment_drop_state_0)
    )
    (unreachable)
   )
   (block
-   (global.set $__mem_segment_drop_state_1
+   (global.set $__mem_segment_drop_state_0
     (i32.const 1)
    )
    (data.drop 3)
@@ -897,12 +897,12 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_2)
+    (global.get $__mem_segment_drop_state_1)
    )
    (unreachable)
   )
   (block
-   (global.set $__mem_segment_drop_state_2
+   (global.set $__mem_segment_drop_state_1
     (i32.const 1)
    )
    (data.drop 6)
@@ -919,12 +919,12 @@
       (i32.const 16)
      )
     )
-    (global.get $__mem_segment_drop_state_3)
+    (global.get $__mem_segment_drop_state_2)
    )
    (unreachable)
   )
   (block
-   (global.set $__mem_segment_drop_state_3
+   (global.set $__mem_segment_drop_state_2
     (i32.const 1)
    )
    (data.drop 8)
@@ -1544,11 +1544,11 @@
  (import "env" "memory" (memory $mimport$0 1 1))
  (data passive "skipped")
  (data passive "included")
- (global $__mem_segment_drop_state_0 (mut i32) (i32.const 0))
+ (global $__mem_segment_drop_state (mut i32) (i32.const 0))
  (export "func_54" (func $0))
  (func $0
   (if
-   (global.get $__mem_segment_drop_state_0)
+   (global.get $__mem_segment_drop_state)
    (unreachable)
   )
   (memory.fill


### PR DESCRIPTION
Such a collision can happen if we run the pass twice, and somehow it finds
more to optimize.

To make this easy, add a general utility for getting a unique name based on
a root + a numeric suffix to avoid collisions.

Fixes the testcase in https://github.com/WebAssembly/binaryen/issues/3225#issuecomment-709395467