### PR TITLE
Fix usage of `allocate` in JS (no longer takes a type argument)

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -9,7 +9,7 @@ function preserveStack(func) {
 }
 
 function strToStack(str) {
-  return str ? allocate(intArrayFromString(str), 'i8', ALLOC_STACK) : 0;
+  return str ? allocate(intArrayFromString(str), ALLOC_STACK) : 0;
 }
 
 function i32sToStack(i32s) {
@@ -2289,7 +2289,7 @@ function wrapModule(module, self = {}) {
       const segmentOffset = new Array(segmentsLen);
       for (let i = 0; i < segmentsLen; i++) {
         const { data, offset, passive } = segments[i];
-        segmentData[i] = allocate(data, 'i8', ALLOC_STACK);
+        segmentData[i] = allocate(data, ALLOC_STACK);
         segmentDataLen[i] = data.length;
         segmentPassive[i] = passive;
         segmentOffset[i] = offset;
@@ -2990,7 +2990,7 @@ Module['emitText'] = function(expr) {
 Object.defineProperty(Module, 'readBinary', { writable: true });
 
 Module['readBinary'] = function(data) {
-  const buffer = allocate(data, 'i8', ALLOC_NORMAL);
+  const buffer = allocate(data, ALLOC_NORMAL);
   const ptr = Module['_BinaryenModuleRead'](buffer, data.length);
   _free(buffer);
   return wrapModule(ptr);


### PR DESCRIPTION
During debugging of a related problem using a debug build of binaryen.js, I was hitting the following error:

```
Error: abort(Error: abort(Assertion failed: allocate no longer takes a type argument)
    at jsStackTrace (path\to\binaryen.js:1279776:19)
    at stackTrace (path\to\binaryen.js:1279793:16)
    at abort (path\to\binaryen.js:1279488:44)
    at assert (path\to\binaryen.js:1278645:5)
    at allocate (path\to\binaryen.js:1278734:3)
    at strToStack (path\to\binaryen.js:1287254:16)
```

triggered [around here](https://github.com/emscripten-core/emscripten/blob/437266ac3dfd61747e53bc6e4ae57b81c92dc093/src/preamble.js#L212-L217), introduced in https://github.com/emscripten-core/emscripten/pull/12279.

Is this the right fix?