### PR TITLE
Fixed .debug_loc parsing for wasm64 files

### DIFF
--- a/third_party/llvm-project/DWARFEmitter.cpp
+++ b/third_party/llvm-project/DWARFEmitter.cpp
@@ -133,8 +133,10 @@ void DWARFYAML::EmitDebugRanges(raw_ostream &OS, const DWARFYAML::Data &DI) {
 // XXX BINARYEN
 void DWARFYAML::EmitDebugLoc(raw_ostream &OS, const DWARFYAML::Data &DI) {
   for (auto Loc : DI.Locs) {
-    writeInteger((uint32_t)Loc.Start, OS, DI.IsLittleEndian);
-    writeInteger((uint32_t)Loc.End, OS, DI.IsLittleEndian);
+    auto AddrSize = DI.CompileUnits[0].AddrSize;  // XXX BINARYEN
+    // FIXME: Loc.Start etc should probably not be 32-bit.
+    writeVariableSizedInteger((uint64_t)(int32_t)Loc.Start, AddrSize, OS, DI.IsLittleEndian);
+    writeVariableSizedInteger((uint64_t)(int32_t)Loc.End, AddrSize, OS, DI.IsLittleEndian);
     if (Loc.Start == 0 && Loc.End == 0) {
       // End of a list.
       continue;

--- a/third_party/llvm-project/dwarf2yaml.cpp
+++ b/third_party/llvm-project/dwarf2yaml.cpp
@@ -116,7 +116,10 @@ void dumpDebugRanges(DWARFContext &DCtx, DWARFYAML::Data &Y) { // XXX BINARYEN
 }
 
 void dumpDebugLoc(DWARFContext &DCtx, DWARFYAML::Data &Y) { // XXX BINARYEN
-  uint8_t savedAddressByteSize = 4;
+  // This blindly grabs the first CU, which should be ok since they all have
+  // the same address size?
+  auto CU = DCtx.normal_units().begin()->get();
+  uint8_t savedAddressByteSize = CU->getFormParams().AddrSize;  // XXX BINARYEN
   DWARFDataExtractor locsData(DCtx.getDWARFObj(), DCtx.getDWARFObj().getLocSection(),
                               DCtx.isLittleEndian(), savedAddressByteSize);
   uint64_t offset = 0;
@@ -126,7 +129,7 @@ void dumpDebugLoc(DWARFContext &DCtx, DWARFYAML::Data &Y) { // XXX BINARYEN
     auto list = locList.parseOneLocationList(locsData, &offset);
     if (!list) {
       errs() << "debug_loc error\n";
-      break;
+      exit(1);
     }
     for (auto& entry : list.get().Entries) {
       DWARFYAML::Loc loc;
@@ -426,9 +429,10 @@ std::error_code dwarf2yaml(DWARFContext &DCtx, DWARFYAML::Data &Y) {
   dumpDebugStrings(DCtx, Y);
   dumpDebugARanges(DCtx, Y);
   dumpDebugRanges(DCtx, Y); // XXX BINARYEN
-  dumpDebugLoc(DCtx, Y); // XXX BINARYEN
   dumpDebugPubSections(DCtx, Y);
   dumpDebugInfo(DCtx, Y);
+  // dumpDebugLoc relies on the address size being known from dumpDebugInfo.
+  dumpDebugLoc(DCtx, Y); // XXX BINARYEN
   dumpDebugLines(DCtx, Y);
   return obj2yaml_error::success;
 }


### PR DESCRIPTION
The address size was hard-coded to 4, it now gets this information from .debug_info.
This required changing the parsing order.
Also made failure to parse .debug_loc fail the program, as before this error was easy to ignore.

Note there is no test specific to the combination of dwarf + wasm64 in binaryen, as I am only just working on the tests in emscripten that uncovered this issue.