### PR TITLE
Inlining fix: Note the start function

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -343,6 +343,9 @@ struct Inlining : public Pass {
         }
       }
     }
+    if (module->start.is()) {
+      infos[module->start].usedGlobally = true;
+    }
   }
 
   bool iteration(PassRunner* runner, Module* module) {

--- a/test/passes/inlining_all-features.txt
+++ b/test/passes/inlining_all-features.txt
@@ -59,3 +59,15 @@
   )
  )
 )
+(module
+ (type $none_=>_none (func))
+ (start $0)
+ (func $0
+  (nop)
+ )
+ (func $1
+  (block $__inlined_func$0
+   (nop)
+  )
+ )
+)

--- a/test/passes/inlining_all-features.wast
+++ b/test/passes/inlining_all-features.wast
@@ -47,3 +47,14 @@
   (call $0)
  )
 )
+(module
+ ;; a function reference in the start should be noticed, and prevent us
+ ;; from removing an inlined function
+ (start $0)
+ (func $0
+  (nop)
+ )
+ (func $1
+  (call $0)
+ )
+)


### PR DESCRIPTION
Without this, we might think a function has no global uses if the only
global use of it is the start.