### PR TITLE
Fix an index error in ArenaVectorBase::insertAt

### DIFF
--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -370,7 +370,7 @@ public:
   void insertAt(size_t index, T item) {
     assert(index <= usedElements); // appending is ok
     resize(usedElements + 1);
-    for (auto i = usedElements; i > index; --i) {
+    for (auto i = usedElements - 1; i > index; --i) {
       data[i] = data[i - 1];
     }
     data[index] = item;


### PR DESCRIPTION
Because `resize()` [sets](https://github.com/WebAssembly/binaryen/blob/dc7184afcbdcc72d0a6d66e2b36fc5857050dd87/src/mixed_arena.h#L204) `usedElements` to its argument, we were
accessing `data[usedElements]`, which can be outside of allocated memory
depending the internal state, i.e., `allocatedElements`'s value.

It is hard to come up with a test case for this because apparently the
failure condition depends on the vector's internal state.