### PR TITLE
Improve lit support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
         name: build-${{ matrix.os }}
         path: out/install
 
+    - name: test binaryen-lit
+      run: python out/bin/binaryen-lit test/lit/parse-error.wast
+
     - name: test
       run: python check.py --binaryen-bin=out/bin
 
@@ -115,6 +118,8 @@ jobs:
         cmake -S . -B out -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
     - name: build
       run: cmake --build out
+    - name: test binaryen-lit
+      run: python out/bin/binaryen-lit test/lit/parse-error.wast
     - name: test
       run: python check.py --binaryen-bin=out/bin
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,3 +394,5 @@ if(EMSCRIPTEN)
   set_property(TARGET binaryen_js PROPERTY CXX_STANDARD_REQUIRED ON)
   install(TARGETS binaryen_js DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
+
+configure_file(scripts/binaryen-lit.in ${CMAKE_BINARY_DIR}/bin/binaryen-lit @ONLY)

--- a/check.py
+++ b/check.py
@@ -42,7 +42,7 @@ def get_changelog_version():
 def run_help_tests():
     print('[ checking --help is useful... ]\n')
 
-    not_executable_suffix = ['.txt', '.js', '.ilk', '.pdb', '.dll', '.wasm', '.manifest']
+    not_executable_suffix = ['.txt', '.js', '.ilk', '.pdb', '.dll', '.wasm', '.manifest', 'binaryen-lit']
     bin_files = [os.path.join(shared.options.binaryen_bin, f) for f in os.listdir(shared.options.binaryen_bin)]
     executables = [f for f in bin_files if os.path.isfile(f) and not any(f.endswith(s) for s in not_executable_suffix)]
     executables = sorted(executables)
@@ -329,10 +329,10 @@ def run_unittest():
 
 
 def run_lit():
-    lit_script = os.path.join(shared.options.binaryen_root, 'scripts', 'lit_wrapper.py')
-    lit_cfg = os.path.join(shared.options.binaryen_build, 'test', 'lit')
+    lit_script = os.path.join(shared.options.binaryen_bin, 'binaryen-lit')
+    lit_tests = os.path.join(shared.options.binaryen_root, 'test', 'lit')
     # lit expects to be run as its own executable
-    cmd = [sys.executable, lit_script, lit_cfg, '-vv']
+    cmd = [sys.executable, lit_script, lit_tests, '-vv']
     result = subprocess.run(cmd)
     if result.returncode != 0:
         shared.num_failures += 1

--- a/scripts/binaryen-lit.in
+++ b/scripts/binaryen-lit.in
@@ -14,9 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from lit.main import main
 
-# A simple wrapper around `lit`'s main function, since it isn't otherwise
-# exposed.
+# A simple wrapper around `lit` test running.   Loosely based on
+# llvm's llvm-lit script
+
+builtin_parameters = {
+    'config_map': {
+        os.path.normcase(os.path.normpath('@CMAKE_SOURCE_DIR@/test/lit/lit.cfg.py')):
+        os.path.normcase(os.path.normpath('@CMAKE_BINARY_DIR@/test/lit/lit.site.cfg.py'))
+    }
+}
+
+print(builtin_parameters)
+
 if __name__ == '__main__':
-    main()
+    main(builtin_parameters)

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -6,16 +6,16 @@ config.test_format = lit.formats.ShTest(True)
 config.suffixes = ['.wat', '.wast']
 
 config.test_source_root = os.path.dirname(__file__)
-config.test_exec_root = os.path.join(config.src_root, 'out', 'test')
+config.test_exec_root = os.path.join(config.binaryen_build_root, 'test')
 
 # Replace all Binaryen tools with their absolute paths
-bin_dir = os.path.join(config.binaryen_root, 'bin')
+bin_dir = os.path.join(config.binaryen_build_root, 'bin')
 for tool_file in os.listdir(bin_dir):
-    tool_path = config.binaryen_root + '/bin/' + tool_file
+    tool_path = config.binaryen_build_root + '/bin/' + tool_file
     tool = tool_file[:-4] if tool_file.endswith('.exe') else tool_file
     config.substitutions.append((tool, tool_path))
 
 # Also make the `not` command available
-not_file = config.src_root + '/scripts/not.py'
+not_file = config.binaryen_src_root + '/scripts/not.py'
 python = sys.executable.replace('\\', '/')
 config.substitutions.append(('not', python + ' ' + not_file))

--- a/test/lit/lit.site.cfg.py.in
+++ b/test/lit/lit.site.cfg.py.in
@@ -1,7 +1,7 @@
 import os
 
-config.src_root = r'@CMAKE_SOURCE_DIR@'
-config.binaryen_root = r'@CMAKE_BINARY_DIR@'
+config.binaryen_src_root = r'@CMAKE_SOURCE_DIR@'
+config.binaryen_build_root = r'@CMAKE_BINARY_DIR@'
 
 lit_config.load_config(
-    config, os.path.join(config.src_root, 'test', 'lit', 'lit.cfg.py'))
+    config, os.path.join(config.binaryen_src_root, 'test', 'lit', 'lit.cfg.py'))


### PR DESCRIPTION
This uses the same technique used in llvm-lit to enable
running on in-tree tests with out-of-tree builds.

So you can run something like this:

  ../binaryen-out/bin/binaryen-lit test/lit/