### PR TITLE
[wasm-emscripten-finalize] Don't emit a global ctor that is not needed

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -1,3 +1,4 @@
+#include <wasm-printing.h>
 /*
  * Copyright 2017 WebAssembly Community Group participants
  *
@@ -22,6 +23,7 @@
 #include <exception>
 
 #include "abi/js.h"
+#include "ir/effects.h"
 #include "ir/trapping.h"
 #include "support/colors.h"
 #include "support/debug.h"
@@ -296,7 +298,8 @@ int main(int argc, const char* argv[]) {
       if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
         if (e->kind == ExternalKind::Function) {
           // If the initializer does nothing, we don't need it.
-          if (wasm.getFunction(e->value)->body->is<Nop>()) {
+          std::cerr << wasm.getFunction(e->value)->body << '\n';
+          if (!EffectAnalyzer(options.passOptions, wasm.features, wasm.getFunction(e->value)->body).hasSideEffects()) {
             // We can also remove the unneeded export (later optimizations can
             // also remove the function, if it is not used elsewhere).
             wasm.removeExport(WASM_CALL_CTORS);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -299,7 +299,10 @@ int main(int argc, const char* argv[]) {
         if (e->kind == ExternalKind::Function) {
           // If the initializer does nothing, we don't need it.
           std::cerr << wasm.getFunction(e->value)->body << '\n';
-          if (!EffectAnalyzer(options.passOptions, wasm.features, wasm.getFunction(e->value)->body).hasSideEffects()) {
+          if (!EffectAnalyzer(options.passOptions,
+                              wasm.features,
+                              wasm.getFunction(e->value)->body)
+                 .hasSideEffects()) {
             // We can also remove the unneeded export (later optimizations can
             // also remove the function, if it is not used elsewhere).
             wasm.removeExport(WASM_CALL_CTORS);

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -1,4 +1,3 @@
-#include <wasm-printing.h>
 /*
  * Copyright 2017 WebAssembly Community Group participants
  *
@@ -298,7 +297,6 @@ int main(int argc, const char* argv[]) {
       if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
         if (e->kind == ExternalKind::Function) {
           // If the initializer does nothing, we don't need it.
-          std::cerr << wasm.getFunction(e->value)->body << '\n';
           if (!EffectAnalyzer(options.passOptions,
                               wasm.features,
                               wasm.getFunction(e->value)->body)

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -294,7 +294,17 @@ int main(int argc, const char* argv[]) {
     // Unless there is no entry point.
     if (!standaloneWasm || !wasm.getExportOrNull("_start")) {
       if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
-        initializerFunctions.push_back(e->name);
+        if (e->kind == ExternalKind::Function) {
+          // If the initializer does nothing, we don't need to call it.
+          if (wasm.getFunction(e->value)->body->is<Nop>()) {
+            // We can also remove the unneeded export (later optimizations can
+            // also remove the function, if it is not used elsewhere).
+            wasm.removeExport(WASM_CALL_CTORS);
+          } else {
+            // It is needed; emit it.
+            initializerFunctions.push_back(e->name);
+          }
+        }
       }
     }
   }

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -296,13 +296,14 @@ int main(int argc, const char* argv[]) {
     if (!standaloneWasm || !wasm.getExportOrNull("_start")) {
       if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
         if (e->kind == ExternalKind::Function) {
-          // If the initializer does nothing, we don't need it.
           if (!EffectAnalyzer(options.passOptions,
                               wasm.features,
                               wasm.getFunction(e->value)->body)
                  .hasSideEffects()) {
-            // We can also remove the unneeded export (later optimizations can
-            // also remove the function, if it is not used elsewhere).
+            // The initializer exists, but doesn't do anything we could notice.
+            // Remove the export, and don't call it from JS (later
+            // optimizations can also remove the function, if it is not used
+            // elsewhere).
             wasm.removeExport(WASM_CALL_CTORS);
           } else {
             // It is needed; emit it.

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -295,7 +295,7 @@ int main(int argc, const char* argv[]) {
     if (!standaloneWasm || !wasm.getExportOrNull("_start")) {
       if (auto* e = wasm.getExportOrNull(WASM_CALL_CTORS)) {
         if (e->kind == ExternalKind::Function) {
-          // If the initializer does nothing, we don't need to call it.
+          // If the initializer does nothing, we don't need it.
           if (wasm.getFunction(e->value)->body->is<Nop>()) {
             // We can also remove the unneeded export (later optimizations can
             // also remove the function, if it is not used elsewhere).

--- a/test/lld/basic_safe_stack.wat.out
+++ b/test/lld/basic_safe_stack.wat.out
@@ -10,7 +10,6 @@
  (global $__stack_base (mut i32) (i32.const 0))
  (global $__stack_limit (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "stackRestore" (func $stackRestore))
  (export "stackAlloc" (func $stackAlloc))
  (export "main" (func $main))
@@ -89,16 +88,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "__handle_stack_overflow"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "stackRestore",
     "stackAlloc",
     "main",

--- a/test/lld/duplicate_imports.wat.out
+++ b/test/lld/duplicate_imports.wat.out
@@ -19,7 +19,6 @@
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 581))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
@@ -68,16 +67,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "puts"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main",
     "dynCall_ffd",
     "dynCall_fdd"

--- a/test/lld/effect_in_global_ctor.wat
+++ b/test/lld/effect_in_global_ctor.wat
@@ -1,0 +1,15 @@
+(module
+ (import "env" "puts" (func $puts (param i32) (result i32)))
+ (memory $0 2)
+ (data (i32.const 568) "Hello, world\00")
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (func $__wasm_call_ctors
+  ;; print hello world from the global constructor
+  (drop
+   (call $puts
+    (i32.const 568)
+   )
+  )
+ )
+)
+

--- a/test/lld/effect_in_global_ctor.wat.out
+++ b/test/lld/effect_in_global_ctor.wat.out
@@ -1,0 +1,40 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_i32 (func (param i32) (result i32)))
+ (import "env" "puts" (func $puts (param i32) (result i32)))
+ (memory $0 2)
+ (data (i32.const 568) "Hello, world\00")
+ (export "__wasm_call_ctors" (func $__wasm_call_ctors))
+ (func $__wasm_call_ctors
+  (drop
+   (call $puts
+    (i32.const 568)
+   )
+  )
+ )
+)
+(;
+--BEGIN METADATA --
+{
+  "tableSize": 0,
+  "initializers": [
+    "__wasm_call_ctors"
+  ],
+  "declares": [
+    "puts"
+  ],
+  "externs": [
+  ],
+  "exports": [
+    "__wasm_call_ctors"
+  ],
+  "namedGlobals": {
+  },
+  "invokeFuncs": [
+  ],
+  "mainReadsParams": 0,
+  "features": [
+  ]
+}
+-- END METADATA --
+;)

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -8,7 +8,6 @@
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66208))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (func $__wasm_call_ctors
   (nop)
@@ -73,16 +72,12 @@
     "625": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "emscripten_asm_const_int"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/em_asm.wat.out
+++ b/test/lld/em_asm.wat.out
@@ -9,7 +9,6 @@
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66208))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (func $__wasm_call_ctors
   (nop)
@@ -74,16 +73,12 @@
     "625": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "emscripten_asm_const_int"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -8,7 +8,6 @@
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66192))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (func $__wasm_call_ctors
   (nop)
@@ -99,16 +98,12 @@
     "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
   },
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "emscripten_asm_const_int"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/em_asm_main_thread.wat.out
+++ b/test/lld/em_asm_main_thread.wat.out
@@ -14,7 +14,6 @@
  (global $global$1 i32 (i32.const 66192))
  (global $global$2 i32 (i32.const 652))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
  (export "main" (func $main))
@@ -199,16 +198,12 @@
     "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]]
   },
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "emscripten_asm_const_int_sync_on_main_thread"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/hello_world.wat.mem.out
+++ b/test/lld/hello_world.wat.mem.out
@@ -8,7 +8,6 @@
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (func $__wasm_call_ctors
   (nop)
@@ -29,16 +28,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "puts"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/hello_world.wat.out
+++ b/test/lld/hello_world.wat.out
@@ -9,7 +9,6 @@
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (func $__wasm_call_ctors
   (nop)
@@ -30,16 +29,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "puts"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/longjmp.wat.out
+++ b/test/lld/longjmp.wat.out
@@ -21,7 +21,6 @@
  (elem (i32.const 1) $fimport$3)
  (global $global$0 (mut i32) (i32.const 66112))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $0))
  (export "main" (func $2))
  (export "dynCall_vii" (func $dynCall_vii))
  (func $0
@@ -142,9 +141,6 @@
 --BEGIN METADATA --
 {
   "tableSize": 2,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "malloc",
     "saveSetjmp",
@@ -157,7 +153,6 @@
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main",
     "dynCall_vii"
   ],

--- a/test/lld/recursive.wat.out
+++ b/test/lld/recursive.wat.out
@@ -8,7 +8,6 @@
  (table $0 1 1 funcref)
  (global $global$0 (mut i32) (i32.const 66128))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (func $__wasm_call_ctors
   (nop)
@@ -87,16 +86,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "iprintf"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main"
   ],
   "namedGlobals": {

--- a/test/lld/recursive_safe_stack.wat.out
+++ b/test/lld/recursive_safe_stack.wat.out
@@ -14,7 +14,6 @@
  (global $__stack_base (mut i32) (i32.const 0))
  (global $__stack_limit (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
  (export "main" (func $main))
@@ -176,9 +175,6 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "printf",
     "__handle_stack_overflow"
@@ -186,7 +182,6 @@
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main",
     "__set_stack_limits"
   ],

--- a/test/lld/reserved_func_ptr.wat.out
+++ b/test/lld/reserved_func_ptr.wat.out
@@ -13,7 +13,6 @@
  (elem (i32.const 1) $address_taken_func\28int\2c\20int\2c\20int\29 $address_taken_func2\28int\2c\20int\2c\20int\29)
  (global $global$0 (mut i32) (i32.const 66112))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
  (export "dynCall_viii" (func $dynCall_viii))
  (func $__wasm_call_ctors
@@ -122,16 +121,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 3,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "_Z4atoiPKc"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main",
     "dynCall_viii"
   ],

--- a/test/lld/safe_stack_standalone-wasm.wat.out
+++ b/test/lld/safe_stack_standalone-wasm.wat.out
@@ -13,7 +13,6 @@
  (global $__stack_base (mut i32) (i32.const 0))
  (global $__stack_limit (mut i32) (i32.const 0))
  (export "memory" (memory $0))
- (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "__heap_base" (global $global$1))
  (export "__data_end" (global $global$2))
  (export "main" (func $main))
@@ -175,16 +174,12 @@
 --BEGIN METADATA --
 {
   "tableSize": 1,
-  "initializers": [
-    "__wasm_call_ctors"
-  ],
   "declares": [
     "printf"
   ],
   "externs": [
   ],
   "exports": [
-    "__wasm_call_ctors",
     "main",
     "__set_stack_limits"
   ],


### PR DESCRIPTION
If a ctor has no side effects, we don't need to call it.

Also add a missing check for a ctor being a function (and not something else,
which never happens in practice).

Fixes https://github.com/emscripten-core/emscripten/issues/12777

This will need to temporarily disable code size and metadce tests on emscripten as looks
like the improvement makes them fail.

cc @juj