### PR TITLE
[Fuzzer] Add a chance to pick particularly important initial contents

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -169,6 +169,13 @@ def randomize_fuzz_settings():
     print('randomized settings (NaNs, OOB, legalize, extra V8_OPTS):', NANS, OOB, LEGALIZE, extra_v8_opts)
 
 
+IMPORTANT_INITIAL_CONTENTS = [
+    os.path.join('passes', 'optimize-instructions_all-features.wast'),
+    os.path.join('passes', 'optimize-instructions_fuzz-exec.wast'),
+]
+IMPORTANT_INITIAL_CONTENTS = [os.path.join(shared.get_test_dir('.'), t) for t in IMPORTANT_INITIAL_CONTENTS]
+
+
 def pick_initial_contents():
     # if we use an initial wasm file's contents as the basis for the
     # fuzzing, then that filename, or None if we start entirely from scratch
@@ -178,7 +185,12 @@ def pick_initial_contents():
     # half the time don't use any initial contents
     if random.random() < 0.5:
         return
-    test_name = random.choice(all_tests)
+    # some of the time use initial contents that are known to be especially
+    # important
+    if random.random() < 0.5:
+        test_name = random.choice(IMPORTANT_INITIAL_CONTENTS)
+    else:
+        test_name = random.choice(all_tests)
     print('initial contents:', test_name)
     assert os.path.exists(test_name)
     # tests that check validation errors are not helpful for us

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -11,8 +11,6 @@
  (type $none_=>_i64 (func (result i64)))
  (type $i64_=>_i64 (func (param i64) (result i64)))
  (type $i32_i64_f32_=>_none (func (param i32 i64 f32)))
