### PR TITLE
Remove .o and .obj from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ CMakeFiles
 /bin/
 /lib/
 /config.h
-*.o
-*.obj
 compile_commands.json
 test/lit/lit.site.cfg.py
 


### PR DESCRIPTION
Cmake puts all its object files inside CMakeFiles so they
are already handled by the CMakeFiles entry.

Having `*.o` in this file means that `git status` and `git clean`
don't help to find stray `.o` files that one might have made
inadvertently in the tree.

I personally often create small source files and object files
at the top level when working on a project and I expect them
to be cleanup by `git clean`.