### PR TITLE
Add requirements-dev.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: install tools
       run: |
-        sudo pip3 install flake8==3.7.8
+        sudo pip3 install -r requirements-dev.txt
         sudo apt-get install clang-format clang-tidy
         echo "::add-path::/usr/lib/llvm-8/bin"
     - run: flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# These requirements are only needed for developers who want to run the test
+# suite or flake8, not for end users.
+
+# Install with `pip3 install -r requirements-dev.txt`
+
+flake8==3.7.8


### PR DESCRIPTION
This file makes it simple for users and CI bots to install all the Python dev
dependencies necessary to run the test suite. Right now it only contains flake8,
but soon it will contain lit and filecheck as well (see #3367).