### PR TITLE
Fix MinGW build & add to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,19 @@ jobs:
       run: |
         source $HOME/emsdk/emsdk_env.sh
         ./scripts/emcc-tests.sh
+
+  # Windows + gcc needs work before the tests will run, so just test the compile
+  build-mingw:
+    name: mingw
+    runs-on: windows-latest
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v1
+    - name: cmake
+      run: |
+        mkdir -p out
+        cmake -S . -B out -G "MSYS Makefiles"
+    - name: build
+      run: cmake --build out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ else()
   add_compile_flag("-Wswitch") # we explicitly expect this in the code
   if(WIN32)
     add_compile_flag("-D_GNU_SOURCE")
+    add_compile_flag("-D__STDC_FORMAT_MACROS")
     add_link_flag("-Wl,--stack,8388608")
   elseif(NOT EMSCRIPTEN)
     add_compile_flag("-fPIC")


### PR DESCRIPTION
This PR adds a failing MinGW build to the CI (as I mentioned in #3039) and then a separate PR that adds the recommended solution from the comments.

I was reading in the `check.py` that Windows + gcc tests need additional work, so I didn't enable tests for the MinGW build, but it at least builds successfully now.

I'm hoping this helps our integration with Binaryen into Grain.