### PR TITLE
Add `-o pipefail` to shell scripts

### DIFF
--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -o errexit
+set -o pipefail
 
 # When we are running on travis and *not* part of a pull request we don't
 # have any upstream branch to compare against.

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -o errexit
+set -o pipefail
 
 if [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"

--- a/scripts/emcc-tests.sh
+++ b/scripts/emcc-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+set -o errexit
+set -o pipefail
 
 mkdir -p emcc-build
 echo "emcc-tests: build:wasm"


### PR DESCRIPTION
This means that if any command in a pipelines fails the whole
pipeline will also fail.