### PR TITLE
Revert "Make unreachable a subtype of everything"

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -960,9 +960,6 @@ bool SubTyper::isSubType(Type a, Type b) {
   if (a == b) {
     return true;
   }
-  if (a == Type::unreachable) {
-    return true;
-  }
   if (a.isRef() && b.isRef()) {
     return (a.isNullable() == b.isNullable() || !a.isNullable()) &&
            isSubType(a.getHeapType(), b.getHeapType());

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -196,6 +196,18 @@ struct ValidationInfo {
     fail(text, curr, func);
     return false;
   }
+
+  // Type 'left' should be a subtype of 'right', or unreachable.
+  bool shouldBeSubTypeOrFirstIsUnreachable(Type left,
+                                           Type right,
+                                           Expression* curr,
+                                           const char* text,
+                                           Function* func = nullptr) {
+    if (left == Type::unreachable) {
+      return true;
+    }
+    return shouldBeSubType(left, right, curr, text, func);
+  }
 };
 
 struct FunctionValidator : public WalkerPass<PostWalker<FunctionValidator>> {
@@ -429,6 +441,14 @@ private:
     return info.shouldBeSubType(left, right, curr, text, getFunction());
   }
 
+  bool shouldBeSubTypeOrFirstIsUnreachable(Type left,
+                                           Type right,
+                                           Expression* curr,
+                                           const char* text) {
+    return info.shouldBeSubTypeOrFirstIsUnreachable(
+      left, right, curr, text, getFunction());
+  }
+
   void validateAlignment(
     size_t align, Type type, Index bytes, bool isAtomic, Expression* curr);
   void validateMemBytes(uint8_t bytes, Type type, Expression* curr);
@@ -448,10 +468,10 @@ private:
     }
     size_t i = 0;
     for (const auto& param : sig.params) {
-      if (!shouldBeSubType(curr->operands[i]->type,
-                           param,
-                           curr,
-                           "call param types must match") &&
+      if (!shouldBeSubTypeOrFirstIsUnreachable(curr->operands[i]->type,
+                                               param,
+                                               curr,
+                                               "call param types must match") &&
           !info.quiet) {
         getStream() << "(on argument " << i << ")\n";
       }
@@ -704,10 +724,11 @@ void FunctionValidator::visitLoop(Loop* curr) {
                     "if loop is not returning a value, final element should "
                     "not flow out a value");
     } else {
-      shouldBeSubType(curr->body->type,
-                      curr->type,
-                      curr,
-                      "loop with value and body must match types");
+      shouldBeSubTypeOrFirstIsUnreachable(
+        curr->body->type,
+        curr->type,
+        curr,
+        "loop with value and body must match types");
     }
   }
 }
