### PR TITLE
[GC] More HeapType instead of Type

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -279,7 +279,7 @@ public:
     return i32;
   }
   int32_t geti31(bool signed_ = true) const {
-    assert(getHeapType() == HeapType::i31);
+    assert(type.getHeapType() == HeapType::i31);
     return signed_ ? (i32 << 1) >> 1 : i32;
   }
   int64_t geti64() const {

--- a/src/literal.h
+++ b/src/literal.h
@@ -279,7 +279,7 @@ public:
     return i32;
   }
   int32_t geti31(bool signed_ = true) const {
-    assert(type == Type::i31ref);
+    assert(getHeapType() == HeapType::i31);
     return signed_ ? (i32 << 1) >> 1 : i32;
   }
   int64_t geti64() const {

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -329,15 +329,6 @@ int main(int argc, const char* argv[]) {
     exit(1);
   }
 
-  {
-    Literal x(Type(HeapType::i31, Nullable));
-    std::cout << x << '\n';
-  }
-  {
-    Literal x(Type(HeapType::i31, NonNullable));
-    std::cout << x << '\n';
-  }
-
   if (checked) {
     Colors::green(std::cerr);
     Colors::bold(std::cerr);

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -329,6 +329,15 @@ int main(int argc, const char* argv[]) {
     exit(1);
   }
 
+{
+Literal x(Type(HeapType::i31, Nullable));
+std::cout << x << '\n';
+}
+{
+Literal x(Type(HeapType::i31, NonNullable));
+std::cout << x << '\n';
+}
+
   if (checked) {
     Colors::green(std::cerr);
     Colors::bold(std::cerr);

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -329,14 +329,14 @@ int main(int argc, const char* argv[]) {
     exit(1);
   }
 
-{
-Literal x(Type(HeapType::i31, Nullable));
-std::cout << x << '\n';
-}
-{
-Literal x(Type(HeapType::i31, NonNullable));
-std::cout << x << '\n';
-}
+  {
+    Literal x(Type(HeapType::i31, Nullable));
+    std::cout << x << '\n';
+  }
+  {
+    Literal x(Type(HeapType::i31, NonNullable));
+    std::cout << x << '\n';
+  }
 
   if (checked) {
     Colors::green(std::cerr);

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -92,13 +92,16 @@ Literal::Literal(const Literal& other) : type(other.type) {
     auto heapType = type.getHeapType();
     if (heapType.isBasic()) {
       switch (heapType.getBasic()) {
-        case HeapType::BasicHeapType::any:
-        case HeapType::BasicHeapType::ext:
-        case HeapType::BasicHeapType::eq:
+        case HeapType::any:
+        case HeapType::ext:
+        case HeapType::eq:
           return; // null
-        case HeapType::BasicHeapType::i31:
+        case HeapType::i31:
           i32 = other.i32;
           return;
+        case HeapType::func:
+        case HeapType::exn:
+          WASM_UNREACHABLE("invalid type");
       }
     }
   }
@@ -117,6 +120,14 @@ Literal::Literal(const Literal& other) : type(other.type) {
       break;
     case Type::none:
       break;
+    case Type::unreachable:
+    case Type::funcref:
+    case Type::externref:
+    case Type::exnref:
+    case Type::anyref:
+    case Type::eqref:
+    case Type::i31ref:
+      WASM_UNREACHABLE("invalid type");
   }
 }
 
@@ -523,6 +534,8 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
         case HeapType::i31:
           o << "i31ref(" << literal.geti31() << ")";
           break;
+        case HeapType::func:
+          WASM_UNREACHABLE("invalid type");
       }
     }
   } else if (literal.type.isRtt()) {
@@ -553,6 +566,14 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
         o << "i32x4 ";
         literal.printVec128(o, literal.getv128());
         break;
+      case Type::funcref:
+      case Type::externref:
+      case Type::exnref:
+      case Type::anyref:
+      case Type::eqref:
+      case Type::i31ref:
+      case Type::unreachable:
+        WASM_UNREACHABLE("unexpected type");
     }
   }
   restoreNormalColor(o);

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -99,8 +99,6 @@ Literal::Literal(const Literal& other) : type(other.type) {
         case HeapType::BasicHeapType::i31:
           i32 = other.i32;
           return;
-        default:
-          WASM_UNREACHABLE("unexpected heap type");
       }
     }
   }
@@ -119,8 +117,6 @@ Literal::Literal(const Literal& other) : type(other.type) {
       break;
     case Type::none:
       break;
-    default:
-      WASM_UNREACHABLE("unexpected type");
   }
 }
 
@@ -527,8 +523,6 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
         case HeapType::i31:
           o << "i31ref(" << literal.geti31() << ")";
           break;
-        default:
-          WASM_UNREACHABLE("invalid heap type");
       }
     }
   } else if (literal.type.isRtt()) {
@@ -559,8 +553,6 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
         o << "i32x4 ";
         literal.printVec128(o, literal.getv128());
         break;
-      default:
-        WASM_UNREACHABLE("invalid type");
     }
   }
   restoreNormalColor(o);

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -556,10 +556,24 @@ void test_effects() {
   assert_equal(EffectAnalyzer(options, features, &nop).trap, false);
 }
 
+void test_literals() {
+  // The i31 heap type may or may not be basic, depending on if it is nullable.
+  // Verify we handle both code paths.
+  {
+    Literal x(Type(HeapType::i31, Nullable));
+    std::cout << x << '\n';
+  }
+  {
+    Literal x(Type(HeapType::i31, NonNullable));
+    std::cout << x << '\n';
+  }
+}
+
 int main() {
   test_bits();
   test_cost();
   test_effects();
+  test_literals();
 
   if (failsCount > 0) {
     abort();

--- a/test/example/cpp-unit.txt
+++ b/test/example/cpp-unit.txt
@@ -1,1 +1,3 @@
+i31ref(0)
+i31ref(0)
 Success


### PR DESCRIPTION
To handle both nullable and non-nullable i31s and other heap types, we cannot
just look at the isBasic case (which is just one of the two).

This *may* fix this issue on the release builder: https://github.com/WebAssembly/binaryen/runs/1669944081?check_suite_focus=true but the issue does not reproduce locally, so I worry it is something else...