### PR TITLE
Support printing recursive types

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -281,20 +281,6 @@ public:
   const Type& operator[](size_t i) const;
 };
 
-// Wrapper type for formatting types as "(param i32 i64 f32)"
-struct ParamType {
-  Type type;
-  ParamType(Type type) : type(type) {}
-  std::string toString() const;
-};
-
-// Wrapper type for formatting types as "(result i32 i64 f32)"
-struct ResultType {
-  Type type;
-  ResultType(Type type) : type(type) {}
-  std::string toString() const;
-};
-
 class HeapType {
   // Unlike `Type`, which represents the types of values on the WebAssembly
   // stack, `HeapType` is used to describe the structures that reference types
@@ -509,14 +495,12 @@ struct TypeBuilder {
 };
 
 std::ostream& operator<<(std::ostream&, Type);
-std::ostream& operator<<(std::ostream&, ParamType);
-std::ostream& operator<<(std::ostream&, ResultType);
+std::ostream& operator<<(std::ostream&, HeapType);
 std::ostream& operator<<(std::ostream&, Tuple);
 std::ostream& operator<<(std::ostream&, Signature);
 std::ostream& operator<<(std::ostream&, Field);
 std::ostream& operator<<(std::ostream&, Struct);
 std::ostream& operator<<(std::ostream&, Array);
-std::ostream& operator<<(std::ostream&, HeapType);
 std::ostream& operator<<(std::ostream&, Rtt);
 
 } // namespace wasm

--- a/test/example/type-builder.cpp
+++ b/test/example/type-builder.cpp
@@ -112,6 +112,7 @@ void test_recursive() {
       builder.setHeapType(0, Signature(Type::none, temp));
       built = builder.build();
     }
+    std::cout << built[0] << "\n\n";
     assert(built[0] == built[0].getSignature().results.getHeapType());
     assert(Type(built[0], Nullable) == built[0].getSignature().results);
   }
@@ -127,6 +128,8 @@ void test_recursive() {
       builder.setHeapType(1, Signature(Type::none, temp0));
       built = builder.build();
     }
+    std::cout << built[0] << "\n";
+    std::cout << built[1] << "\n\n";
     assert(built[0].getSignature().results.getHeapType() == built[1]);
     assert(built[1].getSignature().results.getHeapType() == built[0]);
   }
@@ -148,6 +151,11 @@ void test_recursive() {
       builder.setHeapType(4, Signature(Type::none, temp0));
       built = builder.build();
     }
+    std::cout << built[0] << "\n";
+    std::cout << built[1] << "\n";
+    std::cout << built[2] << "\n";
+    std::cout << built[3] << "\n";
+    std::cout << built[4] << "\n\n";
     assert(built[0].getSignature().results.getHeapType() == built[1]);
     assert(built[1].getSignature().results.getHeapType() == built[2]);
     assert(built[2].getSignature().results.getHeapType() == built[3]);
@@ -175,6 +183,12 @@ void test_recursive() {
       builder.setHeapType(5, Signature(Type::none, temp1));
       built = builder.build();
     }
+    std::cout << built[0] << "\n";
+    std::cout << built[1] << "\n";
+    std::cout << built[2] << "\n";
+    std::cout << built[3] << "\n";
+    std::cout << built[4] << "\n";
+    std::cout << built[5] << "\n\n";
     assert(built[0] != built[1]); // TODO: canonicalize recursive types
     assert(built[2] == built[3]);
     assert(built[4] != built[5]); // Contain "different" recursive types

--- a/test/example/type-builder.txt
+++ b/test/example/type-builder.txt
@@ -22,3 +22,21 @@ After building types:
 
 ;; Test canonicalization
 ;; Test recursive types
+(func (result (ref null ...1)))
+
+(func (result (ref null (func (result (ref null ...3))))))
+(func (result (ref null (func (result (ref null ...3))))))
+
+(func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null ...9)))))))))))))))
+(func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null ...9)))))))))))))))
+(func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null ...9)))))))))))))))
+(func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null ...9)))))))))))))))
+(func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null (func (result (ref null ...9)))))))))))))))
+
+(func (result (ref null ...1) (ref null (func))))
+(func (result (ref null ...1) (ref null (func))))
+(func)
+(func)
+(func (result (ref null (func (result ...1 (ref null (func)))))))
+(func (result (ref null (func (result ...1 (ref null (func)))))))
+


### PR DESCRIPTION
Also fixes a few locations in Print.cpp where types were being printed directly
rather than going through the s-expression type printer and removes vestigial
wrapper types that were no longer used.