### PR TITLE
Use enum instead of bool for StackSignature kind

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -666,8 +666,8 @@ void FunctionValidator::validatePoppyBlockElements(Block* curr) {
         !info.quiet) {
       getStream() << "(on index " << i << ":\n"
                   << expr << "\n), required: " << sig.params << ", available: ";
-      if (blockSig.unreachable) {
-        getStream() << "unreachable, ";
+      if (blockSig.kind == StackSignature::Polymorphic) {
+        getStream() << "polymorphic, ";
       }
       getStream() << blockSig.results << "\n";
       return;
@@ -675,18 +675,22 @@ void FunctionValidator::validatePoppyBlockElements(Block* curr) {
     blockSig += sig;
   }
   if (curr->type == Type::unreachable) {
-    shouldBeTrue(blockSig.unreachable,
+    shouldBeTrue(blockSig.kind == StackSignature::Polymorphic,
                  curr,
                  "unreachable block should have unreachable element");
   } else {
     if (!shouldBeTrue(
           StackSignature::isSubType(
-            blockSig, StackSignature(Type::none, curr->type, false)),
+            blockSig,
+            StackSignature(Type::none, curr->type, StackSignature::Fixed)),
           curr,
           "block contents should satisfy block type") &&
         !info.quiet) {
       getStream() << "contents: " << blockSig.results
-                  << (blockSig.unreachable ? " [unreachable]" : "") << "\n"
+                  << (blockSig.kind == StackSignature::Polymorphic
+                        ? " [polymorphic]"
+                        : "")
+                  << "\n"
                   << "expected: " << curr->type << "\n";
     }
   }

--- a/test/example/stack-utils.cpp
+++ b/test/example/stack-utils.cpp
@@ -35,37 +35,38 @@ void test_stack_signatures() {
   // Typed block
   auto* block = builder.makeBlock({builder.makeUnreachable()}, Type::f32);
   assert(StackSignature(block) ==
-         (StackSignature{Type::none, Type::f32, false}));
+         (StackSignature{Type::none, Type::f32, StackSignature::Fixed}));
   // Unreachable block
   auto* unreachable =
     builder.makeBlock({builder.makeUnreachable()}, Type::unreachable);
   assert(StackSignature(unreachable) ==
-         (StackSignature{Type::none, Type::none, true}));
+         (StackSignature{Type::none, Type::none, StackSignature::Polymorphic}));
   {
     // Typed loop
     auto* loop = builder.makeLoop("loop", unreachable, Type::f32);
     assert(StackSignature(loop) ==
-           (StackSignature{Type::none, Type::f32, false}));
+           (StackSignature{Type::none, Type::f32, StackSignature::Fixed}));
   }
   {
     // Unreachable loop
     auto* loop = builder.makeLoop("loop", unreachable, Type::unreachable);
-    assert(StackSignature(loop) ==
-           (StackSignature{Type::none, Type::none, true}));
+    assert(
+      StackSignature(loop) ==
+      (StackSignature{Type::none, Type::none, StackSignature::Polymorphic}));
   }
   {
     // If (no else)
     auto* if_ = builder.makeIf(
       builder.makePop(Type::i32), unreachable, nullptr, Type::none);
     assert(StackSignature(if_) ==
-           (StackSignature{Type::i32, Type::none, false}));
+           (StackSignature{Type::i32, Type::none, StackSignature::Fixed}));
   }
   {
     // If (with else)
     auto* if_ =
       builder.makeIf(builder.makePop(Type::i32), block, block, Type::f32);
     assert(StackSignature(if_) ==
-           (StackSignature{Type::i32, Type::f32, false}));
+           (StackSignature{Type::i32, Type::f32, StackSignature::Fixed}));
   }
   {
     // Call
@@ -73,9 +74,9 @@ void test_stack_signatures() {
       builder.makeCall("foo",
                        {builder.makePop(Type::i32), builder.makePop(Type::f32)},
                        {Type::i64, Type::f64});
-    assert(
-      StackSignature(call) ==
-      (StackSignature{{Type::i32, Type::f32}, {Type::i64, Type::f64}, false}));
+    assert(StackSignature(call) == (StackSignature{{Type::i32, Type::f32},
+                                                   {Type::i64, Type::f64},
+                                                   StackSignature::Fixed}));
   }
   {
     // Return Call
@@ -83,21 +84,24 @@ void test_stack_signatures() {
       builder.makeCall("bar",
                        {builder.makePop(Type::i32), builder.makePop(Type::f32)},
                        Type::unreachable,
-                       true);
+                       StackSignature::Polymorphic);
     assert(StackSignature(call) ==
-           (StackSignature{{Type::i32, Type::f32}, Type::none, true}));
+           (StackSignature{
+             {Type::i32, Type::f32}, Type::none, StackSignature::Polymorphic}));
   }
   {
     // Return
     auto* ret = builder.makeReturn(builder.makePop(Type::i32));
-    assert(StackSignature(ret) ==
-           (StackSignature{Type::i32, Type::none, true}));
+    assert(
+      StackSignature(ret) ==
+      (StackSignature{Type::i32, Type::none, StackSignature::Polymorphic}));
   }
   {
     // Multivalue return
     auto* ret = builder.makeReturn(builder.makePop({Type::i32, Type::f32}));
     assert(StackSignature(ret) ==
-           (StackSignature{{Type::i32, Type::f32}, Type::none, true}));
+           (StackSignature{
+             {Type::i32, Type::f32}, Type::none, StackSignature::Polymorphic}));
   }
 }
 
