### PR TITLE
[RT] Support expressions in element segments

### DIFF
--- a/src/ir/element-utils.h
+++ b/src/ir/element-utils.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_element_h
+#define wasm_ir_element_h
+
+#include "wasm-builder.h"
+#include "wasm.h"
+
+namespace wasm {
+
+namespace ElementUtils {
+
+// iterate over functions referenced in an element segment
+template<typename T>
+inline void iterElementSegmentFunctionNames(ElementSegment* segment,
+                                            T visitor) {
+  // TODO(reference-types): return early if segment type is non-funcref
+  for (Index i = 0; i < segment->data.size(); i++) {
+    if (auto* get = segment->data[i]->dynCast<RefFunc>()) {
+      visitor(get->func, i);
+    }
+  }
+}
+
+// iterate over functions referenced in all element segments of a module
+template<typename T>
+inline void iterAllElementFunctionNames(const Module* wasm, T visitor) {
+  for (auto& segment : wasm->elementSegments) {
+    iterElementSegmentFunctionNames(
+      segment.get(), [&](Name& name, Index i) { visitor(name); });
+  }
+}
+
+} // namespace ElementUtils
+
+} // namespace wasm
+
+#endif // wasm_ir_element_h

--- a/src/ir/table-utils.cpp
+++ b/src/ir/table-utils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "table-utils.h"
+#include "element-utils.h"
 #include "find_all.h"
 #include "module-utils.h"
 
@@ -31,11 +32,8 @@ std::set<Name> getFunctionsNeedingElemDeclare(Module& wasm) {
   // Find all the names in the tables.
 
   std::unordered_set<Name> tableNames;
-  for (auto& segment : wasm.elementSegments) {
-    for (auto name : segment->data) {
-      tableNames.insert(name);
-    }
-  }
+  ElementUtils::iterAllElementFunctionNames(
+    &wasm, [&](Name name) { tableNames.insert(name); });
 
   // Find all the names in ref.funcs.
   using Names = std::unordered_set<Name>;

--- a/src/ir/table-utils.h
+++ b/src/ir/table-utils.h
@@ -86,9 +86,7 @@ inline Index append(Table& table, Name name, Module& wasm) {
   }
 
   auto* func = wasm.getFunctionOrNull(name);
-  if (func == nullptr) {
-    Fatal() << "Cannot append non-existing function to a table.";
-  }
+  assert(func != nullptr && "Cannot append non-existing function to a table.");
   // FIXME: make the type NonNullable when we support it!
   auto type = Type(HeapType(func->sig), Nullable);
   segment->data.push_back(Builder(wasm).makeRefFunc(name, type));

--- a/src/ir/table-utils.h
+++ b/src/ir/table-utils.h
@@ -17,6 +17,7 @@
 #ifndef wasm_ir_table_h
 #define wasm_ir_table_h
 
+#include "ir/element-utils.h"
 #include "ir/literal-utils.h"
 #include "ir/module-utils.h"
 #include "wasm-traversal.h"
@@ -45,9 +46,8 @@ struct FlatTable {
         if (end > names.size()) {
           names.resize(end);
         }
-        for (Index i = 0; i < segment->data.size(); i++) {
-          names[start + i] = segment->data[i];
-        }
+        ElementUtils::iterElementSegmentFunctionNames(
+          segment, [&](Name entry, Index i) { names[start + i] = entry; });
       });
   }
 };
@@ -84,7 +84,14 @@ inline Index append(Table& table, Name name, Module& wasm) {
     }
     wasm.dylinkSection->tableSize++;
   }
-  segment->data.push_back(name);
+
+  auto* func = wasm.getFunctionOrNull(name);
+  if (func == nullptr) {
+    Fatal() << "Cannot append non-existing function to a table.";
+  }
+  // FIXME: make the type NonNullable when we support it!
+  auto type = Type(HeapType(func->sig), Nullable);
+  segment->data.push_back(Builder(wasm).makeRefFunc(name, type));
   table.initial = table.initial + 1;
   return tableIndex;
 }
