### PR TITLE
Add C and JS API functions for accessing memory info (#3573)

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3511,6 +3511,37 @@ uint32_t BinaryenGetMemorySegmentByteOffset(BinaryenModuleRef module,
   Fatal() << "non-constant offsets aren't supported yet";
   return 0;
 }
+int BinaryenHasMemory(BinaryenModuleRef module) {
+  return ((Module*)module)->memory.exists;
+}
+size_t BinaryenMemoryGetInitial(BinaryenModuleRef module) {
+  return ((Module*)module)->memory.initial;
+}
+int BinaryenMemoryHasMax(BinaryenModuleRef module) {
+  return ((Module*)module)->memory.hasMax();
+}
+size_t BinaryenMemoryGetMax(BinaryenModuleRef module) {
+  return ((Module*)module)->memory.max;
+}
+const char* BinaryenMemoryImportGetModule(BinaryenModuleRef module) {
+  auto& memory = ((Module*)module)->memory;
+  if (memory.imported()) {
+    return memory.module.c_str();
+  } else {
+    return "";
+  }
+}
+const char* BinaryenMemoryImportGetBase(BinaryenModuleRef module) {
+  auto& memory = ((Module*)module)->memory;
+  if (memory.imported()) {
+    return memory.base.c_str();
+  } else {
+    return "";
+  }
+}
+int BinaryenMemoryGetShared(BinaryenModuleRef module) {
+  return ((Module*)module)->memory.shared;
+}
 size_t BinaryenGetMemorySegmentByteLength(BinaryenModuleRef module,
                                           BinaryenIndex id) {
   const auto& segments = ((Module*)module)->memory.segments;

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3514,13 +3514,13 @@ uint32_t BinaryenGetMemorySegmentByteOffset(BinaryenModuleRef module,
 int BinaryenHasMemory(BinaryenModuleRef module) {
   return ((Module*)module)->memory.exists;
 }
-size_t BinaryenMemoryGetInitial(BinaryenModuleRef module) {
+BinaryenIndex BinaryenMemoryGetInitial(BinaryenModuleRef module) {
   return ((Module*)module)->memory.initial;
 }
 int BinaryenMemoryHasMax(BinaryenModuleRef module) {
   return ((Module*)module)->memory.hasMax();
 }
-size_t BinaryenMemoryGetMax(BinaryenModuleRef module) {
+BinaryenIndex BinaryenMemoryGetMax(BinaryenModuleRef module) {
   return ((Module*)module)->memory.max;
 }
 const char* BinaryenMemoryImportGetModule(BinaryenModuleRef module) {
@@ -3539,7 +3539,7 @@ const char* BinaryenMemoryImportGetBase(BinaryenModuleRef module) {
     return "";
   }
 }
-int BinaryenMemoryGetShared(BinaryenModuleRef module) {
+int BinaryenMemoryIsShared(BinaryenModuleRef module) {
   return ((Module*)module)->memory.shared;
 }
 size_t BinaryenGetMemorySegmentByteLength(BinaryenModuleRef module,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2098,13 +2098,13 @@ BINARYEN_API void BinaryenSetMemory(BinaryenModuleRef module,
                                     uint8_t shared);
 
 BINARYEN_API int BinaryenHasMemory(BinaryenModuleRef module);
-BINARYEN_API size_t BinaryenMemoryGetInitial(BinaryenModuleRef module);
+BINARYEN_API BinaryenIndex BinaryenMemoryGetInitial(BinaryenModuleRef module);
 BINARYEN_API int BinaryenMemoryHasMax(BinaryenModuleRef module);
-BINARYEN_API size_t BinaryenMemoryGetMax(BinaryenModuleRef module);
+BINARYEN_API BinaryenIndex BinaryenMemoryGetMax(BinaryenModuleRef module);
 BINARYEN_API const char*
 BinaryenMemoryImportGetModule(BinaryenModuleRef module);
 BINARYEN_API const char* BinaryenMemoryImportGetBase(BinaryenModuleRef module);
-BINARYEN_API int BinaryenMemoryGetShared(BinaryenModuleRef module);
+BINARYEN_API int BinaryenMemoryIsShared(BinaryenModuleRef module);
 
 // Memory segments. Query utilities.
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2101,7 +2101,8 @@ BINARYEN_API int BinaryenHasMemory(BinaryenModuleRef module);
 BINARYEN_API size_t BinaryenMemoryGetInitial(BinaryenModuleRef module);
 BINARYEN_API int BinaryenMemoryHasMax(BinaryenModuleRef module);
 BINARYEN_API size_t BinaryenMemoryGetMax(BinaryenModuleRef module);
-BINARYEN_API const char* BinaryenMemoryImportGetModule(BinaryenModuleRef module);
+BINARYEN_API const char*
+BinaryenMemoryImportGetModule(BinaryenModuleRef module);
 BINARYEN_API const char* BinaryenMemoryImportGetBase(BinaryenModuleRef module);
 BINARYEN_API int BinaryenMemoryGetShared(BinaryenModuleRef module);
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2097,6 +2097,14 @@ BINARYEN_API void BinaryenSetMemory(BinaryenModuleRef module,
                                     BinaryenIndex numSegments,
                                     uint8_t shared);
 
+BINARYEN_API int BinaryenHasMemory(BinaryenModuleRef module);
+BINARYEN_API size_t BinaryenMemoryGetInitial(BinaryenModuleRef module);
+BINARYEN_API int BinaryenMemoryHasMax(BinaryenModuleRef module);
+BINARYEN_API size_t BinaryenMemoryGetMax(BinaryenModuleRef module);
+BINARYEN_API const char* BinaryenMemoryImportGetModule(BinaryenModuleRef module);
+BINARYEN_API const char* BinaryenMemoryImportGetBase(BinaryenModuleRef module);
+BINARYEN_API int BinaryenMemoryGetShared(BinaryenModuleRef module);
+
 // Memory segments. Query utilities.
 
 BINARYEN_API uint32_t BinaryenGetNumMemorySegments(BinaryenModuleRef module);

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2333,7 +2333,7 @@ function wrapModule(module, self = {}) {
       'module': UTF8ToString(Module['_BinaryenMemoryImportGetModule'](module)),
       'base': UTF8ToString(Module['_BinaryenMemoryImportGetBase'](module)),
       'initial': Module['_BinaryenMemoryGetInitial'](module),
-      'shared': Boolean(Module['_BinaryenMemoryGetShared'](module))
+      'shared': Boolean(Module['_BinaryenMemoryIsShared'](module))
     };
 
     if (hasMax) {

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2324,9 +2324,27 @@ function wrapModule(module, self = {}) {
       );
     });
   };
+  self['hasMemory'] = function() {
+    return Boolean(Module['_BinaryenHasMemory'](module));
+  };
+  self['getMemoryInfo'] = function() {
+    var hasMax = Boolean(Module['_BinaryenMemoryHasMax'](module));
+    var memoryInfo = {
+      'module': UTF8ToString(Module['_BinaryenMemoryImportGetModule'](module)),
+      'base': UTF8ToString(Module['_BinaryenMemoryImportGetBase'](module)),
+      'initial': Module['_BinaryenMemoryGetInitial'](module),
+      'shared': Boolean(Module['_BinaryenMemoryGetShared'](module))
+    };
+
+    if (hasMax) {
+      memoryInfo['max'] = Module['_BinaryenMemoryGetMax'](module);
+    }
+
+    return memoryInfo;
+  };
   self['getNumMemorySegments'] = function() {
     return Module['_BinaryenGetNumMemorySegments'](module);
-  }
+  };
   self['getMemorySegmentInfoByIndex'] = function(id) {
     return {
       'offset': Module['_BinaryenGetMemorySegmentByteOffset'](module, id),
@@ -2341,7 +2359,7 @@ function wrapModule(module, self = {}) {
       })(),
       'passive': Boolean(Module['_BinaryenGetMemorySegmentPassive'](module, id))
     };
-  }
+  };
   self['setStart'] = function(start) {
     return Module['_BinaryenSetStart'](module, start);
   };

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2328,18 +2328,17 @@ function wrapModule(module, self = {}) {
     return Boolean(Module['_BinaryenHasMemory'](module));
   };
   self['getMemoryInfo'] = function() {
-    var hasMax = Boolean(Module['_BinaryenMemoryHasMax'](module));
     var memoryInfo = {
       'module': UTF8ToString(Module['_BinaryenMemoryImportGetModule'](module)),
       'base': UTF8ToString(Module['_BinaryenMemoryImportGetBase'](module)),
-      'initial': Module['_BinaryenMemoryGetInitial'](module),
-      'shared': Boolean(Module['_BinaryenMemoryIsShared'](module))
     };
-
-    if (hasMax) {
-      memoryInfo['max'] = Module['_BinaryenMemoryGetMax'](module);
+    if (memoryInfo['module'] === '' && memoryInfo['base'] === '') {
+      memoryInfo['initial'] = Module['_BinaryenMemoryGetInitial'](module);
+      if (Module['_BinaryenMemoryHasMax'](module)) {
+        memoryInfo['max'] = Module['_BinaryenMemoryGetMax'](module);
+      }
     }
-
+    memoryInfo['shared'] = Boolean(Module['_BinaryenMemoryIsShared'](module));
     return memoryInfo;
   };
   self['getNumMemorySegments'] = function() {

--- a/test/binaryen.js/memory-info.js
+++ b/test/binaryen.js/memory-info.js
@@ -1,0 +1,35 @@
+var module = new binaryen.Module();
+assert(module.validate());
+console.log(JSON.stringify(module.hasMemory()));
+
+var initial = 1, maximum = 64;
+
+// Not shared
+module = new binaryen.Module();
+module.setMemory(initial, maximum, '');
+assert(module.validate());
+console.log(JSON.stringify(module.hasMemory()));
+console.log(JSON.stringify(module.getMemoryInfo()));
+
+// Shared
+module = new binaryen.Module();
+module.setFeatures(binaryen.Features.MVP | binaryen.Features.Atomics);
+module.setMemory(initial, maximum, '', [], true);
+assert(module.validate());
+console.log(JSON.stringify(module.hasMemory()));
+console.log(JSON.stringify(module.getMemoryInfo()));
+
+// Imported, not shared
+module = new binaryen.Module();
+module.addMemoryImport('my_mem', 'env', 'memory', false);
+assert(module.validate());
+console.log(JSON.stringify(module.hasMemory()));
+console.log(JSON.stringify(module.getMemoryInfo()));
+
+// Imported, shared
+module = new binaryen.Module();
+module.setFeatures(binaryen.Features.MVP | binaryen.Features.Atomics);
+module.addMemoryImport('my_mem', 'env', 'memory', true);
+assert(module.validate());
+console.log(JSON.stringify(module.hasMemory()));
+console.log(JSON.stringify(module.getMemoryInfo()));

--- a/test/binaryen.js/memory-info.js.txt
+++ b/test/binaryen.js/memory-info.js.txt
@@ -1,0 +1,9 @@
+false
+true
+{"module":"","base":"","initial":1,"max":64,"shared":false}
+true
+{"module":"","base":"","initial":1,"max":64,"shared":true}
+false
+{"module":"env","base":"memory","shared":false}
+false
+{"module":"env","base":"memory","shared":true}


### PR DESCRIPTION
This allows identifying whether a memory is present on the module,
getting its initial and, if present, maximum sizes, and whether it's
shared as well as its import module and base name if imported.

Will require a matching update to index.d.ts in binaryen.js for
type hinting when used via npm.