### PR TITLE
[GC] Feedback for #3536

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -370,7 +370,7 @@ bool Type::isTuple() const {
 
 bool Type::isRef() const {
   if (isBasic()) {
-    return id >= funcref && id <= dataref;
+    return id >= funcref && id <= _last_basic_type;
   } else {
     return getTypeInfo(*this)->isRef();
   }
@@ -685,10 +685,10 @@ Type Type::getLeastUpperBound(Type a, Type b) {
       return handleNullability(HeapType::eq);
     }
     // The LUB of two different reference types is anyref, which may or may
-    // not be a valid type depending on whether the anyref feature is enabled.
-    // When anyref is disabled, it is possible for the finalization of invalid
-    // code to introduce a use of anyref via this function, but that is not a
-    // problem because it will be caught and rejected by validation.
+    // not be a valid type depending on whether the GC feature is enabled. When
+    // GC is disabled, it is possible for the finalization of invalid code to
+    // introduce a use of anyref via this function, but that is not a problem
+    // because it will be caught and rejected by validation.
     return Type::anyref;
   }
   if (a.isTuple()) {


### PR DESCRIPTION
This addresses the feedback to #3536 , except for @tlively 's suggestion to add
an `isEq()` method. I feel that might not be worth it, since it may be used only in
that one place in the last upper bound computation - we won't need it in the
interpreter or anything I can think of, because there is no `br_on_eq` etc. - thoughts?