### PR TITLE
[Wasm Exceptions] Scan catch events in RemoveUnusedModuleElements

### DIFF
--- a/test/passes/remove-unused-module-elements_all-features.txt
+++ b/test/passes/remove-unused-module-elements_all-features.txt
@@ -291,11 +291,12 @@
  )
 )
 (module
- (type $none_=>_none (func))
  (type $i32_=>_none (func (param i32)))
+ (type $none_=>_none (func))
  (type $i64_=>_none (func (param i64)))
  (event $e-export (attr 0) (param i64))
  (event $e-throw (attr 0) (param i32))
+ (event $e-catch (attr 0) (param i32))
  (export "e-export" (event $e-export))
  (start $start)
  (func $start


### PR DESCRIPTION
There was an existing test for this, it turns out.

Also refactor away some annoying repeated code in that pass. `visitTry` is
the only actual change.

Noticed by the exceptions fuzzer https://github.com/emscripten-core/emscripten/pull/13485, e.g. on `wasm-opt -O1` on
```cpp
#include <stdio.h> // avoid iostream C++ code, just test libc++abi, not libc++
#include <stdint.h>

extern void refuel();
extern void checkRecursion();
extern bool getBoolean();

struct Class {
  Class();
  ~Class();
};

void func_0() {
  while (getBoolean()) {
  }
}

int main() {
  // func_0
  puts("calling func_0");
  refuel();
  try {
    func_0();
  } catch(...) {
    puts("main caught from func_0");
  }
  return 0;
}```