### PR TITLE
Fixed reading 64-bit memories and output of globals

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1926,17 +1926,17 @@ void WasmBinaryBuilder::getResizableLimits(Address& initial,
                                            Type& indexType,
                                            Address defaultIfNoMax) {
   auto flags = getU32LEB();
-  initial = getU32LEB();
   bool hasMax = (flags & BinaryConsts::HasMaximum) != 0;
   bool isShared = (flags & BinaryConsts::IsShared) != 0;
   bool is64 = (flags & BinaryConsts::Is64) != 0;
+  initial = is64 ? getU64LEB() : getU32LEB();
   if (isShared && !hasMax) {
     throwError("shared memory must have max size");
   }
   shared = isShared;
   indexType = is64 ? Type::i64 : Type::i32;
   if (hasMax) {
-    max = getU32LEB();
+    max = is64 ? getU64LEB() : getU32LEB();
   } else {
     max = defaultIfNoMax;
   }

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -450,9 +450,9 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata() {
     for (const auto& ex : wasm.exports) {
       if (ex->kind == ExternalKind::Global) {
         const Global* g = wasm.getGlobal(ex->value);
-        assert(g->type == Type::i32);
+        assert(g->type == Type::i32 || g->type == Type::i64);
         Const* init = g->init->cast<Const>();
-        uint32_t addr = init->value.geti32();
+        uint64_t addr = init->value.getInteger();
         meta << nextElement() << '"' << ex->name.str << "\" : \"" << addr
              << '"';
       }


### PR DESCRIPTION
This was triggered by my on-going wasm64 testing in emscripten