### PR TITLE
Remove comment as context is nonexistent

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1790,7 +1790,6 @@ public:
   Address max = kMaxSize32;
   std::vector<Segment> segments;
 
-  // See comment in Table.
   bool shared = false;
   Type indexType = Type::i32;
 


### PR DESCRIPTION
The comment refers the refer to a nonexisting comment in Table.
This comment was added in 95d00d6 and refers to a field (`bool
exists`) that was removed in the meantime, along with the comment in
Table.