### PR TITLE
[effects.h] Refactor hasGlobalSideEffects and throw handling. NFC

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -140,7 +140,7 @@ struct EffectAnalyzer
 
   // Changes something in globally-stored state.
   bool writesGlobalState() const {
-    return globalsWritten.size() > 0 || writesMemory || isAtomic || calls;
+    return globalsWritten.size() || writesMemory || isAtomic || calls;
   }
   bool readsGlobalState() const {
     return globalsRead.size() || readsMemory || isAtomic || calls;
@@ -148,7 +148,7 @@ struct EffectAnalyzer
 
   // Whether this has any effect that could be noticeable from someone outside
   // the current function call. That does not include a write to a local, for
-  // example, but  does include any writes to global state as well as trapping
+  // example, but does include any writes to global state as well as trapping
   // and throwing. Note that this does not consider the return value from the
   // function (which we do not have access to directly here).
   bool hasExternallyNoticeableEffects() const {
@@ -217,7 +217,7 @@ struct EffectAnalyzer
     // function, so transfersControlFlow would be true) - while we allow the
     // reordering of traps with each other, we do not reorder exceptions with
     // anything.
-    assert(!((implicitTrap && other.throws) || (throws && other.implicitTrap)));
+    assert(!(implicitTrap && other.throws) && !(throws && other.implicitTrap));
     // We can't reorder an implicit trap in a way that could alter what global
     // state is modified.
     if ((implicitTrap && other.writesGlobalState()) ||

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -146,17 +146,10 @@ struct EffectAnalyzer
     return globalsRead.size() || readsMemory || isAtomic || calls;
   }
 
-  // Whether this has any effect that could be noticeable from someone outside
-  // the current function call. That does not include a write to a local, for
-  // example, but does include any writes to global state as well as trapping
-  // and throwing. Note that this does not consider the return value from the
-  // function (which we do not have access to directly here).
-  bool hasExternallyNoticeableEffects() const {
-    return writesGlobalState() || implicitTrap || throws;
-  }
   bool hasSideEffects() const {
     return localsWritten.size() > 0 || danglingPop ||
-           hasExternallyNoticeableEffects() || transfersControlFlow();
+           writesGlobalState() || implicitTrap || throws ||
+           transfersControlFlow();
   }
   bool hasAnything() const {
     return hasSideEffects() || accessesLocal() || readsMemory ||

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -147,9 +147,8 @@ struct EffectAnalyzer
   }
 
   bool hasSideEffects() const {
-    return localsWritten.size() > 0 || danglingPop ||
-           writesGlobalState() || implicitTrap || throws ||
-           transfersControlFlow();
+    return localsWritten.size() > 0 || danglingPop || writesGlobalState() ||
+           implicitTrap || throws || transfersControlFlow();
   }
   bool hasAnything() const {
     return hasSideEffects() || accessesLocal() || readsMemory ||

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -114,17 +114,20 @@ struct LoopInvariantCodeMotion
       }
       if (interestingToMove(curr)) {
         // Let's see if we can move this out.
-        // Global side effects would prevent this - we might end up
+        // Global state changes would prevent this - we might end up
         // executing them just once.
         // And we must also move across anything not moved out already,
         // so check for issues there too.
         // The rest of the loop's effects matter too, we must also
         // take into account global state like interacting loads and
         // stores.
-        bool unsafeToMove = effects.hasGlobalSideEffects() ||
-                            effectsSoFar.invalidates(effects) ||
-                            (effects.noticesGlobalSideEffects() &&
-                             loopEffects.hasGlobalSideEffects());
+        bool unsafeToMove =
+          effects.writesGlobalState() || effectsSoFar.invalidates(effects) ||
+          (effects.readsGlobalState() && loopEffects.writesGlobalState());
+        // TODO: look into optimizing this with exceptions. for now, disallow
+        if (effects.throws || loopEffects.throws) {
+          unsafeToMove = true;
+        }
         if (!unsafeToMove) {
           // So far so good. Check if our local dependencies are all
           // outside of the loop, in which case everything is good -


### PR DESCRIPTION
The new `writesGlobalState` has a name that more clearly indicates what it
actually does. This removes `throw` from there, and handles it directly in the
single caller of the method.

Add `hasExternallyNoticeableEffects` which is what the old `hasGlobalSideEffects`
was maybe trying to be, but does it in a clearer way. There are currently no
users but a wip PR of mine will need this very soon.

I wrote this PR because that future PR tried to use `hasGlobalSideEffects` but
it really wasn't well-defined enough. The logic there is somewhat specific to
the single caller of the old method, I guess.