### PR TITLE
wasm-reduce: Do not verify binary roundtripping when not using binary files

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1249,7 +1249,7 @@ int main(int argc, const char* argv[]) {
 
   if (binary) {
     std::cerr << "|checking that command has expected behavior on "
-                " canonicalized (read-written) binary\n";
+                 " canonicalized (read-written) binary\n";
     {
       // read and write it
       auto cmd = Path::getBinaryenBinaryTool("wasm-opt") + " " + input +

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1247,24 +1247,26 @@ int main(int argc, const char* argv[]) {
     }
   }
 
-  std::cerr << "|checking that command has expected behavior on canonicalized "
-               "(read-written) binary\n";
-  {
-    // read and write it
-    auto cmd = Path::getBinaryenBinaryTool("wasm-opt") + " " + input + " -o " +
-               test + " " + extraFlags;
-    if (!binary) {
-      cmd += " -S ";
-    }
-    ProgramResult readWrite(cmd);
-    if (readWrite.failed()) {
-      stopIfNotForced("failed to read and write the binary", readWrite);
-    } else {
-      ProgramResult result(command);
-      if (result != expected) {
-        stopIfNotForced("running command on the canonicalized module should "
-                        "give the same results",
-                        result);
+  if (binary) {
+    std::cerr << "|checking that command has expected behavior on "
+                " canonicalized (read-written) binary\n";
+    {
+      // read and write it
+      auto cmd = Path::getBinaryenBinaryTool("wasm-opt") + " " + input +
+                 " -o " + test + " " + extraFlags;
+      if (!binary) {
+        cmd += " -S ";
+      }
+      ProgramResult readWrite(cmd);
+      if (readWrite.failed()) {
+        stopIfNotForced("failed to read and write the binary", readWrite);
+      } else {
+        ProgramResult result(command);
+        if (result != expected) {
+          stopIfNotForced("running command on the canonicalized module should "
+                          "give the same results",
+                          result);
+        }
       }
     }
   }


### PR DESCRIPTION
A reduction on text files may be done on text because binary writing is
where the bug is.

Diff is 99% whitespace.