### PR TITLE
Fuzzer: Tweak constants during mutation as well

### DIFF
--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,30 +1,30 @@
 total
  [events]       : 0       
- [exports]      : 18      
- [funcs]        : 22      
+ [exports]      : 45      
+ [funcs]        : 72      
  [globals]      : 7       
  [imports]      : 4       
  [memory-data]  : 4       
- [table-data]   : 9       
- [total]        : 4993    
- [vars]         : 58      
- binary         : 397     
- block          : 736     
- break          : 204     
- call           : 173     
- call_indirect  : 32      
- const          : 823     
- drop           : 42      
- global.get     : 421     
- global.set     : 190     
- if             : 292     
- load           : 95      
- local.get      : 392     
- local.set      : 297     
- loop           : 146     
- nop            : 97      
- return         : 189     
- select         : 39      
- store          : 55      
- switch         : 1       
- unary          : 372     
+ [table-data]   : 30      
+ [total]        : 5321    
+ [vars]         : 256     
+ binary         : 416     
+ block          : 755     
+ break          : 178     
+ call           : 234     
+ call_indirect  : 49      
+ const          : 970     
+ drop           : 58      
+ global.get     : 461     
+ global.set     : 201     
+ if             : 313     
+ load           : 98      
+ local.get      : 412     
+ local.set      : 301     
+ loop           : 119     
+ nop            : 80      
+ return         : 209     
+ select         : 46      
+ store          : 43      
+ unary          : 375     
+ unreachable    : 3       


### PR DESCRIPTION
Move the tweak function to an outer location, and call it from `mutate()` with
some probability.