### PR TITLE
Remove unneeded static_assert on number of Names in hashing

### DIFF
--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -255,9 +255,9 @@ size_t ExpressionAnalyzer::hash(Expression* curr) {
   struct Hasher {
     size_t digest = wasm::hash(0);
 
-    Index internalCounter = 0;
+    size_t internalCounter = 0;
     // for each internal name, its unique id
-    std::map<Name, Index> internalNames;
+    std::map<Name, size_t> internalNames;
     ExpressionStack stack;
 
     Hasher(Expression* curr) {
@@ -350,8 +350,6 @@ size_t ExpressionAnalyzer::hash(Expression* curr) {
         return;
       }
       rehash(digest, 2);
-      static_assert(sizeof(Index) == sizeof(int32_t),
-                    "wasm64 will need changes here");
       rehash(digest, internalNames[curr]);
     }
     void visitNonScopeName(Name curr) { rehash(digest, uint64_t(curr.str)); }

--- a/src/ir/ExpressionAnalyzer.cpp
+++ b/src/ir/ExpressionAnalyzer.cpp
@@ -255,9 +255,9 @@ size_t ExpressionAnalyzer::hash(Expression* curr) {
   struct Hasher {
     size_t digest = wasm::hash(0);
 
-    size_t internalCounter = 0;
+    Index internalCounter = 0;
     // for each internal name, its unique id
-    std::map<Name, size_t> internalNames;
+    std::map<Name, Index> internalNames;
     ExpressionStack stack;
 
     Hasher(Expression* curr) {


### PR DESCRIPTION
The assertion is not really needed. Wasm64 will need changes to support
more than `2^32` names, in theory, but (1) wasm64 is just memory64 atm,
and (2) we'd need to add a general option for `Index` to be larger than 32
bits in general, so there is nothing specific to the hashing code here.