### PR TITLE
Revert cmake version requirement bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.13)
+# Version set according the the cmake versions available in Ubuntu/Bionic:
+# https://packages.ubuntu.com/bionic/cmake
+cmake_minimum_required(VERSION 3.10.2)
 project(binaryen LANGUAGES C CXX VERSION 99)
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This was originally landed as part of #3484 but this broke the emsdk CI
because we build binaryen on bionic there which is stuck on 3.10.2:
https://packages.ubuntu.com/bionic/cmake

We do use `add_link_options` but only when EMSCRIPTEN is defined which
doesn't effect normal desktop builds.