@@ -729,14 +750,16 @@ void FunctionValidator::visitIf(If* curr) {
     }
   } else {
     if (curr->type != Type::unreachable) {
-      shouldBeSubType(curr->ifTrue->type,
-                      curr->type,
-                      curr,
-                      "returning if-else's true must have right type");
-      shouldBeSubType(curr->ifFalse->type,
-                      curr->type,
-                      curr,
-                      "returning if-else's false must have right type");
+      shouldBeSubTypeOrFirstIsUnreachable(
+        curr->ifTrue->type,
+        curr->type,
+        curr,
+        "returning if-else's true must have right type");
+      shouldBeSubTypeOrFirstIsUnreachable(
+        curr->ifFalse->type,
+        curr->type,
+        curr,
+        "returning if-else's false must have right type");
     } else {
       if (curr->condition->type != Type::unreachable) {
         shouldBeEqual(curr->ifTrue->type,
@@ -906,10 +929,11 @@ void FunctionValidator::visitGlobalSet(GlobalSet* curr) {
                    "global.set name must be valid (and not an import; imports "
                    "can't be modified)")) {
     shouldBeTrue(global->mutable_, curr, "global.set global must be mutable");
-    shouldBeSubType(curr->value->type,
-                    global->type,
-                    curr,
-                    "global.set value must have right type");
+    shouldBeSubTypeOrFirstIsUnreachable(
+      curr->value->type,
+      global->type,
+      curr,
+      "global.set value must have right type");
   }
 }
 
@@ -2044,14 +2068,16 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
 void FunctionValidator::visitRefEq(RefEq* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "ref.eq requires gc to be enabled");
-  shouldBeSubType(curr->left->type,
-                  Type::eqref,
-                  curr->left,
-                  "ref.eq's left argument should be a subtype of eqref");
-  shouldBeSubType(curr->right->type,
-                  Type::eqref,
-                  curr->right,
-                  "ref.eq's right argument should be a subtype of eqref");
+  shouldBeSubTypeOrFirstIsUnreachable(
+    curr->left->type,
+    Type::eqref,
+    curr->left,
+    "ref.eq's left argument should be a subtype of eqref");
+  shouldBeSubTypeOrFirstIsUnreachable(
+    curr->right->type,
+    Type::eqref,
+    curr->right,
+    "ref.eq's right argument should be a subtype of eqref");
 }
 
 void FunctionValidator::noteDelegate(Name name, Expression* curr) {
@@ -2076,15 +2102,17 @@ void FunctionValidator::visitTry(Try* curr) {
     noteLabelName(curr->name);
   }
   if (curr->type != Type::unreachable) {
-    shouldBeSubType(curr->body->type,
-                    curr->type,
-                    curr->body,
-                    "try's type does not match try body's type");
+    shouldBeSubTypeOrFirstIsUnreachable(
+      curr->body->type,
+      curr->type,
+      curr->body,
+      "try's type does not match try body's type");
     for (auto catchBody : curr->catchBodies) {
-      shouldBeSubType(catchBody->type,
-                      curr->type,
-                      catchBody,
-                      "try's type does not match catch's body type");
+      shouldBeSubTypeOrFirstIsUnreachable(
+        catchBody->type,
+        curr->type,
+        catchBody,
+        "try's type does not match catch's body type");
     }
   } else {
     shouldBeEqual(curr->body->type,
@@ -2138,10 +2166,10 @@ void FunctionValidator::visitThrow(Throw* curr) {
   }
   size_t i = 0;
   for (const auto& param : event->sig.params) {
-    if (!shouldBeSubType(curr->operands[i]->type,
-                         param,
-                         curr->operands[i],
-                         "event param types must match") &&
+    if (!shouldBeSubTypeOrFirstIsUnreachable(curr->operands[i]->type,
+                                             param,
+                                             curr->operands[i],
+                                             "event param types must match") &&
         !info.quiet) {
       getStream() << "(on argument " << i << ")\n";
     }
@@ -2222,10 +2250,10 @@ void FunctionValidator::visitCallRef(CallRef* curr) {
 void FunctionValidator::visitI31New(I31New* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "i31.new requires gc to be enabled");
-  shouldBeSubType(curr->value->type,
-                  Type::i32,
-                  curr->value,
-                  "i31.new's argument should be i32");
+  shouldBeSubTypeOrFirstIsUnreachable(curr->value->type,
+                                      Type::i32,
+                                      curr->value,
+                                      "i31.new's argument should be i32");
 }
 
 void FunctionValidator::visitI31Get(I31Get* curr) {
@@ -2234,10 +2262,11 @@ void FunctionValidator::visitI31Get(I31Get* curr) {
                "i31.get_s/u requires gc to be enabled");
   // FIXME: use i31ref here, which is non-nullable, when we support non-
   // nullability.
-  shouldBeSubType(curr->i31->type,
-                  Type(HeapType::i31, Nullable),
-                  curr->i31,
-                  "i31.get_s/u's argument should be i31ref");
+  shouldBeSubTypeOrFirstIsUnreachable(
+    curr->i31->type,
+    Type(HeapType::i31, Nullable),
+    curr->i31,
+    "i31.get_s/u's argument should be i31ref");
 }
 
 void FunctionValidator::visitRefTest(RefTest* curr) {
@@ -2507,15 +2536,17 @@ void FunctionValidator::visitFunction(Function* curr) {
   }
   // if function has no result, it is ignored
   // if body is unreachable, it might be e.g. a return
-  shouldBeSubType(curr->body->type,
-                  curr->sig.results,
-                  curr->body,
-                  "function body type must match, if function returns");
+  shouldBeSubTypeOrFirstIsUnreachable(
+    curr->body->type,
+    curr->sig.results,
+    curr->body,
+    "function body type must match, if function returns");
   for (Type returnType : returnTypes) {
-    shouldBeSubType(returnType,
-                    curr->sig.results,
-                    curr->body,
-                    "function result must match, if function has returns");
+    shouldBeSubTypeOrFirstIsUnreachable(
+      returnType,
+      curr->sig.results,
+      curr->body,
+      "function result must match, if function has returns");
   }
 
   assert(breakInfos.empty());

--- a/test/passes/remove-unused-names_vacuum.txt
+++ b/test/passes/remove-unused-names_vacuum.txt
@@ -15,7 +15,9 @@
  )
  (func $to-drop-unreachable
   (drop
-   (unreachable)
+   (block (result i32)
+    (unreachable)
+   )
   )
  )
  (func $return-i32-but-body-is-unreachable5 (result i32)


### PR DESCRIPTION
Reverts WebAssembly/binaryen#3673, which accidentally weakened validation by allowing unreachable nodes in places they were previously disallowed.