### PR TITLE
[GC] Fix parsing/printing of ref types using i31

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -405,9 +405,6 @@ inline void collectHeapTypes(Module& wasm,
                              std::unordered_map<HeapType, Index>& typeIndices) {
   struct Counts : public std::unordered_map<HeapType, size_t> {
     bool isRelevant(Type type) {
-      if (type.isBasic()) {
-        return false;
-      }
       if (type.isRef()) {
         return !type.getHeapType().isBasic();
       }

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -405,13 +405,7 @@ inline void collectHeapTypes(Module& wasm,
                              std::unordered_map<HeapType, Index>& typeIndices) {
   struct Counts : public std::unordered_map<HeapType, size_t> {
     bool isRelevant(Type type) {
-      if (type.isBasic()) {
-        return false;
-      }
-      if (type.isRef()) {
-        return !type.getHeapType().isBasic();
-      }
-      return type.isRtt();
+      return !type.isBasic() && (type.isRef() || type.isRtt());
     }
     void note(HeapType type) { (*this)[type]++; }
     void maybeNote(Type type) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -405,7 +405,13 @@ inline void collectHeapTypes(Module& wasm,
                              std::unordered_map<HeapType, Index>& typeIndices) {
   struct Counts : public std::unordered_map<HeapType, size_t> {
     bool isRelevant(Type type) {
-      return !type.isBasic() && (type.isRef() || type.isRtt());
+      if (type.isBasic()) {
+        return false;
+      }
+      if (type.isRef()) {
+        return !type.getHeapType().isBasic();
+      }
+      return type.isRtt();
     }
     void note(HeapType type) { (*this)[type]++; }
     void maybeNote(Type type) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -79,10 +79,13 @@ static void
 printHeapTypeName(std::ostream& os, HeapType type, bool first = true);
 
 static void printTypeName(std::ostream& os, Type type) {
-  if (type.isBasic()) {
+  // If this is simple enough that it is not defined in the type section, just
+  // print it out.
+  if (type.isBasic() || (type.isRef() && type.getHeapType().isBasic())) {
     os << type;
     return;
   }
+  // This will be defined in the type section, emit the proper name.
   if (type.isRtt()) {
     auto rtt = type.getRtt();
     os << "rtt_";

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -67,14 +67,6 @@ static std::ostream& printLocal(Index index, Function* func, std::ostream& o) {
   return printName(name, o);
 }
 
-// Wrapper for printing a type when we try to print the type name as much as
-// possible. For example, for a signature we will print the signature's name,
-// not its contents.
-struct TypeName {
-  Type type;
-  TypeName(Type type) : type(type) {}
-};
-
 static void
 printHeapTypeName(std::ostream& os, HeapType type, bool first = true);
 
@@ -208,10 +200,6 @@ static std::ostream& operator<<(std::ostream& o, const SExprType& sType) {
   return o;
 }
 
-std::ostream& operator<<(std::ostream& os, TypeName typeName) {
-  return os << SExprType(typeName.type);
-}
-
 // TODO: try to simplify or even remove this, as we may be able to do the same
 //       things with SExprType
 struct ResultTypeName {
@@ -229,10 +217,10 @@ std::ostream& operator<<(std::ostream& os, ResultTypeName typeName) {
     for (auto t : type) {
       os << sep;
       sep = " ";
-      os << TypeName(t);
+      os << SExprType(t);
     }
   } else {
-    os << TypeName(type);
+    os << SExprType(type);
   }
   os << ')';
   return os;
@@ -2546,7 +2534,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       o << "(param ";
       auto sep = "";
       for (auto type : curr.params) {
-        o << sep << TypeName(type);
+        o << sep << SExprType(type);
         sep = " ";
       }
       o << ')';
@@ -2556,7 +2544,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       o << "(result ";
       auto sep = "";
       for (auto type : curr.results) {
-        o << sep << TypeName(type);
+        o << sep << SExprType(type);
         sep = " ";
       }
       o << ')';
@@ -2576,7 +2564,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
         WASM_UNREACHABLE("invalid packed type");
       }
     } else {
-      o << TypeName(field.type);
+      o << SExprType(field.type);
     }
     if (field.mutable_) {
       o << ')';
@@ -2711,7 +2699,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
         o << '(';
         printMinor(o, "param ");
         printLocal(i, currFunction, o);
-        o << ' ' << TypeName(param) << ')';
+        o << ' ' << SExprType(param) << ')';
         ++i;
       }
     }
@@ -2725,7 +2713,7 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       o << '(';
       printMinor(o, "local ");
       printLocal(i, currFunction, o)
-        << ' ' << TypeName(curr->getLocalType(i)) << ')';
+        << ' ' << SExprType(curr->getLocalType(i)) << ')';
       o << maybeNewLine;
     }
     // Print the body.

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -116,15 +116,7 @@ inline std::string trim(const std::string& input) {
 }
 
 inline bool isNumber(const std::string& str) {
-  if (str.empty()) {
-    return false;
-  }
-  for (auto c : str) {
-    if (!std::isdigit(c)) {
-      return false;
-    }
-  }
-  return true;
+  return !str.empty() && std::all_of(str.begin(), str.end(), ::isdigit);
 }
 
 } // namespace String

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -115,6 +115,18 @@ inline std::string trim(const std::string& input) {
   return input.substr(0, size);
 }
 
+inline bool isNumber(const std::string& str) {
+  if (str.empty()) {
+    return false;
+  }
+  for (auto c : str) {
+    if (!std::isdigit(c)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // namespace String
 
 } // namespace wasm

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -310,9 +310,8 @@ public:
   HeapType(Struct&& struct_);
   HeapType(Array array);
 
-  bool isBasic() const;
-  bool isCompound() const;
-
+  constexpr bool isBasic() const;
+  constexpr bool isCompound() const;
   bool isFunction() const;
   bool isSignature() const;
   bool isStruct() const;
@@ -323,7 +322,7 @@ public:
   Array getArray() const;
 
   constexpr TypeID getID() const { return id; }
-  BasicHeapType getBasic() const {
+  constexpr BasicHeapType getBasic() const {
     assert(isBasic() && "Basic heap type expected");
     return static_cast<BasicHeapType>(id);
   }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -310,8 +310,8 @@ public:
   HeapType(Struct&& struct_);
   HeapType(Array array);
 
-  constexpr bool isBasic() const;
-  constexpr bool isCompound() const;
+  constexpr bool isBasic() const { return id <= _last_basic_type; }
+  constexpr bool isCompound() const { return id > _last_basic_type; }
   bool isFunction() const;
   bool isSignature() const;
   bool isStruct() const;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -310,8 +310,8 @@ public:
   HeapType(Struct&& struct_);
   HeapType(Array array);
 
-  constexpr bool isBasic() const { return id <= _last_basic_type; }
-  constexpr bool isCompound() const { return id > _last_basic_type; }
+  constexpr bool isBasic() const;
+  constexpr bool isCompound() const;
   bool isFunction() const;
   bool isSignature() const;
   bool isStruct() const;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -310,8 +310,9 @@ public:
   HeapType(Struct&& struct_);
   HeapType(Array array);
 
-  constexpr bool isBasic() const;
-  constexpr bool isCompound() const;
+  bool isBasic() const;
+  bool isCompound() const;
+
   bool isFunction() const;
   bool isSignature() const;
   bool isStruct() const;
@@ -322,7 +323,7 @@ public:
   Array getArray() const;
 
   constexpr TypeID getID() const { return id; }
-  constexpr BasicHeapType getBasic() const {
+  BasicHeapType getBasic() const {
     assert(isBasic() && "Basic heap type expected");
     return static_cast<BasicHeapType>(id);
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1416,7 +1416,8 @@ Type WasmBinaryBuilder::getType(int initial) {
       // FIXME: for now, force all inputs to be nullable
       return Type(getHeapType(), Nullable);
     case BinaryConsts::EncodedType::i31ref:
-      return Type::i31ref;
+      // FIXME: for now, force all inputs to be nullable
+      return Type(HeapType::BasicHeapType::i31, Nullable);
     case BinaryConsts::EncodedType::rtt_n: {
       auto depth = getU32LEB();
       auto heapType = getHeapType();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1416,8 +1416,7 @@ Type WasmBinaryBuilder::getType(int initial) {
       // FIXME: for now, force all inputs to be nullable
       return Type(getHeapType(), Nullable);
     case BinaryConsts::EncodedType::i31ref:
-      // FIXME: for now, force all inputs to be nullable
-      return Type(HeapType::BasicHeapType::i31, Nullable);
+      return Type::i31ref;
     case BinaryConsts::EncodedType::rtt_n: {
       auto depth = getU32LEB();
       auto heapType = getHeapType();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -22,6 +22,7 @@
 
 #include "ir/branch-utils.h"
 #include "shared-constants.h"
+#include "support/string.h"
 #include "wasm-binary.h"
 #include "wasm-builder.h"
 
@@ -2799,7 +2800,7 @@ HeapType SExpressionWasmBuilder::parseHeapType(Element& s) {
       // It may be a numerical index, or it may be a built-in type name like
       // "i31".
       auto* str = s.str().c_str();
-      if (isNumber(str)) {
+      if (String::isNumber(str)) {
         size_t offset = atoi(str);
         if (offset >= types.size()) {
           throw ParseException("unknown indexed function type", s.line, s.col);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -868,7 +868,8 @@ Type SExpressionWasmBuilder::stringToType(const char* str,
     return Type::eqref;
   }
   if (strncmp(str, "i31ref", 6) == 0 && (prefix || str[6] == 0)) {
-    return Type::i31ref;
+    // FIXME: for now, force all inputs to be nullable
+    return Type(HeapType::BasicHeapType::i31, Nullable);
   }
   if (allowError) {
     return Type::none;

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -868,8 +868,7 @@ Type SExpressionWasmBuilder::stringToType(const char* str,
     return Type::eqref;
   }
   if (strncmp(str, "i31ref", 6) == 0 && (prefix || str[6] == 0)) {
-    // FIXME: for now, force all inputs to be nullable
-    return Type(HeapType::BasicHeapType::i31, Nullable);
+    return Type::i31ref;
   }
   if (allowError) {
     return Type::none;

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2796,12 +2796,17 @@ HeapType SExpressionWasmBuilder::parseHeapType(Element& s) {
       }
       return types[it->second];
     } else {
-      // index
-      size_t offset = atoi(s.str().c_str());
-      if (offset >= types.size()) {
-        throw ParseException("unknown indexed function type", s.line, s.col);
+      // It may be a numerical index, or it may be a built-in type name like
+      // "i31".
+      auto* str = s.str().c_str();
+      if (isNumber(str)) {
+        size_t offset = atoi(str);
+        if (offset >= types.size()) {
+          throw ParseException("unknown indexed function type", s.line, s.col);
+        }
+        return types[offset];
       }
-      return types[offset];
+      return stringToHeapType(str, /* prefix = */ false);
     }
   }
   // It's a list.

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -605,7 +605,8 @@ bool Type::isSubType(Type left, Type right) {
       return true;
     }
     // All typed function signatures are subtypes of funcref.
-    if (left.getHeapType().isSignature() && right == Type::funcref) {
+    if (leftHeap.isSignature() && rightHeap == HeapType::func &&
+        (!left.isNullable() || right.isNullable())) {
       return true;
     }
     // A non-nullable type is a supertype of a nullable one

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -377,9 +377,7 @@ bool Type::isBasic() const {
   return id <= _last_basic_type || (isRef() && getHeapType().isBasic());
 }
 
-bool Type::isCompound() const {
-  return !isBasic();
-}
+bool Type::isCompound() const { return !isBasic(); }
 
 bool Type::isFunction() const {
   if (isBasic()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -373,6 +373,14 @@ bool Type::isRef() const {
   }
 }
 
+bool Type::isBasic() const {
+  return id <= _last_basic_type || (isRef() && getHeapType().isBasic());
+}
+
+bool Type::isCompound() const {
+  return !isBasic();
+}
+
 bool Type::isFunction() const {
   if (isBasic()) {
     return id == funcref;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -601,7 +601,7 @@ bool Type::isSubType(Type left, Type right) {
     auto rightHeap = right.getHeapType();
     if ((leftHeap == HeapType::i31 || leftHeap.isArray() ||
          leftHeap.isStruct()) &&
-        rightHeap == Type::eq && (!left.isNullable() || right.isNullable())) {
+        rightHeap == HeapType::eq && (!left.isNullable() || right.isNullable())) {
       return true;
     }
     // All typed function signatures are subtypes of funcref.

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -495,7 +495,8 @@ FeatureSet Type::getFeatures() const {
           case HeapType::BasicHeapType::eq:
           case HeapType::BasicHeapType::i31:
             return FeatureSet::ReferenceTypes | FeatureSet::GC;
-          default: {}
+          default: {
+          }
         }
       }
       // Note: Technically typed function references also require the typed

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -598,9 +598,10 @@ bool Type::isSubType(Type left, Type right) {
     }
     // Various things are subtypes of eqref.
     auto leftHeap = left.getHeapType();
+    auto rightHeap = right.getHeapType();
     if ((leftHeap == HeapType::i31 || leftHeap.isArray() ||
          leftHeap.isStruct()) &&
-        right == Type::eqref) {
+        rightHeap == Type::eq && (!left.isNullable() || right.isNullable())) {
       return true;
     }
     // All typed function signatures are subtypes of funcref.
@@ -608,7 +609,7 @@ bool Type::isSubType(Type left, Type right) {
       return true;
     }
     // A non-nullable type is a supertype of a nullable one
-    if (leftHeap == right.getHeapType() && !left.isNullable()) {
+    if (leftHeap == rightHeap && !left.isNullable()) {
       // The only difference is the nullability.
       assert(right.isNullable());
       return true;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -497,10 +497,11 @@ FeatureSet Type::getFeatures() const {
         switch (heapType.getBasic()) {
           case HeapType::BasicHeapType::func:
           case HeapType::BasicHeapType::ext:
+            return FeatureSet::ReferenceTypes;
           case HeapType::BasicHeapType::exn:
+            return FeatureSet::ReferenceTypes | FeatureSet::ExceptionHandling;
           case HeapType::BasicHeapType::any:
           case HeapType::BasicHeapType::eq:
-            return FeatureSet::ReferenceTypes;
           case HeapType::BasicHeapType::i31:
             return FeatureSet::ReferenceTypes | FeatureSet::GC;
           default:

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -493,6 +493,20 @@ FeatureSet Type::getFeatures() const {
       if (heapType.isStruct() || heapType.isArray()) {
         return FeatureSet::ReferenceTypes | FeatureSet::GC;
       }
+      if (heapType.isBasic()) {
+        switch (heapType.getBasic()) {
+          case HeapType::BasicHeapType::func:
+          case HeapType::BasicHeapType::ext:
+          case HeapType::BasicHeapType::exn:
+          case HeapType::BasicHeapType::any:
+          case HeapType::BasicHeapType::eq: 
+            return FeatureSet::ReferenceTypes;
+          case HeapType::BasicHeapType::i31: 
+            return FeatureSet::ReferenceTypes | FeatureSet::GC;
+          default:
+            WASM_UNREACHABLE("unknown basic type");
+        }
+      }
     } else if (t.isRtt()) {
       return FeatureSet::ReferenceTypes | FeatureSet::GC;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -373,14 +373,6 @@ bool Type::isRef() const {
   }
 }
 
-bool Type::isBasic() const {
-  return id <= _last_basic_type || (isRef() && getHeapType().isBasic());
-}
-
-bool Type::isCompound() const {
-  return !isBasic();
-}
-
 bool Type::isFunction() const {
   if (isBasic()) {
     return id == funcref;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -514,15 +514,6 @@ FeatureSet Type::getFeatures() const {
     switch (t.getBasic()) {
       case Type::v128:
         return FeatureSet::SIMD;
-      case Type::funcref:
-      case Type::externref:
-        return FeatureSet::ReferenceTypes;
-      case Type::exnref:
-        return FeatureSet::ReferenceTypes | FeatureSet::ExceptionHandling;
-      case Type::anyref:
-      case Type::eqref:
-      case Type::i31ref:
-        return FeatureSet::ReferenceTypes | FeatureSet::GC;
       default:
         return FeatureSet::MVP;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -601,7 +601,8 @@ bool Type::isSubType(Type left, Type right) {
     auto rightHeap = right.getHeapType();
     if ((leftHeap == HeapType::i31 || leftHeap.isArray() ||
          leftHeap.isStruct()) &&
-        rightHeap == HeapType::eq && (!left.isNullable() || right.isNullable())) {
+        rightHeap == HeapType::eq &&
+        (!left.isNullable() || right.isNullable())) {
       return true;
     }
     // All typed function signatures are subtypes of funcref.

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -594,22 +594,25 @@ bool Type::isSubType(Type left, Type right) {
     return true;
   }
   if (left.isRef() && right.isRef()) {
+    auto leftHeap = left.getHeapType();
+    auto rightHeap = right.getHeapType();
+
     // Everything is a subtype of anyref.
-    if (right == Type::anyref) {
+    if (rightHeap == HeapType::any) {
       return true;
     }
     // Various things are subtypes of eqref.
-    if ((left == Type::i31ref || left.getHeapType().isArray() ||
-         left.getHeapType().isStruct()) &&
-        right == Type::eqref) {
+    if ((leftHeap == HeapType::i31 || leftHeap.isArray() ||
+         leftHeap.isStruct()) &&
+        rightHeap == HeapType::eq) {
       return true;
     }
     // All typed function signatures are subtypes of funcref.
-    if (left.getHeapType().isSignature() && right == Type::funcref) {
+    if (leftHeap.isSignature() && rightHeap == HeapType::func) {
       return true;
     }
     // A non-nullable type is a supertype of a nullable one
-    if (left.getHeapType() == right.getHeapType() && !left.isNullable()) {
+    if (leftHeap == rightHeap && !left.isNullable()) {
       // The only difference is the nullability.
       assert(right.isNullable());
       return true;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -594,25 +594,23 @@ bool Type::isSubType(Type left, Type right) {
     return true;
   }
   if (left.isRef() && right.isRef()) {
-    auto leftHeap = left.getHeapType();
-    auto rightHeap = right.getHeapType();
-
     // Everything is a subtype of anyref.
-    if (rightHeap == HeapType::any) {
+    if (right == Type::anyref) {
       return true;
     }
     // Various things are subtypes of eqref.
+    auto leftHeap = left.getHeapType();
     if ((leftHeap == HeapType::i31 || leftHeap.isArray() ||
          leftHeap.isStruct()) &&
-        rightHeap == HeapType::eq) {
+        right == Type::eqref) {
       return true;
     }
     // All typed function signatures are subtypes of funcref.
-    if (leftHeap.isSignature() && rightHeap == HeapType::func) {
+    if (left.getHeapType().isSignature() && right == Type::funcref) {
       return true;
     }
     // A non-nullable type is a supertype of a nullable one
-    if (leftHeap == rightHeap && !left.isNullable()) {
+    if (leftHeap == right.getHeapType() && !left.isNullable()) {
       // The only difference is the nullability.
       assert(right.isNullable());
       return true;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -495,8 +495,7 @@ FeatureSet Type::getFeatures() const {
           case HeapType::BasicHeapType::eq:
           case HeapType::BasicHeapType::i31:
             return FeatureSet::ReferenceTypes | FeatureSet::GC;
-          default: {
-          }
+          default: {}
         }
       }
       // Note: Technically typed function references also require the typed

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -499,9 +499,9 @@ FeatureSet Type::getFeatures() const {
           case HeapType::BasicHeapType::ext:
           case HeapType::BasicHeapType::exn:
           case HeapType::BasicHeapType::any:
-          case HeapType::BasicHeapType::eq: 
+          case HeapType::BasicHeapType::eq:
             return FeatureSet::ReferenceTypes;
-          case HeapType::BasicHeapType::i31: 
+          case HeapType::BasicHeapType::i31:
             return FeatureSet::ReferenceTypes | FeatureSet::GC;
           default:
             WASM_UNREACHABLE("unknown basic type");

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -377,7 +377,9 @@ bool Type::isBasic() const {
   return id <= _last_basic_type || (isRef() && getHeapType().isBasic());
 }
 
-bool Type::isCompound() const { return !isBasic(); }
+bool Type::isCompound() const {
+  return !isBasic();
+}
 
 bool Type::isFunction() const {
   if (isBasic()) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2191,9 +2191,11 @@ void FunctionValidator::visitI31Get(I31Get* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "i31.get_s/u requires gc to be enabled");
+  // FIXME: use i31ref here, which is non-nullable, when we support non-
+  // nullability.
   shouldBeSubTypeOrFirstIsUnreachable(
     curr->i31->type,
-    Type::i31ref,
+    Type(HeapType::i31, Nullable),
     curr->i31,
     "i31.get_s/u's argument should be i31ref");
 }

--- a/test/gc.wast
+++ b/test/gc.wast
@@ -68,4 +68,9 @@
     (local.set $local_i32 (i31.get_s (local.get $local_i31ref)))
     (local.set $local_i32 (i31.get_u (local.get $local_i31ref)))
   )
+
+  (func $test-variants
+    (local $local_i31refnull (ref null i31))
+    (local $local_i31refnonnull (ref i31))
+  )
 )

--- a/test/gc.wast.from-wast
+++ b/test/gc.wast.from-wast
@@ -2,7 +2,7 @@
  (type $none_=>_none (func))
  (global $global_anyref (mut anyref) (ref.null any))
  (global $global_eqref (mut eqref) (ref.null eq))
- (global $global_i31ref (mut i31ref) (i31.new
+ (global $global_i31ref (mut ref?|i31|) (i31.new
   (i32.const 0)
  ))
  (global $global_anyref2 (mut anyref) (ref.null eq))
@@ -16,7 +16,7 @@
   (local $local_i32 i32)
   (local $local_anyref anyref)
   (local $local_eqref eqref)
-  (local $local_i31ref i31ref)
+  (local $local_i31ref (ref null i31))
   (local.set $local_anyref
    (local.get $local_anyref)
   )

--- a/test/gc.wast.from-wast
+++ b/test/gc.wast.from-wast
@@ -1,4 +1,5 @@
 (module
+ (type i31 i31)
  (type $none_=>_none (func))
  (global $global_anyref (mut anyref) (ref.null any))
  (global $global_eqref (mut eqref) (ref.null eq))
@@ -147,5 +148,10 @@
     (local.get $local_i31ref)
    )
   )
+ )
+ (func $test-variants
+  (local $local_i31refnull (ref null i31))
+  (local $local_i31refnonnull (ref null i31))
+  (nop)
  )
 )

--- a/test/gc.wast.from-wast
+++ b/test/gc.wast.from-wast
@@ -2,7 +2,7 @@
  (type $none_=>_none (func))
  (global $global_anyref (mut anyref) (ref.null any))
  (global $global_eqref (mut eqref) (ref.null eq))
- (global $global_i31ref (mut ref?|i31|) (i31.new
+ (global $global_i31ref (mut (ref null i31)) (i31.new
   (i32.const 0)
  ))
  (global $global_anyref2 (mut anyref) (ref.null eq))

--- a/test/gc.wast.from-wast
+++ b/test/gc.wast.from-wast
@@ -1,5 +1,4 @@
 (module
- (type i31 i31)
  (type $none_=>_none (func))
  (global $global_anyref (mut anyref) (ref.null any))
  (global $global_eqref (mut eqref) (ref.null eq))

--- a/test/gc.wast.fromBinary
+++ b/test/gc.wast.fromBinary
@@ -2,7 +2,7 @@
  (type $none_=>_none (func))
  (global $global_anyref (mut anyref) (ref.null any))
  (global $global_eqref (mut eqref) (ref.null eq))
- (global $global_i31ref (mut i31ref) (i31.new
+ (global $global_i31ref (mut ref?|i31|) (i31.new
   (i32.const 0)
  ))
  (global $global_anyref2 (mut anyref) (ref.null eq))
@@ -16,7 +16,7 @@
   (local $local_i32 i32)
   (local $local_anyref anyref)
   (local $local_eqref eqref)
-  (local $local_i31ref i31ref)
+  (local $local_i31ref (ref null i31))
   (local.set $local_anyref
    (local.get $local_anyref)
   )

--- a/test/gc.wast.fromBinary
+++ b/test/gc.wast.fromBinary
@@ -2,7 +2,7 @@
  (type $none_=>_none (func))
  (global $global_anyref (mut anyref) (ref.null any))
  (global $global_eqref (mut eqref) (ref.null eq))
- (global $global_i31ref (mut ref?|i31|) (i31.new
+ (global $global_i31ref (mut (ref null i31)) (i31.new
   (i32.const 0)
  ))
  (global $global_anyref2 (mut anyref) (ref.null eq))

--- a/test/gc.wast.fromBinary
+++ b/test/gc.wast.fromBinary
@@ -148,5 +148,10 @@
    )
   )
  )
+ (func $test-variants
+  (local $local_i31refnull (ref null i31))
+  (local $local_i31refnonnull (ref null i31))
+  (nop)
+ )
 )
 

--- a/test/gc.wast.fromBinary.noDebugInfo
+++ b/test/gc.wast.fromBinary.noDebugInfo
@@ -148,5 +148,10 @@
    )
   )
  )
+ (func $1
+  (local $0 (ref null i31))
+  (local $1 (ref null i31))
+  (nop)
+ )
 )
 

--- a/test/gc.wast.fromBinary.noDebugInfo
+++ b/test/gc.wast.fromBinary.noDebugInfo
@@ -2,7 +2,7 @@
  (type $none_=>_none (func))
  (global $global$0 (mut anyref) (ref.null any))
  (global $global$1 (mut eqref) (ref.null eq))
- (global $global$2 (mut i31ref) (i31.new
+ (global $global$2 (mut ref?|i31|) (i31.new
   (i32.const 0)
  ))
  (global $global$3 (mut anyref) (ref.null eq))
@@ -16,7 +16,7 @@
   (local $0 i32)
   (local $1 anyref)
   (local $2 eqref)
-  (local $3 i31ref)
+  (local $3 (ref null i31))
   (local.set $1
    (local.get $1)
   )

--- a/test/gc.wast.fromBinary.noDebugInfo
+++ b/test/gc.wast.fromBinary.noDebugInfo
@@ -2,7 +2,7 @@
  (type $none_=>_none (func))
  (global $global$0 (mut anyref) (ref.null any))
  (global $global$1 (mut eqref) (ref.null eq))
- (global $global$2 (mut ref?|i31|) (i31.new
+ (global $global$2 (mut (ref null i31)) (i31.new
   (i32.const 0)
  ))
  (global $global$3 (mut anyref) (ref.null eq))

--- a/test/passes/simplify-globals_all-features_fuzz-exec.txt
+++ b/test/passes/simplify-globals_all-features_fuzz-exec.txt
@@ -1,11 +1,11 @@
 [fuzz-exec] calling export
 [fuzz-exec] note result: export => funcref(0)
 (module
- (type $f32_i31ref_i64_f64_funcref_=>_none (func (param f32 i31ref i64 f64 funcref)))
+ (type $f32_ref?|i31|_i64_f64_funcref_=>_none (func (param f32 (ref null i31) i64 f64 funcref)))
  (type $none_=>_funcref (func (result funcref)))
  (global $global$0 (mut funcref) (ref.null func))
  (export "export" (func $1))
- (func $0 (param $0 f32) (param $1 i31ref) (param $2 i64) (param $3 f64) (param $4 funcref)
+ (func $0 (param $0 f32) (param $1 (ref null i31)) (param $2 i64) (param $3 f64) (param $4 funcref)
   (nop)
  )
  (func $1 (result funcref)

--- a/test/passes/simplify-locals_all-features.txt
+++ b/test/passes/simplify-locals_all-features.txt
@@ -2041,11 +2041,11 @@
  )
 )
 (module
- (type $eqref_i31ref_=>_i32 (func (param eqref i31ref) (result i32)))
+ (type $eqref_ref?|i31|_=>_i32 (func (param eqref (ref null i31)) (result i32)))
  (export "test" (func $0))
- (func $0 (param $0 eqref) (param $1 i31ref) (result i32)
+ (func $0 (param $0 eqref) (param $1 (ref null i31)) (result i32)
   (local $2 eqref)
-  (local $3 i31ref)
+  (local $3 (ref null i31))
   (local.set $2
    (local.get $0)
   )


### PR DESCRIPTION
This lets us parse `(ref null i31)` and `(ref i31)` and not just `i31ref`.

It also fixes the parsing of `i31ref`, making it nullable for now, which we
need to do until we support non-nullability.

Fix some internal handling of i31 where we had just i31ref (which meant we
just handled the non-nullable type).

After fixing a bug in printing (where we didn't print out `(ref null i31)`
properly), I found some a simplification, to remove `TypeName`.
