### PR TITLE
wasm-emscripten-finalize: Remove staticBump from metadata

### DIFF
--- a/scripts/test/generate_lld_tests.py
+++ b/scripts/test/generate_lld_tests.py
@@ -67,7 +67,6 @@ def generate_wat_files(llvm_bin, emscripten_root):
             obj_path, '-o', wasm_path,
             '--allow-undefined',
             '--export', '__wasm_call_ctors',
-            '--export', '__data_end',
             '--global-base=568',
         ]
         # We had a regression where this test only worked if debug names

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -225,30 +225,6 @@ int main(int argc, const char* argv[]) {
   BYN_DEBUG_WITH_TYPE("emscripten-dump",
                       WasmPrinter::printModule(&wasm, std::cerr));
 
-  uint32_t dataSize = 0;
-
-  if (!sideModule) {
-    if (globalBase == INVALID_BASE) {
-      Fatal() << "globalBase must be set";
-    }
-    Export* dataEndExport = wasm.getExport("__data_end");
-    if (dataEndExport == nullptr) {
-      Fatal() << "__data_end export not found";
-    }
-    Global* dataEnd = wasm.getGlobal(dataEndExport->value);
-    if (dataEnd == nullptr) {
-      Fatal() << "__data_end global not found";
-    }
-    if (dataEnd->type != Type::i32) {
-      Fatal() << "__data_end global has wrong type";
-    }
-    if (dataEnd->imported()) {
-      Fatal() << "__data_end must not be an imported global";
-    }
-    Const* dataEndConst = dataEnd->init->cast<Const>();
-    dataSize = dataEndConst->value.geti32() - globalBase;
-  }
-
   EmscriptenGlueGenerator generator(wasm);
   generator.standalone = standaloneWasm;
   generator.sideModule = sideModule;
@@ -326,7 +302,7 @@ int main(int argc, const char* argv[]) {
   BYN_TRACE("generated metadata\n");
   // Substantial changes to the wasm are done, enough to create the metadata.
   std::string metadata =
-    generator.generateEmscriptenMetadata(dataSize, initializerFunctions);
+    generator.generateEmscriptenMetadata(initializerFunctions);
 
   // Finally, separate out data segments if relevant (they may have been needed
   // for metadata).

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -34,8 +34,7 @@ public:
       useStackPointerGlobal(stackPointerOffset == 0) {}
 
   std::string
-  generateEmscriptenMetadata(Address staticBump,
-                             std::vector<Name> const& initializerFunctions);
+  generateEmscriptenMetadata(std::vector<Name> const& initializerFunctions);
 
   void fixInvokeFunctionNames();
 

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -434,7 +434,7 @@ void printSignatures(std::ostream& o, const std::set<Signature>& c) {
 }
 
 std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
-  Address staticBump, std::vector<Name> const& initializerFunctions) {
+  std::vector<Name> const& initializerFunctions) {
   bool commaFirst;
   auto nextElement = [&commaFirst]() {
     if (commaFirst) {
@@ -479,7 +479,6 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata(
     meta << "\n  },\n";
   }
 
-  meta << "  \"staticBump\": " << staticBump << ",\n";
   meta << "  \"tableSize\": " << wasm.table.initial.addr << ",\n";
 
   if (!initializerFunctions.empty()) {

--- a/test/lld/basic_safe_stack.wat
+++ b/test/lld/basic_safe_stack.wat
@@ -5,13 +5,11 @@
  (memory $0 2)
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 568))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "stackRestore" (func $stackRestore))
  (export "stackAlloc" (func $stackAlloc))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
  (func $stackRestore (param $0 i32)

--- a/test/lld/basic_safe_stack.wat.out
+++ b/test/lld/basic_safe_stack.wat.out
@@ -7,7 +7,6 @@
  (memory $0 2)
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 568))
  (global $__stack_base (mut i32) (i32.const 0))
  (global $__stack_limit (mut i32) (i32.const 0))
  (export "memory" (memory $0))
@@ -15,7 +14,6 @@
  (export "stackRestore" (func $stackRestore))
  (export "stackAlloc" (func $stackAlloc))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (export "__set_stack_limits" (func $__set_stack_limits))
  (func $__wasm_call_ctors
   (nop)
@@ -90,7 +88,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 0,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -108,7 +105,6 @@
     "__set_stack_limits"
   ],
   "namedGlobals": {
-    "__data_end" : "568"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/bigint.wat.out
+++ b/test/lld/bigint.wat.out
@@ -20,7 +20,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 90,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/duplicate_imports.wat.out
+++ b/test/lld/duplicate_imports.wat.out
@@ -67,7 +67,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 13,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"

--- a/test/lld/em_asm.wat
+++ b/test/lld/em_asm.wat
@@ -8,11 +8,9 @@
  (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66208))
- (global $global$1 i32 (i32.const 658))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
  (func $__original_main (result i32)

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -7,11 +7,9 @@
  (memory $0 2)
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66208))
- (global $global$1 i32 (i32.const 658))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -74,7 +72,6 @@
     "602": ["{ return $0 + $1; }", ["iii"], [""]],
     "625": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
