### PR TITLE
[Wasm GC] Fix RTT type parsing

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1648,11 +1648,11 @@ Type WasmBinaryBuilder::getType(int initial) {
       return Type(getHeapType(), Nullable);
     case BinaryConsts::EncodedType::rtt_n: {
       auto depth = getU32LEB();
-      auto heapType = getHeapType();
+      auto heapType = getIndexedHeapType();
       return Type(Rtt(depth, heapType));
     }
     case BinaryConsts::EncodedType::rtt: {
-      return Type(Rtt(getHeapType()));
+      return Type(Rtt(getIndexedHeapType()));
     }
     default:
       throwError("invalid wasm type: " + std::to_string(initial));


### PR DESCRIPTION
RTT types have type indexes, not heap types (there is no `(rtt funcref)`).

Noticed by @manoskouk - thanks!

Fixes https://github.com/WebAssembly/binaryen/issues/3656 after which we can parse
that testcase - but not validate it yet, there is another issue remaining with typing.