@@ -105,118 +109,142 @@ void test_signature_composition() {
   std::cout << ";; Test stack signature composition\n";
   // No unreachables
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, false};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, false};
+    StackSignature a{Type::none, {Type::f32, Type::i32}, StackSignature::Fixed};
+    StackSignature b{{Type::f32, Type::i32}, Type::none, StackSignature::Fixed};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::none, false}));
+    assert(a + b ==
+           (StackSignature{Type::none, Type::none, StackSignature::Fixed}));
   }
   {
-    StackSignature a{Type::none, Type::i32, false};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, false};
+    StackSignature a{Type::none, Type::i32, StackSignature::Fixed};
+    StackSignature b{{Type::f32, Type::i32}, Type::none, StackSignature::Fixed};
     assert(a.composes(b));
-    assert(a + b == StackSignature(Type::f32, Type::none, false));
+    assert(a + b ==
+           StackSignature(Type::f32, Type::none, StackSignature::Fixed));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, false};
-    StackSignature b{Type::i32, Type::none, false};
+    StackSignature a{Type::none, {Type::f32, Type::i32}, StackSignature::Fixed};
+    StackSignature b{Type::i32, Type::none, StackSignature::Fixed};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::f32, false}));
+    assert(a + b ==
+           (StackSignature{Type::none, Type::f32, StackSignature::Fixed}));
   }
   {
-    StackSignature a{Type::none, Type::f32, false};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, false};
+    StackSignature a{Type::none, Type::f32, StackSignature::Fixed};
+    StackSignature b{{Type::f32, Type::i32}, Type::none, StackSignature::Fixed};
     assert(!a.composes(b));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, false};
-    StackSignature b{Type::f32, Type::none, false};
+    StackSignature a{Type::none, {Type::f32, Type::i32}, StackSignature::Fixed};
+    StackSignature b{Type::f32, Type::none, StackSignature::Fixed};
     assert(!a.composes(b));
   }
   // First unreachable
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, true};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, false};
+    StackSignature a{
+      Type::none, {Type::f32, Type::i32}, StackSignature::Polymorphic};
+    StackSignature b{{Type::f32, Type::i32}, Type::none, StackSignature::Fixed};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::none, true}));
+    assert(a + b == (StackSignature{
+                      Type::none, Type::none, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::i32, true};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, false};
+    StackSignature a{Type::none, Type::i32, StackSignature::Polymorphic};
+    StackSignature b{{Type::f32, Type::i32}, Type::none, StackSignature::Fixed};
     assert(a.composes(b));
-    assert(a + b == StackSignature(Type::none, Type::none, true));
+    assert(a + b ==
+           StackSignature(Type::none, Type::none, StackSignature::Polymorphic));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, true};
-    StackSignature b{Type::i32, Type::none, false};
+    StackSignature a{
+      Type::none, {Type::f32, Type::i32}, StackSignature::Polymorphic};
+    StackSignature b{Type::i32, Type::none, StackSignature::Fixed};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::f32, true}));
+    assert(a + b == (StackSignature{
+                      Type::none, Type::f32, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::f32, true};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, false};
+    StackSignature a{Type::none, Type::f32, StackSignature::Polymorphic};
+    StackSignature b{{Type::f32, Type::i32}, Type::none, StackSignature::Fixed};
     assert(!a.composes(b));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, true};
