### PR TITLE
Make the reduction script more robust, and document text reduction

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1207,9 +1207,10 @@ At least one of the next two values should be 0:
 The following value should be 1:
   1
 
-(If it does not, then one possible issue is that -ttf fails to write a valid
-binary. If so, you can print the output of ttf in text form and run the
-reduction from that, passing --text to the reducer.)
+(If it does not, then one possible issue is that the fuzzer fails to write a
+valid binary. If so, you can print the output of the fuzzer's first command
+(using -ttf / --translate-to-fuzz) in text form and run the reduction from that,
+passing --text to the reducer.)
 
 You can also read "%(reduce_sh)s" which has been filled out for you and includes
 docs and suggestions.

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1137,7 +1137,7 @@ echo "At least one of the next two values should be 0:"
 %(wasm_opt)s --detect-features %(temp_wasm)s
 echo "  " $?
 %(wasm_opt)s --all-features %(temp_wasm)s
-echo ":" $?
+echo "  " $?
 
 # run the command
 echo "The following value should be 1:"

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1133,12 +1133,16 @@ on valid wasm files.)
                 with open('reduce.sh', 'w') as reduce_sh:
                     reduce_sh.write('''\
 # check the input is even a valid wasm file
+echo "At least one of the next two values should be 0:"
 %(wasm_opt)s --detect-features %(temp_wasm)s
-echo "should be 0:" $?
+echo "  " $?
+%(wasm_opt)s --all-features %(temp_wasm)s
+echo ":" $?
 
 # run the command
+echo "The following value should be 1:"
 ./scripts/fuzz_opt.py --binaryen-bin %(bin)s %(seed)d %(temp_wasm)s > o 2> e
-echo "should be 1:" $?
+echo "  " $?
 
 #
 # You may want to print out part of "o" or "e", if the output matters and not
@@ -1195,10 +1199,17 @@ vvvv
 ^^^^
 ||||
 
-Make sure to verify by eye that the output says
+Make sure to verify by eye that the output says something like this:
 
-should be 0: 0
-should be 1: 1
+At least one of the next two values should be 0:
+  0
+  1
+The following value should be 1:
+  1
+
+(If it does not, then one possible issue is that -ttf fails to write a valid
+binary. If so, you can print the output of ttf in text form and run the
+reduction from that, passing --text to the reducer.)
 
 You can also read "%(reduce_sh)s" which has been filled out for you and includes
 docs and suggestions.


### PR DESCRIPTION
The check for a valid wasm file must be different if the wasm has
a feature section or not, so just try both ways, with `--detect-features`
and `--all-features`. If the wasm is valid, at least one will work.