### PR TITLE
[wasm-builder] Construct module elements as unique_ptrs

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1572,9 +1572,9 @@ private:
         builder.makeIf(builder.makeBinary(GtUInt32, stackPos, stackEnd),
                        builder.makeUnreachable()));
       body->finalize();
-      auto* func = builder.makeFunction(
+      auto func = builder.makeFunction(
         name, Signature(Type(params), Type::none), {}, body);
-      module->addFunction(func);
+      module->addFunction(std::move(func));
       module->addExport(builder.makeExport(name, name, ExternalKind::Function));
     };
 

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -209,12 +209,12 @@ private:
     for (Index i = 0; i < NUM_PARAMS; i++) {
       thunkParams.push_back(Type::i64);
     }
-    auto* thunkFunc =
+    auto thunkFunc =
       builder.makeFunction(thunk,
                            Signature(Type(thunkParams), Type::i64),
                            {}, // no vars
                            toABI(call, module));
-    module->addFunction(thunkFunc);
+    module->addFunction(std::move(thunkFunc));
     return thunk;
   }
 };

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -120,7 +120,7 @@ void GenerateDynCalls::generateDynCallThunk(Signature sig) {
   for (const auto& param : sig.params) {
     params.emplace_back(std::to_string(p++), param);
   }
-  Function* f = builder.makeFunction(name, std::move(params), sig.results, {});
+  auto f = builder.makeFunction(name, std::move(params), sig.results, {});
   Expression* fptr = builder.makeLocalGet(0, Type::i32);
   std::vector<Expression*> args;
   Index i = 0;
@@ -130,8 +130,8 @@ void GenerateDynCalls::generateDynCallThunk(Signature sig) {
   Expression* call = builder.makeCallIndirect(fptr, args, sig);
   f->body = call;
 
-  wasm->addFunction(f);
-  exportFunction(*wasm, f->name, true);
+  wasm->addFunction(std::move(f));
+  exportFunction(*wasm, name, true);
 }
 
 Pass* createGenerateDynCallsPass() { return new GenerateDynCalls(false); }

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -113,11 +113,10 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
       }
       originallyI64Globals.insert(curr->name);
       curr->type = Type::i32;
-      auto* high = builder->makeGlobal(makeHighName(curr->name),
-                                       Type::i32,
-                                       builder->makeConst(int32_t(0)),
-                                       Builder::Mutable);
-      module->addGlobal(high);
+      auto high = builder->makeGlobal(makeHighName(curr->name),
+                                      Type::i32,
+                                      builder->makeConst(int32_t(0)),
+                                      Builder::Mutable);
       if (curr->imported()) {
         Fatal() << "TODO: imported i64 globals";
       } else {
@@ -134,6 +133,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
         }
         curr->init->type = Type::i32;
       }
+      module->addGlobal(std::move(high));
     }
 
     // For functions that return 64-bit values, we use this global variable

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -53,7 +53,7 @@ struct LegalizeJSInterface : public Pass {
          .getArgumentOrDefault("legalize-js-interface-export-originals", "")
          .empty();
     // for each illegal export, we must export a legalized stub instead
-    std::vector<Export*> newExports;
+    std::vector<std::unique_ptr<Export>> newExports;
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
         // if it's an import, ignore it
@@ -81,8 +81,8 @@ struct LegalizeJSInterface : public Pass {
         }
       }
     }
-    for (auto* ex : newExports) {
-      module->addExport(ex);
+    for (auto& ex : newExports) {
+      module->addExport(std::move(ex));
     }
     // Avoid iterator invalidation later.
     std::vector<Function*> originalFunctions;

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -450,24 +450,24 @@ private:
     }
     for (size_t index = upTo(MAX_GLOBALS); index > 0; --index) {
       auto type = getConcreteType();
-      auto* global =
+      auto global =
         builder.makeGlobal(Names::getValidGlobalName(wasm, "global$"),
                            type,
                            makeConst(type),
                            Builder::Mutable);
-      wasm.addGlobal(global);
       globalsByType[type].push_back(global->name);
+      wasm.addGlobal(std::move(global));
     }
   }
 
   void setupEvents() {
     Index num = upTo(3);
     for (size_t i = 0; i < num; i++) {
-      auto* event =
+      auto event =
         builder.makeEvent(Names::getValidEventName(wasm, "event$"),
                           WASM_EVENT_ATTRIBUTE_EXCEPTION,
                           Signature(getControlFlowType(), Type::none));
-      wasm.addEvent(event);
+      wasm.addEvent(std::move(event));
     }
   }
 
