### PR TITLE
Remove test suite's assumption of minify_check roundtripping perfectly

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -493,18 +493,8 @@ def minify_check(wast, verify_final_result=True):
     print('      ', ' '.join(cmd))
     subprocess.check_call(cmd, stdout=open('a.wast', 'w'), stderr=subprocess.PIPE)
     assert os.path.exists('a.wast')
-    subprocess.check_call(WASM_OPT + ['a.wast', '--print-minified', '-all'],
+    subprocess.check_call(WASM_OPT + ['a.wast', '-all'],
                           stdout=open('b.wast', 'w'), stderr=subprocess.PIPE)
-    assert os.path.exists('b.wast')
-    if verify_final_result:
-        expected = open('a.wast').read()
-        actual = open('b.wast').read()
-        if actual != expected:
-            fail(actual, expected)
-    if os.path.exists('a.wast'):
-        os.unlink('a.wast')
-    if os.path.exists('b.wast'):
-        os.unlink('b.wast')
 
 
 # run a check with BINARYEN_PASS_DEBUG set, to do full validation

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -493,7 +493,7 @@ def minify_check(wast, verify_final_result=True):
     print('      ', ' '.join(cmd))
     subprocess.check_call(cmd, stdout=open('a.wast', 'w'), stderr=subprocess.PIPE)
     subprocess.check_call(WASM_OPT + ['a.wast', '-all'],
-                          stderr=subprocess.PIPE, stderr=subprocess.PIPE)
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 # run a check with BINARYEN_PASS_DEBUG set, to do full validation

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -492,9 +492,8 @@ def minify_check(wast, verify_final_result=True):
     cmd = WASM_OPT + [wast, '--print-minified', '-all']
     print('      ', ' '.join(cmd))
     subprocess.check_call(cmd, stdout=open('a.wast', 'w'), stderr=subprocess.PIPE)
-    assert os.path.exists('a.wast')
     subprocess.check_call(WASM_OPT + ['a.wast', '-all'],
-                          stdout=open('b.wast', 'w'), stderr=subprocess.PIPE)
+                          stderr=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 # run a check with BINARYEN_PASS_DEBUG set, to do full validation


### PR DESCRIPTION
`minify_check` checks that we can print and read minified wast. The test
also, however, assumed that we round-trip such things perfectly. That's
never been true, and only by chance did this go unnoticed until now,
in https://github.com/WebAssembly/binaryen/pull/3523

The specific issue happening there is that we create a block without a
name. Then we write that as text, then read it. When we read it, we give
all such blocks a name (and we rely on optimizations to remove it later
when possible - this avoids optimizing in the parser). The extra name
looks like a bug to minify_check.