@@ -94,8 +101,10 @@ inline Index append(Table& table, Name name, Module& wasm) {
 inline Index getOrAppend(Table& table, Name name, Module& wasm) {
   auto segment = getSingletonSegment(table, wasm);
   for (Index i = 0; i < segment->data.size(); i++) {
-    if (segment->data[i] == name) {
-      return i;
+    if (auto* get = segment->data[i]->dynCast<RefFunc>()) {
+      if (get->func == name) {
+        return i;
+      }
     }
   }
   return append(table, name, wasm);

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -39,6 +39,7 @@
 
 #include "cfg/cfg-traversal.h"
 #include "ir/effects.h"
+#include "ir/element-utils.h"
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "passes/opt-utils.h"
@@ -284,11 +285,8 @@ struct DAE : public Pass {
         infoMap[curr->value].hasUnseenCalls = true;
       }
     }
-    for (auto& segment : module->elementSegments) {
-      for (auto name : segment->data) {
-        infoMap[name].hasUnseenCalls = true;
-      }
-    }
+    ElementUtils::iterAllElementFunctionNames(
+      module, [&](Name name) { infoMap[name].hasUnseenCalls = true; });
     // Scan all the functions.
     DAEScanner(&infoMap).run(runner, module);
     // Combine all the info.

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -24,6 +24,7 @@
 
 #include "abi/js.h"
 #include "asm_v_wasm.h"
+#include "ir/element-utils.h"
 #include "ir/import-utils.h"
 #include "pass.h"
 #include "support/debug.h"
@@ -57,9 +58,10 @@ struct GenerateDynCalls : public WalkerPass<PostWalker<GenerateDynCalls>> {
                            });
     if (it != segments.end()) {
       std::vector<Name> tableSegmentData;
-      for (const auto& indirectFunc : it->get()->data) {
-        generateDynCallThunk(wasm->getFunction(indirectFunc)->sig);
-      }
+      ElementUtils::iterElementSegmentFunctionNames(
+        it->get(), [&](Name name, Index) {
+          generateDynCallThunk(wasm->getFunction(name)->sig);
+        });
     }
   }
 

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -31,6 +31,7 @@
 #include <atomic>
 
 #include "ir/debug.h"
+#include "ir/element-utils.h"
 #include "ir/literal-utils.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
@@ -348,11 +349,8 @@ struct Inlining : public Pass {
         infos[ex->value].usedGlobally = true;
       }
     }
