### PR TITLE
Remove assertions that prevent non-assertion builds

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -156,6 +156,7 @@ Expression* TableSlotManager::Slot::makeExpr(Module& module) {
 
 void TableSlotManager::addSlot(Name func, Slot slot) {
   auto it = funcIndices.insert(std::make_pair(func, slot));
+  WASM_UNUSED(it);
   assert(it.second && "Function already has multiple table slots");
 }
 

--- a/src/passes/Poppify.cpp
+++ b/src/passes/Poppify.cpp
@@ -244,6 +244,7 @@ void Poppifier::emit(Expression* curr) {
 
 void Poppifier::emitIfElse(If* curr) {
   auto& scope = scopeStack.back();
+  WASM_UNUSED(scope);
   assert(scope.kind == Scope::If);
   patchScope(curr->ifTrue);
   scopeStack.emplace_back(Scope::Else);
@@ -251,6 +252,7 @@ void Poppifier::emitIfElse(If* curr) {
 
 void Poppifier::emitCatch(Try* curr, Index i) {
   auto& scope = scopeStack.back();
+  WASM_UNUSED(scope);
   if (i == 0) {
     assert(scope.kind == Scope::Try);
     patchScope(curr->body);
@@ -263,6 +265,7 @@ void Poppifier::emitCatch(Try* curr, Index i) {
 
 void Poppifier::emitCatchAll(Try* curr) {
   auto& scope = scopeStack.back();
+  WASM_UNUSED(scope);
   if (curr->catchBodies.size() == 1) {
     assert(scope.kind == Scope::Try);
     patchScope(curr->body);
@@ -275,6 +278,7 @@ void Poppifier::emitCatchAll(Try* curr) {
 
 void Poppifier::emitDelegate(Try* curr) {
   auto& scope = scopeStack.back();
+  WASM_UNUSED(scope);
   assert(scope.kind == Scope::Try);
   patchScope(curr->body);
   scopeStack.back().instrs.push_back(curr);
@@ -307,6 +311,7 @@ void Poppifier::emitScopeEnd(Expression* curr) {
 
 void Poppifier::emitFunctionEnd() {
   auto& scope = scopeStack.back();
+  WASM_UNUSED(scope);
   assert(scope.kind == Scope::Func);
   patchScope(func->body);
 }

--- a/src/support/debug.h
+++ b/src/support/debug.h
@@ -44,12 +44,6 @@ void setDebugEnabled(const char* types);
 
 #else
 
-// We have an option to build with assertions disabled
-// BYN_ASSERTIONS_ENABLED=OFF, but we currently don't recommend using and we
-// don't test with it.
-#error "binaryen is currently designed to be built with assertions enabled."
-#error "remove these #errors if you want to build without them anyway."
-
 #define BYN_DEBUG_WITH_TYPE(...)                                               \
   do {                                                                         \
   } while (false)

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1896,8 +1896,7 @@ public:
         this->module != nullptr) {
       // If we are evaluating and not replacing the expression, remember the
       // constant value set, if any, for subsequent gets.
-      auto* global = this->module->getGlobal(curr->name);
-      assert(global->mutable_);
+      assert(this->module->getGlobal(curr->name)->mutable_);
       auto setFlow = ExpressionRunner<SubType>::visit(curr->value);
       if (!setFlow.breaking()) {
         setGlobalValue(curr->name, setFlow.values);

--- a/third_party/llvm-project/Twine.cpp
+++ b/third_party/llvm-project/Twine.cpp
@@ -173,7 +173,6 @@ void Twine::printRepr(raw_ostream &OS) const {
   OS << ")";
 }
 
-#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void Twine::dump() const {
   print(dbgs());
 }
@@ -181,4 +180,3 @@ LLVM_DUMP_METHOD void Twine::dump() const {
 LLVM_DUMP_METHOD void Twine::dumpRepr() const {
   printRepr(dbgs());
 }
-#endif


### PR DESCRIPTION
I verified that a build without assertions builds ok with this PR.

Perhaps it makes sense to add a job that builds without assertions here? Extra work, but otherwise we'll have regressions.