### PR TITLE
Support type uses before definitions in text parser

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -175,7 +175,7 @@ static std::ostream& operator<<(std::ostream& o, const SExprType& sType) {
     o << '(';
     auto sep = "";
     for (const auto& t : type) {
-      o << sep << t;
+      o << sep << SExprType(t);
       sep = " ";
     }
     o << ')';

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -70,6 +70,8 @@ public:
   List& list();
   Element* operator[](unsigned i);
   size_t size() { return list().size(); }
+  List::Iterator begin() { return list().begin(); }
+  List::Iterator end() { return list().end(); }
 
   // string methods
   cashew::IString str() const;
@@ -140,6 +142,7 @@ public:
   SExpressionWasmBuilder(Module& wasm, Element& module, IRProfile profile);
 
 private:
+  void preParseHeapTypes(Element& module);
   // pre-parse types and function definitions, so we know function return types
   // before parsing their contents
   void preParseFunctionType(Element& s);
@@ -308,7 +311,6 @@ private:
   // Parses something like (func ..), (array ..), (struct)
   HeapType parseHeapType(Element& s);
 
-  void parseType(Element& s);
   void parseEvent(Element& s, bool preParseImport = false);
 
   Function::DebugLocation getDebugLocation(const SourceLocation& loc);

--- a/test/lit/forward-declared-types.wast
+++ b/test/lit/forward-declared-types.wast
@@ -1,0 +1,21 @@
+;; Test that types can be used before they are defined
+
+;; RUN: wasm-opt %s -all -S -o - | filecheck %s
+
+;; CHECK: (type $none_=>_none (func))
+;; CHECK: (type $[rtt_2_$none_=>_none] (array (rtt 2 $none_=>_none)))
+;; CHECK: (type ${ref?|[rtt_2_$none_=>_none]|_ref?|none_->_none|} (struct (field (ref null $[rtt_2_$none_=>_none])) (field (ref null $none_=>_none))))
+;; CHECK: (type $none_=>_ref?|{ref?|[rtt_2_$none_=>_none]|_ref?|none_->_none|}| (func (result (ref null ${ref?|[rtt_2_$none_=>_none]|_ref?|none_->_none|}))))
+
+(module
+  (type $struct (struct
+    (field (ref $array))
+    (field (ref null $func))
+  ))
+  (type $array (array (field (rtt 2 $func))))
+  (type $func (func))
+
+  (func (result (ref null $struct))
+    (unreachable)
+  )
+)

--- a/test/spec/old_func.wast
+++ b/test/spec/old_func.wast
@@ -170,19 +170,23 @@
   )
 
   (func (export "signature-implicit-reused")
+
+    ;; XXX: Use numeric indices in this test again once we have a
+    ;; spec-compliant text parser. Original comment follows.
+
     ;; The implicit index 16 in this test depends on the function and
     ;; type definitions, and may need adapting if they change.
-    (call_indirect (type 16)
+    (call_indirect (type 2) ;; XXX: was `(type 16)`
       (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
       (i32.const 0)
     )
-    (call_indirect (type 16)
+    (call_indirect (type 2) ;; XXX: was `(type 16)`
       (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
       (i32.const 2)
     )
-    (call_indirect (type 16)
+    (call_indirect (type 2) ;; XXX: was `(type 16)`
       (f64.const 0) (i64.const 0) (f64.const 0) (i64.const 0)
       (f64.const 0) (i64.const 0) (f32.const 0) (i32.const 0)
       (i32.const 3)

--- a/test/typed-function-references.wast
+++ b/test/typed-function-references.wast
@@ -1,7 +1,10 @@
 (module
   ;; inline ref type in result
-  (type $f64_=>_ref_null<_->_eqref> (func (param f64) (result (ref null (func (result eqref))))))
+  (type $_=>_eqref (func (result eqref)))
+  (type $f64_=>_ref_null<_->_eqref> (func (param f64) (result (ref null $_=>_eqref))))
   (type $=>eqref (func (result eqref)))
+  (type $=>anyref (func (result anyref)))
+  (type $mixed_results (func (result anyref f32 anyref f32)))
 
   (type $i32-i32 (func (param i32) (result i32)))
 
@@ -25,20 +28,17 @@
     (local.set $f (ref.func $call-ref-more))
     (call_ref (i32.const 42) (local.get $f))
   )
-  (func $ref-in-sig (param $0 f64) (result (ref null (func (result eqref))))
+  (func $ref-in-sig (param $0 f64) (result (ref null $=>eqref))
     (ref.null $=>eqref)
   )
   (func $type-only-in-tuple-local
-    (local $x (i32 (ref null (func (result anyref))) f64))
+    (local $x (i32 (ref null $=>anyref) f64))
   )
   (func $type-only-in-tuple-block
     (drop
-      (block (result i32 (ref null (func (result anyref f32 anyref f32))) f64)
+      (block (result i32 (ref null $mixed_results) f64)
         (unreachable)
       )
     )
-  )
-  (func $nested-type-only-there (result (ref (func (result (ref (func (param i32 i32 i32 i32 i32)))))))
-    (unreachable)
   )
 )

--- a/test/typed-function-references.wast.from-wast
+++ b/test/typed-function-references.wast.from-wast
@@ -2,15 +2,12 @@
  (type $none_=>_none (func))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_eqref (func (result eqref)))
- (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_anyref (func (result anyref)))
  (type $none_=>_anyref_f32_anyref_f32 (func (result anyref f32 anyref f32)))
  (type $ref?|i32_->_i32|_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
  (type $none_=>_i32_ref?|none_->_anyref_f32_anyref_f32|_f64 (func (result i32 (ref null $none_=>_anyref_f32_anyref_f32) f64)))
- (type $none_=>_ref?|i32_i32_i32_i32_i32_->_none| (func (result (ref null $i32_i32_i32_i32_i32_=>_none))))
  (type $f64_=>_ref?|none_->_eqref| (func (param f64) (result (ref null $none_=>_eqref))))
- (type $none_=>_ref?|none_->_ref?|i32_i32_i32_i32_i32_->_none|| (func (result (ref null $none_=>_ref?|i32_i32_i32_i32_i32_->_none|))))
  (func $call-ref
   (call_ref
    (ref.func $call-ref)
@@ -53,7 +50,7 @@
   (ref.null $none_=>_eqref)
  )
  (func $type-only-in-tuple-local
-  (local $x (i32 (ref null (func (result anyref))) f64))
+  (local $x (i32 (ref null $none_=>_anyref) f64))
   (nop)
  )
  (func $type-only-in-tuple-block
@@ -62,8 +59,5 @@
     (unreachable)
    )
   )
- )
- (func $nested-type-only-there (result (ref null $none_=>_ref?|i32_i32_i32_i32_i32_->_none|))
-  (unreachable)
  )
 )

--- a/test/typed-function-references.wast.fromBinary
+++ b/test/typed-function-references.wast.fromBinary
@@ -3,14 +3,11 @@
  (type $none_=>_anyref_f32_anyref_f32 (func (result anyref f32 anyref f32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_eqref (func (result eqref)))
- (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_anyref (func (result anyref)))
  (type $ref?|i32_->_i32|_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
  (type $none_=>_i32_ref?|none_->_anyref_f32_anyref_f32|_f64 (func (result i32 (ref null $none_=>_anyref_f32_anyref_f32) f64)))
- (type $none_=>_ref?|i32_i32_i32_i32_i32_->_none| (func (result (ref null $i32_i32_i32_i32_i32_=>_none))))
  (type $f64_=>_ref?|none_->_eqref| (func (param f64) (result (ref null $none_=>_eqref))))
- (type $none_=>_ref?|none_->_ref?|i32_i32_i32_i32_i32_->_none|| (func (result (ref null $none_=>_ref?|i32_i32_i32_i32_i32_->_none|))))
  (func $call-ref
   (call_ref
    (ref.func $call-ref)
@@ -59,7 +56,7 @@
   (nop)
  )
  (func $type-only-in-tuple-block
-  (local $0 (i32 (ref null (func (result anyref f32 anyref f32))) f64))
+  (local $0 (i32 (ref null $none_=>_anyref_f32_anyref_f32) f64))
   (local $1 (ref null $none_=>_anyref_f32_anyref_f32))
   (local $2 i32)
   (local.set $0
@@ -92,9 +89,6 @@
     (local.get $2)
    )
   )
- )
- (func $nested-type-only-there (result (ref null $none_=>_ref?|i32_i32_i32_i32_i32_->_none|))
-  (unreachable)
  )
 )
 

--- a/test/typed-function-references.wast.fromBinary.noDebugInfo
+++ b/test/typed-function-references.wast.fromBinary.noDebugInfo
@@ -3,14 +3,11 @@
  (type $none_=>_anyref_f32_anyref_f32 (func (result anyref f32 anyref f32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $none_=>_eqref (func (result eqref)))
- (type $i32_i32_i32_i32_i32_=>_none (func (param i32 i32 i32 i32 i32)))
  (type $none_=>_i32 (func (result i32)))
  (type $none_=>_anyref (func (result anyref)))
  (type $ref?|i32_->_i32|_=>_i32 (func (param (ref null $i32_=>_i32)) (result i32)))
  (type $none_=>_i32_ref?|none_->_anyref_f32_anyref_f32|_f64 (func (result i32 (ref null $none_=>_anyref_f32_anyref_f32) f64)))
- (type $none_=>_ref?|i32_i32_i32_i32_i32_->_none| (func (result (ref null $i32_i32_i32_i32_i32_=>_none))))
  (type $f64_=>_ref?|none_->_eqref| (func (param f64) (result (ref null $none_=>_eqref))))
- (type $none_=>_ref?|none_->_ref?|i32_i32_i32_i32_i32_->_none|| (func (result (ref null $none_=>_ref?|i32_i32_i32_i32_i32_->_none|))))
  (func $0
   (call_ref
    (ref.func $0)
@@ -59,7 +56,7 @@
   (nop)
  )
  (func $8
-  (local $0 (i32 (ref null (func (result anyref f32 anyref f32))) f64))
+  (local $0 (i32 (ref null $none_=>_anyref_f32_anyref_f32) f64))
   (local $1 (ref null $none_=>_anyref_f32_anyref_f32))
   (local $2 i32)
   (local.set $0
@@ -92,9 +89,6 @@
     (local.get $2)
    )
   )
- )
- (func $9 (result (ref null $none_=>_ref?|i32_i32_i32_i32_i32_->_none|))
-  (unreachable)
  )
 )
 


### PR DESCRIPTION
Traverses the module to find type definitions and uses a TypeBuilder to
construct the corresponding HeapTypes rather than constructing them directly.
This allows types to be used in the definitions of other types before they
themselves are defined, which is an important step toward supporting recursive
types. After this PR, no further text parsing changes will be necessary to
support recursive types.

Beyond allowing types to be used before their definitions, this PR also makes a
couple incidental changes to the parser's behavior. First, compound heaptypes
can now only be declared in `(type ...)` elements and cannot be declared inline
at their site of use. This reduces the flexibility of the parser, but is in line
with what the text format spec will probably look like eventually (see
WebAssembly/function-references#42).

The second change is that `(type ...)` elements are now all parsed before `(func
...)` elements rather than in text order with them, so the type indices will be
different and wasts using numeric type indices will be broken. Note however,
that we were already not completely spec compliant in this regard because we
parsed types defined by `(type...)` and `(func...)` elements before types
defined by the type uses of `call_indirect` instructions.