### PR TITLE
Avoid warnings/errors on isTemp(*Type) being unused

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -207,14 +207,20 @@ Type markTemp(Type type) {
 }
 
 bool isTemp(Type type) {
+  // Avoid compiler warnings on this function not being used, as it is only used
+  // in assertions, which might be off.
   bool (*func)(Type) = isTemp;
-  WASM_UNUSED(&func);
+  WASM_UNUSED(func);
+
   return !type.isBasic() && getTypeInfo(type)->isTemp;
 }
 
 bool isTemp(HeapType type) {
+  // Avoid compiler warnings on this function not being used, as it is only used
+  // in assertions, which might be off.
   bool (*func)(HeapType) = isTemp;
-  WASM_UNUSED(&func);
+  WASM_UNUSED(func);
+
   return !type.isBasic() && getHeapTypeInfo(type)->isTemp;
 }
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -206,9 +206,15 @@ Type markTemp(Type type) {
   return type;
 }
 
-bool isTemp(Type type) { return !type.isBasic() && getTypeInfo(type)->isTemp; }
+bool isTemp(Type type) {
+  bool (*func)(Type) = isTemp;
+  WASM_UNUSED(&func);
+  return !type.isBasic() && getTypeInfo(type)->isTemp;
+}
 
 bool isTemp(HeapType type) {
+  bool (*func)(HeapType) = isTemp;
+  WASM_UNUSED(&func);
   return !type.isBasic() && getHeapTypeInfo(type)->isTemp;
 }
 


### PR DESCRIPTION
It is a little "fun" to fake their uses because of the overloaded type.
cppreference says that this is the way to do it, and I've found no
other way than a C cast like this (std::function fails).