### PR TITLE
[Reducer] Don't error on compound types, just skip them for now

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -578,7 +578,10 @@ struct Reducer
           continue; // no conversion
         }
         Expression* fixed = nullptr;
-        TODO_SINGLE_COMPOUND(curr->type);
+        if (!curr->type.isBasic() || !child->type.isBasic()) {
+          // TODO: handle compound types
+          continue;
+        }
         switch (curr->type.getBasic()) {
           case Type::i32: {
             TODO_SINGLE_COMPOUND(child->type);


### PR DESCRIPTION
Let it reduce the other stuff it can, even if it can't reduce some things.