### PR TITLE
Allow em_js strings to be exported as globals 

### DIFF
--- a/test/lit/wasm-emscripten-finalize/em_js.wat
+++ b/test/lit/wasm-emscripten-finalize/em_js.wat
@@ -5,7 +5,7 @@
 
 ;; All functions should be stripped from the binary, regardless
 ;; of internal name
-;; CHECK-NOT: (func
+;; CHECK-NOT: (global
 
 ;; The data section that contains only em_js strings should
 ;; be stripped (shrunk to zero size):
@@ -24,18 +24,12 @@
  (data (i32.const 1024) "some JS string data\00xxx")
  (data (i32.const 512) "Only em_js strings here\00")
  (data (i32.const 2048) "more JS string data\00yyy")
- (export "__em_js__foo" (func $__em_js__foo))
- (export "__em_js__bar" (func $bar))
- (export "__em_js__baz" (func $baz))
+ (export "__em_js__foo" (global $__em_js__foo))
+ (export "__em_js__bar" (global $bar))
+ (export "__em_js__baz" (global $baz))
  ;; Name matches export name
- (func $__em_js__foo (result i32)
-  (i32.const 1024)
- )
+ (global $__em_js__foo i32 (i32.const 1024))
  ;; Name does not match export name
- (func $bar (result i32)
-  (i32.const 2048)
- )
- (func $baz (result i32)
-  (i32.const 512)
- )
+ (global $bar i32 (i32.const 2048))
+ (global $baz i32 (i32.const 512))
 )


### PR DESCRIPTION
Previously emscripten always exports __em_js_XXX strings as function
that return the address of a string.

These days we can do better and simply export the address as a global.
Simpler and cleaner.

I've updated the lit tests to the new style but left the old test to covert
the function-exports.  Once the emscripten side lands I will remove
the legacy support and convert the other tests.


See corresponding emscripten side change: https://github.com/emscripten-core/emscripten/pull/13526

