### PR TITLE
Allow clang-format-diff/clang-tidy-diff to take branch as argument

### DIFF
--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -3,17 +3,12 @@
 set -o errexit
 set -o pipefail
 
-# When we are running on travis and *not* part of a pull request we don't
-# have any upstream branch to compare against.
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  echo "Skipping since not running on travis PR"
-  exit 0
-fi
-
-if [ -n "$TRAVIS_BRANCH" ]; then
-  BRANCH=$TRAVIS_BRANCH
+if [ -n "$1" ]; then
+  BRANCH="$1"
+elif [ -n "$GITHUB_BASE_REF" ]; then
+  BRANCH="origin/$GITHUB_BASE_REF"
 else
-  BRANCH=origin/main
+  BRANCH="@{upstream}"
 fi
 
 MERGE_BASE=$(git merge-base $BRANCH HEAD)

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -3,7 +3,9 @@
 set -o errexit
 set -o pipefail
 
-if [ -n "$GITHUB_BASE_REF" ]; then
+if [ -n "$1" ]; then
+  BRANCH="$1"
+elif [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"
 else
   BRANCH="@{upstream}"


### PR DESCRIPTION
Also update clang-format-diff.sh to match recent changes to branch
name and CI system (these changes mirror those already made to
clang-tidy-diff.sh).