### PR TITLE
Update V8 feature flags for the fuzzer

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -252,10 +252,10 @@ def has_shell_timeout():
 V8_OPTS = [
     '--wasm-staging',
     '--experimental-wasm-eh',
-    '--experimental-wasm-simd',
-    '--experimental-wasm-reftypes',
     '--experimental-wasm-compilation-hints',
-    '--experimental-wasm-return-call'
+    '--experimental-wasm-gc',
+    '--experimental-wasm-typed-funcref',
+    '--experimental-wasm-memory64'
 ]
 
 # external tools


### PR DESCRIPTION
This removes feature flags that are now included in `--wasm-staging` and
adds new experimental flags. Does not change the fuzzer's behavior at
the moment because the fuzzer does not seem to be currently enabled for
GC or typed funcref yet.