### PR TITLE
[Wasm Exceptions] Properly ensure unique try labels after an inlining

### DIFF
--- a/src/parsing.h
+++ b/src/parsing.h
@@ -345,8 +345,8 @@ struct UniqueNameMapper {
 
   // Given an expression, ensures all names are unique
   static void uniquify(Expression* curr) {
-    struct Walker : public ControlFlowWalker<Walker,
-                                             UnifiedExpressionVisitor<Walker>> {
+    struct Walker
+      : public ControlFlowWalker<Walker, UnifiedExpressionVisitor<Walker>> {
       UniqueNameMapper mapper;
 
       static void doPreVisitControlFlow(Walker* self, Expression** currp) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2098,6 +2098,9 @@ void FunctionValidator::visitTry(Try* curr) {
   shouldBeTrue(getModule()->features.hasExceptionHandling(),
                curr,
                "try requires exception-handling to be enabled");
+  if (curr->name.is()) {
+    noteLabelName(curr->name);
+  }
   if (curr->type != Type::unreachable) {
     shouldBeSubTypeOrFirstIsUnreachable(
       curr->body->type,

--- a/test/passes/inlining_all-features.txt
+++ b/test/passes/inlining_all-features.txt
@@ -53,3 +53,29 @@
   )
  )
 )
+(module
+ (type $i32_=>_none (func (param i32)))
+ (type $none_=>_i32 (func (result i32)))
+ (import "a" "b" (func $foo (result i32)))
+ (event $event$0 (attr 0) (param i32))
+ (export "exported" (func $1))
+ (func $1 (param $x i32)
+  (loop $label
+   (block
+    (block $__inlined_func$0
+     (try $label0
+      (do
+       (nop)
+      )
+      (catch $event$0
+       (nop)
+      )
+     )
+    )
+   )
+   (br_if $label
+    (call $foo)
+   )
+  )
+ )
+)

--- a/test/passes/inlining_all-features.wast
+++ b/test/passes/inlining_all-features.wast
@@ -43,3 +43,24 @@
   (call $0)
  )
 )
+;; properly ensure unique try labels after an inlining
+(module
+ (import "a" "b" (func $foo (result i32)))
+ (event $event$0 (attr 0) (param i32))
+ (func $0
+  (try $label
+   (do)
+   (catch $event$0
+    (nop)
+   )
+  )
+ )
+ (func "exported" (param $x i32)
+  (loop $label ;; the same label as the try that will be inlined into here
+   (call $0)
+   (br_if $label
+    (call $foo)
+   )
+  )
+ )
+)


### PR DESCRIPTION
The old code here just referred to Block and Loop. Refactor it to use the
generic helper code that also handles Try.

Also add validation of Try names in the validator.

The testcase here would have `$label` appear twice before this fix. After
the fix there is `$label0` for one of them.