-    StackSignature b{Type::f32, Type::none, false};
+    StackSignature a{
+      Type::none, {Type::f32, Type::i32}, StackSignature::Polymorphic};
+    StackSignature b{Type::f32, Type::none, StackSignature::Fixed};
     assert(!a.composes(b));
   }
   // Second unreachable
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, false};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, true};
+    StackSignature a{Type::none, {Type::f32, Type::i32}, StackSignature::Fixed};
+    StackSignature b{
+      {Type::f32, Type::i32}, Type::none, StackSignature::Polymorphic};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::none, true}));
+    assert(a + b == (StackSignature{
+                      Type::none, Type::none, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::i32, false};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, true};
+    StackSignature a{Type::none, Type::i32, StackSignature::Fixed};
+    StackSignature b{
+      {Type::f32, Type::i32}, Type::none, StackSignature::Polymorphic};
     assert(a.composes(b));
-    assert(a + b == StackSignature(Type::f32, Type::none, true));
+    assert(a + b ==
+           StackSignature(Type::f32, Type::none, StackSignature::Polymorphic));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, false};
-    StackSignature b{Type::i32, Type::none, true};
+    StackSignature a{Type::none, {Type::f32, Type::i32}, StackSignature::Fixed};
+    StackSignature b{Type::i32, Type::none, StackSignature::Polymorphic};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::none, true}));
+    assert(a + b == (StackSignature{
+                      Type::none, Type::none, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::f32, false};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, true};
+    StackSignature a{Type::none, Type::f32, StackSignature::Fixed};
+    StackSignature b{
+      {Type::f32, Type::i32}, Type::none, StackSignature::Polymorphic};
     assert(!a.composes(b));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, false};
-    StackSignature b{Type::f32, Type::none, true};
+    StackSignature a{Type::none, {Type::f32, Type::i32}, StackSignature::Fixed};
+    StackSignature b{Type::f32, Type::none, StackSignature::Polymorphic};
     assert(!a.composes(b));
   }
   // Both unreachable
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, true};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, true};
+    StackSignature a{
+      Type::none, {Type::f32, Type::i32}, StackSignature::Polymorphic};
+    StackSignature b{
+      {Type::f32, Type::i32}, Type::none, StackSignature::Polymorphic};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::none, true}));
+    assert(a + b == (StackSignature{
+                      Type::none, Type::none, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::i32, true};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, true};
+    StackSignature a{Type::none, Type::i32, StackSignature::Polymorphic};
+    StackSignature b{
+      {Type::f32, Type::i32}, Type::none, StackSignature::Polymorphic};
     assert(a.composes(b));
-    assert(a + b == StackSignature(Type::none, Type::none, true));
+    assert(a + b ==
+           StackSignature(Type::none, Type::none, StackSignature::Polymorphic));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, true};
-    StackSignature b{Type::i32, Type::none, true};
+    StackSignature a{
+      Type::none, {Type::f32, Type::i32}, StackSignature::Polymorphic};
+    StackSignature b{Type::i32, Type::none, StackSignature::Polymorphic};
     assert(a.composes(b));
