### PR TITLE
[TypedFunctionReferences] Allow creation of literals with typed function types

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -71,7 +71,8 @@ public:
   explicit Literal(const std::array<Literal, 8>&);
   explicit Literal(const std::array<Literal, 4>&);
   explicit Literal(const std::array<Literal, 2>&);
-  explicit Literal(Name func) : func(func), type(Type::funcref) {}
+  explicit Literal(Name func, Type type = Type::funcref)
+    : func(func), type(type) {}
   explicit Literal(std::unique_ptr<ExceptionPackage>&& exn)
     : exn(std::move(exn)), type(Type::exnref) {}
   Literal(const Literal& other);
@@ -233,7 +234,9 @@ public:
     assert(type.isNullable());
     return Literal(type);
   }
-  static Literal makeFunc(Name func) { return Literal(func.c_str()); }
+  static Literal makeFunc(Name func, Type type = Type::funcref) {
+    return Literal(func.c_str(), type);
+  }
   static Literal makeExn(std::unique_ptr<ExceptionPackage>&& exn) {
     return Literal(std::move(exn));
   }

--- a/src/literal.h
+++ b/src/literal.h
@@ -235,7 +235,7 @@ public:
     return Literal(type);
   }
   static Literal makeFunc(Name func, Type type = Type::funcref) {
-    return Literal(func.c_str(), type);
+    return Literal(func, type);
   }
   static Literal makeExn(std::unique_ptr<ExceptionPackage>&& exn) {
     return Literal(std::move(exn));

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1289,7 +1289,7 @@ public:
   Flow visitRefFunc(RefFunc* curr) {
     NOTE_ENTER("RefFunc");
     NOTE_NAME(curr->func);
-    return Literal::makeFunc(curr->func);
+    return Literal::makeFunc(curr->func, curr->type);
   }
   Flow visitRefEq(RefEq* curr) {
     NOTE_ENTER("RefEq");


### PR DESCRIPTION
Before this, all function literals would have `funcref` type. This allows a custom type
to be provided.

The interpreter passes in the type of the `ref.func` expression. Currently this has
type `funcref` so there is no change, but when typed function references lands and
is enabled then the proper subtype will be used.