### PR TITLE
finalize: Strip "em_js" named data segment.

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1625,9 +1625,9 @@ BINARYEN_API void BinaryenMemoryInitSetSize(BinaryenExpressionRef expr,
 
 // DataDrop
 
-// Gets the index of the segment being dropped by a `memory.drop` expression.
+// Gets the index of the segment being dropped by a `data.drop` expression.
 BINARYEN_API uint32_t BinaryenDataDropGetSegment(BinaryenExpressionRef expr);
-// Sets the index of the segment being dropped by a `memory.drop` expression.
+// Sets the index of the segment being dropped by a `data.drop` expression.
 BINARYEN_API void BinaryenDataDropSetSegment(BinaryenExpressionRef expr,
                                              uint32_t segmentIndex);
 

--- a/test/lit/wasm-emscripten-finalize/em_js.wat
+++ b/test/lit/wasm-emscripten-finalize/em_js.wat
@@ -3,20 +3,32 @@
 
 ;; RUN: wasm-emscripten-finalize %s -S | filecheck %s
 
-;; Both functions should be stripped from the binary
+;; All functions should be stripped from the binary, regardless
+;; of internal name
 ;; CHECK-NOT:  (func
 
+;; The data section that contains only em_js strings should
+;; be stripped.
+;; CHECK-NOT: (i32.const 512) "Only em_js strings here\00")
+
+;; Data sections that also contain other stuff should not be stripped
+;; CHECK: (data (i32.const 1024) "some JS string data\00xxx")
+;; CHECK: (data (i32.const 2048) "more JS string data\00yyy")
+
 ;;      CHECK:  "emJsFuncs": {
-;; CHECK-NEXT:    "bar": "more JS string dara",
-;; CHECK-NEXT:    "foo": "some JS string"
+;; CHECK-NEXT:    "bar": "more JS string data",
+;; CHECK-NEXT:    "baz": "Only em_js strings here
+;; CHECK-NEXT:    "foo": "some JS string data"
 ;; CHECK-NEXT:  },
 
 (module
  (memory 1 1)
- (data (i32.const 1024) "some JS string\00")
- (data (i32.const 2048) "more JS string dara\00")
+ (data (i32.const 512) "Only em_js strings here\00")
+ (data (i32.const 1024) "some JS string data\00xxx")
+ (data (i32.const 2048) "more JS string data\00yyy")
  (export "__em_js__foo" (func $__em_js__foo))
  (export "__em_js__bar" (func $bar))
+ (export "__em_js__baz" (func $baz))
  ;; Name matches export name
  (func $__em_js__foo (result i32)
   (i32.const 1024)
@@ -24,5 +36,8 @@
  ;; Name does not match export name
  (func $bar (result i32)
   (i32.const 2048)
+ )
+ (func $baz (result i32)
+  (i32.const 512)
  )
 )


### PR DESCRIPTION
If we find a data segment with the name "em_js", strip it from the
binary.  Even in debug mode the names given to data segments by clang
will always start with ".data." or ".rodata" so there is no risk of
normal data ending up in a section with this name.

See: https://github.com/emscripten-core/emscripten/pull/13443