-    assert(a + b == (StackSignature{Type::none, Type::none, true}));
+    assert(a + b == (StackSignature{
+                      Type::none, Type::none, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::f32, true};
-    StackSignature b{{Type::f32, Type::i32}, Type::none, true};
+    StackSignature a{Type::none, Type::f32, StackSignature::Polymorphic};
+    StackSignature b{
+      {Type::f32, Type::i32}, Type::none, StackSignature::Polymorphic};
     assert(!a.composes(b));
   }
   {
-    StackSignature a{Type::none, {Type::f32, Type::i32}, true};
-    StackSignature b{Type::f32, Type::none, true};
+    StackSignature a{
+      Type::none, {Type::f32, Type::i32}, StackSignature::Polymorphic};
+    StackSignature b{Type::f32, Type::none, StackSignature::Polymorphic};
     assert(!a.composes(b));
   }
 }
@@ -225,97 +253,103 @@ void test_signature_subtype() {
   std::cout << ";; Test stack signature subtyping\n";
   // Differences in unreachability only
   {
-    StackSignature a(Type::none, Type::none, true);
-    StackSignature b(Type::none, Type::none, false);
+    StackSignature a(Type::none, Type::none, StackSignature::Polymorphic);
+    StackSignature b(Type::none, Type::none, StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
     assert(!StackSignature::isSubType(b, a));
   }
   // Covariance of results
   {
-    StackSignature a(Type::none, Type::funcref, false);
-    StackSignature b(Type::none, Type::anyref, false);
+    StackSignature a(Type::none, Type::funcref, StackSignature::Fixed);
+    StackSignature b(Type::none, Type::anyref, StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
     assert(!StackSignature::isSubType(b, a));
   }
   // Contravariance of params
   {
-    StackSignature a(Type::anyref, Type::none, false);
-    StackSignature b(Type::funcref, Type::none, false);
+    StackSignature a(Type::anyref, Type::none, StackSignature::Fixed);
+    StackSignature b(Type::funcref, Type::none, StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
     assert(!StackSignature::isSubType(b, a));
   }
   // First not unreachable
   {
-    StackSignature a(Type::i32, Type::f32, false);
-    StackSignature b(Type::i32, Type::f32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
+    StackSignature b(Type::i32, Type::f32, StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, false);
-    StackSignature b({Type::i64, Type::i32}, {Type::i64, Type::f32}, false);
-    assert(StackSignature::isSubType(a, b));
-  }
-  {
-    StackSignature a(Type::i32, Type::f32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
     StackSignature b(
-      {Type::i64, Type::i32}, {Type::i64, Type::i64, Type::f32}, false);
+      {Type::i64, Type::i32}, {Type::i64, Type::f32}, StackSignature::Fixed);
+    assert(StackSignature::isSubType(a, b));
+  }
+  {
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
+    StackSignature b({Type::i64, Type::i32},
+                     {Type::i64, Type::i64, Type::f32},
+                     StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, false);
-    StackSignature b({Type::i64, Type::i32}, {Type::f64, Type::f32}, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
+    StackSignature b(
+      {Type::i64, Type::i32}, {Type::f64, Type::f32}, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, false);
-    StackSignature b(Type::none, Type::f32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
+    StackSignature b(Type::none, Type::f32, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, false);
-    StackSignature b(Type::i32, Type::none, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
+    StackSignature b(Type::i32, Type::none, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, false);
-    StackSignature b(Type::f32, Type::i32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Fixed);
+    StackSignature b(Type::f32, Type::i32, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   // First unreachable
   {
-    StackSignature a(Type::i32, Type::f32, true);
-    StackSignature b(Type::i32, Type::f32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
+    StackSignature b(Type::i32, Type::f32, StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, true);
-    StackSignature b({Type::i64, Type::i32}, {Type::i64, Type::f32}, false);
-    assert(StackSignature::isSubType(a, b));
-  }
-  {
-    StackSignature a(Type::i32, Type::f32, true);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
     StackSignature b(
-      {Type::i64, Type::i32}, {Type::i64, Type::i64, Type::f32}, false);
+      {Type::i64, Type::i32}, {Type::i64, Type::f32}, StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, true);
-    StackSignature b({Type::i64, Type::i32}, {Type::f64, Type::f32}, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
+    StackSignature b({Type::i64, Type::i32},
+                     {Type::i64, Type::i64, Type::f32},
+                     StackSignature::Fixed);
     assert(StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, true);
-    StackSignature b(Type::none, Type::f32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
+    StackSignature b(
+      {Type::i64, Type::i32}, {Type::f64, Type::f32}, StackSignature::Fixed);
+    assert(StackSignature::isSubType(a, b));
+  }
+  {
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
+    StackSignature b(Type::none, Type::f32, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, true);
-    StackSignature b(Type::i32, Type::none, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
+    StackSignature b(Type::i32, Type::none, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::f32, true);
-    StackSignature b(Type::f32, Type::i32, false);
+    StackSignature a(Type::i32, Type::f32, StackSignature::Polymorphic);
+    StackSignature b(Type::f32, Type::i32, StackSignature::Fixed);
     assert(!StackSignature::isSubType(a, b));
   }
 }
@@ -323,106 +357,111 @@ void test_signature_subtype() {
 void test_signature_lub() {
   std::cout << ";; Test stack signature lub\n";
   {
-    StackSignature a{Type::none, Type::none, false};
-    StackSignature b{Type::none, Type::none, false};
+    StackSignature a{Type::none, Type::none, StackSignature::Fixed};
+    StackSignature b{Type::none, Type::none, StackSignature::Fixed};
     assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::none, Type::none, false}));
+           (StackSignature{Type::none, Type::none, StackSignature::Fixed}));
   }
   {
-    StackSignature a{Type::none, Type::none, true};
-    StackSignature b{Type::none, Type::none, false};
+    StackSignature a{Type::none, Type::none, StackSignature::Polymorphic};
+    StackSignature b{Type::none, Type::none, StackSignature::Fixed};
     assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::none, Type::none, false}));
+           (StackSignature{Type::none, Type::none, StackSignature::Fixed}));
   }
   {
-    StackSignature a{Type::none, Type::none, false};
-    StackSignature b{Type::none, Type::none, true};
+    StackSignature a{Type::none, Type::none, StackSignature::Fixed};
+    StackSignature b{Type::none, Type::none, StackSignature::Polymorphic};
     assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::none, Type::none, false}));
+           (StackSignature{Type::none, Type::none, StackSignature::Fixed}));
   }
   {
-    StackSignature a{Type::i32, Type::none, true};
-    StackSignature b{Type::none, Type::i32, true};
+    StackSignature a{Type::i32, Type::none, StackSignature::Polymorphic};
+    StackSignature b{Type::none, Type::i32, StackSignature::Polymorphic};
     assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::i32, Type::i32, true}));
