### PR TITLE
Adds BinaryenI31GetGetIsSigned to API for consistency

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3075,10 +3075,13 @@ void BinaryenI31GetSetI31(BinaryenExpressionRef expr,
   assert(i31Expr);
   static_cast<I31Get*>(expression)->i31 = (Expression*)i31Expr;
 }
-int BinaryenI31GetIsSigned(BinaryenExpressionRef expr) {
+int BinaryenI31GetGetIsSigned(BinaryenExpressionRef expr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<I31Get>());
   return static_cast<I31Get*>(expression)->signed_;
+}
+WASM_DEPRECATED int BinaryenI31GetIsSigned(BinaryenExpressionRef expr) {
+  return BinaryenI31GetGetIsSigned(expr);
 }
 void BinaryenI31GetSetSigned(BinaryenExpressionRef expr, int signed_) {
   auto* expression = (Expression*)expr;

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1898,7 +1898,8 @@ BinaryenI31GetGetI31(BinaryenExpressionRef expr);
 BINARYEN_API void BinaryenI31GetSetI31(BinaryenExpressionRef expr,
                                        BinaryenExpressionRef i31Expr);
 // Gets whether an `i31.get` expression returns a signed value (`_s`).
-BINARYEN_API int BinaryenI31GetIsSigned(BinaryenExpressionRef expr);
+BINARYEN_API int BinaryenI31GetGetIsSigned(BinaryenExpressionRef expr);
+WASM_DEPRECATED BINARYEN_API int BinaryenI31GetIsSigned(BinaryenExpressionRef expr);
 // Sets whether an `i31.get` expression returns a signed value (`_s`).
 BINARYEN_API void BinaryenI31GetSetSigned(BinaryenExpressionRef expr,
                                           int signed_);


### PR DESCRIPTION
Marks BinaryenI31GetIsSigned as deprecated.

Fixes #3613