### PR TITLE
[Tools] Apply features to the wasm module before loading it

### DIFF
--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -99,6 +99,7 @@ int main(int argc, const char* argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   try {
     if (options.debug) {
@@ -114,8 +115,6 @@ int main(int argc, const char* argv[]) {
     p.dump(std::cerr);
     Fatal() << "error in parsing input";
   }
-
-  options.applyFeatures(wasm);
 
   if (options.extra["validate"] != "none") {
     if (options.debug) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -449,6 +449,7 @@ int main(int argc, const char* argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   {
     if (options.debug) {
@@ -462,8 +463,6 @@ int main(int argc, const char* argv[]) {
       Fatal() << "error in parsing input";
     }
   }
-
-  options.applyFeatures(wasm);
 
   if (!WasmValidator().validate(wasm)) {
     WasmPrinter::printModule(&wasm);

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -60,6 +60,7 @@ int main(int argc, const char* argv[]) {
     std::cerr << "parsing binary..." << std::endl;
   }
   Module wasm;
+  wasm.features = FeatureSet::All;
   try {
     ModuleReader().readBinary(options.extra["infile"], wasm, sourceMapFilename);
   } catch (ParseException& p) {

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -205,6 +205,8 @@ int main(int argc, const char* argv[]) {
   }
 
   Module wasm;
+  options.applyFeatures(wasm);
+
   ModuleReader reader;
   reader.setDWARF(DWARF);
   try {
@@ -218,8 +220,6 @@ int main(int argc, const char* argv[]) {
     std::cerr << '\n';
     Fatal() << "error in parsing wasm source map";
   }
-
-  options.applyFeatures(wasm);
 
   BYN_TRACE_WITH_TYPE("emscripten-dump", "Module before:\n");
   BYN_DEBUG_WITH_TYPE("emscripten-dump",

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -492,6 +492,7 @@ int main(int argc, const char* argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   {
     if (options.debug) {
@@ -506,8 +507,6 @@ int main(int argc, const char* argv[]) {
       Fatal() << "error in parsing wasm input";
     }
   }
-
-  options.applyFeatures(wasm);
 
   if (options.passOptions.validate) {
     if (!WasmValidator().validate(wasm)) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -218,6 +218,7 @@ int main(int argc, const char* argv[]) {
   options.parse(argc, argv);
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   BYN_TRACE("reading...\n");
 
@@ -260,8 +261,6 @@ int main(int argc, const char* argv[]) {
                  "request for silly amounts of memory)";
     }
 
-    options.applyFeatures(wasm);
-
     if (options.passOptions.validate) {
       if (!WasmValidator().validate(wasm)) {
         exitOnInvalidWasm("error validating input");
@@ -269,7 +268,6 @@ int main(int argc, const char* argv[]) {
     }
   }
   if (translateToFuzz) {
-    options.applyFeatures(wasm);
     TranslateToFuzzReader reader(wasm, options.extra["infile"]);
     if (fuzzPasses) {
       reader.pickPasses(options);


### PR DESCRIPTION
This normally does not matter, but will matter for typed function references,
where the presence of the feature will actually change how the IR is built. But,
it makes sense to do this early anyhow - we know the features already.

`wasm-dis` does not accept feature flags, because the idea is that it just
disassembles. This didn't matter much til now, but for consistency with the
other tools, set the features early, and in this case just set them all (which will
allow typed function references to just work, and I don't see a downside?).