- (type $none_=>_anyref (func (result anyref)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_i32_f64_=>_none (func (param i32 i32 i32 f64)))
  (type $i32_i32_f64_f64_=>_none (func (param i32 i32 f64 f64)))
  (type $i32_i64_f64_i32_=>_none (func (param i32 i64 f64 i32)))
@@ -253,20 +251,6 @@
   )
   (if
    (i32.const 123)
-   (nop)
-  )
-  (if
-   (try (result i32)
-    (do
-     (i32.const 123)
-    )
-    (catch
-     (drop
-      (pop exnref)
-     )
-     (i32.const 456)
-    )
-   )
    (nop)
   )
   (drop
@@ -545,7 +529,7 @@
   )
   (drop
    (i32.and
-    (block $block4 (result i32)
+    (block $block3 (result i32)
      (i32.const -6)
     )
     (local.get $x)
@@ -553,7 +537,7 @@
   )
   (drop
    (i32.and
-    (block $block5 (result i32)
+    (block $block4 (result i32)
      (i32.const 5)
     )
     (loop $loop-in (result i32)
@@ -563,20 +547,20 @@
   )
   (drop
    (i32.and
-    (block $block7 (result i32)
+    (block $block6 (result i32)
      (i32.const 8)
     )
-    (loop $loop-in6 (result i32)
+    (loop $loop-in5 (result i32)
      (i32.const 7)
     )
    )
   )
   (drop
    (i32.and
-    (block $block9 (result i32)
+    (block $block8 (result i32)
      (i32.const 10)
     )
-    (loop $loop-in8 (result i32)
+    (loop $loop-in7 (result i32)
      (call $and-pos1)
      (i32.const 9)
     )
@@ -584,34 +568,34 @@
   )
   (drop
    (i32.and
-    (block $block11 (result i32)
+    (block $block10 (result i32)
      (call $and-pos1)
      (i32.const 12)
     )
-    (loop $loop-in10 (result i32)
+    (loop $loop-in9 (result i32)
      (i32.const 11)
     )
    )
   )
   (drop
    (i32.and
-    (loop $loop-in12 (result i32)
+    (loop $loop-in11 (result i32)
      (call $and-pos1)
      (i32.const 13)
     )
+    (block $block12 (result i32)
+     (call $and-pos1)
+     (i32.const 14)
+    )
+   )
+  )
+  (drop
+   (i32.and
     (block $block13 (result i32)
      (call $and-pos1)
      (i32.const 14)
     )
-   )
-  )
-  (drop
-   (i32.and
-    (block $block14 (result i32)
-     (call $and-pos1)
-     (i32.const 14)
-    )
-    (loop $loop-in15 (result i32)
+    (loop $loop-in14 (result i32)
      (call $and-pos1)
      (i32.const 13)
     )
@@ -619,7 +603,7 @@
   )
   (drop
    (i32.and
-    (block $block16 (result i32)
+    (block $block15 (result i32)
      (i32.const 15)
     )
     (local.get $x)
@@ -627,7 +611,7 @@
   )
   (drop
    (i32.and
-    (block $block17 (result i32)
+    (block $block16 (result i32)
      (i32.const 15)
     )
     (local.get $x)
@@ -4704,16 +4688,6 @@
    (unreachable)
   )
  )
- (func $if-arms-subtype-fold (result anyref)
-  (ref.null extern)
- )
- (func $if-arms-subtype-nofold (result anyref)
-  (if (result anyref)
-   (i32.const 0)
-   (ref.null extern)
-   (ref.null func)
-  )
- )
  (func $optimize-boolean-context (param $x i32) (param $y i32)
   (if
    (local.get $x)
@@ -5012,16 +4986,6 @@
    (i32.ne
     (local.get $x)
     (i32.const 2)
-   )
-  )
-  (drop
-   (i32.extend8_s
-    (local.get $x)
-   )
-  )
-  (drop
-   (i32.extend16_s
-    (local.get $x)
    )
   )
   (drop
@@ -5335,80 +5299,6 @@
    )
   )
  )
- (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
-  (memory.copy
-   (local.get $dst)
-   (local.get $dst)
-   (local.get $sz)
-  )
-  (memory.copy
-   (local.get $dst)
-   (local.get $src)
-   (i32.const 0)
-  )
-  (i32.store8
-   (local.get $dst)
-   (i32.load8_u
-    (local.get $src)
-   )
-  )
-  (i32.store16 align=1
-   (local.get $dst)
-   (i32.load16_u align=1
-    (local.get $src)
-   )
-  )
-  (memory.copy
-   (local.get $dst)
-   (local.get $src)
-   (i32.const 3)
-  )
-  (i32.store align=1
-   (local.get $dst)
-   (i32.load align=1
-    (local.get $src)
-   )
-  )
-  (memory.copy
-   (local.get $dst)
-   (local.get $src)
-   (i32.const 5)
-  )
-  (memory.copy
-   (local.get $dst)
-   (local.get $src)
-   (i32.const 6)
-  )
-  (memory.copy
-   (local.get $dst)
-   (local.get $src)
-   (i32.const 7)
-  )
-  (i64.store align=1
-   (local.get $dst)
-   (i64.load align=1
-    (local.get $src)
-   )
-  )
-  (v128.store align=1
-   (local.get $dst)
-   (v128.load align=1
-    (local.get $src)
-   )
-  )
-  (memory.copy
-   (local.get $dst)
-   (local.get $src)
-   (local.get $sz)
-  )
-  (memory.copy
-   (i32.const 0)
-   (i32.const 0)
-   (i32.load
-    (i32.const 3)
-   )
-  )
- )
  (func $optimize-float-points (param $x0 f64) (param $x1 f64) (param $y0 f32) (param $y1 f32)
   (drop
    (f64.mul
@@ -5616,6 +5506,131 @@
     )
     (i32.const 24)
    )
+  )
+ )
+)
+(module
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (memory $0 0)
+ (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
+  (memory.copy
+   (local.get $dst)
+   (local.get $dst)
+   (local.get $sz)
+  )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (i32.const 0)
+  )
+  (i32.store8
+   (local.get $dst)
+   (i32.load8_u
+    (local.get $src)
+   )
+  )
+  (i32.store16 align=1
+   (local.get $dst)
+   (i32.load16_u align=1
+    (local.get $src)
+   )
+  )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (i32.const 3)
+  )
+  (i32.store align=1
+   (local.get $dst)
+   (i32.load align=1
+    (local.get $src)
+   )
+  )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (i32.const 5)
+  )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (i32.const 6)
+  )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (i32.const 7)
+  )
+  (i64.store align=1
+   (local.get $dst)
+   (i64.load align=1
+    (local.get $src)
+   )
+  )
+  (v128.store align=1
+   (local.get $dst)
+   (v128.load align=1
+    (local.get $src)
+   )
+  )
+  (memory.copy
+   (local.get $dst)
+   (local.get $src)
+   (local.get $sz)
+  )
+  (memory.copy
+   (i32.const 0)
+   (i32.const 0)
+   (i32.load
+    (i32.const 3)
+   )
+  )
+ )
+)
+(module
+ (type $none_=>_anyref (func (result anyref)))
+ (func $if-arms-subtype-fold (result anyref)
+  (ref.null extern)
+ )
+ (func $if-arms-subtype-nofold (result anyref)
+  (if (result anyref)
+   (i32.const 0)
+   (ref.null extern)
+   (ref.null func)
+  )
+ )
+)
+(module
+ (type $i32_i32_i32_f64_=>_none (func (param i32 i32 i32 f64)))
+ (func $duplicate-elimination (param $x i32) (param $y i32) (param $z i32) (param $w f64)
+  (drop
+   (i32.extend8_s
+    (local.get $x)
+   )
+  )
+  (drop
+   (i32.extend16_s
+    (local.get $x)
+   )
+  )
+ )
+)
+(module
+ (type $none_=>_none (func))
+ (func $test
+  (if
+   (try (result i32)
+    (do
+     (i32.const 123)
+    )
+    (catch
+     (drop
+      (pop exnref)
+     )
+     (i32.const 456)
+    )
+   )
+   (nop)
   )
  )
 )

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -284,28 +284,6 @@
       )
       (nop)
     )
-    (if
-      (try (result i32)
-        (do
-          (i32.eqz
-            (i32.eqz
-              (i32.const 123)
-            )
-          )
-        )
-        (catch
-          (drop
-            (pop exnref)
-          )
-          (i32.eqz
-            (i32.eqz
-              (i32.const 456)
-            )
-          )
-        )
-      )
-      (nop)
-    )
     (drop
       (select
         (i32.const 101)
@@ -5180,23 +5158,6 @@
       (unreachable)
     )
   )
-  ;; These functions test if an `if` with subtyped arms is correctly folded
-  ;; 1. if its `ifTrue` and `ifFalse` arms are identical (can fold)
-  (func $if-arms-subtype-fold (result anyref)
-    (if (result anyref)
-      (i32.const 0)
-      (ref.null extern)
-      (ref.null extern)
-    )
-  )
-  ;; 2. if its `ifTrue` and `ifFalse` arms are not identical (cannot fold)
-  (func $if-arms-subtype-nofold (result anyref)
-    (if (result anyref)
-      (i32.const 0)
-      (ref.null extern)
-      (ref.null func)
-    )
-  )
   (func $optimize-boolean-context (param $x i32) (param $y i32)
     ;; 0 - x   ==>   x
     (if
@@ -5465,8 +5426,6 @@
     (drop (i32.eqz (i32.eqz (i64.eqz (i64.const 1)))))
     (drop (i32.eqz (i32.eqz (i32.ne (local.get $x) (i32.const 2)))))
 
-    (drop (i32.extend8_s (i32.extend8_s (local.get $x))))
-    (drop (i32.extend16_s (i32.extend16_s (local.get $x))))
     (drop (i32.eqz
       (i32.eqz
         (i32.and
@@ -5868,87 +5827,6 @@
       )
     ))
   )
-  (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
-    (memory.copy  ;; skip
-      (local.get $dst)
-      (local.get $dst)
-      (local.get $sz)
-    )
-
-    (memory.copy  ;; skip
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 0)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 1)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 2)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 3)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 4)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 5)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 6)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 7)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 8)
-    )
-
-    (memory.copy
-      (local.get $dst)
-      (local.get $src)
-      (i32.const 16)
-    )
-
-    (memory.copy  ;; skip
-      (local.get $dst)
-      (local.get $src)
-      (local.get $sz)
-    )
-
-    (memory.copy  ;; skip
-      (i32.const 0)
-      (i32.const 0)
-      (i32.load
-        (i32.const 3) ;; side effect
-      )
-    )
-  )
   (func $optimize-float-points (param $x0 f64) (param $x1 f64) (param $y0 f32) (param $y1 f32)
     ;; abs(x) * abs(x)   ==>   x * x
     (drop (f64.mul
@@ -6076,6 +5954,7 @@
     ))
   )
 )
