### PR TITLE
[s-expression parsing] Parse typed function reference types

### DIFF
--- a/src/shared-constants.h
+++ b/src/shared-constants.h
@@ -43,6 +43,8 @@ extern Name GLOBAL;
 extern Name ELEM;
 extern Name LOCAL;
 extern Name TYPE;
+extern Name REF;
+extern Name NULL_;
 extern Name CALL;
 extern Name CALL_IMPORT;
 extern Name CALL_INDIRECT;

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -77,6 +77,16 @@ public:
   Element* setString(cashew::IString str__, bool dollared__, bool quoted__);
   Element* setMetadata(size_t line_, size_t col_, SourceLocation* startLoc_);
 
+  // comparisons
+  bool operator==(Name name) {
+    return isStr() && str() == name;
+  }
+
+  template<typename T>
+  bool operator!=(T t) {
+    return !(*this == t);
+  }
+
   // printing
   friend std::ostream& operator<<(std::ostream& o, Element& e);
   void dump();

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -78,14 +78,9 @@ public:
   Element* setMetadata(size_t line_, size_t col_, SourceLocation* startLoc_);
 
   // comparisons
-  bool operator==(Name name) {
-    return isStr() && str() == name;
-  }
+  bool operator==(Name name) { return isStr() && str() == name; }
 
-  template<typename T>
-  bool operator!=(T t) {
-    return !(*this == t);
-  }
+  template<typename T> bool operator!=(T t) { return !(*this == t); }
 
   // printing
   friend std::ostream& operator<<(std::ostream& o, Element& e);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -933,13 +933,15 @@ Type SExpressionWasmBuilder::elementToType(Element& s) {
     // or
     //   (ref null $name)
     if ((size != 2 && size != 3) || !list[1]->isStr()) {
-      throw ParseException(std::string("invalid reference type"), s.line, s.col);
+      throw ParseException(
+        std::string("invalid reference type"), s.line, s.col);
     }
     bool nullable = false;
     size_t i = 1;
     if (size == 3) {
       if (*list[1] != NULL_) {
-        throw ParseException(std::string("invalid reference type qualifier"), s.line, s.col);
+        throw ParseException(
+          std::string("invalid reference type qualifier"), s.line, s.col);
       }
       nullable = true;
       i++;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -72,6 +72,8 @@ Name TABLE("table");
 Name ELEM("elem");
 Name LOCAL("local");
 Name TYPE("type");
+Name REF("ref");
+Name NULL_("null");
 Name CALL("call");
 Name CALL_INDIRECT("call_indirect");
 Name BLOCK("block");


### PR DESCRIPTION
This does not add testing yet - my next PR, which adds `call_ref`, will make
it much easier to test typed function references, and will include tests that
cover this.