### PR TITLE
Add more verbose logging of an assert that only happens on the release builder

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -120,7 +120,12 @@ Literal::~Literal() {
     // Nothing special to do.
   } else {
     // Basic types need no special handling.
-    assert(type.isBasic());
+    // TODO: change this to an assert after we figure out the underlying issue
+    //       on the release builder
+    //       https://github.com/WebAssembly/binaryen/issues/3459
+    if (!type.isBasic()) {
+      Fatal() << "~Literal on unhandled type: " << type << '\n';
+    }
   }
 }
 


### PR DESCRIPTION
I tried to investigate this from every angle I can think of and it makes no sense...
I am 99% sure the type there is an `externref`, which is basic of course. So the
only possibility is that some other type is present somehow..? Anyway, this may
help figure it out.

See https://github.com/WebAssembly/binaryen/issues/3459