### PR TITLE
Simplify set/gets of vectors in binaryen.js

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2492,6 +2492,25 @@ function getAllNested(ref, numFn, getFn) {
   return ret;
 }
 
+function setAllNested(ref, values, numFn, setFn, appendFn, removeFn) {
+  const num = values.length;
+  let prevNum = numFn(ref);
+  let index = 0;
+  while (index < num) {
+    preserveStack(() => {
+      if (index < prevNum) {
+        setFn(ref, index, values[index]);
+      } else {
+        appendFn(ref, values[index]);
+      }
+    });
+    ++index;
+  }
+  while (prevNum > index) {
+    removeFn(ref, --prevNum);
+  }
+}
+
 // Gets the specific id of an 'Expression'
 Module['getExpressionId'] = function(expr) {
   return Module['_BinaryenExpressionGetId'](expr);
@@ -3228,29 +3247,10 @@ Module['Block'] = makeExpressionWrapper({
     return Module['_BinaryenBlockGetNumChildren'](expr);
   },
   'getChildren'(expr) {
-    const numChildren = Module['_BinaryenBlockGetNumChildren'](expr);
-    const children = new Array(numChildren);
-    let index = 0;
-    while (index < numChildren) {
-      children[index] = Module['_BinaryenBlockGetChildAt'](expr, index++);
-    }
-    return children;
+    return getAllNested(expr, Module['_BinaryenBlockGetNumChildren'], Module['_BinaryenBlockGetChildAt']);
   },
   'setChildren'(expr, children) {
-    const numChildren = children.length;
-    let prevNumChildren = Module['_BinaryenBlockGetNumChildren'](expr);
-    let index = 0;
-    while (index < numChildren) {
-      if (index < prevNumChildren) {
-        Module['_BinaryenBlockSetChildAt'](expr, index, children[index]);
-      } else {
-        Module['_BinaryenBlockAppendChild'](expr, children[index]);
-      }
-      ++index;
-    }
-    while (prevNumChildren > index) {
-      Module['_BinaryenBlockRemoveChildAt'](expr, --prevNumChildren);
-    }
+    setAllNested(expr, children, Module['_BinaryenBlockGetNumChildren'], Module['_BinaryenBlockSetChildAt'], Module['_BinaryenBlockAppendChild'], Module['_BinaryenBlockRemoveChildAt']);
   },
   'getChildAt'(expr, index) {
     return Module['_BinaryenBlockGetChildAt'](expr, index);
@@ -3333,31 +3333,10 @@ Module['Switch'] = makeExpressionWrapper({
     return Module['_BinaryenSwitchGetNumNames'](expr);
   },
   'getNames'(expr) {
-    const numNames = Module['_BinaryenSwitchGetNumNames'](expr);
-    const names = new Array(numNames);
-    let index = 0;
-    while (index < numNames) {
-      names[index] = UTF8ToString(Module['_BinaryenSwitchGetNameAt'](expr, index++));
-    }
-    return names;
+    return getAllNested(expr, Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchGetNameAt']).map(p => UTF8ToString(p));
   },
   'setNames'(expr, names) {
-    const numNames = names.length;
-    let prevNumNames = Module['_BinaryenSwitchGetNumNames'](expr);
-    let index = 0;
-    while (index < numNames) {
-      preserveStack(() => {
-        if (index < prevNumNames) {
-          Module['_BinaryenSwitchSetNameAt'](expr, index, strToStack(names[index]));
-        } else {
-          Module['_BinaryenSwitchAppendName'](expr, strToStack(names[index]));
-        }
-      });
-      ++index;
-    }
-    while (prevNumNames > index) {
-      Module['_BinaryenSwitchRemoveNameAt'](expr, --prevNumNames);
-    }
+    setAllNested(expr, names.map(strToStack), Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchSetNameAt'], Module['_BinaryenSwitchAppendName'], Module['_BinaryenSwitchRemoveNameAt']);
   },
   'getDefaultName'(expr) {
     const name = Module['_BinaryenSwitchGetDefaultName'](expr);
@@ -3406,29 +3385,10 @@ Module['Call'] = makeExpressionWrapper({
     return Module['_BinaryenCallGetNumOperands'](expr);
   },
   'getOperands'(expr) {
-    const numOperands = Module['_BinaryenCallGetNumOperands'](expr);
-    const operands = new Array(numOperands);
-    let index = 0;
-    while (index < numOperands) {
-      operands[index] = Module['_BinaryenCallGetOperandAt'](expr, index++);
-    }
-    return operands;
+    return getAllNested(expr, Module['_BinaryenCallGetNumOperands'], Module['_BinaryenCallGetOperandAt']);
   },
   'setOperands'(expr, operands) {
-    const numOperands = operands.length;
-    let prevNumOperands = Module['_BinaryenCallGetNumOperands'](expr);
-    let index = 0;
-    while (index < numOperands) {
-      if (index < prevNumOperands) {
-        Module['_BinaryenCallSetOperandAt'](expr, index, operands[index]);
-      } else {
-        Module['_BinaryenCallAppendOperand'](expr, operands[index]);
-      }
-      ++index;
-    }
-    while (prevNumOperands > index) {
-      Module['_BinaryenCallRemoveOperandAt'](expr, --prevNumOperands);
-    }
+    setAllNested(expr, operands, Module['_BinaryenCallGetNumOperands'], Module['_BinaryenCallSetOperandAt'], Module['_BinaryenCallAppendOperand'], Module['_BinaryenCallRemoveOperandAt']);
   },
   'getOperandAt'(expr, index) {
     return Module['_BinaryenCallGetOperandAt'](expr, index);
@@ -3464,29 +3424,10 @@ Module['CallIndirect'] = makeExpressionWrapper({
     return Module['_BinaryenCallIndirectGetNumOperands'](expr);
   },
   'getOperands'(expr) {
-    const numOperands = Module['_BinaryenCallIndirectGetNumOperands'](expr);
-    const operands = new Array(numOperands);
-    let index = 0;
-    while (index < numOperands) {
-      operands[index] = Module['_BinaryenCallIndirectGetOperandAt'](expr, index++);
-    }
-    return operands;
+    return getAllNested(expr, Module['_BinaryenCallIndirectGetNumOperands'], Module['_BinaryenCallIndirectGetOperandAt']);
   },
   'setOperands'(expr, operands) {
-    const numOperands = operands.length;
-    let prevNumOperands = Module['_BinaryenCallIndirectGetNumOperands'](expr);
-    let index = 0;
-    while (index < numOperands) {
-      if (index < prevNumOperands) {
-        Module['_BinaryenCallIndirectSetOperandAt'](expr, index, operands[index]);
-      } else {
-        Module['_BinaryenCallIndirectAppendOperand'](expr, operands[index]);
-      }
-      ++index;
-    }
-    while (prevNumOperands > index) {
-      Module['_BinaryenCallIndirectRemoveOperandAt'](expr, --prevNumOperands);
-    }
+    setAllNested(expr, operands, Module['_BinaryenCallIndirectGetNumOperands'], Module['_BinaryenCallIndirectSetOperandAt'], Module['_BinaryenCallIndirectAppendOperand'], Module['_BinaryenCallIndirectRemoveOperandAt']);
   },
   'getOperandAt'(expr, index) {
     return Module['_BinaryenCallIndirectGetOperandAt'](expr, index);
@@ -4196,31 +4137,10 @@ Module['Try'] = makeExpressionWrapper({
     return Module['_BinaryenTryGetNumCatchEvents'](expr);
   },
   'getCatchEvents'(expr) {
-    const numCatchEvents = Module['_BinaryenTryGetNumCatchEvents'](expr);
-    const catchEvents = new Array(numCatchEvents);
-    let index = 0;
-    while (index < numCatchEvents) {
-      catchEvents[index] = UTF8ToString(Module['_BinaryenTryGetCatchEventAt'](expr, index++));
-    }
-    return catchEvents;
+    return getAllNested(expr, Module['_BinaryenTryGetNumCatchEvents'], Module['_BinaryenTryGetCatchEventAt']).map(p => UTF8ToString(p));
   },
   'setCatchEvents'(expr, catchEvents) {
-    const numCatchEvents = catchEvents.length;
-    let prevNumCatchEvents = Module['_BinaryenTryGetNumCatchEvents'](expr);
-    let index = 0;
-    while (index < numCatchEvents) {
-      preserveStack(() => {
-        if (index < prevNumCatchEvents) {
-          Module['_BinaryenTrySetCatchEventAt'](expr, index, strToStack(catchEvents[index]));
-        } else {
-          Module['_BinaryenTryAppendCatchEvent'](expr, strToStack(catchEvents[index]));
-        }
-      });
-      ++index;
-    }
-    while (prevNumCatchEvents > index) {
-      Module['_BinaryenTryRemoveCatchEventAt'](expr, --prevNumCatchEvents);
-    }
+    setAllNested(expr, catchEvents.map(strToStack), Module['_BinaryenTryGetNumCatchEvents'], Module['_BinaryenTrySetCatchEventAt'], Module['_BinaryenTryAppendCatchEvent'], Module['_BinaryenTryRemoveCatchEventAt']);
   },
   'getCatchEventAt'(expr, index) {
     return UTF8ToString(Module['_BinaryenTryGetCatchEventAt'](expr, index));
@@ -4241,29 +4161,10 @@ Module['Try'] = makeExpressionWrapper({
     return Module['_BinaryenTryGetNumCatchBodies'](expr);
   },
   'getCatchBodies'(expr) {
-    const numCatchBodies = Module['_BinaryenTryGetNumCatchBodies'](expr);
-    const catchbodies = new Array(numCatchBodies);
-    let index = 0;
-    while (index < numCatchBodies) {
-      catchbodies[index] = Module['_BinaryenTryGetCatchBodyAt'](expr, index++);
-    }
-    return catchbodies;
+    return getAllNested(expr, Module['_BinaryenTryGetNumCatchBodies'], Module['_BinaryenTryGetCatchBodyAt']);
   },
-  'setCatchBodies'(expr, catchbodies) {
-    const numCatchBodies = catchbodies.length;
-    let prevNumCatchBodies = Module['_BinaryenTryGetNumCatchBodies'](expr);
-    let index = 0;
-    while (index < numCatchBodies) {
-      if (index < prevNumCatchBodies) {
-        Module['_BinaryenTrySetCatchBodyAt'](expr, index, catchbodies[index]);
-      } else {
-        Module['_BinaryenTryAppendCatchBody'](expr, catchbodies[index]);
-      }
-      ++index;
-    }
-    while (prevNumCatchBodies > index) {
-      Module['_BinaryenTryRemoveCatchBodyAt'](expr, --prevNumCatchBodies);
-    }
+  'setCatchBodies'(expr, catchBodies) {
+    setAllNested(expr, catchBodies, Module['_BinaryenTryGetNumCatchBodies'], Module['_BinaryenTrySetCatchBodyAt'], Module['_BinaryenTryAppendCatchBody'], Module['_BinaryenTryRemoveCatchBodyAt']);
   },
   'getCatchBodyAt'(expr, index) {
     return Module['_BinaryenTryGetCatchBodyAt'](expr, index);
@@ -4296,29 +4197,10 @@ Module['Throw'] = makeExpressionWrapper({
     return Module['_BinaryenThrowGetNumOperands'](expr);
   },
   'getOperands'(expr) {
-    const numOperands = Module['_BinaryenThrowGetNumOperands'](expr);
-    const operands = new Array(numOperands);
-    let index = 0;
-    while (index < numOperands) {
-      operands[index] = Module['_BinaryenThrowGetOperandAt'](expr, index++);
-    }
-    return operands;
+    return getAllNested(expr, Module['_BinaryenThrowGetNumOperands'], Module['_BinaryenThrowGetOperandAt']);
   },
   'setOperands'(expr, operands) {
-    const numOperands = operands.length;
-    let prevNumOperands = Module['_BinaryenThrowGetNumOperands'](expr);
-    let index = 0;
-    while (index < numOperands) {
-      if (index < prevNumOperands) {
-        Module['_BinaryenThrowSetOperandAt'](expr, index, operands[index]);
-      } else {
-        Module['_BinaryenThrowAppendOperand'](expr, operands[index]);
-      }
-      ++index;
-    }
-    while (prevNumOperands > index) {
-      Module['_BinaryenThrowRemoveOperandAt'](expr, --prevNumOperands);
-    }
+    setAllNested(expr, operands, Module['_BinaryenThrowGetNumOperands'], Module['_BinaryenThrowSetOperandAt'], Module['_BinaryenThrowAppendOperand'], Module['_BinaryenThrowRemoveOperandAt']);
   },
   'getOperandAt'(expr, index) {
     return Module['_BinaryenThrowGetOperandAt'](expr, index);
@@ -4372,29 +4254,10 @@ Module['TupleMake'] = makeExpressionWrapper({
     return Module['_BinaryenTupleMakeGetNumOperands'](expr);
   },
   'getOperands'(expr) {
-    const numOperands = Module['_BinaryenTupleMakeGetNumOperands'](expr);
-    const operands = new Array(numOperands);
-    let index = 0;
-    while (index < numOperands) {
-      operands[index] = Module['_BinaryenTupleMakeGetOperandAt'](expr, index++);
-    }
-    return operands;
+    return getAllNested(expr, Module['_BinaryenTupleMakeGetNumOperands'], Module['_BinaryenTupleMakeGetOperandAt']);
   },
   'setOperands'(expr, operands) {
-    const numOperands = operands.length;
-    let prevNumOperands = Module['_BinaryenTupleMakeGetNumOperands'](expr);
-    let index = 0;
-    while (index < numOperands) {
-      if (index < prevNumOperands) {
-        Module['_BinaryenTupleMakeSetOperandAt'](expr, index, operands[index]);
-      } else {
-        Module['_BinaryenTupleMakeAppendOperand'](expr, operands[index]);
-      }
-      ++index;
-    }
-    while (prevNumOperands > index) {
-      Module['_BinaryenTupleMakeRemoveOperandAt'](expr, --prevNumOperands);
-    }
+    setAllNested(expr, operands, Module['_BinaryenTupleMakeGetNumOperands'], Module['_BinaryenTupleMakeSetOperandAt'], Module['_BinaryenTupleMakeAppendOperand'], Module['_BinaryenTupleMakeRemoveOperandAt']);
   },
   'getOperandAt'(expr, index) {
     return Module['_BinaryenTupleMakeGetOperandAt'](expr, index);

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2497,13 +2497,11 @@ function setAllNested(ref, values, numFn, setFn, appendFn, removeFn) {
   let prevNum = numFn(ref);
   let index = 0;
   while (index < num) {
-    preserveStack(() => {
-      if (index < prevNum) {
-        setFn(ref, index, values[index]);
-      } else {
-        appendFn(ref, values[index]);
-      }
-    });
+    if (index < prevNum) {
+      setFn(ref, index, values[index]);
+    } else {
+      appendFn(ref, values[index]);
+    }
     ++index;
   }
   while (prevNum > index) {
@@ -3336,7 +3334,9 @@ Module['Switch'] = makeExpressionWrapper({
     return getAllNested(expr, Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchGetNameAt']).map(p => UTF8ToString(p));
   },
   'setNames'(expr, names) {
-    setAllNested(expr, names.map(strToStack), Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchSetNameAt'], Module['_BinaryenSwitchAppendName'], Module['_BinaryenSwitchRemoveNameAt']);
+    preserveStack(() => {
+      setAllNested(expr, names.map(strToStack), Module['_BinaryenSwitchGetNumNames'], Module['_BinaryenSwitchSetNameAt'], Module['_BinaryenSwitchAppendName'], Module['_BinaryenSwitchRemoveNameAt']);
+    });
   },
   'getDefaultName'(expr) {
     const name = Module['_BinaryenSwitchGetDefaultName'](expr);
@@ -4140,7 +4140,9 @@ Module['Try'] = makeExpressionWrapper({
     return getAllNested(expr, Module['_BinaryenTryGetNumCatchEvents'], Module['_BinaryenTryGetCatchEventAt']).map(p => UTF8ToString(p));
   },
   'setCatchEvents'(expr, catchEvents) {
-    setAllNested(expr, catchEvents.map(strToStack), Module['_BinaryenTryGetNumCatchEvents'], Module['_BinaryenTrySetCatchEventAt'], Module['_BinaryenTryAppendCatchEvent'], Module['_BinaryenTryRemoveCatchEventAt']);
+    preserveStack(() => {
+      setAllNested(expr, catchEvents.map(strToStack), Module['_BinaryenTryGetNumCatchEvents'], Module['_BinaryenTrySetCatchEventAt'], Module['_BinaryenTryAppendCatchEvent'], Module['_BinaryenTryRemoveCatchEventAt']);
+    });
   },
   'getCatchEventAt'(expr, index) {
     return UTF8ToString(Module['_BinaryenTryGetCatchEventAt'](expr, index));

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -37,6 +37,7 @@ console.log("# Block");
   assert(theBlock.type === binaryen.i32);
   assert(theBlock.numChildren === 0);
   assertDeepEqual(theBlock.children, []);
+  assertDeepEqual(theBlock.getChildren(), []);
 
   var child1 = module.i32.const(1);
   theBlock.appendChild(child1);
@@ -205,11 +206,12 @@ console.log("# Switch");
   assert(theSwitch.value === value);
   assert(theSwitch.type === binaryen.unreachable);
 
-  theSwitch.names = names = [
+  names = [
     "1", // set
-    "2", // set
-    "3"  // append
-  ];
+    "2", //set
+    "3" // append
+  ]
+  theSwitch.setNames(names);
   assertDeepEqual(theSwitch.names, names);
   theSwitch.names = names = [
     "x", // set
@@ -217,6 +219,7 @@ console.log("# Switch");
     // remove
   ];
   assertDeepEqual(theSwitch.names, names);
+  assertDeepEqual(theSwitch.getNames(), names);
   theSwitch.insertNameAt(1, "y");
   theSwitch.condition = condition = module.i32.const(3);
   assert(theSwitch.condition === condition);
@@ -248,6 +251,7 @@ console.log("# Call");
   assert(theCall instanceof binaryen.Expression);
   assert(theCall.target === target);
   assertDeepEqual(theCall.operands, operands);
+  assertDeepEqual(theCall.getOperands(), operands);
   assert(theCall.return === false);
   assert(theCall.type === binaryen.i32);
 
@@ -259,11 +263,12 @@ console.log("# Call");
     module.i32.const(5)  // append
   ];
   assertDeepEqual(theCall.operands, operands);
-  theCall.operands = operands = [
+  operands = [
     module.i32.const(6) // set
     // remove
     // remove
   ];
+  theCall.setOperands(operands);
   assertDeepEqual(theCall.operands, operands);
   theCall.insertOperandAt(0, module.i32.const(7));
   theCall.return = true;
@@ -315,12 +320,14 @@ console.log("# CallIndirect");
     module.i32.const(5)  // append
   ];
   assertDeepEqual(theCallIndirect.operands, operands);
-  theCallIndirect.operands = operands = [
+  operands = [
     module.i32.const(6) // set
     // remove
     // remove
   ];
+  theCallIndirect.setOperands(operands);
   assertDeepEqual(theCallIndirect.operands, operands);
+  assertDeepEqual(theCallIndirect.getOperands(), operands);
   theCallIndirect.insertOperandAt(0, module.i32.const(7));
   theCallIndirect.return = true;
   assert(theCallIndirect.return === true);
@@ -1525,11 +1532,13 @@ console.log("# Throw");
     module.i32.const(5)  // append
   ];
   assertDeepEqual(theThrow.operands, operands);
-  theThrow.operands = operands = [
+  assertDeepEqual(theThrow.getOperands(), operands);
+  operands = [
     module.i32.const(6) // set
     // remove
     // remove
   ];
+  theThrow.setOperands(operands);
   assertDeepEqual(theThrow.operands, operands);
   theThrow.insertOperandAt(1, module.i32.const(7));
   theThrow.type = binaryen.f64;
@@ -1630,12 +1639,14 @@ console.log("# TupleMake");
     module.i32.const(5)  // append
   ];
   assertDeepEqual(theTupleMake.operands, operands);
-  theTupleMake.operands = operands = [
+  operands = [
     module.i32.const(6) // set
     // remove
     // remove
   ];
+  theTupleMake.setOperands(operands);
   assertDeepEqual(theTupleMake.operands, operands);
+  assertDeepEqual(theTupleMake.getOperands(), operands);
   theTupleMake.insertOperandAt(1, module.i32.const(7));
   theTupleMake.type = binaryen.f64;
   theTupleMake.finalize();


### PR DESCRIPTION
This uses existing `getAllNested` function in `ExpressionWrapper`
functions. Also adds `setAllNested` which works in the other direction
and uses it within `ExpressionWrapper` functions.