### PR TITLE
Add C and JS API bindings for ref.as_*

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -712,6 +712,10 @@ BinaryenOp BinaryenRefIsNull(void) { return RefIsNull; }
 BinaryenOp BinaryenRefIsFunc(void) { return RefIsFunc; }
 BinaryenOp BinaryenRefIsData(void) { return RefIsData; }
 BinaryenOp BinaryenRefIsI31(void) { return RefIsI31; }
+BinaryenOp BinaryenRefAsNonNull(void) { return RefAsNonNull; };
+BinaryenOp BinaryenRefAsFunc(void) { return RefAsFunc; }
+BinaryenOp BinaryenRefAsData(void) { return RefAsData; };
+BinaryenOp BinaryenRefAsI31(void) { return RefAsI31; };
 
 BinaryenExpressionRef BinaryenBlock(BinaryenModuleRef module,
                                     const char* name,
@@ -1196,6 +1200,13 @@ BinaryenExpressionRef BinaryenRefIs(BinaryenModuleRef module,
                                     BinaryenExpressionRef value) {
   return static_cast<Expression*>(
     Builder(*(Module*)module).makeRefIs(RefIsOp(op), (Expression*)value));
+}
+
+BinaryenExpressionRef BinaryenRefAs(BinaryenModuleRef module,
+                                    BinaryenOp op,
+                                    BinaryenExpressionRef value) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeRefAs(RefAsOp(op), (Expression*)value));
 }
 
 BinaryenExpressionRef
@@ -2751,6 +2762,29 @@ void BinaryenRefIsSetValue(BinaryenExpressionRef expr,
   assert(expression->is<RefIs>());
   assert(valueExpr);
   static_cast<RefIs*>(expression)->value = (Expression*)valueExpr;
+}
+// RefAs
+BinaryenOp BinaryenRefAsGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefAs>());
+  return static_cast<RefAs*>(expression)->op;
+}
+void BinaryenRefAsSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefAs>());
+  static_cast<RefAs*>(expression)->op = RefAsOp(op);
+}
+BinaryenExpressionRef BinaryenRefAsGetValue(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefAs>());
+  return static_cast<RefAs*>(expression)->value;
+}
+void BinaryenRefAsSetValue(BinaryenExpressionRef expr,
+                           BinaryenExpressionRef valueExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefAs>());
+  assert(valueExpr);
+  static_cast<RefAs*>(expression)->value = (Expression*)valueExpr;
 }
 // RefFunc
 const char* BinaryenRefFuncGetFunc(BinaryenExpressionRef expr) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -563,6 +563,10 @@ BINARYEN_API BinaryenOp BinaryenRefIsNull(void);
 BINARYEN_API BinaryenOp BinaryenRefIsFunc(void);
 BINARYEN_API BinaryenOp BinaryenRefIsData(void);
 BINARYEN_API BinaryenOp BinaryenRefIsI31(void);
+BINARYEN_API BinaryenOp BinaryenRefAsNonNull(void);
+BINARYEN_API BinaryenOp BinaryenRefAsFunc(void);
+BINARYEN_API BinaryenOp BinaryenRefAsData(void);
+BINARYEN_API BinaryenOp BinaryenRefAsI31(void);
 
 BINARYEN_REF(Expression);
 
