### PR TITLE
Stop emitting features section in fuzzer

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -857,7 +857,7 @@ def test_one(random_input, given_wasm):
     else:
         # emit the target features section so that reduction can work later,
         # without needing to specify the features
-        generate_command = [in_bin('wasm-opt'), random_input, '-ttf', '-o', 'a.wasm', '--emit-target-features'] + FUZZ_OPTS + FEATURE_OPTS
+        generate_command = [in_bin('wasm-opt'), random_input, '-ttf', '-o', 'a.wasm'] + FUZZ_OPTS + FEATURE_OPTS
         if INITIAL_CONTENTS:
             generate_command += ['--initial-fuzz=' + INITIAL_CONTENTS]
         if PRINT_WATS:


### PR DESCRIPTION
I'm not sure what this was added - @tlively maybe you know?

It seems unneeded as we call all the commands with all the feature
args on the commandline anyhow.

Also, this caused an actual problem on a particular fuzz testcase I
found. Rather than figure out the details there, it seems simpler to not
depend on the features section while fuzzing?