### PR TITLE
Handle get/setTempRet0 in fuzzer support

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -32,7 +32,6 @@ struct LoggingExternalInterface : public ShellExternalInterface {
   struct State {
     uint32_t tempRet0 = 0;
   } state;
-  ;
 
   LoggingExternalInterface(Loggings& loggings) : loggings(loggings) {}
 

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -31,7 +31,8 @@ struct LoggingExternalInterface : public ShellExternalInterface {
 
   struct State {
     uint32_t tempRet0 = 0;
-  } state;;
+  } state;
+  ;
 
   LoggingExternalInterface(Loggings& loggings) : loggings(loggings) {}
 
@@ -57,7 +58,7 @@ struct LoggingExternalInterface : public ShellExternalInterface {
         state.tempRet0 = arguments[0].geti32();
         return {};
       } else if (import->base == "getTempRet0") {
-        return { Literal(state.tempRet0) };
+        return {Literal(state.tempRet0)};
       }
     }
     std::cerr << "[LoggingExternalInterface ignoring an unknown import "

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -30,6 +30,10 @@ struct LoggingExternalInterface : public ShellExternalInterface {
   Loggings& loggings;
 
   struct State {
+    // Legalization for JS emits get/setTempRet0 calls ("temp ret 0" means a
+    // temporary return value of 32 bits; "0" is the only important value for
+    // 64-bit legalization, which needs one such 32-bit chunk in addition to
+    // the normal return value which can handle 32 bits).
     uint32_t tempRet0 = 0;
   } state;
 

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -29,6 +29,10 @@ typedef std::vector<Literal> Loggings;
 struct LoggingExternalInterface : public ShellExternalInterface {
   Loggings& loggings;
 
+  struct State {
+    uint32_t tempRet0 = 0;
+  } state;;
+
   LoggingExternalInterface(Loggings& loggings) : loggings(loggings) {}
 
   Literals callImport(Function* import, LiteralList& arguments) override {
@@ -49,6 +53,11 @@ struct LoggingExternalInterface : public ShellExternalInterface {
         }
         std::cout << "]\n";
         return {};
+      } else if (import->base == "setTempRet0") {
+        state.tempRet0 = arguments[0].geti32();
+        return {};
+      } else if (import->base == "getTempRet0") {
+        return { Literal(state.tempRet0) };
       }
     }
     std::cerr << "[LoggingExternalInterface ignoring an unknown import "


### PR DESCRIPTION
This avoids it printing a warning and doing nothing for them.

It also increases coverage, for checking 64-bit return values, but any such
bug would have already been found already, I think (as we ignored the
high bits), so likely the fuzzer is not emitting such things when running JS
at least.