### PR TITLE
finalize: strip segments that contain only EM_ASM/EM_JS data

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1633,9 +1633,9 @@ BINARYEN_API void BinaryenMemoryInitSetSize(BinaryenExpressionRef expr,
 
 // DataDrop
 
-// Gets the index of the segment being dropped by a `memory.drop` expression.
+// Gets the index of the segment being dropped by a `data.drop` expression.
 BINARYEN_API uint32_t BinaryenDataDropGetSegment(BinaryenExpressionRef expr);
-// Sets the index of the segment being dropped by a `memory.drop` expression.
+// Sets the index of the segment being dropped by a `data.drop` expression.
 BINARYEN_API void BinaryenDataDropSetSegment(BinaryenExpressionRef expr,
                                              uint32_t segmentIndex);
 

--- a/test/lit/wasm-emscripten-finalize/em_asm.wat
+++ b/test/lit/wasm-emscripten-finalize/em_asm.wat
@@ -1,0 +1,29 @@
+;; Test that em_asm string are extracted correctly when the __start_em_asm
+;; and __stop_em_asm globals are exported.
+
+;; RUN: wasm-emscripten-finalize %s -S | filecheck %s
+
+;; Check that the data segment that contains only EM_ASM strings resized to
+;; zero, and that the string are extracted into the metadata.
+
+;; CHECK:      (data (i32.const 100) "normal data")
+;; CHECK-NEXT: (data (i32.const 512) "")
+;; CHECK-NEXT: (data (i32.const 1024) "more data")
+
+;; CHECK:       "asmConsts": {
+;; CHECK-NEXT:     "512": "{ console.log('JS hello'); }",
+;; CHECK-NEXT:     "541": "{ console.log('hello again'); }"
+;; CHECK-NEXT:   },
+
+;; Check that the exports are removed
+;; CHECK-NOT: export
+
+(module
+ (memory 1 1)
+ (global (export "__start_em_asm") i32 (i32.const 512))
+ (global (export "__stop_em_asm") i32 (i32.const 573))
+
+ (data (i32.const 100) "normal data")
+ (data (i32.const 512) "{ console.log('JS hello'); }\00{ console.log('hello again'); }\00")
+ (data (i32.const 1024) "more data")
+)

--- a/test/lit/wasm-emscripten-finalize/em_asm_partial.wat
+++ b/test/lit/wasm-emscripten-finalize/em_asm_partial.wat
@@ -1,0 +1,24 @@
+;; Test that em_asm string are extraced correctly when the __start_em_asm
+;; and __stop_em_asm globals are exported.
+
+;; RUN: wasm-emscripten-finalize %s -S | filecheck %s
+
+;; Check for the case when __start_em_asm and __stop_em_asm don't define an
+;; entire segment. In this case we preserve the segment but zero the data.
+
+;; CHECK: (data (i32.const 512) "xx\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00yy")
+
+;; CHECK:       "asmConsts": {
+;; CHECK-NEXT:     "514": "{ console.log('JS hello'); }",
+;; CHECK-NEXT:     "543": "{ console.log('hello again'); }"
+;; CHECK-NEXT:   },
+
+;; Check that the exports are removed
+;; CHECK-NOT: export
+
+(module
+ (memory 1 1)
+ (global (export "__start_em_asm") i32 (i32.const 514))
+ (global (export "__stop_em_asm") i32 (i32.const 575))
+ (data (i32.const 512) "xx{ console.log('JS hello'); }\00{ console.log('hello again'); }\00yy")
+)

--- a/test/lit/wasm-emscripten-finalize/em_js.wat
+++ b/test/lit/wasm-emscripten-finalize/em_js.wat
@@ -3,20 +3,32 @@
 
 ;; RUN: wasm-emscripten-finalize %s -S | filecheck %s
 
-;; Both functions should be stripped from the binary
+;; All functions should be stripped from the binary, regardless
+;; of internal name
 ;; CHECK-NOT:  (func
 
+;; The data section that contains only em_js strings should
+;; be stripped.
+;; CHECK-NOT: (i32.const 512) "Only em_js strings here\00")
+
+;; Data sections that also contain other stuff should not be stripped
+;; CHECK: (data (i32.const 1024) "some JS string data\00xxx")
+;; CHECK: (data (i32.const 2048) "more JS string data\00yyy")
+
 ;;      CHECK:  "emJsFuncs": {
-;; CHECK-NEXT:    "bar": "more JS string dara",
-;; CHECK-NEXT:    "foo": "some JS string"
+;; CHECK-NEXT:    "bar": "more JS string data",
+;; CHECK-NEXT:    "baz": "Only em_js strings here
+;; CHECK-NEXT:    "foo": "some JS string data"
 ;; CHECK-NEXT:  },
 
 (module
  (memory 1 1)
- (data (i32.const 1024) "some JS string\00")
- (data (i32.const 2048) "more JS string dara\00")
+ (data (i32.const 512) "Only em_js strings here\00")
+ (data (i32.const 1024) "some JS string data\00xxx")
+ (data (i32.const 2048) "more JS string data\00yyy")
  (export "__em_js__foo" (func $__em_js__foo))
  (export "__em_js__bar" (func $bar))
+ (export "__em_js__baz" (func $baz))
  ;; Name matches export name
  (func $__em_js__foo (result i32)
   (i32.const 1024)
@@ -24,5 +36,8 @@
  ;; Name does not match export name
  (func $bar (result i32)
   (i32.const 2048)
+ )
+ (func $baz (result i32)
+  (i32.const 512)
  )
 )


### PR DESCRIPTION
If we find a data segment whose entire contents is EM_JS or EM_ASM
strings then strip it from the binary.

This change also introduces a new way to exact EM_ASM strings based
on the __start_ and _stop_ sections symbols.   This code will no be active
until the emscripten-side change lands.

See: https://github.com/emscripten-core/emscripten/pull/13443