### PR TITLE
Module splitting

### DIFF
--- a/check.py
+++ b/check.py
@@ -326,7 +326,7 @@ def run_gcc_tests():
         subprocess.check_call(cmd)
         print('run...', output_file)
         actual = subprocess.check_output([os.path.abspath(output_file)]).decode('utf-8')
-        os.remove(output_file)
+        # os.remove(output_file)
         shared.fail_if_not_identical_to_file(actual, expected)
 
 

--- a/check.py
+++ b/check.py
@@ -326,7 +326,7 @@ def run_gcc_tests():
         subprocess.check_call(cmd)
         print('run...', output_file)
         actual = subprocess.check_output([os.path.abspath(output_file)]).decode('utf-8')
-        # os.remove(output_file)
+        os.remove(output_file)
         shared.fail_if_not_identical_to_file(actual, expected)
 
 

--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -5,6 +5,7 @@ set(ir_SOURCES
   LocalGraph.cpp
   ReFinalize.cpp
   stack-utils.cpp
+  module-splitting.cpp
   ${ir_HEADERS}
 )
 add_library(ir OBJECT ${ir_SOURCES})

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -210,7 +210,7 @@ void moveFunctions(Module& primary,
     CallIndirector(const std::set<Name>& secondaryFuncs,
                    const std::map<Name, Signature>& secondarySignatures,
                    std::function<Index(Name)> getIndex,
-                   Builder builder)
+                   Builder& builder)
       : secondaryFuncs(secondaryFuncs),
         secondarySignatures(secondarySignatures), getIndex(getIndex),
         builder(builder) {}

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -301,11 +301,13 @@ void ModuleSplitter::exportImportCalledPrimaryFunctions() {
                       std::vector<Name>& calledPrimaryFuncs)
           : primaryFuncs(primaryFuncs), calledPrimaryFuncs(calledPrimaryFuncs) {
         }
-
         void visitCall(Call* curr) {
           if (primaryFuncs.count(curr->target)) {
             calledPrimaryFuncs.push_back(curr->target);
           }
+        }
+        void visitRefFunc(RefFunc* curr) {
+          assert(false && "TODO: handle ref.func as well");
         }
       };
       CallCollector(primaryFuncs, calledPrimaryFuncs).walkFunction(func);

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -108,7 +108,9 @@ template<class F> void forEachElement(Table& table, F f) {
 }
 
 // Return the first free table slot and the segment to which to append new
-// items, if it exists.
+// items, if it exists. Since it is simpler to append a contiguous vector of new
+// elements, this is actually the index after the highest occupied index, rather
+// than the real first free index.
 Index getFirstFreeTableIndex(Table& table, Table::Segment** outSegment) {
   Index firstFreeIndex = 0;
   *outSegment = nullptr;

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -159,7 +159,9 @@ void moveFunctions(Module& primary,
   });
 
   // Keep track of the new items we have to add to the table and where to add