-  "staticBump": 90,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -89,7 +86,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "658"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/em_asm.wat.out
+++ b/test/lld/em_asm.wat.out
@@ -8,11 +8,9 @@
  (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66208))
- (global $global$1 i32 (i32.const 658))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -75,7 +73,6 @@
     "602": ["{ return $0 + $1; }", ["iii"], [""]],
     "625": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
-  "staticBump": 90,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -90,7 +87,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "658"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/em_asm_O0.wat
+++ b/test/lld/em_asm_O0.wat
@@ -7,11 +7,9 @@
  (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66192))
- (global $global$1 i32 (i32.const 652))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
  (func $main (param $0 i32) (param $1 i32) (result i32)

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -7,11 +7,9 @@
  (data (i32.const 568) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66192))
- (global $global$1 i32 (i32.const 652))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -100,7 +98,6 @@
     "601": ["{ return $0 + $1; }", ["iii"], [""]],
     "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
-  "staticBump": 84,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -115,7 +112,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "652"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/em_asm_main_thread.wat.out
+++ b/test/lld/em_asm_main_thread.wat.out
@@ -198,7 +198,6 @@
     "601": ["{ return $0 + $1; }", ["iii"], ["sync_on_main_thread_"]],
     "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]]
   },
-  "staticBump": 84,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"

--- a/test/lld/em_asm_shared.wat
+++ b/test/lld/em_asm_shared.wat
@@ -4,14 +4,14 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
- (data (global.get $gimport$3) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
- (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
- (import "env" "__stack_pointer" (global $gimport$2 (mut i32)))
- (import "env" "__memory_base" (global $gimport$3 i32))
- (import "env" "__table_base" (global $gimport$4 i32))
- (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (global $gimport$6 (mut i32)))
- (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $gimport$7 (mut i32)))
- (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (global $gimport$8 (mut i32)))
+ (data (global.get $gimport$1) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
+ (import "env" "__stack_pointer" (global $gimport$0 (mut i32)))
+ (import "env" "__memory_base" (global $gimport$1 i32))
+ (import "env" "__table_base" (global $gimport$2 i32))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (global $gimport$3 (mut i32)))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $gimport$4 (mut i32)))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (global $gimport$5 (mut i32)))
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (global $global$0 i32 (i32.const 33))
  (global $global$1 i32 (i32.const 54))
@@ -30,10 +30,10 @@
  (func $__original_main (result i32)
   (local $0 i32)
   (local $1 i32)
-  (global.set $gimport$2
+  (global.set $gimport$0
    (local.tee $0
     (i32.sub
-     (global.get $gimport$2)
+     (global.get $gimport$0)
      (i32.const 32)
     )
    )
@@ -42,11 +42,11 @@
    (call $emscripten_asm_const_int
     (i32.add
      (local.tee $1
-      (global.get $gimport$3)
+      (global.get $gimport$1)
      )
      (i32.const 0)
     )
-    (global.get $gimport$6)
+    (global.get $gimport$3)
     (i32.const 0)
    )
   )
@@ -61,7 +61,7 @@
      (local.get $1)
      (i32.const 34)
     )
-    (global.get $gimport$7)
+    (global.get $gimport$4)
     (i32.add
      (local.get $0)
      (i32.const 16)
@@ -74,11 +74,11 @@
      (local.get $1)
      (i32.const 57)
     )
-    (global.get $gimport$8)
+    (global.get $gimport$5)
     (local.get $0)
    )
   )
