### PR TITLE
Print the features section in a comment

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3240,6 +3240,10 @@ struct PrintSExpression : public OverriddenVisitor<PrintSExpression> {
       }
       o << maybeNewLine;
     }
+    if (curr->hasFeaturesSection) {
+      doIndent(o, indent);
+      o << ";; features section: " << curr->features.toString() << '\n';
+    }
     decIndent();
     o << maybeNewLine;
     currModule = nullptr;

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -75,6 +75,21 @@ struct FeatureSet {
     }
   }
 
+  std::string toString() {
+    std::string ret;
+    uint32_t x = 1;
+    while (x != Feature::All + 1) {
+      if (features & x) {
+        if (!ret.empty()) {
+          ret += ", ";
+        }
+        ret += toString(Feature(x));
+      }
+      x <<= 1;
+    }
+    return ret;
+  }
+
   FeatureSet() : features(MVP) {}
   FeatureSet(uint32_t features) : features(features) {}
   operator uint32_t() const { return features; }

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -78,7 +78,7 @@ struct FeatureSet {
   std::string toString() {
     std::string ret;
     uint32_t x = 1;
-    while (x != Feature::All + 1) {
+    while (x & Feature::All) {
       if (features & x) {
         if (!ret.empty()) {
           ret += ", ";

--- a/test/example/c-api-multiple-tables.c
+++ b/test/example/c-api-multiple-tables.c
@@ -1,6 +1,6 @@
 #include <assert.h>
-#include <string.h>
 #include <binaryen-c.h>
+#include <string.h>
 
 // "hello world" type example: create a function that adds two i32s and returns
 // the result

--- a/test/passes/dwarf_with_exceptions.bin.txt
+++ b/test/passes/dwarf_with_exceptions.bin.txt
@@ -120,6 +120,7 @@
  ;; custom section ".debug_line", size 92
  ;; custom section ".debug_str", size 194
  ;; custom section "producers", size 137
+ ;; features section: exception-handling, reference-types
 )
 DWARF debug info
 ================
@@ -541,4 +542,5 @@ file_names[  1]:
  ;; custom section ".debug_line", size 145
  ;; custom section ".debug_str", size 194
  ;; custom section "producers", size 137
+ ;; features section: exception-handling, reference-types
 )


### PR DESCRIPTION
This can help in debugging issues with the features section.

As it happens we already had a wasm using the features section
in the test suite, so no addition was needed here...