@@ -547,11 +547,11 @@ private:
   }
 
   void addHangLimitSupport() {
-    auto* glob = builder.makeGlobal(HANG_LIMIT_GLOBAL,
-                                    Type::i32,
-                                    builder.makeConst(int32_t(HANG_LIMIT)),
-                                    Builder::Mutable);
-    wasm.addGlobal(glob);
+    auto glob = builder.makeGlobal(HANG_LIMIT_GLOBAL,
+                                   Type::i32,
+                                   builder.makeConst(int32_t(HANG_LIMIT)),
+                                   Builder::Mutable);
+    wasm.addGlobal(std::move(glob));
 
     Name exportName = "hangLimitInitializer";
     auto funcName = Names::getValidFunctionName(wasm, exportName);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1362,7 +1362,7 @@ public:
   Index endOfFunction = -1;
 
   // we store globals here before wasm.addGlobal after we know their names
-  std::vector<Global*> globals;
+  std::vector<std::unique_ptr<Global>> globals;
   // we store global imports here before wasm.addGlobalImport after we know
   // their names
   std::vector<Global*> globalImports;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -41,11 +41,11 @@ public:
 
   // make* functions, other globals
 
-  Function* makeFunction(Name name,
-                         Signature sig,
-                         std::vector<Type>&& vars,
-                         Expression* body = nullptr) {
-    auto* func = new Function;
+  static std::unique_ptr<Function> makeFunction(Name name,
+                                                Signature sig,
+                                                std::vector<Type>&& vars,
+                                                Expression* body = nullptr) {
+    auto func = std::make_unique<Function>();
     func->name = name;
     func->sig = sig;
     func->body = body;
@@ -53,12 +53,12 @@ public:
     return func;
   }
 
-  Function* makeFunction(Name name,
-                         std::vector<NameType>&& params,
-                         Type resultType,
-                         std::vector<NameType>&& vars,
-                         Expression* body = nullptr) {
-    auto* func = new Function;
+  static std::unique_ptr<Function> makeFunction(Name name,
+                                                std::vector<NameType>&& params,
+                                                Type resultType,
+                                                std::vector<NameType>&& vars,
+                                                Expression* body = nullptr) {
+    auto func = std::make_unique<Function>();
     func->name = name;
     func->body = body;
     std::vector<Type> paramVec;
@@ -78,12 +78,34 @@ public:
     return func;
   }
 
-  Export* makeExport(Name name, Name value, ExternalKind kind) {
-    auto* export_ = new Export();
+  static std::unique_ptr<Export>
+  makeExport(Name name, Name value, ExternalKind kind) {
+    auto export_ = std::make_unique<Export>();
     export_->name = name;
     export_->value = value;
     export_->kind = kind;
     return export_;
+  }
+
+  enum Mutability { Mutable, Immutable };
+
+  static std::unique_ptr<Global>
+  makeGlobal(Name name, Type type, Expression* init, Mutability mutable_) {
+    auto glob = std::make_unique<Global>();
+    glob->name = name;
+    glob->type = type;
+    glob->init = init;
+    glob->mutable_ = mutable_ == Mutable;
+    return glob;
+  }
+
+  static std::unique_ptr<Event>
+  makeEvent(Name name, uint32_t attribute, Signature sig) {
+    auto event = std::make_unique<Event>();
+    event->name = name;
+    event->attribute = attribute;
+    event->sig = sig;
+    return event;
   }
 
   // IR nodes
@@ -968,28 +990,6 @@ public:
         return ExpressionManipulator::unreachable(curr);
     }
     return makeConst(value);
-  }
-
-  // Module-level helpers
-
-  enum Mutability { Mutable, Immutable };
-
-  static Global*
-  makeGlobal(Name name, Type type, Expression* init, Mutability mutable_) {
-    auto* glob = new Global;
-    glob->name = name;
-    glob->type = type;
-    glob->init = init;
-    glob->mutable_ = mutable_ == Mutable;
-    return glob;
-  }
-
-  static Event* makeEvent(Name name, uint32_t attribute, Signature sig) {
-    auto* event = new Event;
-    event->name = name;
-    event->attribute = attribute;
-    event->sig = sig;
-    return event;
   }
 };
 


### PR DESCRIPTION
When Functions, Globals, Events, and Exports are added to a module, if they are
not already in std::unique_ptrs, they are wrapped in a new std::unique_ptr owned
by the Module. This adds an extra layer of indirection when accessing those
elements that can be avoided by allocating those elements as std::unique_ptrs.
This PR updates wasm-builder to allocate module elements via std::make_unique
rather than `new`. In the future, we should remove the raw pointer versions of
Module::add* to encourage using std::unique_ptrs more broadly.