### PR TITLE
[GC] Do not crash on unreachable inputs to struct.get/set

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1840,10 +1840,16 @@ struct PrintExpressionContents
     o << "with_rtt ";
     printHeapTypeName(o, curr->rtt->type.getHeapType());
   }
+  void printUnreachableReplacement() {
+    // If we cannot print a valid unreachable instruction (say, a struct.get,
+    // where if the ref is unreachable, we don't know what heap type to print),
+    // then print the children in a block, which is good enough as this
+    // instruction is never reached anyhow.
+    printMedium(o, "block ");
+  }
   void visitStructGet(StructGet* curr) {
     if (curr->ref->type == Type::unreachable) {
-      printMedium(o, "struct.get[unreachable] ");
-      o << curr->index;
+      printUnreachableReplacement();
       return;
     }
     const auto& field =
@@ -1863,8 +1869,7 @@ struct PrintExpressionContents
   }
   void visitStructSet(StructSet* curr) {
     if (curr->ref->type == Type::unreachable) {
-      printMedium(o, "struct.set[unreachable] ");
-      o << curr->index;
+      printUnreachableReplacement();
       return;
     }
     printMedium(o, "struct.set ");

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1841,6 +1841,11 @@ struct PrintExpressionContents
     printHeapTypeName(o, curr->rtt->type.getHeapType());
   }
   void visitStructGet(StructGet* curr) {
+    if (curr->ref->type == Type::unreachable) {
+      printMedium(o, "struct.get[unreachable] ");
+      o << curr->index;
+      return;
+    }
     const auto& field =
       curr->ref->type.getHeapType().getStruct().fields[curr->index];
     if (field.type == Type::i32 && field.packedType != Field::not_packed) {
@@ -1857,6 +1862,11 @@ struct PrintExpressionContents
     o << curr->index;
   }
   void visitStructSet(StructSet* curr) {
+    if (curr->ref->type == Type::unreachable) {
+      printMedium(o, "struct.set[unreachable] ");
+      o << curr->index;
+      return;
+    }
     printMedium(o, "struct.set ");
     printHeapTypeName(o, curr->ref->type.getHeapType());
     o << ' ';

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2296,9 +2296,14 @@ void FunctionValidator::visitStructGet(StructGet* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "struct.get requires gc to be enabled");
-  shouldBeTrue(curr->ref->type.isStruct(),
-               curr->ref,
-               "struct.get ref must be a struct");
+  if (curr->ref->type == Type::unreachable) {
+    return;
+  }
+  if (!shouldBeTrue(curr->ref->type.isStruct(),
+                    curr->ref,
+                    "struct.get ref must be a struct")) {
+    return;
+  }
   const auto& fields = curr->ref->type.getHeapType().getStruct().fields;
   shouldBeTrue(curr->index < fields.size(), curr, "bad struct.get field");
   auto field = fields[curr->index];
@@ -2318,9 +2323,14 @@ void FunctionValidator::visitStructSet(StructSet* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "struct.set requires gc to be enabled");
-  shouldBeTrue(curr->ref->type.isStruct(),
-               curr->ref,
-               "struct.set ref must be a struct");
+  if (curr->ref->type == Type::unreachable) {
+    return;
+  }
+  if (!shouldBeTrue(curr->ref->type.isStruct(),
+                    curr->ref,
+                    "struct.set ref must be a struct")) {
+    return;
+  }
   if (curr->ref->type != Type::unreachable) {
     const auto& fields = curr->ref->type.getHeapType().getStruct().fields;
     shouldBeTrue(curr->index < fields.size(), curr, "bad struct.get field");

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2296,6 +2296,9 @@ void FunctionValidator::visitStructGet(StructGet* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "struct.get requires gc to be enabled");
+  shouldBeTrue(curr->ref->type.isStruct(),
+               curr,
+               "struct.get requires a struct");
   const auto& fields = curr->ref->type.getHeapType().getStruct().fields;
   shouldBeTrue(curr->index < fields.size(), curr, "bad struct.get field");
   auto field = fields[curr->index];
@@ -2315,6 +2318,9 @@ void FunctionValidator::visitStructSet(StructSet* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "struct.set requires gc to be enabled");
+  shouldBeTrue(curr->ref->type.isStruct(),
+               curr,
+               "struct.set requires a struct");
   if (curr->ref->type != Type::unreachable) {
     const auto& fields = curr->ref->type.getHeapType().getStruct().fields;
     shouldBeTrue(curr->index < fields.size(), curr, "bad struct.get field");

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2297,8 +2297,8 @@ void FunctionValidator::visitStructGet(StructGet* curr) {
                curr,
                "struct.get requires gc to be enabled");
   shouldBeTrue(curr->ref->type.isStruct(),
-               curr,
-               "struct.get requires a struct");
+               curr->ref,
+               "struct.get ref must be a struct");
   const auto& fields = curr->ref->type.getHeapType().getStruct().fields;
   shouldBeTrue(curr->index < fields.size(), curr, "bad struct.get field");
   auto field = fields[curr->index];
@@ -2319,8 +2319,8 @@ void FunctionValidator::visitStructSet(StructSet* curr) {
                curr,
                "struct.set requires gc to be enabled");
   shouldBeTrue(curr->ref->type.isStruct(),
-               curr,
-               "struct.set requires a struct");
+               curr->ref,
+               "struct.set ref must be a struct");
   if (curr->ref->type != Type::unreachable) {
     const auto& fields = curr->ref->type.getHeapType().getStruct().fields;
     shouldBeTrue(curr->index < fields.size(), curr, "bad struct.get field");

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -226,4 +226,12 @@
       )
     )
   )
+  (func $unreachables
+    (drop
+      (struct.get $struct.A 0 (unreachable))
+    )
+    (drop
+      (struct.set $struct.A 0 (unreachable) (unreachable))
+    )
+  )
 )

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -282,4 +282,17 @@
    )
   )
  )
+ (func $unreachables
+  (drop
+   (block 
+    (unreachable)
+   )
+  )
+  (drop
+   (block 
+    (unreachable)
+    (unreachable)
+   )
+  )
+ )
 )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -281,5 +281,8 @@
    )
   )
  )
+ (func $unreachables
+  (unreachable)
+ )
 )
 

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -281,5 +281,8 @@
    )
   )
  )
+ (func $8
+  (unreachable)
+ )
 )
 


### PR DESCRIPTION
If the reference is unreachable then we cannot find the heap type to print
in the text format. Instead of crashing or emitting something invalid, print
a block instead -  the block contains the children so they are emitted, and
as the instruction was unreachable anyhow, this has no noticeable effect.
It also parallels what we do in the binary format - skip unreachable code.