### PR TITLE
[Wasm GC] Consider subtyping in least upper bounds

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -640,6 +640,12 @@ Type Type::getLeastUpperBound(Type a, Type b) {
   if (b == Type::unreachable) {
     return a;
   }
+  if (isSubType(a, b)) {
+    return b;
+  }
+  if (isSubType(b, a)) {
+    return a;
+  }
   if (a.size() != b.size()) {
     return Type::none; // a poison value that must not be consumed
   }

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -569,11 +569,20 @@ void test_literals() {
   }
 }
 
+void test_LUB() {
+  // b is a subtype of a, and so the least upper bound is a.
+  auto a = Type(Struct({ Field(Type::i32, Mutable) }), Nullable);
+  auto b = Type(Struct({ Field(Type::i32, Mutable), Field(Type::f64, Mutable) }), Nullable);
+  assert_equal(Type::getLeastUpperBound(a, b), a);
+  assert_equal(Type::getLeastUpperBound(b, a), a);
+}
+
 int main() {
   test_bits();
   test_cost();
   test_effects();
   test_literals();
+  test_LUB();
 
   if (failsCount > 0) {
     abort();

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -571,8 +571,9 @@ void test_literals() {
 
 void test_LUB() {
   // b is a subtype of a, and so the least upper bound is a.
-  auto a = Type(Struct({ Field(Type::i32, Mutable) }), Nullable);
-  auto b = Type(Struct({ Field(Type::i32, Mutable), Field(Type::f64, Mutable) }), Nullable);
+  auto a = Type(Struct({Field(Type::i32, Mutable)}), Nullable);
+  auto b = Type(Struct({Field(Type::i32, Mutable), Field(Type::f64, Mutable)}),
+                Nullable);
   assert_equal(Type::getLeastUpperBound(a, b), a);
   assert_equal(Type::getLeastUpperBound(b, a), a);
 }


### PR DESCRIPTION
Unless I am missing something, since we have structural subtyping
in wasm then when computing an LUB that must be taken into account.

Without this, the LUB of `{i32}, {i32, f64}` will be `dataref`. That breaks
on testcases like this when using SimplifyLocals:
```wat
(module
 (type $struct.A (struct (field i32)))
 (type $struct.B (struct (field i32) (field f64)))
 (func "test" (result (ref null $struct.A))
  (local $temp (ref null $struct.A))
  ;; this block will get a return value (replacing the sets to $temp). that
  ;; block's type must be valid. in the testcase here, B extends A, and so we
  ;; can use A, and do not need to go all the way up to the 'data' heap type.
  (block $return.label
   (if
    (i32.const 0)
    (block
     (local.set $temp
      (ref.null $struct.A)
     )
     (br $return.label)
    )
   )
   (local.set $temp
    (struct.new_default_with_rtt $struct.B
     (rtt.canon $struct.B)
    )
   )
  )
  (local.get $temp)
 )
)
```
Reduced from a real-world testcase.