### PR TITLE
[GC] Add Array operations

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -586,12 +586,20 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, Index> {
     return 1 + nullCheckCost(curr->ref) + visit(curr->ref);
   }
   Index visitStructSet(StructSet* curr) {
-    return 1 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->value);
+    return 2 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->value);
   }
-  Index visitArrayNew(ArrayNew* curr) { WASM_UNREACHABLE("TODO: GC"); }
-  Index visitArrayGet(ArrayGet* curr) { WASM_UNREACHABLE("TODO: GC"); }
-  Index visitArraySet(ArraySet* curr) { WASM_UNREACHABLE("TODO: GC"); }
-  Index visitArrayLen(ArrayLen* curr) { WASM_UNREACHABLE("TODO: GC"); }
+  Index visitArrayNew(ArrayNew* curr) {
+    return 4 + visit(curr->rtt) + visit(curr->size) + visit(curr->init);
+  }
+  Index visitArrayGet(ArrayGet* curr) {
+    return 1 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->index);
+  }
+  Index visitArraySet(ArraySet* curr) {
+    return 2 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->index) + visit(curr->value);
+  }
+  Index visitArrayLen(ArrayLen* curr) {
+    return 1 + nullCheckCost(curr->ref) + visit(curr->ref);
+  }
 
 private:
   Index nullCheckCost(Expression* ref) {

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -595,7 +595,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, Index> {
     return 1 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->index);
   }
   Index visitArraySet(ArraySet* curr) {
-    return 2 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->index) + visit(curr->value);
+    return 2 + nullCheckCost(curr->ref) + visit(curr->ref) +
+           visit(curr->index) + visit(curr->value);
   }
   Index visitArrayLen(ArrayLen* curr) {
     return 1 + nullCheckCost(curr->ref) + visit(curr->ref);

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -556,8 +556,7 @@ private:
     }
     void visitRttCanon(RttCanon* curr) {}
     void visitRttSub(RttSub* curr) {}
-    void visitStructNew(StructNew* curr) {
-    }
+    void visitStructNew(StructNew* curr) {}
     void visitStructGet(StructGet* curr) {
       // traps when the arg is null
       if (curr->ref->type.isNullable()) {
@@ -570,8 +569,7 @@ private:
         parent.implicitTrap = true;
       }
     }
-    void visitArrayNew(ArrayNew* curr) {
-    }
+    void visitArrayNew(ArrayNew* curr) {}
     void visitArrayGet(ArrayGet* curr) {
       // traps when the arg is null or the index out of bounds
       parent.implicitTrap = true;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -571,16 +571,20 @@ private:
       }
     }
     void visitArrayNew(ArrayNew* curr) {
-      WASM_UNREACHABLE("TODO (gc): array.new");
     }
     void visitArrayGet(ArrayGet* curr) {
-      WASM_UNREACHABLE("TODO (gc): array.get");
+      // traps when the arg is null or the index out of bounds
+      parent.implicitTrap = true;
     }
     void visitArraySet(ArraySet* curr) {
-      WASM_UNREACHABLE("TODO (gc): array.set");
+      // traps when the arg is null or the index out of bounds
+      parent.implicitTrap = true;
     }
     void visitArrayLen(ArrayLen* curr) {
-      WASM_UNREACHABLE("TODO (gc): array.len");
+      // traps when the arg is null
+      if (curr->ref->type.isNullable()) {
+        parent.implicitTrap = true;
+      }
     }
   };
 

--- a/src/literal.h
+++ b/src/literal.h
@@ -654,7 +654,9 @@ public:
       assert(lit.isConcrete());
     }
 #endif
-  };
+  }
+  Literals(size_t initialSize) : SmallVector(initialSize) {}
+
   Type getType() {
     std::vector<Type> types;
     for (auto& val : *this) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1732,18 +1732,34 @@ struct PrintExpressionContents
     o << curr->index;
   }
   void visitArrayNew(ArrayNew* curr) {
-    WASM_UNREACHABLE("TODO (gc): array.new");
+    printMedium(o, "array.new_");
+    if (curr->isWithDefault()) {
+      o << "default_";
+    }
+    o << "with_rtt ";
+    printHeapTypeName(o, curr->rtt->type.getRtt().heapType);
   }
   void visitArrayGet(ArrayGet* curr) {
-    WASM_UNREACHABLE("TODO (gc): array.get");
+    const auto& element =
+      curr->ref->type.getHeapType().getArray().element;
+    if (field.type == Type::i32 && field.packedType != Field::not_packed) {
+      if (curr->signed_) {
+        printMedium(o, "array.get_s ");
+      } else {
+        printMedium(o, "array.get_u ");
+      }
+    } else {
+      printMedium(o, "array.get ");
+    }
+    printHeapTypeName(o, curr->ref->type.getHeapType());
   }
   void visitArraySet(ArraySet* curr) {
-    printMedium(o, "array.set");
-    WASM_UNREACHABLE("TODO (gc): array.set");
+    printMedium(o, "array.set ");
+    printHeapTypeName(o, curr->ref->type.getHeapType());
   }
   void visitArrayLen(ArrayLen* curr) {
-    printMedium(o, "array.len");
-    WASM_UNREACHABLE("TODO (gc): array.len");
+    printMedium(o, "array.len ");
+    printHeapTypeName(o, curr->ref->type.getHeapType());
   }
 };
 
@@ -2421,22 +2437,37 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
   void visitArrayNew(ArrayNew* curr) {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
-    WASM_UNREACHABLE("TODO (gc): array.new");
+    incIndent();
+    printFullLine(curr->rtt);
+    printFullLine(curr->size);
+    if (curr->init) {
+      printFullLine(curr->init);
+    }
+    decIndent();
   }
   void visitArrayGet(ArrayGet* curr) {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
-    WASM_UNREACHABLE("TODO (gc): array.get");
+    incIndent();
+    printFullLine(curr->ref);
+    printFullLine(curr->index);
+    decIndent();
   }
   void visitArraySet(ArraySet* curr) {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
-    WASM_UNREACHABLE("TODO (gc): array.set");
+    incIndent();
+    printFullLine(curr->ref);
+    printFullLine(curr->index);
+    printFullLine(curr->value);
+    decIndent();
   }
   void visitArrayLen(ArrayLen* curr) {
     o << '(';
     PrintExpressionContents(currFunction, o).visit(curr);
-    WASM_UNREACHABLE("TODO (gc): array.len");
+    incIndent();
+    printFullLine(curr->ref);
+    decIndent();
   }
   // Module-level visitors
   void handleSignature(Signature curr, Name name = Name()) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -104,6 +104,23 @@ static void printTypeName(std::ostream& os, Type type) {
   WASM_UNREACHABLE("unsupported print type");
 }
 
