### PR TITLE
[Types] Identify subtyping between funcref and all typed function references

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -522,15 +522,13 @@ bool Type::isSubType(Type left, Type right) {
   }
   if (left.isRef() && right.isRef()) {
     if (right == Type::anyref) {
-      // Everything is a subtype of anyref.
       return true;
     }
-    if (left == Type::i31ref && right == Type::eqref) {
-      // i31 is a subtype of eqref.
+    if ((left == Type::i31ref || left == Type::array || left == Type::struct) && right == Type::eqref) {
       return true;
     }
     if (left.getHeapType().isSignature() && right == Type::funcref) {
-      // All function signatures are subtypes of funcref.
+      // All typed function signatures are subtypes of funcref.
       return true;
     }
     return false;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -524,7 +524,8 @@ bool Type::isSubType(Type left, Type right) {
     if (right == Type::anyref) {
       return true;
     }
-    if ((left == Type::i31ref || left == Type::array || left == Type::struct) && right == Type::eqref) {
+    if ((left == Type::i31ref || left == Type::array || left == Type::struct) &&
+        right == Type::eqref) {
       return true;
     }
     if (left.getHeapType().isSignature() && right == Type::funcref) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -521,8 +521,19 @@ bool Type::isSubType(Type left, Type right) {
     return true;
   }
   if (left.isRef() && right.isRef()) {
-    return right == Type::anyref ||
-           (left == Type::i31ref && right == Type::eqref);
+    if (right == Type::anyref) {
+      // Everything is a subtype of anyref.
+      return true;
+    }
+    if (left == Type::i31ref && right == Type::eqref) {
+      // i31 is a subtype of eqref.
+      return true;
+    }
+    if (right == Type::funcref && left.getHeapType().isSignature()) {
+      // All function signatures are subtypes of funcref.
+      return true;
+    }
+    return false;
   }
   if (left.isTuple() && right.isTuple()) {
     if (left.size() != right.size()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -524,7 +524,7 @@ bool Type::isSubType(Type left, Type right) {
     if (right == Type::anyref) {
       return true;
     }
-    if ((left == Type::i31ref || left == Type::array || left == Type::struct) &&
+    if ((left == Type::i31ref || left.getHeapType().isArray() || left.getHeapType().isStruct()) &&
         right == Type::eqref) {
       return true;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -529,7 +529,7 @@ bool Type::isSubType(Type left, Type right) {
       // i31 is a subtype of eqref.
       return true;
     }
-    if (right == Type::funcref && left.getHeapType().isSignature()) {
+    if (left.getHeapType().isSignature() && right == Type::funcref) {
       // All function signatures are subtypes of funcref.
       return true;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -521,15 +521,18 @@ bool Type::isSubType(Type left, Type right) {
     return true;
   }
   if (left.isRef() && right.isRef()) {
+    // Everything is a subtype of anyref.
     if (right == Type::anyref) {
       return true;
     }
-    if ((left == Type::i31ref || left.getHeapType().isArray() || left.getHeapType().isStruct()) &&
+    // Various things are subtypes of eqref.
+    if ((left == Type::i31ref || left.getHeapType().isArray() ||
+         left.getHeapType().isStruct()) &&
         right == Type::eqref) {
       return true;
     }
+    // All typed function signatures are subtypes of funcref.
     if (left.getHeapType().isSignature() && right == Type::funcref) {
-      // All typed function signatures are subtypes of funcref.
       return true;
     }
     return false;


### PR DESCRIPTION
This is necessary to support typed function references.
