### PR TITLE
[Wasm Exceptions] Fix/work around delegate 0 issues in Inlining pass

### DIFF
--- a/src/parsing.h
+++ b/src/parsing.h
@@ -321,6 +321,11 @@ struct UniqueNameMapper {
   }
 
   Name sourceToUnique(Name sName) {
+    // DELEGATE_CALLER_TARGET is a fake target used to denote delegating to the
+    // caller. We do not need to modify it, as it has no definitions, only uses.
+    if (sName == DELEGATE_CALLER_TARGET) {
+      return DELEGATE_CALLER_TARGET;
+    }
     if (labelMappings.find(sName) == labelMappings.end()) {
       throw ParseException("bad label in sourceToUnique");
     }

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -48,6 +48,7 @@ struct FunctionInfo {
   Index size;
   bool hasCalls;
   bool hasLoops;
+  bool hasTryDelegate;
   bool usedGlobally; // in a table or export
 
   FunctionInfo() {
@@ -55,11 +56,16 @@ struct FunctionInfo {
     size = 0;
     hasCalls = false;
     hasLoops = false;
+    hasTryDelegate = false;
     usedGlobally = false;
   }
 
   // See pass.h for how defaults for these options were chosen.
   bool worthInlining(PassOptions& options) {
+    // Until we have proper support for try-delegate, ignore such functions.
+    if (hasTryDelegate) {
+      return false;
+    }
     // If it's small enough that we always want to inline such things, do so.
     if (size <= options.inlining.alwaysInlineMaxSize) {
       return true;
@@ -111,6 +117,12 @@ struct FunctionInfoScanner
     (*infos)[curr->target].refs++;
     // having a call
     (*infos)[getFunction()->name].hasCalls = true;
+  }
+
+  void visitTry(Try* curr) {
+    if (curr->isDelegate()) {
+      (*infos)[getFunction()->name].hasTryDelegate = true;
+    }
   }
 
   void visitRefFunc(RefFunc* curr) {

--- a/test/passes/inlining_all-features.txt
+++ b/test/passes/inlining_all-features.txt
@@ -93,3 +93,19 @@
   (call $0)
  )
 )
+(module
+ (type $none_=>_i32 (func (result i32)))
+ (func $1 (result i32)
+  (try $label$3
+   (do
+    (nop)
+   )
+   (delegate 0)
+  )
+  (block (result i32)
+   (block $__inlined_func$0 (result i32)
+    (i32.const 42)
+   )
+  )
+ )
+)

--- a/test/passes/inlining_all-features.txt
+++ b/test/passes/inlining_all-features.txt
@@ -79,3 +79,17 @@
   )
  )
 )
+(module
+ (type $none_=>_none (func))
+ (func $0
+  (try $label$3
+   (do
+    (nop)
+   )
+   (delegate 0)
+  )
+ )
+ (func $1
+  (call $0)
+ )
+)

--- a/test/passes/inlining_all-features.wast
+++ b/test/passes/inlining_all-features.wast
@@ -69,13 +69,25 @@
  (type $none_=>_none (func))
  (func $0
   (try $label$3
-   (do
-    (nop)
-   )
+   (do)
    (delegate 0)
   )
  )
  (func $1
+  (call $0)
+ )
+)
+;; properly support inlining into a function with a try-delegate
+(module
+ (type $none_=>_none (func))
+ (func $0 (result i32)
+  (i32.const 42)
+ )
+ (func $1 (result i32)
+  (try $label$3
+   (do)
+   (delegate 0)
+  )
   (call $0)
  )
 )

--- a/test/passes/inlining_all-features.wast
+++ b/test/passes/inlining_all-features.wast
@@ -64,3 +64,18 @@
   )
  )
 )
+;; for now, do not inline a try-delegate
+(module
+ (type $none_=>_none (func))
+ (func $0
+  (try $label$3
+   (do
+    (nop)
+   )
+   (delegate 0)
+  )
+ )
+ (func $1
+  (call $0)
+ )
+)


### PR DESCRIPTION
1. Ignore the fake delegate target in the unique name mapper. The mapper
  is run after inlining, so this fixes inlining into a function that has a delegate 0.
2. Do not inline a function with delegate 0. We should support this eventually,
  but for now I think this is good enough.

(Btw what are the proper semantics of an inlined delegate 0? Should it delegate
to a new try at the inlining site, and do a rethrow from there, something like
that?)

After this Inlining should be safe to run on exceptions code.