### PR TITLE
Add a test for memory.size in wasm2js

### DIFF
--- a/test/wasm2js/emscripten-grow-yes.2asm.js
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js
@@ -50,6 +50,10 @@ function asmFunc(env) {
  var infinity = Infinity;
  // EMSCRIPTEN_START_FUNCS
 ;
+ function $0() {
+  return __wasm_memory_size() | 0;
+ }
+ 
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
@@ -92,7 +96,8 @@ function asmFunc(env) {
     }
     
    }
-  })
+  }), 
+  "get_size": $0
  };
 }
 

--- a/test/wasm2js/emscripten-grow-yes.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js.opt
@@ -50,6 +50,10 @@ function asmFunc(env) {
  var infinity = Infinity;
  // EMSCRIPTEN_START_FUNCS
 ;
+ function $0() {
+  return __wasm_memory_size() | 0;
+ }
+ 
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
@@ -92,7 +96,8 @@ function asmFunc(env) {
     }
     
    }
-  })
+  }), 
+  "get_size": $0
  };
 }
 

--- a/test/wasm2js/emscripten-grow-yes.wast
+++ b/test/wasm2js/emscripten-grow-yes.wast
@@ -3,5 +3,6 @@
  (import "env" "memory" (memory $0 256 1024))
  (data (i32.const 1600) "abc")
  (export "memory" (memory $0))
+ (func (export "get_size") (result i32) (memory.size))
 )
 


### PR DESCRIPTION
Support has been there all along, but we didn't have a reference test of it.