### PR TITLE
Fix binary writing of local name indexes

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1275,6 +1275,11 @@ private:
   // the function is written out.
   std::vector<Expression*> binaryLocationTrackedExpressionsForFunc;
 
+  // Maps function names to their mapped locals. This is used when we emit the
+  // local names section: we map the locals when writing the function, save that
+  // info here, and then use it when writing the names.
+  std::unordered_map<Name, MappedLocals> funcMappedLocals;
+
   void prepare();
 };
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1090,6 +1090,9 @@ enum FeaturePrefix {
 
 } // namespace BinaryConsts
 
+// (local index in IR, tuple index) => binary local index
+using MappedLocals = std::unordered_map<std::pair<Index, Index>, size_t>;
+
 // Writes out wasm to the binary format
 
 class WasmBinaryWriter {

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -82,9 +82,6 @@ public:
   Type type;
 };
 
-// (local index, tuple index) => binary local index
-using MappedLocals = std::unordered_map<std::pair<Index, Index>, size_t>;
-
 class BinaryInstWriter : public OverriddenVisitor<BinaryInstWriter> {
 public:
   BinaryInstWriter(WasmBinaryWriter& parent,

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -82,6 +82,9 @@ public:
   Type type;
 };
 
+// (local index, tuple index) => binary local index
+using MappedLocals = std::unordered_map<std::pair<Index, Index>, size_t>;
+
 class BinaryInstWriter : public OverriddenVisitor<BinaryInstWriter> {
 public:
   BinaryInstWriter(WasmBinaryWriter& parent,
@@ -118,6 +121,8 @@ public:
   void emitUnreachable();
   void mapLocalsAndEmitHeader();
 
+  MappedLocals mappedLocals;
+
 private:
   void emitMemoryAccess(size_t alignment, size_t bytes, uint32_t offset);
   int32_t getBreakIndex(Name name);
@@ -130,10 +135,12 @@ private:
 
   std::vector<Name> breakStack;
 
+  // The types of locals in the compact form, in order.
+  std::vector<Type> localTypes;
   // type => number of locals of that type in the compact form
-  std::map<Type, size_t> numLocalsByType;
-  // (local index, tuple index) => binary local index
-  std::map<std::pair<Index, Index>, size_t> mappedLocals;
+  std::unordered_map<Type, size_t> numLocalsByType;
+
+  void noteLocalType(Type type);
 
   // Keeps track of the binary index of the scratch locals used to lower
   // tuple.extract.
@@ -401,6 +408,8 @@ public:
     }
   }
 
+  MappedLocals& getMappedLocals() { return writer.mappedLocals; }
+
 private:
   WasmBinaryWriter& parent;
   BinaryInstWriter writer;
@@ -457,6 +466,8 @@ public:
       func(func) {}
 
   void write();
+
+  MappedLocals& getMappedLocals() { return writer.mappedLocals; }
 
 private:
   BinaryInstWriter writer;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -338,14 +338,14 @@ void WasmBinaryWriter::writeFunctions() {
       StackIRToBinaryWriter writer(*this, o, func);
       writer.write();
       if (debugInfo) {
-        funcMappedLocals[func->name].swap(writer.getMappedLocals());
+        funcMappedLocals[func->name] = std::move(writer.getMappedLocals());
       }
     } else {
       BYN_TRACE("write Binaryen IR\n");
       BinaryenIRToBinaryWriter writer(*this, o, func, sourceMap, DWARF);
       writer.write();
       if (debugInfo) {
-        funcMappedLocals[func->name].swap(writer.getMappedLocals());
+        funcMappedLocals[func->name] = std::move(writer.getMappedLocals());
       }
     }
     size_t size = o.size() - start;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -689,7 +689,8 @@ void WasmBinaryWriter::writeNames() {
           auto indexInFunc = indexedLocal.first;
           auto name = indexedLocal.second;
           // TODO: handle multivalue
-          auto indexInBinary = funcMappedLocals.at(func->name)[std::pair(indexInFunc, 0)];
+          auto indexInBinary =
+            funcMappedLocals.at(func->name)[std::pair(indexInFunc, 0)];
           o << U32LEB(localIndexInFunc);
           writeEscapedName(name.str);
         }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -335,10 +335,18 @@ void WasmBinaryWriter::writeFunctions() {
     // Emit Stack IR if present, and if we can
     if (func->stackIR && !sourceMap && !DWARF) {
       BYN_TRACE("write Stack IR\n");
-      StackIRToBinaryWriter(*this, o, func).write();
+      StackIRToBinaryWriter writer(*this, o, func);
+      writer.write();
+      if (debugInfo) {
+        funcMappedLocals[func->name].swap(writer.getMappedLocals());
+      }
     } else {
       BYN_TRACE("write Binaryen IR\n");
-      BinaryenIRToBinaryWriter(*this, o, func, sourceMap, DWARF).write();
+      BinaryenIRToBinaryWriter writer(*this, o, func, sourceMap, DWARF);
+      writer.write();
+      if (debugInfo) {
+        funcMappedLocals[func->name].swap(writer.getMappedLocals());
+      }
     }
     size_t size = o.size() - start;
     assert(size <= std::numeric_limits<uint32_t>::max());
@@ -663,20 +671,27 @@ void WasmBinaryWriter::writeNames() {
         startSubsection(BinaryConsts::UserSections::Subsection::NameLocal);
       o << U32LEB(functionsWithLocalNames.size());
       Index emitted = 0;
-      for (auto& indexedFunc : functionsWithLocalNames) {
+      for (auto& kv : functionsWithLocalNames) {
+        auto index = kv.first;
+        auto* func = kv.second;
+        // Pairs of (local index in function, name).
         std::vector<std::pair<Index, Name>> localsWithNames;
-        auto numLocals = indexedFunc.second->getNumLocals();
+        auto numLocals = func->getNumLocals();
         for (Index i = 0; i < numLocals; ++i) {
-          if (indexedFunc.second->hasLocalName(i)) {
-            localsWithNames.push_back({i, indexedFunc.second->getLocalName(i)});
+          if (func->hasLocalName(i)) {
+            localsWithNames.push_back({i, func->getLocalName(i)});
           }
         }
         assert(localsWithNames.size());
-        o << U32LEB(indexedFunc.first);
+        o << U32LEB(index);
         o << U32LEB(localsWithNames.size());
         for (auto& indexedLocal : localsWithNames) {
-          o << U32LEB(indexedLocal.first);
-          writeEscapedName(indexedLocal.second.str);
+          auto indexInFunc = indexedLocal.first;
+          auto name = indexedLocal.second;
+          // TODO: handle multivalue
+          auto indexInBinary = funcMappedLocals.at(func->name)[std::pair(indexInFunc, 0)];
+          o << U32LEB(localIndexInFunc);
+          writeEscapedName(name.str);
         }
         emitted++;
       }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -674,7 +674,7 @@ void WasmBinaryWriter::writeNames() {
       for (auto& kv : functionsWithLocalNames) {
         auto index = kv.first;
         auto* func = kv.second;
-        // Pairs of (local index in function, name).
+        // Pairs of (local index in IR, name).
         std::vector<std::pair<Index, Name>> localsWithNames;
         auto numLocals = func->getNumLocals();
         for (Index i = 0; i < numLocals; ++i) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -690,8 +690,8 @@ void WasmBinaryWriter::writeNames() {
           auto name = indexedLocal.second;
           // TODO: handle multivalue
           auto indexInBinary =
-            funcMappedLocals.at(func->name)[std::pair(indexInFunc, 0)];
-          o << U32LEB(localIndexInFunc);
+            funcMappedLocals.at(func->name)[{indexInFunc, 0}];
+          o << U32LEB(indexInBinary);
           writeEscapedName(name.str);
         }
         emitted++;

--- a/test/atomics64.wast.fromBinary
+++ b/test/atomics64.wast.fromBinary
@@ -2,183 +2,183 @@
  (type $0 (func))
  (memory $0 (shared i64 23 256))
  (func $atomic-loadstore
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (i32.atomic.load8_u offset=4
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i32.atomic.load16_u offset=4
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i32.atomic.load offset=4
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load8_u
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load16_u
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load32_u
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load
-    (local.get $1)
+    (local.get $0)
    )
   )
   (i32.atomic.store offset=4
-   (local.get $1)
    (local.get $0)
+   (local.get $2)
   )
   (i32.atomic.store8 offset=4
-   (local.get $1)
    (local.get $0)
+   (local.get $2)
   )
   (i32.atomic.store16 offset=4
-   (local.get $1)
    (local.get $0)
+   (local.get $2)
   )
   (i64.atomic.store offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
   (i64.atomic.store8 offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
   (i64.atomic.store16 offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
   (i64.atomic.store32 offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
  )
  (func $atomic-rmw
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (i32.atomic.rmw.add offset=4
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw8.add_u offset=4
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw16.and_u
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (i64.atomic.rmw32.or_u
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw8.xchg_u
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
  )
  (func $atomic-cmpxchg
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (i32.atomic.rmw.cmpxchg offset=4
-    (local.get $1)
     (local.get $0)
-    (local.get $0)
+    (local.get $2)
+    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw8.cmpxchg_u
-    (local.get $1)
     (local.get $0)
-    (local.get $0)
+    (local.get $2)
+    (local.get $2)
    )
   )
   (drop
    (i64.atomic.rmw.cmpxchg offset=4
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (i64.atomic.rmw32.cmpxchg_u
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
  )
  (func $atomic-wait-notify
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (memory.atomic.wait32
-    (local.get $1)
     (local.get $0)
     (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (memory.atomic.wait32 offset=4
-    (local.get $1)
     (local.get $0)
     (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (memory.atomic.notify
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (memory.atomic.notify offset=24
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (memory.atomic.wait64
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (memory.atomic.wait64 offset=16
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
  )

--- a/test/atomics64.wast.fromBinary.noDebugInfo
+++ b/test/atomics64.wast.fromBinary.noDebugInfo
@@ -2,183 +2,183 @@
  (type $none_=>_none (func))
  (memory $0 (shared i64 23 256))
  (func $0
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (i32.atomic.load8_u offset=4
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i32.atomic.load16_u offset=4
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i32.atomic.load offset=4
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load8_u
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load16_u
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load32_u
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
    (i64.atomic.load
-    (local.get $1)
+    (local.get $0)
    )
   )
   (i32.atomic.store offset=4
-   (local.get $1)
    (local.get $0)
+   (local.get $2)
   )
   (i32.atomic.store8 offset=4
-   (local.get $1)
    (local.get $0)
+   (local.get $2)
   )
   (i32.atomic.store16 offset=4
-   (local.get $1)
    (local.get $0)
+   (local.get $2)
   )
   (i64.atomic.store offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
   (i64.atomic.store8 offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
   (i64.atomic.store16 offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
   (i64.atomic.store32 offset=4
+   (local.get $0)
    (local.get $1)
-   (local.get $2)
   )
  )
  (func $1
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (i32.atomic.rmw.add offset=4
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw8.add_u offset=4
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw16.and_u
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (i64.atomic.rmw32.or_u
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw8.xchg_u
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
  )
  (func $2
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (i32.atomic.rmw.cmpxchg offset=4
-    (local.get $1)
     (local.get $0)
-    (local.get $0)
+    (local.get $2)
+    (local.get $2)
    )
   )
   (drop
    (i32.atomic.rmw8.cmpxchg_u
-    (local.get $1)
     (local.get $0)
-    (local.get $0)
+    (local.get $2)
+    (local.get $2)
    )
   )
   (drop
    (i64.atomic.rmw.cmpxchg offset=4
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (i64.atomic.rmw32.cmpxchg_u
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
  )
  (func $3
-  (local $0 i32)
+  (local $0 i64)
   (local $1 i64)
-  (local $2 i64)
+  (local $2 i32)
   (drop
    (memory.atomic.wait32
-    (local.get $1)
     (local.get $0)
     (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (memory.atomic.wait32 offset=4
-    (local.get $1)
     (local.get $0)
     (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (memory.atomic.notify
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (memory.atomic.notify offset=24
-    (local.get $1)
     (local.get $0)
+    (local.get $2)
    )
   )
   (drop
    (memory.atomic.wait64
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
   (drop
    (memory.atomic.wait64 offset=16
+    (local.get $0)
     (local.get $1)
-    (local.get $2)
-    (local.get $2)
+    (local.get $1)
    )
   )
  )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -26,8 +26,8 @@
   (local $tA (ref null $struct.A))
   (local $tB (ref null $struct.B))
   (local $tc (ref null $struct.C))
-  (local $tv (ref null $matrix))
-  (local $tm (ref null $vector))
+  (local $tv (ref null $vector))
+  (local $tm (ref null $matrix))
   (drop
    (local.get $x)
   )
@@ -118,10 +118,10 @@
   (unreachable)
  )
  (func $arrays (param $x (ref null $vector)) (result (ref null $matrix))
-  (local $tv (ref null $matrix))
-  (local $tm (ref null $words))
+  (local $tv (ref null $vector))
+  (local $tm (ref null $matrix))
   (local $tb (ref null $bytes))
-  (local $tw (ref null $vector))
+  (local $tw (ref null $words))
   (drop
    (array.new_with_rtt $vector
     (f64.const 3.14159)
@@ -153,7 +153,7 @@
   )
   (drop
    (array.get $words
-    (local.get $tm)
+    (local.get $tw)
     (i32.const 1)
    )
   )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -26,8 +26,8 @@
   (local $1 (ref null ${i32_f32_f64}))
   (local $2 (ref null ${i8_mut:i16_ref?|{i32_f32_f64}|_mut:ref?|{i32_f32_f64}|}))
   (local $3 (ref null ${mut:f32}))
-  (local $4 (ref null $[ref?|[mut:f64]|]))
-  (local $5 (ref null $[mut:f64]))
+  (local $4 (ref null $[mut:f64]))
+  (local $5 (ref null $[ref?|[mut:f64]|]))
   (drop
    (local.get $0)
   )
@@ -118,10 +118,10 @@
   (unreachable)
  )
  (func $1 (param $0 (ref null $[mut:f64])) (result (ref null $[ref?|[mut:f64]|]))
-  (local $1 (ref null $[ref?|[mut:f64]|]))
-  (local $2 (ref null $[mut:i32]))
+  (local $1 (ref null $[mut:f64]))
+  (local $2 (ref null $[ref?|[mut:f64]|]))
   (local $3 (ref null $[mut:i8]))
-  (local $4 (ref null $[mut:f64]))
+  (local $4 (ref null $[mut:i32]))
   (drop
    (array.new_with_rtt $[mut:f64]
     (f64.const 3.14159)
@@ -153,7 +153,7 @@
   )
   (drop
    (array.get $[mut:i32]
-    (local.get $2)
+    (local.get $4)
     (i32.const 1)
    )
   )

--- a/test/passes/reorder-locals_print_roundtrip.txt
+++ b/test/passes/reorder-locals_print_roundtrip.txt
@@ -1,0 +1,58 @@
+(module
+ (type $none_=>_none (func))
+ (func $a
+  (local $x i32)
+  (local $y f64)
+  (drop
+   (local.get $x)
+  )
+  (drop
+   (local.get $x)
+  )
+  (drop
+   (local.get $y)
+  )
+ )
+ (func $b
+  (local $y f64)
+  (local $x i32)
+  (drop
+   (local.get $x)
+  )
+  (drop
+   (local.get $y)
+  )
+  (drop
+   (local.get $y)
+  )
+ )
+)
+(module
+ (type $none_=>_none (func))
+ (func $a
+  (local $x i32)
+  (local $y f64)
+  (drop
+   (local.get $x)
+  )
+  (drop
+   (local.get $x)
+  )
+  (drop
+   (local.get $y)
+  )
+ )
+ (func $b
+  (local $y f64)
+  (local $x i32)
+  (drop
+   (local.get $x)
+  )
+  (drop
+   (local.get $y)
+  )
+  (drop
+   (local.get $y)
+  )
+ )
+)

--- a/test/passes/reorder-locals_print_roundtrip.wast
+++ b/test/passes/reorder-locals_print_roundtrip.wast
@@ -1,0 +1,19 @@
+(module
+  (func $a
+    (local $x i32)
+    (local $y f64)
+    ;; x appears twice
+    (drop (local.get $x))
+    (drop (local.get $x))
+    (drop (local.get $y))
+  )
+  (func $b
+    (local $x i32)
+    (local $y f64)
+    ;; y appears twice, so it will be reordered to be first, and that should be
+    ;; preserved in the binary format
+    (drop (local.get $x))
+    (drop (local.get $y))
+    (drop (local.get $y))
+  )
+)

--- a/test/reference-types.wast.fromBinary
+++ b/test/reference-types.wast.fromBinary
@@ -35,28 +35,28 @@
   (nop)
  )
  (func $test
-  (local $local_externref funcref)
-  (local $local_funcref externref)
+  (local $local_externref externref)
+  (local $local_funcref funcref)
   (local $local_anyref anyref)
-  (local.set $local_funcref
-   (local.get $local_funcref)
-  )
-  (local.set $local_funcref
-   (global.get $global_externref)
-  )
-  (local.set $local_funcref
-   (ref.null extern)
-  )
   (local.set $local_externref
    (local.get $local_externref)
   )
   (local.set $local_externref
+   (global.get $global_externref)
+  )
+  (local.set $local_externref
+   (ref.null extern)
+  )
+  (local.set $local_funcref
+   (local.get $local_funcref)
+  )
+  (local.set $local_funcref
    (global.get $global_funcref)
   )
-  (local.set $local_externref
+  (local.set $local_funcref
    (ref.null func)
   )
-  (local.set $local_externref
+  (local.set $local_funcref
    (ref.func $foo)
   )
   (local.set $local_anyref
@@ -69,7 +69,7 @@
    (ref.null any)
   )
   (local.set $local_anyref
-   (local.get $local_funcref)
+   (local.get $local_externref)
   )
   (local.set $local_anyref
    (global.get $global_externref)
@@ -78,7 +78,7 @@
    (ref.null extern)
   )
   (local.set $local_anyref
-   (local.get $local_externref)
+   (local.get $local_funcref)
   )
   (local.set $local_anyref
    (global.get $global_funcref)
@@ -93,7 +93,7 @@
    (global.get $global_externref)
   )
   (global.set $global_externref
-   (local.get $local_funcref)
+   (local.get $local_externref)
   )
   (global.set $global_externref
    (ref.null extern)
@@ -102,7 +102,7 @@
    (global.get $global_funcref)
   )
   (global.set $global_funcref
-   (local.get $local_externref)
+   (local.get $local_funcref)
   )
   (global.set $global_funcref
    (ref.null func)
@@ -123,7 +123,7 @@
    (global.get $global_externref)
   )
   (global.set $global_anyref
-   (local.get $local_funcref)
+   (local.get $local_externref)
   )
   (global.set $global_anyref
    (ref.null extern)
@@ -132,7 +132,7 @@
    (global.get $global_funcref)
   )
   (global.set $global_anyref
-   (local.get $local_externref)
+   (local.get $local_funcref)
   )
   (global.set $global_anyref
    (ref.null func)
@@ -141,7 +141,7 @@
    (ref.func $foo)
   )
   (call $take_externref
-   (local.get $local_funcref)
+   (local.get $local_externref)
   )
   (call $take_externref
    (global.get $global_externref)
@@ -150,7 +150,7 @@
    (ref.null extern)
   )
   (call $take_funcref
-   (local.get $local_externref)
+   (local.get $local_funcref)
   )
   (call $take_funcref
    (global.get $global_funcref)
@@ -171,7 +171,7 @@
    (ref.null any)
   )
   (call $take_anyref
-   (local.get $local_funcref)
+   (local.get $local_externref)
   )
   (call $take_anyref
    (global.get $global_externref)
@@ -180,7 +180,7 @@
    (ref.null extern)
   )
   (call $take_anyref
-   (local.get $local_externref)
+   (local.get $local_funcref)
   )
   (call $take_anyref
    (global.get $global_funcref)
@@ -192,7 +192,7 @@
    (ref.func $foo)
   )
   (call_indirect $0 (type $sig_externref)
-   (local.get $local_funcref)
+   (local.get $local_externref)
    (i32.const 0)
   )
   (call_indirect $0 (type $sig_externref)
@@ -204,7 +204,7 @@
    (i32.const 0)
   )
   (call_indirect $0 (type $sig_funcref)
-   (local.get $local_externref)
+   (local.get $local_funcref)
    (i32.const 1)
   )
   (call_indirect $0 (type $sig_funcref)
@@ -232,7 +232,7 @@
    (i32.const 3)
   )
   (call_indirect $0 (type $sig_anyref)
-   (local.get $local_funcref)
+   (local.get $local_externref)
    (i32.const 3)
   )
   (call_indirect $0 (type $sig_anyref)
@@ -244,7 +244,7 @@
    (i32.const 3)
   )
   (call_indirect $0 (type $sig_anyref)
-   (local.get $local_externref)
+   (local.get $local_funcref)
    (i32.const 3)
   )
   (call_indirect $0 (type $sig_anyref)
@@ -262,7 +262,7 @@
   (drop
    (block $label$1 (result externref)
     (br_if $label$1
-     (local.get $local_funcref)
+     (local.get $local_externref)
      (i32.const 1)
     )
    )
@@ -286,7 +286,7 @@
   (drop
    (block $label$4 (result funcref)
     (br_if $label$4
-     (local.get $local_externref)
+     (local.get $local_funcref)
      (i32.const 1)
     )
    )
@@ -342,7 +342,7 @@
   (drop
    (block $label$11 (result anyref)
     (br_if $label$11
-     (local.get $local_funcref)
+     (local.get $local_externref)
      (i32.const 1)
     )
    )
@@ -350,7 +350,7 @@
   (drop
    (block $label$12 (result anyref)
     (br_if $label$12
-     (local.get $local_externref)
+     (local.get $local_funcref)
      (i32.const 1)
     )
    )
@@ -381,7 +381,7 @@
   )
   (drop
    (loop $label$16 (result externref)
-    (local.get $local_funcref)
+    (local.get $local_externref)
    )
   )
   (drop
@@ -396,7 +396,7 @@
   )
   (drop
    (loop $label$19 (result funcref)
-    (local.get $local_externref)
+    (local.get $local_funcref)
    )
   )
   (drop
@@ -431,7 +431,7 @@
   )
   (drop
    (loop $label$26 (result anyref)
-    (local.get $local_funcref)
+    (local.get $local_externref)
    )
   )
   (drop
@@ -446,7 +446,7 @@
   )
   (drop
    (loop $label$29 (result anyref)
-    (local.get $local_externref)
+    (local.get $local_funcref)
    )
   )
   (drop
@@ -467,14 +467,14 @@
   (drop
    (if (result externref)
     (i32.const 1)
-    (local.get $local_funcref)
+    (local.get $local_externref)
     (ref.null extern)
    )
   )
   (drop
    (if (result funcref)
     (i32.const 1)
-    (local.get $local_externref)
+    (local.get $local_funcref)
     (ref.null func)
    )
   )
@@ -488,8 +488,8 @@
   (drop
    (if (result anyref)
     (i32.const 1)
-    (local.get $local_funcref)
     (local.get $local_externref)
+    (local.get $local_funcref)
    )
   )
   (drop
@@ -509,7 +509,7 @@
   (drop
    (try $label$47 (result externref)
     (do
-     (local.get $local_funcref)
+     (local.get $local_externref)
     )
     (catch $event$0
      (drop
@@ -535,7 +535,7 @@
   (drop
    (try $label$53 (result anyref)
     (do
-     (local.get $local_funcref)
+     (local.get $local_externref)
     )
     (catch $event$0
      (drop
@@ -554,20 +554,20 @@
      (drop
       (pop i32)
      )
-     (local.get $local_funcref)
+     (local.get $local_externref)
     )
    )
   )
   (drop
    (select (result externref)
-    (local.get $local_funcref)
+    (local.get $local_externref)
     (ref.null extern)
     (i32.const 1)
    )
   )
   (drop
    (select (result funcref)
-    (local.get $local_externref)
+    (local.get $local_funcref)
     (ref.null func)
     (i32.const 1)
    )
@@ -581,21 +581,21 @@
   )
   (drop
    (select (result anyref)
-    (local.get $local_funcref)
     (local.get $local_externref)
+    (local.get $local_funcref)
     (i32.const 1)
    )
   )
   (drop
    (select (result anyref)
-    (local.get $local_externref)
     (local.get $local_funcref)
+    (local.get $local_externref)
     (i32.const 1)
    )
   )
   (drop
    (ref.is_null
-    (local.get $local_funcref)
+    (local.get $local_externref)
    )
   )
   (drop
@@ -610,7 +610,7 @@
   )
   (drop
    (ref.is_null
-    (local.get $local_externref)
+    (local.get $local_funcref)
    )
   )
   (drop
@@ -719,10 +719,10 @@
   )
  )
  (func $returns_anyref2 (result anyref)
-  (local $local_externref funcref)
-  (local $local_funcref externref)
+  (local $local_externref externref)
+  (local $local_funcref funcref)
   (return
-   (local.get $local_funcref)
+   (local.get $local_externref)
   )
  )
 )

--- a/test/reference-types.wast.fromBinary.noDebugInfo
+++ b/test/reference-types.wast.fromBinary.noDebugInfo
@@ -35,28 +35,28 @@
   (nop)
  )
  (func $4
-  (local $0 funcref)
-  (local $1 externref)
+  (local $0 externref)
+  (local $1 funcref)
   (local $2 anyref)
-  (local.set $1
-   (local.get $1)
-  )
-  (local.set $1
-   (global.get $global$0)
-  )
-  (local.set $1
-   (ref.null extern)
-  )
   (local.set $0
    (local.get $0)
   )
   (local.set $0
+   (global.get $global$0)
+  )
+  (local.set $0
+   (ref.null extern)
+  )
+  (local.set $1
+   (local.get $1)
+  )
+  (local.set $1
    (global.get $global$1)
   )
-  (local.set $0
+  (local.set $1
    (ref.null func)
   )
-  (local.set $0
+  (local.set $1
    (ref.func $3)
   )
   (local.set $2
@@ -69,7 +69,7 @@
    (ref.null any)
   )
   (local.set $2
-   (local.get $1)
+   (local.get $0)
   )
   (local.set $2
    (global.get $global$0)
@@ -78,7 +78,7 @@
    (ref.null extern)
   )
   (local.set $2
-   (local.get $0)
+   (local.get $1)
   )
   (local.set $2
    (global.get $global$1)
@@ -93,7 +93,7 @@
    (global.get $global$0)
   )
   (global.set $global$0
-   (local.get $1)
+   (local.get $0)
   )
   (global.set $global$0
    (ref.null extern)
@@ -102,7 +102,7 @@
    (global.get $global$1)
   )
   (global.set $global$1
-   (local.get $0)
+   (local.get $1)
   )
   (global.set $global$1
    (ref.null func)
@@ -123,7 +123,7 @@
    (global.get $global$0)
   )
   (global.set $global$3
-   (local.get $1)
+   (local.get $0)
   )
   (global.set $global$3
    (ref.null extern)
@@ -132,7 +132,7 @@
    (global.get $global$1)
   )
   (global.set $global$3
-   (local.get $0)
+   (local.get $1)
   )
   (global.set $global$3
    (ref.null func)
@@ -141,7 +141,7 @@
    (ref.func $3)
   )
   (call $0
-   (local.get $1)
+   (local.get $0)
   )
   (call $0
    (global.get $global$0)
@@ -150,7 +150,7 @@
    (ref.null extern)
   )
   (call $1
-   (local.get $0)
+   (local.get $1)
   )
   (call $1
    (global.get $global$1)
@@ -171,7 +171,7 @@
    (ref.null any)
   )
   (call $2
-   (local.get $1)
+   (local.get $0)
   )
   (call $2
    (global.get $global$0)
@@ -180,7 +180,7 @@
    (ref.null extern)
   )
   (call $2
-   (local.get $0)
+   (local.get $1)
   )
   (call $2
    (global.get $global$1)
@@ -192,7 +192,7 @@
    (ref.func $3)
   )
   (call_indirect $0 (type $externref_=>_none)
-   (local.get $1)
+   (local.get $0)
    (i32.const 0)
   )
   (call_indirect $0 (type $externref_=>_none)
@@ -204,7 +204,7 @@
    (i32.const 0)
   )
   (call_indirect $0 (type $funcref_=>_none)
-   (local.get $0)
+   (local.get $1)
    (i32.const 1)
   )
   (call_indirect $0 (type $funcref_=>_none)
@@ -232,7 +232,7 @@
    (i32.const 3)
   )
   (call_indirect $0 (type $anyref_=>_none)
-   (local.get $1)
+   (local.get $0)
    (i32.const 3)
   )
   (call_indirect $0 (type $anyref_=>_none)
@@ -244,7 +244,7 @@
    (i32.const 3)
   )
   (call_indirect $0 (type $anyref_=>_none)
-   (local.get $0)
+   (local.get $1)
    (i32.const 3)
   )
   (call_indirect $0 (type $anyref_=>_none)
@@ -262,7 +262,7 @@
   (drop
    (block $label$1 (result externref)
     (br_if $label$1
-     (local.get $1)
+     (local.get $0)
      (i32.const 1)
     )
    )
@@ -286,7 +286,7 @@
   (drop
    (block $label$4 (result funcref)
     (br_if $label$4
-     (local.get $0)
+     (local.get $1)
      (i32.const 1)
     )
    )
@@ -342,7 +342,7 @@
   (drop
    (block $label$11 (result anyref)
     (br_if $label$11
-     (local.get $1)
+     (local.get $0)
      (i32.const 1)
     )
    )
@@ -350,7 +350,7 @@
   (drop
    (block $label$12 (result anyref)
     (br_if $label$12
-     (local.get $0)
+     (local.get $1)
      (i32.const 1)
     )
    )
@@ -381,7 +381,7 @@
   )
   (drop
    (loop $label$16 (result externref)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -396,7 +396,7 @@
   )
   (drop
    (loop $label$19 (result funcref)
-    (local.get $0)
+    (local.get $1)
    )
   )
   (drop
@@ -431,7 +431,7 @@
   )
   (drop
    (loop $label$26 (result anyref)
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -446,7 +446,7 @@
   )
   (drop
    (loop $label$29 (result anyref)
-    (local.get $0)
+    (local.get $1)
    )
   )
   (drop
@@ -467,14 +467,14 @@
   (drop
    (if (result externref)
     (i32.const 1)
-    (local.get $1)
+    (local.get $0)
     (ref.null extern)
    )
   )
   (drop
    (if (result funcref)
     (i32.const 1)
-    (local.get $0)
+    (local.get $1)
     (ref.null func)
    )
   )
@@ -488,8 +488,8 @@
   (drop
    (if (result anyref)
     (i32.const 1)
-    (local.get $1)
     (local.get $0)
+    (local.get $1)
    )
   )
   (drop
@@ -509,7 +509,7 @@
   (drop
    (try $label$47 (result externref)
     (do
-     (local.get $1)
+     (local.get $0)
     )
     (catch $event$0
      (drop
@@ -535,7 +535,7 @@
   (drop
    (try $label$53 (result anyref)
     (do
-     (local.get $1)
+     (local.get $0)
     )
     (catch $event$0
      (drop
@@ -554,20 +554,20 @@
      (drop
       (pop i32)
      )
-     (local.get $1)
+     (local.get $0)
     )
    )
   )
   (drop
    (select (result externref)
-    (local.get $1)
+    (local.get $0)
     (ref.null extern)
     (i32.const 1)
    )
   )
   (drop
    (select (result funcref)
-    (local.get $0)
+    (local.get $1)
     (ref.null func)
     (i32.const 1)
    )
@@ -581,21 +581,21 @@
   )
   (drop
    (select (result anyref)
-    (local.get $1)
     (local.get $0)
+    (local.get $1)
     (i32.const 1)
    )
   )
   (drop
    (select (result anyref)
-    (local.get $0)
     (local.get $1)
+    (local.get $0)
     (i32.const 1)
    )
   )
   (drop
    (ref.is_null
-    (local.get $1)
+    (local.get $0)
    )
   )
   (drop
@@ -610,7 +610,7 @@
   )
   (drop
    (ref.is_null
-    (local.get $0)
+    (local.get $1)
    )
   )
   (drop
@@ -719,10 +719,10 @@
   )
  )
  (func $25 (result anyref)
-  (local $0 funcref)
-  (local $1 externref)
+  (local $0 externref)
+  (local $1 funcref)
   (return
-   (local.get $1)
+   (local.get $0)
   )
  )
 )

--- a/test/typed-function-references.wast.fromBinary
+++ b/test/typed-function-references.wast.fromBinary
@@ -51,8 +51,8 @@
  )
  (func $type-only-in-tuple-local
   (local $x i32)
-  (local $1 f64)
-  (local $2 (ref null $=>anyref))
+  (local $1 (ref null $=>anyref))
+  (local $2 f64)
   (nop)
  )
  (func $type-only-in-tuple-block

--- a/test/typed-function-references.wast.fromBinary.noDebugInfo
+++ b/test/typed-function-references.wast.fromBinary.noDebugInfo
@@ -51,8 +51,8 @@
  )
  (func $7
   (local $0 i32)
-  (local $1 f64)
-  (local $2 (ref null $none_=>_anyref))
+  (local $1 (ref null $none_=>_anyref))
+  (local $2 f64)
   (nop)
  )
  (func $8


### PR DESCRIPTION
When writing a binary, we take the local indexes in the IR and turn
them into the format in the binary, which clumps them by type. When
writing the names section we should be aware of that ordering, but
we never were, as noticed in https://github.com/WebAssembly/binaryen/issues/3499

This fixes that by saving the mapping of locals when we are emitting
the name section, then using it when emitting the local names.

This also fixes the order of the types themselves as part of the
refactoring. We used to depend on the ordering of types to decide
which to emit first, but that isn't good for at least two reasons. First,
it hits https://github.com/WebAssembly/binaryen/issues/3648 - that order is not fully
defined for recursive types. Also, it's not good for code size - we've
ordered the locals in a way we think is best already (ReorderLocals pass).
This PR makes us pick an order of types based on that, as much as
possible, that is, when we see a type for the first time we append it to
a list whose order we use.

Test changes: Some are just because we use a different order than
before, as in `atomics64`. But some are actual fixes, e.g. in `heap-types`
where we now have ` (local $tv (ref null $vector))` which is indeed
right - `v` there is for `vector`, and likewise `m` for `matrix` etc. - we
just had wrong names before. Another example, we now have
`(local $local_externref externref)` whereas before the name was
`funcref`, and which was wrong... seems like the incorrectness was
more common on reference types and GC types, which is why this was
not noticed before.

Fixes https://github.com/WebAssembly/binaryen/issues/3499

Makes part of https://github.com/WebAssembly/binaryen/issues/3648 moot.
