### PR TITLE
[module-splitting] Fix a crash when a function is exported twice

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -345,6 +345,10 @@ void ModuleSplitter::thunkExportedSecondaryFunctions() {
       continue;
     }
     Name secondaryFunc = ex->value;
+    if (primary.getFunctionOrNull(secondaryFunc)) {
+      // We've already created a thunk for this function
+      continue;
+    }
     auto tableSlot = tableManager.getSlot(secondaryFunc);
     auto func = std::make_unique<Function>();
 

--- a/test/example/module-splitting.cpp
+++ b/test/example/module-splitting.cpp
@@ -387,4 +387,12 @@ int main() {
       (call $foo (i32.const 1))
      )
     ))");
+
+  // Multiple exports of a secondary function
+  do_test({}, R"(
+    (module
+     (export "foo1" (func $foo))
+     (export "foo2" (func $foo))
+     (func $foo)
+    ))");
 }

--- a/test/example/module-splitting.txt
+++ b/test/example/module-splitting.txt
@@ -943,3 +943,39 @@ Secondary:
 )
 
 
+Before:
+(module
+ (type $none_=>_none (func))
+ (export "foo1" (func $foo))
+ (export "foo2" (func $foo))
+ (func $foo
+  (nop)
+ )
+)
+Keeping: <none>
+After:
+(module
+ (type $none_=>_none (func))
+ (import "placeholder" "0" (func $placeholder_0))
+ (table $0 1 funcref)
+ (elem (i32.const 0) $placeholder_0)
+ (export "foo1" (func $foo))
+ (export "foo2" (func $foo))
+ (export "%table" (table $0))
+ (func $foo
+  (call_indirect (type $none_=>_none)
+   (i32.const 0)
+  )
+ )
+)
+Secondary:
+(module
+ (type $none_=>_none (func))
+ (import "primary" "%table" (table $0 1 funcref))
+ (elem (i32.const 0) $foo)
+ (func $foo
+  (nop)
+ )
+)
+
+


### PR DESCRIPTION
`ModuleSplitter::thunkExportedSecondaryFunctions` creates a thunk for each
secondary function that needs to be exported from the main module. Previously,
if a secondary function was exported twice, this code would try to create two
thunks for it rather than just making one thunk and exporting it twice. This
caused a fatal error because the second thunk had the same name as the first
thunk and therefore could not be added to the module. This PR fixes the issue by
creating no more than one thunk per function.