### PR TITLE
Fix wasm-split name collision bug

### DIFF
--- a/test/lit/wasm-split/name-collision.wast
+++ b/test/lit/wasm-split/name-collision.wast
@@ -1,0 +1,16 @@
+;; Regression test for a bug in which colliding internal names between
+;; non-function exports would result in the wrong import names being used in the
+;; secondary module.
+
+;; RUN: wasm-split %s -o1 %t.1.wasm -o2 %t.2.wasm
+;; RUN: wasm-dis %t.2.wasm | filecheck %s
+
+;; CHECK-NOT: (import "primary" "memory" (table
+;; CHECK: (import "primary" "table" (table
+
+(module
+ (table $collide 1 funcref)
+ (memory $collide 1 1)
+ (export "table" (table $collide))
+ (export "memory" (memory $collide))
+)


### PR DESCRIPTION
During module splitting, a map is constructed from internal names to their
corresponding export names. This code previously did not take into account the
fact that the same internal name may be used by different kinds of
entities (e.g. a table and a memory may have the same internal name), which
resulted in the secondary module incorrectly using the same import name for all
of the entities that shared an internal name. This PR fixes the problem by
including the ExternalKind of the entity in the keys of the export map.