### PR TITLE
[Printing] Print type names where possible.

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2355,11 +2355,23 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
     }
     if (curr.params.size() > 0) {
       o << maybeSpace;
-      o << ParamType(curr.params);
+      o << "(param ";
+      auto sep = "";
+      for (auto type : curr.params) {
+        o << sep << TypeName(type);
+        sep = " ";
+      }
+      o << ')';
     }
     if (curr.results.size() > 0) {
       o << maybeSpace;
-      o << ResultType(curr.results);
+      o << "(result ";
+      auto sep = "";
+      for (auto type : curr.results) {
+        o << sep << TypeName(type);
+        sep = " ";
+      }
+      o << ')';
     }
     o << ")";
   }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -156,7 +156,7 @@ std::ostream& operator<<(std::ostream& os, TypeName typeName) {
     }
     os << ')';
     return os;
-  } 
+  }
   return os << SExprType(typeName.type);
 }
 

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -5688,7 +5688,7 @@
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null (func (param i32) (result i32)))) (result i32)))
- (func $call_from-param (param $f (ref null (func (param i32) (result i32)))) (result i32)
+ (func $call_from-param (param $f (ref null $i32_=>_i32)) (result i32)
   (unreachable)
  )
 )

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -5687,7 +5687,7 @@
 )
 (module
  (type $i32_=>_i32 (func (param i32) (result i32)))
- (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null (func (param i32) (result i32)))) (result i32)))
+ (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
  (func $call_from-param (param $f (ref null $i32_=>_i32)) (result i32)
   (unreachable)
  )

--- a/test/typed-function-references.wast.from-wast
+++ b/test/typed-function-references.wast.from-wast
@@ -40,7 +40,7 @@
   )
  )
  (func $call_from-local-null (result i32)
-  (local $f (ref null (func (param i32) (result i32))))
+  (local $f $i32_=>_i32)
   (local.set $f
    (ref.func $call-ref-more)
   )

--- a/test/typed-function-references.wast.from-wast
+++ b/test/typed-function-references.wast.from-wast
@@ -6,11 +6,11 @@
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_anyref (func (result anyref)))
  (type $none_=>_anyref_f32_anyref_f32 (func (result anyref f32 anyref f32)))
