### PR TITLE
[GC] Support casts of function types

### DIFF
--- a/src/asm_v_wasm.h
+++ b/src/asm_v_wasm.h
@@ -26,7 +26,6 @@ namespace wasm {
 AsmType wasmToAsmType(Type type);
 
 char getSig(Type type);
-std::string getSig(Function* func);
 std::string getSig(Type results, Type params);
 
 template<typename ListType>

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -190,7 +190,8 @@ public:
   ExpressionRunner(Module* module = nullptr,
                    Index maxDepth = NO_LIMIT,
                    Index maxLoopIterations = NO_LIMIT)
-    : module(module), maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {}
+    : module(module), maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {
+  }
 
   Flow visit(Expression* curr) {
     depth++;
@@ -1888,7 +1889,8 @@ public:
   Flow visitGlobalSet(GlobalSet* curr) {
     NOTE_ENTER("GlobalSet");
     NOTE_NAME(curr->name);
-    if (!(flags & FlagValues::PRESERVE_SIDEEFFECTS) && this->module != nullptr) {
+    if (!(flags & FlagValues::PRESERVE_SIDEEFFECTS) &&
+        this->module != nullptr) {
       // If we are evaluating and not replacing the expression, remember the
       // constant value set, if any, for subsequent gets.
       auto* global = this->module->getGlobal(curr->name);
@@ -2036,7 +2038,8 @@ class InitializerExpressionRunner
 
 public:
   InitializerExpressionRunner(GlobalManager& globals, Index maxDepth)
-    : ExpressionRunner<InitializerExpressionRunner<GlobalManager>>(nullptr, maxDepth),
+    : ExpressionRunner<InitializerExpressionRunner<GlobalManager>>(nullptr,
+                                                                   maxDepth),
       globals(globals) {}
 
   Flow visitGlobalGet(GlobalGet* curr) { return Flow(globals[curr->name]); }
@@ -2397,8 +2400,8 @@ private:
     RuntimeExpressionRunner(ModuleInstanceBase& instance,
                             FunctionScope& scope,
                             Index maxDepth)
-      : ExpressionRunner<RuntimeExpressionRunner>(&instance.wasm, maxDepth), instance(instance),
-        scope(scope) {}
+      : ExpressionRunner<RuntimeExpressionRunner>(&instance.wasm, maxDepth),
+        instance(instance), scope(scope) {}
 
     Flow visitCall(Call* curr) {
       NOTE_ENTER("Call");

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1827,7 +1827,7 @@ public:
                            Index maxDepth,
                            Index maxLoopIterations)
     : ExpressionRunner<SubType>(module, maxDepth, maxLoopIterations)
-      flags(flags) {}
+        flags(flags) {}
 
   // Sets a known local value to use.
   void setLocalValue(Index index, Literals& values) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1448,6 +1448,8 @@ public:
     if (cast.originalRef.isFunction()) {
       // Function casts are simple in that they have no RTT hierarchies; instead
       // each reference has the canonical RTT for the signature.
+      // We must have a module in order to perform the cast, to get the type.
+      assert(module);
       auto* func = module->getFunction(cast.originalRef.getFunc());
       seenRtt = Literal(Type(Rtt(0, func->sig)));
       cast.castRef =

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -192,10 +192,6 @@ public:
                    Index maxLoopIterations = NO_LIMIT)
     : module(module), maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {}
 
-  ExpressionRunner(Index maxDepth = NO_LIMIT,
-                   Index maxLoopIterations = NO_LIMIT)
-    : module(nullptr), maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {}
-
   Flow visit(Expression* curr) {
     depth++;
     if (maxDepth != NO_LIMIT && depth > maxDepth) {
@@ -1452,7 +1448,7 @@ public:
       // Function casts are simple in that they have no RTT hierarchies; instead
       // each reference has the canonical RTT for the signature.
       auto* func = module->getFunction(cast.originalRef.getFunc());
-      seenRtt = Literal(Type(Rtt(func->sig)));
+      seenRtt = Literal(Type(Rtt(0, func->sig)));
       cast.castRef =
         Literal(func->name, Type(intendedRtt.type.getHeapType(), Nullable));
     } else {
@@ -2040,7 +2036,7 @@ class InitializerExpressionRunner
 
 public:
   InitializerExpressionRunner(GlobalManager& globals, Index maxDepth)
-    : ExpressionRunner<InitializerExpressionRunner<GlobalManager>>(maxDepth),
+    : ExpressionRunner<InitializerExpressionRunner<GlobalManager>>(nullptr, maxDepth),
       globals(globals) {}
 
   Flow visitGlobalGet(GlobalGet* curr) { return Flow(globals[curr->name]); }
@@ -2401,7 +2397,7 @@ private:
     RuntimeExpressionRunner(ModuleInstanceBase& instance,
                             FunctionScope& scope,
                             Index maxDepth)
-      : ExpressionRunner<RuntimeExpressionRunner>(maxDepth), instance(instance),
+      : ExpressionRunner<RuntimeExpressionRunner>(&instance.wasm, maxDepth), instance(instance),
         scope(scope) {}
 
     Flow visitCall(Call* curr) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -187,9 +187,14 @@ public:
   // Indicates no limit of maxDepth or maxLoopIterations.
   static const Index NO_LIMIT = 0;
 
+  ExpressionRunner(Module* module = nullptr,
+                   Index maxDepth = NO_LIMIT,
+                   Index maxLoopIterations = NO_LIMIT)
+    : module(module), maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {}
+
   ExpressionRunner(Index maxDepth = NO_LIMIT,
                    Index maxLoopIterations = NO_LIMIT)
-    : maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {}
+    : module(nullptr), maxDepth(maxDepth), maxLoopIterations(maxLoopIterations) {}
 
   Flow visit(Expression* curr) {
     depth++;

--- a/test/passes/Oz_fuzz-exec_all-features.txt
+++ b/test/passes/Oz_fuzz-exec_all-features.txt
@@ -25,6 +25,13 @@
 [LoggingExternalInterface logging 0]
 [fuzz-exec] calling br_on_data
 [LoggingExternalInterface logging 1]
+[fuzz-exec] calling $rtt-and-cast-on-func
+[LoggingExternalInterface logging 0]
+[LoggingExternalInterface logging 1]
+[LoggingExternalInterface logging 2]
+[LoggingExternalInterface logging 1337]
+[LoggingExternalInterface logging 3]
+[trap cast error]
 (module
  (type ${mut:i32} (struct (field (mut i32))))
  (type $none_=>_none (func))
@@ -32,6 +39,7 @@
  (type $[mut:i8] (array (mut i8)))
  (type $i32_=>_none (func (param i32)))
  (type $anyref_=>_none (func (param anyref)))
+ (type $none_=>_i32 (func (result i32)))
  (import "fuzzing-support" "log-i32" (func $log (param i32)))
  (export "structs" (func $0))
  (export "arrays" (func $1))
@@ -39,6 +47,7 @@
  (export "br_on_cast" (func $3))
  (export "cast-null-anyref-to-gc" (func $4))
  (export "br_on_data" (func $5))
+ (export "$rtt-and-cast-on-func" (func $7))
  (func $0 (; has Stack IR ;)
   (local $0 (ref null ${mut:i32}))
   (call $log
@@ -187,6 +196,42 @@
    )
   )
  )
+ (func $a-void-func (; has Stack IR ;)
+  (call $log
+   (i32.const 1337)
+  )
+ )
+ (func $7 (; has Stack IR ;)
+  (call $log
+   (i32.const 0)
+  )
+  (call $log
+   (i32.const 1)
+  )
+  (call $log
+   (i32.const 2)
+  )
+  (call_ref
+   (ref.cast $none_=>_none
+    (ref.func $a-void-func)
+    (rtt.canon $none_=>_none)
+   )
+  )
+  (call $log
+   (i32.const 3)
+  )
+  (drop
+   (call_ref
+    (ref.cast $none_=>_i32
+     (ref.func $a-void-func)
+     (rtt.canon $none_=>_i32)
+    )
+   )
+  )
+  (call $log
+   (i32.const 4)
+  )
+ )
 )
 [fuzz-exec] calling structs
 [LoggingExternalInterface logging 0]
@@ -215,3 +260,10 @@
 [LoggingExternalInterface logging 0]
 [fuzz-exec] calling br_on_data
 [LoggingExternalInterface logging 1]
+[fuzz-exec] calling $rtt-and-cast-on-func
+[LoggingExternalInterface logging 0]
+[LoggingExternalInterface logging 1]
+[LoggingExternalInterface logging 2]
+[LoggingExternalInterface logging 1337]
+[LoggingExternalInterface logging 3]
+[trap cast error]

--- a/test/passes/Oz_fuzz-exec_all-features.wast
+++ b/test/passes/Oz_fuzz-exec_all-features.wast
@@ -214,13 +214,16 @@
    (rtt.canon $int_func)
   )
   (call $log (i32.const 2))
-  (drop ;; a valid cast
+  ;; a valid cast
+  (call_ref
    (ref.cast $void_func (ref.func $a-void-func) (rtt.canon $void_func))
   )
   (call $log (i32.const 3))
-  (drop ;; an invalid cast
+  ;; an invalid cast
+  (drop (call_ref
    (ref.cast $int_func (ref.func $a-void-func) (rtt.canon $int_func))
-  )
+  ))
+  ;; will never be reached
   (call $log (i32.const 4))
  )
 )

--- a/test/passes/Oz_fuzz-exec_all-features.wast
+++ b/test/passes/Oz_fuzz-exec_all-features.wast
@@ -2,7 +2,12 @@
  (type $struct (struct (mut i32)))
  (type $extendedstruct (struct i32 f64))
  (type $bytes (array (mut i8)))
+
+ (type $void_func (func))
+ (type $int_func (func (result i32)))
+
  (import "fuzzing-support" "log-i32" (func $log (param i32)))
+
  (func "structs"
   (local $x (ref null $struct))
   (local $y (ref null $struct))
@@ -195,5 +200,27 @@
     (ref.null data)
    )
   )
+ )
+ (func $a-void-func
+  (call $log (i32.const 1337))
+ )
+ (func "$rtt-and-cast-on-func"
+  (call $log (i32.const 0))
+  (drop
+   (rtt.canon $void_func)
+  )
+  (call $log (i32.const 1))
+  (drop
+   (rtt.canon $int_func)
+  )
+  (call $log (i32.const 2))
+  (drop ;; a valid cast
+   (ref.cast $void_func (ref.func $a-void-func) (rtt.canon $void_func))
+  )
+  (call $log (i32.const 3))
+  (drop ;; an invalid cast
+   (ref.cast $int_func (ref.func $a-void-func) (rtt.canon $int_func))
+  )
+  (call $log (i32.const 4))
  )
 )


### PR DESCRIPTION
I had completely missed that the spec allows `ref.cast` etc. of function types,
and not just data. Function types do not have an RTT, unlike GC data, but we
can still cast them. A function reference has the canonical RTT of the signature
for that type, so it's like a simplified case of the GC world, without a hierarchy
of RTTs.

cc @jakobkummerow who pointed this out - thanks!

As it turns out, our validation did not rule out `rtt.canon` of a function type,
nor `ref.cast` of one, so we unintentionally already had all the support for this
aside from the actual casting, which this PR adds.

The addition is mostly trivial, except that we now need a Module in the base
ExpressionRunner class, so that we can go from a function name to the actual
function. This PR refactors things to allow that.