### PR TITLE
Simplify printing code

### DIFF
--- a/test/passes/dce_all-features.txt
+++ b/test/passes/dce_all-features.txt
@@ -581,8 +581,7 @@
  (func $throw
   (block $label$0
    (block $label$1
-    (throw $e
-    )
+    (throw $e)
    )
   )
  )


### PR DESCRIPTION
We can just iterate on children using the standard order as in
delegates.h, as used by the binary format as well. The only
exceptions are control flow instructions which need some
special handling.