### PR TITLE
[Wasm GC] Fix Vaccum pass after #3669

### DIFF
--- a/test/passes/vacuum_all-features.txt
+++ b/test/passes/vacuum_all-features.txt
@@ -488,3 +488,30 @@
   (unreachable)
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_eqref_v128_i32_i64_externref_eqref (func (result eqref v128 i32 i64 externref eqref)))
+ (global $global$0 (mut i32) (i32.const 10))
+ (func $0
+  (drop
+   (block $label$1 (result funcref)
+    (drop
+     (br_if $label$1
+      (ref.null $none_=>_eqref_v128_i32_i64_externref_eqref)
+      (i32.const 0)
+     )
+    )
+    (drop
+     (br_if $label$1
+      (ref.null $none_=>_none)
+      (i32.const 1)
+     )
+    )
+    (global.set $global$0
+     (i32.const 0)
+    )
+    (ref.null func)
+   )
+  )
+ )
+)

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -869,3 +869,32 @@
     )
   )
 )
+;; Multiple brs to a a block that is dropped must be taken into account before
+;; deciding to remove the block's value entirely.
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_eqref_v128_i32_i64_externref_eqref (func (result eqref v128 i32 i64 externref eqref)))
+ (global $global$0 (mut i32) (i32.const 10))
+ (func $0
+  (drop
+   (block $label$1 (result funcref)
+    (drop
+     (br_if $label$1
+      (ref.null $none_=>_eqref_v128_i32_i64_externref_eqref)
+      (i32.const 0)
+     )
+    )
+    (drop
+     (br_if $label$1
+      (ref.null $none_=>_none)
+      (i32.const 1)
+     )
+    )
+    (global.set $global$0
+     (i32.const 0)
+    )
+    (ref.null func)
+   )
+  )
+ )
+)


### PR DESCRIPTION
This fixes another regression from the LUB removal that the fuzzer found.

`getSuperType` was not doing the right thing in that context - it thought it
could remove the block's value in the attached testcase. But it seems
pointless to even call that method, so I just removed all code. As the pre-existing
comment says, we can remove it if there are no brs, so just check that.

Also a drive-by fix of an if finalize. Not sure if that could have led to a
bug or not, but it's definitely better to finalize with the known type for
efficiency reasons.