-  // them.
+  // them. We are adding secondary function names to the primary table here, but
+  // they will be replaced with placeholder functions later along with any
+  // references to secondary functions that were already in the table.
   Table::Segment* lastSegment = nullptr;
   Index firstFreeIndex = getFirstFreeTableIndex(primary.table, &lastSegment);
   std::vector<Name> newTableElems;

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -251,6 +251,18 @@ void moveFunctions(Module& primary,
 
   // Insert new table elements
   if (newTableElems.size()) {
+    primary.table.exists = true;
+    secondary.table.exists = true;
+    // Update table sizes if necessary
+    size_t tableSize = firstFreeIndex + newTableElems.size();
+    if (primary.table.initial < tableSize) {
+      primary.table.initial = tableSize;
+      secondary.table.initial = tableSize;
+    }
+    if (primary.table.max < tableSize) {
+      primary.table.max = tableSize;
+      secondary.table.max = tableSize;
+    }
     if (lastSegment != nullptr) {
       lastSegment->data.insert(
         lastSegment->data.end(), newTableElems.begin(), newTableElems.end());
@@ -258,17 +270,6 @@ void moveFunctions(Module& primary,
       primary.table.segments.emplace_back(
         builder.makeConst(Literal(int32_t(firstFreeIndex))), newTableElems);
     }
-  }
-
-  // Update table sizes if necessary
-  size_t tableSize = firstFreeIndex + newTableElems.size();
-  if (primary.table.initial < tableSize) {
-    primary.table.initial = tableSize;
-    secondary.table.initial = tableSize;
-  }
-  if (primary.table.max < tableSize) {
-    primary.table.max = tableSize;
-    secondary.table.max = tableSize;
   }
 }
 

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -391,12 +391,12 @@ std::unique_ptr<Module> splitFunctions(Module& primary, const Config& config) {
 
   auto ret = initializeSecondary(primary);
   Module& secondary = *ret;
-  shareImportableItems(primary, secondary, config.importNamespace);
   moveFunctions(primary, secondary, secondaryFuncs);
   exportImportPrimaryFunctions(
     primary, secondary, config.primaryFuncs, config.importNamespace);
   setupTablePatching(
     primary, secondary, secondaryFuncs, config.placeholderNamespace);
+  shareImportableItems(primary, secondary, config.importNamespace);
   return ret;
 }
 

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/module-splitting.h"
+#include "ir/manipulation.h"
+#include "ir/module-utils.h"
+#include "ir/names.h"
+#include "pass.h"
+#include "wasm-builder.h"
+#include "wasm.h"
+
+namespace wasm {
+
+namespace ModuleSplitting {
+
+namespace {
+
+std::unique_ptr<Module> initializeSecondary(const Module& primary) {
+  // Create the secondary module and copy trivial properties.
+  auto secondary = std::make_unique<Module>();
+  secondary->features = primary.features;
+  secondary->hasFeaturesSection = primary.hasFeaturesSection;
+  return secondary;
+}
+
+void shareImportableItems(Module& primary,
+                          Module& secondary,
+                          Name importNamespace) {
+  // Map internal names to (one of) their corresponding export names.
+  std::unordered_map<Name, Name> exports;
+  for (auto& ex : primary.exports) {
+    if (ex->kind != ExternalKind::Function) {
+      exports[ex->value] = ex->name;
+    }
+  }
+
+  auto makeImportExport = [&](Importable& primaryItem,
+                              Importable& secondaryItem,
+                              Name exportName,
+                              ExternalKind kind) {
+    secondaryItem.name = primaryItem.name;
+    secondaryItem.hasExplicitName = primaryItem.hasExplicitName;
+    secondaryItem.module = importNamespace;
+    auto exportIt = exports.find(primaryItem.name);
+    if (exportIt != exports.end()) {
+      secondaryItem.base = exportIt->second;
+    } else {
+      exportName = Names::getValidExportName(primary, exportName);
+      primary.addExport(new Export{exportName, primaryItem.name, kind});
+      secondaryItem.base = exportName;
+    }
+  };
+
+  // TODO: Be more selective by only sharing global items that are actually used
+  // in the secondary module, just like we do for functions.
+
+  auto shareMemory = [&](Memory* memory) {
+    secondary.memory.exists = true;
+    secondary.memory.initial = memory->initial;
+    secondary.memory.max = memory->max;
+    secondary.memory.shared = memory->shared;
+    secondary.memory.indexType = memory->indexType;
+    makeImportExport(*memory, secondary.memory, "memory", ExternalKind::Memory);
+  };
+  ModuleUtils::iterImportedMemories(primary, shareMemory);
+  ModuleUtils::iterDefinedMemories(primary, shareMemory);
+
+  auto shareTable = [&](Table* table) {
+    secondary.table.exists = true;
+    secondary.table.initial = table->initial;
+    secondary.table.max = table->max;
+    makeImportExport(*table, secondary.table, "table", ExternalKind::Table);
+  };
+  ModuleUtils::iterImportedTables(primary, shareTable);
+  ModuleUtils::iterDefinedTables(primary, shareTable);
+
+  auto shareGlobal = [&](Global* global) {
+    assert(primary.features.hasMutableGlobals() &&
+           "TODO: add wrapper functions for disallowed mutable globals");
+    auto secondaryGlobal = std::make_unique<Global>();
+    secondaryGlobal->type = global->type;
+    secondaryGlobal->mutable_ = global->mutable_;
+    secondaryGlobal->init =
+      global->init == nullptr
+        ? nullptr
+        : ExpressionManipulator::copy(global->init, secondary);
+    makeImportExport(*global, *secondaryGlobal, "global", ExternalKind::Global);
+    secondary.addGlobal(std::move(secondaryGlobal));
+  };
+  ModuleUtils::iterImportedGlobals(primary, shareGlobal);
+  ModuleUtils::iterDefinedGlobals(primary, shareGlobal);
+
+  auto shareEvent = [&](Event* event) {
+    auto secondaryEvent = std::make_unique<Event>();
+    secondaryEvent->attribute = event->attribute;
+    secondaryEvent->sig = event->sig;
+    makeImportExport(*event, *secondaryEvent, "event", ExternalKind::Event);
+    secondary.addEvent(std::move(secondaryEvent));
+  };
+  ModuleUtils::iterImportedEvents(primary, shareEvent);
+  ModuleUtils::iterDefinedEvents(primary, shareEvent);
+}
+
+template<class F> void forEachElement(Table& table, F f) {
+  for (auto& segment : table.segments) {
+    assert(segment.offset->is<Const>() &&
+           "TODO: handle non-constant segment offsets");
+    Index baseOffset = segment.offset->cast<Const>()->value.geti32();
+    for (size_t i = 0; i < segment.data.size(); ++i) {
+      f(Index(baseOffset + i), segment.data[i]);
+    }
+  }
+}
+
+// Return the first free table slot and the segment to which to append new
+// items, if it exists.
+Index getFirstFreeTableIndex(Table& table, Table::Segment** outSegment) {
+  Index firstFreeIndex = 0;
+  *outSegment = nullptr;
+  for (auto& segment : table.segments) {
+    assert(segment.offset->is<Const>() &&
+           "TODO: handle non-constant segment offsets");
+    Index segmentBase = segment.offset->cast<Const>()->value.geti32();
+    if (segmentBase + segment.data.size() > firstFreeIndex) {
+      firstFreeIndex = segmentBase + segment.data.size();
+      *outSegment = &segment;
+    }
+  }
+  return firstFreeIndex;
+}
+
+// Move the secondary functions out of the primary module and return a map from
+// their names to their (eventual) table indices.
+void moveFunctions(Module& primary,
+                   Module& secondary,
+                   const std::set<Name>& secondaryFuncs) {
+  // Move the specified functions from the primary to the secondary module.
+  std::map<Name, Signature> secondarySignatures;
+  for (auto funcName : secondaryFuncs) {
+    auto* func = primary.getFunction(funcName);
+    secondarySignatures[funcName] = func->sig;
+    assert(!func->imported() && "Cannot split off imported functions");
+    assert(funcName != primary.start && "Cannot split off start function");
+    ModuleUtils::copyFunction(func, secondary);
+    primary.removeFunction(funcName);
+  }
+
+  // Map secondary functions to their table indices. Assumes each function
+  // appears at most once in the table.
+  std::map<Name, Index> secondaryIndices;
+  auto addIndex = [&](Name secondaryFunc, Index index) {
+    auto it = secondaryIndices.insert(std::make_pair(secondaryFunc, index));
+    assert(it.second && "Function already has multiple indices");
+  };
+
+  // Initialize `secondaryIndices` with the secondary functions that already
+  // have table slots.
+  forEachElement(primary.table, [&](Index index, Name elem) {
+    if (secondaryFuncs.find(elem) != secondaryFuncs.end()) {
+      addIndex(elem, index);
+    }
+  });
+
+  // Keep track of the new items we have to add to the table and where to add
+  // them.
+  Table::Segment* lastSegment = nullptr;
+  Index firstFreeIndex = getFirstFreeTableIndex(primary.table, &lastSegment);
+  std::vector<Name> newTableElems;
+
+  auto getIndex = [&](Name secondaryFunc) {
+    auto indexIt = secondaryIndices.find(secondaryFunc);
+    if (indexIt != secondaryIndices.end()) {
+      return indexIt->second;
+    } else {
+      Index newIndex = firstFreeIndex + newTableElems.size();
+      newTableElems.push_back(secondaryFunc);
+      addIndex(secondaryFunc, newIndex);
+      return newIndex;
+    }
+  };
+
+  // Update exports of secondary functions in the primary module to export
+  // wrapper functions that indirectly call the secondary functions. Reuse the
+  // exported function's existing table slot if it exists, otherwise create a
+  // new table slot.
+  Builder builder(primary);
+  for (auto& ex : primary.exports) {
+    if (ex->kind != ExternalKind::Function ||
+        secondaryFuncs.find(ex->value) == secondaryFuncs.end()) {
+      continue;
+    }
+    Name secondaryFunc = ex->value;
+    Index tableIndex = getIndex(secondaryFunc);
+    auto func = std::make_unique<Function>();
+    func->name = secondaryFunc;
+    func->sig = secondarySignatures[secondaryFunc];
+    std::vector<Expression*> args;
+    for (size_t i = 0, size = func->sig.params.size(); i < size; ++i) {
+      args.push_back(builder.makeLocalGet(i, func->sig.params[i]));
+    }
+    func->body = builder.makeCallIndirect(
+      builder.makeConst(Literal(int32_t(tableIndex))), args, func->sig);
+    primary.addFunction(std::move(func));
+  }
+
+  // Update direct calls of secondary functions to be indirect calls of their
+  // corresponding table indices instead.
+  struct CallIndirector : public WalkerPass<PostWalker<CallIndirector>> {
+    const std::set<Name>& secondaryFuncs;
+    const std::map<Name, Signature>& secondarySignatures;
+    std::function<Index(Name)> getIndex;
+    Builder builder;
+    CallIndirector(const std::set<Name>& secondaryFuncs,
+                   const std::map<Name, Signature>& secondarySignatures,
+                   std::function<Index(Name)> getIndex,
+                   Builder builder)
+      : secondaryFuncs(secondaryFuncs),
+        secondarySignatures(secondarySignatures), getIndex(getIndex),
+        builder(builder) {}
+    void visitCall(Call* curr) {
+      if (secondaryFuncs.find(curr->target) == secondaryFuncs.end()) {
+        return;
+      }
+      replaceCurrent(builder.makeCallIndirect(
+        builder.makeConst(Literal(int32_t(getIndex(curr->target)))),
+        curr->operands,
+        secondarySignatures.find(curr->target)->second,
+        curr->isReturn));
+    }
+    void visitRefFunc(RefFunc* curr) {
+      assert(false && "TODO: handle ref.func as well");
+    }
+  };
+  PassRunner runner(&primary);
+  CallIndirector(
+    secondaryFuncs, secondarySignatures, getIndex, Builder(primary))
+    .run(&runner, &primary);
+
+  // Insert new table elements
+  if (newTableElems.size()) {
+    if (lastSegment != nullptr) {
+      lastSegment->data.insert(
+        lastSegment->data.end(), newTableElems.begin(), newTableElems.end());
+    } else {
+      primary.table.segments.emplace_back(
+        builder.makeConst(Literal(int32_t(firstFreeIndex))), newTableElems);
+    }
+  }
+
+  // Update table sizes if necessary
+  size_t tableSize = firstFreeIndex + newTableElems.size();
+  if (primary.table.initial < tableSize) {
+    primary.table.initial = tableSize;
+    secondary.table.initial = tableSize;
+  }
+  if (primary.table.max < tableSize) {
+    primary.table.max = tableSize;
+    secondary.table.max = tableSize;
+  }
+}
+
+void exportImportPrimaryFunctions(Module& primary,
+                                  Module& secondary,
+                                  const std::set<Name>& primaryFuncs,
+                                  Name importNamespace) {
+  // Find primary functions called in the secondary module.
+  ModuleUtils::ParallelFunctionAnalysis<std::set<Name>> callCollector(
+    secondary, [&](Function* func, std::set<Name>& calledPrimaryFuncs) {
+      struct CallCollector : PostWalker<CallCollector> {
+        const std::set<Name>& primaryFuncs;
+        std::set<Name>& calledPrimaryFuncs;
+        CallCollector(const std::set<Name>& primaryFuncs,
+                      std::set<Name>& calledPrimaryFuncs)
+          : primaryFuncs(primaryFuncs), calledPrimaryFuncs(calledPrimaryFuncs) {
+        }
+
+        void visitCall(Call* curr) {
+          if (primaryFuncs.find(curr->target) != primaryFuncs.end()) {
+            calledPrimaryFuncs.insert(curr->target);
+          }
+        }
+      };
+      CallCollector(primaryFuncs, calledPrimaryFuncs).walkFunction(func);
+    });
+  std::set<Name> calledPrimaryFuncs;
+  for (auto& entry : callCollector.map) {
+    auto& calledFuncs = entry.second;
+    calledPrimaryFuncs.insert(calledFuncs.begin(), calledFuncs.end());
+  }
+
+  // Find exported primary functions and map to their export names
+  std::map<Name, Name> exportedPrimaryFuncs;
+  for (auto& ex : primary.exports) {
+    if (ex->kind == ExternalKind::Function) {
+      exportedPrimaryFuncs.insert(std::make_pair(ex->value, ex->name));
+    }
+  }
+
+  // Ensure each called primary function is exported and imported
+  for (auto primaryFunc : calledPrimaryFuncs) {
+    Name exportName;
+    auto exportIt = exportedPrimaryFuncs.find(primaryFunc);
+    if (exportIt != exportedPrimaryFuncs.end()) {
+      exportName = exportIt->second;
+    } else {
+      exportName = Names::getValidExportName(primary, primaryFunc);
+      primary.addExport(
+        new Export{exportName, primaryFunc, ExternalKind::Function});
+    }
+    auto func = std::make_unique<Function>();
+    func->module = importNamespace;
+    func->base = exportName;
+    func->name = primaryFunc;
+    func->sig = primary.getFunction(primaryFunc)->sig;
+    secondary.addFunction(std::move(func));
+  }
+}
+
+void setupTablePatching(Module& primary,
+                        Module& secondary,
+                        const std::set<Name>& secondaryFuncs,
+                        Name placeholderNamespace) {
+  std::map<Index, Name> replacedElems;
+  // Replace table references to secondary functions with an imported
+  // placeholder that encodes the table index in its name:
+  // `importNamespace`.`index`.
+  forEachElement(primary.table, [&](Index index, Name& elem) {
+    if (secondaryFuncs.find(elem) != secondaryFuncs.end()) {
+      replacedElems[index] = elem;
+      auto* secondaryFunc = secondary.getFunction(elem);
+      auto placeholder = std::make_unique<Function>();
+      placeholder->module = placeholderNamespace;
+      placeholder->base = std::to_string(index);
+      placeholder->name = Names::getValidFunctionName(
+        primary,
+        std::string("placeholder_") + std::string(placeholder->base.c_str()));
+      placeholder->hasExplicitName = false;
+      placeholder->sig = secondaryFunc->sig;
+      elem = placeholder->name;
+      primary.addFunction(std::move(placeholder));
+    }
+  });
+
+  // Create active table segments in the secondary module to patch in the
+  // original functions when it is instantiated.
+  Index currBase = 0;
+  std::vector<Name> currData;
+  auto finishSegment = [&]() {
+    auto* offset = Builder(secondary).makeConst(Literal(int32_t(currBase)));
+    secondary.table.segments.emplace_back(offset, currData);
+  };
+  if (replacedElems.size()) {
+    currBase = replacedElems.begin()->first;
+  }
+  for (auto curr = replacedElems.begin(); curr != replacedElems.end(); ++curr) {
+    if (curr->first != currBase + currData.size()) {
+      finishSegment();
+      currBase = curr->first;
+      currData.clear();
+    }
+    currData.push_back(curr->second);
+  }
+  if (currData.size()) {
+    finishSegment();
+  }
+}
+
+} // anonymous namespace
+
+std::unique_ptr<Module> splitFunctions(Module& primary, const Config& config) {
+  std::set<Name> secondaryFuncs;
+  for (auto& func : primary.functions) {
+    if (config.primaryFuncs.find(func->name) == config.primaryFuncs.end()) {
+      secondaryFuncs.insert(func->name);
+    }
+  }
+
+  auto ret = initializeSecondary(primary);
+  Module& secondary = *ret;
+  shareImportableItems(primary, secondary, config.importNamespace);
+  moveFunctions(primary, secondary, secondaryFuncs);
+  exportImportPrimaryFunctions(
+    primary, secondary, config.primaryFuncs, config.importNamespace);
+  setupTablePatching(
+    primary, secondary, secondaryFuncs, config.placeholderNamespace);
+  return ret;
+}
+
+} // namespace ModuleSplitting
+
+} // namespace wasm

--- a/src/ir/module-splitting.h
+++ b/src/ir/module-splitting.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_module_splitting_h
+#define wasm_ir_module_splitting_h
+
+#include "wasm.h"
+
+namespace wasm {
+
+namespace ModuleSplitting {
+
+struct Config {
+  // The set of functions to keep in the primary module. All others are split
+  // out into the new secondary module.
+  std::set<Name> primaryFuncs;
+  // The namespace from which to import primary functions into the secondary
+  // module.
+  Name importNamespace;
+  // The namespace from which to import placeholder functions into the primary
+  // module.
+  Name placeholderNamespace;
+};
+
+std::unique_ptr<Module> splitFunctions(Module& primary, const Config& config);
+
+} // namespace ModuleSplitting
+
+} // namespace wasm
+
+#endif // wasm_ir_module_splitting_h

--- a/src/ir/module-splitting.h
+++ b/src/ir/module-splitting.h
@@ -46,8 +46,9 @@ namespace ModuleSplitting {
 
 struct Config {
   // The set of functions to keep in the primary module. All others are split
-  // out into the new secondary module. May or may not include imported
-  // functions, which are always kept in the primary module.
+  // out into the new secondary module. Must include the start function if it
+  // exists. May or may not include imported functions, which are always kept in
+  // the primary module regardless.
   std::set<Name> primaryFuncs;
   // The namespace from which to import primary functions into the secondary
   // module.

--- a/src/ir/module-splitting.h
+++ b/src/ir/module-splitting.h
@@ -14,6 +14,27 @@
  * limitations under the License.
  */
 
+// module-splitting.h: Provides an interface for decomposing WebAssembly modules
+// into multiple modules that can be loaded independently. This works by moving
+// functions to a new secondary module and rewriting the primary module to call
+// them indirectly. Until the secondary module is instantiated, those indirect
+// calls will go to placeholder functions newly imported into the primary
+// module. The import names of the placeholder functions are the table indexes
+// they are placed at. The secondary module imports all of its dependencies from
+// the primary module.
+//
+// This code currently makes a few assumptions about the modules that will be
+// split and will fail assertions if those assumptions are not true.
+//
+//   1) It assumes that mutable-globals are allowed.
+//
+//   2) It assumes that all table segment offsets are constants.
+//
+//   3) It assumes that each function appears in the table at most once.
+//
+// These requirements will be relaxed as necessary in the future, but for now
+// this code should be considered experimental and used with care.
+
 #ifndef wasm_ir_module_splitting_h
 #define wasm_ir_module_splitting_h
 
@@ -25,7 +46,7 @@ namespace ModuleSplitting {
 
 struct Config {
   // The set of functions to keep in the primary module. All others are split
-  // out into the new secondary module.
+  // out into the new secondary module. Must include all imported functions.
   std::set<Name> primaryFuncs;
   // The namespace from which to import primary functions into the secondary
   // module.
@@ -35,6 +56,7 @@ struct Config {
   Name placeholderNamespace = "placeholder";
 };
 
+// Returns the new secondary module and modifies the `primary` module in place.
 std::unique_ptr<Module> splitFunctions(Module& primary, const Config& config);
 
 } // namespace ModuleSplitting

--- a/src/ir/module-splitting.h
+++ b/src/ir/module-splitting.h
@@ -46,7 +46,8 @@ namespace ModuleSplitting {
 
 struct Config {
   // The set of functions to keep in the primary module. All others are split
-  // out into the new secondary module. Must include all imported functions.
+  // out into the new secondary module. May or may not include imported
+  // functions, which are always kept in the primary module.
   std::set<Name> primaryFuncs;
   // The namespace from which to import primary functions into the secondary
   // module.

--- a/src/ir/module-splitting.h
+++ b/src/ir/module-splitting.h
@@ -29,10 +29,10 @@ struct Config {
   std::set<Name> primaryFuncs;
   // The namespace from which to import primary functions into the secondary
   // module.
-  Name importNamespace;
+  Name importNamespace = "primary";
   // The namespace from which to import placeholder functions into the primary
   // module.
-  Name placeholderNamespace;
+  Name placeholderNamespace = "placeholder";
 };
 
 std::unique_ptr<Module> splitFunctions(Module& primary, const Config& config);

--- a/src/ir/module-splitting.h
+++ b/src/ir/module-splitting.h
@@ -54,6 +54,10 @@ struct Config {
   // The namespace from which to import placeholder functions into the primary
   // module.
   Name placeholderNamespace = "placeholder";
+  // The prefix to attach to the name of any newly created exports. This can be
+  // used to differentiate between "real" exports of the module and exports that
+  // should only be consumed by the secondary module.
+  std::string newExportPrefix = "";
 };
 
 // Returns the new secondary module and modifies the `primary` module in place.

--- a/src/ir/names.h
+++ b/src/ir/names.h
@@ -64,6 +64,10 @@ getValidName(Module& module, Name root, std::function<bool(Name)> check) {
   }
 }
 
+inline Name getValidExportName(Module& module, Name root) {
+  return getValidName(
+    module, root, [&](Name test) { return !module.getExportOrNull(test); });
+}
 inline Name getValidGlobalName(Module& module, Name root) {
   return getValidName(
     module, root, [&](Name test) { return !module.getGlobalOrNull(test); });

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -221,8 +221,9 @@ public:
     call->finalize();
     return call;
   }
+  template<typename T>
   CallIndirect* makeCallIndirect(Expression* target,
-                                 const std::vector<Expression*>& args,
+                                 const T& args,
                                  Signature sig,
                                  bool isReturn = false) {
     auto* call = wasm.allocator.alloc<CallIndirect>();

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1734,10 +1734,10 @@ public:
   Global* addGlobal(Global* curr);
   Event* addEvent(Event* curr);
 
-  Export* addExport(std::unique_ptr<Export> curr);
-  Function* addFunction(std::unique_ptr<Function> curr);
-  Global* addGlobal(std::unique_ptr<Global> curr);
-  Event* addEvent(std::unique_ptr<Event> curr);
+  Export* addExport(std::unique_ptr<Export>&& curr);
+  Function* addFunction(std::unique_ptr<Function>&& curr);
+  Global* addGlobal(std::unique_ptr<Global>&& curr);
+  Event* addEvent(std::unique_ptr<Event>&& curr);
 
   void addStart(const Name& s);
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1241,20 +1241,20 @@ Event* Module::addEvent(Event* curr) {
   return addModuleElement(events, eventsMap, curr, "addEvent");
 }
 
-Export* Module::addExport(std::unique_ptr<Export> curr) {
+Export* Module::addExport(std::unique_ptr<Export>&& curr) {
   return addModuleElement(exports, exportsMap, std::move(curr), "addExport");
 }
 
-Function* Module::addFunction(std::unique_ptr<Function> curr) {
+Function* Module::addFunction(std::unique_ptr<Function>&& curr) {
   return addModuleElement(
     functions, functionsMap, std::move(curr), "addFunction");
 }
 
-Global* Module::addGlobal(std::unique_ptr<Global> curr) {
+Global* Module::addGlobal(std::unique_ptr<Global>&& curr) {
   return addModuleElement(globals, globalsMap, std::move(curr), "addGlobal");
 }
 
-Event* Module::addEvent(std::unique_ptr<Event> curr) {
+Event* Module::addEvent(std::unique_ptr<Event>&& curr) {
   return addModuleElement(events, eventsMap, std::move(curr), "addEvent");
 }
 

--- a/test/example/module-splitting.cpp
+++ b/test/example/module-splitting.cpp
@@ -1,0 +1,57 @@
+#include <cassert>
+#include <iostream>
+
+#include "ir/module-splitting.h"
+#include "ir/stack-utils.h"
+#include "wasm-printing.h"
+#include "wasm-s-parser.h"
+#include "wasm.h"
+
+using namespace wasm;
+
+std::unique_ptr<Module> parse(char* module) {
+  auto wasm = std::make_unique<Module>();
+  try {
+    SExpressionParser parser(module);
+    Element& root = *parser.root;
+    SExpressionWasmBuilder builder(*wasm, *root[0], IRProfile::Normal);
+  } catch (ParseException& p) {
+    p.dump(std::cerr);
+    Fatal() << "error in parsing wasm text";
+  }
+  return wasm;
+}
+
+void do_test(ModuleSplitting::Config config, std::string module) {
+  auto primary = parse(&module.front());
+
+  std::cout << "Before:\n";
+  WasmPrinter::printModule(primary.get());
+  auto secondary = splitFunctions(*primary, config);
+  std::cout << "After:\n";
+  WasmPrinter::printModule(primary.get());
+  std::cout << "Secondary:\n";
+  WasmPrinter::printModule(secondary.get());
+  std::cout << "\n\n";
+}
+
+void test_split() {
+  std::cout << ";; Test module splitting\n";
+  do_test(ModuleSplitting::Config{{"foo"}, "primary", "placeholder"},
+          R"(
+            (module
+             (memory $mem 0 0)
+             (table $table 2 2 funcref)
+             (elem (i32.const 0) $foo $bar)
+             (export "bar" (func $bar))
+             (func $foo (param i32) (result i32)
+              (drop (call $bar (i32.const 0)))
+             )
+             (func $bar (param i32) (result i32)
+              (drop (call $foo (i32.const 1)))
+             )
+            )
+          )");
+}
+
+int main() { test_split(); }

--- a/test/example/module-splitting.cpp
+++ b/test/example/module-splitting.cpp
@@ -53,16 +53,16 @@ void do_test(const std::set<Name>& keptFuncs, std::string&& module) {
   config.newExportPrefix = "%";
   auto secondary = splitFunctions(*primary, config);
 
-  valid = validator.validate(*primary);
-  assert(valid && "after invalid!");
-  valid = validator.validate(*secondary);
-  assert(valid && "secondary invalid!");
-
   std::cout << "After:\n";
   WasmPrinter::printModule(primary.get());
   std::cout << "Secondary:\n";
   WasmPrinter::printModule(secondary.get());
   std::cout << "\n\n";
+
+  valid = validator.validate(*primary);
+  assert(valid && "after invalid!");
+  valid = validator.validate(*secondary);
+  assert(valid && "secondary invalid!");
 }
 
 int main() {

--- a/test/example/module-splitting.cpp
+++ b/test/example/module-splitting.cpp
@@ -50,6 +50,7 @@ void do_test(const std::set<Name>& keptFuncs, std::string&& module) {
 
   ModuleSplitting::Config config;
   config.primaryFuncs = keptFuncs;
+  config.newExportPrefix = "%";
   auto secondary = splitFunctions(*primary, config);
 
   valid = validator.validate(*primary);
@@ -226,7 +227,7 @@ int main() {
   // Deferred function calling non-deferred function with clashing export name
   do_test({"foo"}, R"(
     (module
-     (export "foo" (func $bar))
+     (export "%foo" (func $bar))
      (func $foo
       (nop)
      )

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -1,6 +1,7 @@
 Before:
 (module
 )
+Keeping: <none>
 After:
 (module
 )
@@ -13,19 +14,20 @@ Before:
 (module
  (type $i32_=>_none (func (param i32)))
  (memory $mem (shared 3 42))
- (table $table 3 42 funcref)
+ (table $tab 3 42 funcref)
  (global $glob (mut i32) (i32.const 7))
  (event $e (attr 0) (param i32))
 )
+Keeping: <none>
 After:
 (module
  (type $i32_=>_none (func (param i32)))
  (memory $mem (shared 3 42))
- (table $table 3 42 funcref)
+ (table $tab 3 42 funcref)
  (global $glob (mut i32) (i32.const 7))
  (event $e (attr 0) (param i32))
  (export "memory" (memory $mem))
- (export "table" (table $table))
+ (export "table" (table $tab))
  (export "global" (global $glob))
  (export "event" (event $e))
 )
@@ -33,7 +35,7 @@ Secondary:
 (module
  (type $i32_=>_none (func (param i32)))
  (import "primary" "memory" (memory $mem (shared 3 42)))
- (import "primary" "table" (table $table 3 42 funcref))
+ (import "primary" "table" (table $tab 3 42 funcref))
  (import "primary" "global" (global $glob (mut i32)))
  (import "primary" "event" (event $e (attr 0) (param i32)))
 )
@@ -41,20 +43,87 @@ Secondary:
 
 Before:
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (func $foo (param $0 i32) (result i32)
-  (local.get $0)
- )
+ (type $i32_=>_none (func (param i32)))
+ (import "env" "mem" (memory $mem (shared 3 42)))
+ (import "env" "tab" (table $tab 3 42 funcref))
+ (import "env" "glob" (global $glob (mut i32)))
+ (import "env" "e" (event $e (attr 0) (param i32)))
 )
+Keeping: <none>
 After:
 (module
+ (type $i32_=>_none (func (param i32)))
+ (import "env" "mem" (memory $mem (shared 3 42)))
+ (import "env" "tab" (table $tab 3 42 funcref))
+ (import "env" "glob" (global $glob (mut i32)))
+ (import "env" "e" (event $e (attr 0) (param i32)))
+ (export "memory" (memory $mem))
+ (export "table" (table $tab))
+ (export "global" (global $glob))
+ (export "event" (event $e))
 )
 Secondary:
 (module
+ (type $i32_=>_none (func (param i32)))
+ (import "primary" "memory" (memory $mem (shared 3 42)))
+ (import "primary" "table" (table $tab 3 42 funcref))
+ (import "primary" "global" (global $glob (mut i32)))
+ (import "primary" "event" (event $e (attr 0) (param i32)))
+)
+
+
+Before:
+(module
+ (type $i32_=>_none (func (param i32)))
+ (memory $mem (shared 3 42))
+ (table $tab 3 42 funcref)
+ (global $glob (mut i32) (i32.const 7))
+ (event $e (attr 0) (param i32))
+ (export "mem" (memory $mem))
+ (export "tab" (table $tab))
+ (export "glob" (global $glob))
+ (export "e" (event $e))
+)
+Keeping: <none>
+After:
+(module
+ (type $i32_=>_none (func (param i32)))
+ (memory $mem (shared 3 42))
+ (table $tab 3 42 funcref)
+ (global $glob (mut i32) (i32.const 7))
+ (event $e (attr 0) (param i32))
+ (export "mem" (memory $mem))
+ (export "tab" (table $tab))
+ (export "glob" (global $glob))
+ (export "e" (event $e))
+)
+Secondary:
+(module
+ (type $i32_=>_none (func (param i32)))
+ (import "primary" "mem" (memory $mem (shared 3 42)))
+ (import "primary" "tab" (table $tab 3 42 funcref))
+ (import "primary" "glob" (global $glob (mut i32)))
+ (import "primary" "e" (event $e (attr 0) (param i32)))
+)
+
+
+Before:
+(module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (func $foo (param $0 i32) (result i32)
   (local.get $0)
  )
+)
+Keeping: foo
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Secondary:
+(module
 )
 
 
@@ -66,28 +135,17 @@ Before:
   (local.get $0)
  )
 )
+Keeping: foo
 After:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
- (table $0 1 funcref)
- (elem (i32.const 0) $placeholder_0)
  (export "foo" (func $foo))
  (func $foo (param $0 i32) (result i32)
-  (call_indirect (type $i32_=>_i32)
-   (local.get $0)
-   (i32.const 0)
-  )
+  (local.get $0)
  )
 )
 Secondary:
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (table $0 1 funcref)
- (elem (i32.const 0) $foo)
- (func $foo (param $0 i32) (result i32)
-  (local.get $0)
- )
 )
 
 
@@ -96,25 +154,139 @@ Before:
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (table $table 1 funcref)
  (elem (i32.const 0) $foo)
- (export "foo" (func $foo))
  (func $foo (param $0 i32) (result i32)
   (local.get $0)
  )
 )
+Keeping: foo
 After:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
  (table $table 1 funcref)
- (elem (i32.const 0) $placeholder_0)
- (export "foo" (func $foo))
+ (elem (i32.const 0) $foo)
  (export "table" (table $table))
  (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Secondary:
+(module
+ (import "primary" "table" (table $table 1 funcref))
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "foo" (func $foo (param i32) (result i32)))
+)
+Keeping: foo
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "foo" (func $foo (param i32) (result i32)))
+)
+Secondary:
+(module
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "foo" (func $foo (param i32) (result i32)))
+ (table $table 1000 funcref)
+ (elem (i32.const 42) $foo)
+ (export "foo" (func $foo))
+)
+Keeping: foo
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "foo" (func $foo (param i32) (result i32)))
+ (table $table 1000 funcref)
+ (elem (i32.const 42) $foo)
+ (export "foo" (func $foo))
+ (export "table" (table $table))
+)
+Secondary:
+(module
+ (import "primary" "table" (table $table 1000 funcref))
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Keeping: <none>
+After:
+(module
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Keeping: <none>
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "foo" (func $foo))
+ (export "table" (table $0))
+ (func $foo (param $0 i32) (result i32)
   (call_indirect (type $i32_=>_i32)
    (local.get $0)
    (i32.const 0)
   )
  )
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "primary" "table" (table $0 1 funcref))
+ (elem (i32.const 0) $foo)
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (table $table 1 funcref)
+ (elem (i32.const 0) $foo)
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Keeping: <none>
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+ (table $table 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "table" (table $table))
 )
 Secondary:
 (module
@@ -137,6 +309,7 @@ Before:
   (local.get $0)
  )
 )
+Keeping: <none>
 After:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
@@ -165,37 +338,23 @@ Secondary:
 
 Before:
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (func $foo (param $0 i32) (result i32)
-  (local.get $0)
+ (type $none_=>_none (func))
+ (func $foo
+  (call $bar)
+ )
+ (func $bar
+  (nop)
  )
 )
+Keeping: bar, foo
 After:
 (module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (func $foo (param $0 i32) (result i32)
-  (local.get $0)
+ (type $none_=>_none (func))
+ (func $foo
+  (call $bar)
  )
-)
-Secondary:
-(module
-)
-
-
-Before:
-(module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (export "foo" (func $foo))
- (func $foo (param $0 i32) (result i32)
-  (local.get $0)
- )
-)
-After:
-(module
- (type $i32_=>_i32 (func (param i32) (result i32)))
- (export "foo" (func $foo))
- (func $foo (param $0 i32) (result i32)
-  (local.get $0)
+ (func $bar
+  (nop)
  )
 )
 Secondary:
@@ -207,26 +366,88 @@ Before:
 (module
  (type $none_=>_none (func))
  (func $foo
-  (nop)
+  (call $bar)
  )
  (func $bar
-  (call $foo)
+  (nop)
  )
 )
+Keeping: bar
 After:
 (module
  (type $none_=>_none (func))
- (export "foo" (func $foo))
- (func $foo
+ (export "bar" (func $bar))
+ (func $bar
   (nop)
  )
 )
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "foo" (func $foo))
+ (import "primary" "bar" (func $bar))
+ (func $foo
+  (call $bar)
+ )
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (func $foo
+  (call $bar)
+ )
  (func $bar
-  (call $foo)
+  (nop)
+ )
+)
+Keeping: foo
+After:
+(module
+ (type $none_=>_none (func))
+ (import "placeholder" "0" (func $placeholder_0))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "table" (table $0))
+ (func $foo
+  (call_indirect (type $none_=>_none)
+   (i32.const 0)
+  )
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (import "primary" "table" (table $0 1 funcref))
+ (elem (i32.const 0) $bar)
+ (func $bar
+  (nop)
+ )
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (func $foo
+  (call $bar)
+ )
+ (func $bar
+  (nop)
+ )
+)
+Keeping: <none>
+After:
+(module
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (func $bar
+  (nop)
+ )
+ (func $foo
+  (call $bar)
  )
 )
 
@@ -242,6 +463,7 @@ Before:
   (call $foo)
  )
 )
+Keeping: foo
 After:
 (module
  (type $none_=>_none (func))
@@ -250,6 +472,7 @@ After:
  (elem (i32.const 0) $placeholder_0)
  (export "foo" (func $bar))
  (export "foo_0" (func $foo))
+ (export "table" (table $0))
  (func $foo
   (nop)
  )
@@ -262,44 +485,11 @@ After:
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "foo_0" (func $foo))
- (table $0 1 funcref)
+ (import "primary" "table" (table $0 1 funcref))
  (elem (i32.const 0) $bar)
+ (import "primary" "foo_0" (func $foo))
  (func $bar
   (call $foo)
- )
-)
-
-
-Before:
-(module
- (type $none_=>_none (func))
- (func $foo
-  (nop)
- )
- (func $bar
-  (call $foo)
- )
-)
-After:
-(module
- (type $none_=>_none (func))
- (import "placeholder" "0" (func $placeholder_0))
- (table $0 1 funcref)
- (elem (i32.const 0) $placeholder_0)
- (func $bar
-  (call_indirect (type $none_=>_none)
-   (i32.const 0)
-  )
- )
-)
-Secondary:
-(module
- (type $none_=>_none (func))
- (table $0 1 funcref)
- (elem (i32.const 0) $foo)
- (func $foo
-  (nop)
  )
 )
 
