### PR TITLE
[EH] Update C and binaryen.js API for delegate

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -802,13 +802,16 @@ BINARYEN_API BinaryenExpressionRef BinaryenRefFunc(BinaryenModuleRef module,
 BINARYEN_API BinaryenExpressionRef BinaryenRefEq(BinaryenModuleRef module,
                                                  BinaryenExpressionRef left,
                                                  BinaryenExpressionRef right);
+// Try: name can be NULL. delegateTarget should be NULL in try-catch.
 BINARYEN_API BinaryenExpressionRef
 BinaryenTry(BinaryenModuleRef module,
+            const char* name,
             BinaryenExpressionRef body,
             const char** catchEvents,
             BinaryenIndex numCatchEvents,
             BinaryenExpressionRef* catchBodies,
-            BinaryenIndex numCatchBodies);
+            BinaryenIndex numCatchBodies,
+            const char* delegateTarget);
 BINARYEN_API BinaryenExpressionRef
 BinaryenThrow(BinaryenModuleRef module,
               const char* event,
@@ -1719,6 +1722,11 @@ BINARYEN_API void BinaryenRefEqSetRight(BinaryenExpressionRef expr,
 
 // Try
 
+// Gets the name (label) of a `try` expression.
+BINARYEN_API const char* BinaryenTryGetName(BinaryenExpressionRef expr);
+// Sets the name (label) of a `try` expression.
+BINARYEN_API void BinaryenTrySetName(BinaryenExpressionRef expr,
+                                     const char* name);
 // Gets the body expression of a `try` expression.
 BINARYEN_API BinaryenExpressionRef
 BinaryenTryGetBody(BinaryenExpressionRef expr);
@@ -1774,8 +1782,16 @@ BINARYEN_API void BinaryenTryInsertCatchBodyAt(BinaryenExpressionRef expr,
 // expression.
 BINARYEN_API BinaryenExpressionRef
 BinaryenTryRemoveCatchBodyAt(BinaryenExpressionRef expr, BinaryenIndex index);
-// Gets whether an `try` expression has a catch_all clause.
+// Gets whether a `try` expression has a catch_all clause.
 BINARYEN_API int BinaryenTryHasCatchAll(BinaryenExpressionRef expr);
+// Gets the target label of a `delegate`.
+BINARYEN_API const char*
+BinaryenTryGetDelegateTarget(BinaryenExpressionRef expr);
+// Sets the target label of a `delegate`.
+BINARYEN_API void BinaryenTrySetDelegateTarget(BinaryenExpressionRef expr,
+                                               const char* delegateTarget);
+// Gets whether a `try` expression is a try-delegate.
+BINARYEN_API int BinaryenTryIsDelegate(BinaryenExpressionRef expr);
 
 // Throw
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -637,81 +637,64 @@ public:
     ret->finalize();
     return ret;
   }
-  Try* makeTry(Expression* body,
-               const std::vector<Name>& catchEvents,
-               const std::vector<Expression*>& catchBodies) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->body = body;
-    ret->catchEvents.set(catchEvents);
-    ret->catchBodies.set(catchBodies);
-    ret->finalize();
-    return ret;
-  }
+private:
   Try* makeTry(Name name,
                Expression* body,
                const std::vector<Name>& catchEvents,
-               const std::vector<Expression*>& catchBodies) {
+               const std::vector<Expression*>& catchBodies,
+               Name delegateTarget,
+               Type type,
+               bool hasType) { // differentiate whether a type was passed in
     auto* ret = wasm.allocator.alloc<Try>();
     ret->name = name;
     ret->body = body;
     ret->catchEvents.set(catchEvents);
     ret->catchBodies.set(catchBodies);
-    ret->finalize();
+    if (hasType) {
+      ret->finalize(type);
+    } else {
+      ret->finalize();
+    }
     return ret;
+  }
+public:
+  Try* makeTry(Expression* body,
+               const std::vector<Name>& catchEvents,
+               const std::vector<Expression*>& catchBodies) {
+    return makeTry(
+      Name(), body, catchEvents, catchBodies, Name(), Type::none, false);
   }
   Try* makeTry(Expression* body,
                const std::vector<Name>& catchEvents,
                const std::vector<Expression*>& catchBodies,
                Type type) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->body = body;
-    ret->catchEvents.set(catchEvents);
-    ret->catchBodies.set(catchBodies);
-    ret->finalize(type);
-    return ret;
+    return makeTry(Name(), body, catchEvents, catchBodies, Name(), type, true);
+  }
+  Try* makeTry(Name name,
+               Expression* body,
+               const std::vector<Name>& catchEvents,
+               const std::vector<Expression*>& catchBodies) {
+    return makeTry(
+      name, body, catchEvents, catchBodies, Name(), Type::none, false);
   }
   Try* makeTry(Name name,
                Expression* body,
                const std::vector<Name>& catchEvents,
                const std::vector<Expression*>& catchBodies,
                Type type) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->name = name;
