### PR TITLE
Remove OptimizeCalls from PostEmscripten. 

### DIFF
--- a/src/asmjs/shared-constants.cpp
+++ b/src/asmjs/shared-constants.cpp
@@ -51,7 +51,6 @@ cashew::IString I32S_DIV("i32s-div");
 cashew::IString I32U_DIV("i32u-div");
 cashew::IString I32S_REM("i32s-rem");
 cashew::IString I32U_REM("i32u-rem");
-cashew::IString GLOBAL_MATH("global.Math");
 cashew::IString ABS("abs");
 cashew::IString FLOOR("floor");
 cashew::IString CEIL("ceil");

--- a/src/asmjs/shared-constants.h
+++ b/src/asmjs/shared-constants.h
@@ -54,7 +54,6 @@ extern cashew::IString I32S_DIV;
 extern cashew::IString I32U_DIV;
 extern cashew::IString I32S_REM;
 extern cashew::IString I32U_REM;
-extern cashew::IString GLOBAL_MATH;
 extern cashew::IString ABS;
 extern cashew::IString FLOOR;
 extern cashew::IString CEIL;

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -41,46 +41,10 @@ static bool isInvoke(Function* F) {
   return F->imported() && F->module == ENV && F->base.startsWith("invoke_");
 }
 
-struct OptimizeCalls : public WalkerPass<PostWalker<OptimizeCalls>> {
-  bool isFunctionParallel() override { return true; }
-
-  Pass* create() override { return new OptimizeCalls; }
-
-  void visitCall(Call* curr) {
-    // special asm.js imports can be optimized
-    auto* func = getModule()->getFunction(curr->target);
-    if (!func->imported()) {
-      return;
-    }
-    if (func->module == GLOBAL_MATH) {
-      if (func->base == POW) {
-        if (auto* exponent = curr->operands[1]->dynCast<Const>()) {
-          if (exponent->value == Literal(double(2.0))) {
-            // This is just a square operation, do a multiply
-            Localizer localizer(curr->operands[0], getFunction(), getModule());
-            Builder builder(*getModule());
-            replaceCurrent(builder.makeBinary(
-              MulFloat64,
-              localizer.expr,
-              builder.makeLocalGet(localizer.index, localizer.expr->type)));
-          } else if (exponent->value == Literal(double(0.5))) {
-            // This is just a square root operation
-            replaceCurrent(
-              Builder(*getModule()).makeUnary(SqrtFloat64, curr->operands[0]));
-          }
-        }
-      }
-    }
-  }
-};
-
 } // namespace
 
 struct PostEmscripten : public Pass {
   void run(PassRunner* runner, Module* module) override {
-    // Optimize calls
-    OptimizeCalls().run(runner, module);
-
     // Optimize exceptions
     optimizeExceptions(runner, module);
   }

--- a/test/passes/post-emscripten.txt
+++ b/test/passes/post-emscripten.txt
@@ -2,83 +2,19 @@
  (type $i32_f32_=>_none (func (param i32 f32)))
  (type $none_=>_none (func))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
- (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
- (import "global.Math" "pow" (func $Math_pow (param f64 f64) (result f64)))
  (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
  (memory $0 256 256)
  (table $0 7 7 funcref)
- (elem (i32.const 0) $pow2 $pow.2 $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
- (func $pow2
-  (local $x f64)
-  (local $y f64)
-  (local $2 f64)
-  (local $3 f64)
-  (drop
-   (f64.mul
-    (local.tee $2
-     (f64.const 1)
-    )
-    (local.get $2)
-   )
-  )
-  (drop
-   (call $Math_pow
-    (f64.const 1)
-    (f64.const 3)
-   )
-  )
-  (drop
-   (call $Math_pow
-    (f64.const 2)
-    (f64.const 1)
-   )
-  )
-  (local.set $x
-   (f64.const 5)
-  )
-  (drop
-   (f64.mul
-    (local.get $x)
-    (local.get $x)
-   )
-  )
-  (drop
-   (f64.mul
-    (local.tee $y
-     (f64.const 7)
-    )
-    (local.get $y)
-   )
-  )
-  (drop
-   (f64.mul
-    (local.tee $3
-     (f64.const 8)
-    )
-    (local.get $3)
-   )
-  )
- )
- (func $pow.2
-  (drop
-   (f64.sqrt
-    (f64.const 1)
-   )
-  )
-  (drop
-   (call $Math_pow
-    (f64.const 1)
-    (f64.const 0.51)
-   )
-  )
+ (elem (i32.const 0) $f1 $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
+ (func $f1
+  (nop)
  )
  (func $exc
   (call $other_safe
    (i32.const 42)
    (f32.const 3.141590118408203)
   )
-  (call $invoke_vif
-   (i32.const 4)
+  (call $other_unsafe
    (i32.const 55)
    (f32.const 2.1828181743621826)
   )
@@ -86,8 +22,7 @@
    (i32.const 100)
    (f32.const 1.1109999418258667)
   )
-  (call $invoke_vif
-   (i32.const 6)
+  (call $deep_unsafe
    (i32.const 999)
    (f32.const 1.4140000343322754)
   )
@@ -104,12 +39,7 @@
   (nop)
  )
  (func $other_unsafe (param $0 i32) (param $1 f32)
-  (drop
-   (call $Math_pow
-    (f64.const 1)
-    (f64.const 3)
-   )
-  )
+  (nop)
  )
  (func $deep_safe (param $0 i32) (param $1 f32)
   (call $other_safe
@@ -134,9 +64,7 @@
  (type $none_=>_none (func))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
- (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
  (import "env" "glob" (global $glob i32))
- (import "global.Math" "pow" (func $Math_pow (param f64 f64) (result f64)))
  (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
  (memory $0 256 256)
  (table $0 7 7 funcref)
@@ -156,9 +84,7 @@
  (type $none_=>_none (func))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
  (type $i32_f32_=>_none (func (param i32 f32)))
- (type $f64_f64_=>_f64 (func (param f64 f64) (result f64)))
  (import "env" "glob" (global $glob i32))
- (import "global.Math" "pow" (func $Math_pow (param f64 f64) (result f64)))
  (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
  (memory $0 256 256)
  (table $0 7 7 funcref)

--- a/test/passes/post-emscripten.wast
+++ b/test/passes/post-emscripten.wast
@@ -1,83 +1,28 @@
 (module
   (type $0 (func (param i32)))
-  (import "global.Math" "pow" (func $Math_pow (param f64 f64) (result f64)))
   (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
   (memory 256 256)
   (table 7 7 funcref)
-  (elem (i32.const 0) $pow2 $pow.2 $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
-  (func $pow2
-    (local $x f64)
-    (local $y f64)
-    (drop
-      (call $Math_pow
-        (f64.const 1)
-        (f64.const 2)
-      )
-    )
-    (drop
-      (call $Math_pow
-        (f64.const 1)
-        (f64.const 3)
-      )
-    )
-    (drop
-      (call $Math_pow
-        (f64.const 2)
-        (f64.const 1)
-      )
-    )
-    (local.set $x (f64.const 5))
-    (drop
-      (call $Math_pow
-        (local.get $x)
-        (f64.const 2)
-      )
-    )
-    (drop
-      (call $Math_pow
-        (local.tee $y (f64.const 7))
-        (f64.const 2)
-      )
-    )
-    (drop
-      (call $Math_pow
-        (f64.const 8)
-        (f64.const 2)
-      )
-    )
-  )
-  (func $pow.2
-    (drop
-      (call $Math_pow
-        (f64.const 1)
-        (f64.const 0.5)
-      )
-    )
-    (drop
-      (call $Math_pow
-        (f64.const 1)
-        (f64.const 0.51)
-      )
-    )
-  )
+  (elem (i32.const 0) $f1 $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
+  (func $f1)
   (func $exc
     (call $invoke_vif
-      (i32.const 3) ;; other_safe()
+      (i32.const 2) ;; other_safe()
       (i32.const 42)
       (f32.const 3.14159)
     )
     (call $invoke_vif
-      (i32.const 4) ;; other_unsafe()
+      (i32.const 3) ;; other_unsafe()
       (i32.const 55)
       (f32.const 2.18281828)
     )
     (call $invoke_vif
-      (i32.const 5) ;; deep_safe()
+      (i32.const 4) ;; deep_safe()
       (i32.const 100)
       (f32.const 1.111)
     )
     (call $invoke_vif
-      (i32.const 6) ;; deep_unsafe()
+      (i32.const 5) ;; deep_unsafe()
       (i32.const 999)
       (f32.const 1.414)
     )
@@ -90,12 +35,6 @@
   (func $other_safe (param i32) (param f32)
   )
   (func $other_unsafe (param i32) (param f32)
-    (drop
-      (call $Math_pow
-        (f64.const 1)
-        (f64.const 3)
-      )
-    )
   )
   (func $deep_safe (param i32) (param f32)
     (call $other_safe (unreachable) (unreachable))
@@ -111,7 +50,6 @@
 )
 (module ;; non-constant base for elem
   (type $0 (func (param i32)))
-  (import "global.Math" "pow" (func $Math_pow (param f64 f64) (result f64)))
   (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
   (import "env" "glob" (global $glob i32)) ;; non-constant table offset
   (memory 256 256)
@@ -129,7 +67,6 @@
 )
 (module ;; indirect call in the invoke target, which we assume might throw
   (type $none_=>_none (func))
-  (import "global.Math" "pow" (func $Math_pow (param f64 f64) (result f64)))
   (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
   (import "env" "glob" (global $glob i32)) ;; non-constant table offset
   (memory 256 256)


### PR DESCRIPTION
We no longer build modules that import `global.Math`.