-  (global.set $gimport$2
+  (global.set $gimport$0
    (i32.add
     (local.get $0)
     (i32.const 32)

--- a/test/lld/em_asm_shared.wat.out
+++ b/test/lld/em_asm_shared.wat.out
@@ -4,14 +4,14 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
- (data (global.get $gimport$3) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
- (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
- (import "env" "__stack_pointer" (global $gimport$2 (mut i32)))
- (import "env" "__memory_base" (global $gimport$3 i32))
- (import "env" "__table_base" (global $gimport$4 i32))
- (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (global $gimport$6 (mut i32)))
- (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $gimport$7 (mut i32)))
- (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (global $gimport$8 (mut i32)))
+ (data (global.get $gimport$1) "{ Module.print(\"Hello world\"); }\00\00{ return $0 + $1; }\00ii\00{ Module.print(\"Got \" + $0); }\00i\00")
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
+ (import "env" "__stack_pointer" (global $gimport$0 (mut i32)))
+ (import "env" "__memory_base" (global $gimport$1 i32))
+ (import "env" "__table_base" (global $gimport$2 i32))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJEEE6bufferE" (global $gimport$3 (mut i32)))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiiEEE6bufferE" (global $gimport$4 (mut i32)))
+ (import "GOT.mem" "_ZN20__em_asm_sig_builderI19__em_asm_type_tupleIJiEEE6bufferE" (global $gimport$5 (mut i32)))
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (global $global$0 i32 (i32.const 33))
  (global $global$1 i32 (i32.const 54))
@@ -31,10 +31,10 @@
  (func $__original_main (result i32)
   (local $0 i32)
   (local $1 i32)
-  (global.set $gimport$2
+  (global.set $gimport$0
    (local.tee $0
     (i32.sub
-     (global.get $gimport$2)
+     (global.get $gimport$0)
      (i32.const 32)
     )
    )
@@ -43,11 +43,11 @@
    (call $emscripten_asm_const_int
     (i32.add
      (local.tee $1
-      (global.get $gimport$3)
+      (global.get $gimport$1)
      )
      (i32.const 0)
     )
-    (global.get $gimport$6)
+    (global.get $gimport$3)
     (i32.const 0)
    )
   )
@@ -62,7 +62,7 @@
      (local.get $1)
      (i32.const 34)
     )
-    (global.get $gimport$7)
+    (global.get $gimport$4)
     (i32.add
      (local.get $0)
      (i32.const 16)
@@ -75,11 +75,11 @@
      (local.get $1)
      (i32.const 57)
     )
-    (global.get $gimport$8)
+    (global.get $gimport$5)
     (local.get $0)
    )
   )
-  (global.set $gimport$2
+  (global.set $gimport$0
    (i32.add
     (local.get $0)
     (i32.const 32)
@@ -99,7 +99,6 @@
     "34": ["{ return $0 + $1; }", ["iii"], [""]],
     "57": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
-  "staticBump": 0,
   "tableSize": 0,
   "declares": [
     "emscripten_asm_const_int"

--- a/test/lld/em_asm_table.wat.out
+++ b/test/lld/em_asm_table.wat.out
@@ -32,7 +32,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 480,
   "tableSize": 159609,
   "declares": [
     "emscripten_log",

--- a/test/lld/em_js_O0.wat.out
+++ b/test/lld/em_js_O0.wat.out
@@ -15,7 +15,6 @@
   "emJsFuncs": {
     "noarg": "(void)<::>{ out(\"no args works\"); }"
   },
-  "staticBump": 6664,
   "tableSize": 0,
   "declares": [
   ],

--- a/test/lld/hello_world.passive.wat.out
+++ b/test/lld/hello_world.passive.wat.out
@@ -40,7 +40,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 13,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"

--- a/test/lld/hello_world.wat
+++ b/test/lld/hello_world.wat
@@ -8,11 +8,9 @@
  (data (i32.const 568) "Hello, world\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
- (global $global$1 i32 (i32.const 581))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
  (func $__original_main (result i32)

--- a/test/lld/hello_world.wat.mem.out
+++ b/test/lld/hello_world.wat.mem.out
@@ -7,11 +7,9 @@
  (memory $0 2)
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
- (global $global$1 i32 (i32.const 581))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -30,7 +28,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 13,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -45,7 +42,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "581"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/hello_world.wat.out
+++ b/test/lld/hello_world.wat.out
@@ -8,11 +8,9 @@
  (data (i32.const 568) "Hello, world\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
- (global $global$1 i32 (i32.const 581))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -31,7 +29,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 13,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -46,7 +43,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "581"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/init.wat
+++ b/test/lld/init.wat
@@ -5,11 +5,9 @@
  (memory $0 2)
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 576))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (call $init_x)
   (call $init_y)

--- a/test/lld/init.wat.out
+++ b/test/lld/init.wat.out
@@ -5,11 +5,9 @@
  (memory $0 2)
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 576))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (call $init_x)
   (call $init_y)
@@ -43,7 +41,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 8,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -57,7 +54,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "576"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/longjmp.wat
+++ b/test/lld/longjmp.wat
@@ -20,11 +20,9 @@
  (table $0 2 2 funcref)
  (elem (i32.const 1) $fimport$3)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 576))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $0))
  (export "main" (func $2))
- (export "__data_end" (global $global$1))
  (func $0
  )
  (func $1 (result i32)

--- a/test/lld/longjmp.wat.out
+++ b/test/lld/longjmp.wat.out
@@ -20,11 +20,9 @@
  (table $0 2 2 funcref)
  (elem (i32.const 1) $fimport$3)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 576))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $0))
  (export "main" (func $2))
