### PR TITLE
[wasm-split] Record checksums in profiles

### DIFF
--- a/test/lit/wasm-split/instrument-funcs.wast
+++ b/test/lit/wasm-split/instrument-funcs.wast
@@ -59,7 +59,7 @@
 ;; CHECK-NEXT:     (block
 ;; CHECK-NEXT:       (i64.store align=1
 ;; CHECK-NEXT:         (local.get $addr)
-;; CHECK-NEXT:         (i64.const 0)
+;; CHECK-NEXT:         (i64.const {{.*}})
 ;; CHECK-NEXT:       )
 ;; CHECK-NEXT:       (i32.store offset=8 align=1
 ;; CHECK-NEXT:         (local.get $addr)

--- a/test/lit/wasm-split/mismatched-hashes.wast
+++ b/test/lit/wasm-split/mismatched-hashes.wast
@@ -1,0 +1,20 @@
+;; Check that using different inputs for the instrumentation and splitting steps
+;; results in an error.
+
+;; Instrument the module
+;; RUN: wasm-split --instrument %s -o %t.instrumented.wasm
+
+;; Generate a profile
+;; RUN: node %S/call_exports.mjs %t.instrumented.wasm %t.prof
+
+;; Attempt to split the instrumented module
+;; RUN: not wasm-split %t.instrumented.wasm --profile=%t.prof -o1 %t.1.wasm -o2 %t.2.wasm \
+;; RUN:   2>&1 | filecheck %s
+
+;; CHECK:      error: checksum in profile does not match module checksum.
+;; CHECK-SAME: The split module must be the original module that was instrumented
+;; CHECK-SAME: to generate the profile.
+
+(module
+ (export "memory" (memory 0 0))
+)

--- a/test/lit/wasm-split/mismatched-hashes.wast
+++ b/test/lit/wasm-split/mismatched-hashes.wast
@@ -15,6 +15,9 @@
 ;; CHECK-SAME: The split module must be the original module that was instrumented
 ;; CHECK-SAME: to generate the profile.
 
+;; Check that the matcing module succeeds
+;; RUN: wasm-split %s --profile=%t.prof -o1 %t.1.wasm -o2 %t.2.wasm
+
 (module
  (export "memory" (memory 0 0))
 )


### PR DESCRIPTION
Calculate a checksum of the original uninstrumented module and emit it as part
of the profile data. When reading the profile, compare the checksum it contains
to the checksum of the module that is being split. Error out if the module being
split is not the same as the module that was originally instrumented.

Also fixes a bug in how the profile data was being read. When `char` is signed,
bytes read from the profile were being incorrectly sign extended. We had not
noticed this before because the profiles we have tested have contained only
small-valued counts.

cc @sbc100 @awtcode.