### PR TITLE
[OptimizeInstructions] Fix a fuzz bug with getting the shifts of an unreachable

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -188,6 +188,10 @@ inline Index getAlmostSignExtBits(Expression* curr, Index& extraLeftShifts) {
 // Check if an expression is a zero-extend, and if so, returns the value
 // that is extended, otherwise nullptr
 inline Expression* getZeroExtValue(Expression* curr) {
+  // We only care about i32s here, and ignore i64s, unreachables, etc.
+  if (curr->type != Type::i32) {
+    return nullptr;
+  }
   using namespace Match;
   int32_t mask = 0;
   Expression* extended = nullptr;

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -132,6 +132,10 @@ inline Literals getLiterals(const Expression* curr) {
 // Check if an expression is a sign-extend, and if so, returns the value
 // that is extended, otherwise nullptr
 inline Expression* getSignExtValue(Expression* curr) {
+  // We only care about i32s here, and ignore i64s, unreachables, etc.
+  if (curr->type != Type::i32) {
+    return nullptr;
+  }
   using namespace Match;
   int32_t leftShift = 0, rightShift = 0;
   Expression* extended = nullptr;

--- a/test/passes/optimize-instructions_all-features.txt
+++ b/test/passes/optimize-instructions_all-features.txt
@@ -969,6 +969,19 @@
     (i32.const 0)
    )
   )
+  (drop
+   (if (result i32)
+    (i32.shr_s
+     (i32.shl
+      (unreachable)
+      (i32.const 16)
+     )
+     (i32.const 16)
+    )
+    (i32.const 111)
+    (i32.const 222)
+   )
+  )
  )
  (func $sign-ext-input (param $0 i32) (param $1 i32)
   (drop

--- a/test/passes/optimize-instructions_all-features.wast
+++ b/test/passes/optimize-instructions_all-features.wast
@@ -805,6 +805,19 @@
         (i32.const 0)
       )
     )
+    (drop
+      (if (result i32)
+        (i32.shr_s
+          (i32.shl
+            (unreachable) ;; ignore an unreachable value
+            (i32.const 16)
+          )
+          (i32.const 16)
+        )
+        (i32.const 111)
+        (i32.const 222)
+      )
+    )
   )
   (func $sign-ext-input (param $0 i32) (param $1 i32)
     (drop


### PR DESCRIPTION
This code was edited recently but it seems to not be a regression, rather a
bug that was there all along.