### PR TITLE
[Wasm Exceptions] Fix StackIR writing of nested delegates

### DIFF
--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -350,6 +350,8 @@ template<typename SubType> void BinaryenIRWriter<SubType>::visitTry(Try* curr) {
   }
   if (curr->isDelegate()) {
     emitDelegate(curr);
+    // Note that when we emit a delegate we do not need to also emit a scope
+    // ending, as the delegate ends the scope.
   } else {
     emitScopeEnd(curr);
   }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1925,6 +1925,9 @@ void BinaryInstWriter::emitCatchAll(Try* curr) {
 }
 
 void BinaryInstWriter::emitDelegate(Try* curr) {
+  // The delegate ends the scope in effect, and pops the try's name. Note that
+  // the getBreakIndex is intentionally after that pop, as the delegate cannot
+  // target its own try.
   assert(!breakStack.empty());
   breakStack.pop_back();
   o << int8_t(BinaryConsts::Delegate)
@@ -2333,6 +2336,8 @@ void StackIRToBinaryWriter::write() {
       }
       case StackInst::Delegate: {
         writer.emitDelegate(inst->origin->cast<Try>());
+        // Delegates end the try, like a TryEnd.
+        catchIndexStack.pop_back();
         break;
       }
       default:

--- a/test/passes/generate-stack-ir_roundtrip_all-features.txt
+++ b/test/passes/generate-stack-ir_roundtrip_all-features.txt
@@ -1,0 +1,32 @@
+(module
+ (type $none_=>_none (func))
+ (type $i32_=>_none (func (param i32)))
+ (event $event$0 (attr 0) (param i32))
+ (func $delegate-child
+  (try $label$9
+   (do
+    (try $label$7
+     (do
+      (nop)
+     )
+     (catch $event$0
+      (drop
+       (pop i32)
+      )
+      (try $label$6
+       (do
+        (nop)
+       )
+       (delegate 2)
+      )
+     )
+    )
+   )
+   (catch $event$0
+    (drop
+     (pop i32)
+    )
+   )
+  )
+ )
+)

--- a/test/passes/generate-stack-ir_roundtrip_all-features.wast
+++ b/test/passes/generate-stack-ir_roundtrip_all-features.wast
@@ -11,6 +11,10 @@
       )
       (try
        (do)
+       ;; the binary writer must properly handle this delegate which is the
+       ;; child of other try's, and not get confused by their information on the
+       ;; stack (this is a regression test for us properly ending the scope with
+       ;; a delegate and popping the stack of break targets).
        (delegate 2)
       )
      )

--- a/test/passes/generate-stack-ir_roundtrip_all-features.wast
+++ b/test/passes/generate-stack-ir_roundtrip_all-features.wast
@@ -14,7 +14,7 @@
        ;; the binary writer must properly handle this delegate which is the
        ;; child of other try's, and not get confused by their information on the
        ;; stack (this is a regression test for us properly ending the scope with
-       ;; a delegate and popping the stack of break targets).
+       ;; a delegate and popping the relevant stack).
        (delegate 2)
       )
      )

--- a/test/passes/generate-stack-ir_roundtrip_all-features.wast
+++ b/test/passes/generate-stack-ir_roundtrip_all-features.wast
@@ -1,0 +1,27 @@
+(module
+ (event $event (attr 0) (param i32))
+ (func $delegate-child
+  (try
+   (do
+    (try
+     (do)
+     (catch $event
+      (drop
+       (pop i32)
+      )
+      (try
+       (do)
+       (delegate 2)
+      )
+     )
+    )
+   )
+   (catch $event
+    (drop
+     (pop i32)
+    )
+   )
+  )
+ )
+)
+


### PR DESCRIPTION
We were missing a pop of catchIndexStack at a Delegate. It ends the scope,
so it should do that, like TryEnd does.

Found by https://github.com/emscripten-core/emscripten/pull/13485 on `-O2`.