+;; atomics
 (module
   (import "env" "memory" (memory $0 (shared 256 256)))
   (func $x
@@ -6090,5 +5969,144 @@
      (i32.const 24)
     )
    )
+  )
+)
+;; bulk memory
+(module
+  (memory 0)
+  (func $optimize-bulk-memory-copy (param $dst i32) (param $src i32) (param $sz i32)
+    (memory.copy  ;; skip
+      (local.get $dst)
+      (local.get $dst)
+      (local.get $sz)
+    )
+
+    (memory.copy  ;; skip
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 0)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 1)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 2)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 3)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 4)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 5)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 6)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 7)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 8)
+    )
+
+    (memory.copy
+      (local.get $dst)
+      (local.get $src)
+      (i32.const 16)
+    )
+
+    (memory.copy  ;; skip
+      (local.get $dst)
+      (local.get $src)
+      (local.get $sz)
+    )
+
+    (memory.copy  ;; skip
+      (i32.const 0)
+      (i32.const 0)
+      (i32.load
+        (i32.const 3) ;; side effect
+      )
+    )
+  )
+)
+;; reference types
+(module
+  ;; These functions test if an `if` with subtyped arms is correctly folded
+  ;; 1. if its `ifTrue` and `ifFalse` arms are identical (can fold)
+  (func $if-arms-subtype-fold (result anyref)
+    (if (result anyref)
+      (i32.const 0)
+      (ref.null extern)
+      (ref.null extern)
+    )
+  )
+  ;; 2. if its `ifTrue` and `ifFalse` arms are not identical (cannot fold)
+  (func $if-arms-subtype-nofold (result anyref)
+    (if (result anyref)
+      (i32.const 0)
+      (ref.null extern)
+      (ref.null func)
+    )
+  )
+)
+;; sign-extensions
+(module
+  (func $duplicate-elimination (param $x i32) (param $y i32) (param $z i32) (param $w f64)
+    (drop (i32.extend8_s (i32.extend8_s (local.get $x))))
+    (drop (i32.extend16_s (i32.extend16_s (local.get $x))))
+  )
+)
+;; exceptions
+(module
+  (func $test
+    (if
+      (try (result i32)
+        (do
+          (i32.eqz
+            (i32.eqz
+              (i32.const 123)
+            )
+          )
+        )
+        (catch
+          (drop
+            (pop exnref)
+          )
+          (i32.eqz
+            (i32.eqz
+              (i32.const 456)
+            )
+          )
+        )
+      )
+      (nop)
+    )
   )
 )


### PR DESCRIPTION
`OptimizeInstructions` is seeing the most work these days (thanks @MaxGraey !)
so it's good for the fuzzer to focus on that some more.

Also move some code around in the main test wast: it's useful to put each
feature in its own module to maximize the chance of getting them to be used.
That is, if a module has a single use of atomics, then if atomics are disabled
in the current run, we can't use any of the module and we skip initial contents
entirely. Moving each feature to it's own module reduces that risk. (We do
pick randomly between the modules, and atm a small module has the same
chance as a big one, but this still seems worth it.)