### PR TITLE
Memcpy data instead of bytewise copies

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1262,6 +1262,7 @@ public:
 
   bool more() { return pos < input.size(); }
 
+  std::vector<char> getBytes(size_t size);
   uint8_t getInt8();
   uint16_t getInt16();
   uint32_t getInt32();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1262,7 +1262,7 @@ public:
 
   bool more() { return pos < input.size(); }
 
-  std::vector<char> getBytes(size_t size);
+  std::pair<const char*, const char*> getByteView(size_t size);
   uint8_t getInt8();
   uint16_t getInt16();
   uint32_t getInt32();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1269,7 +1269,8 @@ void WasmBinaryBuilder::readUserSection(size_t payloadLen) {
   }
 }
 
-std::pair<const char*, const char*> WasmBinaryBuilder::getByteView(size_t size) {
+std::pair<const char*, const char*>
+WasmBinaryBuilder::getByteView(size_t size) {
   if (size > input.size() || pos > input.size() - size) {
     throwError("unexpected end of input");
   }
@@ -1512,9 +1513,9 @@ Name WasmBinaryBuilder::getInlineString() {
 
   std::string str(data.first, data.second);
   if (str.find('\0') != std::string::npos) {
-      throwError(
-        "inline string contains NULL (0). that is technically valid in wasm, "
-        "but you shouldn't do it, and it's not supported in binaryen");
+    throwError(
+      "inline string contains NULL (0). that is technically valid in wasm, "
+      "but you shouldn't do it, and it's not supported in binaryen");
   }
   BYN_TRACE("getInlineString: " << str << " ==>\n");
   return Name(str);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1264,12 +1264,16 @@ void WasmBinaryBuilder::readUserSection(size_t payloadLen) {
     wasm.userSections.resize(wasm.userSections.size() + 1);
     auto& section = wasm.userSections.back();
     section.name = sectionName.str;
-    auto sectionSize = payloadLen;
-    section.data.resize(sectionSize);
-    for (size_t i = 0; i < sectionSize; i++) {
-      section.data[i] = getInt8();
-    }
+    section.data = getBytes(payloadLen);
   }
+}
+
+std::vector<char> WasmBinaryBuilder::getBytes(size_t size) {
+  if (size >= input.size() || pos >= input.size() - size) {
+    throwError("unexpected end of input");
+  }
+  pos += size;
+  return {&input[pos - size], &input[pos]};
 }
 
 uint8_t WasmBinaryBuilder::getInt8() {
@@ -2390,10 +2394,7 @@ void WasmBinaryBuilder::readDataSegments() {
       curr.offset = readExpression();
     }
     auto size = getU32LEB();
-    curr.data.resize(size);
-    for (size_t j = 0; j < size; j++) {
-      curr.data[j] = char(getInt8());
-    }
+    curr.data = getBytes(size);
     wasm.memory.segments.push_back(curr);
   }
 }


### PR DESCRIPTION
wasm-finalize currently makes byte-wise copies of section data in the user and data sections. If the section is large, that's extraordinarily expensive. With a memcpy instead I see a speedup of 1.6 for a large wasm binary with DWARF data.