### PR TITLE
[Types] Return const& for HeapTypes and their Structs and Arrays. NFC

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -158,7 +158,7 @@ public:
   FeatureSet getFeatures() const;
 
   // Gets the heap type corresponding to this type
-  HeapType getHeapType() const;
+  const HeapType& getHeapType() const;
 
   // Returns a number type based on its size in bytes and whether it is a float
   // type.
@@ -365,12 +365,12 @@ struct HeapType {
     return signature;
   }
   bool isStruct() const { return kind == StructKind; }
-  Struct getStruct() const {
+  const Struct& getStruct() const {
     assert(isStruct() && "Not a struct");
     return struct_;
   }
   bool isArray() const { return kind == ArrayKind; }
-  Array getArray() const {
+  const Array& getArray() const {
     assert(isArray() && "Not an array");
     return array;
   }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -513,24 +513,29 @@ FeatureSet Type::getFeatures() const {
   return getSingleFeatures(*this);
 }
 
-HeapType Type::getHeapType() const {
+static HeapType funcHeapType(HeapType::FuncKind),
+  externHeapType(HeapType::ExternKind), exnHeapType(HeapType::ExnKind),
+  anyHeapType(HeapType::AnyKind), eqHeapType(HeapType::EqKind),
+  i31HeapType(HeapType::I31Kind);
+
+const HeapType& Type::getHeapType() const {
   if (isRef()) {
     if (isCompound()) {
       return getTypeInfo(*this)->ref.heapType;
     }
     switch (getBasic()) {
       case funcref:
-        return HeapType::FuncKind;
+        return funcHeapType;
       case externref:
-        return HeapType::ExternKind;
+        return externHeapType;
       case exnref:
-        return HeapType::ExnKind;
+        return exnHeapType;
       case anyref:
-        return HeapType::AnyKind;
+        return anyHeapType;
       case eqref:
-        return HeapType::EqKind;
+        return eqHeapType;
       case i31ref:
-        return HeapType::I31Kind;
+        return i31HeapType;
       default:
         break;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -513,10 +513,17 @@ FeatureSet Type::getFeatures() const {
   return getSingleFeatures(*this);
 }
 
+// getHeapType() returns a const HeapType&, so we need a canonical object to
+// return for the basic types, so that we don't create a temporary copy on each
+// call.
+namespace statics {
+
 static HeapType funcHeapType(HeapType::FuncKind),
   externHeapType(HeapType::ExternKind), exnHeapType(HeapType::ExnKind),
   anyHeapType(HeapType::AnyKind), eqHeapType(HeapType::EqKind),
   i31HeapType(HeapType::I31Kind);
+
+}
 
 const HeapType& Type::getHeapType() const {
   if (isRef()) {
@@ -525,17 +532,17 @@ const HeapType& Type::getHeapType() const {
     }
     switch (getBasic()) {
       case funcref:
-        return funcHeapType;
+        return statics::funcHeapType;
       case externref:
-        return externHeapType;
+        return statics::externHeapType;
       case exnref:
-        return exnHeapType;
+        return statics::exnHeapType;
       case anyref:
-        return anyHeapType;
+        return statics::anyHeapType;
       case eqref:
-        return eqHeapType;
+        return statics::eqHeapType;
       case i31ref:
-        return i31HeapType;
+        return statics::i31HeapType;
       default:
         break;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -517,12 +517,10 @@ FeatureSet Type::getFeatures() const {
 // return for the basic types, so that we don't create a temporary copy on each
 // call.
 namespace statics {
-
 static HeapType funcHeapType(HeapType::FuncKind),
   externHeapType(HeapType::ExternKind), exnHeapType(HeapType::ExnKind),
   anyHeapType(HeapType::AnyKind), eqHeapType(HeapType::EqKind),
   i31HeapType(HeapType::I31Kind);
-
 }
 
 const HeapType& Type::getHeapType() const {


### PR DESCRIPTION
I am starting to write lines like
```cpp
curr->value->type.getHeapType().getStruct().fields[curr->index].type
```
and it scares me to think that there may be copies going on there.
The issue is that Types are interned, but HeapTypes and their components
are not.

Talking to @tlively , we think this should avoid the perf issue and also
allow for possible interning of more things in the future. I am happy to see
that it compiles without needing any changes.