### PR TITLE
Add feature options to wasm-dis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- `wasm-dis` now supports options to enable or disable Wasm features.
+
 v99
 ---
 

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -466,7 +466,7 @@ def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'],
     subprocess.check_call(cmd, stdout=subprocess.PIPE)
     assert os.path.exists('a.wasm')
 
-    cmd = WASM_DIS + ['a.wasm', '-o', 'ab.wast']
+    cmd = WASM_DIS + ['a.wasm', '-o', 'ab.wast', '-all']
     print('            ', ' '.join(cmd))
     if os.path.exists('ab.wast'):
         os.unlink('ab.wast')

--- a/scripts/test/wasm_opt.py
+++ b/scripts/test/wasm_opt.py
@@ -226,7 +226,7 @@ def update_wasm_opt_tests():
             subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             assert os.path.exists('a.wasm')
 
-            cmd = shared.WASM_DIS + ['a.wasm', '-o', 'a.wast']
+            cmd = shared.WASM_DIS + ['a.wasm', '-o', 'a.wast', '-all']
             print(' '.join(cmd))
             if os.path.exists('a.wast'):
                 os.unlink('a.wast')

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -72,6 +72,8 @@ int main(int argc, const char* argv[]) {
     Fatal() << "error in parsing wasm source mapping";
   }
 
+  options.applyFeatures(wasm);
+
   if (options.debug) {
     std::cerr << "Printing..." << std::endl;
   }

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -19,7 +19,6 @@
 //
 
 #include "support/colors.h"
-#include "support/command-line.h"
 #include "support/file.h"
 #include "wasm-io.h"
 
@@ -31,8 +30,8 @@ using namespace wasm;
 int main(int argc, const char* argv[]) {
   std::string sourceMapFilename;
   ToolOptions options("wasm-dis",
-                  "Un-assemble a .wasm (WebAssembly binary format) into a "
-                  ".wat (WebAssembly text format)");
+                      "Un-assemble a .wasm (WebAssembly binary format) into a "
+                      ".wat (WebAssembly text format)");
   options
     .add("--output",
          "-o",

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -23,12 +23,14 @@
 #include "support/file.h"
 #include "wasm-io.h"
 
+#include "tool-options.h"
+
 using namespace cashew;
 using namespace wasm;
 
 int main(int argc, const char* argv[]) {
   std::string sourceMapFilename;
-  Options options("wasm-dis",
+  ToolOptions options("wasm-dis",
                   "Un-assemble a .wasm (WebAssembly binary format) into a "
                   ".wat (WebAssembly text format)");
   options


### PR DESCRIPTION
This will allow .fromBinary tests be executed with the desired features
so there will be no difference between those tests and .from-wast tests.

Fixes #3545, unblocks #3517