### PR TITLE
[cost.h] Define costs for I31New and I31Get which the fuzzer emits

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -552,7 +552,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, Index> {
   Index visitUnreachable(Unreachable* curr) { return 0; }
   Index visitDataDrop(DataDrop* curr) { return 5; }
   Index visitI31New(I31New* curr) { return 3 + visit(curr->value); }
-  Index visitI31Get(I31Get* curr) { return 1 + visit(curr->i31); }
+  Index visitI31Get(I31Get* curr) { return 2 + visit(curr->i31); }
   Index visitRefTest(RefTest* curr) { WASM_UNREACHABLE("TODO: GC"); }
   Index visitRefCast(RefCast* curr) { WASM_UNREACHABLE("TODO: GC"); }
   Index visitBrOnCast(BrOnCast* curr) { WASM_UNREACHABLE("TODO: GC"); }

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -551,8 +551,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, Index> {
   Index visitNop(Nop* curr) { return 0; }
   Index visitUnreachable(Unreachable* curr) { return 0; }
   Index visitDataDrop(DataDrop* curr) { return 5; }
-  Index visitI31New(I31New* curr) { WASM_UNREACHABLE("TODO: GC"); }
-  Index visitI31Get(I31Get* curr) { WASM_UNREACHABLE("TODO: GC"); }
+  Index visitI31New(I31New* curr) { return 3; }
+  Index visitI31Get(I31Get* curr) { return 1; }
   Index visitRefTest(RefTest* curr) { WASM_UNREACHABLE("TODO: GC"); }
   Index visitRefCast(RefCast* curr) { WASM_UNREACHABLE("TODO: GC"); }
   Index visitBrOnCast(BrOnCast* curr) { WASM_UNREACHABLE("TODO: GC"); }

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -551,8 +551,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, Index> {
   Index visitNop(Nop* curr) { return 0; }
   Index visitUnreachable(Unreachable* curr) { return 0; }
   Index visitDataDrop(DataDrop* curr) { return 5; }
-  Index visitI31New(I31New* curr) { return 3; }
-  Index visitI31Get(I31Get* curr) { return 1; }
+  Index visitI31New(I31New* curr) { return 3 + visit(curr->value); }
+  Index visitI31Get(I31Get* curr) { return 1 + visit(curr->i31); }
   Index visitRefTest(RefTest* curr) { WASM_UNREACHABLE("TODO: GC"); }
   Index visitRefCast(RefCast* curr) { WASM_UNREACHABLE("TODO: GC"); }
   Index visitBrOnCast(BrOnCast* curr) { WASM_UNREACHABLE("TODO: GC"); }


### PR DESCRIPTION
cost.h now requires costs be defined, or it halts at runtime. But the fuzzer
already emits those two, so define them to unbreak the fuzzer.

Both access a reference, so they should be at least as costly as a load.
I31New also allocates, which is very cheap on a generational GC, so do not
add much for that.