+           (StackSignature{Type::i32, Type::i32, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::i32, true};
-    StackSignature b{Type::i32, Type::none, true};
+    StackSignature a{Type::none, Type::i32, StackSignature::Polymorphic};
+    StackSignature b{Type::i32, Type::none, StackSignature::Polymorphic};
     assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::i32, Type::i32, true}));
+           (StackSignature{Type::i32, Type::i32, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::none, Type::externref, true};
-    StackSignature b{Type::none, Type::funcref, true};
+    StackSignature a{Type::none, Type::externref, StackSignature::Polymorphic};
+    StackSignature b{Type::none, Type::funcref, StackSignature::Polymorphic};
     assert(StackSignature::haveLeastUpperBound(a, b));
-    assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{Type::none, Type::anyref, true}));
+    assert(
+      StackSignature::getLeastUpperBound(a, b) ==
+      (StackSignature{Type::none, Type::anyref, StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{Type::anyref, Type::none, true};
-    StackSignature b{Type::funcref, Type::none, true};
+    StackSignature a{Type::anyref, Type::none, StackSignature::Polymorphic};
+    StackSignature b{Type::funcref, Type::none, StackSignature::Polymorphic};
     // assert(StackSignature::haveLeastUpperBound(a, b));
     // assert(StackSignature::getLeastUpperBound(a, b) ==
-    //        (StackSignature{Type::funcref, Type::none, true}));
+    //        (StackSignature{Type::funcref, Type::none,
+    //        StackSignature::Polymorphic}));
   }
   {
-    StackSignature a{{Type::i32, Type::funcref}, Type::funcref, true};
-    StackSignature b{Type::funcref, {Type::f32, Type::externref}, true};
+    StackSignature a{
+      {Type::i32, Type::funcref}, Type::funcref, StackSignature::Polymorphic};
+    StackSignature b{
+      Type::funcref, {Type::f32, Type::externref}, StackSignature::Polymorphic};
     assert(StackSignature::haveLeastUpperBound(a, b));
     assert(StackSignature::getLeastUpperBound(a, b) ==
-           (StackSignature{
-             {Type::i32, Type::funcref}, {Type::f32, Type::anyref}, true}));
+           (StackSignature{{Type::i32, Type::funcref},
+                           {Type::f32, Type::anyref},
+                           StackSignature::Polymorphic}));
   }
   // No LUB
   {
-    StackSignature a(Type::none, Type::i32, false);
-    StackSignature b(Type::none, Type::f32, false);
+    StackSignature a(Type::none, Type::i32, StackSignature::Fixed);
+    StackSignature b(Type::none, Type::f32, StackSignature::Fixed);
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a(Type::none, Type::i32, true);
-    StackSignature b(Type::none, Type::f32, true);
+    StackSignature a(Type::none, Type::i32, StackSignature::Polymorphic);
+    StackSignature b(Type::none, Type::f32, StackSignature::Polymorphic);
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::none, false);
-    StackSignature b(Type::f32, Type::none, false);
+    StackSignature a(Type::i32, Type::none, StackSignature::Fixed);
+    StackSignature b(Type::f32, Type::none, StackSignature::Fixed);
     // assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a(Type::i32, Type::none, true);
-    StackSignature b(Type::f32, Type::none, true);
+    StackSignature a(Type::i32, Type::none, StackSignature::Polymorphic);
+    StackSignature b(Type::f32, Type::none, StackSignature::Polymorphic);
     // assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a(Type::none, Type::none, false);
-    StackSignature b(Type::none, Type::i32, true);
+    StackSignature a(Type::none, Type::none, StackSignature::Fixed);
+    StackSignature b(Type::none, Type::i32, StackSignature::Polymorphic);
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a(Type::none, Type::none, false);
-    StackSignature b(Type::i32, Type::none, true);
+    StackSignature a(Type::none, Type::none, StackSignature::Fixed);
+    StackSignature b(Type::i32, Type::none, StackSignature::Polymorphic);
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a{Type::none, Type::i32, false};
-    StackSignature b{Type::i32, Type::none, false};
+    StackSignature a{Type::none, Type::i32, StackSignature::Fixed};
+    StackSignature b{Type::i32, Type::none, StackSignature::Fixed};
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a{Type::none, Type::i32, true};
-    StackSignature b{Type::i32, Type::none, false};
+    StackSignature a{Type::none, Type::i32, StackSignature::Polymorphic};
+    StackSignature b{Type::i32, Type::none, StackSignature::Fixed};
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
   {
-    StackSignature a{Type::none, Type::i32, false};
-    StackSignature b{Type::i32, Type::none, true};
+    StackSignature a{Type::none, Type::i32, StackSignature::Fixed};
+    StackSignature b{Type::i32, Type::none, StackSignature::Polymorphic};
     assert(!StackSignature::haveLeastUpperBound(a, b));
   }
 }
@@ -556,7 +595,7 @@ void test_stack_flow() {
     assert(flow.getSignature(ret) ==
            (StackSignature{{Type::i32, Type::i64, Type::f32},
                            {Type::i64, Type::f64, Type::i32},
-                           true}));
+                           StackSignature::Polymorphic}));
     assert(flow.getSignature(quux) == StackSignature(quux));
   }
 }


### PR DESCRIPTION
As a readability improvement, use an enum with `Polymorphic` and `Fixed`
variants to represent the polymorphic behavior of StackSignatures rather than a
`bool uneachable`.

As suggested in https://github.com/WebAssembly/binaryen/pull/3543#discussion_r570421727.