### PR TITLE
Skip function bodies in wasm-emscripten-finalize when we don't need them

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -27,6 +27,7 @@ high chance for set at start of loop
 
 // TODO Generate exception handling instructions
 
+#include "ir/branch-utils.h"
 #include "ir/memory-utils.h"
 #include <ir/find_all.h>
 #include <ir/literal-utils.h>
@@ -865,39 +866,20 @@ private:
 
       void visitExpression(Expression* curr) {
         // Note all scope names, and fix up all uses.
-
-#define DELEGATE_ID curr->_id
-
-#define DELEGATE_START(id)                                                     \
-  auto* cast = curr->cast<id>();                                               \
-  WASM_UNUSED(cast);
-
-#define DELEGATE_GET_FIELD(id, name) cast->name
-
-#define DELEGATE_FIELD_SCOPE_NAME_DEF(id, name)                                \
-  if (cast->name.is()) {                                                       \
-    if (seen.count(cast->name)) {                                              \
-      replace();                                                               \
-    } else {                                                                   \
-      seen.insert(cast->name);                                                 \
-    }                                                                          \
-  }
-
-#define DELEGATE_FIELD_SCOPE_NAME_USE(id, name) replaceIfInvalid(cast->name);
-
-#define DELEGATE_FIELD_CHILD(id, name)
-#define DELEGATE_FIELD_OPTIONAL_CHILD(id, name)
-#define DELEGATE_FIELD_INT(id, name)
-#define DELEGATE_FIELD_INT_ARRAY(id, name)
-#define DELEGATE_FIELD_LITERAL(id, name)
-#define DELEGATE_FIELD_NAME(id, name)
-#define DELEGATE_FIELD_NAME_VECTOR(id, name)
-#define DELEGATE_FIELD_SCOPE_NAME_USE_VECTOR(id, name)
-#define DELEGATE_FIELD_SIGNATURE(id, name)
-#define DELEGATE_FIELD_TYPE(id, name)
-#define DELEGATE_FIELD_ADDRESS(id, name)
-
-#include "wasm-delegations-fields.h"
+        BranchUtils::operateOnScopeNameDefs(curr, [&](Name& name) {
+          if (name.is()) {
+            if (seen.count(name)) {
+              replace();
+            } else {
+              seen.insert(name);
+            }
+          }
+        });
+        BranchUtils::operateOnScopeNameUses(curr, [&](Name& name) {
+          if (name.is()) {
+            replaceIfInvalid(name);
+          }
+        });
       }
 
       bool replaceIfInvalid(Name target) {

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -203,9 +203,21 @@ int main(int argc, const char* argv[]) {
     Fatal() << "Need to specify an infile\n";
   }
 
+  // We will write the modified wasm if the user asked us to, either by
+  // specifying an output file or requesting text output (which goes to stdout
+  // by default).
+  auto writeOutput = outfile.size() > 0 || !emitBinary;
+
   Module wasm;
   ModuleReader reader;
   reader.setDWARF(DWARF);
+  if (!writeOutput) {
+    // If we are not writing the output then all we are doing is simple parsing
+    // of metadata from global parts of the wasm such as imports and exports. In
+    // that case, it is unnecessary to parse function contents which are the
+    // great bulk of the work, and we can skip all that.
+    reader.setSkipFunctionBodies(true);
+  }
   try {
     reader.read(infile, wasm, inputSourceMapFilename);
   } catch (ParseException& p) {
@@ -303,9 +315,7 @@ int main(int argc, const char* argv[]) {
   BYN_TRACE_WITH_TYPE("emscripten-dump", "Module after:\n");
   BYN_DEBUG_WITH_TYPE("emscripten-dump", std::cerr << wasm << '\n');
 
-  // Write the modified wasm if the user asked us to, either by specifying an
-  // output file, or requesting text output (which goes to stdout by default).
-  if (outfile.size() > 0 || !emitBinary) {
+  if (writeOutput) {
     Output output(outfile, emitBinary ? Flags::Binary : Flags::Text);
     ModuleWriter writer;
     writer.setDebugInfo(debugInfo);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1307,6 +1307,7 @@ class WasmBinaryBuilder {
   std::istream* sourceMap;
   std::pair<uint32_t, Function::DebugLocation> nextDebugLocation;
   bool DWARF = false;
+  bool skipFunctionBodies = false;
 
   size_t pos = 0;
   Index startIndex = -1;
@@ -1324,6 +1325,9 @@ public:
       nextDebugLocation(0, {0, 0, 0}), debugLocation() {}
 
   void setDWARF(bool value) { DWARF = value; }
+  void setSkipFunctionBodies(bool skipFunctionBodies_) {
+    skipFunctionBodies = skipFunctionBodies_;
+  }
   void read();
   void readUserSection(size_t payloadLen);
 

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -35,6 +35,11 @@ public:
 
   void setProfile(IRProfile profile_) { profile = profile_; }
 
+  // TODO: add support for this in the text format as well
+  void setSkipFunctionBodies(bool skipFunctionBodies_) {
+    skipFunctionBodies = skipFunctionBodies_;
+  }
+
   // read text
   void readText(std::string filename, Module& wasm);
   // read binary
@@ -52,6 +57,8 @@ private:
   bool DWARF = false;
 
   IRProfile profile = IRProfile::Normal;
+
+  bool skipFunctionBodies = false;
 
   void readStdin(Module& wasm, std::string sourceMapFilename);
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2137,7 +2137,17 @@ void WasmBinaryBuilder::readFunctions() {
       assert(controlFlowStack.empty());
       assert(letStack.empty());
       assert(depth == 0);
-      func->body = getBlockOrSingleton(func->sig.results);
+      if (!skipFunctionBodies) {
+        func->body = getBlockOrSingleton(func->sig.results);
+      } else {
+        // When skipping the function body we need to put something valid in
+        // their place so we validate. An unreachable is always acceptable
+        // there.
+        func->body = Builder(wasm).makeUnreachable();
+
+        // Skip reading the contents.
+        pos = endOfFunction;
+      }
       assert(depth == 0);
       assert(breakStack.empty());
       assert(breakTargetNames.empty());

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -51,6 +51,7 @@ void ModuleReader::readBinaryData(std::vector<char>& input,
   std::unique_ptr<std::ifstream> sourceMapStream;
   WasmBinaryBuilder parser(wasm, input);
   parser.setDWARF(DWARF);
+  parser.setSkipFunctionBodies(skipFunctionBodies);
   if (sourceMapFilename.size()) {
     sourceMapStream = make_unique<std::ifstream>();
     sourceMapStream->open(sourceMapFilename);


### PR DESCRIPTION
After @sbc100 's work on `EM_ASM` and `EM_JS` they are now parsed from
the wasm using exports etc. and so we no longer need to parse function bodies.
As a result if we are not emitting a wasm from `wasm-emscripten-finalize` then all we are
doing is scanning global structures like imports and exports and emitting metadata
about them. And indeed we do not need to emit a wasm in some cases, specifically
when not optimizing and when using `WASM_BIGINT` (to avoid needing to
legalize).

We had considering skipping wasm-emscripten-finalize entirely in that situation,
and instead to parse the metadata from the wasm in python on the emscripten
side. However @sbc100 had the brilliant idea today to just skip function bodies.
That is very simple to do - no need to write another parser for wasm, and also
look at how simple this PR is - and also it will be faster to run
`wasm-emscripten-finalize` in this mode than to run python. (With the only
downside that the bytes of the wasm are loaded even if they aren't parsed; but
almost certainly they are in the disk cache anyhow.)

This PR implements that idea: when `wasm-emscripten-finalize` knows it will
not write a wasm output, it notes "skip function bodies". The binary reader then
skips the bodies and places `unreachable`s there instead (so that the wasm still
validates).

There are no new tests here because this can't be tested - by design it is an
unobservable optimization. (If we could notice the bodies have been skipped,
we would not have skipped them.) This is also why no changes are needed on
the emscripten side to benefit from this speedup. Basically when binaryen sees
it will not need X, it skips parsing of X automatically.

Benchmarking speed, it is as fast as you'd expect: the `wasm-emscripten-finalize`
step is 15x faster on SQLite (1MB of wasm) and almost 50x faster on the biggest
wasm I have on my drive (40MB of LLVM).

Tested manually and also on `wasm0 wasm2 other` on emscripten.

cc @pfaffe @bmeurer - you might like this!