### PR TITLE
[wasm-type] Introduce a function for walking type trees

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -116,6 +116,12 @@ public:
   bool isNullable() const;
   bool isRtt() const;
 
+  // Scans the type tree rooted at `type`, first calling `noteRecursion` on the
+  // root of any cycles, then calling `VisitType` on each type in the tree in
+  // reverse postorder.
+  void walk(std::function<void(const Type&)> noteRecursion,
+            std::function<void(const Type&)> visitType);
+
 private:
   template<bool (Type::*pred)() const> bool hasPredicate() {
     for (const auto& type : *this) {


### PR DESCRIPTION
Since types can be arbitrarily deeply nested, even discovering all the types
used in a module requires being able to traverse type definition trees. This PR
introduces a function to do just that. It takes two callbacks, a function to
call on each visited type and a function to call whenever a recursion is
encountered. Note that it is not currently possible to construct a recursive
type, but the recursion callback will be useful in an upcoming PR to allow
constructing recursive types.