### PR TITLE
Refactor OptimizeInstructions to use visit* methods. NFC

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -269,6 +269,13 @@ struct OptimizeInstructions
   }
 
   void visitBinary(Binary* curr) {
+    // If this contains dead code, don't bother trying to optimize it, the type
+    // might change (if might not be unreachable if just one arm is, for
+    // example). This optimization pass focuses on actually executing code.
+    if (curr->type == Type::unreachable) {
+      return;
+    }
+
     if (shouldCanonicalize(curr)) {
       canonicalize(curr);
     }
@@ -737,6 +744,10 @@ struct OptimizeInstructions
   }
 
   void visitUnary(Unary* curr) {
+    if (curr->type == Type::unreachable) {
+      return;
+    }
+
     {
       using namespace Match;
       using namespace Abstract;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -418,9 +418,9 @@ struct OptimizeInstructions
       Index extraLeftShifts;
       auto bits = Properties::getAlmostSignExtBits(curr, extraLeftShifts);
       if (extraLeftShifts == 0) {
-        if (auto* load =
-              Properties::getFallthrough(ext, getPassOptions(), getModule()->features)
-                ->dynCast<Load>()) {
+        if (auto* load = Properties::getFallthrough(
+                           ext, getPassOptions(), getModule()->features)
+                           ->dynCast<Load>()) {
           // pattern match a load of 8 bits and a sign extend using a shl of
           // 24 then shr_s of 24 as well, etc.
           if (LoadUtils::canBeSigned(load) &&

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -856,12 +856,18 @@ struct OptimizeInstructions
   }
 
   void visitSelect(Select* curr) {
+    if (curr->type == Type::unreachable) {
+      return;
+    }
     if (auto* ret = optimizeSelect(curr)) {
       return replaceCurrent(ret);
     }
   }
 
   void visitGlobalSet(GlobalSet* curr) {
+    if (curr->type == Type::unreachable) {
+      return;
+    }
     // optimize out a set of a get
     auto* get = curr->value->dynCast<GlobalGet>();
     if (get && get->name == curr->name) {
@@ -915,9 +921,17 @@ struct OptimizeInstructions
     }
   }
 
-  void visitLoad(Load* curr) { optimizeMemoryAccess(curr->ptr, curr->offset); }
+  void visitLoad(Load* curr) {
+    if (curr->type == Type::unreachable) {
+      return;
+    }
+    optimizeMemoryAccess(curr->ptr, curr->offset);
+  }
 
   void visitStore(Store* curr) {
+    if (curr->type == Type::unreachable) {
+      return;
+    }
     optimizeMemoryAccess(curr->ptr, curr->offset);
     if (curr->valueType.isInteger()) {
       // truncates constant values during stores
@@ -962,6 +976,9 @@ struct OptimizeInstructions
   }
 
   void visitMemoryCopy(MemoryCopy* curr) {
+    if (curr->type == Type::unreachable) {
+      return;
+    }
     assert(getModule()->features.hasBulkMemory());
     if (auto* ret = optimizeMemoryCopy(curr)) {
       return replaceCurrent(ret);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -235,13 +235,13 @@ struct OptimizeInstructions
     WalkerPass<PostWalker<OptimizeInstructions>>::replaceCurrent(rep);
     // We may be able to apply multiple patterns as one may open opportunities
     // for others. NB: patterns must not have cycles
+
     // To avoid recursion, this uses the following pattern: the initial call to
     // this method comes from one of the visit*() methods. We then loop in here,
     // and if we are called again we set |changed| instead of recursing, so that
     // we can loop on that value.
     if (inReplaceCurrent) {
-      // We are in the replaceCurrent loop(), so just report a change and return
-      // to there.
+      // We are in the loop below so just note a change and return to there.
       changed = true;
       return;
     }


### PR DESCRIPTION
Instead of a single big `optimize()` method we now use separate functions
per instruction. This gives us smaller functions and less nesting in some cases,
and avoids manually casting and checking etc.

The reason this was not done originally is that this pass does repeated
applications. That is, if `optimize()` changed something, it would run again
on the result, perhaps further optimizing it. It did not need to run on the
children, but just on the result itself, so it didn't just do another full walk,
and so the simplest way was to just do a loop on `optimize()`. To replace that,
this PR modifies `replaceCurrent()` which the methods now call to report
that the current node can be replaced. There is some code in there now that
keeps doing more processing while changes happen. It's not trivial code as
it avoids recursion, but that slight complexity seems worthwhile in order to
simplify the bulk of the (very large) pass.