### PR TITLE
Use enums for mutability and nullability

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -1478,7 +1478,7 @@ private:
     for (const auto& type : target->sig.params) {
       args.push_back(make(type));
     }
-    auto targetType = Type(HeapType(target->sig), /* nullable = */ true);
+    auto targetType = Type(HeapType(target->sig), Nullable);
     // TODO: half the time make a completely random item with that type.
     return builder.makeCallRef(
       builder.makeRefFunc(target->name, targetType), args, type, isReturn);
@@ -2066,7 +2066,7 @@ private:
         if (!wasm.functions.empty() && !oneIn(wasm.functions.size())) {
           target = pick(wasm.functions).get();
         }
-        auto type = Type(HeapType(target->sig), /* nullable = */ true);
+        auto type = Type(HeapType(target->sig), Nullable);
         return builder.makeRefFunc(target->name, type);
       }
       if (type == Type::i31ref) {
@@ -2079,7 +2079,7 @@ private:
       for (auto& func : wasm.functions) {
         // FIXME: RefFunc type should be non-nullable, but we emit nullable
         //        types for now.
-        if (type == Type(HeapType(func->sig), /* nullable = */ true)) {
+        if (type == Type(HeapType(func->sig), Nullable)) {
           return builder.makeRefFunc(func->name, type);
         }
       }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1276,6 +1276,7 @@ public:
   Type getType(int initial);
 
   HeapType getHeapType();
+  Mutability getMutability();
   Field getField();
   Type getConcreteType();
   Name getInlineString();

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -45,7 +45,7 @@ struct Array;
 struct Rtt;
 
 enum Nullability { NonNullable, Nullable };
-enum Mutability { NonMutable, Mutable };
+enum Mutability { Immutable, Mutable };
 
 // The type used for interning IDs in the public interfaces of Type and
 // HeapType.

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -44,6 +44,9 @@ struct Struct;
 struct Array;
 struct Rtt;
 
+enum Nullability { NonNullable, Nullable };
+enum Mutability { NonMutable, Mutable };
+
 // The type used for interning IDs in the public interfaces of Type and
 // HeapType.
 using TypeID = uint64_t;
@@ -93,7 +96,7 @@ public:
 
   // Construct from a heap type description. Also covers construction from
   // Signature, Struct or Array via implicit conversion to HeapType.
-  Type(HeapType, bool nullable);
+  Type(HeapType, Nullability nullable);
 
   // Construct from rtt description
   Type(Rtt);
@@ -384,12 +387,12 @@ struct Field {
     i8,
     i16,
   } packedType; // applicable iff type=i32
-  bool mutable_;
+  Mutability mutable_;
   Name name;
 
-  Field(Type type, bool mutable_, Name name = Name())
+  Field(Type type, Mutability mutable_, Name name = Name())
     : type(type), packedType(not_packed), mutable_(mutable_), name(name) {}
-  Field(PackedType packedType, bool mutable_, Name name = Name())
+  Field(PackedType packedType, Mutability mutable_, Name name = Name())
     : type(Type::i32), packedType(packedType), mutable_(mutable_), name(name) {}
 
   constexpr bool isPacked() const {
@@ -483,7 +486,7 @@ struct TypeBuilder {
   // TypeBuilder's HeapTypes. Temporary Ref and Rtt types are backed by the
   // HeapType at index `i`.
   Type getTempTupleType(const Tuple&);
-  Type getTempRefType(size_t i, bool nullable);
+  Type getTempRefType(size_t i, Nullability nullable);
   Type getTempRttType(size_t i, uint32_t depth);
 
   // Canonicalizes and returns all of the heap types. May only be called once

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1464,7 +1464,7 @@ HeapType WasmBinaryBuilder::getHeapType() {
 Mutability WasmBinaryBuilder::getMutability() {
   switch (getU32LEB()) {
     case 0:
-      return NonMutable;
+      return Immutable;
     case 1:
       return Mutable;
     default:

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1411,10 +1411,10 @@ Type WasmBinaryBuilder::getType(int initial) {
     case BinaryConsts::EncodedType::eqref:
       return Type::eqref;
     case BinaryConsts::EncodedType::nullable:
-      return Type(getHeapType(), /* nullable = */ true);
+      return Type(getHeapType(), Nullable);
     case BinaryConsts::EncodedType::nonnullable:
       // FIXME: for now, force all inputs to be nullable
-      return Type(getHeapType(), /* nullable = */ true);
+      return Type(getHeapType(), Nullable);
     case BinaryConsts::EncodedType::i31ref:
       return Type::i31ref;
     case BinaryConsts::EncodedType::rtt_n: {
@@ -1461,21 +1461,32 @@ HeapType WasmBinaryBuilder::getHeapType() {
   WASM_UNREACHABLE("unexpected type");
 }
 
+Mutability WasmBinaryBuilder::getMutability() {
+  switch (getU32LEB()) {
+    case 0:
+      return NonMutable;
+    case 1:
+      return Mutable;
+    default:
+      throw ParseException("Expected 0 or 1 for mutability");
+  }
+}
+
 Field WasmBinaryBuilder::getField() {
   // The value may be a general wasm type, or one of the types only possible in
   // a field.
   auto initial = getS32LEB();
   if (initial == BinaryConsts::EncodedType::i8) {
-    auto mutable_ = getU32LEB();
+    auto mutable_ = getMutability();
     return Field(Field::i8, mutable_);
   }
   if (initial == BinaryConsts::EncodedType::i16) {
-    auto mutable_ = getU32LEB();
+    auto mutable_ = getMutability();
     return Field(Field::i16, mutable_);
   }
   // It's a regular wasm value.
   auto type = getType(initial);
-  auto mutable_ = getU32LEB();
+  auto mutable_ = getMutability();
   return Field(type, mutable_);
 }
 
@@ -5433,8 +5444,7 @@ void WasmBinaryBuilder::visitRefFunc(RefFunc* curr) {
   // To support typed function refs, we give the reference not just a general
   // funcref, but a specific subtype with the actual signature.
   // FIXME: for now, emit a nullable type here
-  curr->finalize(Type(HeapType(getSignatureByFunctionIndex(index)),
-                      /* nullable = */ true));
+  curr->finalize(Type(HeapType(getSignatureByFunctionIndex(index)), Nullable));
 }
 
 void WasmBinaryBuilder::visitRefEq(RefEq* curr) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -932,10 +932,10 @@ Type SExpressionWasmBuilder::elementToType(Element& s) {
         std::string("invalid reference type qualifier"), s.line, s.col);
     }
     // FIXME: for now, force all inputs to be nullable
-    bool nullable = true;
+    Nullability nullable = Nullable;
     size_t i = 1;
     if (size == 3) {
-      nullable = true;
+      nullable = Nullable;
       i++;
     }
     return Type(parseHeapType(*s[i]), nullable);
@@ -1925,8 +1925,7 @@ Expression* SExpressionWasmBuilder::makeRefFunc(Element& s) {
   ret->func = func;
   // To support typed function refs, we give the reference not just a general
   // funcref, but a specific subtype with the actual signature.
-  ret->finalize(
-    Type(HeapType(functionSignatures[func]), /* nullable = */ true));
+  ret->finalize(Type(HeapType(functionSignatures[func]), Nullable));
   return ret;
 }
 
@@ -2826,7 +2825,7 @@ HeapType SExpressionWasmBuilder::parseHeapType(Element& s) {
   }
   // It's a struct or an array.
   auto parseField = [&](Element* t) {
-    bool mutable_ = false;
+    Mutability mutable_ = NonMutable;
     // t is a list, containing either
     //   TYPE
     // or
@@ -2842,7 +2841,7 @@ HeapType SExpressionWasmBuilder::parseHeapType(Element& s) {
     }
     // The element may also be (mut (..)).
     if (elementStartsWith(t, MUT)) {
-      mutable_ = true;
+      mutable_ = Mutable;
       t = (*t)[1];
     }
     if (t->isStr()) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2825,7 +2825,7 @@ HeapType SExpressionWasmBuilder::parseHeapType(Element& s) {
   }
   // It's a struct or an array.
   auto parseField = [&](Element* t) {
-    Mutability mutable_ = NonMutable;
+    Mutability mutable_ = Immutable;
     // t is a list, containing either
     //   TYPE
     // or

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -39,7 +39,7 @@ struct TypeInfo {
   } kind;
   struct Ref {
     HeapType heapType;
-    bool nullable;
+    Nullability nullable;
   };
   union {
     Tuple tuple;
@@ -49,7 +49,7 @@ struct TypeInfo {
 
   TypeInfo(const Tuple& tuple) : kind(TupleKind), tuple(tuple) {}
   TypeInfo(Tuple&& tuple) : kind(TupleKind), tuple(std::move(tuple)) {}
-  TypeInfo(HeapType heapType, bool nullable)
+  TypeInfo(HeapType heapType, Nullability nullable)
     : kind(RefKind), ref{heapType, nullable} {}
   TypeInfo(Rtt rtt) : kind(RttKind), rtt(rtt) {}
   TypeInfo(const TypeInfo& other);
@@ -351,7 +351,7 @@ Type::Type(Tuple&& tuple) {
   new (this) Type(globalTypeStore.canonicalize(std::move(tuple)));
 }
 
-Type::Type(HeapType heapType, bool nullable) {
+Type::Type(HeapType heapType, Nullability nullable) {
   new (this) Type(globalTypeStore.canonicalize(TypeInfo(heapType, nullable)));
 }
 
@@ -1053,7 +1053,7 @@ Type TypeBuilder::getTempTupleType(const Tuple& tuple) {
   return impl->typeStore.canonicalize(tuple);
 }
 
-Type TypeBuilder::getTempRefType(size_t i, bool nullable) {
+Type TypeBuilder::getTempRefType(size_t i, Nullability nullable) {
   assert(i < impl->entries.size() && "Index out of bounds");
   return impl->typeStore.canonicalize(
     TypeInfo(impl->entries[i].get(), nullable));

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -978,7 +978,7 @@ void MemoryGrow::finalize() {
   }
 }
 
-void RefNull::finalize(HeapType heapType) { type = Type(heapType, true); }
+void RefNull::finalize(HeapType heapType) { type = Type(heapType, Nullable); }
 
 void RefNull::finalize(Type type_) {
   type = type_;
@@ -1098,7 +1098,7 @@ void RefCast::finalize() {
     type = Type::unreachable;
   } else {
     // TODO: make non-nullable when we support that
-    type = Type(rtt->type.getHeapType(), /* nullable = */ true);
+    type = Type(rtt->type.getHeapType(), Nullable);
   }
 }
 
@@ -1125,7 +1125,7 @@ void StructNew::finalize() {
     return;
   }
   // TODO: make non-nullable when we support that
-  type = Type(rtt->type.getHeapType(), /* nullable = */ true);
+  type = Type(rtt->type.getHeapType(), Nullable);
 }
 
 void StructGet::finalize() {
@@ -1151,7 +1151,7 @@ void ArrayNew::finalize() {
     return;
   }
   // TODO: make non-nullable when we support that
-  type = Type(rtt->type.getHeapType(), /* nullable = */ true);
+  type = Type(rtt->type.getHeapType(), Nullable);
 }
 
 void ArrayGet::finalize() {

--- a/test/example/type-builder.cpp
+++ b/test/example/type-builder.cpp
@@ -23,7 +23,7 @@ void test_builder() {
   Type refNullExt(HeapType::ext, Nullable);
 
   Signature sig(refStruct, builder.getTempTupleType({refArray, Type::i32}));
-  Struct struct_({Field(refNullArray, NonMutable), Field(rttArray, Mutable)});
+  Struct struct_({Field(refNullArray, Immutable), Field(rttArray, Mutable)});
   Array array(Field(refNullExt, Mutable));
 
   std::cout << "Before setting heap types:\n";
@@ -73,7 +73,7 @@ void test_canonicalization() {
   // (type $struct (struct (field (ref null $sig))))
   // (type $sig (func))
   HeapType sig = Signature(Type::none, Type::none);
-  HeapType struct_ = Struct({Field(Type(sig, Nullable), NonMutable)});
+  HeapType struct_ = Struct({Field(Type(sig, Nullable), Immutable)});
 
   TypeBuilder builder(4);
 
@@ -84,8 +84,8 @@ void test_canonicalization() {
   assert(tempSigRef1 != Type(sig, Nullable));
   assert(tempSigRef2 != Type(sig, Nullable));
 
-  builder.setHeapType(0, Struct({Field(tempSigRef1, NonMutable)}));
-  builder.setHeapType(1, Struct({Field(tempSigRef2, NonMutable)}));
+  builder.setHeapType(0, Struct({Field(tempSigRef1, Immutable)}));
+  builder.setHeapType(1, Struct({Field(tempSigRef2, Immutable)}));
   builder.setHeapType(2, Signature(Type::none, Type::none));
   builder.setHeapType(3, Signature(Type::none, Type::none));
 

--- a/test/example/type-builder.cpp
+++ b/test/example/type-builder.cpp
@@ -15,16 +15,16 @@ void test_builder() {
 
   TypeBuilder builder(3);
 
-  Type refSig = builder.getTempRefType(0, false);
-  Type refStruct = builder.getTempRefType(1, false);
-  Type refArray = builder.getTempRefType(2, false);
-  Type refNullArray = builder.getTempRefType(2, true);
+  Type refSig = builder.getTempRefType(0, NonNullable);
+  Type refStruct = builder.getTempRefType(1, NonNullable);
+  Type refArray = builder.getTempRefType(2, NonNullable);
+  Type refNullArray = builder.getTempRefType(2, Nullable);
   Type rttArray = builder.getTempRttType(2, 0);
-  Type refNullExt(HeapType::ext, true);
+  Type refNullExt(HeapType::ext, Nullable);
 
   Signature sig(refStruct, builder.getTempTupleType({refArray, Type::i32}));
-  Struct struct_({Field(refNullArray, false), Field(rttArray, true)});
-  Array array(Field(refNullExt, true));
+  Struct struct_({Field(refNullArray, NonMutable), Field(rttArray, Mutable)});
+  Array array(Field(refNullExt, Mutable));
 
   std::cout << "Before setting heap types:\n";
   std::cout << "(ref $sig) => " << refSig << "\n";
@@ -46,10 +46,10 @@ void test_builder() {
 
   std::vector<HeapType> built = builder.build();
 
-  Type newRefSig = Type(built[0], false);
-  Type newRefStruct = Type(built[1], false);
-  Type newRefArray = Type(built[2], false);
-  Type newRefNullArray = Type(built[2], true);
+  Type newRefSig = Type(built[0], NonNullable);
+  Type newRefStruct = Type(built[1], NonNullable);
+  Type newRefArray = Type(built[2], NonNullable);
+  Type newRefNullArray = Type(built[2], Nullable);
   Type newRttArray = Type(Rtt(0, built[2]));
 
   assert(refSig != newRefSig);
@@ -73,19 +73,19 @@ void test_canonicalization() {
   // (type $struct (struct (field (ref null $sig))))
   // (type $sig (func))
   HeapType sig = Signature(Type::none, Type::none);
-  HeapType struct_ = Struct({Field(Type(sig, true), false)});
+  HeapType struct_ = Struct({Field(Type(sig, Nullable), NonMutable)});
 
   TypeBuilder builder(4);
 
-  Type tempSigRef1 = builder.getTempRefType(2, true);
-  Type tempSigRef2 = builder.getTempRefType(3, true);
+  Type tempSigRef1 = builder.getTempRefType(2, Nullable);
+  Type tempSigRef2 = builder.getTempRefType(3, Nullable);
 
   assert(tempSigRef1 != tempSigRef2);
-  assert(tempSigRef1 != Type(sig, true));
-  assert(tempSigRef2 != Type(sig, true));
+  assert(tempSigRef1 != Type(sig, Nullable));
+  assert(tempSigRef2 != Type(sig, Nullable));
 
-  builder.setHeapType(0, Struct({Field(tempSigRef1, false)}));
-  builder.setHeapType(1, Struct({Field(tempSigRef2, false)}));
+  builder.setHeapType(0, Struct({Field(tempSigRef1, NonMutable)}));
+  builder.setHeapType(1, Struct({Field(tempSigRef2, NonMutable)}));
   builder.setHeapType(2, Signature(Type::none, Type::none));
   builder.setHeapType(3, Signature(Type::none, Type::none));
 
@@ -103,7 +103,7 @@ void test_recursive() {
   {
     // Trivial recursion
     TypeBuilder builder(1);
-    Type temp = builder.getTempRefType(0, true);
+    Type temp = builder.getTempRefType(0, Nullable);
     builder.setHeapType(0, Signature(Type::none, temp));
     // std::vector<HeapType> built = builder.build();
   }
@@ -111,8 +111,8 @@ void test_recursive() {
   {
     // Mutual recursion
     TypeBuilder builder(2);
-    Type temp0 = builder.getTempRefType(0, true);
-    Type temp1 = builder.getTempRefType(1, true);
+    Type temp0 = builder.getTempRefType(0, Nullable);
+    Type temp1 = builder.getTempRefType(1, Nullable);
     builder.setHeapType(0, Signature(Type::none, temp1));
     builder.setHeapType(1, Signature(Type::none, temp0));
     // std::vector<HeapType> built = builder.build();
@@ -121,11 +121,11 @@ void test_recursive() {
   {
     // A longer chain of recursion
     TypeBuilder builder(5);
-    Type temp0 = builder.getTempRefType(0, true);
-    Type temp1 = builder.getTempRefType(1, true);
-    Type temp2 = builder.getTempRefType(2, true);
-    Type temp3 = builder.getTempRefType(3, true);
-    Type temp4 = builder.getTempRefType(4, true);
+    Type temp0 = builder.getTempRefType(0, Nullable);
+    Type temp1 = builder.getTempRefType(1, Nullable);
+    Type temp2 = builder.getTempRefType(2, Nullable);
+    Type temp3 = builder.getTempRefType(3, Nullable);
+    Type temp4 = builder.getTempRefType(4, Nullable);
     builder.setHeapType(0, Signature(Type::none, temp1));
     builder.setHeapType(1, Signature(Type::none, temp2));
     builder.setHeapType(2, Signature(Type::none, temp3));

--- a/test/example/typeinfo.cpp
+++ b/test/example/typeinfo.cpp
@@ -8,81 +8,97 @@ using namespace wasm;
 void test_compound() {
   {
     HeapType func(HeapType::func);
-    assert(Type(func, true).getID() == Type::funcref);
-    assert(Type(func, false).getID() == Type(func, false).getID());
-    assert(Type(func, false).getID() != Type(func, true).getID());
+    assert(Type(func, Nullable).getID() == Type::funcref);
+    assert(Type(func, NonNullable).getID() == Type(func, NonNullable).getID());
+    assert(Type(func, NonNullable).getID() != Type(func, Nullable).getID());
     HeapType sameFunc(HeapType::func);
-    assert(Type(func, false).getID() == Type(sameFunc, false).getID());
+    assert(Type(func, NonNullable).getID() ==
+           Type(sameFunc, NonNullable).getID());
 
     HeapType extern_(HeapType::ext);
-    assert(Type(extern_, true).getID() == Type::externref);
-    assert(Type(extern_, false).getID() == Type(extern_, false).getID());
-    assert(Type(extern_, false).getID() != Type(extern_, true).getID());
+    assert(Type(extern_, Nullable).getID() == Type::externref);
+    assert(Type(extern_, NonNullable).getID() ==
+           Type(extern_, NonNullable).getID());
+    assert(Type(extern_, NonNullable).getID() !=
+           Type(extern_, Nullable).getID());
     HeapType sameExtern(HeapType::ext);
-    assert(Type(extern_, false).getID() == Type(sameExtern, false).getID());
+    assert(Type(extern_, NonNullable).getID() ==
+           Type(sameExtern, NonNullable).getID());
 
     HeapType exn(HeapType::exn);
-    assert(Type(exn, true).getID() == Type::exnref);
-    assert(Type(exn, false).getID() == Type(exn, false).getID());
-    assert(Type(exn, false).getID() != Type(exn, true).getID());
+    assert(Type(exn, Nullable).getID() == Type::exnref);
+    assert(Type(exn, NonNullable).getID() == Type(exn, NonNullable).getID());
+    assert(Type(exn, NonNullable).getID() != Type(exn, Nullable).getID());
     HeapType sameExn(HeapType::exn);
-    assert(Type(exn, false).getID() == Type(sameExn, false).getID());
+    assert(Type(exn, NonNullable).getID() ==
+           Type(sameExn, NonNullable).getID());
 
     HeapType any(HeapType::any);
-    assert(Type(any, true).getID() == Type::anyref);
-    assert(Type(any, false).getID() == Type(any, false).getID());
-    assert(Type(any, false).getID() != Type(any, true).getID());
+    assert(Type(any, Nullable).getID() == Type::anyref);
+    assert(Type(any, NonNullable).getID() == Type(any, NonNullable).getID());
+    assert(Type(any, NonNullable).getID() != Type(any, Nullable).getID());
     HeapType sameAny(HeapType::any);
-    assert(Type(any, false).getID() == Type(sameAny, false).getID());
+    assert(Type(any, NonNullable).getID() ==
+           Type(sameAny, NonNullable).getID());
 
     HeapType eq(HeapType::eq);
-    // assert(Type(eq, true).getID() == Type::eqref);
-    assert(Type(eq, false).getID() == Type(eq, false).getID());
-    assert(Type(eq, false).getID() != Type(eq, true).getID());
+    // assert(Type(eq, Nullable).getID() == Type::eqref);
+    assert(Type(eq, NonNullable).getID() == Type(eq, NonNullable).getID());
+    assert(Type(eq, NonNullable).getID() != Type(eq, Nullable).getID());
     HeapType sameEq(HeapType::eq);
-    assert(Type(eq, false).getID() == Type(sameEq, false).getID());
+    assert(Type(eq, NonNullable).getID() == Type(sameEq, NonNullable).getID());
 
     HeapType i31(HeapType::i31);
-    // assert(Type(i31, false).getID() == Type::i31ref);
-    assert(Type(i31, false).getID() == Type(i31, false).getID());
-    assert(Type(i31, false).getID() != Type(i31, true).getID());
+    // assert(Type(i31, NonNullable).getID() == Type::i31ref);
+    assert(Type(i31, NonNullable).getID() == Type(i31, NonNullable).getID());
+    assert(Type(i31, NonNullable).getID() != Type(i31, Nullable).getID());
     HeapType sameI31(HeapType::i31);
-    assert(Type(i31, false).getID() == Type(sameI31, false).getID());
+    assert(Type(i31, NonNullable).getID() ==
+           Type(sameI31, NonNullable).getID());
   }
   {
     Signature signature(Type::i32, Type::none);
-    assert(Type(signature, false).getID() == Type(signature, false).getID());
-    assert(Type(signature, false).getID() != Type(signature, true).getID());
+    assert(Type(signature, NonNullable).getID() ==
+           Type(signature, NonNullable).getID());
+    assert(Type(signature, NonNullable).getID() !=
+           Type(signature, Nullable).getID());
 
     Signature sameSignature(Type::i32, Type::none);
-    assert(Type(signature, false).getID() ==
-           Type(sameSignature, false).getID());
+    assert(Type(signature, NonNullable).getID() ==
+           Type(sameSignature, NonNullable).getID());
 
     Signature otherSignature(Type::f64, Type::none);
-    assert(Type(signature, false).getID() !=
-           Type(otherSignature, false).getID());
+    assert(Type(signature, NonNullable).getID() !=
+           Type(otherSignature, NonNullable).getID());
   }
   {
     Struct struct_({});
-    assert(Type(struct_, false).getID() == Type(struct_, false).getID());
-    assert(Type(struct_, false).getID() != Type(struct_, true).getID());
+    assert(Type(struct_, NonNullable).getID() ==
+           Type(struct_, NonNullable).getID());
+    assert(Type(struct_, NonNullable).getID() !=
+           Type(struct_, Nullable).getID());
 
     Struct sameStruct({});
-    assert(Type(struct_, false).getID() == Type(sameStruct, false).getID());
+    assert(Type(struct_, NonNullable).getID() ==
+           Type(sameStruct, NonNullable).getID());
 
-    Struct otherStruct({{Type::i32, false}});
-    assert(Type(struct_, false).getID() != Type(otherStruct, false).getID());
+    Struct otherStruct({{Type::i32, NonMutable}});
+    assert(Type(struct_, NonNullable).getID() !=
+           Type(otherStruct, NonNullable).getID());
   }
   {
-    Array array({Type::i32, false});
-    assert(Type(array, false).getID() == Type(array, false).getID());
-    assert(Type(array, false).getID() != Type(array, true).getID());
+    Array array({Type::i32, NonMutable});
+    assert(Type(array, NonNullable).getID() ==
+           Type(array, NonNullable).getID());
+    assert(Type(array, NonNullable).getID() != Type(array, Nullable).getID());
 
-    Array sameArray({Type::i32, false});
-    assert(Type(array, false).getID() == Type(sameArray, false).getID());
+    Array sameArray({Type::i32, NonMutable});
+    assert(Type(array, NonNullable).getID() ==
+           Type(sameArray, NonNullable).getID());
 
-    Array otherArray({Type::f64, true});
-    assert(Type(array, false).getID() != Type(otherArray, false).getID());
+    Array otherArray({Type::f64, Mutable});
+    assert(Type(array, NonNullable).getID() !=
+           Type(otherArray, NonNullable).getID());
   }
   {
     Tuple singleTuple({Type::i32});
@@ -120,7 +136,7 @@ void test_compound() {
     assert(structRtt == sameStructRtt);
     assert(Type(structRtt).getID() == Type(sameStructRtt).getID());
 
-    Rtt otherStructRtt(0, Struct({{Type::i32, false}}));
+    Rtt otherStructRtt(0, Struct({{Type::i32, NonMutable}}));
     assert(structRtt != otherStructRtt);
     assert(Type(structRtt).getID() != Type(otherStructRtt).getID());
   }
@@ -130,65 +146,65 @@ void test_printing() {
   {
     std::cout << ";; Heap types\n";
     std::cout << HeapType(HeapType::func) << "\n";
-    std::cout << Type(HeapType::func, true) << "\n";
-    std::cout << Type(HeapType::func, false) << "\n";
+    std::cout << Type(HeapType::func, Nullable) << "\n";
+    std::cout << Type(HeapType::func, NonNullable) << "\n";
     std::cout << HeapType(HeapType::ext) << "\n";
-    std::cout << Type(HeapType::ext, true) << "\n";
-    std::cout << Type(HeapType::ext, false) << "\n";
+    std::cout << Type(HeapType::ext, Nullable) << "\n";
+    std::cout << Type(HeapType::ext, NonNullable) << "\n";
     std::cout << HeapType(HeapType::any) << "\n";
-    std::cout << Type(HeapType::any, true) << "\n";
-    std::cout << Type(HeapType::any, false) << "\n";
+    std::cout << Type(HeapType::any, Nullable) << "\n";
+    std::cout << Type(HeapType::any, NonNullable) << "\n";
     std::cout << HeapType(HeapType::eq) << "\n";
-    std::cout << Type(HeapType::eq, true) << "\n";
-    std::cout << Type(HeapType::eq, false) << "\n";
+    std::cout << Type(HeapType::eq, Nullable) << "\n";
+    std::cout << Type(HeapType::eq, NonNullable) << "\n";
     std::cout << HeapType(HeapType::i31) << "\n";
-    std::cout << Type(HeapType::i31, true) << "\n";
-    std::cout << Type(HeapType::i31, false) << "\n";
+    std::cout << Type(HeapType::i31, Nullable) << "\n";
+    std::cout << Type(HeapType::i31, NonNullable) << "\n";
     std::cout << HeapType(HeapType::exn) << "\n";
-    std::cout << Type(HeapType::exn, true) << "\n";
-    std::cout << Type(HeapType::exn, false) << "\n";
+    std::cout << Type(HeapType::exn, Nullable) << "\n";
+    std::cout << Type(HeapType::exn, NonNullable) << "\n";
     std::cout << HeapType(Signature(Type::none, Type::none)) << "\n";
     std::cout << HeapType(Struct({})) << "\n";
-    std::cout << HeapType(Array({Type::i32, false})) << "\n";
+    std::cout << HeapType(Array({Type::i32, NonMutable})) << "\n";
   }
   {
     std::cout << "\n;; Signature\n";
     Signature emptySignature(Type::none, Type::none);
     std::cout << emptySignature << "\n";
-    std::cout << Type(emptySignature, false) << "\n";
-    std::cout << Type(emptySignature, true) << "\n";
+    std::cout << Type(emptySignature, NonNullable) << "\n";
+    std::cout << Type(emptySignature, Nullable) << "\n";
     Signature signature(Type::i32, Type::f64);
     std::cout << signature << "\n";
-    std::cout << Type(signature, false) << "\n";
-    std::cout << Type(signature, true) << "\n";
+    std::cout << Type(signature, NonNullable) << "\n";
+    std::cout << Type(signature, Nullable) << "\n";
   }
   {
     std::cout << "\n;; Struct\n";
     Struct emptyStruct({});
     std::cout << emptyStruct << "\n";
-    std::cout << Type(emptyStruct, false) << "\n";
-    std::cout << Type(emptyStruct, true) << "\n";
+    std::cout << Type(emptyStruct, NonNullable) << "\n";
+    std::cout << Type(emptyStruct, Nullable) << "\n";
     Struct struct_({
-      {Type::i32, false},
-      {Type::i64, false},
-      {Type::f32, true},
-      {Type::f64, true},
-      {Type::externref, false},
+      {Type::i32, NonMutable},
+      {Type::i64, NonMutable},
+      {Type::f32, Mutable},
+      {Type::f64, Mutable},
+      {Type::externref, NonMutable},
     });
     std::cout << struct_ << "\n";
-    std::cout << Type(struct_, false) << "\n";
-    std::cout << Type(struct_, true) << "\n";
+    std::cout << Type(struct_, NonNullable) << "\n";
+    std::cout << Type(struct_, Nullable) << "\n";
   }
   {
     std::cout << "\n;; Array\n";
-    Array array({Type::i32, false});
+    Array array({Type::i32, NonMutable});
     std::cout << array << "\n";
-    std::cout << Type(array, false) << "\n";
-    std::cout << Type(array, true) << "\n";
-    Array arrayMut({Type::externref, true});
+    std::cout << Type(array, NonNullable) << "\n";
+    std::cout << Type(array, Nullable) << "\n";
+    Array arrayMut({Type::externref, Mutable});
     std::cout << arrayMut << "\n";
-    std::cout << Type(arrayMut, false) << "\n";
-    std::cout << Type(arrayMut, true) << "\n";
+    std::cout << Type(arrayMut, NonNullable) << "\n";
+    std::cout << Type(arrayMut, Nullable) << "\n";
   }
   {
     std::cout << "\n;; Tuple\n";
@@ -223,92 +239,93 @@ void test_printing() {
     Rtt structRtt(7, Struct({}));
     std::cout << structRtt << "\n";
     std::cout << Type(structRtt) << "\n";
-    Rtt arrayRtt(8, Array({Type::i32, false}));
+    Rtt arrayRtt(8, Array({Type::i32, NonMutable}));
     std::cout << arrayRtt << "\n";
     std::cout << Type(arrayRtt) << "\n";
   }
   {
     std::cout << "\n;; Signature of references (param/result)\n";
-    Signature signature(Type(Struct({}), true),
-                        Type(Array({Type::i32, true}), false));
+    Signature signature(Type(Struct({}), Nullable),
+                        Type(Array({Type::i32, Mutable}), NonNullable));
     std::cout << signature << "\n";
   }
   {
     std::cout << "\n;; Signature of references (params/results)\n";
     Signature signature(Type({
-                          Type(Struct({}), true),
-                          Type(Array({Type::i32, true}), false),
+                          Type(Struct({}), Nullable),
+                          Type(Array({Type::i32, Mutable}), NonNullable),
                         }),
                         Type({
-                          Type(Struct({}), false),
-                          Type(Array({Type::i32, false}), true),
+                          Type(Struct({}), NonNullable),
+                          Type(Array({Type::i32, NonMutable}), Nullable),
                         }));
     std::cout << signature << "\n";
   }
   {
     std::cout << "\n;; Struct of references\n";
     Struct structOfSignature({
-      {Type(Signature(Type::none, Type::none), false), false},
-      {Type(Signature(Type::none, Type::none), false), true},
-      {Type(Signature(Type::none, Type::none), true), false},
-      {Type(Signature(Type::none, Type::none), true), true},
+      {Type(Signature(Type::none, Type::none), NonNullable), NonMutable},
+      {Type(Signature(Type::none, Type::none), NonNullable), Mutable},
+      {Type(Signature(Type::none, Type::none), Nullable), NonMutable},
+      {Type(Signature(Type::none, Type::none), Nullable), Mutable},
     });
     std::cout << structOfSignature << "\n";
-    std::cout << Type(structOfSignature, false) << "\n";
-    std::cout << Type(structOfSignature, true) << "\n";
+    std::cout << Type(structOfSignature, NonNullable) << "\n";
+    std::cout << Type(structOfSignature, Nullable) << "\n";
     Struct structOfStruct({
-      {Type(Struct({}), false), false},
-      {Type(Struct({}), false), true},
-      {Type(Struct({}), true), false},
-      {Type(Struct({}), true), true},
+      {Type(Struct({}), NonNullable), NonMutable},
+      {Type(Struct({}), NonNullable), Mutable},
+      {Type(Struct({}), Nullable), NonMutable},
+      {Type(Struct({}), Nullable), Mutable},
     });
     std::cout << structOfStruct << "\n";
-    std::cout << Type(structOfStruct, false) << "\n";
-    std::cout << Type(structOfStruct, true) << "\n";
+    std::cout << Type(structOfStruct, NonNullable) << "\n";
+    std::cout << Type(structOfStruct, Nullable) << "\n";
     Struct structOfArray({
-      {Type(Array({Type::i32, false}), false), false},
-      {Type(Array({Type::i32, false}), false), true},
-      {Type(Array({Type::i32, false}), true), false},
-      {Type(Array({Type::i32, false}), true), true},
+      {Type(Array({Type::i32, NonMutable}), NonNullable), NonMutable},
+      {Type(Array({Type::i32, NonMutable}), NonNullable), Mutable},
+      {Type(Array({Type::i32, NonMutable}), Nullable), NonMutable},
+      {Type(Array({Type::i32, NonMutable}), Nullable), Mutable},
     });
     std::cout << structOfArray << "\n";
-    std::cout << Type(structOfArray, false) << "\n";
-    std::cout << Type(structOfArray, true) << "\n";
+    std::cout << Type(structOfArray, NonNullable) << "\n";
+    std::cout << Type(structOfArray, Nullable) << "\n";
     Struct structOfEverything({
-      {Type::i32, true},
-      {Type(Signature(Type::none, Type::none), true), true},
-      {Type(Struct({}), true), true},
-      {Type(Array({Type::i32, true}), true), true},
+      {Type::i32, Mutable},
+      {Type(Signature(Type::none, Type::none), Nullable), Mutable},
+      {Type(Struct({}), Nullable), Mutable},
+      {Type(Array({Type::i32, Mutable}), Nullable), Mutable},
     });
     std::cout << structOfEverything << "\n";
-    std::cout << Type(structOfEverything, false) << "\n";
-    std::cout << Type(structOfEverything, true) << "\n";
+    std::cout << Type(structOfEverything, NonNullable) << "\n";
+    std::cout << Type(structOfEverything, Nullable) << "\n";
   }
   {
     std::cout << "\n;; Array of references\n";
     Array arrayOfSignature(
-      {Type(Signature(Type::none, Type::none), true), false});
+      {Type(Signature(Type::none, Type::none), Nullable), NonMutable});
     std::cout << arrayOfSignature << "\n";
-    std::cout << Type(arrayOfSignature, false) << "\n";
-    std::cout << Type(arrayOfSignature, true) << "\n";
-    Array arrayOfStruct({Type(Struct({}), true), true});
+    std::cout << Type(arrayOfSignature, NonNullable) << "\n";
+    std::cout << Type(arrayOfSignature, Nullable) << "\n";
+    Array arrayOfStruct({Type(Struct({}), Nullable), Mutable});
     std::cout << arrayOfStruct << "\n";
-    std::cout << Type(arrayOfStruct, false) << "\n";
-    std::cout << Type(arrayOfStruct, true) << "\n";
-    Array arrayOfArray({Type(Array({Type::i32, false}), true), false});
+    std::cout << Type(arrayOfStruct, NonNullable) << "\n";
+    std::cout << Type(arrayOfStruct, Nullable) << "\n";
+    Array arrayOfArray(
+      {Type(Array({Type::i32, NonMutable}), Nullable), NonMutable});
     std::cout << arrayOfArray << "\n";
-    std::cout << Type(arrayOfArray, false) << "\n";
-    std::cout << Type(arrayOfArray, true) << "\n";
+    std::cout << Type(arrayOfArray, NonNullable) << "\n";
+    std::cout << Type(arrayOfArray, Nullable) << "\n";
   }
   {
     std::cout << "\n;; Tuple of references\n";
     Tuple tuple({
-      Type(Signature(Type::none, Type::none), false),
-      Type(Signature(Type::none, Type::none), true),
-      Type(Struct({}), false),
-      Type(Struct({}), true),
-      Type(Array({Type::i32, false}), false),
-      Type(Array({Type::i32, false}), true),
+      Type(Signature(Type::none, Type::none), NonNullable),
+      Type(Signature(Type::none, Type::none), Nullable),
+      Type(Struct({}), NonNullable),
+      Type(Struct({}), Nullable),
+      Type(Array({Type::i32, NonMutable}), NonNullable),
+      Type(Array({Type::i32, NonMutable}), Nullable),
     });
     std::cout << tuple << "\n";
     std::cout << Type(tuple) << "\n";
@@ -317,16 +334,17 @@ void test_printing() {
   {
     std::cout << "\n;; Recursive (not really)\n";
     Signature signatureSignature(Type::none, Type::none);
-    signatureSignature.params = Type(signatureSignature, false);
+    signatureSignature.params = Type(signatureSignature, NonNullable);
     //                                ^ copies
     std::cout << signatureSignature << "\n";
-    std::cout << Type(signatureSignature, false) << "\n";
+    std::cout << Type(signatureSignature, NonNullable) << "\n";
     Signature signatureArraySignature(Type::none, Type::none);
     signatureArraySignature.params =
-      Type(Array({Type(signatureArraySignature, false), false}), false);
+      Type(Array({Type(signatureArraySignature, NonNullable), NonMutable}),
+           NonNullable);
     //                 ^ copies
     std::cout << signatureArraySignature << "\n";
-    std::cout << Type(signatureArraySignature, false) << "\n";
+    std::cout << Type(signatureArraySignature, NonNullable) << "\n";
   }
 }
 

--- a/test/example/typeinfo.cpp
+++ b/test/example/typeinfo.cpp
@@ -82,17 +82,17 @@ void test_compound() {
     assert(Type(struct_, NonNullable).getID() ==
            Type(sameStruct, NonNullable).getID());
 
-    Struct otherStruct({{Type::i32, NonMutable}});
+    Struct otherStruct({{Type::i32, Immutable}});
     assert(Type(struct_, NonNullable).getID() !=
            Type(otherStruct, NonNullable).getID());
   }
   {
-    Array array({Type::i32, NonMutable});
+    Array array({Type::i32, Immutable});
     assert(Type(array, NonNullable).getID() ==
            Type(array, NonNullable).getID());
     assert(Type(array, NonNullable).getID() != Type(array, Nullable).getID());
 
-    Array sameArray({Type::i32, NonMutable});
+    Array sameArray({Type::i32, Immutable});
     assert(Type(array, NonNullable).getID() ==
            Type(sameArray, NonNullable).getID());
 
@@ -136,7 +136,7 @@ void test_compound() {
     assert(structRtt == sameStructRtt);
     assert(Type(structRtt).getID() == Type(sameStructRtt).getID());
 
-    Rtt otherStructRtt(0, Struct({{Type::i32, NonMutable}}));
+    Rtt otherStructRtt(0, Struct({{Type::i32, Immutable}}));
     assert(structRtt != otherStructRtt);
     assert(Type(structRtt).getID() != Type(otherStructRtt).getID());
   }
@@ -165,7 +165,7 @@ void test_printing() {
     std::cout << Type(HeapType::exn, NonNullable) << "\n";
     std::cout << HeapType(Signature(Type::none, Type::none)) << "\n";
     std::cout << HeapType(Struct({})) << "\n";
-    std::cout << HeapType(Array({Type::i32, NonMutable})) << "\n";
+    std::cout << HeapType(Array({Type::i32, Immutable})) << "\n";
   }
   {
     std::cout << "\n;; Signature\n";
@@ -185,11 +185,11 @@ void test_printing() {
     std::cout << Type(emptyStruct, NonNullable) << "\n";
     std::cout << Type(emptyStruct, Nullable) << "\n";
     Struct struct_({
-      {Type::i32, NonMutable},
-      {Type::i64, NonMutable},
+      {Type::i32, Immutable},
+      {Type::i64, Immutable},
       {Type::f32, Mutable},
       {Type::f64, Mutable},
-      {Type::externref, NonMutable},
+      {Type::externref, Immutable},
     });
     std::cout << struct_ << "\n";
     std::cout << Type(struct_, NonNullable) << "\n";
@@ -197,7 +197,7 @@ void test_printing() {
   }
   {
     std::cout << "\n;; Array\n";
-    Array array({Type::i32, NonMutable});
+    Array array({Type::i32, Immutable});
     std::cout << array << "\n";
     std::cout << Type(array, NonNullable) << "\n";
     std::cout << Type(array, Nullable) << "\n";
@@ -239,7 +239,7 @@ void test_printing() {
     Rtt structRtt(7, Struct({}));
     std::cout << structRtt << "\n";
     std::cout << Type(structRtt) << "\n";
-    Rtt arrayRtt(8, Array({Type::i32, NonMutable}));
+    Rtt arrayRtt(8, Array({Type::i32, Immutable}));
     std::cout << arrayRtt << "\n";
     std::cout << Type(arrayRtt) << "\n";
   }
@@ -257,35 +257,35 @@ void test_printing() {
                         }),
                         Type({
                           Type(Struct({}), NonNullable),
-                          Type(Array({Type::i32, NonMutable}), Nullable),
+                          Type(Array({Type::i32, Immutable}), Nullable),
                         }));
     std::cout << signature << "\n";
   }
   {
     std::cout << "\n;; Struct of references\n";
     Struct structOfSignature({
-      {Type(Signature(Type::none, Type::none), NonNullable), NonMutable},
+      {Type(Signature(Type::none, Type::none), NonNullable), Immutable},
       {Type(Signature(Type::none, Type::none), NonNullable), Mutable},
-      {Type(Signature(Type::none, Type::none), Nullable), NonMutable},
+      {Type(Signature(Type::none, Type::none), Nullable), Immutable},
       {Type(Signature(Type::none, Type::none), Nullable), Mutable},
     });
     std::cout << structOfSignature << "\n";
     std::cout << Type(structOfSignature, NonNullable) << "\n";
     std::cout << Type(structOfSignature, Nullable) << "\n";
     Struct structOfStruct({
-      {Type(Struct({}), NonNullable), NonMutable},
+      {Type(Struct({}), NonNullable), Immutable},
       {Type(Struct({}), NonNullable), Mutable},
-      {Type(Struct({}), Nullable), NonMutable},
+      {Type(Struct({}), Nullable), Immutable},
       {Type(Struct({}), Nullable), Mutable},
     });
     std::cout << structOfStruct << "\n";
     std::cout << Type(structOfStruct, NonNullable) << "\n";
     std::cout << Type(structOfStruct, Nullable) << "\n";
     Struct structOfArray({
-      {Type(Array({Type::i32, NonMutable}), NonNullable), NonMutable},
-      {Type(Array({Type::i32, NonMutable}), NonNullable), Mutable},
-      {Type(Array({Type::i32, NonMutable}), Nullable), NonMutable},
-      {Type(Array({Type::i32, NonMutable}), Nullable), Mutable},
+      {Type(Array({Type::i32, Immutable}), NonNullable), Immutable},
+      {Type(Array({Type::i32, Immutable}), NonNullable), Mutable},
+      {Type(Array({Type::i32, Immutable}), Nullable), Immutable},
+      {Type(Array({Type::i32, Immutable}), Nullable), Mutable},
     });
     std::cout << structOfArray << "\n";
     std::cout << Type(structOfArray, NonNullable) << "\n";
@@ -303,7 +303,7 @@ void test_printing() {
   {
     std::cout << "\n;; Array of references\n";
     Array arrayOfSignature(
-      {Type(Signature(Type::none, Type::none), Nullable), NonMutable});
+      {Type(Signature(Type::none, Type::none), Nullable), Immutable});
     std::cout << arrayOfSignature << "\n";
     std::cout << Type(arrayOfSignature, NonNullable) << "\n";
     std::cout << Type(arrayOfSignature, Nullable) << "\n";
@@ -312,7 +312,7 @@ void test_printing() {
     std::cout << Type(arrayOfStruct, NonNullable) << "\n";
     std::cout << Type(arrayOfStruct, Nullable) << "\n";
     Array arrayOfArray(
-      {Type(Array({Type::i32, NonMutable}), Nullable), NonMutable});
+      {Type(Array({Type::i32, Immutable}), Nullable), Immutable});
     std::cout << arrayOfArray << "\n";
     std::cout << Type(arrayOfArray, NonNullable) << "\n";
     std::cout << Type(arrayOfArray, Nullable) << "\n";
@@ -324,8 +324,8 @@ void test_printing() {
       Type(Signature(Type::none, Type::none), Nullable),
       Type(Struct({}), NonNullable),
       Type(Struct({}), Nullable),
-      Type(Array({Type::i32, NonMutable}), NonNullable),
-      Type(Array({Type::i32, NonMutable}), Nullable),
+      Type(Array({Type::i32, Immutable}), NonNullable),
+      Type(Array({Type::i32, Immutable}), Nullable),
     });
     std::cout << tuple << "\n";
     std::cout << Type(tuple) << "\n";
@@ -340,7 +340,7 @@ void test_printing() {
     std::cout << Type(signatureSignature, NonNullable) << "\n";
     Signature signatureArraySignature(Type::none, Type::none);
     signatureArraySignature.params =
-      Type(Array({Type(signatureArraySignature, NonNullable), NonMutable}),
+      Type(Array({Type(signatureArraySignature, NonNullable), Immutable}),
            NonNullable);
     //                 ^ copies
     std::cout << signatureArraySignature << "\n";


### PR DESCRIPTION
Previously we were using bools for both of these concepts, but using enums makes
the code clearer. In particular, the PR removes many instances of
`/*nullability=*/ true`.