+static void printFieldName(std::ostream& os, const Field& field) {
+  if (field.mutable_) {
+    os << "mut:";
+  }
+  if (field.type == Type::i32 && field.packedType != Field::not_packed) {
+    if (field.packedType == Field::i8) {
+      os << "i8";
+    } else if (field.packedType == Field::i16) {
+      os << "i16";
+    } else {
+      WASM_UNREACHABLE("invalid packed type");
+    }
+  } else {
+    printTypeName(os, field.type);
+  }
+}
+
 static void printHeapTypeName(std::ostream& os, HeapType type, bool first) {
   if (type.isBasic()) {
     os << type;
@@ -128,19 +145,12 @@ static void printHeapTypeName(std::ostream& os, HeapType type, bool first) {
     for (auto& field : struct_.fields) {
       os << sep;
       sep = "_";
-      if (field.mutable_) {
-        os << "mut:";
-      }
-      printTypeName(os, field.type);
+      printFieldName(os, field);
     }
     os << "}";
   } else if (type.isArray()) {
     os << "[";
-    auto element = type.getArray().element;
-    if (element.mutable_) {
-      os << "mut:";
-    }
-    printTypeName(os, element.type);
+    printFieldName(os, type.getArray().element);
     os << "]";
   } else {
     os << type;

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1742,7 +1742,7 @@ struct PrintExpressionContents
   void visitArrayGet(ArrayGet* curr) {
     const auto& element =
       curr->ref->type.getHeapType().getArray().element;
-    if (field.type == Type::i32 && field.packedType != Field::not_packed) {
+    if (element.type == Type::i32 && element.packedType != Field::not_packed) {
       if (curr->signed_) {
         printMedium(o, "array.get_s ");
       } else {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1740,8 +1740,7 @@ struct PrintExpressionContents
     printHeapTypeName(o, curr->rtt->type.getRtt().heapType);
   }
   void visitArrayGet(ArrayGet* curr) {
-    const auto& element =
-      curr->ref->type.getHeapType().getArray().element;
+    const auto& element = curr->ref->type.getHeapType().getArray().element;
     if (element.type == Type::i32 && element.packedType != Field::not_packed) {
       if (curr->signed_) {
         printMedium(o, "array.get_s ");

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -46,6 +46,7 @@ public:
       push_back(item);
     }
   }
+  SmallVector(size_t initialSize) { resize(initialSize); }
 
   T& operator[](size_t i) {
     if (i < N) {

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1503,6 +1503,13 @@ public:
 
   void throwError(std::string text);
 
+  // Struct/Array instructions have an unnecessary heap type that is just for
+  // validation (except for the case of unreachability, but that's not a problem
+  // anyhow, we can ignore it there). That is, we also have a reference / rtt
+  // child from which we can infer the type anyhow, and we just need to check
+  // that type is the same.
+  void validateHeapTypeUsingChild(Expression* child, HeapType heapType);
+
 private:
   bool hasDWARFSections();
 };

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -753,27 +753,33 @@ public:
     ret->finalize();
     return ret;
   }
-  ArrayNew* makeArrayNew() {
+  ArrayNew* makeArrayNew(Expression* rtt, Expression* size, Expression* init=nullptr) {
     auto* ret = wasm.allocator.alloc<ArrayNew>();
-    WASM_UNREACHABLE("TODO (gc): array.new");
+    ret->rtt = rtt;
+    ret->size = size;
+    ret->init = init;
     ret->finalize();
     return ret;
   }
-  ArrayGet* makeArrayGet() {
+  ArrayGet* makeArrayGet(Expression* ref, Expression* index, bool signed_ = false) {
     auto* ret = wasm.allocator.alloc<ArrayGet>();
-    WASM_UNREACHABLE("TODO (gc): array.get");
+    ret->ref = ref;
+    ret->index = index;
+    ret->signed_ = signed_;
     ret->finalize();
     return ret;
   }
-  ArraySet* makeArraySet() {
+  ArraySet* makeArraySet(Expression* ref, Expression* index, Expression* value) {
     auto* ret = wasm.allocator.alloc<ArraySet>();
-    WASM_UNREACHABLE("TODO (gc): array.set");
+    ret->ref = ref;
+    ret->index = index;
+    ret->value = value;
     ret->finalize();
     return ret;
   }
-  ArrayLen* makeArrayLen() {
+  ArrayLen* makeArrayLen(Expression* ref) {
     auto* ret = wasm.allocator.alloc<ArrayLen>();
-    WASM_UNREACHABLE("TODO (gc): array.len");
+    ret->ref = ref;
     ret->finalize();
     return ret;
   }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -753,7 +753,8 @@ public:
     ret->finalize();
     return ret;
   }
-  ArrayNew* makeArrayNew(Expression* rtt, Expression* size, Expression* init=nullptr) {
+  ArrayNew*
+  makeArrayNew(Expression* rtt, Expression* size, Expression* init = nullptr) {
     auto* ret = wasm.allocator.alloc<ArrayNew>();
     ret->rtt = rtt;
     ret->size = size;
@@ -761,7 +762,8 @@ public:
     ret->finalize();
     return ret;
   }
-  ArrayGet* makeArrayGet(Expression* ref, Expression* index, bool signed_ = false) {
+  ArrayGet*
+  makeArrayGet(Expression* ref, Expression* index, bool signed_ = false) {
     auto* ret = wasm.allocator.alloc<ArrayGet>();
     ret->ref = ref;
     ret->index = index;
@@ -769,7 +771,8 @@ public:
     ret->finalize();
     return ret;
   }
-  ArraySet* makeArraySet(Expression* ref, Expression* index, Expression* value) {
+  ArraySet*
+  makeArraySet(Expression* ref, Expression* index, Expression* value) {
     auto* ret = wasm.allocator.alloc<ArraySet>();
     ret->ref = ref;
     ret->index = index;

--- a/src/wasm-delegations-fields.h
+++ b/src/wasm-delegations-fields.h
@@ -597,7 +597,7 @@ switch (DELEGATE_ID) {
     DELEGATE_START(StructGet);
     DELEGATE_FIELD_INT(StructGet, index);
     DELEGATE_FIELD_CHILD(StructGet, ref);
-    DELEGATE_FIELD_INT(Load, signed_);
+    DELEGATE_FIELD_INT(StructGet, signed_);
     DELEGATE_END(StructGet);
     break;
   }
@@ -611,25 +611,31 @@ switch (DELEGATE_ID) {
   }
   case Expression::Id::ArrayNewId: {
     DELEGATE_START(ArrayNew);
-    WASM_UNREACHABLE("TODO (gc): array.new");
+    DELEGATE_FIELD_CHILD(ArrayNew, rtt);
+    DELEGATE_FIELD_CHILD(ArrayNew, size);
+    DELEGATE_FIELD_OPTIONAL_CHILD(ArrayNew, init);
     DELEGATE_END(ArrayNew);
     break;
   }
   case Expression::Id::ArrayGetId: {
     DELEGATE_START(ArrayGet);
-    WASM_UNREACHABLE("TODO (gc): array.get");
+    DELEGATE_FIELD_CHILD(ArrayGet, ref);
+    DELEGATE_FIELD_CHILD(ArrayGet, index);
+    DELEGATE_FIELD_INT(ArrayGet, signed_);
     DELEGATE_END(ArrayGet);
     break;
   }
   case Expression::Id::ArraySetId: {
     DELEGATE_START(ArraySet);
-    WASM_UNREACHABLE("TODO (gc): array.set");
+    DELEGATE_FIELD_CHILD(ArrayGet, ref);
+    DELEGATE_FIELD_CHILD(ArrayGet, index);
+    DELEGATE_FIELD_CHILD(ArrayGet, value);
     DELEGATE_END(ArraySet);
     break;
   }
   case Expression::Id::ArrayLenId: {
     DELEGATE_START(ArrayLen);
-    WASM_UNREACHABLE("TODO (gc): array.len");
+    DELEGATE_FIELD_CHILD(ArrayLen, ref);
     DELEGATE_END(ArrayLen);
     break;
   }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1461,14 +1461,14 @@ public:
     }
     const auto& element = curr->rtt->type.getHeapType().getArray().element;
     Literals data;
-    auto num = size.getSingleValue().geti32();
+    Index num = size.getSingleValue().geti32();
     data.resize(num);
     if (curr->isWithDefault()) {
       for (Index i = 0; i < num; i++) {
-        data[i] = Literal::makeZero(fields[i].type);
+        data[i] = Literal::makeZero(element.type);
       }
     } else {
-      auto init = this->visit(curr->operands[i]);
+      auto init = this->visit(curr->init);
       if (init.breaking()) {
         return init;
       }
@@ -1494,7 +1494,7 @@ public:
     if (!data) {
       trap("null ref");
     }
-    auto i = index.getSingleValue().geti32();
+    Index i = index.getSingleValue().geti32();
     if (i >= data->size()) {
       trap("array oob");
     }
@@ -1518,7 +1518,7 @@ public:
     if (!data) {
       trap("null ref");
     }
-    auto i = index.getSingleValue().geti32();
+    Index i = index.getSingleValue().geti32();
     if (i >= data->size()) {
       trap("array oob");
     }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1478,7 +1478,7 @@ public:
       }
     }
     return Flow(
-      Literal(std::shared_ptr<Literals>(new Literals(data)), curr->type));
+      Literal(std::make_shared<Literals>(data), curr->type);
   }
   Flow visitArrayGet(ArrayGet* curr) {
     NOTE_ENTER("ArrayGet");

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1456,7 +1456,7 @@ public:
       return rtt;
     }
     auto size = this->visit(curr->size);
-    if (size.breaking());
+    if (size.breaking()) {
       return size;
     }
     const auto& element = curr->rtt->type.getHeapType().getArray().element;
@@ -1536,6 +1536,8 @@ public:
   virtual void throwException(Literal exn) { WASM_UNREACHABLE("unimp"); }
 
 private:
+  // Truncate the value if we need to. The storage is just a list of Literals,
+  // so we can't just write the value like we would to a C struct field.
   Literal getMaybePackedValue(Literal value, const Field& field) {
     if (field.type == Type::i32) {
       if (field.packedType == Field::i8) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1403,8 +1403,7 @@ public:
       return rtt;
     }
     const auto& fields = curr->rtt->type.getHeapType().getStruct().fields;
-    Literals data;
-    data.resize(fields.size());
+    Literals data(fields.size());
     for (Index i = 0; i < fields.size(); i++) {
       if (curr->isWithDefault()) {
         data[i] = Literal::makeZero(fields[i].type);
@@ -1460,9 +1459,8 @@ public:
       return size;
     }
     const auto& element = curr->rtt->type.getHeapType().getArray().element;
-    Literals data;
     Index num = size.getSingleValue().geti32();
-    data.resize(num);
+    Literals data(num);
     if (curr->isWithDefault()) {
       for (Index i = 0; i < num; i++) {
         data[i] = Literal::makeZero(element.type);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1528,7 +1528,15 @@ public:
   }
   Flow visitArrayLen(ArrayLen* curr) {
     NOTE_ENTER("ArrayLen");
-    WASM_UNREACHABLE("TODO (gc): array.len");
+    Flow ref = this->visit(curr->ref);
+    if (ref.breaking()) {
+      return ref;
+    }
+    auto data = ref.getSingleValue().getGCData();
+    if (!data) {
+      trap("null ref");
+    }
+    return Literal(int32_t(data->size()));
   }
 
   virtual void trap(const char* why) { WASM_UNREACHABLE("unimp"); }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1415,8 +1415,7 @@ public:
         data[i] = value.getSingleValue();
       }
     }
-    return Flow(
-      Literal(std::make_shared<Literals>(data), curr->type));
+    return Flow(Literal(std::make_shared<Literals>(data), curr->type));
   }
   Flow visitStructGet(StructGet* curr) {
     NOTE_ENTER("StructGet");
@@ -1475,8 +1474,7 @@ public:
         data[i] = value;
       }
     }
-    return Flow(
-      Literal(std::make_shared<Literals>(data), curr->type));
+    return Flow(Literal(std::make_shared<Literals>(data), curr->type));
   }
   Flow visitArrayGet(ArrayGet* curr) {
     NOTE_ENTER("ArrayGet");

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1416,7 +1416,7 @@ public:
       }
     }
     return Flow(
-      Literal(std::shared_ptr<Literals>(new Literals(data)), curr->type));
+      Literal(std::make_shared<Literals>(data), curr->type));
   }
   Flow visitStructGet(StructGet* curr) {
     NOTE_ENTER("StructGet");
@@ -1476,7 +1476,7 @@ public:
       }
     }
     return Flow(
-      Literal(std::make_shared<Literals>(data), curr->type);
+      Literal(std::make_shared<Literals>(data), curr->type));
   }
   Flow visitArrayGet(ArrayGet* curr) {
     NOTE_ENTER("ArrayGet");

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -309,8 +309,8 @@ private:
   // anyhow, we can ignore it there). That is, we also have a reference / rtt
   // child from which we can infer the type anyhow, and we just need to check
   // that type is the same.
-  void validateHeapTypeUsingChild(Expression* child, HeapType heapType,
-  Element& s);
+  void
+  validateHeapTypeUsingChild(Expression* child, HeapType heapType, Element& s);
 };
 
 } // namespace wasm

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -303,6 +303,14 @@ private:
   void parseEvent(Element& s, bool preParseImport = false);
 
   Function::DebugLocation getDebugLocation(const SourceLocation& loc);
+
+  // Struct/Array instructions have an unnecessary heap type that is just for
+  // validation (except for the case of unreachability, but that's not a problem
+  // anyhow, we can ignore it there). That is, we also have a reference / rtt
+  // child from which we can infer the type anyhow, and we just need to check
+  // that type is the same.
+  void validateHeapTypeUsingChild(Expression* child, HeapType heapType,
+  Element& s);
 };
 
 } // namespace wasm

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -266,8 +266,7 @@ private:
   Expression* makeStructGet(Element& s, bool signed_ = false);
   Expression* makeStructSet(Element& s);
   Expression* makeArrayNew(Element& s, bool default_);
-  Expression* makeArrayGet(Element& s);
-  Expression* makeArrayGet(Element& s, bool signed_);
+  Expression* makeArrayGet(Element& s, bool signed_ = false);
   Expression* makeArraySet(Element& s);
   Expression* makeArrayLen(Element& s);
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1385,28 +1385,48 @@ class ArrayNew : public SpecificExpression<Expression::ArrayNewId> {
 public:
   ArrayNew(MixedArena& allocator) {}
 
-  void finalize() { WASM_UNREACHABLE("TODO (gc): array.new"); }
+  Expression* rtt;
+  Expression* size;
+  // If set, then the initial value is assigned to all entries in the array. If
+  // not set, this is array.new_with_default and the default of the type is
+  // used.
+  Expression* init = nullptr;
+
+  bool isWithDefault() { return !!init; }
+
+  void finalize();
 };
 
 class ArrayGet : public SpecificExpression<Expression::ArrayGetId> {
 public:
   ArrayGet(MixedArena& allocator) {}
 
-  void finalize() { WASM_UNREACHABLE("TODO (gc): array.get"); }
+  Expression* ref;
+  Expression* index;
+  // Packed fields have a sign.
+  bool signed_ = false;
+
+  void finalize();
 };
 
 class ArraySet : public SpecificExpression<Expression::ArraySetId> {
 public:
   ArraySet(MixedArena& allocator) {}
 
-  void finalize() { WASM_UNREACHABLE("TODO (gc): array.set"); }
+  Expression* ref;
+  Expression* index;
+  Expression* value;
+
+  void finalize();
 };
 
 class ArrayLen : public SpecificExpression<Expression::ArrayLenId> {
 public:
   ArrayLen(MixedArena& allocator) {}
 
-  void finalize() { WASM_UNREACHABLE("TODO (gc): array.len"); }
+  Expression* ref;
+
+  void finalize();
 };
 
 // Globals

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1392,7 +1392,7 @@ public:
   // used.
   Expression* init = nullptr;
 
-  bool isWithDefault() { return !!init; }
+  bool isWithDefault() { return !init; }
 
   void finalize();
 };

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5742,7 +5742,8 @@ void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child,
   if (child->type == Type::unreachable) {
     return;
   }