-    ret->body = body;
-    ret->catchEvents.set(catchEvents);
-    ret->catchBodies.set(catchBodies);
-    ret->finalize(type);
-    return ret;
+    return makeTry(name, body, catchEvents, catchBodies, Name(), type, true);
   }
   Try* makeTry(Expression* body, Name delegateTarget) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->body = body;
-    ret->delegateTarget = delegateTarget;
-    ret->finalize();
-    return ret;
-  }
-  Try* makeTry(Name name, Expression* body, Name delegateTarget) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->name = name;
-    ret->body = body;
-    ret->delegateTarget = delegateTarget;
-    ret->finalize();
-    return ret;
+    return makeTry(Name(), body, {}, {}, delegateTarget, Type::none, false);
   }
   Try* makeTry(Expression* body, Name delegateTarget, Type type) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->body = body;
-    ret->delegateTarget = delegateTarget;
-    ret->finalize(type);
-    return ret;
+    return makeTry(Name(), body, {}, {}, delegateTarget, type, true);
+  }
+  Try* makeTry(Name name, Expression* body, Name delegateTarget) {
+    return makeTry(name, body, {}, {}, delegateTarget, Type::none, false);
   }
   Try* makeTry(Name name, Expression* body, Name delegateTarget, Type type) {
-    auto* ret = wasm.allocator.alloc<Try>();
-    ret->name = name;
-    ret->body = body;
-    ret->delegateTarget = delegateTarget;
-    ret->finalize(type);
-    return ret;
+    return makeTry(name, body, {}, {}, delegateTarget, type, true);
   }
   Throw* makeThrow(Event* event, const std::vector<Expression*>& args) {
     return makeThrow(event->name, args);

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -647,6 +647,18 @@ public:
     ret->finalize();
     return ret;
   }
+  Try* makeTry(Name name,
+               Expression* body,
+               const std::vector<Name>& catchEvents,
+               const std::vector<Expression*>& catchBodies) {
+    auto* ret = wasm.allocator.alloc<Try>();
+    ret->name = name;
+    ret->body = body;
+    ret->catchEvents.set(catchEvents);
+    ret->catchBodies.set(catchBodies);
+    ret->finalize();
+    return ret;
+  }
   Try* makeTry(Expression* body,
                const std::vector<Name>& catchEvents,
                const std::vector<Expression*>& catchBodies,
@@ -655,6 +667,49 @@ public:
     ret->body = body;
     ret->catchEvents.set(catchEvents);
     ret->catchBodies.set(catchBodies);
+    ret->finalize(type);
+    return ret;
+  }
+  Try* makeTry(Name name,
+               Expression* body,
+               const std::vector<Name>& catchEvents,
+               const std::vector<Expression*>& catchBodies,
+               Type type) {
+    auto* ret = wasm.allocator.alloc<Try>();
+    ret->name = name;
+    ret->body = body;
+    ret->catchEvents.set(catchEvents);
+    ret->catchBodies.set(catchBodies);
+    ret->finalize(type);
+    return ret;
+  }
+  Try* makeTry(Expression* body, Name delegateTarget) {
+    auto* ret = wasm.allocator.alloc<Try>();
+    ret->body = body;
+    ret->delegateTarget = delegateTarget;
+    ret->finalize();
+    return ret;
+  }
+  Try* makeTry(Name name, Expression* body, Name delegateTarget) {
+    auto* ret = wasm.allocator.alloc<Try>();
+    ret->name = name;
+    ret->body = body;
+    ret->delegateTarget = delegateTarget;
+    ret->finalize();
+    return ret;
+  }
+  Try* makeTry(Expression* body, Name delegateTarget, Type type) {
+    auto* ret = wasm.allocator.alloc<Try>();
+    ret->body = body;
+    ret->delegateTarget = delegateTarget;
+    ret->finalize(type);
+    return ret;
+  }
+  Try* makeTry(Name name, Expression* body, Name delegateTarget, Type type) {
+    auto* ret = wasm.allocator.alloc<Try>();
+    ret->name = name;
+    ret->body = body;
+    ret->delegateTarget = delegateTarget;
     ret->finalize(type);
     return ret;
   }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -637,6 +637,7 @@ public:
     ret->finalize();
     return ret;
   }
+
 private:
   Try* makeTry(Name name,
                Expression* body,
@@ -657,6 +658,7 @@ private:
     }
     return ret;
   }