@@ -795,6 +799,9 @@ BinaryenMemoryFill(BinaryenModuleRef module,
 BINARYEN_API BinaryenExpressionRef BinaryenRefNull(BinaryenModuleRef module,
                                                    BinaryenType type);
 BINARYEN_API BinaryenExpressionRef BinaryenRefIs(BinaryenModuleRef module,
+                                                 BinaryenOp op,
+                                                 BinaryenExpressionRef value);
+BINARYEN_API BinaryenExpressionRef BinaryenRefAs(BinaryenModuleRef module,
                                                  BinaryenOp op,
                                                  BinaryenExpressionRef value);
 BINARYEN_API BinaryenExpressionRef BinaryenRefFunc(BinaryenModuleRef module,
@@ -1700,6 +1707,19 @@ BINARYEN_API BinaryenExpressionRef
 BinaryenRefIsGetValue(BinaryenExpressionRef expr);
 // Sets the value expression tested by a `ref.is_*` expression.
 BINARYEN_API void BinaryenRefIsSetValue(BinaryenExpressionRef expr,
+                                        BinaryenExpressionRef valueExpr);
+
+// RefAs
+
+// Gets the operation performed by a `ref.as_*` expression.
+BINARYEN_API BinaryenOp BinaryenRefAsGetOp(BinaryenExpressionRef expr);
+// Sets the operation performed by a `ref.as_*` expression.
+BINARYEN_API void BinaryenRefAsSetOp(BinaryenExpressionRef expr, BinaryenOp op);
+// Gets the value expression tested by a `ref.as_*` expression.
+BINARYEN_API BinaryenExpressionRef
+BinaryenRefAsGetValue(BinaryenExpressionRef expr);
+// Sets the value expression tested by a `ref.as_*` expression.
+BINARYEN_API void BinaryenRefAsSetValue(BinaryenExpressionRef expr,
                                         BinaryenExpressionRef valueExpr);
 
 // RefFunc

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -491,6 +491,10 @@ function initializeConstants() {
     'RefIsFunc',
     'RefIsData',
     'RefIsI31',
+    'RefAsNonNull',
+    'RefAsFunc',
+    'RefAsData',
+    'RefAsI31',
   ].forEach(name => {
     Module['Operations'][name] = Module[name] = Module['_Binaryen' + name]();
   });
@@ -2118,6 +2122,18 @@ function wrapModule(module, self = {}) {
     'is_i31'(value) {
       return Module['_BinaryenRefIs'](module, Module['RefIsI31'], value);
     },
+    'as_non_null'(value) {
+      return Module['_BinaryenRefAs'](module, Module['RefAsNonNull'], value);
+    },
+    'as_func'(value) {
+      return Module['_BinaryenRefAs'](module, Module['RefAsFunc'], value);
+    },
+    'as_data'(value) {
+      return Module['_BinaryenRefAs'](module, Module['RefAsData'], value);
+    },
+    'as_i31'(value) {
+      return Module['_BinaryenRefAs'](module, Module['RefAsI31'], value);
+    },
     'func'(func, type) {
       return preserveStack(() => Module['_BinaryenRefFunc'](module, strToStack(func), type));
     },
@@ -2879,7 +2895,15 @@ Module['getExpressionInfo'] = function(expr) {
       return {
         'id': id,
         'type': type,
+        'op': Module['_BinaryenRefIsGetOp'](expr),
         'value': Module['_BinaryenRefIsGetValue'](expr)
+      };
+    case Module['RefAsId']:
+      return {
+        'id': id,
+        'type': type,
+        'op': Module['_BinaryenRefAsGetOp'](expr),
+        'value': Module['_BinaryenRefAsGetValue'](expr)
       };
     case Module['RefFuncId']:
       return {
@@ -4154,6 +4178,21 @@ Module['RefIs'] = makeExpressionWrapper({
   },
   'setValue'(expr, valueExpr) {
     Module['_BinaryenRefIsSetValue'](expr, valueExpr);
+  }
+});
+
+Module['RefAs'] = makeExpressionWrapper({
+  'getOp'(expr) {
+    return Module['_BinaryenRefAsGetOp'](expr);
+  },
+  'setOp'(expr, op) {
+    Module['_BinaryenRefAsSetOp'](expr, op);
+  },
+  'getValue'(expr) {
+    return Module['_BinaryenRefAsGetValue'](expr);
+  },
+  'setValue'(expr, valueExpr) {
+    Module['_BinaryenRefAsSetValue'](expr, valueExpr);
   }
 });
 

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -1403,6 +1403,54 @@ console.log("# RefIs");
   module.dispose();
 })();
 
+console.log("# RefAs");
+(function testRefAs() {
+  const module = new binaryen.Module();
+
+  var op = binaryen.Operations.RefAsNonNull;
+  var value = module.local.get(1, binaryen.anyref);
+  const theRefAs = binaryen.RefAs(module.ref.as_non_null(value));
+  assert(theRefAs instanceof binaryen.RefAs);
+  assert(theRefAs instanceof binaryen.Expression);
+  assert(theRefAs.op === op);
+  assert(theRefAs.value === value);
+  assert(theRefAs.type !== binaryen.i32); // TODO: === (ref any)
+
+  theRefAs.op = op = binaryen.Operations.RefAsFunc;
+  assert(theRefAs.op === op);
+  theRefAs.op = op = binaryen.Operations.RefAsNull;
+  theRefAs.value = value = module.local.get(2, binaryen.anyref);
+  assert(theRefAs.value === value);
+  theRefAs.type = binaryen.f64;
+  theRefAs.finalize();
+  assert(theRefAs.type !== binaryen.f64); // TODO: === (ref any)
+
+  console.log(theRefAs.toText());
+  assert(
+    theRefAs.toText()
+    ==
+    "(ref.as_non_null\n (local.get $2)\n)\n"
+  );
+
+  assert(
+    binaryen.RefAs(module.ref.as_func(value)).toText()
+    ==
+    "(ref.as_func\n (local.get $2)\n)\n"
+  );
+  assert(
+    binaryen.RefAs(module.ref.as_data(value)).toText()
+    ==
+    "(ref.as_data\n (local.get $2)\n)\n"
+  );
+  assert(
+    binaryen.RefAs(module.ref.as_i31(value)).toText()
+    ==
+    "(ref.as_i31\n (local.get $2)\n)\n"
+  );
+
+  module.dispose();
+})();
+
 console.log("# RefFunc");
 (function testRefFunc() {
   const module = new binaryen.Module();

--- a/test/binaryen.js/expressions.js.txt
+++ b/test/binaryen.js/expressions.js.txt
@@ -207,6 +207,11 @@
  (local.get $2)
 )
 
+# RefAs
+(ref.as_non_null
+ (local.get $2)
+)
+
 # RefFunc
 (ref.func $b)
 

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -731,6 +731,13 @@ void test_core() {
     BinaryenRefEq(module,
                   BinaryenRefNull(module, BinaryenTypeEqref()),
                   BinaryenRefNull(module, BinaryenTypeEqref())),
+    BinaryenRefIs(module, BinaryenRefIsFunc(), BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefIs(module, BinaryenRefIsData(), BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefIs(module, BinaryenRefIsI31(), BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefAs(module, BinaryenRefAsNonNull(), BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefAs(module, BinaryenRefAsFunc(), BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefAs(module, BinaryenRefAsData(), BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefAs(module, BinaryenRefAsI31(), BinaryenRefNull(module, BinaryenTypeAnyref())),
     // Exception handling
     BinaryenTry(module, NULL, tryBody, catchEvents, 1, catchBodies, 2, NULL),
     // (try $try_outer

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -1761,6 +1761,41 @@ BinaryenFeatureAll: 8191
         (ref.null eq)
        )
       )
+      (drop
+       (ref.is_func
+        (ref.null any)
+       )
+      )
+      (drop
+       (ref.is_data
+        (ref.null any)
+       )
+      )
+      (drop
+       (ref.is_i31
+        (ref.null any)
+       )
+      )
+      (drop
+       (ref.as_non_null
+        (ref.null any)
+       )
+      )
+      (drop
+       (ref.as_func
+        (ref.null any)
+       )
+      )
+      (drop
+       (ref.as_data
+        (ref.null any)
+       )
+      )
+      (drop
+       (ref.as_i31
+        (ref.null any)
+       )
+      )
       (try
        (do
         (throw $a-event


### PR DESCRIPTION
Adds C / JS bindings for the constants

* BinaryenRefAsNonNull / Operations.RefAsNonNull
* BinaryenRefAsFunc / Operations.RefAsFunc
* BinaryenRefAsData / Operations.RefAsData
* BinaryenRefAsI31 / Operations.RefAsI31

and the respective construction, inspection and modification APIs

* BinaryenRefAs / RefAs wrapper, ref.as_non_null, ref.as_func, ref.as_data, ref.as_i31
* BinaryenRefAsGetOp / RefAs#getOp
* BinaryenRefAsSetOp / RefAs#setOp
* BinaryenRefAsGetValue / RefAs#getValue
* BinaryenRefAsSetValue / RefAs#setValue

plus descriptions and preliminary (cannot represent non-nullable reference types yet) tests.