@@ -322,6 +512,7 @@ Before:
   (nop)
  )
 )
+Keeping: bar, quux
 After:
 (module
  (type $none_=>_none (func))
@@ -370,6 +561,7 @@ Before:
   (nop)
  )
 )
+Keeping: baz
 After:
 (module
  (type $none_=>_none (func))
@@ -417,14 +609,15 @@ Before:
   )
  )
 )
+Keeping: foo
 After:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "placeholder" "1" (func $placeholder_1 (param i32) (result i32)))
  (table $table 2 2 funcref)
  (elem (i32.const 0) $foo $placeholder_1)
- (export "table" (table $table))
  (export "foo" (func $foo))
+ (export "table" (table $table))
  (func $foo (param $0 i32) (result i32)
   (call_indirect (type $i32_=>_i32)
    (i32.const 0)

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -26,18 +26,18 @@ After:
  (table $tab 3 42 funcref)
  (global $glob (mut i32) (i32.const 7))
  (event $e (attr 0) (param i32))
- (export "memory" (memory $mem))
- (export "table" (table $tab))
- (export "global" (global $glob))
- (export "event" (event $e))
+ (export "%memory" (memory $mem))
+ (export "%table" (table $tab))
+ (export "%global" (global $glob))
+ (export "%event" (event $e))
 )
 Secondary:
 (module
  (type $i32_=>_none (func (param i32)))
- (import "primary" "memory" (memory $mem (shared 3 42)))
- (import "primary" "table" (table $tab 3 42 funcref))
- (import "primary" "global" (global $glob (mut i32)))
- (import "primary" "event" (event $e (attr 0) (param i32)))
+ (import "primary" "%memory" (memory $mem (shared 3 42)))
+ (import "primary" "%table" (table $tab 3 42 funcref))
+ (import "primary" "%global" (global $glob (mut i32)))
+ (import "primary" "%event" (event $e (attr 0) (param i32)))
 )
 
 
@@ -57,18 +57,18 @@ After:
  (import "env" "tab" (table $tab 3 42 funcref))
  (import "env" "glob" (global $glob (mut i32)))
  (import "env" "e" (event $e (attr 0) (param i32)))
- (export "memory" (memory $mem))
- (export "table" (table $tab))
- (export "global" (global $glob))
- (export "event" (event $e))
+ (export "%memory" (memory $mem))
+ (export "%table" (table $tab))
+ (export "%global" (global $glob))
+ (export "%event" (event $e))
 )
 Secondary:
 (module
  (type $i32_=>_none (func (param i32)))
- (import "primary" "memory" (memory $mem (shared 3 42)))
- (import "primary" "table" (table $tab 3 42 funcref))
- (import "primary" "global" (global $glob (mut i32)))
- (import "primary" "event" (event $e (attr 0) (param i32)))
+ (import "primary" "%memory" (memory $mem (shared 3 42)))
+ (import "primary" "%table" (table $tab 3 42 funcref))
+ (import "primary" "%global" (global $glob (mut i32)))
+ (import "primary" "%event" (event $e (attr 0) (param i32)))
 )
 
 
