### PR TITLE
[Wasm GC] Avoid std::map<Type,..> in mapLocals

### DIFF
--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2170,7 +2170,7 @@ void BinaryInstWriter::mapLocalsAndEmitHeader() {
     }
   }
   countScratchLocals();
-  std::map<Type, size_t> currLocalsByType;
+  std::unordered_map<Type, size_t> currLocalsByType;
   for (Index i = func->getVarIndexBase(); i < func->getNumLocals(); i++) {
     Index j = 0;
     for (const auto& type : func->getLocalType(i)) {


### PR DESCRIPTION
Works around https://github.com/WebAssembly/binaryen/issues/3682 With this, I can roundtrip
a large real-world testcase.

There are other cases of `std::map<Type,..>` in the codebase, but none on
a critical path, so this PR only changes that one place.