### PR TITLE
StackSignature LUBs

### DIFF
--- a/src/ir/stack-utils.cpp
+++ b/src/ir/stack-utils.cpp
@@ -186,7 +186,7 @@ StackSignature StackSignature::getLeastUpperBound(StackSignature a,
       Type::getLeastUpperBound(a.results[i], b.results[i + resultsDiff]));
   }
   return StackSignature{
-    Type(params), Type(results), a.unreachable || b.unreachable};
+    Type(params), Type(results), a.unreachable && b.unreachable};
 }
 
 StackFlow::StackFlow(Block* block) {

--- a/src/ir/stack-utils.h
+++ b/src/ir/stack-utils.h
@@ -109,17 +109,23 @@ struct StackSignature {
 
   // Whether a block whose contents have stack signature `a` could be typed with
   // stack signature `b`, i.e. whether it could be used in a context that
-  // expects signature `b`. Formally:
+  // expects signature `b`. Formally, where `a` is the LHS and `b` the RHS:
   //
   // [t1*] -> [t2*] <: [s1* t1'*] -> [s2* t2'*] iff
   //
-  //  - t1'_i <: t1_i
-  //  - t2_i <: t2'_i
-  //  - s1_i <: s2_i
+  //  - t1' <: t1
+  //  - t2 <: t2'
+  //  - s1 <: s2
+  //
+  //  Note that neither signature is unreachable in this rule and that the
+  //  cardinalities of t1* and t1'*, t2* and t2'*, and s1* and s2* must match.
   //
   // [t1*] -> [t2*] {u} <: [s1* t1'*] -> [s2* t2'*] {u?} iff
   //
   //  - [t1*] -> [t2*] <: [t1'*] -> [t2'*]
+  //
+  //  Note that s1* and s2* can have different cardinalities and arbitrary types
+  //  in this rule.
   //
   // As an example of the first rule, consider this instruction sequence:
   //

--- a/src/ir/stack-utils.h
+++ b/src/ir/stack-utils.h
@@ -111,7 +111,9 @@ struct StackSignature {
            unreachable == other.unreachable;
   }
 
-  // Returns the LUB of `a` and `b`. Assumes that a LUB exists.
+  // Returns the LUB of `a` and `b`, i.e. the minimal StackSignature that could
+  // type block contents of either type `a` or type `b`. Assumes that a LUB
+  // exists.
   static StackSignature getLeastUpperBound(StackSignature a, StackSignature b);
 };
 

--- a/src/ir/stack-utils.h
+++ b/src/ir/stack-utils.h
@@ -16,7 +16,7 @@
 
 //
 // stack-utils.h: Utilities for manipulating and analyzing stack machine code in
-// the form of Poppy IR. See src/passes/Stackify.cpp for Poppy IR documentation.
+// the form of Poppy IR. See src/passes/Poppify.cpp for Poppy IR documentation.
 //
 
 #ifndef wasm_ir_stack_h

--- a/src/ir/stack-utils.h
+++ b/src/ir/stack-utils.h
@@ -73,7 +73,7 @@ struct StackSignature {
 
   StackSignature()
     : params(Type::none), results(Type::none), unreachable(false) {}
-  StackSignature(Type params, Type results, bool unreachable = false)
+  StackSignature(Type params, Type results, bool unreachable)
     : params(params), results(results), unreachable(unreachable) {}
 
   StackSignature(const StackSignature&) = default;
@@ -98,10 +98,6 @@ struct StackSignature {
   // Return `true` iff `next` composes after this stack signature.
   bool composes(const StackSignature& next) const;
 
-  // Whether a block whose contents have this stack signature could be typed
-  // with `sig`.
-  bool satisfies(Signature sig) const;
-
   // Compose stack signatures. Assumes they actually compose.
   StackSignature& operator+=(const StackSignature& next);
   StackSignature operator+(const StackSignature& next) const;
@@ -111,9 +107,64 @@ struct StackSignature {
            unreachable == other.unreachable;
   }
 
-  // Returns the LUB of `a` and `b`, i.e. the minimal StackSignature that could
-  // type block contents of either type `a` or type `b`. Assumes that a LUB
-  // exists.
+  // Whether a block whose contents have stack signature `a` could be typed with
+  // stack signature `b`, i.e. whether it could be used in a context that
+  // expects signature `b`. Formally:
+  //
+  // [t1*] -> [t2*] <: [s1* t1'*] -> [s2* t2'*] iff
+  //
+  //  - t1'_i <: t1_i
+  //  - t2_i <: t2'_i
+  //  - s1_i <: s2_i
+  //
+  // [t1*] -> [t2*] {u} <: [s1* t1'*] -> [s2* t2'*] {u?} iff
+  //
+  //  - [t1*] -> [t2*] <: [t1'*] -> [t2'*]
+  //
+  // As an example of the first rule, consider this instruction sequence:
+  //
+  //   ref.as_func
+  //   drop
+  //   i32.add
+  //
+  // The most specific type you could give this sequence is [i32, i32, anyref]
+  // -> [i32]. But it could also be used in a context that expects [i32, i32,
+  // funcref] -> [i32] because ref.as_func can accept funcref or any other
+  // subtype of anyref. That's where the contravariance comes from. This
+  // instruction sequence could also be used anywhere that expects [f32, i32,
+  // i32, anyref] -> [f32, anyref] because the f32 simply stays on the stack
+  // throughout the sequence. That's where the the prefix extension comes from.
+  //
+  // For the second rule, consider this sequence:
+  //
+  //   ref.as_func
+  //   drop
+  //   i32.add
+  //   unreachable
+  //   i32.const 0
+  //
+  // This instruction sequence has the specific type [i32, i32, anyref] -> [i32]
+  // {u}. It can be used in any situation the previous block can be used in, but
+  // can additionally be used in contexts that expect something like [f32, i32,
+  // i32, anyref] -> [v128, i32]. Because of the unreachable polymorphism, the
+  // additional prefixes on the params and results do not need to match.
+  //
+  // Note that a reachable stack signature (without a {u}) is never a subtype of
+  // any unreachable stack signature (with a {u}). This makes sense because a
+  // sequence of instructions that has no polymorphic unreachable behavior
+  // cannot be given a type that says it does have polymorphic unreachable
+  // behavior.
+  //
+  // Also, [] -> [] {u} is the bottom type here; it is a subtype of every other
+  // stack signature. This corresponds to (unreachable) being able to be given
+  // any stack signature.
+  static bool isSubType(StackSignature a, StackSignature b);
+
+  // Returns true iff `a` and `b` have a LUB, i.e. a minimal StackSignature that
+  // could type block contents of either type `a` or type `b`.
+  static bool haveLeastUpperBound(StackSignature a, StackSignature b);
+
+  // Returns the LUB of `a` and `b`. Assumes that the LUB exists.
   static StackSignature getLeastUpperBound(StackSignature a, StackSignature b);
 };
 

--- a/src/ir/stack-utils.h
+++ b/src/ir/stack-utils.h
@@ -132,7 +132,7 @@ struct StackSignature {
   // funcref] -> [i32] because ref.as_func can accept funcref or any other
   // subtype of anyref. That's where the contravariance comes from. This
   // instruction sequence could also be used anywhere that expects [f32, i32,
-  // i32, anyref] -> [f32, anyref] because the f32 simply stays on the stack
+  // i32, anyref] -> [f32, i32] because the f32 simply stays on the stack
   // throughout the sequence. That's where the the prefix extension comes from.
   //
   // For the second rule, consider this sequence:

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -633,9 +633,11 @@ void FunctionValidator::validatePoppyBlockElements(Block* curr) {
                  curr,
                  "unreachable block should have unreachable element");
   } else {
-    if (!shouldBeTrue(blockSig.satisfies(Signature(Type::none, curr->type)),
-                      curr,
-                      "block contents should satisfy block type") &&
+    if (!shouldBeTrue(
+          StackSignature::isSubType(
+            blockSig, StackSignature(Type::none, curr->type, false)),
+          curr,
+          "block contents should satisfy block type") &&
         !info.quiet) {
       getStream() << "contents: " << blockSig.results
                   << (blockSig.unreachable ? " [unreachable]" : "") << "\n"

--- a/test/example/stack-utils.cpp
+++ b/test/example/stack-utils.cpp
@@ -221,79 +221,102 @@ void test_signature_composition() {
   }
 }
 
-void test_signature_satisfaction() {
-  std::cout << ";; Test stack signature satisfaction\n";
-  // No unreachable
+void test_signature_subtype() {
+  std::cout << ";; Test stack signature subtyping\n";
+  // Differences in unreachability only
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b(Type::i32, Type::f32);
-    assert(a.satisfies(b));
+    StackSignature a(Type::none, Type::none, true);
+    StackSignature b(Type::none, Type::none, false);
+    assert(StackSignature::isSubType(a, b));
+    assert(!StackSignature::isSubType(b, a));
+  }
+  // Covariance of results
+  {
+    StackSignature a(Type::none, Type::funcref, false);
+    StackSignature b(Type::none, Type::anyref, false);
+    assert(StackSignature::isSubType(a, b));
+    assert(!StackSignature::isSubType(b, a));
+  }
+  // Contravariance of params
+  {
+    StackSignature a(Type::anyref, Type::none, false);
+    StackSignature b(Type::funcref, Type::none, false);
+    // assert(StackSignature::isSubType(a, b));
+    // assert(!StackSignature::isSubType(b, a));
+  }
+  // First not unreachable
+  {
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b(Type::i32, Type::f32, false);
+    assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b({Type::i64, Type::i32}, {Type::i64, Type::f32});
-    assert(a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b({Type::i64, Type::i32}, {Type::i64, Type::f32}, false);
+    assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b({Type::i64, Type::i32}, {Type::i64, Type::i64, Type::f32});
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b(
+      {Type::i64, Type::i32}, {Type::i64, Type::i64, Type::f32}, false);
+    assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b({Type::i64, Type::i32}, {Type::f64, Type::f32});
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b({Type::i64, Type::i32}, {Type::f64, Type::f32}, false);
+    assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b(Type::none, Type::f32);
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b(Type::none, Type::f32, false);
+    assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b(Type::i32, Type::none);
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b(Type::i32, Type::none, false);
+    assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, false};
-    Signature b(Type::f32, Type::i32);
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature b(Type::f32, Type::i32, false);
+    assert(!StackSignature::isSubType(a, b));
   }
-  // With unreachable
+  // First unreachable
   {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b(Type::i32, Type::f32);
-    assert(a.satisfies(b));
-  }
-  {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b({Type::i64, Type::i32}, {Type::i64, Type::f32});
-    assert(a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b(Type::i32, Type::f32, false);
+    assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b({Type::i64, Type::i32}, {Type::i64, Type::i64, Type::f32});
-    assert(a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b({Type::i64, Type::i32}, {Type::i64, Type::f32}, false);
+    assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b({Type::i64, Type::i32}, {Type::f64, Type::f32});
-    assert(a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b(
+      {Type::i64, Type::i32}, {Type::i64, Type::i64, Type::f32}, false);
+    assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b(Type::none, Type::f32);
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b({Type::i64, Type::i32}, {Type::f64, Type::f32}, false);
+    assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b(Type::i32, Type::none);
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b(Type::none, Type::f32, false);
+    assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a{Type::i32, Type::f32, true};
-    Signature b(Type::f32, Type::i32);
-    assert(!a.satisfies(b));
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b(Type::i32, Type::none, false);
+    assert(!StackSignature::isSubType(a, b));
+  }
+  {
+    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature b(Type::f32, Type::i32, false);
+    assert(!StackSignature::isSubType(a, b));
   }
 }
 
@@ -302,46 +325,90 @@ void test_signature_lub() {
   {
     StackSignature a{Type::none, Type::none, false};
     StackSignature b{Type::none, Type::none, false};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
            (StackSignature{Type::none, Type::none, false}));
   }
   {
     StackSignature a{Type::none, Type::none, true};
     StackSignature b{Type::none, Type::none, false};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
            (StackSignature{Type::none, Type::none, false}));
   }
   {
     StackSignature a{Type::none, Type::none, false};
     StackSignature b{Type::none, Type::none, true};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
            (StackSignature{Type::none, Type::none, false}));
   }
   {
     StackSignature a{Type::i32, Type::none, true};
     StackSignature b{Type::none, Type::i32, true};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
            (StackSignature{Type::i32, Type::i32, true}));
   }
   {
     StackSignature a{Type::none, Type::i32, true};
     StackSignature b{Type::i32, Type::none, true};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
            (StackSignature{Type::i32, Type::i32, true}));
   }
   {
-    StackSignature a{Type::funcref, Type::externref, true};
-    StackSignature b{Type::externref, Type::funcref, true};
+    StackSignature a{Type::none, Type::externref, true};
+    StackSignature b{Type::none, Type::funcref, true};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::anyref, Type::anyref, true}));
+           (StackSignature{Type::none, Type::anyref, true}));
   }
   {
-    StackSignature a{{Type::funcref, Type::funcref}, Type::funcref, true};
-    StackSignature b{Type::externref, {Type::externref, Type::externref}, true};
+    StackSignature a{Type::anyref, Type::none, true};
+    StackSignature b{Type::funcref, Type::none, true};
+    // assert(StackSignature::haveLeastUpperBound(a, b));
+    // assert(StackSignature::getLeastUpperBound(a, b) ==
+    //        (StackSignature{Type::funcref, Type::none, true}));
+  }
+  {
+    StackSignature a{{Type::i32, Type::funcref}, Type::funcref, true};
+    StackSignature b{Type::funcref, {Type::f32, Type::externref}, true};
+    assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{{Type::anyref, Type::funcref},
-                           {Type::externref, Type::anyref},
-                           true}));
+           (StackSignature{
+             {Type::i32, Type::funcref}, {Type::f32, Type::anyref}, true}));
+  }
+  // No LUB
+  {
+    StackSignature a(Type::none, Type::i32, false);
+    StackSignature b(Type::none, Type::f32, false);
+    assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a(Type::none, Type::i32, true);
+    StackSignature b(Type::none, Type::f32, true);
+    assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a(Type::i32, Type::none, false);
+    StackSignature b(Type::f32, Type::none, false);
+    // assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a(Type::i32, Type::none, true);
+    StackSignature b(Type::f32, Type::none, true);
+    // assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a(Type::none, Type::none, false);
+    StackSignature b(Type::none, Type::i32, true);
+    assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a(Type::none, Type::none, false);
+    StackSignature b(Type::i32, Type::none, true);
+    assert(!StackSignature::haveLeastUpperBound(a, b));
   }
 }
 
