### PR TITLE
[Wasm GC] Move struct field names to their proper place

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -405,12 +405,11 @@ struct Field {
     i16,
   } packedType; // applicable iff type=i32
   Mutability mutable_;
-  Name name;
 
-  Field(Type type, Mutability mutable_, Name name = Name())
-    : type(type), packedType(not_packed), mutable_(mutable_), name(name) {}
-  Field(PackedType packedType, Mutability mutable_, Name name = Name())
-    : type(Type::i32), packedType(packedType), mutable_(mutable_), name(name) {}
+  Field(Type type, Mutability mutable_)
+    : type(type), packedType(not_packed), mutable_(mutable_) {}
+  Field(PackedType packedType, Mutability mutable_)
+    : type(Type::i32), packedType(packedType), mutable_(mutable_) {}
 
   constexpr bool isPacked() const {
     if (packedType != not_packed) {
@@ -421,8 +420,6 @@ struct Field {
   }
 
   bool operator==(const Field& other) const {
-    // Note that the name is not checked here - it is pure metadata for printing
-    // purposes only.
     return type == other.type && packedType == other.packedType &&
            mutable_ == other.mutable_;
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -782,7 +782,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
                      builder.getTempTupleType(results));
   };
 
-  // Mapes type indexes to a mapping of field index => name. We store the data
+  // Maps type indexes to a mapping of field index => name. We store the data
   // here while parsing as types have not been created yet.
   std::unordered_map<size_t, std::unordered_map<Index, Name>> fieldNames;
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -787,38 +787,39 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
   std::unordered_map<size_t, std::unordered_map<Index, Name>> fieldNames;
 
   // Parses a field, and optionally notes the name with a type index.
-  auto parseField = [&](Element* elem, size_t typeIndex = -1, size_t fieldIndex = -1) {
-    Mutability mutable_ = Immutable;
-    // elem is a list, containing either
-    //   TYPE
-    // or
-    //   (field TYPE)
-    // or
-    //   (field $name TYPE)
-    if (elementStartsWith(elem, FIELD)) {
-      if (elem->size() == 3 && typeIndex != size_t(-1)) {
-        Name name = (*elem)[1]->str();
-        fieldNames[typeIndex][fieldIndex] = name;
+  auto parseField =
+    [&](Element* elem, size_t typeIndex = -1, size_t fieldIndex = -1) {
+      Mutability mutable_ = Immutable;
+      // elem is a list, containing either
+      //   TYPE
+      // or
+      //   (field TYPE)
+      // or
+      //   (field $name TYPE)
+      if (elementStartsWith(elem, FIELD)) {
+        if (elem->size() == 3 && typeIndex != size_t(-1)) {
+          Name name = (*elem)[1]->str();
+          fieldNames[typeIndex][fieldIndex] = name;
+        }
+        elem = (*elem)[elem->size() - 1];
       }
-      elem = (*elem)[elem->size() - 1];
-    }
-    // The element may also be (mut (..)).
-    if (elementStartsWith(elem, MUT)) {
-      mutable_ = Mutable;
-      elem = (*elem)[1];
-    }
-    if (elem->isStr()) {
-      // elem is a simple string name like "i32". It can be a normal wasm type,
-      // or one of the special types only available in fields.
-      if (*elem == I8) {
-        return Field(Field::i8, mutable_);
-      } else if (*elem == I16) {
-        return Field(Field::i16, mutable_);
+      // The element may also be (mut (..)).
+      if (elementStartsWith(elem, MUT)) {
+        mutable_ = Mutable;
+        elem = (*elem)[1];
       }
-    }
-    // Otherwise it's an arbitrary type.
-    return Field(parseValType(*elem), mutable_);
-  };
+      if (elem->isStr()) {
+        // elem is a simple string name like "i32". It can be a normal wasm
+        // type, or one of the special types only available in fields.
+        if (*elem == I8) {
+          return Field(Field::i8, mutable_);
+        } else if (*elem == I16) {
+          return Field(Field::i16, mutable_);
+        }
+      }
+      // Otherwise it's an arbitrary type.
+      return Field(parseValType(*elem), mutable_);
+    };
 
   auto parseStructDef = [&](Element& elem, size_t typeIndex) {
     FieldList fields;

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -787,38 +787,37 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
   std::unordered_map<size_t, std::unordered_map<Index, Name>> fieldNames;
 
   // Parses a field, and notes the name if one is found.
-  auto parseField =
-    [&](Element* elem, Name& name) {
-      Mutability mutable_ = Immutable;
-      // elem is a list, containing either
-      //   TYPE
-      // or
-      //   (field TYPE)
-      // or
-      //   (field $name TYPE)
-      if (elementStartsWith(elem, FIELD)) {
-        if (elem->size() == 3) {
-          name = (*elem)[1]->str();
-        }
-        elem = (*elem)[elem->size() - 1];
+  auto parseField = [&](Element* elem, Name& name) {
+    Mutability mutable_ = Immutable;
+    // elem is a list, containing either
+    //   TYPE
+    // or
+    //   (field TYPE)
+    // or
+    //   (field $name TYPE)
+    if (elementStartsWith(elem, FIELD)) {
+      if (elem->size() == 3) {
+        name = (*elem)[1]->str();
       }
-      // The element may also be (mut (..)).
-      if (elementStartsWith(elem, MUT)) {
-        mutable_ = Mutable;
-        elem = (*elem)[1];
+      elem = (*elem)[elem->size() - 1];
+    }
+    // The element may also be (mut (..)).
+    if (elementStartsWith(elem, MUT)) {
+      mutable_ = Mutable;
+      elem = (*elem)[1];
+    }
+    if (elem->isStr()) {
+      // elem is a simple string name like "i32". It can be a normal wasm
+      // type, or one of the special types only available in fields.
+      if (*elem == I8) {
+        return Field(Field::i8, mutable_);
+      } else if (*elem == I16) {
+        return Field(Field::i16, mutable_);
       }
-      if (elem->isStr()) {
-        // elem is a simple string name like "i32". It can be a normal wasm
-        // type, or one of the special types only available in fields.
-        if (*elem == I8) {
-          return Field(Field::i8, mutable_);
-        } else if (*elem == I16) {
-          return Field(Field::i16, mutable_);
-        }
-      }
-      // Otherwise it's an arbitrary type.
-      return Field(parseValType(*elem), mutable_);
-    };
+    }
+    // Otherwise it's an arbitrary type.
+    return Field(parseValType(*elem), mutable_);
+  };
 
   auto parseStructDef = [&](Element& elem, size_t typeIndex) {
     FieldList fields;

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -828,8 +828,8 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
   };
 
   auto parseArrayDef = [&](Element& elem) {
-    Name dummy;
-    return Array(parseField(elem[1], dummy));
+    Name unused;
+    return Array(parseField(elem[1], unused));
   };
 
   size_t index = 0;


### PR DESCRIPTION
#3591 adds type and field names to the Module object, and used that
for the type but not the fields. This uses it for the fields as well, and removes
the "name" field from the Field objects itself, completing the refactoring.

After this, binary format support can be added as a proper replacement for
#3589

edit: a big part of this is just whitespace