### PR TITLE
Fuzzer: Handle log_execution instrumentation, and warn on unknown imports

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -40,7 +40,19 @@ struct LoggingExternalInterface : public ShellExternalInterface {
         loggings.push_back(argument);
       }
       std::cout << "]\n";
+      return {};
+    } else if (import->module == ENV) {
+      if (import->base == "log_execution") {
+        std::cout << "[LoggingExternalInterface log-execution";
+        for (auto argument : arguments) {
+          std::cout << ' ' << argument;
+        }
+        std::cout << "]\n";
+        return {};
+      }
     }
+    std::cerr << "[LoggingExternalInterface ignoring an unknown import "
+              << import->module << " . " << import->base << '\n';
     return {};
   }
 };


### PR DESCRIPTION
`log_execution` can be useful to run on a fuzz testcase for debugging purposes. This
adds support to `--fuzz-exec` for printing out those values.

In general `--fuzz-exec` ignores unknown imports (so that it can be run on more wasm
files, for at least some fuzz testing there). This also adds a warning in that case, so it
is less surprising (the behavior does not change in this PR).