+
 public:
   Try* makeTry(Expression* body,
                const std::vector<Name>& catchEvents,

--- a/test/binaryen.js/exception-handling.js
+++ b/test/binaryen.js/exception-handling.js
@@ -3,7 +3,8 @@ function cleanInfo(info) {
   for (var x in info) {
     // Filter out address pointers and only print meaningful info
     if (x == 'id' || x == 'type' || x == 'name' || x == 'event' ||
-        x == 'depth' || x == 'hasCatchAll') {
+        x == 'depth' || x == 'hasCatchAll' || x == 'delegateTarget' ||
+        x == 'isDelegate') {
       ret[x] = info[x];
     }
   }
@@ -31,7 +32,8 @@ var event_ = module.addEvent("e", 0, binaryen.i32, binaryen.none);
 // )
 var throw_ = module.throw("e", [module.i32.const(0)]);
 var rethrow = module.rethrow(0);
-var try_ = module.try(
+var try_catch = module.try(
+  '',
   throw_,
   ["e"],
   [
@@ -42,14 +44,42 @@ var try_ = module.try(
       ],
       binaryen.none
     )
-  ]
+  ],
+  ''
 );
 
-var func = module.addFunction("test", binaryen.none, binaryen.none, [], try_);
+// (try $try_outer
+//   (do
+//     (try
+//       (do
+//         (throw $a-event (i32.const 0))
+//       )
+//       (delegate $try_outer)
+//     )
+//   )
+//   (catch_all)
+// )
+var try_delegate = module.try(
+  'try_outer',
+  module.try(
+    '',
+    throw_,
+    [],
+    [],
+    'try_outer'
+  ),
+  [],
+  [module.nop()],
+  ''
+);
+
+var body = module.block('', [try_catch, try_delegate])
+var func = module.addFunction("test", binaryen.none, binaryen.none, [], body);
 
 console.log(module.emitText());
 assert(module.validate());
 
 console.log("getExpressionInfo(throw) = " + stringify(throw_));
 console.log("getExpressionInfo(rethrow) = " + stringify(rethrow));
-console.log("getExpressionInfo(try) = " + stringify(try_));
+console.log("getExpressionInfo(try_catch) = " + stringify(try_catch));
+console.log("getExpressionInfo(try_delegate) = " + stringify(try_delegate));

--- a/test/binaryen.js/exception-handling.js.txt
+++ b/test/binaryen.js/exception-handling.js.txt
@@ -16,9 +16,25 @@
     (rethrow 0)
    )
   )
+  (try $try_outer
+   (do
+    (try
+     (do
+      (throw $e
+       (i32.const 0)
+      )
+     )
+     (delegate $try_outer)
+    )
+   )
+   (catch_all
+    (nop)
+   )
+  )
  )
 )
 
 getExpressionInfo(throw) = {"id":48,"type":1,"event":"e"}
 getExpressionInfo(rethrow) = {"id":49,"type":1,"depth":0}
-getExpressionInfo(try) = {"id":47,"type":1,"hasCatchAll":0}
+getExpressionInfo(try_catch) = {"id":47,"type":1,"name":"","hasCatchAll":0,"delegateTarget":"","isDelegate":0}
+getExpressionInfo(try_delegate) = {"id":47,"type":0,"name":"try_outer","hasCatchAll":1,"delegateTarget":"","isDelegate":0}

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -1469,7 +1469,7 @@ console.log("# Try");
     module.i32.const(2),
     module.i32.const(3)
   ];
-  const theTry = binaryen.Try(module.try(body, ["event1"], catchBodies));
+  const theTry = binaryen.Try(module.try('', body, ["event1"], catchBodies, ''));
   assert(theTry instanceof binaryen.Try);
   assert(theTry instanceof binaryen.Expression);
   assert(theTry.body === body);
@@ -1523,6 +1523,14 @@ console.log("# Try");
   assert(theTry.type === binaryen.i32);
 
   console.log(theTry.toText());
+
+  const tryDelegate = binaryen.Try(module.try('', body, [], [], "try_blah"));
+  assert(tryDelegate.isDelegate() == 1);
+  assert(tryDelegate.getDelegateTarget() == "try_blah");
+  tryDelegate.setDelegateTarget("try_outer");
+  assert(tryDelegate.getDelegateTarget() == "try_outer");
+  console.log(tryDelegate.toText());
+
   module.dispose();
 })();
 

--- a/test/binaryen.js/expressions.js.txt
+++ b/test/binaryen.js/expressions.js.txt
@@ -283,6 +283,13 @@
  )
 )
 
+(try (result i32)
+ (do
+  (i32.const 4)
+ )
+ (delegate $try_outer)
+)
+
 # Throw
 (throw $bar
  (i32.const 6)

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -545,9 +545,11 @@ function test_core() {
 
     // Exception handling
     module.try(
+      '',
       module.throw("a-event", [module.i32.const(0)]),
       ["a-event"],
-      [module.drop(module.i32.pop())]
+      [module.drop(module.i32.pop())],
+      ''
     ),
 
     // Atomics

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1775,6 +1775,21 @@ BinaryenFeatureAll: 8191
         (nop)
        )
       )
+      (try $try_outer
+       (do
+        (try
+         (do
+          (throw $a-event
+           (i32.const 0)
+          )
+         )
+         (delegate $try_outer)
+        )
+       )
+       (catch_all
+        (nop)
+       )
+      )
       (i32.atomic.store
        (i32.const 0)
        (i32.atomic.load


### PR DESCRIPTION
This updates C and binaryen.js API to match the new `Try` structure to
support `delegate`, added in #3561. Now `try` can take a name (which can
be null) like a block, and also has an additional `delegateTarget` field
argument which should only be used for try-delegate and otherwise null.

This also adds several more variant of `makeTry` methods in
wasm-builder. Some are for making try-delegate and some are for
try-catch(_all).