### PR TITLE
Simplify asmConst handling. NFC.

### DIFF
--- a/test/lit/wasm-emscripten-finalize/passive-pic.wat
+++ b/test/lit/wasm-emscripten-finalize/passive-pic.wat
@@ -4,7 +4,7 @@
 ;; RUN: wasm-emscripten-finalize --enable-bulk-memory %s -o out.wasm | filecheck %s
 
 ;; CHECK:  "asmConsts": {
-;; CHECK:    "3": ["hello", ["iii"], [""]]
+;; CHECK:    "3": "hello"
 ;; CHECK:  },
 
 (module

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -68,9 +68,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "602": ["{ return $0 + $1; }", ["iii"], [""]],
-    "625": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
+    "568": "{ Module.print(\"Hello world\"); }",
+    "602": "{ return $0 + $1; }",
+    "625": "{ Module.print(\"Got \" + $0); }"
   },
   "tableSize": 1,
   "declares": [

--- a/test/lld/em_asm.wat.out
+++ b/test/lld/em_asm.wat.out
@@ -69,9 +69,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "602": ["{ return $0 + $1; }", ["iii"], [""]],
-    "625": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
+    "568": "{ Module.print(\"Hello world\"); }",
+    "602": "{ return $0 + $1; }",
+    "625": "{ Module.print(\"Got \" + $0); }"
   },
   "tableSize": 1,
   "declares": [

--- a/test/lld/em_asm64.wat.out
+++ b/test/lld/em_asm64.wat.out
@@ -69,9 +69,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "568": ["{ Module.print(\"Hello world\"); }", ["ijj"], [""]],
-    "602": ["{ return $0 + $1; }", ["ijj"], [""]],
-    "625": ["{ Module.print(\"Got \" + $0); }", ["ijj"], [""]]
+    "568": "{ Module.print(\"Hello world\"); }",
+    "602": "{ return $0 + $1; }",
+    "625": "{ Module.print(\"Got \" + $0); }"
   },
   "tableSize": 1,
   "declares": [

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -94,9 +94,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "601": ["{ return $0 + $1; }", ["iii"], [""]],
-    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
+    "568": "{ Module.print(\"Hello world\"); }",
+    "601": "{ return $0 + $1; }",
+    "621": "{ Module.print(\"Got \" + $0); }"
   },
   "tableSize": 1,
   "declares": [

--- a/test/lld/em_asm_main_thread.wat.out
+++ b/test/lld/em_asm_main_thread.wat.out
@@ -194,9 +194,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "568": ["{ Module.print(\"Hello world\"); }", ["iii"], ["sync_on_main_thread_"]],
-    "601": ["{ return $0 + $1; }", ["iii"], ["sync_on_main_thread_"]],
-    "621": ["{ Module.print(\"Got \" + $0); }", ["iii"], ["sync_on_main_thread_"]]
+    "568": "{ Module.print(\"Hello world\"); }",
+    "601": "{ return $0 + $1; }",
+    "621": "{ Module.print(\"Got \" + $0); }"
   },
   "tableSize": 1,
   "declares": [

--- a/test/lld/em_asm_shared.wat.out
+++ b/test/lld/em_asm_shared.wat.out
@@ -95,9 +95,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "0": ["{ Module.print(\"Hello world\"); }", ["iii"], [""]],
-    "34": ["{ return $0 + $1; }", ["iii"], [""]],
-    "57": ["{ Module.print(\"Got \" + $0); }", ["iii"], [""]]
+    "0": "{ Module.print(\"Hello world\"); }",
+    "34": "{ return $0 + $1; }",
+    "57": "{ Module.print(\"Got \" + $0); }"
   },
   "tableSize": 0,
   "declares": [


### PR DESCRIPTION
Support for multiple signatures per JS code string was removed in #2422.

emscripten now only needs to know that address and the body of the JS
function.
    
See https://github.com/emscripten-core/emscripten/pull/13452 for the
emscripten side that ignores this data.