### PR TITLE
Slightly improve new table C APIs

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3910,13 +3910,24 @@ void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func,
 const char* BinaryenTableGetName(BinaryenTableRef table) {
   return ((Table*)table)->name.c_str();
 }
-int BinaryenTableGetInitial(BinaryenTableRef table) {
+void BinaryenTableSetName(BinaryenTableRef table, const char* name) {
+  ((Table*)table)->name = name;
+}
+BinaryenIndex BinaryenTableGetInitial(BinaryenTableRef table) {
   return ((Table*)table)->initial;
+}
+void BinaryenTableSetInitial(BinaryenTableRef table, BinaryenIndex initial) {
+  ((Table*)table)->initial = initial;
 }
 int BinaryenTableHasMax(BinaryenTableRef table) {
   return ((Table*)table)->hasMax();
 }
-int BinaryenTableGetMax(BinaryenTableRef table) { return ((Table*)table)->max; }
+BinaryenIndex BinaryenTableGetMax(BinaryenTableRef table) {
+  return ((Table*)table)->max;
+}
+void BinaryenTableSetMax(BinaryenTableRef table, BinaryenIndex max) {
+  ((Table*)table)->max = max;
+}
 
 //
 // =========== Global operations ===========

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2376,10 +2376,23 @@ BINARYEN_API void BinaryenFunctionSetDebugLocation(BinaryenFunctionRef func,
 // ========== Table Operations ==========
 //
 
+// Gets the name of the specified `Table`.
 BINARYEN_API const char* BinaryenTableGetName(BinaryenTableRef table);
-BINARYEN_API int BinaryenTableGetInitial(BinaryenTableRef table);
+// Sets the name of the specified `Table`.
+BINARYEN_API void BinaryenTableSetName(BinaryenTableRef table,
+                                       const char* name);
+// Gets the initial number of pages of the specified `Table`.
+BINARYEN_API BinaryenIndex BinaryenTableGetInitial(BinaryenTableRef table);
+// Sets the initial number of pages of the specified `Table`.
+BINARYEN_API void BinaryenTableSetInitial(BinaryenTableRef table,
+                                          BinaryenIndex initial);
+// Tests whether the specified `Table` has a maximum number of pages.
 BINARYEN_API int BinaryenTableHasMax(BinaryenTableRef table);
-BINARYEN_API int BinaryenTableGetMax(BinaryenTableRef table);
+// Gets the maximum number of pages of the specified `Table`.
+BINARYEN_API BinaryenIndex BinaryenTableGetMax(BinaryenTableRef table);
+// Sets the maximum number of pages of the specified `Table`.
+BINARYEN_API void BinaryenTableSetMax(BinaryenTableRef table,
+                                      BinaryenIndex max);
 
 //
 // ========== Global Operations ==========

--- a/test/example/c-api-multiple-tables.c
+++ b/test/example/c-api-multiple-tables.c
@@ -51,9 +51,15 @@ int main() {
     assert(t2 != NULL);
 
     assert(strcmp(BinaryenTableGetName(t2), "t2") == 0);
+    BinaryenTableSetName(t2, "table2");
+    assert(strcmp(BinaryenTableGetName(t2), "table2") == 0);
     assert(BinaryenTableGetInitial(t2) == 1);
+    BinaryenTableSetInitial(t2, 2);
+    assert(BinaryenTableGetInitial(t2) == 2);
     assert(BinaryenTableHasMax(t2) == 1);
     assert(BinaryenTableGetMax(t2) == 1);
+    BinaryenTableSetMax(t2, 2);
+    assert(BinaryenTableGetMax(t2) == 2);
     assert(strcmp(BinaryenTableImportGetModule(t2), "") == 0);
     assert(strcmp(BinaryenTableImportGetBase(t2), "") == 0);
 

--- a/test/example/c-api-multiple-tables.txt
+++ b/test/example/c-api-multiple-tables.txt
@@ -2,8 +2,8 @@
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
  (table $tab 1 1 funcref)
  (elem (table $tab) (i32.const 0) func $adder)
- (table $t2 1 1 funcref)
- (elem (table $t2) (i32.const 0) func $adder)
+ (table $table2 2 2 funcref)
+ (elem (table $table2) (i32.const 0) func $adder)
  (func $adder (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (local.get $0)


### PR DESCRIPTION
Uses `BinaryenIndex` instead of `int` to mirror parameter types in table construction, and adds setters for `name`, `initial` and `max`. Plus descriptions and tests.