### PR TITLE
Ignore missing CUs in DWARF rewriting

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -624,12 +624,6 @@ struct LocationUpdater {
   }
 
   BinaryLocation getNewDebugLineLocation(BinaryLocation old) const {
-if (debugLineMap.count(old) == 0) {
-  std::cout << "sad " << old << '\n';
-  for (auto& kv : debugLineMap) {
-    std::cout << kv.first << " : " << kv.second << '\n';
-  }
-}
     return debugLineMap.at(old);
   }
 

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -760,12 +760,13 @@ static void updateDebugLines(llvm::DWARFYAML::Data& data,
   // debug_line section.
   std::vector<size_t> computedLengths;
   llvm::DWARFYAML::ComputeDebugLine(data, computedLengths);
-  BinaryLocation oldLocation = 0, newLocation = 0;
+  BinaryLocation newLocation = 0;
   for (size_t i = 0; i < data.DebugLines.size(); i++) {
     auto& table = data.DebugLines[i];
+    auto oldLocation = table.Position;
     locationUpdater.debugLineMap[oldLocation] = newLocation;
-    oldLocation += table.Length.getLength() + AddressSize;
     newLocation += computedLengths[i] + AddressSize;
+    table.Position = newLocation;
     table.Length.setLength(computedLengths[i]);
   }
 }

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -635,6 +635,11 @@ if (debugLineMap.count(old) == 0) {
 
   // Given an offset in .debug_loc, get the old and new compile unit bases.
   OldToNew getCompileUnitBasesForLoc(size_t offset) const {
+    if (locToUnitMap.count(offset) == 0) {
+      // There is no compile unit for this loc. It doesn't matter what we set
+      // here.
+      return OldToNew{0, 0};
+    }
     auto index = locToUnitMap.at(offset);
     auto iter = compileUnitBases.find(index);
     if (iter != compileUnitBases.end()) {

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -624,6 +624,12 @@ struct LocationUpdater {
   }
 
   BinaryLocation getNewDebugLineLocation(BinaryLocation old) const {
+if (debugLineMap.count(old) == 0) {
+  std::cout << "sad " << old << '\n';
+  for (auto& kv : debugLineMap) {
+    std::cout << kv.first << " : " << kv.second << '\n';
+  }
+}
     return debugLineMap.at(old);
   }
 

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -764,8 +764,8 @@ static void updateDebugLines(llvm::DWARFYAML::Data& data,
     auto& table = data.DebugLines[i];
     auto oldLocation = table.Position;
     locationUpdater.debugLineMap[oldLocation] = newLocation;
-    newLocation += computedLengths[i] + AddressSize;
     table.Position = newLocation;
+    newLocation += computedLengths[i] + AddressSize;
     table.Length.setLength(computedLengths[i]);
   }
 }

--- a/third_party/llvm-project/dwarf2yaml.cpp
+++ b/third_party/llvm-project/dwarf2yaml.cpp
@@ -330,7 +330,8 @@ std::cout << "dDL2\n";
       DataExtractor LineData(DCtx.getDWARFObj().getLineSection().Data,
                              DCtx.isLittleEndian(), CU->getAddressByteSize());
       uint64_t Offset = *StmtOffset;
-
+      DebugLines.Position = Offset;
+std::cout << "offset: " << Offset << '\n';
 {
 StringRef ref = DCtx.getDWARFObj().getLineSection().Data;
 size_t size = ref.size();

--- a/third_party/llvm-project/dwarf2yaml.cpp
+++ b/third_party/llvm-project/dwarf2yaml.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 //===------ dwarf2yaml.cpp - obj2yaml conversion tool -----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -317,39 +316,23 @@ bool dumpFileEntry(DataExtractor &Data, uint64_t &Offset,
 
 void dumpDebugLines(DWARFContext &DCtx, DWARFYAML::Data &Y) {
   for (const auto &CU : DCtx.compile_units()) {
-std::cout << "dDL1\n";
     auto CUDIE = CU->getUnitDIE();
-    if (!CUDIE) {
-std::cout << " dDL skipp\n";
+    if (!CUDIE)
       continue;
-    }
     if (auto StmtOffset =
             dwarf::toSectionOffset(CUDIE.find(dwarf::DW_AT_stmt_list))) {
-std::cout << "dDL2\n";
       DWARFYAML::LineTable DebugLines;
       DataExtractor LineData(DCtx.getDWARFObj().getLineSection().Data,
                              DCtx.isLittleEndian(), CU->getAddressByteSize());
       uint64_t Offset = *StmtOffset;
       DebugLines.Position = Offset;
-std::cout << "offset: " << Offset << '\n';
-{
-StringRef ref = DCtx.getDWARFObj().getLineSection().Data;
-size_t size = ref.size();
-std::cout << "\n\n\nnew LT\n";// of data size " << size << '\n';
-for (size_t i = 0; i < 20; i++ ) {
-  std::cout << ' ' << std::hex << unsigned(uint8_t(ref.data()[Offset + i])) << std::dec;
-}
-std::cout << '\n';
-}
 
       dumpInitialLength(LineData, Offset, DebugLines.Length);
       uint64_t LineTableLength = DebugLines.Length.getLength();
-errs() << "LTL " << LineTableLength << '\n';//" (" << hex << LineTableLength << std::dec << ")\n";
       uint64_t SizeOfPrologueLength = DebugLines.Length.isDWARF64() ? 8 : 4;
       DebugLines.Version = LineData.getU16(&Offset);
       DebugLines.PrologueLength =
           LineData.getUnsigned(&Offset, SizeOfPrologueLength);
-errs() << "  " << DebugLines.Version << " : " << DebugLines.PrologueLength << '\n';
       const uint64_t EndPrologue = DebugLines.PrologueLength + Offset;
 
       DebugLines.MinInstLength = LineData.getU8(&Offset);
@@ -358,7 +341,6 @@ errs() << "  " << DebugLines.Version << " : " << DebugLines.PrologueLength << '\
       DebugLines.DefaultIsStmt = LineData.getU8(&Offset);
       DebugLines.LineBase = LineData.getU8(&Offset);
       DebugLines.LineRange = LineData.getU8(&Offset);
-errs() << "  line range " << int(DebugLines.LineRange) << '\n';
       DebugLines.OpcodeBase = LineData.getU8(&Offset);
 
       DebugLines.StandardOpcodeLengths.reserve(DebugLines.OpcodeBase - 1);
@@ -439,7 +421,6 @@ errs() << "  line range " << int(DebugLines.LineRange) << '\n';
         DebugLines.Opcodes.push_back(NewOp);
       }
       Y.DebugLines.push_back(DebugLines);
-std::cout << "dDL3\n";
     }
   }
 }

--- a/third_party/llvm-project/include/llvm/ObjectYAML/DWARFYAML.h
+++ b/third_party/llvm-project/include/llvm/ObjectYAML/DWARFYAML.h
@@ -151,6 +151,7 @@ struct LineTableOpcode {
 };
 
 struct LineTable {
+  uint64_t Position; // XXX BINARYEN: the binary location in .debug_line
   InitialLength Length;
   uint16_t Version;
   uint64_t PrologueLength;


### PR DESCRIPTION
A recent change in LLVM causes it to sometimes end up with a thing
with no parent. That is, a debug_line or a debug_loc that has no CU that
refers to it. This is perhaps LLVM DCEing CUs, or something else that
changed - not sure. But it seems like valid DWARF we should handle.

This PR handles that in our code. Two things broke here. First, locs must
be simply ignored when there is no CU. Second, lines are trickier as we
used to compute their position by scanning them, and that list contained
only ones with a CU. So we missed some and ended up with wrong offsets.
To make things simpler and more robust, just track the position of each
line table on itself.

Fixes https://github.com/WebAssembly/binaryen/issues/3697