### PR TITLE
Rename Indirect to NonDirect in CallGraphPropertyAnalysis

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -677,7 +677,7 @@ public:
                             }
                             info.canChangeState = true;
                           },
-                          scanner.IgnoreIndirectCalls);
+                          scanner.IgnoreNonDirectCalls);
 
     map.swap(scanner.map);
 
@@ -1408,8 +1408,10 @@ struct Asyncify : public Pass {
     bool allImportsCanChangeState =
       stateChangingImports == "" && ignoreImports == "";
     String::Split listedImports(stateChangingImports, ",");
-    auto ignoreIndirect = runner->options.getArgumentOrDefault(
-                            "asyncify-ignore-indirect", "") == "";
+    // TODO: consider renaming asyncify-ignore-indirect to
+    //       asyncify-ignore-nondirect, but that could break users.
+    auto ignoreNonDirect = runner->options.getArgumentOrDefault(
+                             "asyncify-ignore-indirect", "") == "";
     std::string removeListInput =
       runner->options.getArgumentOrDefault("asyncify-removelist", "");
     if (removeListInput.empty()) {
@@ -1462,7 +1464,7 @@ struct Asyncify : public Pass {
     // Scan the module.
     ModuleAnalyzer analyzer(*module,
                             canImportChangeState,
-                            ignoreIndirect,
+                            ignoreNonDirect,
                             removeList,
                             addList,
                             onlyList,

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -86,12 +86,12 @@ struct PostEmscripten : public Pass {
         }
       });
 
-    // Assume an indirect call might throw.
+    // Assume a non-direct call might throw.
     analyzer.propagateBack(
       [](const Info& info) { return info.canThrow; },
       [](const Info& info) { return true; },
       [](Info& info, Function* reason) { info.canThrow = true; },
-      analyzer.IndirectCallsHaveProperty);
+      analyzer.NonDirectCallsHaveProperty);
 
     // Apply the information.
     struct OptimizeInvokes : public WalkerPass<PostWalker<OptimizeInvokes>> {


### PR DESCRIPTION
This is in preparation for [`CallRef`](https://github.com/WebAssembly/function-references/blob/master/proposals/function-references/Overview.md), which takes a reference to a function
and calls it.

CallGraphPropertyAnalysis needs to be aware of anything that is not a
direct call, and the best name I can think of that covers `CallIndirect` and
`CallRef` is "non-direct". Maybe there's a better idea though?