@@ -483,7 +550,7 @@ int main() {
   test_remove_nops();
   test_stack_signatures();
   test_signature_composition();
-  test_signature_satisfaction();
+  test_signature_subtype();
   test_signature_lub();
   test_stack_flow();
 }

--- a/test/example/stack-utils.cpp
+++ b/test/example/stack-utils.cpp
@@ -309,13 +309,13 @@ void test_signature_lub() {
     StackSignature a{Type::none, Type::none, true};
     StackSignature b{Type::none, Type::none, false};
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::none, Type::none, true}));
+           (StackSignature{Type::none, Type::none, false}));
   }
   {
     StackSignature a{Type::none, Type::none, false};
     StackSignature b{Type::none, Type::none, true};
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::none, Type::none, true}));
+           (StackSignature{Type::none, Type::none, false}));
   }
   {
     StackSignature a{Type::i32, Type::none, true};

--- a/test/example/stack-utils.cpp
+++ b/test/example/stack-utils.cpp
@@ -410,6 +410,21 @@ void test_signature_lub() {
     StackSignature b(Type::i32, Type::none, true);
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
+  {
+    StackSignature a{Type::none, Type::i32, false};
+    StackSignature b{Type::i32, Type::none, false};
+    assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a{Type::none, Type::i32, true};
+    StackSignature b{Type::i32, Type::none, false};
+    assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
+  {
+    StackSignature a{Type::none, Type::i32, false};
+    StackSignature b{Type::i32, Type::none, true};
+    assert(!StackSignature::haveLeastUpperBound(a, b));
+  }
 }
 
 void test_stack_flow() {

--- a/test/example/stack-utils.cpp
+++ b/test/example/stack-utils.cpp
@@ -241,8 +241,8 @@ void test_signature_subtype() {
   {
     StackSignature a(Type::anyref, Type::none, false);
     StackSignature b(Type::funcref, Type::none, false);
-    // assert(StackSignature::isSubType(a, b));
-    // assert(!StackSignature::isSubType(b, a));
+    assert(StackSignature::isSubType(a, b));
+    assert(!StackSignature::isSubType(b, a));
   }
   // First not unreachable
   {

--- a/test/example/stack-utils.cpp
+++ b/test/example/stack-utils.cpp
@@ -297,6 +297,54 @@ void test_signature_satisfaction() {
   }
 }
 
+void test_signature_lub() {
+  std::cout << ";; Test stack signature lub\n";
+  {
+    StackSignature a{Type::none, Type::none, false};
+    StackSignature b{Type::none, Type::none, false};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{Type::none, Type::none, false}));
+  }
+  {
+    StackSignature a{Type::none, Type::none, true};
+    StackSignature b{Type::none, Type::none, false};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{Type::none, Type::none, true}));
+  }
+  {
+    StackSignature a{Type::none, Type::none, false};
+    StackSignature b{Type::none, Type::none, true};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{Type::none, Type::none, true}));
+  }
+  {
+    StackSignature a{Type::i32, Type::none, true};
+    StackSignature b{Type::none, Type::i32, true};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{Type::i32, Type::i32, true}));
+  }
+  {
+    StackSignature a{Type::none, Type::i32, true};
+    StackSignature b{Type::i32, Type::none, true};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{Type::i32, Type::i32, true}));
+  }
+  {
+    StackSignature a{Type::funcref, Type::externref, true};
+    StackSignature b{Type::externref, Type::funcref, true};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{Type::anyref, Type::anyref, true}));
+  }
+  {
+    StackSignature a{{Type::funcref, Type::funcref}, Type::funcref, true};
+    StackSignature b{Type::externref, {Type::externref, Type::externref}, true};
+    assert(StackSignature::getLeastUpperBound(a, b) ==
+           (StackSignature{{Type::anyref, Type::funcref},
+                           {Type::externref, Type::anyref},
+                           true}));
+  }
+}
+
 void test_stack_flow() {
   std::cout << ";; Test stack flow\n";
   {
@@ -436,5 +484,6 @@ int main() {
   test_stack_signatures();
   test_signature_composition();
   test_signature_satisfaction();
+  test_signature_lub();
   test_stack_flow();
 }

--- a/test/example/stack-utils.txt
+++ b/test/example/stack-utils.txt
@@ -13,6 +13,6 @@
 )
 ;; Test stack signatures
 ;; Test stack signature composition
-;; Test stack signature satisfaction
+;; Test stack signature subtyping
 ;; Test stack signature lub
 ;; Test stack flow

--- a/test/example/stack-utils.txt
+++ b/test/example/stack-utils.txt
@@ -14,4 +14,5 @@
 ;; Test stack signatures
 ;; Test stack signature composition
 ;; Test stack signature satisfaction
+;; Test stack signature lub
 ;; Test stack flow


### PR DESCRIPTION
Add a utility for calculating the least upper bounds of two StackSignatures,
taking into account polymorphic unreachable behavior. This will important in the
finalization and validation of Poppy IR blocks, where a block is allowed to
directly produce fewer values than the branches that target it carry if the
difference can be made up for by polymorphism due to an unreachable instruction
in the block.

Also removes the Poppy IR documentation from stack-utils.h because that
documentation is moved to the Stackify pass in #3541.