### PR TITLE
Reduce boilerplate with a C macro for class delegations. NFC

### DIFF
--- a/src/wasm-delegations.h
+++ b/src/wasm-delegations.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+DELEGATE(Nop);
+DELEGATE(Block);
+DELEGATE(If);
+DELEGATE(Loop);
+DELEGATE(Break);
+DELEGATE(Switch);
+DELEGATE(Call);
+DELEGATE(CallIndirect);
+DELEGATE(LocalGet);
+DELEGATE(LocalSet);
+DELEGATE(GlobalGet);
+DELEGATE(GlobalSet);
+DELEGATE(Load);
+DELEGATE(Store);
+DELEGATE(AtomicRMW);
+DELEGATE(AtomicCmpxchg);
+DELEGATE(AtomicWait);
+DELEGATE(AtomicNotify);
+DELEGATE(AtomicFence);
+DELEGATE(SIMDExtract);
+DELEGATE(SIMDReplace);
+DELEGATE(SIMDShuffle);
+DELEGATE(SIMDTernary);
+DELEGATE(SIMDShift);
+DELEGATE(SIMDLoad);
+DELEGATE(SIMDLoadStoreLane);
+DELEGATE(MemoryInit);
+DELEGATE(DataDrop);
+DELEGATE(MemoryCopy);
+DELEGATE(MemoryFill);
+DELEGATE(Const);
+DELEGATE(Unary);
+DELEGATE(Binary);
+DELEGATE(Select);
+DELEGATE(Drop);
+DELEGATE(Return);
+DELEGATE(MemorySize);
+DELEGATE(MemoryGrow);
+DELEGATE(Unreachable);
+DELEGATE(Pop);
+DELEGATE(RefNull);
+DELEGATE(RefIsNull);
+DELEGATE(RefFunc);
+DELEGATE(RefEq);
+DELEGATE(Try);
+DELEGATE(Throw);
+DELEGATE(Rethrow);
+DELEGATE(BrOnExn);
+DELEGATE(TupleMake);
+DELEGATE(TupleExtract);
+DELEGATE(I31New);
+DELEGATE(I31Get);
+DELEGATE(RefTest);
+DELEGATE(RefCast);
+DELEGATE(BrOnCast);
+DELEGATE(RttCanon);
+DELEGATE(RttSub);
+DELEGATE(StructNew);
+DELEGATE(StructGet);
+DELEGATE(StructSet);
+DELEGATE(ArrayNew);
+DELEGATE(ArrayGet);
+DELEGATE(ArraySet);
+DELEGATE(ArrayLen);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -58,9 +58,9 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
 
     switch (curr->_id) {
 #define DELEGATE(CLASS_TO_VISIT)                                               \
-      case Expression::Id::CLASS_TO_VISIT##Id:                                 \
-        return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(             \
-          static_cast<CLASS_TO_VISIT*>(curr))
+  case Expression::Id::CLASS_TO_VISIT##Id:                                     \
+    return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                 \
+      static_cast<CLASS_TO_VISIT*>(curr))
 
 #include "wasm-delegations.h"
 
@@ -69,7 +69,6 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
       default:
         WASM_UNREACHABLE("unexpected expression type");
     }
-
   }
 };
 
