### PR TITLE
Fix TypeBuilder bug with repeated uses of a type

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1129,8 +1129,9 @@ struct Canonicalizer {
     Item(HeapType* heapType) : kind(HeapTypeKind), heapType(heapType) {}
   };
 
-  // IDs of scanned Types and HeapTypes, used to prevent repeated scanning.
-  std::unordered_set<TypeID> scanned;
+  // Addresses of scanned Types and HeapTypes, used to prevent repeated
+  // scanning.
+  std::unordered_set<void*> scanned;
 
   // The work list of Types and HeapTypes remaining to be scanned.
   std::vector<Item> scanList;
@@ -1231,10 +1232,10 @@ void Canonicalizer::noteChild(T1 parent, T2* child) {
 void Canonicalizer::scanHeapType(HeapType* ht) {
   assert(ht->isCompound());
   visitList.push_back(ht);
-  if (scanned.count(ht->getID())) {
+  if (scanned.count(ht)) {
     return;
   }
-  scanned.insert(ht->getID());
+  scanned.insert(ht);
 
   auto* info = getHeapTypeInfo(*ht);
   switch (info->kind) {
@@ -1256,10 +1257,10 @@ void Canonicalizer::scanHeapType(HeapType* ht) {
 void Canonicalizer::scanType(Type* type) {
   assert(type->isCompound());
   visitList.push_back(type);
-  if (scanned.count(type->getID())) {
+  if (scanned.count(type)) {
     return;
   }
-  scanned.insert(type->getID());
+  scanned.insert(type);
 
   auto* info = getTypeInfo(*type);
   switch (info->kind) {

--- a/test/example/type-builder.cpp
+++ b/test/example/type-builder.cpp
@@ -70,10 +70,11 @@ void test_builder() {
 void test_canonicalization() {
   std::cout << ";; Test canonicalization\n";
 
-  // (type $struct (struct (field (ref null $sig))))
+  // (type $struct (struct (field (ref null $sig) (ref null $sig))))
   // (type $sig (func))
   HeapType sig = Signature(Type::none, Type::none);
-  HeapType struct_ = Struct({Field(Type(sig, Nullable), Immutable)});
+  HeapType struct_ = Struct({Field(Type(sig, Nullable), Immutable),
+                             Field(Type(sig, Nullable), Immutable)});
 
   TypeBuilder builder(4);
 
@@ -84,8 +85,10 @@ void test_canonicalization() {
   assert(tempSigRef1 != Type(sig, Nullable));
   assert(tempSigRef2 != Type(sig, Nullable));
 
-  builder.setHeapType(0, Struct({Field(tempSigRef1, Immutable)}));
-  builder.setHeapType(1, Struct({Field(tempSigRef2, Immutable)}));
+  builder.setHeapType(
+    0, Struct({Field(tempSigRef1, Immutable), Field(tempSigRef1, Immutable)}));
+  builder.setHeapType(
+    1, Struct({Field(tempSigRef2, Immutable), Field(tempSigRef2, Immutable)}));
   builder.setHeapType(2, Signature(Type::none, Type::none));
   builder.setHeapType(3, Signature(Type::none, Type::none));
 


### PR DESCRIPTION
Previously TypeBuilder would fail to properly replace all temporary types with
globally canonical types when a type was used more than once. Consider this
temporary type:

```
(struct (field (ref (struct)) (ref (struct))))
```

This heap type contains two `(ref (struct))` each of which contains an empty
`(struct)` heap type. The logic for avoiding duplicate scanning meant that the
first inner `(struct)` was scanned, but the second one was not. The expectation
was that this would be fine because both occurrences of `(ref (struct))` are
backed by the same temporary `TypeInfo`, so replacing the inner type of one
would update both at once. However, because scanning is depth-first, the second
`(ref (struct))` is scanned after and therefore canonicalized before the first
inner `(struct)`. Since `(ref (struct))` was canonicalized before its inner
`(struct)`, the temporary `(struct)` heap-type was accidentally leaked into the
global canonicalization of the type. This caused the global canonicalization to
be incorrect and also caused use-after-free bugs once the TypeBuilder was
disposed of.

One solution would have been to calculate a topological sort of the types to
determine the canonicalization order, but a simpler solution is to simply not
worry about duplicate work, scanning and canonicalizing every occurrence of
every type in the TypeBuilder's entries. This PR implements the simpler
solution.