### PR TITLE
Don't apply SafeHeap to wasm start function

### DIFF
--- a/test/passes/safe-heap_start-function.passes
+++ b/test/passes/safe-heap_start-function.passes
@@ -1,0 +1,1 @@
+safe-heap

--- a/test/passes/safe-heap_start-function.txt
+++ b/test/passes/safe-heap_start-function.txt
@@ -1,0 +1,1932 @@
+(module
+ (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
+ (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
+ (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
+ (type $none_=>_none (func))
+ (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
+ (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
+ (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
+ (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "env" "emscripten_get_sbrk_ptr" (func $emscripten_get_sbrk_ptr (result i32)))
+ (import "env" "segfault" (func $segfault))
+ (import "env" "alignfault" (func $alignfault))
+ (memory $0 1 1)
+ (start $foo)
+ (func $foo
+  (i32.store
+   (i32.load
+    (i32.const 1234)
+   )
+   (i32.const 5678)
+  )
+ )
+ (func $bar
+  (call $SAFE_HEAP_STORE_i32_4_4
+   (call $SAFE_HEAP_LOAD_i32_4_4
+    (i32.const 1234)
+    (i32.const 0)
+   )
+   (i32.const 0)
+   (i32.const 5678)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_1 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_1_U_1 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_1 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_2 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_1 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_2_U_2 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_1 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_2 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i32_4_4 (param $0 i32) (param $1 i32) (result i32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_1_U_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load8_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_2 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load16_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_2_U_2 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load16_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_s align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_2 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_4 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_s
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load32_u align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_2 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_4_U_4 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load32_u
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_1 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_2 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_4 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_i64_8_8 (param $0 i32) (param $1 i32) (result i64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_1 (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_2 (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f32_4_4 (param $0 i32) (param $1 i32) (result f32)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_1 (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.load align=1
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_2 (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=2
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_4 (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.load align=4
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_LOAD_f64_8_8 (param $0 i32) (param $1 i32) (result f64)
+  (local $2 i32)
+  (local.set $2
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $2)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $2)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $2)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.load
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_2_2 (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_1 (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_2 (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_1_1 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 1)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store8
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store16 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_2_2 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 2)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store16
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_1 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store32 align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_2 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store32 align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store32
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_1 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (i64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_2 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_4 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (i64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (i64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_1 (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f32.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_2 (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f32.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f32_4_4 (param $0 i32) (param $1 i32) (param $2 f32)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 4)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f32.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_1 (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (f64.store align=1
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_2 (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 1)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=2
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_4 (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 3)
+   )
+   (call $alignfault)
+  )
+  (f64.store align=4
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+ (func $SAFE_HEAP_STORE_f64_8_8 (param $0 i32) (param $1 i32) (param $2 f64)
+  (local $3 i32)
+  (local.set $3
+   (i32.add
+    (local.get $0)
+    (local.get $1)
+   )
+  )
+  (if
+   (i32.or
+    (i32.eq
+     (local.get $3)
+     (i32.const 0)
+    )
+    (i32.gt_u
+     (i32.add
+      (local.get $3)
+      (i32.const 8)
+     )
+     (i32.load
+      (call $emscripten_get_sbrk_ptr)
+     )
+    )
+   )
+   (call $segfault)
+  )
+  (if
+   (i32.and
+    (local.get $3)
+    (i32.const 7)
+   )
+   (call $alignfault)
+  )
+  (f64.store
+   (local.get $3)
+   (local.get $2)
+  )
+ )
+)

--- a/test/passes/safe-heap_start-function.wast
+++ b/test/passes/safe-heap_start-function.wast
@@ -1,0 +1,11 @@
+(module
+  (memory 1 1)
+  (func $foo
+   ;; should not be modified because its the start function
+   (i32.store (i32.load (i32.const 1234)) (i32.const 5678))
+  )
+  (func $bar
+   (i32.store (i32.load (i32.const 1234)) (i32.const 5678))
+  )
+  (start $foo)
+)


### PR DESCRIPTION
In relocable code (MAIN/SIDE modules) we use the start function to run
`__wasm_init_memory` which loads the data segments into place.   We
can't call get_sbkr pointer during that function because the sbrk
pointer itself lives in static data segment.