-  if (!child->type.isRef() || child->type.getHeapType() != heapType) {
+  if ((!child->type.isRef() && !child->type.isRtt()) ||
+      child->type.getHeapType() != heapType) {
     throwError("bad heap type");
   }
 }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5611,20 +5611,6 @@ bool WasmBinaryBuilder::maybeVisitRttSub(Expression*& out, uint32_t code) {
   return true;
 }
 
-// Struct/Array instructions have an unnecessary heap type that is just for
-// validation (except for the case of unreachability, but that's not a problem
-// anyhow, we can ignore it there). That is, we also have a reference or an rtt
-// child from which we can infer the type anyhow, and we just need to check that
-// type is the same.
-static void validateHeapType(Expression* child, HeapType heapType) {
-  if (child->type == Type::unreachable) {
-    return;
-  }
-  if (!child->type.isRef() || child->type.getHeapType() == heapType) {
-    throwError("bad heap type");
-  }
-}
-
 bool WasmBinaryBuilder::maybeVisitStructNew(Expression*& out, uint32_t code) {
   if (code != BinaryConsts::StructNewWithRtt &&
       code != BinaryConsts::StructNewDefaultWithRtt) {
@@ -5632,7 +5618,7 @@ bool WasmBinaryBuilder::maybeVisitStructNew(Expression*& out, uint32_t code) {
   }
   auto heapType = getHeapType();
   auto* rtt = popNonVoidExpression();
-  validateHeapType(rtt, heapType);
+  validateHeapTypeUsingChild(rtt, heapType);
   std::vector<Expression*> operands;
   if (code == BinaryConsts::StructNewWithRtt) {
     auto numOperands = heapType.getStruct().fields.size();
@@ -5665,7 +5651,7 @@ bool WasmBinaryBuilder::maybeVisitStructGet(Expression*& out, uint32_t code) {
   auto heapType = getHeapType();
   curr->index = getU32LEB();
   curr->ref = popNonVoidExpression();
-  validateHeapType(curr->ref, heapType);
+  validateHeapTypeUsingChild(curr->ref, heapType);
   curr->finalize();
   out = curr;
   return true;
@@ -5679,11 +5665,7 @@ bool WasmBinaryBuilder::maybeVisitStructSet(Expression*& out, uint32_t code) {
   auto heapType = getHeapType();
   curr->index = getU32LEB();
   curr->ref = popNonVoidExpression();
-  if (curr->ref->type != Type::unreachable) {
-    if (!curr->ref->type.isRef() || curr->ref->type.getHeapType() != heapType) {
-      throwError("bad struct.get heap type");
-    }
-  }
+  validateHeapTypeUsingChild(curr->ref, heapType);
   curr->value = popNonVoidExpression();
   curr->finalize();
   out = curr;
@@ -5697,7 +5679,7 @@ bool WasmBinaryBuilder::maybeVisitArrayNew(Expression*& out, uint32_t code) {
   }
   auto heapType = getHeapType();
   auto* rtt = popNonVoidExpression();
-  validateHeapType(rtt, heapType);
+  validateHeapTypeUsingChild(rtt, heapType);
   auto* size = popNonVoidExpression();
   Expression* init = nullptr;
   if (code == BinaryConsts::ArrayNewWithRtt) {
@@ -5714,16 +5696,16 @@ bool WasmBinaryBuilder::maybeVisitArrayGet(Expression*& out, uint32_t code) {
     case BinaryConsts::ArrayGetU:
       break;
     case BinaryConsts::ArrayGetS:
-      curr->signed_ = true;
+      signed_ = true;
       break;
     default:
       return false;
   }
   auto heapType = getHeapType();
   auto* ref = popNonVoidExpression();
-  validateHeapType(ref, heapType);
+  validateHeapTypeUsingChild(ref, heapType);
   auto* index = popNonVoidExpression();
-  out = Builder(wasm).makeArrayGet(ref, index);
+  out = Builder(wasm).makeArrayGet(ref, index, signed_);
   return true;
 }
 
@@ -5733,7 +5715,7 @@ bool WasmBinaryBuilder::maybeVisitArraySet(Expression*& out, uint32_t code) {
   }
   auto heapType = getHeapType();
   auto* ref = popNonVoidExpression();
-  validateHeapType(ref, heapType();
+  validateHeapTypeUsingChild(ref, heapType);
   auto* index = popNonVoidExpression();
   auto* value = popNonVoidExpression();
   out = Builder(wasm).makeArraySet(ref, index, value);
@@ -5746,13 +5728,22 @@ bool WasmBinaryBuilder::maybeVisitArrayLen(Expression*& out, uint32_t code) {
   }
   auto heapType = getHeapType();
   auto* ref = popNonVoidExpression();
-  validateHeapType(ref, heapType();
+  validateHeapTypeUsingChild(ref, heapType);
   out = Builder(wasm).makeArrayLen(ref);
   return true;
 }
 
 void WasmBinaryBuilder::throwError(std::string text) {
   throw ParseException(text, 0, pos);
+}
+
+void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child, HeapType heapType) {
+  if (child->type == Type::unreachable) {
+    return;
+  }
+  if (!child->type.isRef() || child->type.getHeapType() == heapType) {
+    throwError("bad heap type");
+  }
 }
 
 } // namespace wasm

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5744,8 +5744,8 @@ void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child,
   }
   if ((!child->type.isRef() && !child->type.isRtt()) ||
       child->type.getHeapType() != heapType) {
-    throwError("bad heap type: expected " + heapType.toString() + " but found "
-               + child->type.toString());
+    throwError("bad heap type: expected " + heapType.toString() +
+               " but found " + child->type.toString());
   }
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5658,8 +5658,8 @@ bool WasmBinaryBuilder::maybeVisitStructGet(Expression*& out, uint32_t code) {
   auto heapType = getHeapType();
   curr->index = getU32LEB();
   curr->ref = popNonVoidExpression();
-  if (ref->type != Type::unreachable) {
-    if (!ref->type.isRef() || ref->type.getHeapType() != heapType) {
+  if (curr->ref->type != Type::unreachable) {
+    if (!curr->ref->type.isRef() || curr->ref->type.getHeapType() != heapType) {
       throwError("bad struct.get heap type");
     }
   }
@@ -5676,8 +5676,8 @@ bool WasmBinaryBuilder::maybeVisitStructSet(Expression*& out, uint32_t code) {
   auto heapType = getHeapType();
   curr->index = getU32LEB();
   curr->ref = popNonVoidExpression();
-  if (ref->type != Type::unreachable) {
-    if (!ref->type.isRef() || ref->type.getHeapType() != heapType) {
+  if (curr->ref->type != Type::unreachable) {
+    if (!curr->ref->type.isRef() || curr->ref->type.getHeapType() != heapType) {
       throwError("bad struct.get heap type");
     }
   }
@@ -5703,7 +5703,7 @@ bool WasmBinaryBuilder::maybeVisitArrayNew(Expression*& out, uint32_t code) {
     }
   }
   auto* size = popNonVoidExpression();
-  auto* init = nullptr;
+  Expression* init = nullptr;
   if (code == BinaryConsts::ArrayNewWithRtt) {
     init = popNonVoidExpression();
   }
@@ -5730,8 +5730,8 @@ bool WasmBinaryBuilder::maybeVisitArrayGet(Expression*& out, uint32_t code) {
   }
   auto heapType = getHeapType();
   curr->ref = popNonVoidExpression();
-  if (ref->type != Type::unreachable) {
-    if (!ref->type.isRef() || ref->type.getHeapType() != heapType) {
+  if (curr->ref->type != Type::unreachable) {
+    if (!curr->ref->type.isRef() || curr->ref->type.getHeapType() != heapType) {
       throwError("bad array.get heap type");
     }
   }
@@ -5748,9 +5748,9 @@ bool WasmBinaryBuilder::maybeVisitArraySet(Expression*& out, uint32_t code) {
   auto* curr = allocator.alloc<ArraySet>();
   auto heapType = getHeapType();
   curr->ref = popNonVoidExpression();
-  if (ref->type != Type::unreachable) {
-    if (!ref->type.isRef() || ref->type.getHeapType() != heapType) {
-      throwError("bad array.get heap type");
+  if (curr->ref->type != Type::unreachable) {
+    if (!curr->ref->type.isRef() || curr->ref->type.getHeapType() != heapType) {
+      throwError("bad array.set heap type");
     }
   }
   curr->index = popNonVoidExpression();
@@ -5767,9 +5767,9 @@ bool WasmBinaryBuilder::maybeVisitArrayLen(Expression*& out, uint32_t code) {
   auto* curr = allocator.alloc<ArrayLen>();
   auto heapType = getHeapType();
   curr->ref = popNonVoidExpression();
-  if (ref->type != Type::unreachable) {
-    if (!ref->type.isRef() || ref->type.getHeapType() != heapType) {
-      throwError("bad array.get heap type");
+  if (curr->ref->type != Type::unreachable) {
+    if (!curr->ref->type.isRef() || curr->ref->type.getHeapType() != heapType) {
+      throwError("bad array.len heap type");
     }
   }
   curr->finalize();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5723,7 +5723,7 @@ bool WasmBinaryBuilder::maybeVisitArraySet(Expression*& out, uint32_t code) {
 }
 
 bool WasmBinaryBuilder::maybeVisitArrayLen(Expression*& out, uint32_t code) {
-  if (code != BinaryConsts::ArraySet) {
+  if (code != BinaryConsts::ArrayLen) {
     return false;
   }
   auto heapType = getHeapType();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5742,7 +5742,7 @@ void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child,
   if (child->type == Type::unreachable) {
     return;
   }
-  if (!child->type.isRef() || child->type.getHeapType() == heapType) {
+  if (!child->type.isRef() || child->type.getHeapType() != heapType) {
     throwError("bad heap type");
   }
 }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5744,7 +5744,8 @@ void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child,
   }
   if ((!child->type.isRef() && !child->type.isRtt()) ||
       child->type.getHeapType() != heapType) {
-    throwError("bad heap type");
+    throwError("bad heap type: expected " + heapType.toString() + " but found "
+               + child->type.toString());
   }
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5737,7 +5737,8 @@ void WasmBinaryBuilder::throwError(std::string text) {
   throw ParseException(text, 0, pos);
 }
 
-void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child, HeapType heapType) {
+void WasmBinaryBuilder::validateHeapTypeUsingChild(Expression* child,
+                                                   HeapType heapType) {
   if (child->type == Type::unreachable) {
     return;
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2969,8 +2969,10 @@ void SExpressionWasmBuilder::validateHeapTypeUsingChild(Expression* child,
   }
   if ((!child->type.isRef() && !child->type.isRtt()) ||
       child->type.getHeapType() != heapType) {
-        throw ParseException("bad heap type: expected " + heapType.toString() + " but found "
-               + child->type.toString(), s.line, s.col);
+    throw ParseException("bad heap type: expected " + heapType.toString() +
+                           " but found " + child->type.toString(),
+                         s.line,
+                         s.col);
   }
 }
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2969,7 +2969,8 @@ void SExpressionWasmBuilder::validateHeapTypeUsingChild(Expression* child,
   }
   if ((!child->type.isRef() && !child->type.isRtt()) ||
       child->type.getHeapType() != heapType) {
-    throw ParseException("bad heap type", s.line, s.col);
+        throw ParseException("bad heap type: expected " + heapType.toString() + " but found "
+               + child->type.toString(), s.line, s.col);
   }
 }
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2187,7 +2187,7 @@ Expression* SExpressionWasmBuilder::makeArrayNew(Element& s, bool default_) {
 }
 
 Expression* SExpressionWasmBuilder::makeArrayGet(Element& s, bool signed_) {
-  auto arrayType = parseHeapType(*s[1]);
+  auto heapType = parseHeapType(*s[1]);
   auto ref = parseExpression(*s[2]);
   validateHeapTypeUsingChild(ref, heapType, s);
   auto index = parseExpression(*s[3]);
@@ -2195,7 +2195,7 @@ Expression* SExpressionWasmBuilder::makeArrayGet(Element& s, bool signed_) {
 }
 
 Expression* SExpressionWasmBuilder::makeArraySet(Element& s) {
-  auto arrayType = parseHeapType(*s[1]);
+  auto heapType = parseHeapType(*s[1]);
   auto ref = parseExpression(*s[2]);
   validateHeapTypeUsingChild(ref, heapType, s);
   auto index = parseExpression(*s[3]);
@@ -2204,7 +2204,7 @@ Expression* SExpressionWasmBuilder::makeArraySet(Element& s) {
 }
 
 Expression* SExpressionWasmBuilder::makeArrayLen(Element& s) {
-  auto arrayType = parseHeapType(*s[1]);
+  auto heapType = parseHeapType(*s[1]);
   auto ref = parseExpression(*s[2]);
   validateHeapTypeUsingChild(ref, heapType, s);
   return Builder(wasm).makeArrayLen(ref);
@@ -2967,7 +2967,8 @@ void SExpressionWasmBuilder::validateHeapTypeUsingChild(Expression* child,
   if (child->type == Type::unreachable) {
     return;
   }
-  if (!child->type.isRef() || child->type.getHeapType() == heapType) {
+  if ((!child->type.isRef() && !child->type.isRtt()) ||
+      child->type.getHeapType() != heapType) {
     throw ParseException("bad heap type", s.line, s.col);
   }
 }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1950,7 +1950,7 @@ void BinaryInstWriter::visitArrayNew(ArrayNew* curr) {
 }
 
 void BinaryInstWriter::visitArrayGet(ArrayGet* curr) {
-  const auto& heapType = curr->ref->type.getHeapType();
+  auto heapType = curr->ref->type.getHeapType();
   const auto& field = heapType.getArray().element;
   int8_t op;
   if (field.type != Type::i32 || field.packedType == Field::not_packed) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1928,13 +1928,13 @@ void BinaryInstWriter::visitStructGet(StructGet* curr) {
   } else {
     op = BinaryConsts::StructGetU;
   }
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(op);
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(op);
   parent.writeHeapType(heapType);
   o << U32LEB(curr->index);
 }
 
 void BinaryInstWriter::visitStructSet(StructSet* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::StructSet);
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StructSet);
   parent.writeHeapType(curr->ref->type.getHeapType());
   o << U32LEB(curr->index);
 }
@@ -1960,17 +1960,17 @@ void BinaryInstWriter::visitArrayGet(ArrayGet* curr) {
   } else {
     op = BinaryConsts::ArrayGetU;
   }
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(op);
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(op);
   parent.writeHeapType(heapType);
 }
 
 void BinaryInstWriter::visitArraySet(ArraySet* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::ArraySet);
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::ArraySet);
   parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArrayLen(ArrayLen* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::ArrayLen);
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::ArrayLen);
   parent.writeHeapType(curr->ref->type.getHeapType());
 }
 

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1950,8 +1950,18 @@ void BinaryInstWriter::visitArrayNew(ArrayNew* curr) {
 }
 
 void BinaryInstWriter::visitArrayGet(ArrayGet* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::ArrayGet);
-  parent.writeHeapType(curr->ref->type.getHeapType());
+  const auto& heapType = curr->ref->type.getHeapType();
+  const auto& field = heapType.getArray().element;
+  int8_t op;
+  if (field.type != Type::i32 || field.packedType == Field::not_packed) {
+    op = BinaryConsts::ArrayGet;
+  } else if (curr->signed_) {
+    op = BinaryConsts::ArrayGetS;
+  } else {
+    op = BinaryConsts::ArrayGetU;
+  }
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(op);
+  parent.writeHeapType(heapType);
 }
 
 void BinaryInstWriter::visitArraySet(ArraySet* curr) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1940,21 +1940,28 @@ void BinaryInstWriter::visitStructSet(StructSet* curr) {
 }
 
 void BinaryInstWriter::visitArrayNew(ArrayNew* curr) {
-  WASM_UNREACHABLE("TODO (gc): array.new");
+  o << int8_t(BinaryConsts::GCPrefix);
+  if (curr->isWithDefault()) {
+    o << U32LEB(BinaryConsts::ArrayNewDefaultWithRtt);
+  } else {
+    o << U32LEB(BinaryConsts::ArrayNewWithRtt);
+  }
+  parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArrayGet(ArrayGet* curr) {
-  WASM_UNREACHABLE("TODO (gc): array.get");
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConst::ArrayGet);
+  parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArraySet(ArraySet* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::ArraySet);
-  WASM_UNREACHABLE("TODO (gc): array.set");
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConst::ArraySet);
+  parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArrayLen(ArrayLen* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::ArrayLen);
-  WASM_UNREACHABLE("TODO (gc): array.len");
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConst::ArrayLen);
+  parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::emitScopeEnd(Expression* curr) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1946,21 +1946,21 @@ void BinaryInstWriter::visitArrayNew(ArrayNew* curr) {
   } else {
     o << U32LEB(BinaryConsts::ArrayNewWithRtt);
   }
-  parent.writeHeapType(curr->ref->type.getHeapType());
+  parent.writeHeapType(curr->rtt->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArrayGet(ArrayGet* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConst::ArrayGet);
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::ArrayGet);
   parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArraySet(ArraySet* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConst::ArraySet);
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::ArraySet);
   parent.writeHeapType(curr->ref->type.getHeapType());
 }
 
 void BinaryInstWriter::visitArrayLen(ArrayLen* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConst::ArrayLen);
+  o << int8_t(BinaryConsts::GCPrefix) << int8_t(BinaryConsts::ArrayLen);
   parent.writeHeapType(curr->ref->type.getHeapType());
 }
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -763,7 +763,7 @@ bool Field::operator<(const Field& other) const {
   if (mutable_ != other.mutable_) {
     return mutable_ < other.mutable_;
   }
-  if (type == Type::i32) {
+  if (type == Type::i32 && other.type == Type::i32) {
     return packedType < other.packedType;
   }
   return type < other.type;

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2302,14 +2302,10 @@ void FunctionValidator::visitStructSet(StructSet* curr) {
 }
 
 void FunctionValidator::visitArrayNew(ArrayNew* curr) {
-  shouldBeTrue(getModule()->features.hasGC(),
-               curr,
-               "array.new requires gc to be enabled");
+  shouldBeTrue(
+    getModule()->features.hasGC(), curr, "array.new requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->size->type,
-    Type::i32,
-    curr,
-    "array.new size must be an i32");
+    curr->size->type, Type::i32, curr, "array.new size must be an i32");
   if (curr->type == Type::unreachable) {
     return;
   }
@@ -2324,18 +2320,15 @@ void FunctionValidator::visitArrayNew(ArrayNew* curr) {
   }
   const auto& element = heapType.getArray().element;
   if (curr->isWithDefault()) {
-    shouldBeTrue(!curr->init,
-                 curr,
-                 "array.new_with_default should have no init");
+    shouldBeTrue(
+      !curr->init, curr, "array.new_with_default should have no init");
     // The element must be defaultable.
     // TODO: add type.isDefaultable()?
     shouldBeTrue(!element.type.isRef() || element.type.isNullable(),
                  element,
                  "array.new_with_default value type must be defaultable");
   } else {
-    shouldBeTrue(!!curr->init,
-                 curr,
-                 "array.new should have an init");
+    shouldBeTrue(!!curr->init, curr, "array.new should have an init");
     // The inits must have the proper type.
     shouldBeSubType(curr->init->type,
                     element.type,
@@ -2345,33 +2338,23 @@ void FunctionValidator::visitArrayNew(ArrayNew* curr) {
 }
 
 void FunctionValidator::visitArrayGet(ArrayGet* curr) {
-  shouldBeTrue(getModule()->features.hasGC(),
-               curr,
-               "array.get requires gc to be enabled");
+  shouldBeTrue(
+    getModule()->features.hasGC(), curr, "array.get requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->index->type,
-    Type::i32,
-    curr,
-    "array.get index must be an i32");
+    curr->index->type, Type::i32, curr, "array.get index must be an i32");
   if (curr->type == Type::unreachable) {
     return;
   }
   const auto& element = curr->ref->type.getHeapType().getArray().element;
-  shouldBeEqual(curr->type,
-                element.type,
-                curr,
-                "array.get must have the proper type");
+  shouldBeEqual(
+    curr->type, element.type, curr, "array.get must have the proper type");
 }
 
 void FunctionValidator::visitArraySet(ArraySet* curr) {
-  shouldBeTrue(getModule()->features.hasGC(),
-               curr,
-               "array.set requires gc to be enabled");
+  shouldBeTrue(
+    getModule()->features.hasGC(), curr, "array.set requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->index->type,
-    Type::i32,
-    curr,
-    "array.set index must be an i32");
+    curr->index->type, Type::i32, curr, "array.set index must be an i32");
   if (curr->type == Type::unreachable) {
     return;
   }
@@ -2383,14 +2366,10 @@ void FunctionValidator::visitArraySet(ArraySet* curr) {
 }
 
 void FunctionValidator::visitArrayLen(ArrayLen* curr) {
-  shouldBeTrue(getModule()->features.hasGC(),
-               curr,
-               "array.len requires gc to be enabled");
+  shouldBeTrue(
+    getModule()->features.hasGC(), curr, "array.len requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->type,
-    Type::i32,
-    curr,
-    "array.len result must be an i32");
+    curr->type, Type::i32, curr, "array.len result must be an i32");
 }
 
 void FunctionValidator::visitFunction(Function* curr) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2305,7 +2305,7 @@ void FunctionValidator::visitArrayNew(ArrayNew* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "array.new requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->size->type, Type::i32, curr, "array.new size must be an i32");
+    curr->size->type, Type(Type::i32), curr, "array.new size must be an i32");
   if (curr->type == Type::unreachable) {
     return;
   }
@@ -2341,7 +2341,7 @@ void FunctionValidator::visitArrayGet(ArrayGet* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "array.get requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->index->type, Type::i32, curr, "array.get index must be an i32");
+    curr->index->type, Type(Type::i32), curr, "array.get index must be an i32");
   if (curr->type == Type::unreachable) {
     return;
   }
@@ -2354,7 +2354,7 @@ void FunctionValidator::visitArraySet(ArraySet* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "array.set requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->index->type, Type::i32, curr, "array.set index must be an i32");
+    curr->index->type, Type(Type::i32), curr, "array.set index must be an i32");
   if (curr->type == Type::unreachable) {
     return;
   }
@@ -2369,7 +2369,7 @@ void FunctionValidator::visitArrayLen(ArrayLen* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "array.len requires gc to be enabled");
   shouldBeEqualOrFirstIsUnreachable(
-    curr->type, Type::i32, curr, "array.len result must be an i32");
+    curr->type, Type(Type::i32), curr, "array.len result must be an i32");
 }
 
 void FunctionValidator::visitFunction(Function* curr) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1104,7 +1104,8 @@ void StructNew::finalize() {
   if (handleUnreachableOperands(this)) {
     return;
   }
-  type = Type(rtt->type.getHeapType(), /* nullable = */ false);
+  // TODO: make non-nullable when we support that
+  type = Type(rtt->type.getHeapType(), /* nullable = */ true);
 }
 
 void StructGet::finalize() {
@@ -1129,7 +1130,8 @@ void ArrayNew::finalize() {
     type = Type::unreachable;
     return;
   }
-  type = Type(rtt->type.getHeapType(), /* nullable = */ false);
+  // TODO: make non-nullable when we support that
+  type = Type(rtt->type.getHeapType(), /* nullable = */ true);
 }
 
 void ArrayGet::finalize() {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1123,10 +1123,39 @@ void StructSet::finalize() {
   }
 }
 
-// TODO (gc): array.new
-// TODO (gc): array.get
-// TODO (gc): array.set
-// TODO (gc): array.len
+void ArrayNew::finalize() {
+  if (rtt->type == Type::unreachable || size->type == Type::unreachable ||
+      (init && init->type == Type::unreachable)) {
+    type = Type::unreachable;
+    return;
+  }
+  type = Type(rtt->type.getHeapType(), /* nullable = */ false);
+}
+
+void ArrayGet::finalize() {
+  if (ref->type == Type::unreachable || index->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = ref->type.getHeapType().getArray().element.type;
+  }
+}
+
+void ArraySet::finalize() {
+  if (ref->type == Type::unreachable || index->type == Type::unreachable ||
+      value->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = Type::none;
+  }
+}
+
+void ArrayLen::finalize() {
+  if (ref->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = Type::i32;
+  }
+}
 
 size_t Function::getNumParams() { return sig.params.size(); }
 

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -19,6 +19,7 @@
   ;; Arrays
   (type $vector (array (mut f64)))
   (type $matrix (array (ref $vector)))
+  (type $bytes (array (mut i8)))
 
   ;; RTT
   (type $parent (struct))
@@ -104,6 +105,7 @@
   (func $arrays (param $x (ref $vector)) (result (ref $matrix))
     (local $tv (ref null $vector))
     (local $tm (ref null $matrix))
+    (local $tb (ref null $bytes))
     (drop
       (array.new_with_rtt $vector
         (rtt.canon $vector)
@@ -131,6 +133,24 @@
     (drop
       (array.len $vector
         (local.get $x)
+      )
+    )
+    (drop
+      (array.get $bytes
+        (local.get $tb)
+        (i32.const 1)
+      )
+    )
+    (drop
+      (array.get_u $bytes
+        (local.get $tb)
+        (i32.const 2)
+      )
+    )
+    (drop
+      (array.get_s $bytes
+        (local.get $tb)
+        (i32.const 3)
       )
     )
     (unreachable)

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -114,6 +114,7 @@
     (drop
       (array.new_default_with_rtt $matrix
         (rtt.canon $matrix)
+        (i32.const 10)
       )
     )
     (drop

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -123,18 +123,17 @@
         (i32.const 2)
       )
     )
-    (drop
-      (array.set $vector
-        (local.get $x)
-        (i32.const 2)
-        (f64.const 2.18281828)
-      )
+    (array.set $vector
+      (local.get $x)
+      (i32.const 2)
+      (f64.const 2.18281828)
     )
     (drop
       (array.len $vector
         (local.get $x)
       )
     )
+    (unreachable)
   )
   ;; RTT types as parameters
   (func $rtt-param-with-depth (param $rtt (rtt 1 $parent)))

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -20,6 +20,7 @@
   (type $vector (array (mut f64)))
   (type $matrix (array (ref $vector)))
   (type $bytes (array (mut i8)))
+  (type $words (array (mut i32)))
 
   ;; RTT
   (type $parent (struct))
@@ -106,6 +107,7 @@
     (local $tv (ref null $vector))
     (local $tm (ref null $matrix))
     (local $tb (ref null $bytes))
+    (local $tw (ref null $words))
     (drop
       (array.new_with_rtt $vector
         (rtt.canon $vector)
@@ -136,8 +138,8 @@
       )
     )
     (drop
-      (array.get $bytes
-        (local.get $tb)
+      (array.get $words
+        (local.get $tw)
         (i32.const 1)
       )
     )

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -28,7 +28,7 @@
   (global $rttchild (rtt 1 $child) (rtt.sub $child (global.get $rttparent)))
   (global $rttgrandchild (rtt 2 $grandchild) (rtt.sub $grandchild (global.get $rttchild)))
 
-  (func "foo" (param $x (ref $struct.A)) (result (ref $struct.B))
+  (func $structs (param $x (ref $struct.A)) (result (ref $struct.B))
     (local $tA (ref null $struct.A))
     (local $tB (ref null $struct.B))
     (local $tc (ref null $struct.C))
@@ -100,6 +100,40 @@
       )
     )
     (unreachable)
+  )
+  (func $arrays (param $x (ref $vector)) (result (ref $matrix))
+    (local $tv (ref null $vector))
+    (local $tm (ref null $matrix))
+    (drop
+      (array.new_with_rtt $vector
+        (rtt.canon $vector)
+        (i32.const 3)
+        (f64.const 3.14159)
+      )
+    )
+    (drop
+      (array.new_default_with_rtt $matrix
+        (rtt.canon $matrix)
+      )
+    )
+    (drop
+      (array.get $vector
+        (local.get $x)
+        (i32.const 2)
+      )
+    )
+    (drop
+      (array.set $vector
+        (local.get $x)
+        (i32.const 2)
+        (f64.const 2.18281828)
+      )
+    )
+    (drop
+      (array.len $vector
+        (local.get $x)
+      )
+    )
   )
   ;; RTT types as parameters
   (func $rtt-param-with-depth (param $rtt (rtt 1 $parent)))

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -1,15 +1,16 @@
 (module
  (type ${i32_f32_f64} (struct (field i32) (field f32) (field f64)))
- (type ${} (struct ))
  (type $[mut:f64] (array (mut f64)))
+ (type ${} (struct ))
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
+ (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_${}_=>_none (func (param (rtt ${}))))
- (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $ref?|{i32_f32_f64}|_=>_ref?|{i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
+ (type $ref?|[mut:f64]|_=>_ref?|[ref?|[mut:f64]|]| (func (param (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))))
  (global $rttparent (rtt 0 ${}) (rtt.canon ${}))
  (global $rttchild (rtt 1 ${i32}) (rtt.sub ${i32}
   (global.get $rttparent)
@@ -17,8 +18,7 @@
  (global $rttgrandchild (rtt 2 ${i32_i64}) (rtt.sub ${i32_i64}
   (global.get $rttchild)
  ))
- (export "foo" (func $0))
- (func $0 (param $x (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+ (func $structs (param $x (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tA (ref null ${i32_f32_f64}))
   (local $tB (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tc (ref null ${mut:f32}))
@@ -99,6 +99,40 @@
     (i32.const 1)
     (f32.const 2.3450000286102295)
     (f64.const 3.14159)
+   )
+  )
+  (unreachable)
+ )
+ (func $arrays (param $x (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
+  (local $tv (ref null $[mut:f64]))
+  (local $tm (ref null $[ref?|[mut:f64]|]))
+  (drop
+   (array.new_with_rtt $[mut:f64]
+    (rtt.canon $[mut:f64])
+    (i32.const 3)
+    (f64.const 3.14159)
+   )
+  )
+  (drop
+   (array.new_default_with_rtt $[ref?|[mut:f64]|]
+    (rtt.canon $[ref?|[mut:f64]|])
+    (i32.const 10)
+   )
+  )
+  (drop
+   (array.get $[mut:f64]
+    (local.get $x)
+    (i32.const 2)
+   )
+  )
+  (array.set $[mut:f64]
+   (local.get $x)
+   (i32.const 2)
+   (f64.const 2.18281828)
+  )
+  (drop
+   (array.len $[mut:f64]
+    (local.get $x)
    )
   )
   (unreachable)

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -5,6 +5,7 @@
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
+ (type $[mut:i32] (array (mut i8)))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
@@ -106,6 +107,7 @@
  (func $arrays (param $x (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
   (local $tv (ref null $[mut:f64]))
   (local $tm (ref null $[ref?|[mut:f64]|]))
+  (local $tb (ref null $[mut:i32]))
   (drop
    (array.new_with_rtt $[mut:f64]
     (rtt.canon $[mut:f64])
@@ -133,6 +135,24 @@
   (drop
    (array.len $[mut:f64]
     (local.get $x)
+   )
+  )
+  (drop
+   (array.get_u $[mut:i32]
+    (local.get $tb)
+    (i32.const 1)
+   )
+  )
+  (drop
+   (array.get_u $[mut:i32]
+    (local.get $tb)
+    (i32.const 2)
+   )
+  )
+  (drop
+   (array.get_s $[mut:i32]
+    (local.get $tb)
+    (i32.const 3)
    )
   )
   (unreachable)

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -5,6 +5,7 @@
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
+ (type $[mut:i32] (array (mut i32)))
  (type $[mut:i32] (array (mut i8)))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
@@ -108,6 +109,7 @@
   (local $tv (ref null $[mut:f64]))
   (local $tm (ref null $[ref?|[mut:f64]|]))
   (local $tb (ref null $[mut:i32]))
+  (local $tw (ref null $[mut:i32]))
   (drop
    (array.new_with_rtt $[mut:f64]
     (rtt.canon $[mut:f64])
@@ -138,8 +140,8 @@
    )
   )
   (drop
-   (array.get_u $[mut:i32]
-    (local.get $tb)
+   (array.get $[mut:i32]
+    (local.get $tw)
     (i32.const 1)
    )
   )

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -6,12 +6,12 @@
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
  (type $[mut:i32] (array (mut i32)))
- (type $[mut:i32] (array (mut i8)))
- (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
+ (type $[mut:i8] (array (mut i8)))
+ (type ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_${}_=>_none (func (param (rtt ${}))))
- (type $ref?|{i32_f32_f64}|_=>_ref?|{i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
+ (type $ref?|{i32_f32_f64}|_=>_ref?|{i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
  (type $ref?|[mut:f64]|_=>_ref?|[ref?|[mut:f64]|]| (func (param (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))))
  (global $rttparent (rtt 0 ${}) (rtt.canon ${}))
  (global $rttchild (rtt 1 ${i32}) (rtt.sub ${i32}
@@ -20,9 +20,9 @@
  (global $rttgrandchild (rtt 2 ${i32_i64}) (rtt.sub ${i32_i64}
   (global.get $rttchild)
  ))
- (func $structs (param $x (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+ (func $structs (param $x (ref null ${i32_f32_f64})) (result (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tA (ref null ${i32_f32_f64}))
-  (local $tB (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+  (local $tB (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tc (ref null ${mut:f32}))
   (local $tv (ref null $[mut:f64]))
   (local $tm (ref null $[ref?|[mut:f64]|]))
@@ -50,12 +50,12 @@
    )
   )
   (drop
-   (struct.get_u ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
+   (struct.get_u ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
     (local.get $tB)
    )
   )
   (drop
-   (struct.get_s ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
+   (struct.get_s ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
     (local.get $tB)
    )
   )
@@ -108,7 +108,7 @@
  (func $arrays (param $x (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
   (local $tv (ref null $[mut:f64]))
   (local $tm (ref null $[ref?|[mut:f64]|]))
-  (local $tb (ref null $[mut:i32]))
+  (local $tb (ref null $[mut:i8]))
   (local $tw (ref null $[mut:i32]))
   (drop
    (array.new_with_rtt $[mut:f64]
@@ -146,13 +146,13 @@
    )
   )
   (drop
-   (array.get_u $[mut:i32]
+   (array.get_u $[mut:i8]
     (local.get $tb)
     (i32.const 2)
    )
   )
   (drop
-   (array.get_s $[mut:i32]
+   (array.get_s $[mut:i8]
     (local.get $tb)
     (i32.const 3)
    )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -6,12 +6,12 @@
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
  (type $[mut:i32] (array (mut i32)))
- (type $[mut:i32] (array (mut i8)))
- (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
+ (type $[mut:i8] (array (mut i8)))
+ (type ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_${}_=>_none (func (param (rtt ${}))))
- (type $ref?|{i32_f32_f64}|_=>_ref?|{i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
+ (type $ref?|{i32_f32_f64}|_=>_ref?|{i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
  (type $ref?|[mut:f64]|_=>_ref?|[ref?|[mut:f64]|]| (func (param (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))))
  (global $rttparent (rtt 0 ${}) (rtt.canon ${}))
  (global $rttchild (rtt 1 ${i32}) (rtt.sub ${i32}
@@ -20,9 +20,9 @@
  (global $rttgrandchild (rtt 2 ${i32_i64}) (rtt.sub ${i32_i64}
   (global.get $rttchild)
  ))
- (func $structs (param $x (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+ (func $structs (param $x (ref null ${i32_f32_f64})) (result (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tA (ref null ${i32_f32_f64}))
-  (local $tB (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+  (local $tB (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tc (ref null ${mut:f32}))
   (local $tv (ref null $[ref?|[mut:f64]|]))
   (local $tm (ref null $[mut:f64]))
@@ -50,12 +50,12 @@
    )
   )
   (drop
-   (struct.get_u ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
+   (struct.get_u ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
     (local.get $tB)
    )
   )
   (drop
-   (struct.get_s ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
+   (struct.get_s ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
     (local.get $tB)
    )
   )
@@ -108,7 +108,7 @@
  (func $arrays (param $x (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
   (local $tv (ref null $[ref?|[mut:f64]|]))
   (local $tm (ref null $[mut:i32]))
-  (local $tb (ref null $[mut:i32]))
+  (local $tb (ref null $[mut:i8]))
   (local $tw (ref null $[mut:f64]))
   (drop
    (array.new_with_rtt $[mut:f64]
@@ -146,13 +146,13 @@
    )
   )
   (drop
-   (array.get_u $[mut:i32]
+   (array.get_u $[mut:i8]
     (local.get $tb)
     (i32.const 2)
    )
   )
   (drop
-   (array.get_s $[mut:i32]
+   (array.get_s $[mut:i8]
     (local.get $tb)
     (i32.const 3)
    )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -1,15 +1,16 @@
 (module
  (type ${i32_f32_f64} (struct (field i32) (field f32) (field f64)))
- (type ${} (struct ))
  (type $[mut:f64] (array (mut f64)))
+ (type ${} (struct ))
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
+ (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_${}_=>_none (func (param (rtt ${}))))
- (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $ref?|{i32_f32_f64}|_=>_ref?|{i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
+ (type $ref?|[mut:f64]|_=>_ref?|[ref?|[mut:f64]|]| (func (param (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))))
  (global $rttparent (rtt 0 ${}) (rtt.canon ${}))
  (global $rttchild (rtt 1 ${i32}) (rtt.sub ${i32}
   (global.get $rttparent)
@@ -17,8 +18,7 @@
  (global $rttgrandchild (rtt 2 ${i32_i64}) (rtt.sub ${i32_i64}
   (global.get $rttchild)
  ))
- (export "foo" (func $0))
- (func $0 (param $x (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+ (func $structs (param $x (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tA (ref null ${i32_f32_f64}))
   (local $tB (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $tc (ref null ${mut:f32}))
@@ -99,6 +99,40 @@
     (i32.const 1)
     (f32.const 2.3450000286102295)
     (f64.const 3.14159)
+   )
+  )
+  (unreachable)
+ )
+ (func $arrays (param $x (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
+  (local $tv (ref null $[ref?|[mut:f64]|]))
+  (local $tm (ref null $[mut:f64]))
+  (drop
+   (array.new_with_rtt $[mut:f64]
+    (rtt.canon $[mut:f64])
+    (i32.const 3)
+    (f64.const 3.14159)
+   )
+  )
+  (drop
+   (array.new_default_with_rtt $[ref?|[mut:f64]|]
+    (rtt.canon $[ref?|[mut:f64]|])
+    (i32.const 10)
+   )
+  )
+  (drop
+   (array.get $[mut:f64]
+    (local.get $x)
+    (i32.const 2)
+   )
+  )
+  (array.set $[mut:f64]
+   (local.get $x)
+   (i32.const 2)
+   (f64.const 2.18281828)
+  )
+  (drop
+   (array.len $[mut:f64]
+    (local.get $x)
    )
   )
   (unreachable)

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -5,6 +5,8 @@
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
+ (type $[mut:i32] (array (mut i32)))
+ (type $[mut:i32] (array (mut i8)))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
@@ -105,7 +107,9 @@
  )
  (func $arrays (param $x (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
   (local $tv (ref null $[ref?|[mut:f64]|]))
-  (local $tm (ref null $[mut:f64]))
+  (local $tm (ref null $[mut:i32]))
+  (local $tb (ref null $[mut:i32]))
+  (local $tw (ref null $[mut:f64]))
   (drop
    (array.new_with_rtt $[mut:f64]
     (rtt.canon $[mut:f64])
@@ -133,6 +137,24 @@
   (drop
    (array.len $[mut:f64]
     (local.get $x)
+   )
+  )
+  (drop
+   (array.get $[mut:i32]
+    (local.get $tm)
+    (i32.const 1)
+   )
+  )
+  (drop
+   (array.get_u $[mut:i32]
+    (local.get $tb)
+    (i32.const 2)
+   )
+  )
+  (drop
+   (array.get_s $[mut:i32]
+    (local.get $tb)
+    (i32.const 3)
    )
   )
   (unreachable)

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -6,12 +6,12 @@
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
  (type $[mut:i32] (array (mut i32)))
- (type $[mut:i32] (array (mut i8)))
- (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
+ (type $[mut:i8] (array (mut i8)))
+ (type ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_${}_=>_none (func (param (rtt ${}))))
- (type $ref?|{i32_f32_f64}|_=>_ref?|{i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
+ (type $ref?|{i32_f32_f64}|_=>_ref?|{i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
  (type $ref?|[mut:f64]|_=>_ref?|[ref?|[mut:f64]|]| (func (param (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))))
  (global $global$0 (rtt 0 ${}) (rtt.canon ${}))
  (global $global$1 (rtt 1 ${i32}) (rtt.sub ${i32}
@@ -20,9 +20,9 @@
  (global $global$2 (rtt 2 ${i32_i64}) (rtt.sub ${i32_i64}
   (global.get $global$1)
  ))
- (func $0 (param $0 (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+ (func $0 (param $0 (ref null ${i32_f32_f64})) (result (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $1 (ref null ${i32_f32_f64}))
-  (local $2 (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
+  (local $2 (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $3 (ref null ${mut:f32}))
   (local $4 (ref null $[ref?|[mut:f64]|]))
   (local $5 (ref null $[mut:f64]))
@@ -50,12 +50,12 @@
    )
   )
   (drop
-   (struct.get_u ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
+   (struct.get_u ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
     (local.get $2)
    )
   )
   (drop
-   (struct.get_s ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
+   (struct.get_s ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} 0
     (local.get $2)
    )
   )
@@ -108,7 +108,7 @@
  (func $1 (param $0 (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
   (local $1 (ref null $[ref?|[mut:f64]|]))
   (local $2 (ref null $[mut:i32]))
-  (local $3 (ref null $[mut:i32]))
+  (local $3 (ref null $[mut:i8]))
   (local $4 (ref null $[mut:f64]))
   (drop
    (array.new_with_rtt $[mut:f64]
@@ -146,13 +146,13 @@
    )
   )
   (drop
-   (array.get_u $[mut:i32]
+   (array.get_u $[mut:i8]
     (local.get $3)
     (i32.const 2)
    )
   )
   (drop
-   (array.get_s $[mut:i32]
+   (array.get_s $[mut:i8]
     (local.get $3)
     (i32.const 3)
    )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -5,6 +5,8 @@
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
+ (type $[mut:i32] (array (mut i32)))
+ (type $[mut:i32] (array (mut i8)))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
  (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
@@ -105,7 +107,9 @@
  )
  (func $1 (param $0 (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
   (local $1 (ref null $[ref?|[mut:f64]|]))
-  (local $2 (ref null $[mut:f64]))
+  (local $2 (ref null $[mut:i32]))
+  (local $3 (ref null $[mut:i32]))
+  (local $4 (ref null $[mut:f64]))
   (drop
    (array.new_with_rtt $[mut:f64]
     (rtt.canon $[mut:f64])
@@ -133,6 +137,24 @@
   (drop
    (array.len $[mut:f64]
     (local.get $0)
+   )
+  )
+  (drop
+   (array.get $[mut:i32]
+    (local.get $2)
+    (i32.const 1)
+   )
+  )
+  (drop
+   (array.get_u $[mut:i32]
+    (local.get $3)
+    (i32.const 2)
+   )
+  )
+  (drop
+   (array.get_s $[mut:i32]
+    (local.get $3)
+    (i32.const 3)
    )
   )
   (unreachable)

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -1,15 +1,16 @@
 (module
  (type ${i32_f32_f64} (struct (field i32) (field f32) (field f64)))
- (type ${} (struct ))
  (type $[mut:f64] (array (mut f64)))
+ (type ${} (struct ))
  (type ${i32} (struct (field i32)))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type ${mut:f32} (struct (field (mut f32))))
  (type ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref null ${i32_f32_f64})) (field (mut (ref null ${i32_f32_f64})))))
+ (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $rtt_1_${}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_${}_=>_none (func (param (rtt ${}))))
- (type $[ref?|[mut:f64]|] (array (ref null $[mut:f64])))
  (type $ref?|{i32_f32_f64}|_=>_ref?|{i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}| (func (param (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))))
+ (type $ref?|[mut:f64]|_=>_ref?|[ref?|[mut:f64]|]| (func (param (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))))
  (global $global$0 (rtt 0 ${}) (rtt.canon ${}))
  (global $global$1 (rtt 1 ${i32}) (rtt.sub ${i32}
   (global.get $global$0)
@@ -17,7 +18,6 @@
  (global $global$2 (rtt 2 ${i32_i64}) (rtt.sub ${i32_i64}
   (global.get $global$1)
  ))
- (export "foo" (func $0))
  (func $0 (param $0 (ref null ${i32_f32_f64})) (result (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $1 (ref null ${i32_f32_f64}))
   (local $2 (ref null ${i32_mut:i32_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
@@ -103,10 +103,44 @@
   )
   (unreachable)
  )
- (func $1 (param $0 (rtt 1 ${}))
+ (func $1 (param $0 (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
+  (local $1 (ref null $[ref?|[mut:f64]|]))
+  (local $2 (ref null $[mut:f64]))
+  (drop
+   (array.new_with_rtt $[mut:f64]
+    (rtt.canon $[mut:f64])
+    (i32.const 3)
+    (f64.const 3.14159)
+   )
+  )
+  (drop
+   (array.new_default_with_rtt $[ref?|[mut:f64]|]
+    (rtt.canon $[ref?|[mut:f64]|])
+    (i32.const 10)
+   )
+  )
+  (drop
+   (array.get $[mut:f64]
+    (local.get $0)
+    (i32.const 2)
+   )
+  )
+  (array.set $[mut:f64]
+   (local.get $0)
+   (i32.const 2)
+   (f64.const 2.18281828)
+  )
+  (drop
+   (array.len $[mut:f64]
+    (local.get $0)
+   )
+  )
+  (unreachable)
+ )
+ (func $2 (param $0 (rtt 1 ${}))
   (nop)
  )
- (func $2 (param $0 (rtt ${}))
+ (func $3 (param $0 (rtt ${}))
   (nop)
  )
 )


### PR DESCRIPTION
array.new/get/set/len - pretty straightforward after structs and all the
infrastructure for them.

Also fixes validation of the unnecessary heapType param in the
text and binary formats in structs as well as arrays.

Fixes printing of packed types in type names, which emitted i32
for them. That broke when we emitted the same name for an array
of i8 and i32 as in the new testing here.

Also fix a bug in `Field::operator<` which was wrong for packed
types; again, this was easy to notice with the new testing.