### PR TITLE
[Wasm GC] Do not consider reference type equality in fuzzer due to roundtripping creating new recursive types

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -134,7 +134,8 @@ struct ExecutionResults {
       // reference between such things. We can only compare things structurally,
       // for which we compare the types.
       // Another issue is that the same module, when passed through --roundtrip,
-      // will end up with a type that does not compare equallygi.
+      // will end up with a type that does not compare equally as we do not
+      // currently globally canonicalize recursive types.
       return true;
     }
     if (a != b) {

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -121,7 +121,11 @@ struct ExecutionResults {
   }
 
   bool areEqual(Literal a, Literal b) {
-    if (a.type.isRef() && b.type.isRef()) {
+    if (!Type::isSubType(a.type, b.type) && !Type::isSubType(b.type, a.type)) {
+      std::cout << "types not compatible! " << a << " != " << b << '\n';
+      return false;
+    }
+    if (a.type.isRef()) {
       // Don't compare references - only their types. There are several issues
       // here that we can't fully handle, see
       // https://github.com/WebAssembly/binaryen/issues/3378, but the core issue
@@ -130,12 +134,8 @@ struct ExecutionResults {
       // reference between such things. We can only compare things structurally,
       // for which we compare the types.
       // Another issue is that the same module, when passed through --roundtrip,
-      // will end up with a type that does not compare equally.
+      // will end up with a type that does not compare equallygi.
       return true;
-    }
-    if (a.type != b.type) {
-      std::cout << "types not identical! " << a << " != " << b << '\n';
-      return false;
     }
     if (a != b) {
       std::cout << "values not identical! " << a << " != " << b << '\n';

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -121,11 +121,7 @@ struct ExecutionResults {
   }
 
   bool areEqual(Literal a, Literal b) {
-    if (a.type != b.type) {
-      std::cout << "types not identical! " << a << " != " << b << '\n';
-      return false;
-    }
-    if (a.type.isRef()) {
+    if (a.type.isRef() && b.type.isRef()) {
       // Don't compare references - only their types. There are several issues
       // here that we can't fully handle, see
       // https://github.com/WebAssembly/binaryen/issues/3378, but the core issue
@@ -133,7 +129,13 @@ struct ExecutionResults {
       // a separate instance of each) - we can't really identify an identical
       // reference between such things. We can only compare things structurally,
       // for which we compare the types.
+      // Another issue is that the same module, when passed through --roundtrip,
+      // will end up with a type that does not compare equally.
       return true;
+    }
+    if (a.type != b.type) {
+      std::cout << "types not identical! " << a << " != " << b << '\n';
+      return false;
     }
     if (a != b) {
       std::cout << "values not identical! " << a << " != " << b << '\n';

--- a/test/passes/roundtrip_fuzz-exec_all-features.txt
+++ b/test/passes/roundtrip_fuzz-exec_all-features.txt
@@ -1,0 +1,13 @@
+[fuzz-exec] calling foo
+[fuzz-exec] note result: foo => funcref(null)
+(module
+ (type $A (func (result (ref null $A))))
+ (type $none_=>_funcref (func (result funcref)))
+ (export "foo" (func $0))
+ (func $0 (result funcref)
+  (ref.null $A)
+ )
+)
+[fuzz-exec] calling foo
+[fuzz-exec] note result: foo => funcref(null)
+[fuzz-exec] comparing foo

--- a/test/passes/roundtrip_fuzz-exec_all-features.wast
+++ b/test/passes/roundtrip_fuzz-exec_all-features.wast
@@ -1,0 +1,7 @@
+(module
+ (type $A (func (result (ref null $A))))
+ (func "foo" (result funcref)
+  (ref.null $A)
+ )
+)
+


### PR DESCRIPTION
The testcase here passes with `--fuzz-exec` but fails when adding `--roundtrip`,
as then the type appears different. Is that expected @tlively ?