-    for (auto& segment : module->elementSegments) {
-      for (auto name : segment->data) {
-        infos[name].usedGlobally = true;
-      }
-    }
+    ElementUtils::iterAllElementFunctionNames(
+      module, [&](Name name) { infos[name].usedGlobally = true; });
 
     for (auto& global : module->globals) {
       if (!global->imported()) {

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -31,6 +31,7 @@
 //
 
 #include "asmjs/shared-constants.h"
+#include "ir/element-utils.h"
 #include "ir/import-utils.h"
 #include "ir/literal-utils.h"
 #include "ir/utils.h"
@@ -97,13 +98,11 @@ struct LegalizeJSInterface : public Pass {
         // we need to use the legalized version in the tables, as the import
         // from JS is legal for JS. Our stub makes it look like a native wasm
         // function.
-        for (auto& segment : module->elementSegments) {
-          for (auto& name : segment->data) {
-            if (name == im->name) {
-              name = funcName;
-            }
+        ElementUtils::iterAllElementFunctionNames(module, [&](Name& name) {
+          if (name == im->name) {
+            name = funcName;
           }
-        }
+        });
       }
     }
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2704,12 +2704,12 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
     if (curr->data.empty()) {
       return;
     }
-    bool useAbbreviatedForm =
+    bool allElementsRefFunc =
       std::all_of(curr->data.begin(), curr->data.end(), [](Expression* entry) {
         return entry->is<RefFunc>();
       });
     auto printElemType = [&]() {
-      if (useAbbreviatedForm) {
+      if (allElementsRefFunc) {
         TypeNamePrinter(o, currModule).print(HeapType::func);
       } else {
         TypeNamePrinter(o, currModule).print(Type::funcref);
@@ -2726,7 +2726,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
 
     if (curr->table.is()) {
       // TODO(reference-types): check for old-style based on the complete spec
-      if (currModule->tables.size() > 1) {
+      if (!allElementsRefFunc || currModule->tables.size() > 1) {
         // tableuse
         o << " (table ";
         printName(curr->table, o);
@@ -2736,7 +2736,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
       o << ' ';
       visit(curr->offset);
 
-      if (currModule->tables.size() > 1) {
+      if (!allElementsRefFunc || currModule->tables.size() > 1) {
         o << ' ';
         printElemType();
       }
@@ -2745,7 +2745,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
       printElemType();
     }
 
-    if (useAbbreviatedForm) {
+    if (allElementsRefFunc) {
       for (auto* entry : curr->data) {
         auto* refFunc = entry->cast<RefFunc>();
         o << ' ';

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -22,6 +22,7 @@
 #include <iomanip>
 #include <memory>
 
+#include "ir/element-utils.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
 #include "pass.h"
@@ -96,12 +97,10 @@ struct PrintCallGraph : public Pass {
     CallPrinter printer(module);
 
     // Indirect Targets
-    for (auto& segment : module->elementSegments) {
-      for (auto& curr : segment->data) {
-        auto* func = module->getFunction(curr);
-        o << "  \"" << func->name << "\" [style=\"filled, rounded\"];\n";
-      }
-    }
+    ElementUtils::iterAllElementFunctionNames(module, [&](Name& name) {
+      auto* func = module->getFunction(name);
+      o << "  \"" << func->name << "\" [style=\"filled, rounded\"];\n";
+    });
 
     o << "}\n";
   }

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -22,6 +22,7 @@
 // look at all the rest of the code).
 //
 
+#include "ir/element-utils.h"
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "wasm.h"
@@ -49,11 +50,8 @@ struct RemoveImports : public WalkerPass<PostWalker<RemoveImports>> {
       *curr, [&](Function* func) { names.push_back(func->name); });
     // Do not remove names referenced in a table
     std::set<Name> indirectNames;
-    for (auto& segment : curr->elementSegments) {
-      for (auto& name : segment->data) {
-        indirectNames.insert(name);
-      }
-    }
+    ElementUtils::iterAllElementFunctionNames(
+      curr, [&](Name& name) { indirectNames.insert(name); });
     for (auto& name : names) {
       if (indirectNames.find(name) == indirectNames.end()) {
         curr->removeFunction(name);

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -22,6 +22,7 @@
 
 #include <memory>
 
+#include "ir/element-utils.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
 #include "pass.h"
@@ -194,11 +195,9 @@ struct RemoveUnusedModuleElements : public Pass {
       importsMemory = true;
     }
     // For now, all functions that can be called indirectly are marked as roots.
-    for (auto& segment : module->elementSegments) {
-      for (auto& curr : segment->data) {
-        roots.emplace_back(ModuleElementKind::Function, curr);
-      }
-    }
+    ElementUtils::iterAllElementFunctionNames(module, [&](Name& name) {
+      roots.emplace_back(ModuleElementKind::Function, name);
+    });
     // Compute reachability starting from the root set.
     ReachabilityAnalyzer analyzer(module, roots);
     // Remove unreachable elements.

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -29,6 +29,7 @@
 
 #include <memory>
 
+#include <ir/element-utils.h>
 #include <pass.h>
 #include <wasm.h>
 
@@ -70,11 +71,8 @@ struct ReorderFunctions : public Pass {
     for (auto& curr : module->exports) {
       counts[curr->value]++;
     }
-    for (auto& segment : module->elementSegments) {
-      for (auto& curr : segment->data) {
-        counts[curr]++;
-      }
-    }
+    ElementUtils::iterAllElementFunctionNames(
+      module, [&](Name& name) { counts[name]++; });
     // sort
     std::sort(module->functions.begin(),
               module->functions.end(),

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <unordered_set>
 
+#include <ir/element-utils.h>
 #include <pass.h>
 #include <wasm.h>
 
@@ -86,11 +87,7 @@ inline void replaceFunctions(PassRunner* runner,
   // replace direct calls
   FunctionRefReplacer(maybeReplace).run(runner, &module);
   // replace in table
-  for (auto& segment : module.elementSegments) {
-    for (auto& name : segment->data) {
-      maybeReplace(name);
-    }
-  }
+  ElementUtils::iterAllElementFunctionNames(&module, maybeReplace);
 
   // replace in start
   if (module.start.is()) {

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -86,7 +86,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     }
   } memory;
 
-  std::unordered_map<Name, std::vector<Name>> tables;
+  std::unordered_map<Name, std::vector<Literal>> tables;
 
   ShellExternalInterface() : memory() {}
   virtual ~ShellExternalInterface() = default;
@@ -177,7 +177,10 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     if (index >= table.size()) {
       trap("callTable overflow");
     }
-    auto* func = instance.wasm.getFunctionOrNull(table[index]);
+    Function* func = nullptr;
+    if (table[index].isFunction() && !table[index].isNull()) {
+      func = instance.wasm.getFunctionOrNull(table[index].getFunc());
+    }
     if (!func) {
       trap("uninitialized table element");
     }
@@ -231,7 +234,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     memory.set<std::array<uint8_t, 16>>(addr, value);
   }
 
-  void tableStore(Name tableName, Address addr, Name entry) override {
+  void tableStore(Name tableName, Address addr, Literal entry) override {
     tables[tableName][addr] = entry;
   }
 

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 
+#include "ir/element-utils.h"
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "support/colors.h"
@@ -216,13 +217,14 @@ struct MetaDCEGraph {
     ModuleUtils::iterActiveElementSegments(wasm, [&](ElementSegment* segment) {
       // TODO: currently, all functions in the table are roots, but we
       //       should add an option to refine that
-      for (auto& name : segment->data) {
-        if (!wasm.getFunction(name)->imported()) {
-          roots.insert(functionToDCENode[name]);
-        } else {
-          roots.insert(importIdToDCENode[getFunctionImportId(name)]);
-        }
-      }
+      ElementUtils::iterElementSegmentFunctionNames(
+        segment, [&](Name name, Index) {
+          if (!wasm.getFunction(name)->imported()) {
+            roots.insert(functionToDCENode[name]);
+          } else {
+            roots.insert(importIdToDCENode[getFunctionImportId(name)]);
+          }
+        });
       rooter.walk(segment->offset);
     });
     for (auto& segment : wasm.memory.segments) {

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -858,13 +858,13 @@ struct Reducer
           if (entry->is<RefNull>()) {
             // we don't need to replace a ref.null
             return true;
-          } else if (!first || first->is<RefNull>()) {
+          } else if (first->is<RefNull>()) {
             return false;
           } else {
             // Both are ref.func
             auto* f = first->cast<RefFunc>();
             auto* e = entry->cast<RefFunc>();
-            return f->func == e->func && f->type == e->type;
+            return f->func == e->func;
           }
         },
         100,

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -838,6 +838,11 @@ struct Reducer
     if (it != module->elementSegments.end()) {
       first = it->get()->data[0];
     }
+    if (first == nullptr) {
+      // The elements are all empty, nothing to shrink
+      return;
+    }
+
     // try to reduce to first function. first, shrink segment elements.
     // while we are shrinking successfully, keep going exponentially.
     bool shrank = false;
@@ -845,10 +850,6 @@ struct Reducer
       shrank = shrinkByReduction(segment.get(), 100);
     }
     // the "opposite" of shrinking: copy a 'zero' element
-    if (first == nullptr) {
-      return;
-    }
-
     for (auto& segment : module->elementSegments) {
       reduceByZeroing(
         segment.get(),

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -829,7 +829,7 @@ struct Reducer
 
   void shrinkElementSegments(Module* module) {
     std::cerr << "|    try to simplify elem segments\n";
-    Expression* first;
+    Expression* first = nullptr;
     auto it =
       std::find_if_not(module->elementSegments.begin(),
                        module->elementSegments.end(),
@@ -845,7 +845,7 @@ struct Reducer
       shrank = shrinkByReduction(segment.get(), 100);
     }
     // the "opposite" of shrinking: copy a 'zero' element
-    if (!first) {
+    if (first == nullptr) {
       return;
     }
 
@@ -857,7 +857,7 @@ struct Reducer
           if (entry->is<RefNull>()) {
             // we don't need to replace a ref.null
             return true;
-          } else if (first->is<RefNull>()) {
+          } else if (!first || first->is<RefNull>()) {
             return false;
           } else {
             // Both are ref.func

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -766,7 +766,31 @@ struct Reducer
     }
     // the "opposite" of shrinking: copy a 'zero' element
     for (auto& segment : curr->segments) {
-      reduceByZeroing(&segment, 0, 2, shrank);
+      reduceByZeroing(
+        &segment, 0, [](char item) { return item == 0; }, 2, shrank);
+    }
+  }
+
+  template<typename T, typename U, typename C>
+  void
+  reduceByZeroing(T* segment, U zero, C isZero, size_t bonus, bool shrank) {
+    for (auto& item : segment->data) {
+      if (!shouldTryToReduce(bonus) || isZero(item)) {
+        continue;
+      }
+      auto save = item;
+      item = zero;
+      if (writeAndTestReduction()) {
+        std::cerr << "|      zeroed elem segment\n";
+        noteReduction();
+      } else {
+        item = save;
+      }
+      if (shrank) {
+        // zeroing is fairly inefficient. if we are managing to shrink
+        // (which we do exponentially), just zero one per segment at most
+        break;
+      }
     }
   }
 
@@ -803,37 +827,9 @@ struct Reducer
     return shrank;
   }
 
-  template<typename T, typename U>
-  void reduceByZeroing(T* segment, U zero, size_t bonus, bool shrank) {
-    if (segment->data.empty()) {
-      return;
-    }
-    for (auto& item : segment->data) {
-      if (!shouldTryToReduce(bonus)) {
-        continue;
-      }
-      if (item == zero) {
-        continue;
-      }
-      auto save = item;
-      item = zero;
-      if (writeAndTestReduction()) {
-        std::cerr << "|      zeroed elem segment\n";
-        noteReduction();
-      } else {
-        item = save;
-      }
-      if (shrank) {
-        // zeroing is fairly inefficient. if we are managing to shrink
-        // (which we do exponentially), just zero one per segment at most
-        break;
-      }
-    }
-  }
-
   void shrinkElementSegments(Module* module) {
     std::cerr << "|    try to simplify elem segments\n";
-    Name first;
+    Expression* first;
     auto it =
       std::find_if_not(module->elementSegments.begin(),
                        module->elementSegments.end(),
@@ -842,7 +838,6 @@ struct Reducer
     if (it != module->elementSegments.end()) {
       first = it->get()->data[0];
     }
-
     // try to reduce to first function. first, shrink segment elements.
     // while we are shrinking successfully, keep going exponentially.
     bool shrank = false;
@@ -851,7 +846,24 @@ struct Reducer
     }
     // the "opposite" of shrinking: copy a 'zero' element
     for (auto& segment : module->elementSegments) {
-      reduceByZeroing(segment.get(), first, 100, shrank);
+      reduceByZeroing(
+        segment.get(),
+        first,
+        [&](Expression* entry) {
+          if (entry->is<RefNull>()) {
+            // we don't need to replace a ref.null
+            return true;
+          } else if (first->is<RefNull>()) {
+            return false;
+          } else {
+            // Both are ref.func
+            auto* f = first->cast<RefFunc>();
+            auto* e = entry->cast<RefFunc>();
+            return f->func == e->func && f->type == e->type;
+          }
+        },
+        100,
+        shrank);
     }
   }
 

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -845,6 +845,10 @@ struct Reducer
       shrank = shrinkByReduction(segment.get(), 100);
     }
     // the "opposite" of shrinking: copy a 'zero' element
+    if (!first) {
+      return;
+    }
+
     for (auto& segment : module->elementSegments) {
       reduceByZeroing(
         segment.get(),

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "execution-results.h"
+#include "ir/element-utils.h"
 #include "pass.h"
 #include "shell-interface.h"
 #include "support/command-line.h"
@@ -166,18 +167,16 @@ run_asserts(Name moduleName,
             reportUnknownImport(import);
           }
         });
-        for (auto& segment : wasm.elementSegments) {
-          for (auto name : segment->data) {
-            // spec tests consider it illegal to use spectest.print in a table
-            if (auto* import = wasm.getFunction(name)) {
-              if (import->imported() && import->module == SPECTEST &&
-                  import->base.startsWith(PRINT)) {
-                std::cerr << "cannot put spectest.print in table\n";
-                invalid = true;
-              }
+        ElementUtils::iterAllElementFunctionNames(&wasm, [&](Name name) {
+          // spec tests consider it illegal to use spectest.print in a table
+          if (auto* import = wasm.getFunction(name)) {
+            if (import->imported() && import->module == SPECTEST &&
+                import->base.startsWith(PRINT)) {
+              std::cerr << "cannot put spectest.print in table\n";
+              invalid = true;
             }
           }
-        }
+        });
         if (wasm.memory.imported()) {
           reportUnknownImport(&wasm.memory);
         }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1531,9 +1531,6 @@ public:
   void readDataSegments();
   void readDataCount();
 
-  // A map from elem segment indexes to their entries
-  std::map<Index, std::vector<Index>> functionTable;
-
   void readTableDeclarations();
   void readElementSegments();
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -317,7 +317,8 @@ private:
   void parseElem(Element& s, Table* table = nullptr);
   ElementSegment* parseElemFinish(Element& s,
                                   std::unique_ptr<ElementSegment>& segment,
-                                  Index i = 1);
+                                  Index i = 1,
+                                  bool usesExpressions = false);
 
   // Parses something like (func ..), (array ..), (struct)
   HeapType parseHeapType(Element& s);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -196,6 +196,9 @@ struct Walker : public VisitorType {
     if (segment->table.is()) {
       walk(segment->offset);
     }
+    for (auto* expr : segment->data) {
+      walk(expr);
+    }
     static_cast<SubType*>(this)->visitElementSegment(segment);
   }
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1726,12 +1726,12 @@ class ElementSegment : public Named {
 public:
   Name table;
   Expression* offset;
-  std::vector<Name> data;
+  std::vector<Expression*> data;
 
   ElementSegment() = default;
   ElementSegment(Name table, Expression* offset)
     : table(table), offset(offset) {}
-  ElementSegment(Name table, Expression* offset, std::vector<Name>& init)
+  ElementSegment(Name table, Expression* offset, std::vector<Expression*>& init)
     : table(table), offset(offset) {
     data.swap(init);
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -570,9 +570,11 @@ void WasmBinaryWriter::writeElementSegments() {
     Index tableIdx = 0;
 
     bool isPassive = segment->table.isNull();
-    // TODO(reference-types): add support for writing expressions instead of
-    // function indices.
-    bool usesExpressions = false;
+    // if all items are ref.func, we can use the shorter form.
+    bool usesExpressions =
+      std::any_of(segment->data.begin(),
+                  segment->data.end(),
+                  [](Expression* curr) { return !curr->is<RefFunc>(); });
 
     bool hasTableIndex = false;
     if (!isPassive) {
@@ -599,13 +601,27 @@ void WasmBinaryWriter::writeElementSegments() {
       o << int8_t(BinaryConsts::End);
     }
 
-    if (!usesExpressions && (isPassive || hasTableIndex)) {
-      // elemKind funcref
-      o << U32LEB(0);
+    if (isPassive || hasTableIndex) {
+      if (usesExpressions) {
+        // elemType funcref
+        writeType(Type::funcref);
+      } else {
+        // elemKind funcref
+        o << U32LEB(0);
+      }
     }
     o << U32LEB(segment->data.size());
-    for (auto& name : segment->data) {
-      o << U32LEB(getFunctionIndex(name));
+    if (usesExpressions) {
+      for (auto* item : segment->data) {
+        writeExpression(item);
+        o << int8_t(BinaryConsts::End);
+      }
+    } else {
+      for (auto& item : segment->data) {
+        // We've ensured that all items are ref.func.
+        auto& name = item->cast<RefFunc>()->func;
+        o << U32LEB(getFunctionIndex(name));
+      }
     }
   }
 
@@ -2665,14 +2681,6 @@ void WasmBinaryBuilder::processNames() {
     }
   }
 
-  for (auto& pair : functionTable) {
-    auto i = pair.first;
-    auto& indices = pair.second;
-    for (auto j : indices) {
-      wasm.elementSegments[i]->data.push_back(getFunctionName(j));
-    }
-  }
-
   for (auto& iter : globalRefs) {
     size_t index = iter.first;
     auto& refs = iter.second;
@@ -2776,10 +2784,6 @@ void WasmBinaryBuilder::readElementSegments() {
       continue;
     }
 
-    if (usesExpressions) {
-      throwError("Only elem segments with function indexes are supported.");
-    }
-
     if (!isPassive) {
       Index tableIdx = 0;
       if (hasTableIdx) {
@@ -2808,17 +2812,35 @@ void WasmBinaryBuilder::readElementSegments() {
     }
 
     if (isPassive || hasTableIdx) {
-      auto elemKind = getU32LEB();
-      if (elemKind != 0x0) {
-        throwError("Only funcref elem kinds are valid.");
+      if (usesExpressions) {
+        auto type = getType();
+        if (type != Type::funcref) {
+          throwError("Only funcref elem kinds are valid.");
+        }
+      } else {
+        auto elemKind = getU32LEB();
+        if (elemKind != 0x0) {
+          throwError("Only funcref elem kinds are valid.");
+        }
       }
     }
 
-    size_t segmentIndex = functionTable.size();
-    auto& indexSegment = functionTable[segmentIndex];
+    auto& segmentData = elementSegments.back()->data;
     auto size = getU32LEB();
-    for (Index j = 0; j < size; j++) {
-      indexSegment.push_back(getU32LEB());
+    if (usesExpressions) {
+      for (Index j = 0; j < size; j++) {
+        segmentData.push_back(readExpression());
+      }
+    } else {
+      for (Index j = 0; j < size; j++) {
+        Index index = getU32LEB();
+        auto sig = getSignatureByFunctionIndex(index);
+        // Use a placeholder name for now
+        auto* refFunc = Builder(wasm).makeRefFunc(
+          Name::fromInt(index), Type(HeapType(sig), Nullable));
+        functionRefs[index].push_back(refFunc);
+        segmentData.push_back(refFunc);
+      }
     }
   }
 }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3273,12 +3273,14 @@ void SExpressionWasmBuilder::parseElem(Element& s, Table* table) {
   Index i = 1;
   Name name = Name::fromInt(elemCounter++);
   bool hasExplicitName = false;
+  bool isPassive = false;
+  bool usesExpressions = false;
 
   if (table) {
     Expression* offset = allocator.alloc<Const>()->set(Literal(int32_t(0)));
     auto segment = std::make_unique<ElementSegment>(table->name, offset);
     segment->setName(name, hasExplicitName);
-    parseElemFinish(s, segment, i);
+    parseElemFinish(s, segment, i, false);
     return;
   }
 
@@ -3291,10 +3293,20 @@ void SExpressionWasmBuilder::parseElem(Element& s, Table* table) {
     return;
   }
 
-  if (s[i]->isStr() && s[i]->str() == FUNC) {
+  if (s[i]->isStr()) {
+    if (s[i]->str() == FUNC) {
+      isPassive = true;
+      usesExpressions = false;
+    } else if (s[i]->str() == FUNCREF) {
+      isPassive = true;
+      usesExpressions = true;
+    }
+  }
+
+  if (isPassive) {
     auto segment = std::make_unique<ElementSegment>();
     segment->setName(name, hasExplicitName);
-    parseElemFinish(s, segment, i + 1);
+    parseElemFinish(s, segment, i + 1, usesExpressions);
     return;
   }
 
@@ -3331,11 +3343,11 @@ void SExpressionWasmBuilder::parseElem(Element& s, Table* table) {
   }
 
   if (!oldStyle) {
-    if (s[i]->str() != FUNC) {
-      throw ParseException(
-        "only the abbreviated form of elemList is supported.");
+    if (s[i]->str() == FUNCREF) {
+      usesExpressions = true;
+    } else if (s[i]->str() != FUNC) {
+      throw ParseException("expected func or funcref.");
     }
-    // ignore elemType for now
     i += 1;
   }
 
@@ -3345,13 +3357,40 @@ void SExpressionWasmBuilder::parseElem(Element& s, Table* table) {
 
   auto segment = std::make_unique<ElementSegment>(table->name, offset);
   segment->setName(name, hasExplicitName);
-  parseElemFinish(s, segment, i);
+  parseElemFinish(s, segment, i, usesExpressions);
 }
 
 ElementSegment* SExpressionWasmBuilder::parseElemFinish(
-  Element& s, std::unique_ptr<ElementSegment>& segment, Index i) {
-  for (; i < s.size(); i++) {
-    segment->data.push_back(getFunctionName(*s[i]));
+  Element& s,
+  std::unique_ptr<ElementSegment>& segment,
+  Index i,
+  bool usesExpressions) {
+
+  if (usesExpressions) {
+    for (; i < s.size(); i++) {
+      if (!s[i]->isList()) {
+        throw ParseException("expected a ref.* expression.");
+      }
+      auto& inner = *s[i];
+      if (elementStartsWith(inner, ITEM)) {
+        if (inner[1]->isList()) {
+          // (item (ref.func $f))
+          segment->data.push_back(parseExpression(inner[1]));
+        } else {
+          // (item ref.func $f)
+          inner.list().removeAt(0);
+          segment->data.push_back(parseExpression(inner));
+        }
+      } else {
+        segment->data.push_back(parseExpression(inner));
+      }
+    }
+  } else {
+    for (; i < s.size(); i++) {
+      auto func = getFunctionName(*s[i]);
+      segment->data.push_back(Builder(wasm).makeRefFunc(
+        func, Type(HeapType(functionSignatures[func]), Nullable)));
+    }
   }
   return wasm.addElementSegment(std::move(segment));
 }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1960,6 +1960,9 @@ void FunctionValidator::visitMemoryGrow(MemoryGrow* curr) {
 }
 
 void FunctionValidator::visitRefNull(RefNull* curr) {
+  // If we are not in a function, this is a global location like a table. We
+  // allow RefNull there as we represent tables that way regardless of what
+  // features are enabled.
   shouldBeTrue(!getFunction() || getModule()->features.hasReferenceTypes(),
                curr,
                "ref.null requires reference-types to be enabled");
@@ -1978,6 +1981,9 @@ void FunctionValidator::visitRefIs(RefIs* curr) {
 }
 
 void FunctionValidator::visitRefFunc(RefFunc* curr) {
+  // If we are not in a function, this is a global location like a table. We
+  // allow RefFunc there as we represent tables that way regardless of what
+  // features are enabled.
   shouldBeTrue(!getFunction() || getModule()->features.hasReferenceTypes(),
                curr,
                "ref.func requires reference-types to be enabled");

--- a/test/multi-table.wast
+++ b/test/multi-table.wast
@@ -1,6 +1,7 @@
 (module
   (import "a" "b" (table $t1 1 10 funcref))
   (table $t2 3 3 funcref)
+  (table $t3 4 4 funcref)
 
   ;; add to $t1
   (elem (i32.const 0) $f)
@@ -9,7 +10,10 @@
   (elem (table $t2) (i32.const 0) func $f)
   (elem $activeNonZeroOffset (table $t2) (offset (i32.const 1)) func $f $g)
 
-  (elem $passive func $f $g)
+  (elem $e3-1 (table $t3) (i32.const 0) funcref (ref.func $f) (ref.null func))
+  (elem $e3-2 (table $t3) (offset (i32.const 2)) funcref (item ref.func $f) (item (ref.func $g)))
+
+  (elem $passive funcref (item ref.func $f) (item (ref.func $g)) (ref.null func))
   (elem $empty func)
   (elem $declarative declare func $h)
 

--- a/test/multi-table.wast.from-wast
+++ b/test/multi-table.wast.from-wast
@@ -5,7 +5,10 @@
  (table $t2 3 3 funcref)
  (elem (table $t2) (i32.const 0) func $f)
  (elem $activeNonZeroOffset (table $t2) (i32.const 1) func $f $g)
- (elem $passive func $f $g)
+ (table $t3 4 4 funcref)
+ (elem $e3-1 (table $t3) (i32.const 0) funcref (ref.func $f) (ref.null func))
+ (elem $e3-2 (table $t3) (i32.const 2) func $f $g)
+ (elem $passive funcref (ref.func $f) (ref.func $g) (ref.null func))
  (elem declare func $h)
  (func $f
   (drop

--- a/test/multi-table.wast.fromBinary
+++ b/test/multi-table.wast.fromBinary
@@ -5,7 +5,10 @@
  (table $t2 3 3 funcref)
  (elem (table $t2) (i32.const 0) func $f)
  (elem $activeNonZeroOffset (table $t2) (i32.const 1) func $f $g)
- (elem $passive func $f $g)
+ (table $t3 4 4 funcref)
+ (elem $e3-1 (table $t3) (i32.const 0) funcref (ref.func $f) (ref.null func))
+ (elem $e3-2 (table $t3) (i32.const 2) func $f $g)
+ (elem $passive funcref (ref.func $f) (ref.func $g) (ref.null func))
  (elem declare func $h)
  (func $f
   (drop

--- a/test/multi-table.wast.fromBinary.noDebugInfo
+++ b/test/multi-table.wast.fromBinary.noDebugInfo
@@ -5,7 +5,10 @@
  (table $0 3 3 funcref)
  (elem (table $0) (i32.const 0) func $0)
  (elem (table $0) (i32.const 1) func $0 $1)
- (elem func $0 $1)
+ (table $1 4 4 funcref)
+ (elem (table $1) (i32.const 0) funcref (ref.func $0) (ref.null func))
+ (elem (table $1) (i32.const 2) func $0 $1)
+ (elem funcref (ref.func $0) (ref.func $1) (ref.null func))
  (elem declare func $2)
  (func $0
   (drop

--- a/test/passes/converge_O3_metrics.bin.txt
+++ b/test/passes/converge_O3_metrics.bin.txt
@@ -7,7 +7,7 @@ total
  [memory-data]  : 28      
  [table-data]   : 429     
  [tables]       : 0       
- [total]        : 129     
+ [total]        : 558     
  [vars]         : 4       
  Binary         : 12      
  Block          : 8       
@@ -23,6 +23,7 @@ total
  LocalGet       : 18      
  LocalSet       : 7       
  Loop           : 1       
+ RefFunc        : 429     
  Store          : 5       
 (module
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
@@ -249,7 +250,7 @@ total
  [memory-data]  : 28      
  [table-data]   : 429     
  [tables]       : 0       
- [total]        : 129     
+ [total]        : 558     
  [vars]         : 4       
  Binary         : 12      
  Block          : 8       
@@ -265,6 +266,7 @@ total
  LocalGet       : 18      
  LocalSet       : 7       
  Loop           : 1       
+ RefFunc        : 429     
  Store          : 5       
 (module
  (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))

--- a/test/passes/func-metrics.txt
+++ b/test/passes/func-metrics.txt
@@ -7,8 +7,9 @@ global
  [memory-data]  : 9       
  [table-data]   : 3       
  [tables]       : 1       
- [total]        : 3       
+ [total]        : 6       
  Const          : 3       
+ RefFunc        : 3       
 func: empty
  [binary-bytes] : 3       
  [total]        : 1       

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -7,7 +7,7 @@ total
  [memory-data]  : 4       
  [table-data]   : 17      
  [tables]       : 1       
- [total]        : 5797    
+ [total]        : 5814    
  [vars]         : 160     
  Binary         : 467     
  Block          : 810     
@@ -24,6 +24,7 @@ total
  LocalSet       : 292     
  Loop           : 127     
  Nop            : 69      
+ RefFunc        : 17      
  Return         : 259     
  Select         : 53      
  Store          : 53      

--- a/test/passes/metrics_all-features.txt
+++ b/test/passes/metrics_all-features.txt
@@ -7,13 +7,14 @@ total
  [memory-data]  : 9       
  [table-data]   : 3       
  [tables]       : 1       
- [total]        : 27      
+ [total]        : 30      
  [vars]         : 1       
  Binary         : 1       
  Block          : 1       
  Const          : 15      
  Drop           : 6       
  If             : 4       
+ RefFunc        : 3       
 (module
  (type $0 (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))

--- a/test/spec/call_indirect_refnull.wast
+++ b/test/spec/call_indirect_refnull.wast
@@ -1,0 +1,12 @@
+(module
+  (table $t 1 1 funcref)
+  (elem (table $t) (i32.const 0) funcref (ref.null func))
+
+  (func $call-refnull (export "call-refnull") (result f32)
+    (call_indirect (result f32) (i32.const 0))
+  )
+)
+(assert_trap
+  (invoke "call-refnull")
+  "uninitialized table element"
+)


### PR DESCRIPTION
This will add support for `ref.null t` as a valid element segment
item, by turning element segment data into a vector of `Expression*`
instead of just `Name`.

The abbreviated format of `(elem ... func $f $g...)` is kept in
both printing and binary emitting if all items are `ref.func`s. Public
APIs aren't updated in this PR.