### PR TITLE
[effects.h] Add a trap effect for unreachable

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -77,14 +77,9 @@ public:
   // each other, but it is not ok to remove them or reorder them with other
   // effects in a noticeable way.
   bool trap = false;
-
-private:
   // A trap from an instruction like a load or div/rem, which may trap on corner
-  // cases. If we do not ignore implicit traps then these are counted as a trap,
-  // and so this field is private and just for internal use.
+  // cases. If we do not ignore implicit traps then these are counted as a trap.
   bool implicitTrap = false;
-
-public:
   // An atomic load/store/RMW/Cmpxchg or an operator that has a defined ordering
   // wrt atomics (e.g. memory.grow)
   bool isAtomic = false;
@@ -206,6 +201,7 @@ public:
     readsMemory = readsMemory || other.readsMemory;
     writesMemory = writesMemory || other.writesMemory;
     trap = trap || other.trap;
+    implicitTrap = implicitTrap || other.implicitTrap;
     isAtomic = isAtomic || other.isAtomic;
     throws = throws || other.throws;
     danglingPop = danglingPop || other.danglingPop;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -111,7 +111,7 @@ public:
   // caught in the function at all, which would mean control flow cannot be
   // transferred inside the function, but this expression does not know that).
   bool transfersControlFlow() const {
-    return branchesOut || throws || trap || hasExternalBreakTargets();
+    return branchesOut || throws || hasExternalBreakTargets();
   }
 
   // Changes something in globally-stored state.

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -524,9 +524,7 @@ private:
       parent.implicitTrap = true;
     }
     void visitNop(Nop* curr) {}
-    void visitUnreachable(Unreachable* curr) {
-      parent.trap = true;
-    }
+    void visitUnreachable(Unreachable* curr) { parent.trap = true; }
     void visitPop(Pop* curr) {
       if (parent.catchDepth == 0) {
         parent.danglingPop = true;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -77,11 +77,14 @@ public:
   // each other, but it is not ok to remove them or reorder them with other
   // effects in a noticeable way.
   bool trap = false;
+
+private:
   // A trap from an instruction like a load or div/rem, which may trap on corner
   // cases. If we do not ignore implicit traps then these are counted as a trap,
-  // and normally you would look at the "trap" property and not "implicitTrap"
-  // (unless you specifically care about the type of the trap).
+  // and so this field is private and just for internal use.
   bool implicitTrap = false;
+
+public:
   // An atomic load/store/RMW/Cmpxchg or an operator that has a defined ordering
   // wrt atomics (e.g. memory.grow)
   bool isAtomic = false;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -71,11 +71,16 @@ public:
   std::set<Name> globalsWritten;
   bool readsMemory = false;
   bool writesMemory = false;
+  // A trap, either from an unreachable instruction, or from an implicit trap
+  // that we do not ignore (see below).
+  // Note that we ignore trap differences, so it is ok to reorder traps with
+  // each other, but it is not ok to remove them or reorder them with other
+  // effects in a noticeable way.
   bool trap = false;
-  // a load or div/rem, which may trap. we ignore trap differences, so it is ok
-  // to reorder these, but we can't remove them, as they count as side effects,
-  // and we can't move them in a way that would cause other noticeable (global)
-  // side effects
+  // A trap from an instruction like a load or div/rem, which may trap on corner
+  // cases. If we do not ignore implicit traps then these are counted as a trap,
+  // and normally you would look at the "trap" property and not "implicitTrap"
+  // (unless you specifically care about the type of the trap).
   bool implicitTrap = false;
   // An atomic load/store/RMW/Cmpxchg or an operator that has a defined ordering
   // wrt atomics (e.g. memory.grow)

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -111,7 +111,7 @@ public:
   // caught in the function at all, which would mean control flow cannot be
   // transferred inside the function, but this expression does not know that).
   bool transfersControlFlow() const {
-    return branchesOut || throws || hasExternalBreakTargets();
+    return branchesOut || throws || trap || hasExternalBreakTargets();
   }
 
   // Changes something in globally-stored state.
@@ -525,7 +525,6 @@ private:
     }
     void visitNop(Nop* curr) {}
     void visitUnreachable(Unreachable* curr) {
-      parent.branchesOut = true;
       parent.trap = true;
     }
     void visitPop(Pop* curr) {

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -4,6 +4,8 @@
 
 #include <ir/bits.h>
 #include <ir/cost.h>
+#include <ir/effects.h>
+#include <pass.h>
 #include <wasm.h>
 
 using namespace wasm;
@@ -543,9 +545,21 @@ void test_cost() {
   assert_equal(CostAnalyzer(&get).cost, 0);
 }
 
+void test_effects() {
+  PassOptions options;
+  FeatureSet features;
+  // Unreachables trap.
+  Unreachable unreachable;
+  assert_equal(EffectAnalyzer(options, features, &unreachable).trap, true);
+  // Nops... do not.
+  Nop nop;
+  assert_equal(EffectAnalyzer(options, features, &nop).trap, false);
+}
+
 int main() {
   test_bits();
   test_cost();
+  test_effects();
 
   if (failsCount > 0) {
     abort();


### PR DESCRIPTION
We did not really model the effects of `unreachable` properly before. It
always traps, so it's not an implicit trap, but we didn't do anything but mark
it as "branches out", which is not really enough, as while yes it does
branch inside the current function, it also traps which is noticeable outside.

To fix that, add a `trap` effect to track this. `implicitTrap` will set `trap` as well,
automatically, if we do not ignore implicit traps, so it is enough to check just
that (unless one cares about the difference between implicit and explicit
ones).
