### PR TITLE
Allow empty body within catch block

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2237,7 +2237,7 @@ Expression* SExpressionWasmBuilder::makeTry(Element& s) {
 
   while (i < s.size() && elementStartsWith(*s[i], "catch")) {
     Element& inner = *s[i++];
-    if (inner.size() < 3) {
+    if (inner.size() < 2) {
       throw ParseException("invalid catch block", inner.line, inner.col);
     }
     Name event = getEventName(*inner[1]);

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -2,6 +2,7 @@
   (event $e-i32 (attr 0) (param i32))
   (event $e-i64 (attr 0) (param i64))
   (event $e-i32-i64 (attr 0) (param i32 i64))
+  (event $e-empty (attr 0))
 
   (func $foo)
   (func $bar)
@@ -187,6 +188,12 @@
         )
       )
       (delegate 0)
+    )
+
+    ;; 'catch' body can be empty when the event's type is none.
+    (try
+      (do)
+      (catch $e-empty)
     )
   )
 

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -6,6 +6,7 @@
  (event $e-i32 (attr 0) (param i32))
  (event $e-i64 (attr 0) (param i64))
  (event $e-i32-i64 (attr 0) (param i32 i64))
+ (event $e-empty (attr 0) (param))
  (func $foo
   (nop)
  )
@@ -226,6 +227,14 @@
    )
    (delegate 0)
   )
+  (try $try17
+   (do
+    (nop)
+   )
+   (catch $e-empty
+    (nop)
+   )
+  )
  )
  (func $rethrow-test
   (try $l0
@@ -242,8 +251,8 @@
     (rethrow $l0)
    )
   )
-  (block $l018
-   (try $l017
+  (block $l019
+   (try $l018
     (do
      (call $foo)
     )
@@ -251,14 +260,14 @@
      (drop
       (pop i32)
      )
-     (rethrow $l017)
+     (rethrow $l018)
     )
     (catch_all
-     (br $l018)
+     (br $l019)
     )
    )
   )
-  (try $l019
+  (try $l020
    (do
     (call $foo)
    )
@@ -271,20 +280,20 @@
       (drop
        (pop i32)
       )
-      (rethrow $l019)
+      (rethrow $l020)
      )
      (catch_all
-      (rethrow $l019)
+      (rethrow $l020)
      )
     )
    )
   )
-  (try $l020
+  (try $l021
    (do
     (call $foo)
    )
    (catch_all
-    (try $try21
+    (try $try22
      (do
       (call $foo)
      )
@@ -293,25 +302,25 @@
        (pop i32)
       )
       (block $b0
-       (rethrow $l020)
+       (rethrow $l021)
       )
      )
      (catch_all
       (block $b1
-       (rethrow $l020)
+       (rethrow $l021)
       )
      )
     )
    )
   )
-  (try $l022
+  (try $l023
    (do
     (call $foo)
    )
    (catch_all
-    (try $try23
+    (try $try24
      (do
-      (rethrow $l022)
+      (rethrow $l023)
      )
      (catch_all
       (nop)
@@ -319,14 +328,14 @@
     )
    )
   )
-  (try $l024
+  (try $l025
    (do
     (call $foo)
    )
    (catch_all
-    (try $try25
+    (try $try26
      (do
-      (rethrow $l024)
+      (rethrow $l025)
      )
      (catch_all
       (nop)

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -6,6 +6,7 @@
  (event $event$0 (attr 0) (param i32))
  (event $event$1 (attr 0) (param i64))
  (event $event$2 (attr 0) (param i32 i64))
+ (event $event$3 (attr 0) (param))
  (func $foo
   (nop)
  )
@@ -256,6 +257,14 @@
     )
    )
    (delegate 0)
+  )
+  (try $label$28
+   (do
+    (nop)
+   )
+   (catch $event$3
+    (nop)
+   )
   )
  )
  (func $rethrow-test

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -6,6 +6,7 @@
  (event $event$0 (attr 0) (param i32))
  (event $event$1 (attr 0) (param i64))
  (event $event$2 (attr 0) (param i32 i64))
+ (event $event$3 (attr 0) (param))
  (func $0
   (nop)
  )
@@ -256,6 +257,14 @@
     )
    )
    (delegate 0)
+  )
+  (try $label$28
+   (do
+    (nop)
+   )
+   (catch $event$3
+    (nop)
+   )
   )
  )
  (func $4


### PR DESCRIPTION
Previously we assumed catch body's size should be at least 3: `catch`
keyword, event name, and body. But catch's body can be empty when the
event's type is none. This PR fixes the bug and allows empty catch
bodies to be parsed correctly.

Fixes #3629.