### PR TITLE
Allow specifying additional features past the features section

### DIFF
--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -148,8 +148,8 @@ struct ToolOptions : public Options {
         FeatureSet optionsFeatures = FeatureSet::MVP;
         optionsFeatures.enable(enabledFeatures);
         optionsFeatures.disable(disabledFeatures);
-        if (module.features != optionsFeatures) {
-          Fatal() << "module features do not match specified features. "
+        if (!(module.features <= optionsFeatures)) {
+          Fatal() << "features section is not a subset of specified features. "
                   << "Use --detect-features to resolve.";
         }
       }

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -349,6 +349,10 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
         self.assertIn('anyref', disassembly)
         self.assertIn('eqref', disassembly)
 
+    def test_superset(self):
+        # It is ok to enable additional features past what is in the section.
+        self.check_features('signext_target_feature.wasm', ['sign-ext', 'simd'])
+
     def test_incompatible_features(self):
         path = self.input_path('signext_target_feature.wasm')
         p = shared.run_process(
@@ -357,7 +361,7 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
             check=False, capture_output=True
         )
         self.assertNotEqual(p.returncode, 0)
-        self.assertIn('Fatal: module features do not match specified features. ' +
+        self.assertIn('Fatal: features section is not a subset of specified features. ' +
                       'Use --detect-features to resolve.',
                       p.stderr)
 

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -351,7 +351,10 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
 
     def test_superset(self):
         # It is ok to enable additional features past what is in the section.
-        self.check_features('signext_target_feature.wasm', ['sign-ext', 'simd'])
+        shared.run_process(
+            shared.WASM_OPT + ['--print', '--detect-features', '-mvp',
+                               '--enable-simd', '--enable-sign-ext',
+                               self.input_path('signext_target_feature.wasm')])
 
     def test_incompatible_features(self):
         path = self.input_path('signext_target_feature.wasm')


### PR DESCRIPTION
Perhaps I'm missing something, but is there a reason not to allow this?
That is, if a wasm says "simd", it seems ok to let the user specify simd
as well as more features, and the the optimizer can perhaps do something
with them.