### PR TITLE
[GC] Support RTT constants in Builder::makeConstantExpression

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2101,13 +2101,7 @@ private:
       return builder.makeRefFunc(func->name, type);
     }
     if (type.isRtt()) {
-      Expression* ret = builder.makeRttCanon(type.getHeapType());
-      if (type.getRtt().hasDepth()) {
-        for (Index i = 0; i < type.getRtt().depth; i++) {
-          ret = builder.makeRttSub(type.getHeapType(), ret);
-        }
-      }
-      return ret;
+      return builder.makeRtt(type);
     }
     if (type.isTuple()) {
       std::vector<Expression*> operands;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -826,6 +826,9 @@ public:
     if (type.isFunction()) {
       return makeRefFunc(value.getFunc(), type);
     }
+    if (type.isRtt()) {
+      return makeRtt(value.type);
+    }
     TODO_SINGLE_COMPOUND(type);
     switch (type.getBasic()) {
       case Type::externref:
@@ -851,6 +854,18 @@ public:
       }
       return makeTupleMake(consts);
     }
+  }
+
+  // Given a type, creates an RTT expression of that type, using a combination
+  // of rtt.canon and rtt.subs.
+  Expression* makeRtt(Type type) {
+    Expression* ret = makeRttCanon(type.getHeapType());
+    if (type.getRtt().hasDepth()) {
+      for (Index i = 0; i < type.getRtt().depth; i++) {
+        ret = makeRttSub(type.getHeapType(), ret);
+      }
+    }
+    return ret;
   }
 
   // Additional utility functions for building on top of nodes


### PR DESCRIPTION
This allows the reducer to operate on RTTs, but could help other
things too.