### PR TITLE
Add compile_commands.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ CMakeFiles
 /config.h
 *.o
 *.obj
+compile_commands.json
 
 # files related to bulding in-tree on windows
 /.vs/


### PR DESCRIPTION
This file is emitted by CMake when -DCMAKE_EXPORT_COMPILE_COMMANDS is set.