### PR TITLE
[s-parsing] Store full function signatures

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -123,7 +123,7 @@ class SExpressionWasmBuilder {
   int tableCounter = 0;
   int memoryCounter = 0;
   // we need to know function return types before we parse their contents
-  std::map<Name, Type> functionTypes;
+  std::map<Name, Signature> functionSignatures;
   std::unordered_map<cashew::IString, Index> debugInfoFileIndices;
 
 public:

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -673,7 +673,7 @@ void SExpressionWasmBuilder::preParseFunctionType(Element& s) {
   functionCounter++;
   Signature sig;
   parseTypeUse(s, i, sig);
-  functionTypes[name] = sig.results;
+  functionSignatures[name] = sig;
 }
 
 size_t SExpressionWasmBuilder::parseFunctionNames(Element& s,
@@ -765,7 +765,7 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     im->module = importModule;
     im->base = importBase;
     im->sig = sig;
-    functionTypes[name] = sig.results;
+    functionSignatures[name] = sig;
     if (wasm.getFunctionOrNull(im->name)) {
       throw ParseException("duplicate import", s.line, s.col);
     }
@@ -1773,7 +1773,7 @@ Expression* SExpressionWasmBuilder::makeCall(Element& s, bool isReturn) {
   auto target = getFunctionName(*s[1]);
   auto ret = allocator.alloc<Call>();
   ret->target = target;
-  ret->type = functionTypes[ret->target];
+  ret->type = functionSignatures[ret->target].results;
   parseCallOperands(s, 2, s.size(), ret);
   ret->isReturn = isReturn;
   ret->finalize();
@@ -2444,7 +2444,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     func->setName(name, hasExplicitName);
     func->module = module;
     func->base = base;
-    functionTypes[name] = func->sig.results;
+    functionSignatures[name] = func->sig;
     wasm.addFunction(func.release());
   } else if (kind == ExternalKind::Global) {
     Type type;


### PR DESCRIPTION
We will need this for typed function references support, as then we need
to know full function signatures for all functions when we reach a `ref.func`,
whose type is then that signature and not the generic `funcref`.