### PR TITLE
[wasm64] fix for Memory64Lowering affecting DWARF data

### DIFF
--- a/third_party/llvm-project/DWARFEmitter.cpp
+++ b/third_party/llvm-project/DWARFEmitter.cpp
@@ -190,9 +190,11 @@ protected:
   // XXX BINARYEN Make sure we emit the right size. We should not change the
   // size as we only modify relocatable fields like addresses, and such fields
   // have a fixed size, so any change is a bug.
+  // We make an exception for AddrSizeChanged, which happens when we have run
+  // the Memory64Lowering pass to turn wasm64 into wasm32.
   void onEndCompileUnit(const DWARFYAML::Unit &CU) {
     size_t EndPos = OS.tell();
-    if (EndPos - StartPos != CU.Length.getLength()) {
+    if (EndPos - StartPos != CU.Length.getLength() && !CU.AddrSizeChanged) {
       llvm_unreachable("compile unit size was incorrect");
     }
   }

--- a/third_party/llvm-project/include/llvm/ObjectYAML/DWARFYAML.h
+++ b/third_party/llvm-project/include/llvm/ObjectYAML/DWARFYAML.h
@@ -128,6 +128,7 @@ struct Unit {
   llvm::dwarf::UnitType Type; // Added in DWARF 5
   uint32_t AbbrOffset;
   uint8_t AddrSize;
+  bool AddrSizeChanged = false;  // XXX BINARYEN
   std::vector<Entry> Entries;
 };
 


### PR DESCRIPTION
We change the AddrSize which causes all DW_FORM_addr to be written differently.
Depends on https://reviews.llvm.org/D91395

This may need a test.. sadly dwarfdump doesn't show the size of DW_FORM_addr, they're always 64-bit. So its only `addr_size = 0x04` in the header thats evidence of this code working.