### PR TITLE
[ReReloop] Pass module when calling ReFinalize

### DIFF
--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -362,7 +362,7 @@ struct ReReloop final : public Pass {
       }
     }
     // TODO: should this be in the relooper itself?
-    ReFinalize().walk(function->body);
+    ReFinalize().walkFunctionInModule(function, module);
   }
 };
 


### PR DESCRIPTION
I happened to notice that this was the one place that calls ReFinalize
without the module. That could error if the module is actually needed,
which the pass might use, based on the code (but rare enough that it's
never been an issue I guess).