- (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null (func (param i32) (result i32)))) (result i32)))
- (type $none_=>_i32_ref_null[_->_anyref_f32_anyref_f32]_f64 (func (result i32 (ref null (func (result anyref f32 anyref f32))) f64)))
- (type $none_=>_ref_null[i32_i32_i32_i32_i32_->_] (func (result (ref null (func (param i32 i32 i32 i32 i32))))))
- (type $f64_=>_ref_null[_->_eqref] (func (param f64) (result (ref null (func (result eqref))))))
- (type $none_=>_ref_null[_->_ref_null[i32_i32_i32_i32_i32_->_]] (func (result (ref null (func (result (ref null (func (param i32 i32 i32 i32 i32)))))))))
+ (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
+ (type $none_=>_i32_ref_null[_->_anyref_f32_anyref_f32]_f64 (func (result i32 (ref null $none_=>_anyref_f32_anyref_f32) f64)))
+ (type $none_=>_ref_null[i32_i32_i32_i32_i32_->_] (func (result (ref null $i32_i32_i32_i32_i32_=>_none))))
+ (type $f64_=>_ref_null[_->_eqref] (func (param f64) (result (ref null $none_=>_eqref))))
+ (type $none_=>_ref_null[_->_ref_null[i32_i32_i32_i32_i32_->_]] (func (result (ref null $none_=>_ref_null[i32_i32_i32_i32_i32_->_]))))
  (func $call-ref
   (call_ref
    (ref.func $call-ref)

--- a/test/typed-function-references.wast.from-wast
+++ b/test/typed-function-references.wast.from-wast
@@ -27,20 +27,20 @@
    (ref.func $call-ref-more)
   )
  )
- (func $call_from-param (param $f (ref null (func (param i32) (result i32)))) (result i32)
+ (func $call_from-param (param $f (ref null $i32_=>_i32)) (result i32)
   (call_ref
    (i32.const 42)
    (local.get $f)
   )
  )
- (func $call_from-param-null (param $f (ref null (func (param i32) (result i32)))) (result i32)
+ (func $call_from-param-null (param $f (ref null $i32_=>_i32)) (result i32)
   (call_ref
    (i32.const 42)
    (local.get $f)
   )
  )
  (func $call_from-local-null (result i32)
-  (local $f $i32_=>_i32)
+  (local $f (ref null $i32_=>_i32))
   (local.set $f
    (ref.func $call-ref-more)
   )

--- a/test/typed-function-references.wast.fromBinary
+++ b/test/typed-function-references.wast.fromBinary
@@ -6,11 +6,11 @@
  (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_anyref (func (result anyref)))
- (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null (func (param i32) (result i32)))) (result i32)))
- (type $none_=>_i32_ref_null[_->_anyref_f32_anyref_f32]_f64 (func (result i32 (ref null (func (result anyref f32 anyref f32))) f64)))
- (type $none_=>_ref_null[i32_i32_i32_i32_i32_->_] (func (result (ref null (func (param i32 i32 i32 i32 i32))))))
- (type $f64_=>_ref_null[_->_eqref] (func (param f64) (result (ref null (func (result eqref))))))
- (type $none_=>_ref_null[_->_ref_null[i32_i32_i32_i32_i32_->_]] (func (result (ref null (func (result (ref null (func (param i32 i32 i32 i32 i32)))))))))
+ (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
+ (type $none_=>_i32_ref_null[_->_anyref_f32_anyref_f32]_f64 (func (result i32 (ref null $none_=>_anyref_f32_anyref_f32) f64)))
+ (type $none_=>_ref_null[i32_i32_i32_i32_i32_->_] (func (result (ref null $i32_i32_i32_i32_i32_=>_none))))
+ (type $f64_=>_ref_null[_->_eqref] (func (param f64) (result (ref null $none_=>_eqref))))
+ (type $none_=>_ref_null[_->_ref_null[i32_i32_i32_i32_i32_->_]] (func (result (ref null $none_=>_ref_null[i32_i32_i32_i32_i32_->_]))))
  (func $call-ref
   (call_ref
    (ref.func $call-ref)

--- a/test/typed-function-references.wast.fromBinary
+++ b/test/typed-function-references.wast.fromBinary
@@ -40,7 +40,7 @@
   )
  )
  (func $call_from-local-null (result i32)
-  (local $f (ref null (func (param i32) (result i32))))
+  (local $f $i32_=>_i32)
   (local.set $f
    (ref.func $call-ref-more)
   )
@@ -55,12 +55,12 @@
  (func $type-only-in-tuple-local
   (local $x i32)
   (local $1 f64)
-  (local $2 (ref null (func (result anyref))))
+  (local $2 $none_=>_anyref)
   (nop)
  )
  (func $type-only-in-tuple-block
   (local $0 (i32 (ref null (func (result anyref f32 anyref f32))) f64))
-  (local $1 (ref null (func (result anyref f32 anyref f32))))
+  (local $1 $none_=>_anyref_f32_anyref_f32)
   (local $2 i32)
   (local.set $0
    (block $label$1 (result i32 (ref null (func (result anyref f32 anyref f32))) f64)

--- a/test/typed-function-references.wast.fromBinary
+++ b/test/typed-function-references.wast.fromBinary
@@ -27,20 +27,20 @@
    (ref.func $call-ref-more)
   )
  )
- (func $call_from-param (param $f (ref null (func (param i32) (result i32)))) (result i32)
+ (func $call_from-param (param $f (ref null $i32_=>_i32)) (result i32)
   (call_ref
    (i32.const 42)
    (local.get $f)
   )
  )
- (func $call_from-param-null (param $f (ref null (func (param i32) (result i32)))) (result i32)
+ (func $call_from-param-null (param $f (ref null $i32_=>_i32)) (result i32)
   (call_ref
    (i32.const 42)
    (local.get $f)
   )
  )
  (func $call_from-local-null (result i32)
-  (local $f $i32_=>_i32)
+  (local $f (ref null $i32_=>_i32))
   (local.set $f
    (ref.func $call-ref-more)
   )
@@ -55,12 +55,12 @@
  (func $type-only-in-tuple-local
   (local $x i32)
   (local $1 f64)
-  (local $2 $none_=>_anyref)
+  (local $2 (ref null $none_=>_anyref))
   (nop)
  )
  (func $type-only-in-tuple-block
   (local $0 (i32 (ref null (func (result anyref f32 anyref f32))) f64))
-  (local $1 $none_=>_anyref_f32_anyref_f32)
+  (local $1 (ref null $none_=>_anyref_f32_anyref_f32))
   (local $2 i32)
   (local.set $0
    (block $label$1 (result i32 (ref null (func (result anyref f32 anyref f32))) f64)

--- a/test/typed-function-references.wast.fromBinary.noDebugInfo
+++ b/test/typed-function-references.wast.fromBinary.noDebugInfo
@@ -40,7 +40,7 @@
   )
  )
  (func $5 (result i32)
-  (local $0 (ref null (func (param i32) (result i32))))
+  (local $0 $i32_=>_i32)
   (local.set $0
    (ref.func $2)
   )
@@ -55,12 +55,12 @@
  (func $7
   (local $0 i32)
   (local $1 f64)
-  (local $2 (ref null (func (result anyref))))
+  (local $2 $none_=>_anyref)
   (nop)
  )
  (func $8
   (local $0 (i32 (ref null (func (result anyref f32 anyref f32))) f64))
-  (local $1 (ref null (func (result anyref f32 anyref f32))))
+  (local $1 $none_=>_anyref_f32_anyref_f32)
   (local $2 i32)
   (local.set $0
    (block $label$1 (result i32 (ref null (func (result anyref f32 anyref f32))) f64)

--- a/test/typed-function-references.wast.fromBinary.noDebugInfo
+++ b/test/typed-function-references.wast.fromBinary.noDebugInfo
@@ -27,20 +27,20 @@
    (ref.func $2)
   )
  )
- (func $3 (param $0 (ref null (func (param i32) (result i32)))) (result i32)
+ (func $3 (param $0 (ref null $i32_=>_i32)) (result i32)
   (call_ref
    (i32.const 42)
    (local.get $0)
   )
  )
- (func $4 (param $0 (ref null (func (param i32) (result i32)))) (result i32)
+ (func $4 (param $0 (ref null $i32_=>_i32)) (result i32)
   (call_ref
    (i32.const 42)
    (local.get $0)
   )
  )
  (func $5 (result i32)
-  (local $0 $i32_=>_i32)
+  (local $0 (ref null $i32_=>_i32))
   (local.set $0
    (ref.func $2)
   )
@@ -55,12 +55,12 @@
  (func $7
   (local $0 i32)
   (local $1 f64)
-  (local $2 $none_=>_anyref)
+  (local $2 (ref null $none_=>_anyref))
   (nop)
  )
  (func $8
   (local $0 (i32 (ref null (func (result anyref f32 anyref f32))) f64))
-  (local $1 $none_=>_anyref_f32_anyref_f32)
+  (local $1 (ref null $none_=>_anyref_f32_anyref_f32))
   (local $2 i32)
   (local.set $0
    (block $label$1 (result i32 (ref null (func (result anyref f32 anyref f32))) f64)

--- a/test/typed-function-references.wast.fromBinary.noDebugInfo
+++ b/test/typed-function-references.wast.fromBinary.noDebugInfo
@@ -6,11 +6,11 @@
  (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_anyref (func (result anyref)))
- (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null (func (param i32) (result i32)))) (result i32)))
- (type $none_=>_i32_ref_null[_->_anyref_f32_anyref_f32]_f64 (func (result i32 (ref null (func (result anyref f32 anyref f32))) f64)))
- (type $none_=>_ref_null[i32_i32_i32_i32_i32_->_] (func (result (ref null (func (param i32 i32 i32 i32 i32))))))
- (type $f64_=>_ref_null[_->_eqref] (func (param f64) (result (ref null (func (result eqref))))))
- (type $none_=>_ref_null[_->_ref_null[i32_i32_i32_i32_i32_->_]] (func (result (ref null (func (result (ref null (func (param i32 i32 i32 i32 i32)))))))))
+ (type $ref_null[i32_->_i32]_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
+ (type $none_=>_i32_ref_null[_->_anyref_f32_anyref_f32]_f64 (func (result i32 (ref null $none_=>_anyref_f32_anyref_f32) f64)))
+ (type $none_=>_ref_null[i32_i32_i32_i32_i32_->_] (func (result (ref null $i32_i32_i32_i32_i32_=>_none))))
+ (type $f64_=>_ref_null[_->_eqref] (func (param f64) (result (ref null $none_=>_eqref))))
+ (type $none_=>_ref_null[_->_ref_null[i32_i32_i32_i32_i32_->_]] (func (result (ref null $none_=>_ref_null[i32_i32_i32_i32_i32_->_]))))
  (func $0
   (call_ref
    (ref.func $0)


### PR DESCRIPTION
For a nested type, we used to print e.g.
```wat
(param $x (ref (func (param i32))))
```
Instead of expanding the full type inline, which can get long for
a deeply nested type, print a name when running the Print pass.
In this example that would be something like
```wat
(param $x (ref $i32_=>_none))
```
