### PR TITLE
[Wasm Exceptions] Fix RemoveUnusedNames on Try

### DIFF
--- a/test/passes/remove-unused-names_all-features.txt
+++ b/test/passes/remove-unused-names_all-features.txt
@@ -1,0 +1,29 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (event $event$0 (attr 0) (param i32))
+ (func $0
+  (try $label$9
+   (do
+    (nop)
+   )
+   (catch $event$0
+    (try $label$8
+     (do
+      (try
+       (do
+        (rethrow $label$9)
+       )
+       (delegate $label$8)
+      )
+     )
+     (catch $event$0
+      (drop
+       (pop i32)
+      )
+     )
+    )
+   )
+  )
+ )
+)

--- a/test/passes/remove-unused-names_all-features.wast
+++ b/test/passes/remove-unused-names_all-features.wast
@@ -1,0 +1,26 @@
+(module
+ (event $event$0 (attr 0) (param i32))
+ (func $0
+  (try $label$9 ;; needed due to a rethrow
+   (do
+   )
+   (catch $event$0
+    (try $label$8 ;; needed due to a delegate
+     (do
+      (try $label$6 ;; this one is not needed
+       (do
+        (rethrow $label$9)
+       )
+       (delegate $label$8)
+      )
+     )
+     (catch $event$0
+      (drop
+       (pop i32)
+      )
+     )
+    )
+   )
+  )
+ )
+)


### PR DESCRIPTION
The `delegate` field of Try was not being scanned, so we could
remove a name that was used only by a delegate.

The bug was because `visitTry` overrides the generic visitor
`visitExpression`. So we need to call it manually. Sadly the code here
was pretty old (I probably wrote it back in 2015 or so) and it was
misleading, as it had unnecessary calls from the generic visitor
to `visitBlock, visitLoop`, which are not needed. This PR removes
them which is shorter and cleaner.

Also, we must handle the case of the delegate field being unset,
so check `name.is()`.