### PR TITLE
[NFC] Rename BasicID to BasicType

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -55,7 +55,7 @@ public:
 
   Literal() : v128(), type(Type::none) {}
   explicit Literal(Type type);
-  explicit Literal(Type::BasicID typeId) : Literal(Type(typeId)) {}
+  explicit Literal(Type::BasicType type) : Literal(Type(type)) {}
   explicit Literal(int32_t init) : i32(init), type(Type::i32) {}
   explicit Literal(uint32_t init) : i32(init), type(Type::i32) {}
   explicit Literal(int64_t init) : i64(init), type(Type::i64) {}

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -33,13 +33,13 @@ namespace wasm {
 
 class Type {
   // The `id` uniquely represents each type, so type equality is just a
-  // comparison of the ids. For basic types the `id` is just the `BasicID`
+  // comparison of the ids. For basic types the `id` is just the `BasicType`
   // enum value below, and for constructed types the `id` is the address of the
   // canonical representation of the type, making lookups cheap for all types.
   uintptr_t id;
 
 public:
-  enum BasicID : uint32_t {
+  enum BasicType : uint32_t {
     none,
     unreachable,
     i32,
@@ -58,8 +58,8 @@ public:
 
   Type() = default;
 
-  // BasicID can be implicitly upgraded to Type
-  constexpr Type(BasicID id) : id(id){};
+  // BasicType can be implicitly upgraded to Type
+  constexpr Type(BasicType id) : id(id){};
 
   // But converting raw uint32_t is more dangerous, so make it explicit
   explicit Type(uint64_t id) : id(id){};
@@ -131,18 +131,18 @@ public:
   bool hasRef() { return hasPredicate<&Type::isRef>(); }
 
   constexpr uint64_t getID() const { return id; }
-  constexpr BasicID getBasic() const {
+  constexpr BasicType getBasic() const {
     assert(isBasic() && "Basic type expected");
-    return static_cast<BasicID>(id);
+    return static_cast<BasicType>(id);
   }
 
-  // (In)equality must be defined for both Type and BasicID because it is
+  // (In)equality must be defined for both Type and BasicType because it is
   // otherwise ambiguous whether to convert both this and other to int or
   // convert other to Type.
   bool operator==(const Type& other) const { return id == other.id; }
-  bool operator==(const BasicID& otherId) const { return id == otherId; }
+  bool operator==(const BasicType& otherId) const { return id == otherId; }
   bool operator!=(const Type& other) const { return id != other.id; }
-  bool operator!=(const BasicID& otherId) const { return id != otherId; }
+  bool operator!=(const BasicType& otherId) const { return id != otherId; }
 
   // Order types by some notion of simplicity
   bool operator<(const Type& other) const;

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -1569,7 +1569,8 @@ Literal Literal::shuffleV8x16(const Literal& other,
   return Literal(bytes);
 }
 
-template<Type::BasicID Ty, int Lanes> static Literal splat(const Literal& val) {
+template<Type::BasicType Ty, int Lanes>
+static Literal splat(const Literal& val) {
   assert(val.type == Ty);
   LaneArray<Lanes> lanes;
   lanes.fill(val);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -243,9 +243,9 @@ struct TypeStore {
     // If a Type is constructed from a list of types, the list of types becomes
     // implicitly converted to a TypeInfo before canonicalizing its id. This is
     // also the case if a list of just one type is provided, even though such a
-    // list of types will be canonicalized to the BasicID of the single type. As
-    // such, the following entries are solely placeholders to enable the lookup
-    // of lists of just one type to the BasicID of the single type.
+    // list of types will be canonicalized to the BasicType of the single type.
+    // As such, the following entries are solely placeholders to enable the
+    // lookup of lists of just one type to the BasicType of the single type.
     {TypeInfo(Tuple()), Type::none},
     {TypeInfo({Type::unreachable}), Type::unreachable},
     {TypeInfo({Type::i32}), Type::i32},


### PR DESCRIPTION
This name is more descriptive and paves the way toward interning HeapTypes as
well, with an analogous BasicHeapType.