### PR TITLE
Revert the effect of #3689

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -220,8 +220,9 @@ int main(int argc, const char* argv[]) {
     // If we are not writing the output then all we are doing is simple parsing
     // of metadata from global parts of the wasm such as imports and exports. In
     // that case, it is unnecessary to parse function contents which are the
-    // great bulk of the work, and we can skip all that.
-    reader.setSkipFunctionBodies(true);
+    // great bulk of the work, and we can skip all that. However, the one
+    // exception is pthreads, which does require scanning the code, and so for
+    // now we cannot do reader.setSkipFunctionBodies(true); here yet.
   }
   try {
     reader.read(infile, wasm, inputSourceMapFilename);


### PR DESCRIPTION
That PR assumed that wasm-emscripten-finalize does not need to scan
function bodies for metadata. But there is a case where it does, which is
that EM_ASMs with pthreads do still require scanning of the code. So that
approach is not valid.

We could maybe disable the optimization just on pthreads, but I think
major use cases need that. Also there is no simple way to disable it atm,
we'd need changes on both emscripten and binaryen. Also that PR can
no longer be reverted cleanly due to other changes. For all those reasons,
this just disables the optimization so that users of `tot` are no longer
broken, while we figure out how a valid way to optimize this use case.
