### PR TITLE
[Wasm Exceptions] Handle delegation to the caller in RemoveUnusedNames

### DIFF
--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -21,6 +21,7 @@
 
 #include <ir/branch-utils.h>
 #include <pass.h>
+#include <shared-constants.h>
 #include <wasm.h>
 
 namespace wasm {
@@ -85,7 +86,11 @@ struct RemoveUnusedNames
     visitExpression(curr);
   }
 
-  void visitFunction(Function* curr) { assert(branchesSeen.empty()); }
+  void visitFunction(Function* curr) {
+    // When we reach the function body we can erase delegations to the caller.
+    branchesSeen.erase(DELEGATE_CALLER_TARGET);
+    assert(branchesSeen.empty());
+  }
 };
 
 Pass* createRemoveUnusedNamesPass() { return new RemoveUnusedNames(); }

--- a/test/passes/remove-unused-names_all-features.txt
+++ b/test/passes/remove-unused-names_all-features.txt
@@ -26,4 +26,12 @@
    )
   )
  )
+ (func $1
+  (try
+   (do
+    (nop)
+   )
+   (delegate 0)
+  )
+ )
 )

--- a/test/passes/remove-unused-names_all-features.wast
+++ b/test/passes/remove-unused-names_all-features.wast
@@ -23,4 +23,12 @@
    )
   )
  )
+ (func $1
+  (try $label$3
+   (do
+    (nop)
+   )
+   (delegate 0) ;; delegates to the caller
+  )
+ )
 )


### PR DESCRIPTION
Without this, the assertion just below fires, as we should erase each
branch target after we reach it, end end up with nothing left.

After this fix it looks like fuzzing can't find anything new after ~1000
iterations (100x more than before).