### PR TITLE
Make unreachable a subtype of everything

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -863,13 +863,14 @@ struct OptimizeInstructions
           // sides are identical, fold
           // if we can replace the if with one arm, and no side effects in the
           // condition, do that
-          auto needCondition = effects(iff->condition).hasSideEffects();
-          auto isSubType = Type::isSubType(iff->ifTrue->type, iff->type);
-          if (isSubType && !needCondition) {
+          bool needCondition = effects(iff->condition).hasSideEffects();
+          bool wouldBecomeUnreachable =
+            iff->type.isConcrete() && iff->ifTrue->type == Type::unreachable;
+          if (!wouldBecomeUnreachable && !needCondition) {
             return iff->ifTrue;
           } else {
             Builder builder(*getModule());
-            if (isSubType) {
+            if (!wouldBecomeUnreachable) {
               return builder.makeSequence(builder.makeDrop(iff->condition),
                                           iff->ifTrue);
             } else {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -960,6 +960,9 @@ bool SubTyper::isSubType(Type a, Type b) {
   if (a == b) {
     return true;
   }
+  if (a == Type::unreachable) {
+    return true;
+  }
   if (a.isRef() && b.isRef()) {
     return (a.isNullable() == b.isNullable() || !a.isNullable()) &&
            isSubType(a.getHeapType(), b.getHeapType());

--- a/test/passes/remove-unused-names_vacuum.txt
+++ b/test/passes/remove-unused-names_vacuum.txt
@@ -15,9 +15,7 @@
  )
  (func $to-drop-unreachable
   (drop
-   (block (result i32)
-    (unreachable)
-   )
+   (unreachable)
   )
  )
  (func $return-i32-but-body-is-unreachable5 (result i32)


### PR DESCRIPTION
Since in principle an unreachable expression can be used in any position. An
exception to this rule is in OptimizeInstructions, which avoids replacing
concrete expressions with unreachable expressions so that it doesn't need to
refinalize any expressions. Notably, Type::getLeastUpperBound was already
treating unreachable as the bottom type.