- (export "__data_end" (global $global$1))
  (export "dynCall_vii" (func $dynCall_vii))
  (func $0
   (nop)
@@ -143,7 +141,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 8,
   "tableSize": 2,
   "initializers": [
     "__wasm_call_ctors"
@@ -165,7 +162,6 @@
     "dynCall_vii"
   ],
   "namedGlobals": {
-    "__data_end" : "576"
   },
   "invokeFuncs": [
     "invoke_vii"

--- a/test/lld/main_module.wat.out
+++ b/test/lld/main_module.wat.out
@@ -56,7 +56,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 4294966770,
   "tableSize": 0,
   "initializers": [
     "__wasm_call_ctors"

--- a/test/lld/main_module_table.wat.out
+++ b/test/lld/main_module_table.wat.out
@@ -12,7 +12,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 4294966770,
   "tableSize": 0,
   "declares": [
   ],

--- a/test/lld/main_module_table_2.wat.out
+++ b/test/lld/main_module_table_2.wat.out
@@ -13,7 +13,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 4294966770,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/main_module_table_3.wat.out
+++ b/test/lld/main_module_table_3.wat.out
@@ -13,7 +13,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 4294966770,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/main_module_table_4.wat.out
+++ b/test/lld/main_module_table_4.wat.out
@@ -14,7 +14,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 4294966770,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/main_module_table_5.wat.out
+++ b/test/lld/main_module_table_5.wat.out
@@ -28,7 +28,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 4294966770,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/recursive.wat
+++ b/test/lld/recursive.wat
@@ -7,11 +7,9 @@
  (data (i32.const 568) "%d:%d\n\00Result: %d\n\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
- (global $global$1 i32 (i32.const 587))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
  (func $foo (param $0 i32) (param $1 i32) (result i32)

--- a/test/lld/recursive.wat.out
+++ b/test/lld/recursive.wat.out
@@ -7,11 +7,9 @@
  (data (i32.const 568) "%d:%d\n\00Result: %d\n\00")
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
- (global $global$1 i32 (i32.const 587))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
   (nop)
  )
@@ -88,7 +86,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 19,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"
@@ -103,7 +100,6 @@
     "main"
   ],
   "namedGlobals": {
-    "__data_end" : "587"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/recursive_safe_stack.wat.out
+++ b/test/lld/recursive_safe_stack.wat.out
@@ -175,7 +175,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 19,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"

--- a/test/lld/reserved_func_ptr.wat
+++ b/test/lld/reserved_func_ptr.wat
@@ -11,11 +11,9 @@
  (table $0 3 3 funcref)
  (elem (i32.const 1) $address_taken_func\28int\2c\20int\2c\20int\29 $address_taken_func2\28int\2c\20int\2c\20int\29)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 568))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (func $__wasm_call_ctors
  )
  (func $address_taken_func\28int\2c\20int\2c\20int\29 (param $0 i32) (param $1 i32) (param $2 i32)

--- a/test/lld/reserved_func_ptr.wat.out
+++ b/test/lld/reserved_func_ptr.wat.out
@@ -12,11 +12,9 @@
  (table $0 3 3 funcref)
  (elem (i32.const 1) $address_taken_func\28int\2c\20int\2c\20int\29 $address_taken_func2\28int\2c\20int\2c\20int\29)
  (global $global$0 (mut i32) (i32.const 66112))
- (global $global$1 i32 (i32.const 568))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__data_end" (global $global$1))
  (export "dynCall_viii" (func $dynCall_viii))
  (func $__wasm_call_ctors
   (nop)
@@ -123,7 +121,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 0,
   "tableSize": 3,
   "initializers": [
     "__wasm_call_ctors"
@@ -139,7 +136,6 @@
     "dynCall_viii"
   ],
   "namedGlobals": {
-    "__data_end" : "568"
   },
   "invokeFuncs": [
   ],

--- a/test/lld/safe_stack_standalone-wasm.wat.out
+++ b/test/lld/safe_stack_standalone-wasm.wat.out
@@ -174,7 +174,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 19,
   "tableSize": 1,
   "initializers": [
     "__wasm_call_ctors"

--- a/test/lld/shared.wat
+++ b/test/lld/shared.wat
@@ -3,13 +3,13 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
- (data (global.get $gimport$2) "Hello, world\00\00\00\00\00\00\00\00\00\00\00\00")
- (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
- (import "env" "__memory_base" (global $gimport$2 i32))
- (import "env" "__table_base" (global $gimport$3 i32))
- (import "GOT.mem" "external_var" (global $gimport$5 (mut i32)))
- (import "GOT.func" "puts" (global $gimport$6 (mut i32)))
- (import "GOT.func" "_Z13print_messagev" (global $gimport$7 (mut i32)))
+ (data (global.get $gimport$0) "Hello, world\00\00\00\00\00\00\00\00\00\00\00\00")
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
+ (import "env" "__memory_base" (global $gimport$0 i32))
+ (import "env" "__table_base" (global $gimport$1 i32))
+ (import "GOT.mem" "external_var" (global $gimport$2 (mut i32)))
+ (import "GOT.func" "puts" (global $gimport$3 (mut i32)))
+ (import "GOT.func" "_Z13print_messagev" (global $gimport$4 (mut i32)))
  (import "env" "puts" (func $puts (param i32) (result i32)))
  (global $global$0 i32 (i32.const 16))
  (global $global$1 i32 (i32.const 20))
@@ -23,30 +23,30 @@
  (func $__wasm_apply_relocs
   (i32.store
    (i32.add
-    (global.get $gimport$2)
+    (global.get $gimport$0)
     (i32.const 16)
    )
-   (global.get $gimport$6)
+   (global.get $gimport$3)
   )
   (i32.store
    (i32.add
-    (global.get $gimport$2)
+    (global.get $gimport$0)
     (i32.const 20)
    )
-   (global.get $gimport$7)
+   (global.get $gimport$4)
   )
  )
  (func $print_message\28\29 (result i32)
   (drop
    (call $puts
     (i32.add
-     (global.get $gimport$2)
+     (global.get $gimport$0)
      (i32.const 0)
     )
    )
   )
   (i32.load
-   (global.get $gimport$5)
+   (global.get $gimport$2)
   )
  )
  ;; dylink section

--- a/test/lld/shared.wat.out
+++ b/test/lld/shared.wat.out
@@ -3,13 +3,13 @@
  (type $none_=>_i32 (func (result i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
- (data (global.get $gimport$2) "Hello, world\00\00\00\00\00\00\00\00\00\00\00\00")
- (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
- (import "env" "__memory_base" (global $gimport$2 i32))
- (import "env" "__table_base" (global $gimport$3 i32))
- (import "GOT.mem" "external_var" (global $gimport$5 (mut i32)))
- (import "GOT.func" "puts" (global $gimport$6 (mut i32)))
- (import "GOT.func" "_Z13print_messagev" (global $gimport$7 (mut i32)))
+ (data (global.get $gimport$0) "Hello, world\00\00\00\00\00\00\00\00\00\00\00\00")
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
+ (import "env" "__memory_base" (global $gimport$0 i32))
+ (import "env" "__table_base" (global $gimport$1 i32))
+ (import "GOT.mem" "external_var" (global $gimport$2 (mut i32)))
+ (import "GOT.func" "puts" (global $gimport$3 (mut i32)))
+ (import "GOT.func" "_Z13print_messagev" (global $gimport$4 (mut i32)))
  (import "env" "puts" (func $puts (param i32) (result i32)))
  (global $global$0 i32 (i32.const 16))
  (global $global$1 i32 (i32.const 20))
@@ -23,37 +23,36 @@
  (func $__wasm_apply_relocs
   (i32.store
    (i32.add
-    (global.get $gimport$2)
+    (global.get $gimport$0)
     (i32.const 16)
    )
-   (global.get $gimport$6)
+   (global.get $gimport$3)
   )
   (i32.store
    (i32.add
-    (global.get $gimport$2)
+    (global.get $gimport$0)
     (i32.const 20)
    )
-   (global.get $gimport$7)
+   (global.get $gimport$4)
   )
  )
  (func $print_message\28\29 (result i32)
   (drop
    (call $puts
     (i32.add
-     (global.get $gimport$2)
+     (global.get $gimport$0)
      (i32.const 0)
     )
    )
   )
   (i32.load
-   (global.get $gimport$5)
+   (global.get $gimport$2)
   )
  )
 )
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 0,
   "tableSize": 0,
   "declares": [
     "puts"

--- a/test/lld/shared_add_to_table.wasm.out
+++ b/test/lld/shared_add_to_table.wasm.out
@@ -71,7 +71,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 0,
   "tableSize": 0,
   "declares": [
     "_Z16waka_func_theirsi"

--- a/test/lld/shared_longjmp.wat
+++ b/test/lld/shared_longjmp.wat
@@ -8,21 +8,21 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
- (data (global.get $gimport$2) "\00\00\00\00\00\00\00\00")
- (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
- (import "env" "__memory_base" (global $gimport$2 i32))
- (import "env" "__table_base" (global $gimport$3 i32))
- (import "GOT.mem" "__THREW__" (global $gimport$12 (mut i32)))
- (import "GOT.func" "emscripten_longjmp" (global $gimport$13 (mut i32)))
- (import "GOT.mem" "__threwValue" (global $gimport$14 (mut i32)))
- (import "env" "malloc" (func $fimport$4 (param i32) (result i32)))
- (import "env" "saveSetjmp" (func $fimport$5 (param i32 i32 i32 i32) (result i32)))
- (import "env" "getTempRet0" (func $fimport$6 (result i32)))
- (import "env" "emscripten_longjmp" (func $fimport$7 (param i32 i32)))
- (import "env" "invoke_vii" (func $fimport$8 (param i32 i32 i32)))
- (import "env" "testSetjmp" (func $fimport$9 (param i32 i32 i32) (result i32)))
- (import "env" "setTempRet0" (func $fimport$10 (param i32)))
- (import "env" "free" (func $fimport$11 (param i32)))
+ (data (global.get $gimport$0) "\00\00\00\00\00\00\00\00")
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
+ (import "env" "__memory_base" (global $gimport$0 i32))
+ (import "env" "__table_base" (global $gimport$1 i32))
+ (import "GOT.mem" "__THREW__" (global $gimport$2 (mut i32)))
+ (import "GOT.func" "emscripten_longjmp" (global $gimport$3 (mut i32)))
+ (import "GOT.mem" "__threwValue" (global $gimport$4 (mut i32)))
+ (import "env" "malloc" (func $fimport$0 (param i32) (result i32)))
+ (import "env" "saveSetjmp" (func $fimport$1 (param i32 i32 i32 i32) (result i32)))
+ (import "env" "getTempRet0" (func $fimport$2 (result i32)))
+ (import "env" "emscripten_longjmp" (func $fimport$3 (param i32 i32)))
+ (import "env" "invoke_vii" (func $fimport$4 (param i32 i32 i32)))
+ (import "env" "testSetjmp" (func $fimport$5 (param i32 i32 i32) (result i32)))
+ (import "env" "setTempRet0" (func $fimport$6 (param i32)))
+ (import "env" "free" (func $fimport$7 (param i32)))
  (global $global$0 i32 (i32.const 0))
  (global $global$1 i32 (i32.const 4))
  (export "__wasm_call_ctors" (func $0))
@@ -41,14 +41,14 @@
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (call $fimport$4
+    (call $fimport$0
      (i32.const 40)
     )
    )
    (i32.const 0)
   )
   (local.set $1
-   (call $fimport$5
+   (call $fimport$1
     (local.get $0)
     (i32.const 1)
     (local.get $0)
@@ -56,7 +56,7 @@
    )
   )
   (local.set $2
-   (call $fimport$6)
+   (call $fimport$2)
   )
   (local.set $0
    (i32.const 0)
@@ -69,12 +69,12 @@
      )
      (i32.store
       (local.tee $0
-       (global.get $gimport$12)
+       (global.get $gimport$2)
       )
       (i32.const 0)
      )
-     (call $fimport$8
-      (global.get $gimport$13)
+     (call $fimport$4
+      (global.get $gimport$3)
       (local.get $0)
       (i32.const 1)
      )
@@ -88,7 +88,7 @@
       (i32.const 0)
      )
      (local.set $0
-      (global.get $gimport$14)
+      (global.get $gimport$4)
      )
      (block $label$4
       (br_if $label$4
@@ -107,7 +107,7 @@
       )
       (br_if $label$1
        (i32.eqz
-        (call $fimport$9
+        (call $fimport$5
          (i32.load
           (local.get $3)
          )
@@ -116,22 +116,22 @@
         )
        )
       )
-      (call $fimport$10
+      (call $fimport$6
        (local.get $0)
       )
      )
      (local.set $0
-      (call $fimport$6)
+      (call $fimport$2)
      )
      (br $label$3)
     )
    )
-   (call $fimport$11
+   (call $fimport$7
     (local.get $1)
    )
    (return)
   )
-  (call $fimport$7
+  (call $fimport$3
    (local.get $3)
    (local.get $0)
   )

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -8,21 +8,21 @@
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
  (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
- (data (global.get $gimport$2) "\00\00\00\00\00\00\00\00")
- (import "env" "__indirect_function_table" (table $timport$1 0 funcref))
- (import "env" "__memory_base" (global $gimport$2 i32))
- (import "env" "__table_base" (global $gimport$3 i32))
- (import "GOT.mem" "__THREW__" (global $gimport$12 (mut i32)))
- (import "GOT.func" "emscripten_longjmp" (global $gimport$13 (mut i32)))
- (import "GOT.mem" "__threwValue" (global $gimport$14 (mut i32)))
- (import "env" "malloc" (func $fimport$4 (param i32) (result i32)))
- (import "env" "saveSetjmp" (func $fimport$5 (param i32 i32 i32 i32) (result i32)))
- (import "env" "getTempRet0" (func $fimport$6 (result i32)))
- (import "env" "emscripten_longjmp" (func $fimport$7 (param i32 i32)))
- (import "env" "invoke_vii" (func $fimport$8 (param i32 i32 i32)))
- (import "env" "testSetjmp" (func $fimport$9 (param i32 i32 i32) (result i32)))
- (import "env" "setTempRet0" (func $fimport$10 (param i32)))
- (import "env" "free" (func $fimport$11 (param i32)))
+ (data (global.get $gimport$0) "\00\00\00\00\00\00\00\00")
+ (import "env" "__indirect_function_table" (table $timport$0 0 funcref))
+ (import "env" "__memory_base" (global $gimport$0 i32))
+ (import "env" "__table_base" (global $gimport$1 i32))
+ (import "GOT.mem" "__THREW__" (global $gimport$2 (mut i32)))
+ (import "GOT.func" "emscripten_longjmp" (global $gimport$3 (mut i32)))
+ (import "GOT.mem" "__threwValue" (global $gimport$4 (mut i32)))
+ (import "env" "malloc" (func $fimport$0 (param i32) (result i32)))
+ (import "env" "saveSetjmp" (func $fimport$1 (param i32 i32 i32 i32) (result i32)))
+ (import "env" "getTempRet0" (func $fimport$2 (result i32)))
+ (import "env" "emscripten_longjmp" (func $fimport$3 (param i32 i32)))
+ (import "env" "invoke_vii" (func $fimport$4 (param i32 i32 i32)))
+ (import "env" "testSetjmp" (func $fimport$5 (param i32 i32 i32) (result i32)))
+ (import "env" "setTempRet0" (func $fimport$6 (param i32)))
+ (import "env" "free" (func $fimport$7 (param i32)))
  (global $global$0 i32 (i32.const 0))
  (global $global$1 i32 (i32.const 4))
  (export "__post_instantiate" (func $0))
@@ -43,14 +43,14 @@
   (local $3 i32)
   (i32.store
    (local.tee $0
-    (call $fimport$4
+    (call $fimport$0
      (i32.const 40)
     )
    )
    (i32.const 0)
   )
   (local.set $1
-   (call $fimport$5
+   (call $fimport$1
     (local.get $0)
     (i32.const 1)
     (local.get $0)
@@ -58,7 +58,7 @@
    )
   )
   (local.set $2
-   (call $fimport$6)
+   (call $fimport$2)
   )
   (local.set $0
    (i32.const 0)
@@ -71,12 +71,12 @@
      )
      (i32.store
       (local.tee $0
-       (global.get $gimport$12)
+       (global.get $gimport$2)
       )
       (i32.const 0)
      )
-     (call $fimport$8
-      (global.get $gimport$13)
+     (call $fimport$4
+      (global.get $gimport$3)
       (local.get $0)
       (i32.const 1)
      )
@@ -90,7 +90,7 @@
       (i32.const 0)
      )
      (local.set $0
-      (global.get $gimport$14)
+      (global.get $gimport$4)
      )
      (block $label$4
       (br_if $label$4
@@ -109,7 +109,7 @@
       )
       (br_if $label$1
        (i32.eqz
-        (call $fimport$9
+        (call $fimport$5
          (i32.load
           (local.get $3)
          )
@@ -118,22 +118,22 @@
         )
        )
       )
-      (call $fimport$10
+      (call $fimport$6
        (local.get $0)
       )
      )
      (local.set $0
-      (call $fimport$6)
+      (call $fimport$2)
      )
      (br $label$3)
     )
    )
-   (call $fimport$11
+   (call $fimport$7
     (local.get $1)
    )
    (return)
   )
-  (call $fimport$7
+  (call $fimport$3
    (local.get $3)
    (local.get $0)
   )
@@ -150,7 +150,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 0,
   "tableSize": 0,
   "declares": [
     "malloc",

--- a/test/lld/standalone-wasm-with-start.wat.out
+++ b/test/lld/standalone-wasm-with-start.wat.out
@@ -20,7 +20,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 8,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/standalone-wasm.wat.out
+++ b/test/lld/standalone-wasm.wat.out
@@ -24,7 +24,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 8,
   "tableSize": 1,
   "declares": [
   ],

--- a/test/lld/standalone-wasm2.wat.out
+++ b/test/lld/standalone-wasm2.wat.out
@@ -21,7 +21,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 8,
   "tableSize": 0,
   "declares": [
   ],

--- a/test/lld/standalone-wasm3.wat.out
+++ b/test/lld/standalone-wasm3.wat.out
@@ -14,7 +14,6 @@
 (;
 --BEGIN METADATA --
 {
-  "staticBump": 8,
   "tableSize": 0,
   "declares": [
   ],


### PR DESCRIPTION
Emscripten no longer needs this information as of
https://github.com/emscripten-core/emscripten/pull/12643.

This also removes the need to export __data_end.

The test directory changes here were generated using:

$ ./scripts/test/generate_lld_tests.py
$ ./auto_update_tests.py lld