### PR TITLE
build/linux: more correct rpath handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ function(binaryen_setup_rpath name)
     set(_install_name_dir INSTALL_NAME_DIR "@rpath")
     set(_install_rpath "@loader_path/../lib")
   elseif(UNIX)
-    set(_install_rpath "\$ORIGIN/../lib")
+    set(_install_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
     if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
       set_property(TARGET ${name} APPEND_STRING PROPERTY
                    LINK_FLAGS " -Wl,-z,origin ")


### PR DESCRIPTION
Don't hardcode `lib`, it's incorrect for many systems (e.g. `lib64` is common on some x86_64 distros like openSUSE). Use `CMAKE_INSTALL_LIBDIR` instead.

The `APPLE` branch may need the same change, but I don't have any apple systems to confirm this, so I left it as-is.