### PR TITLE
Add support for building with thinLTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.13)
 # it is invoked directly by CMake rather than by the compiler.
 option(BYN_ENABLE_LTO "Build with LTO" Off)
 if(BYN_ENABLE_LTO AND NOT MSVC)
-  set(CMAKE_EXE_LINKER_FLAGS "$CMAKE_EXE_LINKER_FLAGS -fuse-ld=lld")
-  set(CMAKE_SHARED_LINKER_FLAGS "$CMAKE_SHARED_LINKER_FLAGS -fuse-ld=lld")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
 endif()
 
 project(binaryen LANGUAGES C CXX VERSION 99)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ ENDFOREACH()
 
 option(BYN_ENABLE_LTO "Build with LTO" Off)
 if(BYN_ENABLE_LTO)
-  add_compile_flag("-flto")
+  add_compile_flag("-flto=thin")
   add_link_options("-fuse-ld=lld")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,4 @@
 cmake_minimum_required(VERSION 3.13)
-
-# These linker flags must be set before the project() command below, because
-# linker flags set later are not passed to CMake's test compiles at configure
-# time. On Windows, the linker must be overridden with -DCMAKE_LINKER= because
-# it is invoked directly by CMake rather than by the compiler.
-option(BYN_ENABLE_LTO "Build with LTO" Off)
-if(BYN_ENABLE_LTO AND NOT MSVC)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
-endif()
-
 project(binaryen LANGUAGES C CXX VERSION 99)
 include(GNUInstallDirs)
 
@@ -79,7 +68,7 @@ endfunction()
 
 function(ADD_LINK_FLAG value)
   message(STATUS "Linking with ${value}")
-  FOREACH(variable CMAKE_EXE_LINKER_FLAGS)
+  FOREACH(variable CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
     set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
   ENDFOREACH(variable)
 endfunction()
@@ -146,8 +135,14 @@ FOREACH(SUFFIX "_DEBUG" "_RELEASE" "_RELWITHDEBINFO" "_MINSIZEREL" "")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY${SUFFIX} "${PROJECT_BINARY_DIR}/lib")
 ENDFOREACH()
 
-
+option(BYN_ENABLE_LTO "Build with LTO" Off)
 if(BYN_ENABLE_LTO)
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "ThinLTO is only supported by clang")
+  endif()
+  if(NOT APPLE)
+    add_link_flag("-fuse-ld=lld")
+  endif()
   add_compile_flag("-flto=thin")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,15 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.13)
+
+# These linker flags must be set before the project() command below, because
+# linker flags set later are not passed to CMake's test compiles at configure
+# time. On Windows, the linker must be overridden with -DCMAKE_LINKER= because
+# it is invoked directly by CMake rather than by the compiler.
+option(BYN_ENABLE_LTO "Build with LTO" Off)
+if(BYN_ENABLE_LTO AND NOT MSVC)
+  set(CMAKE_EXE_LINKER_FLAGS "$CMAKE_EXE_LINKER_FLAGS -fuse-ld=lld")
+  set(CMAKE_SHARED_LINKER_FLAGS "$CMAKE_SHARED_LINKER_FLAGS -fuse-ld=lld")
+endif()
+
 project(binaryen LANGUAGES C CXX VERSION 99)
 include(GNUInstallDirs)
 
@@ -68,7 +79,7 @@ endfunction()
 
 function(ADD_LINK_FLAG value)
   message(STATUS "Linking with ${value}")
-  FOREACH(variable CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
+  FOREACH(variable CMAKE_EXE_LINKER_FLAGS)
     set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
   ENDFOREACH(variable)
 endfunction()
@@ -135,10 +146,9 @@ FOREACH(SUFFIX "_DEBUG" "_RELEASE" "_RELWITHDEBINFO" "_MINSIZEREL" "")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY${SUFFIX} "${PROJECT_BINARY_DIR}/lib")
 ENDFOREACH()
 
-option(BYN_ENABLE_LTO "Build with LTO" Off)
+
 if(BYN_ENABLE_LTO)
   add_compile_flag("-flto=thin")
-  add_link_options("-fuse-ld=lld")
 endif()
 
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endfunction()
 
 function(ADD_LINK_FLAG value)
   message(STATUS "Linking with ${value}")
-  FOREACH(variable CMAKE_EXE_LINKER_FLAGS)
+  FOREACH(variable CMAKE_EXE_LINKER_FLAGS CMAKE_SHARED_LINKER_FLAGS)
     set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
   ENDFOREACH(variable)
 endfunction()
@@ -134,6 +134,12 @@ FOREACH(SUFFIX "_DEBUG" "_RELEASE" "_RELWITHDEBINFO" "_MINSIZEREL" "")
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY${SUFFIX} "${PROJECT_BINARY_DIR}/lib")
   set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY${SUFFIX} "${PROJECT_BINARY_DIR}/lib")
 ENDFOREACH()
+
+option(BYN_ENABLE_LTO "Build with LTO" Off)
+if(BYN_ENABLE_LTO)
+  add_compile_flag("-flto")
+  add_link_options("-fuse-ld=lld")
+endif()
 
 if(MSVC)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.0") # VS2013 and older explicitly need /arch:sse2 set, VS2015 no longer has that option, but always enabled.


### PR DESCRIPTION
Also uses lld as the linker. Not on by default, so far tested on Linux and Windows.