### PR TITLE
Change upstream to origin/main in clang-tidy-diff.sh

### DIFF
--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -5,7 +5,7 @@ set -o errexit
 if [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"
 else
-  BRANCH="@{upstream}"
+  BRANCH=origin/main
 fi
 
 CLANG_TIDY=$(which clang-tidy)


### PR DESCRIPTION
We changed the upstream branch from `origin/main` to `@{upstream}` in
 #3619:
Context:
https://github.com/WebAssembly/binaryen/pull/3619#discussion_r583338724
https://github.com/WebAssembly/binaryen/pull/3619#discussion_r583717142

But I don't think we were actually able to test that part in that PR,
because PRs use `$GITHUB_BASE_REF` instead. And it looks `@{upstream}`
doesn't work on my local machine with branches. Is it supposed to work
locally?

Also, it looks all clang-tidy operations in the repo's commits are
failing, which I think uses the upstream thing. But strangely the step
is reported as success.
Failure link:
https://github.com/WebAssembly/binaryen/runs/2134499599#step:8:50
I'm not sure why, because clang-tidy-diff.sh is
supposed to fail whenever a command in there fails, because we have
`set -o errexit` at the top.

This anyway reverts `@{upstream}` to `origin/main`. This makes it work
locally. (There is still one constraint: You have to commit your changes
locally to a branch before you run this. We use
`git diff -U0 $BRANCH...`, and the three dots thing doesn't work with
uncommitted local changes.) I can't test the repo commit issue locally,
but let's hope this also fixes the commit issue.