### PR TITLE
[Wasm GC] Fix cost.h on array.new_default

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -615,7 +615,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, Index> {
     return 2 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->value);
   }
   Index visitArrayNew(ArrayNew* curr) {
-    return 4 + visit(curr->rtt) + visit(curr->size) + visit(curr->init);
+    return 4 + visit(curr->rtt) + visit(curr->size) + maybeVisit(curr->init);
   }
   Index visitArrayGet(ArrayGet* curr) {
     return 1 + nullCheckCost(curr->ref) + visit(curr->ref) + visit(curr->index);

--- a/test/passes/remove-unused-brs_all-features.txt
+++ b/test/passes/remove-unused-brs_all-features.txt
@@ -1,0 +1,18 @@
+(module
+ (type $struct (struct (field (ref null $vector))))
+ (type $vector (array (mut i32)))
+ (type $none_=>_ref?|$struct| (func (result (ref null $struct))))
+ (func $foo (result (ref null $struct))
+  (if (result (ref null $struct))
+   (i32.const 1)
+   (struct.new_with_rtt $struct
+    (array.new_default_with_rtt $vector
+     (i32.const 1)
+     (rtt.canon $vector)
+    )
+    (rtt.canon $struct)
+   )
+   (ref.null $struct)
+  )
+ )
+)

--- a/test/passes/remove-unused-brs_all-features.wast
+++ b/test/passes/remove-unused-brs_all-features.wast
@@ -1,0 +1,19 @@
+(module
+ (type $vector (array (mut i32)))
+ (type $struct (struct (field (ref null $vector))))
+ (func $foo (result (ref null $struct))
+  (if (result (ref null $struct))
+   (i32.const 1)
+   (struct.new_with_rtt $struct
+    ;; regression test for computing the cost of an array.new_default, which
+    ;; lacks the optional field "init"
+    (array.new_default_with_rtt $vector
+     (i32.const 1)
+     (rtt.canon $vector)
+    )
+    (rtt.canon $struct)
+   )
+   (ref.null $struct)
+  )
+ )
+)


### PR DESCRIPTION
Trivial fix. Found by reducing a real-world codebase.

The test here is what actually crashed, a case of a pass that uses
cost analysis. With some extra work this could be a unit test perhaps
in C++. Would that be worth it?