### PR TITLE
[GC] isGCData => isData

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -97,14 +97,17 @@ public:
   Literal& operator=(const Literal& other);
   ~Literal();
 
-  bool isConcrete() const { return type != Type::none; }
+  bool isConcrete() const { return type.isConcrete(); }
   bool isNone() const { return type == Type::none; }
+  bool isFunction() const { return type.isFunction(); }
+  bool isData() const { return type.isData(); }
+
   bool isNull() const {
     if (type.isNullable()) {
       if (type.isFunction()) {
         return func.isNull();
       }
-      if (isGCData()) {
+      if (isData()) {
         return !gcData;
       }
       return true;
@@ -171,7 +174,6 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-  bool isGCData() const { return type.isStruct() || type.isArray(); }
 
   static Literals makeZeros(Type type);
   static Literals makeOnes(Type type);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1320,7 +1320,7 @@ public:
       case RefIsFunc:
         return Literal(!value.isNull() && value.type.isFunction());
       case RefIsData:
-        return Literal(!value.isNull() && value.isGCData());
+        return Literal(!value.isNull() && value.isData());
       case RefIsI31:
         return Literal(!value.isNull() &&
                        value.type.getHeapType() == HeapType::i31);
@@ -1429,7 +1429,7 @@ public:
     // anyref of null (already handled above) or anything else (handled here,
     // but this is for future use as atm the binaryen interpreter cannot
     // represent external references).
-    if (!cast.originalRef.isGCData()) {
+    if (!cast.originalRef.isData()) {
       cast.outcome = cast.Failure;
       return cast;
     }
@@ -1509,7 +1509,7 @@ public:
         }
         break;
       case BrOnData:
-        if (!value.isGCData()) {
+        if (!value.isData()) {
           return {value};
         }
         break;
@@ -1699,7 +1699,7 @@ public:
         }
         break;
       case RefAsData:
-        if (value.isGCData()) {
+        if (value.isData()) {
           trap("not a data");
         }
         break;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -136,6 +136,7 @@ public:
   bool isSingle() const { return isConcrete() && !isTuple(); }
   bool isRef() const;
   bool isFunction() const;
+  bool isData() const;
   bool isException() const;
   bool isNullable() const;
   bool isRtt() const;
@@ -314,6 +315,7 @@ public:
   constexpr bool isBasic() const { return id <= _last_basic_type; }
   constexpr bool isCompound() const { return id > _last_basic_type; }
   bool isFunction() const;
+  bool isData() const;
   bool isSignature() const;
   bool isStruct() const;
   bool isArray() const;

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -90,7 +90,6 @@ Literal::Literal(const Literal& other) : type(other.type) {
           return;
         case HeapType::func:
         case HeapType::data:
-        std::cout << other.type << '\n';
           WASM_UNREACHABLE("invalid type");
       }
     }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -35,7 +35,7 @@ Literal::Literal(Type type) : type(type) {
     i32 = 0;
   } else {
     assert(type != Type::unreachable && (!type.isRef() || type.isNullable()));
-    if (isGCData()) {
+    if (isData()) {
       new (&gcData) std::shared_ptr<GCData>();
     } else if (type.isRtt()) {
       // Allocate a new RttSupers (with no data).
@@ -55,7 +55,7 @@ Literal::Literal(std::shared_ptr<GCData> gcData, Type type)
   // Null data is only allowed if nullable.
   assert(gcData || type.isNullable());
   // The type must be a proper type for GC data.
-  assert(isGCData());
+  assert(isData());
 }
 
 Literal::Literal(std::unique_ptr<RttSupers>&& rttSupers, Type type)
@@ -64,7 +64,7 @@ Literal::Literal(std::unique_ptr<RttSupers>&& rttSupers, Type type)
 }
 
 Literal::Literal(const Literal& other) : type(other.type) {
-  if (other.isGCData()) {
+  if (other.isData()) {
     new (&gcData) std::shared_ptr<GCData>(other.gcData);
     return;
   }
@@ -90,6 +90,7 @@ Literal::Literal(const Literal& other) : type(other.type) {
           return;
         case HeapType::func:
         case HeapType::data:
+        std::cout << other.type << '\n';
           WASM_UNREACHABLE("invalid type");
       }
     }
@@ -121,7 +122,7 @@ Literal::Literal(const Literal& other) : type(other.type) {
 }
 
 Literal::~Literal() {
-  if (isGCData()) {
+  if (isData()) {
     gcData.~shared_ptr();
   } else if (type.isRtt()) {
     rttSupers.~unique_ptr();
@@ -241,7 +242,7 @@ std::array<uint8_t, 16> Literal::getv128() const {
 }
 
 std::shared_ptr<GCData> Literal::getGCData() const {
-  assert(isGCData());
+  assert(isData());
   return gcData;
 }
 
@@ -486,7 +487,7 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
       o << "funcref(" << literal.getFunc() << ")";
     }
   } else if (literal.type.isRef()) {
-    if (literal.isGCData()) {
+    if (literal.isData()) {
       auto data = literal.getGCData();
       if (data) {
         o << "[ref " << data->rtt << ' ' << data->values << ']';

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -384,6 +384,15 @@ bool Type::isFunction() const {
   }
 }
 
+bool Type::isData() const {
+  if (isBasic()) {
+    return id == dataref;
+  } else {
+    auto* info = getTypeInfo(*this);
+    return info->isRef() && info->ref.heapType.isData();
+  }
+}
+
 bool Type::isNullable() const {
   if (isBasic()) {
     return id >= funcref && id <= eqref; // except i31ref
@@ -737,6 +746,14 @@ bool HeapType::isFunction() const {
   }
 }
 
+bool HeapType::isData() const {
+  if (isBasic()) {
+    return id == data;
+  } else {
+    return getHeapTypeInfo(*this)->isData();
+  }
+}
+
 bool HeapType::isSignature() const {
   if (isBasic()) {
     return false;
@@ -750,6 +767,14 @@ bool HeapType::isStruct() const {
     return false;
   } else {
     return getHeapTypeInfo(*this)->isStruct();
+  }
+}
+
+bool HeapType::isArray() const {
+  if (isBasic()) {
+    return false;
+  } else {
+    return getHeapTypeInfo(*this)->isArray();
   }
 }
 
@@ -767,14 +792,6 @@ bool HeapType::operator<(const HeapType& other) const {
     return false;
   }
   return *getHeapTypeInfo(*this) < *getHeapTypeInfo(other);
-}
-
-bool HeapType::isArray() const {
-  if (isBasic()) {
-    return false;
-  } else {
-    return getHeapTypeInfo(*this)->isArray();
-  }
 }
 
 Signature HeapType::getSignature() const {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -90,6 +90,7 @@ struct HeapTypeInfo {
   constexpr bool isSignature() const { return kind == SignatureKind; }
   constexpr bool isStruct() const { return kind == StructKind; }
   constexpr bool isArray() const { return kind == ArrayKind; }
+  constexpr bool isData() const { return isStruct() || isArray(); }
 
   HeapTypeInfo& operator=(const HeapTypeInfo& other);
   bool operator==(const HeapTypeInfo& other) const;


### PR DESCRIPTION
We added `isGCData()` before we had dataref. But now there is a clear
parallel of Function vs Data. This PR makes us more consistent there,
renaming `isGCData` to `isData` and using that throughout.

This also fixes a bug where the old isGCData just checked if the input
was an Array or a Struct, and ignored the `data` heap type itself. It is not
possible to test that, however, due to other bugs, so that is deferred.