@@ -78,7 +77,7 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
 template<typename SubType, typename ReturnType = void>
 struct OverriddenVisitor {
 // Expression visitors, which must be overridden
-#define DELEGATE(CLASS_TO_VISIT)                                          \
+#define DELEGATE(CLASS_TO_VISIT)                                               \
   ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
     static_assert(                                                             \
       &SubType::visit##CLASS_TO_VISIT !=                                       \
@@ -96,9 +95,9 @@ struct OverriddenVisitor {
 
     switch (curr->_id) {
 #define DELEGATE(CLASS_TO_VISIT)                                               \
-      case Expression::Id::CLASS_TO_VISIT##Id:                                 \
-        return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(             \
-          static_cast<CLASS_TO_VISIT*>(curr))
+  case Expression::Id::CLASS_TO_VISIT##Id:                                     \
+    return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                 \
+      static_cast<CLASS_TO_VISIT*>(curr))
 
 #include "wasm-delegations.h"
 
@@ -107,7 +106,6 @@ struct OverriddenVisitor {
       default:
         WASM_UNREACHABLE("unexpected expression type");
     }
-
   }
 };
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -37,72 +37,13 @@ namespace wasm {
 
 template<typename SubType, typename ReturnType = void> struct Visitor {
   // Expression visitors
-  ReturnType visitBlock(Block* curr) { return ReturnType(); }
-  ReturnType visitIf(If* curr) { return ReturnType(); }
-  ReturnType visitLoop(Loop* curr) { return ReturnType(); }
-  ReturnType visitBreak(Break* curr) { return ReturnType(); }
-  ReturnType visitSwitch(Switch* curr) { return ReturnType(); }
-  ReturnType visitCall(Call* curr) { return ReturnType(); }
-  ReturnType visitCallIndirect(CallIndirect* curr) { return ReturnType(); }
-  ReturnType visitLocalGet(LocalGet* curr) { return ReturnType(); }
-  ReturnType visitLocalSet(LocalSet* curr) { return ReturnType(); }
-  ReturnType visitGlobalGet(GlobalGet* curr) { return ReturnType(); }
-  ReturnType visitGlobalSet(GlobalSet* curr) { return ReturnType(); }
-  ReturnType visitLoad(Load* curr) { return ReturnType(); }
-  ReturnType visitStore(Store* curr) { return ReturnType(); }
-  ReturnType visitAtomicRMW(AtomicRMW* curr) { return ReturnType(); }
-  ReturnType visitAtomicCmpxchg(AtomicCmpxchg* curr) { return ReturnType(); }
-  ReturnType visitAtomicWait(AtomicWait* curr) { return ReturnType(); }
-  ReturnType visitAtomicNotify(AtomicNotify* curr) { return ReturnType(); }
-  ReturnType visitAtomicFence(AtomicFence* curr) { return ReturnType(); }
-  ReturnType visitSIMDExtract(SIMDExtract* curr) { return ReturnType(); }
-  ReturnType visitSIMDReplace(SIMDReplace* curr) { return ReturnType(); }
-  ReturnType visitSIMDShuffle(SIMDShuffle* curr) { return ReturnType(); }
-  ReturnType visitSIMDTernary(SIMDTernary* curr) { return ReturnType(); }
-  ReturnType visitSIMDShift(SIMDShift* curr) { return ReturnType(); }
-  ReturnType visitSIMDLoad(SIMDLoad* curr) { return ReturnType(); }
-  ReturnType visitSIMDLoadStoreLane(SIMDLoadStoreLane* curr) {
-    return ReturnType();
+#define DELEGATE(CLASS_TO_VISIT)                                               \
+  ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
+    return ReturnType();                                                       \
   }
-  ReturnType visitMemoryInit(MemoryInit* curr) { return ReturnType(); }
-  ReturnType visitDataDrop(DataDrop* curr) { return ReturnType(); }
-  ReturnType visitMemoryCopy(MemoryCopy* curr) { return ReturnType(); }
-  ReturnType visitMemoryFill(MemoryFill* curr) { return ReturnType(); }
-  ReturnType visitConst(Const* curr) { return ReturnType(); }
-  ReturnType visitUnary(Unary* curr) { return ReturnType(); }
-  ReturnType visitBinary(Binary* curr) { return ReturnType(); }
-  ReturnType visitSelect(Select* curr) { return ReturnType(); }
-  ReturnType visitDrop(Drop* curr) { return ReturnType(); }
-  ReturnType visitReturn(Return* curr) { return ReturnType(); }
-  ReturnType visitMemorySize(MemorySize* curr) { return ReturnType(); }
-  ReturnType visitMemoryGrow(MemoryGrow* curr) { return ReturnType(); }
-  ReturnType visitRefNull(RefNull* curr) { return ReturnType(); }
-  ReturnType visitRefIsNull(RefIsNull* curr) { return ReturnType(); }
-  ReturnType visitRefFunc(RefFunc* curr) { return ReturnType(); }
-  ReturnType visitRefEq(RefEq* curr) { return ReturnType(); }
-  ReturnType visitTry(Try* curr) { return ReturnType(); }
-  ReturnType visitThrow(Throw* curr) { return ReturnType(); }
-  ReturnType visitRethrow(Rethrow* curr) { return ReturnType(); }
-  ReturnType visitBrOnExn(BrOnExn* curr) { return ReturnType(); }
-  ReturnType visitNop(Nop* curr) { return ReturnType(); }
-  ReturnType visitUnreachable(Unreachable* curr) { return ReturnType(); }
-  ReturnType visitPop(Pop* curr) { return ReturnType(); }
-  ReturnType visitTupleMake(TupleMake* curr) { return ReturnType(); }
-  ReturnType visitTupleExtract(TupleExtract* curr) { return ReturnType(); }
-  ReturnType visitI31New(I31New* curr) { return ReturnType(); }
-  ReturnType visitI31Get(I31Get* curr) { return ReturnType(); }
-  ReturnType visitRefTest(RefTest* curr) { return ReturnType(); }
-  ReturnType visitRefCast(RefCast* curr) { return ReturnType(); }
-  ReturnType visitBrOnCast(BrOnCast* curr) { return ReturnType(); }
-  ReturnType visitRttCanon(RttCanon* curr) { return ReturnType(); }
-  ReturnType visitRttSub(RttSub* curr) { return ReturnType(); }
-  ReturnType visitStructNew(StructNew* curr) { return ReturnType(); }
-  ReturnType visitStructGet(StructGet* curr) { return ReturnType(); }
-  ReturnType visitStructSet(StructSet* curr) { return ReturnType(); }
-  ReturnType visitArrayNew(ArrayNew* curr) { return ReturnType(); }
-  ReturnType visitArrayGet(ArrayGet* curr) { return ReturnType(); }
-  ReturnType visitArraySet(ArraySet* curr) { return ReturnType(); }
-  ReturnType visitArrayLen(ArrayLen* curr) { return ReturnType(); }
+#include "wasm-delegations.h"
+#undef DELEGATE
+
   // Module-level visitors
   ReturnType visitExport(Export* curr) { return ReturnType(); }
   ReturnType visitGlobal(Global* curr) { return ReturnType(); }
@@ -115,143 +56,20 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
   ReturnType visit(Expression* curr) {
     assert(curr);
 
-#define DELEGATE(CLASS_TO_VISIT)                                               \
-  return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                   \
-    static_cast<CLASS_TO_VISIT*>(curr))
-
     switch (curr->_id) {
-      case Expression::Id::BlockId:
-        DELEGATE(Block);
-      case Expression::Id::IfId:
-        DELEGATE(If);
-      case Expression::Id::LoopId:
-        DELEGATE(Loop);
-      case Expression::Id::BreakId:
-        DELEGATE(Break);
-      case Expression::Id::SwitchId:
-        DELEGATE(Switch);
-      case Expression::Id::CallId:
-        DELEGATE(Call);
-      case Expression::Id::CallIndirectId:
-        DELEGATE(CallIndirect);
-      case Expression::Id::LocalGetId:
-        DELEGATE(LocalGet);
-      case Expression::Id::LocalSetId:
-        DELEGATE(LocalSet);
-      case Expression::Id::GlobalGetId:
-        DELEGATE(GlobalGet);
-      case Expression::Id::GlobalSetId:
-        DELEGATE(GlobalSet);
-      case Expression::Id::LoadId:
-        DELEGATE(Load);
-      case Expression::Id::StoreId:
-        DELEGATE(Store);
-      case Expression::Id::AtomicRMWId:
-        DELEGATE(AtomicRMW);
-      case Expression::Id::AtomicCmpxchgId:
-        DELEGATE(AtomicCmpxchg);
-      case Expression::Id::AtomicWaitId:
-        DELEGATE(AtomicWait);
-      case Expression::Id::AtomicNotifyId:
-        DELEGATE(AtomicNotify);
-      case Expression::Id::AtomicFenceId:
-        DELEGATE(AtomicFence);
-      case Expression::Id::SIMDExtractId:
-        DELEGATE(SIMDExtract);
-      case Expression::Id::SIMDReplaceId:
-        DELEGATE(SIMDReplace);
-      case Expression::Id::SIMDShuffleId:
-        DELEGATE(SIMDShuffle);
-      case Expression::Id::SIMDTernaryId:
-        DELEGATE(SIMDTernary);
-      case Expression::Id::SIMDShiftId:
-        DELEGATE(SIMDShift);
-      case Expression::Id::SIMDLoadId:
-        DELEGATE(SIMDLoad);
-      case Expression::Id::MemoryInitId:
-        DELEGATE(MemoryInit);
-      case Expression::Id::DataDropId:
-        DELEGATE(DataDrop);
-      case Expression::Id::MemoryCopyId:
-        DELEGATE(MemoryCopy);
-      case Expression::Id::MemoryFillId:
-        DELEGATE(MemoryFill);
-      case Expression::Id::ConstId:
-        DELEGATE(Const);
-      case Expression::Id::UnaryId:
-        DELEGATE(Unary);
-      case Expression::Id::BinaryId:
-        DELEGATE(Binary);
-      case Expression::Id::SelectId:
-        DELEGATE(Select);
-      case Expression::Id::DropId:
-        DELEGATE(Drop);
-      case Expression::Id::ReturnId:
-        DELEGATE(Return);
-      case Expression::Id::MemorySizeId:
-        DELEGATE(MemorySize);
-      case Expression::Id::MemoryGrowId:
-        DELEGATE(MemoryGrow);
-      case Expression::Id::RefNullId:
-        DELEGATE(RefNull);
-      case Expression::Id::RefIsNullId:
-        DELEGATE(RefIsNull);
-      case Expression::Id::RefFuncId:
-        DELEGATE(RefFunc);
-      case Expression::Id::RefEqId:
-        DELEGATE(RefEq);
-      case Expression::Id::TryId:
-        DELEGATE(Try);
-      case Expression::Id::ThrowId:
-        DELEGATE(Throw);
-      case Expression::Id::RethrowId:
-        DELEGATE(Rethrow);
-      case Expression::Id::BrOnExnId:
-        DELEGATE(BrOnExn);
-      case Expression::Id::NopId:
-        DELEGATE(Nop);
-      case Expression::Id::UnreachableId:
-        DELEGATE(Unreachable);
-      case Expression::Id::PopId:
-        DELEGATE(Pop);
-      case Expression::Id::TupleMakeId:
-        DELEGATE(TupleMake);
-      case Expression::Id::TupleExtractId:
-        DELEGATE(TupleExtract);
-      case Expression::Id::I31NewId:
-        DELEGATE(I31New);
-      case Expression::Id::I31GetId:
-        DELEGATE(I31Get);
-      case Expression::Id::RefTestId:
-        DELEGATE(RefTest);
-      case Expression::Id::RefCastId:
-        DELEGATE(RefCast);
-      case Expression::Id::BrOnCastId:
-        DELEGATE(BrOnCast);
-      case Expression::Id::RttCanonId:
-        DELEGATE(RttCanon);
-      case Expression::Id::RttSubId:
-        DELEGATE(RttSub);
-      case Expression::Id::StructNewId:
-        DELEGATE(StructNew);
-      case Expression::Id::StructGetId:
-        DELEGATE(StructGet);
-      case Expression::Id::StructSetId:
-        DELEGATE(StructSet);
-      case Expression::Id::ArrayNewId:
-        DELEGATE(ArrayNew);
-      case Expression::Id::ArrayGetId:
-        DELEGATE(ArrayGet);
-      case Expression::Id::ArraySetId:
-        DELEGATE(ArraySet);
-      case Expression::Id::ArrayLenId:
-        DELEGATE(ArrayLen);
-      case Expression::Id::InvalidId:
+#define DELEGATE(CLASS_TO_VISIT)                                               \
+      case Expression::Id::CLASS_TO_VISIT##Id:                                 \
+        return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(             \
+          static_cast<CLASS_TO_VISIT*>(curr))
+
+#include "wasm-delegations.h"
+
+#undef DELEGATE
+
       default:
         WASM_UNREACHABLE("unexpected expression type");
     }
 
-#undef DELEGATE
   }
 };
 
@@ -260,7 +78,7 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
 template<typename SubType, typename ReturnType = void>
 struct OverriddenVisitor {
 // Expression visitors, which must be overridden
-#define UNIMPLEMENTED(CLASS_TO_VISIT)                                          \
+#define DELEGATE(CLASS_TO_VISIT)                                          \
   ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
     static_assert(                                                             \
       &SubType::visit##CLASS_TO_VISIT !=                                       \
@@ -269,222 +87,27 @@ struct OverriddenVisitor {
     WASM_UNREACHABLE("Derived class must implement visit" #CLASS_TO_VISIT);    \
   }
 
-  UNIMPLEMENTED(Block);
-  UNIMPLEMENTED(If);
-  UNIMPLEMENTED(Loop);
-  UNIMPLEMENTED(Break);
-  UNIMPLEMENTED(Switch);
-  UNIMPLEMENTED(Call);
-  UNIMPLEMENTED(CallIndirect);
-  UNIMPLEMENTED(LocalGet);
-  UNIMPLEMENTED(LocalSet);
-  UNIMPLEMENTED(GlobalGet);
-  UNIMPLEMENTED(GlobalSet);
-  UNIMPLEMENTED(Load);
-  UNIMPLEMENTED(Store);
-  UNIMPLEMENTED(AtomicRMW);
-  UNIMPLEMENTED(AtomicCmpxchg);
-  UNIMPLEMENTED(AtomicWait);
-  UNIMPLEMENTED(AtomicNotify);
-  UNIMPLEMENTED(AtomicFence);
-  UNIMPLEMENTED(SIMDExtract);
-  UNIMPLEMENTED(SIMDReplace);
-  UNIMPLEMENTED(SIMDShuffle);
-  UNIMPLEMENTED(SIMDTernary);
-  UNIMPLEMENTED(SIMDShift);
-  UNIMPLEMENTED(SIMDLoad);
-  UNIMPLEMENTED(SIMDLoadStoreLane);
-  UNIMPLEMENTED(MemoryInit);
-  UNIMPLEMENTED(DataDrop);
-  UNIMPLEMENTED(MemoryCopy);
-  UNIMPLEMENTED(MemoryFill);
-  UNIMPLEMENTED(Const);
-  UNIMPLEMENTED(Unary);
-  UNIMPLEMENTED(Binary);
-  UNIMPLEMENTED(Select);
-  UNIMPLEMENTED(Drop);
-  UNIMPLEMENTED(Return);
-  UNIMPLEMENTED(MemorySize);
-  UNIMPLEMENTED(MemoryGrow);
-  UNIMPLEMENTED(RefNull);
-  UNIMPLEMENTED(RefIsNull);
-  UNIMPLEMENTED(RefFunc);
-  UNIMPLEMENTED(RefEq);
-  UNIMPLEMENTED(Try);
-  UNIMPLEMENTED(Throw);
-  UNIMPLEMENTED(Rethrow);
-  UNIMPLEMENTED(BrOnExn);
-  UNIMPLEMENTED(Nop);
-  UNIMPLEMENTED(Unreachable);
-  UNIMPLEMENTED(Pop);
-  UNIMPLEMENTED(TupleMake);
-  UNIMPLEMENTED(TupleExtract);
-  UNIMPLEMENTED(I31New);
-  UNIMPLEMENTED(I31Get);
-  UNIMPLEMENTED(RefTest);
-  UNIMPLEMENTED(RefCast);
-  UNIMPLEMENTED(BrOnCast);
-  UNIMPLEMENTED(RttCanon);
-  UNIMPLEMENTED(RttSub);
-  UNIMPLEMENTED(StructNew);
-  UNIMPLEMENTED(StructGet);
-  UNIMPLEMENTED(StructSet);
-  UNIMPLEMENTED(ArrayNew);
-  UNIMPLEMENTED(ArrayGet);
-  UNIMPLEMENTED(ArraySet);
-  UNIMPLEMENTED(ArrayLen);
-  UNIMPLEMENTED(Export);
-  UNIMPLEMENTED(Global);
-  UNIMPLEMENTED(Function);
-  UNIMPLEMENTED(Table);
-  UNIMPLEMENTED(Memory);
-  UNIMPLEMENTED(Event);
-  UNIMPLEMENTED(Module);
+#include "wasm-delegations.h"
 
-#undef UNIMPLEMENTED
+#undef DELEGATE
 
   ReturnType visit(Expression* curr) {
     assert(curr);
 
-#define DELEGATE(CLASS_TO_VISIT)                                               \
-  return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                   \
-    static_cast<CLASS_TO_VISIT*>(curr))
-
     switch (curr->_id) {
-      case Expression::Id::BlockId:
-        DELEGATE(Block);
-      case Expression::Id::IfId:
-        DELEGATE(If);
-      case Expression::Id::LoopId:
-        DELEGATE(Loop);
-      case Expression::Id::BreakId:
-        DELEGATE(Break);
-      case Expression::Id::SwitchId:
-        DELEGATE(Switch);
-      case Expression::Id::CallId:
-        DELEGATE(Call);
-      case Expression::Id::CallIndirectId:
-        DELEGATE(CallIndirect);
-      case Expression::Id::LocalGetId:
-        DELEGATE(LocalGet);
-      case Expression::Id::LocalSetId:
-        DELEGATE(LocalSet);
-      case Expression::Id::GlobalGetId:
-        DELEGATE(GlobalGet);
-      case Expression::Id::GlobalSetId:
-        DELEGATE(GlobalSet);
-      case Expression::Id::LoadId:
-        DELEGATE(Load);
-      case Expression::Id::StoreId:
-        DELEGATE(Store);
-      case Expression::Id::AtomicRMWId:
-        DELEGATE(AtomicRMW);
-      case Expression::Id::AtomicCmpxchgId:
-        DELEGATE(AtomicCmpxchg);
-      case Expression::Id::AtomicWaitId:
-        DELEGATE(AtomicWait);
-      case Expression::Id::AtomicNotifyId:
-        DELEGATE(AtomicNotify);
-      case Expression::Id::AtomicFenceId:
-        DELEGATE(AtomicFence);
-      case Expression::Id::SIMDExtractId:
-        DELEGATE(SIMDExtract);
-      case Expression::Id::SIMDReplaceId:
-        DELEGATE(SIMDReplace);
-      case Expression::Id::SIMDShuffleId:
-        DELEGATE(SIMDShuffle);
-      case Expression::Id::SIMDTernaryId:
-        DELEGATE(SIMDTernary);
-      case Expression::Id::SIMDShiftId:
-        DELEGATE(SIMDShift);
-      case Expression::Id::SIMDLoadId:
-        DELEGATE(SIMDLoad);
-      case Expression::Id::SIMDLoadStoreLaneId:
-        DELEGATE(SIMDLoadStoreLane);
-      case Expression::Id::MemoryInitId:
-        DELEGATE(MemoryInit);
-      case Expression::Id::DataDropId:
-        DELEGATE(DataDrop);
-      case Expression::Id::MemoryCopyId:
-        DELEGATE(MemoryCopy);
-      case Expression::Id::MemoryFillId:
-        DELEGATE(MemoryFill);
-      case Expression::Id::ConstId:
-        DELEGATE(Const);
-      case Expression::Id::UnaryId:
-        DELEGATE(Unary);
-      case Expression::Id::BinaryId:
-        DELEGATE(Binary);
-      case Expression::Id::SelectId:
-        DELEGATE(Select);
-      case Expression::Id::DropId:
-        DELEGATE(Drop);
-      case Expression::Id::ReturnId:
-        DELEGATE(Return);
-      case Expression::Id::MemorySizeId:
-        DELEGATE(MemorySize);
-      case Expression::Id::MemoryGrowId:
-        DELEGATE(MemoryGrow);
-      case Expression::Id::RefNullId:
-        DELEGATE(RefNull);
-      case Expression::Id::RefIsNullId:
-        DELEGATE(RefIsNull);
-      case Expression::Id::RefFuncId:
-        DELEGATE(RefFunc);
-      case Expression::Id::RefEqId:
-        DELEGATE(RefEq);
-      case Expression::Id::TryId:
-        DELEGATE(Try);
-      case Expression::Id::ThrowId:
-        DELEGATE(Throw);
-      case Expression::Id::RethrowId:
-        DELEGATE(Rethrow);
-      case Expression::Id::BrOnExnId:
-        DELEGATE(BrOnExn);
-      case Expression::Id::NopId:
-        DELEGATE(Nop);
-      case Expression::Id::UnreachableId:
-        DELEGATE(Unreachable);
-      case Expression::Id::PopId:
-        DELEGATE(Pop);
-      case Expression::Id::TupleMakeId:
-        DELEGATE(TupleMake);
-      case Expression::Id::TupleExtractId:
-        DELEGATE(TupleExtract);
-      case Expression::Id::I31NewId:
-        DELEGATE(I31New);
-      case Expression::Id::I31GetId:
-        DELEGATE(I31Get);
-      case Expression::Id::RefTestId:
-        DELEGATE(RefTest);
-      case Expression::Id::RefCastId:
-        DELEGATE(RefCast);
-      case Expression::Id::BrOnCastId:
-        DELEGATE(BrOnCast);
-      case Expression::Id::RttCanonId:
-        DELEGATE(RttCanon);
-      case Expression::Id::RttSubId:
-        DELEGATE(RttSub);
-      case Expression::Id::StructNewId:
-        DELEGATE(StructNew);
-      case Expression::Id::StructGetId:
-        DELEGATE(StructGet);
-      case Expression::Id::StructSetId:
-        DELEGATE(StructSet);
-      case Expression::Id::ArrayNewId:
-        DELEGATE(ArrayNew);
-      case Expression::Id::ArrayGetId:
-        DELEGATE(ArrayGet);
-      case Expression::Id::ArraySetId:
-        DELEGATE(ArraySet);
-      case Expression::Id::ArrayLenId:
-        DELEGATE(ArrayLen);
-      case Expression::Id::InvalidId:
+#define DELEGATE(CLASS_TO_VISIT)                                               \
+      case Expression::Id::CLASS_TO_VISIT##Id:                                 \
+        return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(             \
+          static_cast<CLASS_TO_VISIT*>(curr))
+
+#include "wasm-delegations.h"
+
+#undef DELEGATE
+
       default:
         WASM_UNREACHABLE("unexpected expression type");
     }
 
-#undef DELEGATE
   }
 };
 
@@ -497,195 +120,14 @@ struct UnifiedExpressionVisitor : public Visitor<SubType, ReturnType> {
   ReturnType visitExpression(Expression* curr) { return ReturnType(); }
 
   // redirects
-  ReturnType visitBlock(Block* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
+#define DELEGATE(CLASS_TO_VISIT)                                               \
+  ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
+    return static_cast<SubType*>(this)->visitExpression(curr);                 \
   }
-  ReturnType visitIf(If* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitLoop(Loop* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitBreak(Break* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSwitch(Switch* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitCall(Call* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitCallIndirect(CallIndirect* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitLocalGet(LocalGet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitLocalSet(LocalSet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitGlobalGet(GlobalGet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitGlobalSet(GlobalSet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitLoad(Load* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitStore(Store* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitAtomicRMW(AtomicRMW* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitAtomicCmpxchg(AtomicCmpxchg* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitAtomicWait(AtomicWait* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitAtomicNotify(AtomicNotify* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitAtomicFence(AtomicFence* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSIMDExtract(SIMDExtract* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSIMDReplace(SIMDReplace* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSIMDShuffle(SIMDShuffle* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSIMDTernary(SIMDTernary* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSIMDShift(SIMDShift* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSIMDLoad(SIMDLoad* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitMemoryInit(MemoryInit* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitDataDrop(DataDrop* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitMemoryCopy(MemoryCopy* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitMemoryFill(MemoryFill* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitConst(Const* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitUnary(Unary* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitBinary(Binary* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitSelect(Select* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitDrop(Drop* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitReturn(Return* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitMemorySize(MemorySize* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitMemoryGrow(MemoryGrow* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRefNull(RefNull* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRefIsNull(RefIsNull* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRefFunc(RefFunc* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRefEq(RefEq* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitTry(Try* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitThrow(Throw* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRethrow(Rethrow* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitBrOnExn(BrOnExn* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitNop(Nop* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitUnreachable(Unreachable* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitPop(Pop* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitTupleMake(TupleMake* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitTupleExtract(TupleExtract* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitI31New(I31New* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitI31Get(I31Get* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRefTest(RefTest* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRefCast(RefCast* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitBrOnCast(BrOnCast* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRttCanon(RttCanon* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitRttSub(RttSub* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitStructNew(StructNew* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitStructGet(StructGet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitStructSet(StructSet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitArrayNew(ArrayNew* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitArrayGet(ArrayGet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitArraySet(ArraySet* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
-  ReturnType visitArrayLen(ArrayLen* curr) {
-    return static_cast<SubType*>(this)->visitExpression(curr);
-  }
+
+#include "wasm-delegations.h"
+
+#undef DELEGATE
 };
 
 //
@@ -859,198 +301,14 @@ struct Walker : public VisitorType {
 
   // task hooks to call visitors
 
-  static void doVisitBlock(SubType* self, Expression** currp) {
-    self->visitBlock((*currp)->cast<Block>());
-  }
-  static void doVisitIf(SubType* self, Expression** currp) {
-    self->visitIf((*currp)->cast<If>());
-  }
-  static void doVisitLoop(SubType* self, Expression** currp) {
-    self->visitLoop((*currp)->cast<Loop>());
-  }
-  static void doVisitBreak(SubType* self, Expression** currp) {
-    self->visitBreak((*currp)->cast<Break>());
-  }
-  static void doVisitSwitch(SubType* self, Expression** currp) {
-    self->visitSwitch((*currp)->cast<Switch>());
-  }
-  static void doVisitCall(SubType* self, Expression** currp) {
-    self->visitCall((*currp)->cast<Call>());
-  }
-  static void doVisitCallIndirect(SubType* self, Expression** currp) {
-    self->visitCallIndirect((*currp)->cast<CallIndirect>());
-  }
-  static void doVisitLocalGet(SubType* self, Expression** currp) {
-    self->visitLocalGet((*currp)->cast<LocalGet>());
-  }
-  static void doVisitLocalSet(SubType* self, Expression** currp) {
-    self->visitLocalSet((*currp)->cast<LocalSet>());
-  }
-  static void doVisitGlobalGet(SubType* self, Expression** currp) {
-    self->visitGlobalGet((*currp)->cast<GlobalGet>());
-  }
-  static void doVisitGlobalSet(SubType* self, Expression** currp) {
-    self->visitGlobalSet((*currp)->cast<GlobalSet>());
-  }
-  static void doVisitLoad(SubType* self, Expression** currp) {
-    self->visitLoad((*currp)->cast<Load>());
-  }
-  static void doVisitStore(SubType* self, Expression** currp) {
-    self->visitStore((*currp)->cast<Store>());
-  }
-  static void doVisitAtomicRMW(SubType* self, Expression** currp) {
-    self->visitAtomicRMW((*currp)->cast<AtomicRMW>());
-  }
-  static void doVisitAtomicCmpxchg(SubType* self, Expression** currp) {
-    self->visitAtomicCmpxchg((*currp)->cast<AtomicCmpxchg>());
-  }
-  static void doVisitAtomicWait(SubType* self, Expression** currp) {
-    self->visitAtomicWait((*currp)->cast<AtomicWait>());
-  }
-  static void doVisitAtomicNotify(SubType* self, Expression** currp) {
-    self->visitAtomicNotify((*currp)->cast<AtomicNotify>());
-  }
-  static void doVisitAtomicFence(SubType* self, Expression** currp) {
-    self->visitAtomicFence((*currp)->cast<AtomicFence>());
-  }
-  static void doVisitSIMDExtract(SubType* self, Expression** currp) {
-    self->visitSIMDExtract((*currp)->cast<SIMDExtract>());
-  }
-  static void doVisitSIMDReplace(SubType* self, Expression** currp) {
-    self->visitSIMDReplace((*currp)->cast<SIMDReplace>());
-  }
-  static void doVisitSIMDShuffle(SubType* self, Expression** currp) {
-    self->visitSIMDShuffle((*currp)->cast<SIMDShuffle>());
-  }
-  static void doVisitSIMDTernary(SubType* self, Expression** currp) {
-    self->visitSIMDTernary((*currp)->cast<SIMDTernary>());
-  }
-  static void doVisitSIMDShift(SubType* self, Expression** currp) {
-    self->visitSIMDShift((*currp)->cast<SIMDShift>());
-  }
-  static void doVisitSIMDLoad(SubType* self, Expression** currp) {
-    self->visitSIMDLoad((*currp)->cast<SIMDLoad>());
-  }
-  static void doVisitSIMDLoadStoreLane(SubType* self, Expression** currp) {
-    self->visitSIMDLoadStoreLane((*currp)->cast<SIMDLoadStoreLane>());
-  }
-  static void doVisitMemoryInit(SubType* self, Expression** currp) {
-    self->visitMemoryInit((*currp)->cast<MemoryInit>());
-  }
-  static void doVisitDataDrop(SubType* self, Expression** currp) {
-    self->visitDataDrop((*currp)->cast<DataDrop>());
-  }
-  static void doVisitMemoryCopy(SubType* self, Expression** currp) {
-    self->visitMemoryCopy((*currp)->cast<MemoryCopy>());
-  }
-  static void doVisitMemoryFill(SubType* self, Expression** currp) {
-    self->visitMemoryFill((*currp)->cast<MemoryFill>());
-  }
-  static void doVisitConst(SubType* self, Expression** currp) {
-    self->visitConst((*currp)->cast<Const>());
-  }
-  static void doVisitUnary(SubType* self, Expression** currp) {
-    self->visitUnary((*currp)->cast<Unary>());
-  }
-  static void doVisitBinary(SubType* self, Expression** currp) {
-    self->visitBinary((*currp)->cast<Binary>());
-  }
-  static void doVisitSelect(SubType* self, Expression** currp) {
-    self->visitSelect((*currp)->cast<Select>());
-  }
-  static void doVisitDrop(SubType* self, Expression** currp) {
-    self->visitDrop((*currp)->cast<Drop>());
-  }
-  static void doVisitReturn(SubType* self, Expression** currp) {
-    self->visitReturn((*currp)->cast<Return>());
-  }
-  static void doVisitMemorySize(SubType* self, Expression** currp) {
-    self->visitMemorySize((*currp)->cast<MemorySize>());
-  }
-  static void doVisitMemoryGrow(SubType* self, Expression** currp) {
-    self->visitMemoryGrow((*currp)->cast<MemoryGrow>());
-  }
-  static void doVisitRefNull(SubType* self, Expression** currp) {
-    self->visitRefNull((*currp)->cast<RefNull>());
-  }
-  static void doVisitRefIsNull(SubType* self, Expression** currp) {
-    self->visitRefIsNull((*currp)->cast<RefIsNull>());
-  }
-  static void doVisitRefFunc(SubType* self, Expression** currp) {
-    self->visitRefFunc((*currp)->cast<RefFunc>());
-  }
-  static void doVisitRefEq(SubType* self, Expression** currp) {
-    self->visitRefEq((*currp)->cast<RefEq>());
-  }
-  static void doVisitTry(SubType* self, Expression** currp) {
-    self->visitTry((*currp)->cast<Try>());
-  }
-  static void doVisitThrow(SubType* self, Expression** currp) {
-    self->visitThrow((*currp)->cast<Throw>());
-  }
-  static void doVisitRethrow(SubType* self, Expression** currp) {
-    self->visitRethrow((*currp)->cast<Rethrow>());
-  }
-  static void doVisitBrOnExn(SubType* self, Expression** currp) {
-    self->visitBrOnExn((*currp)->cast<BrOnExn>());
-  }
-  static void doVisitNop(SubType* self, Expression** currp) {
-    self->visitNop((*currp)->cast<Nop>());
-  }
-  static void doVisitUnreachable(SubType* self, Expression** currp) {
-    self->visitUnreachable((*currp)->cast<Unreachable>());
-  }
-  static void doVisitPop(SubType* self, Expression** currp) {
-    self->visitPop((*currp)->cast<Pop>());
-  }
-  static void doVisitTupleMake(SubType* self, Expression** currp) {
-    self->visitTupleMake((*currp)->cast<TupleMake>());
-  }
-  static void doVisitTupleExtract(SubType* self, Expression** currp) {
-    self->visitTupleExtract((*currp)->cast<TupleExtract>());
-  }
-  static void doVisitI31New(SubType* self, Expression** currp) {
-    self->visitI31New((*currp)->cast<I31New>());
-  }
-  static void doVisitI31Get(SubType* self, Expression** currp) {
-    self->visitI31Get((*currp)->cast<I31Get>());
-  }
-  static void doVisitRefTest(SubType* self, Expression** currp) {
-    self->visitRefTest((*currp)->cast<RefTest>());
-  }
-  static void doVisitRefCast(SubType* self, Expression** currp) {
-    self->visitRefCast((*currp)->cast<RefCast>());
-  }
-  static void doVisitBrOnCast(SubType* self, Expression** currp) {
-    self->visitBrOnCast((*currp)->cast<BrOnCast>());
-  }
-  static void doVisitRttCanon(SubType* self, Expression** currp) {
-    self->visitRttCanon((*currp)->cast<RttCanon>());
-  }
-  static void doVisitRttSub(SubType* self, Expression** currp) {
-    self->visitRttSub((*currp)->cast<RttSub>());
-  }
-  static void doVisitStructNew(SubType* self, Expression** currp) {
-    self->visitStructNew((*currp)->cast<StructNew>());
-  }
-  static void doVisitStructGet(SubType* self, Expression** currp) {
-    self->visitStructGet((*currp)->cast<StructGet>());
-  }
-  static void doVisitStructSet(SubType* self, Expression** currp) {
-    self->visitStructSet((*currp)->cast<StructSet>());
-  }
-  static void doVisitArrayNew(SubType* self, Expression** currp) {
-    self->visitArrayNew((*currp)->cast<ArrayNew>());
-  }
-  static void doVisitArrayGet(SubType* self, Expression** currp) {
-    self->visitArrayGet((*currp)->cast<ArrayGet>());
-  }
-  static void doVisitArraySet(SubType* self, Expression** currp) {
-    self->visitArraySet((*currp)->cast<ArraySet>());
-  }
-  static void doVisitArrayLen(SubType* self, Expression** currp) {
-    self->visitArrayLen((*currp)->cast<ArrayLen>());
-  }
+#define DELEGATE(CLASS_TO_VISIT)                                               \
+  static void doVisit##CLASS_TO_VISIT(SubType* self, Expression** currp) {     \
+    self->visit##CLASS_TO_VISIT((*currp)->cast<CLASS_TO_VISIT>());             \
+  }
+
+#include "wasm-delegations.h"
+
+#undef DELEGATE
 
   void setModule(Module* module) { currModule = module; }
 


### PR DESCRIPTION
Split off from #3264, this part is hopefully non-controversial.