### PR TITLE
Made FuncCastEmulation make and export thunks for exports

### DIFF
--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -184,6 +184,41 @@ struct FuncCastEmulation : public Pass {
         }
       }
     }
+    // make sure everything in exports has a thunk
+    // so dlsym works
+    std::unordered_map<Name, Name> exportThunks;
+    for(auto& function: module->exports)
+    {
+        auto& exportName=function->name;
+        auto& exportValue=function->value;
+        if(module->getFunctionOrNull(exportValue))
+        {
+          Name exportThunkName = std::string("byn$fpcast-emu$") + exportName.str;
+          auto iter = funcThunks.find(exportValue);
+          if (iter == funcThunks.end()) 
+          {
+            // an export without a thunk yet - make it and export it
+            auto thunk = makeThunk(exportValue, module, numParams);
+            funcThunks[exportValue] = thunk;
+            exportThunks[exportThunkName]=thunk;
+          }else
+          {
+            // just export existing thunk
+            exportThunks[exportThunkName]=iter->second;
+          }
+       }
+     }
+    
+     // add thunks to exports if their unthunked version is in exports
+     for(auto& thunk: exportThunks)
+        {
+		auto* export_ = new Export;
+		export_->name = thunk.first;
+	        export_->value = thunk.second;
+	        export_->kind = ExternalKind::Function;
+	        module->addExport(export_);
+        }
+
     // update call_indirects
     ParallelFuncCastEmulation(ABIType, numParams).run(runner, module);
   }


### PR DESCRIPTION
This is a fix for some problems I had when building pyodide with upstream wasm, which exposed that the EMULATE_FUNCTION_POINTER_CASTS function doesn't properly work between SIDE_MODULE and MAIN_MODULE yet.

In particular it fixes:
1) Using dlsym to call a function in a SIDE_MODULE is entirely broken with this setting on.
2) If a SIDE_MODULE passes a function pointer to the MAIN_MODULE and the main module calls it, the code crashes.

This is because currently the code only outputs thunks for things in the wasm table.
This breaks dynamic linking emscripten SIDE_MODULES because they don't have a table, 
they instead load things into the main module table on import.

This means dlopen and dlsym don't work if EMULATE_FUNCTION_POINTER_CASTS==1, because EMULATE_FUNCTION_POINTER_CASTS in the calling module makes all indirect calls have the fixed call signature, whereas the functions returned from dlsym are still the original call signature. In combination with a version of emscripten which knows about this change (separate pull request headed their way), function pointers can work through dlsym, as also does passing a function pointer out of a module, which currently breaks as the function pointer in the wasm table is still hooked up to the old function on import, whereas with this fix emscripten can hook it up to the fixed call signature version.

This is my first PR to binaryen, so please feel free to be super critical and/or hack it apart by the way.