### PR TITLE
Support Stack IR for new try-catch(_all)

### DIFF
--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -257,6 +257,7 @@ private:
       case StackInst::IfEnd:
       case StackInst::LoopEnd:
       case StackInst::Catch:
+      case StackInst::CatchAll:
       case StackInst::TryEnd: {
         return true;
       }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2316,6 +2316,10 @@ void StackIRToBinaryWriter::write() {
         writer.emitCatch(inst->origin->cast<Try>(), catchIndexStack.back()++);
         break;
       }
+      case StackInst::CatchAll: {
+        writer.emitCatchAll(inst->origin->cast<Try>());
+        break;
+      }
       default:
         WASM_UNREACHABLE("unexpected op");
     }

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.txt
@@ -6,9 +6,11 @@
   try
    i32.const 0
    throw $e0
-  catch
+  catch $e0
    
    drop
+   rethrow 0
+  catch_all
    rethrow 0
   end
   unreachable
@@ -29,6 +31,9 @@
     (drop
      (pop i32)
     )
+    (rethrow 0)
+   )
+   (catch_all
     (rethrow 0)
    )
   )

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.wast
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_all-features.wast
@@ -10,6 +10,9 @@
         (drop (pop i32))
         (rethrow 0)
       )
+      (catch_all
+        (rethrow 0)
+      )
     )
   )
 )


### PR DESCRIPTION
This adds missing stack IR printing support for the new form of
try-catch-catch_all. Also uses `printMedium` when printing instructions
consistently.