@@ -164,14 +164,14 @@ After:
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (table $table 1 funcref)
  (elem (i32.const 0) $foo)
- (export "table" (table $table))
+ (export "%table" (table $table))
  (func $foo (param $0 i32) (result i32)
   (local.get $0)
  )
 )
 Secondary:
 (module
- (import "primary" "table" (table $table 1 funcref))
+ (import "primary" "%table" (table $table 1 funcref))
 )
 
 
@@ -207,11 +207,11 @@ After:
  (table $table 1000 funcref)
  (elem (i32.const 42) $foo)
  (export "foo" (func $foo))
- (export "table" (table $table))
+ (export "%table" (table $table))
 )
 Secondary:
 (module
- (import "primary" "table" (table $table 1000 funcref))
+ (import "primary" "%table" (table $table 1000 funcref))
 )
 
 
@@ -251,7 +251,7 @@ After:
  (table $0 1 funcref)
  (elem (i32.const 0) $placeholder_0)
  (export "foo" (func $foo))
- (export "table" (table $0))
+ (export "%table" (table $0))
  (func $foo (param $0 i32) (result i32)
   (call_indirect (type $i32_=>_i32)
    (local.get $0)
@@ -262,7 +262,7 @@ After:
 Secondary:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "primary" "table" (table $0 1 funcref))
+ (import "primary" "%table" (table $0 1 funcref))
  (elem (i32.const 0) $foo)
  (func $foo (param $0 i32) (result i32)
   (local.get $0)
@@ -286,12 +286,12 @@ After:
  (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
  (table $table 1 funcref)
  (elem (i32.const 0) $placeholder_0)
- (export "table" (table $table))
+ (export "%table" (table $table))
 )
 Secondary:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "primary" "table" (table $table 1 funcref))
+ (import "primary" "%table" (table $table 1 funcref))
  (elem (i32.const 0) $foo)
  (func $foo (param $0 i32) (result i32)
   (local.get $0)
@@ -317,7 +317,7 @@ After:
  (table $table 1000 funcref)
  (elem (i32.const 42) $placeholder_42)
  (export "foo" (func $foo))
- (export "table" (table $table))
+ (export "%table" (table $table))
  (func $foo (param $0 i32) (result i32)
   (call_indirect (type $i32_=>_i32)
    (local.get $0)
@@ -328,7 +328,7 @@ After:
 Secondary:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "primary" "table" (table $table 1000 funcref))
+ (import "primary" "%table" (table $table 1000 funcref))
  (elem (i32.const 42) $foo)
  (func $foo (param $0 i32) (result i32)
   (local.get $0)
@@ -376,7 +376,7 @@ Keeping: bar
 After:
 (module
  (type $none_=>_none (func))
- (export "bar" (func $bar))
+ (export "%bar" (func $bar))
  (func $bar
   (nop)
  )
@@ -384,7 +384,7 @@ After:
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "bar" (func $bar))
+ (import "primary" "%bar" (func $bar))
  (func $foo
   (call $bar)
  )
@@ -408,7 +408,7 @@ After:
  (import "placeholder" "0" (func $placeholder_0))
  (table $0 1 funcref)
  (elem (i32.const 0) $placeholder_0)
- (export "table" (table $0))
+ (export "%table" (table $0))
  (func $foo
   (call_indirect (type $none_=>_none)
    (i32.const 0)
@@ -418,7 +418,7 @@ After:
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "table" (table $0 1 funcref))
+ (import "primary" "%table" (table $0 1 funcref))
  (elem (i32.const 0) $bar)
  (func $bar
   (nop)
@@ -455,7 +455,7 @@ Secondary:
 Before:
 (module
  (type $none_=>_none (func))
- (export "foo" (func $bar))
+ (export "%foo" (func $bar))
  (func $foo
   (nop)
  )
@@ -470,9 +470,9 @@ After:
  (import "placeholder" "0" (func $placeholder_0))
  (table $0 1 funcref)
  (elem (i32.const 0) $placeholder_0)
- (export "foo" (func $bar))
- (export "foo_0" (func $foo))
- (export "table" (table $0))
+ (export "%foo" (func $bar))
+ (export "%foo_0" (func $foo))
+ (export "%table" (table $0))
  (func $foo
   (nop)
  )
@@ -485,9 +485,9 @@ After:
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "table" (table $0 1 funcref))
+ (import "primary" "%table" (table $0 1 funcref))
  (elem (i32.const 0) $bar)
- (import "primary" "foo_0" (func $foo))
+ (import "primary" "%foo_0" (func $foo))
  (func $bar
   (call $foo)
  )
@@ -520,7 +520,7 @@ After:
  (import "placeholder" "2" (func $placeholder_2))
  (table $table 4 funcref)
  (elem (i32.const 0) $placeholder_0 $bar $placeholder_2 $quux)
- (export "table" (table $table))
+ (export "%table" (table $table))
  (func $bar
   (nop)
  )
@@ -531,7 +531,7 @@ After:
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "table" (table $table 4 funcref))
+ (import "primary" "%table" (table $table 4 funcref))
  (elem (i32.const 0) $foo)
  (elem (i32.const 2) $baz)
  (func $baz
@@ -570,7 +570,7 @@ After:
  (import "placeholder" "3" (func $placeholder_3))
  (table $table 4 funcref)
  (elem (i32.const 0) $placeholder_0 $placeholder_1 $baz $placeholder_3)
- (export "table" (table $table))
+ (export "%table" (table $table))
  (func $baz
   (nop)
  )
@@ -578,7 +578,7 @@ After:
 Secondary:
 (module
  (type $none_=>_none (func))
- (import "primary" "table" (table $table 4 funcref))
+ (import "primary" "%table" (table $table 4 funcref))
  (elem (i32.const 0) $foo $bar)
  (elem (i32.const 3) $quux)
  (func $bar
@@ -616,8 +616,8 @@ After:
  (import "placeholder" "1" (func $placeholder_1 (param i32) (result i32)))
  (table $table 2 2 funcref)
  (elem (i32.const 0) $foo $placeholder_1)
- (export "foo" (func $foo))
- (export "table" (table $table))
+ (export "%foo" (func $foo))
+ (export "%table" (table $table))
  (func $foo (param $0 i32) (result i32)
   (call_indirect (type $i32_=>_i32)
    (i32.const 0)
@@ -628,9 +628,9 @@ After:
 Secondary:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "primary" "table" (table $table 2 2 funcref))
+ (import "primary" "%table" (table $table 2 2 funcref))
  (elem (i32.const 1) $bar)
- (import "primary" "foo" (func $foo (param i32) (result i32)))
+ (import "primary" "%foo" (func $foo (param i32) (result i32)))
  (func $bar (param $0 i32) (result i32)
   (call $foo
    (i32.const 1)

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -1,0 +1,66 @@
+;; Test module splitting
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (memory $mem 0 0)
+ (table $table 2 2 funcref)
+ (elem (i32.const 0) $foo $bar)
+ (export "bar" (func $bar))
+ (func $foo (param $0 i32) (result i32)
+  (drop
+   (call $bar
+    (i32.const 0)
+   )
+  )
+ )
+ (func $bar (param $0 i32) (result i32)
+  (drop
+   (call $foo
+    (i32.const 1)
+   )
+  )
+ )
+)
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "placeholder" "1" (func $placeholder_1 (param i32) (result i32)))
+ (memory $mem 0 0)
+ (table $table 2 2 funcref)
+ (elem (i32.const 0) $foo $placeholder_1)
+ (export "bar" (func $bar))
+ (export "memory" (memory $mem))
+ (export "table" (table $table))
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (drop
+   (call_indirect (type $i32_=>_i32)
+    (i32.const 0)
+    (i32.const 1)
+   )
+  )
+ )
+ (func $bar (param $0 i32) (result i32)
+  (call_indirect (type $i32_=>_i32)
+   (local.get $0)
+   (i32.const 1)
+  )
+ )
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "primary" "memory" (memory $mem 0 0))
+ (import "primary" "table" (table $table 2 2 funcref))
+ (elem (i32.const 1) $bar)
+ (import "primary" "foo" (func $foo (param i32) (result i32)))
+ (func $bar (param $0 i32) (result i32)
+  (drop
+   (call $foo
+    (i32.const 1)
+   )
+  )
+ )
+)
+
+

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -1,23 +1,419 @@
-;; Test module splitting
+Before:
+(module
+)
+After:
+(module
+)
+Secondary:
+(module
+)
+
+
+Before:
+(module
+ (type $i32_=>_none (func (param i32)))
+ (memory $mem (shared 3 42))
+ (table $table 3 42 funcref)
+ (global $glob (mut i32) (i32.const 7))
+ (event $e (attr 0) (param i32))
+)
+After:
+(module
+ (type $i32_=>_none (func (param i32)))
+ (memory $mem (shared 3 42))
+ (table $table 3 42 funcref)
+ (global $glob (mut i32) (i32.const 7))
+ (event $e (attr 0) (param i32))
+ (export "memory" (memory $mem))
+ (export "table" (table $table))
+ (export "global" (global $glob))
+ (export "event" (event $e))
+)
+Secondary:
+(module
+ (type $i32_=>_none (func (param i32)))
+ (import "primary" "memory" (memory $mem (shared 3 42)))
+ (import "primary" "table" (table $table 3 42 funcref))
+ (import "primary" "global" (global $glob (mut i32)))
+ (import "primary" "event" (event $e (attr 0) (param i32)))
+)
+
+
 Before:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (memory $mem 0 0)
- (table $table 2 2 funcref)
- (elem (i32.const 0) $foo $bar)
- (export "bar" (func $bar))
  (func $foo (param $0 i32) (result i32)
-  (drop
-   (call $bar
-    (i32.const 0)
-   )
+  (local.get $0)
+ )
+)
+After:
+(module
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (call_indirect (type $i32_=>_i32)
+   (local.get $0)
+   (i32.const 0)
+  )
+ )
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $foo)
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (table $table 1 funcref)
+ (elem (i32.const 0) $foo)
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+ (table $table 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "foo" (func $foo))
+ (export "table" (table $table))
+ (func $foo (param $0 i32) (result i32)
+  (call_indirect (type $i32_=>_i32)
+   (local.get $0)
+   (i32.const 0)
+  )
+ )
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "primary" "table" (table $table 1 funcref))
+ (elem (i32.const 0) $foo)
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (table $table 1000 funcref)
+ (elem (i32.const 42) $foo)
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "placeholder" "42" (func $placeholder_42 (param i32) (result i32)))
+ (table $table 1000 funcref)
+ (elem (i32.const 42) $placeholder_42)
+ (export "foo" (func $foo))
+ (export "table" (table $table))
+ (func $foo (param $0 i32) (result i32)
+  (call_indirect (type $i32_=>_i32)
+   (local.get $0)
+   (i32.const 42)
+  )
+ )
+)
+Secondary:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "primary" "table" (table $table 1000 funcref))
+ (elem (i32.const 42) $foo)
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Secondary:
+(module
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+After:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (export "foo" (func $foo))
+ (func $foo (param $0 i32) (result i32)
+  (local.get $0)
+ )
+)
+Secondary:
+(module
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (func $foo
+  (nop)
+ )
+ (func $bar
+  (call $foo)
+ )
+)
+After:
+(module
+ (type $none_=>_none (func))
+ (export "foo" (func $foo))
+ (func $foo
+  (nop)
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (import "primary" "foo" (func $foo))
+ (func $bar
+  (call $foo)
+ )
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (export "foo" (func $bar))
+ (func $foo
+  (nop)
+ )
+ (func $bar
+  (call $foo)
+ )
+)
+After:
+(module
+ (type $none_=>_none (func))
+ (import "placeholder" "0" (func $placeholder_0))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "foo" (func $bar))
+ (export "foo_0" (func $foo))
+ (func $foo
+  (nop)
+ )
+ (func $bar
+  (call_indirect (type $none_=>_none)
+   (i32.const 0)
+  )
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (import "primary" "foo_0" (func $foo))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $bar)
+ (func $bar
+  (call $foo)
+ )
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (func $foo
+  (nop)
+ )
+ (func $bar
+  (call $foo)
+ )
+)
+After:
+(module
+ (type $none_=>_none (func))
+ (import "placeholder" "0" (func $placeholder_0))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (func $bar
+  (call_indirect (type $none_=>_none)
+   (i32.const 0)
+  )
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $foo)
+ (func $foo
+  (nop)
+ )
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (table $table 4 funcref)
+ (elem (i32.const 0) $foo $bar $baz $quux)
+ (func $foo
+  (nop)
+ )
+ (func $bar
+  (nop)
+ )
+ (func $baz
+  (nop)
+ )
+ (func $quux
+  (nop)
+ )
+)
+After:
+(module
+ (type $none_=>_none (func))
+ (import "placeholder" "0" (func $placeholder_0))
+ (import "placeholder" "2" (func $placeholder_2))
+ (table $table 4 funcref)
+ (elem (i32.const 0) $placeholder_0 $bar $placeholder_2 $quux)
+ (export "table" (table $table))
+ (func $bar
+  (nop)
+ )
+ (func $quux
+  (nop)
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (import "primary" "table" (table $table 4 funcref))
+ (elem (i32.const 0) $foo)
+ (elem (i32.const 2) $baz)
+ (func $baz
+  (nop)
+ )
+ (func $foo
+  (nop)
+ )
+)
+
+
+Before:
+(module
+ (type $none_=>_none (func))
+ (table $table 4 funcref)
+ (elem (i32.const 0) $foo $bar $baz $quux)
+ (func $foo
+  (nop)
+ )
+ (func $bar
+  (nop)
+ )
+ (func $baz
+  (nop)
+ )
+ (func $quux
+  (nop)
+ )
+)
+After:
+(module
+ (type $none_=>_none (func))
+ (import "placeholder" "0" (func $placeholder_0))
+ (import "placeholder" "1" (func $placeholder_1))
+ (import "placeholder" "3" (func $placeholder_3))
+ (table $table 4 funcref)
+ (elem (i32.const 0) $placeholder_0 $placeholder_1 $baz $placeholder_3)
+ (export "table" (table $table))
+ (func $baz
+  (nop)
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (import "primary" "table" (table $table 4 funcref))
+ (elem (i32.const 0) $foo $bar)
+ (elem (i32.const 3) $quux)
+ (func $bar
+  (nop)
+ )
+ (func $foo
+  (nop)
+ )
+ (func $quux
+  (nop)
+ )
+)
+
+
+Before:
+(module
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (table $table 1 1 funcref)
+ (elem (i32.const 0) $foo)
+ (func $foo (param $0 i32) (result i32)
+  (call $bar
+   (i32.const 0)
   )
  )
  (func $bar (param $0 i32) (result i32)
-  (drop
-   (call $foo
-    (i32.const 1)
-   )
+  (call $foo
+   (i32.const 1)
   )
  )
 )
@@ -25,24 +421,13 @@ After:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (import "placeholder" "1" (func $placeholder_1 (param i32) (result i32)))
- (memory $mem 0 0)
  (table $table 2 2 funcref)
  (elem (i32.const 0) $foo $placeholder_1)
- (export "bar" (func $bar))
- (export "memory" (memory $mem))
  (export "table" (table $table))
  (export "foo" (func $foo))
  (func $foo (param $0 i32) (result i32)
-  (drop
-   (call_indirect (type $i32_=>_i32)
-    (i32.const 0)
-    (i32.const 1)
-   )
-  )
- )
- (func $bar (param $0 i32) (result i32)
   (call_indirect (type $i32_=>_i32)
-   (local.get $0)
+   (i32.const 0)
    (i32.const 1)
   )
  )
@@ -50,15 +435,12 @@ After:
 Secondary:
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (import "primary" "memory" (memory $mem 0 0))
  (import "primary" "table" (table $table 2 2 funcref))
  (elem (i32.const 1) $bar)
  (import "primary" "foo" (func $foo (param i32) (result i32)))
  (func $bar (param $0 i32) (result i32)
-  (drop
-   (call $foo
-    (i32.const 1)
-   )
+  (call $foo
+   (i32.const 1)
   )
  )
 )


### PR DESCRIPTION
Adds the capability to programatically split a module into a primary and
secondary module such that the primary module can be compiled and run before the
secondary module has been instantiated. All calls to secondary functions (i.e.
functions that have been split out into the secondary module) in the primary
module are rewritten to be indirect calls through the table. Initially, the
table slots of all secondary functions contain references to imported
placeholder functions. When the secondary module is instantiated, it will
automatically patch the table to insert references to the original functions.

The process of module splitting involves these steps:

 1. Create the new secondary module.

 2. Export globals, events, tables, and memories from the primary module and
    import them in the secondary module.

 3. Move the deferred functions from the primary to the secondary module.

 4. For any secondary function exported from the primary module, export in
    its place a trampoline function that makes an indirect call to its
    placeholder function (and eventually to the original secondary function),
    allocating a new table slot for the placeholder if necessary.

 5. Rewrite direct calls from primary functions to secondary functions to be
    indirect calls to their placeholder functions (and eventually to their
    original secondary functions), allocating new table slots for the
    placeholders if necessary.

 6. For each primary function directly called from a secondary function, export
    the primary function if it is not already exported and import it into the
    secondary module.

 7. Replace all references to secondary functions in the primary module's table
    segments with references to imported placeholder functions.

 8. Create new active table segments in the secondary module that will replace
    all the placeholder function references in the table with references to
    their corresponding secondary functions upon instantiation.

Functions can be used or referenced three ways in a WebAssembly module: they can
be exported, called, or placed in a table. The above procedure introduces a
layer of indirection to each of those mechanisms that removes all references to
secondary functions from the primary module but restores the original program's
semantics once the secondary module is instantiated. As more mechanisms that
reference functions are added in the future, such as ref.func instructions, they
will have to be modified to use a similar layer of indirection.

The code as currently written makes a few assumptions about the module that is
being split:

 1. It assumes that mutable-globals is allowed. This could be worked around by
    introducing wrapper functions for globals and rewriting secondary code that
    accesses them, but now that mutable-globals is shipped on all browsers,
    hopefully that extra complexity won't be necessary.

 2. It assumes that all table segment offsets are constants. This simplifies the
    generation of segments to actively patch in the secondary functions without
    overwriting any other table slots. This assumption could be relaxed by 1)
    having secondary segments re-write primary function slots as well, 2)
    allowing addition in segment offsets, or 3) synthesizing a start function to
    modify the table instead of using segments.

 3. It assumes that each function appears in the table at most once. This isn't
    necessarily true in general or even for LLVM output after function
    deduplication. Relaxing this assumption would just require slightly more
    complex code, so it is a good candidate for a follow up PR.

Future Binaryen work for this feature includes providing a command line tool
exposing this functionality as well as C API, JS API, and fuzzer support. We
will also want to provide a simple instrumentation pass for finding dead or
late-executing functions that would be good candidates for splitting out. It
would also be good to integrate that instrumentation with future function
outlining work so that dead or exceptional basic blocks could be split out into
a separate module.