### PR TITLE
[GC] Don't emit i31ref in fuzzer

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -337,13 +337,13 @@ private:
             options.push_back(Type::externref);
             if (wasm.features.hasGC()) {
               options.push_back(Type::eqref);
-              options.push_back(Type::i31ref);
+              // TODO: i31ref, dataref, etc.
             }
           }
           break;
         case Type::eqref:
           if (wasm.features.hasGC()) {
-            options.push_back(Type::i31ref);
+            // TODO: i31ref, dataref, etc.
           }
           break;
         default:
@@ -1108,8 +1108,8 @@ private:
     if (type == Type::i32) {
       options.add(FeatureSet::ReferenceTypes, &Self::makeRefIsNull);
       options.add(FeatureSet::ReferenceTypes | FeatureSet::GC,
-                  &Self::makeRefEq,
-                  &Self::makeI31Get);
+                  &Self::makeRefEq);
+      //  TODO: makeI31Get
     }
     if (type.isTuple()) {
       options.add(FeatureSet::Multivalue, &Self::makeTupleMake);
@@ -3035,10 +3035,9 @@ private:
         .add(FeatureSet::ReferenceTypes, Type::funcref, Type::externref)
         .add(FeatureSet::ReferenceTypes | FeatureSet::GC,
              Type::anyref,
-             Type::eqref,
-             Type::i31ref));
+             Type::eqref));
     // TODO: emit typed function references types
-    // TODO: dataref
+    // TODO: i31ref, dataref
   }
 
   Type getSingleConcreteType() { return pick(getSingleConcreteTypes()); }
@@ -3049,16 +3048,16 @@ private:
         .add(FeatureSet::ReferenceTypes, Type::funcref, Type::externref)
         .add(FeatureSet::ReferenceTypes | FeatureSet::GC,
              Type::anyref,
-             Type::eqref,
-             Type::i31ref));
-    // TODO: dataref
+             Type::eqref));
+    // TODO: i31ref, dataref
   }
 
   Type getReferenceType() { return pick(getReferenceTypes()); }
 
   std::vector<Type> getEqReferenceTypes() {
     return items(FeatureOptions<Type>().add(
-      FeatureSet::ReferenceTypes | FeatureSet::GC, Type::eqref, Type::i31ref));
+      FeatureSet::ReferenceTypes | FeatureSet::GC, Type::eqref));
+    // TODO: i31ref, dataref
   }
 
   Type getEqReferenceType() { return pick(getEqReferenceTypes()); }

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,38 +1,39 @@
 total
- [events]       : 1       
- [exports]      : 7       
- [funcs]        : 8       
+ [events]       : 2       
+ [exports]      : 8       
+ [funcs]        : 9       
  [globals]      : 6       
  [imports]      : 5       
  [memory-data]  : 22      
- [table-data]   : 1       
- [total]        : 461     
- [vars]         : 11      
+ [table-data]   : 3       
+ [total]        : 549     
+ [vars]         : 37      
+ AtomicFence    : 1       
+ AtomicNotify   : 1       
  AtomicRMW      : 1       
- Binary         : 72      
- Block          : 40      
- Break          : 5       
- Call           : 13      
- CallRef        : 1       
- Const          : 124     
- Drop           : 3       
- GlobalGet      : 20      
- GlobalSet      : 11      
- I31Get         : 1       
- I31New         : 8       
- If             : 17      
- Load           : 19      
- LocalGet       : 34      
+ Binary         : 80      
+ Block          : 69      
+ Break          : 10      
+ Call           : 11      
+ CallRef        : 3       
+ Const          : 117     
+ Drop           : 7       
+ GlobalGet      : 30      
+ GlobalSet      : 16      
+ If             : 24      
+ Load           : 26      
+ LocalGet       : 35      
  LocalSet       : 18      
- Loop           : 4       
+ Loop           : 9       
+ MemoryFill     : 1       
  MemoryInit     : 1       
- Nop            : 8       
- RefFunc        : 1       
- RefNull        : 11      
- Return         : 14      
- SIMDExtract    : 2       
- Select         : 1       
- Store          : 3       
- TupleExtract   : 1       
- TupleMake      : 8       
- Unary          : 20      
+ Nop            : 24      
+ RefFunc        : 3       
+ RefIs          : 2       
+ RefNull        : 9       
+ Return         : 18      
+ SIMDExtract    : 1       
+ Select         : 2       
+ Store          : 2       
+ TupleMake      : 2       
+ Unary          : 26      


### PR DESCRIPTION
That type is non-nullable, so we need to disable it until we fully support that.
Right now if we emit such locals we immediately get a validation error.

With this change the fuzzer can run at least a few thousand iterations with
no errors once more.