### PR TITLE
Simplify fuzzer fixup code for names

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -867,12 +867,12 @@ private:
       void visitExpression(Expression* curr) {
         // Note all scope names, and fix up all uses.
         BranchUtils::operateOnScopeNameDefs(curr, [&](Name& name) {
-          if (name.is()) {                                                      
+          if (name.is()) {
             if (seen.count(name)) {
-              replace();        
-            } else {            
+              replace();
+            } else {
               seen.insert(name);
-            }                                                                     
+            }
           }
         });
         BranchUtils::operateOnScopeNameUses(curr, [&](Name& name) {


### PR DESCRIPTION
Rather than use delegates.h, we have helpers for scope names.