### PR TITLE
Create a table if there is none in GenerateDynCalls::generateDynCallThunk (?)

### DIFF
--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -127,9 +127,9 @@ void GenerateDynCalls::generateDynCallThunk(Signature sig) {
   for (const auto& param : sig.params) {
     args.push_back(builder.makeLocalGet(++i, param));
   }
-  // FIXME: Should the existence of a table be ensured here? i.e. create one if
-  // there is none?
-  assert(wasm->tables.size() > 0);
+  if (wasm->tables.empty()) {
+    wasm->addTable(Builder::makeTable(Name::fromInt(0)));
+  }
   f->body = builder.makeCallIndirect(wasm->tables[0]->name, fptr, args, sig);
 
   wasm->addFunction(std::move(f));

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -128,6 +128,8 @@ void GenerateDynCalls::generateDynCallThunk(Signature sig) {
     args.push_back(builder.makeLocalGet(++i, param));
   }
   if (wasm->tables.empty()) {
+    // Add an imported table in exactly the same manner as the LLVM wasm backend
+    // would add one.
     auto* table = wasm->addTable(Builder::makeTable(Name::fromInt(0)));
     table->module = ENV;
     table->base = "__indirect_function_table";

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -128,7 +128,9 @@ void GenerateDynCalls::generateDynCallThunk(Signature sig) {
     args.push_back(builder.makeLocalGet(++i, param));
   }
   if (wasm->tables.empty()) {
-    wasm->addTable(Builder::makeTable(Name::fromInt(0)));
+    auto* table = wasm->addTable(Builder::makeTable(Name::fromInt(0)));
+    table->module = ENV;
+    table->base = "__indirect_function_table";
   }
   f->body = builder.makeCallIndirect(wasm->tables[0]->name, fptr, args, sig);
 


### PR DESCRIPTION
This was intended to fix [current LLVM=>emscripten autoroller breakage](https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8854969628629209744/+/steps/Emscripten_testsuite__upstream__wasms_/0/stdout) due to https://github.com/llvm/llvm-project/commit/f48923e884611e6271a8da821a58aedd24d91cf7
```
commit f48923e884611e6271a8da821a58aedd24d91cf7 (HEAD)
Author: Andy Wingo <wingo@igalia.com>
Date:   Wed Feb 17 17:20:28 2021 +0100

    [WebAssembly][lld] --importTable flag only imports table if needed
    
    Before, --importTable forced the creation of an indirect function table,
    whether it was needed or not.  Now it only imports a table if needed.
    
    Differential Revision: https://reviews.llvm.org/D96872
```
However, this does **not** fix the issue. The assert does not occur, but instead the test fails at runtime with
```
RuntimeError: invalid index into function table
```
I have not followed the LLVM work here so I'm not sure if there is something wrong with that LLVM change or if we need more work on the binaryen side?

cc @wingo @tlively @sbc100 
