### PR TITLE
MemoryPacking: Preserve segment names

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3274,7 +3274,8 @@ void BinaryenSetMemory(BinaryenModuleRef module,
     wasm->addExport(memoryExport.release());
   }
   for (BinaryenIndex i = 0; i < numSegments; i++) {
-    wasm->memory.segments.emplace_back(segmentPassive[i],
+    wasm->memory.segments.emplace_back(Name(),
+                                       segmentPassive[i],
                                        (Expression*)segmentOffsets[i],
                                        segments[i],
                                        segmentSizes[i]);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -288,7 +288,8 @@ private:
   void stringToBinary(const char* input, size_t size, std::vector<char>& data);
   void parseMemory(Element& s, bool preParseImport = false);
   void parseData(Element& s);
-  void parseInnerData(Element& s, Index i, Expression* offset, bool isPassive);
+  void parseInnerData(
+    Element& s, Index i, Name name, Expression* offset, bool isPassive);
   void parseExport(Element& s);
   void parseImport(Element& s);
   void parseGlobal(Element& s, bool preParseImport = false);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1704,8 +1704,12 @@ public:
     Segment(Expression* offset, std::vector<char>& init) : offset(offset) {
       data.swap(init);
     }
-    Segment(bool isPassive, Expression* offset, const char* init, Address size)
-      : isPassive(isPassive), offset(offset) {
+    Segment(Name name,
+            bool isPassive,
+            Expression* offset,
+            const char* init,
+            Address size)
+      : name(name), isPassive(isPassive), offset(offset) {
       data.resize(size);
       std::copy_n(init, size, data.begin());
     }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2337,7 +2337,7 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
       // (memory (data ..)) format
       auto j = parseMemoryIndex(inner, 1);
       auto offset = allocator.alloc<Const>()->set(Literal(int32_t(0)));
-      parseInnerData(inner, j, offset, false);
+      parseInnerData(inner, j, {}, offset, false);
       wasm.memory.initial = wasm.memory.segments[0].data.size();
       return;
     }
@@ -2399,16 +2399,11 @@ void SExpressionWasmBuilder::parseData(Element& s) {
   if (s.size() != 3 && s.size() != 4) {
     throw ParseException("Unexpected data items", s.line, s.col);
   }
-  parseInnerData(s, s.size() - 1, offset, isPassive);
-  if (name.is()) {
-    wasm.memory.segments.back().name = name;
-  }
+  parseInnerData(s, s.size() - 1, name, offset, isPassive);
 }
 
-void SExpressionWasmBuilder::parseInnerData(Element& s,
-                                            Index i,
-                                            Expression* offset,
-                                            bool isPassive) {
+void SExpressionWasmBuilder::parseInnerData(
+  Element& s, Index i, Name name, Expression* offset, bool isPassive) {
   std::vector<char> data;
   while (i < s.size()) {
     const char* input = s[i++]->c_str();
@@ -2417,7 +2412,7 @@ void SExpressionWasmBuilder::parseInnerData(Element& s,
     }
   }
   wasm.memory.segments.emplace_back(
-    isPassive, offset, data.data(), data.size());
+    name, isPassive, offset, data.data(), data.size());
 }
 
 void SExpressionWasmBuilder::parseExport(Element& s) {

--- a/test/unit/test_memory_packing.py
+++ b/test/unit/test_memory_packing.py
@@ -13,7 +13,7 @@ class MemoryPackingTest(utils.BinaryenTestCase):
         module = '''
         (module
          (memory 256 256)
-         (data (i32.const 0) %s)
+         (data $d (i32.const 0) %s)
         )
         ''' % data
         opts = ['--memory-packing', '--disable-bulk-memory', '--print',
@@ -21,9 +21,10 @@ class MemoryPackingTest(utils.BinaryenTestCase):
         p = shared.run_process(shared.WASM_OPT + opts, input=module,
                                check=False, capture_output=True)
         output = [
-            '(data (i32.const 999970) "A")',
-            '(data (i32.const 999980) "A")',
-            '(data (i32.const 999990) "A' + ('\\00' * 9) + 'A")'
+            '(data $d (i32.const 0) "A")',
+            '(data $d.1 (i32.const 10) "A")',
+            '(data $d.99998 (i32.const 999980) "A")',
+            '(data $d.99999 (i32.const 999990) "A' + ('\\00' * 9) + 'A")'
         ]
         self.assertEqual(p.returncode, 0)
         for line in output:


### PR DESCRIPTION
Also avoid packing builtin llvm segments names so that
segments such as `__llvm_covfun` (use by llvm-cov) are
preserved in the final output.