### PR TITLE
Reducer: skip more functions when failing to remove them

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -303,8 +303,7 @@ struct Reducer
             // see if it is still has the property we are preserving
             if (ProgramResult(command) == expected) {
               std::cerr << "|    command \"" << currCommand
-                        << "\" succeeded, reduced size to " << newSize
-                        << ", and preserved the property\n";
+                        << "\" succeeded, reduced size to " << newSize << '\n';
               copy_file(test, working);
               more = true;
               oldSize = newSize;
@@ -897,6 +896,7 @@ struct Reducer
         skip = std::min(size_t(factor), 2 * skip);
       } else {
         skip = std::max(skip / 2, size_t(1)); // or 1?
+        i += factor / 100;
       }
     }
     // try to remove exports


### PR DESCRIPTION
This avoids an annoying case where in each iteration we try to remove
every function one by one and keep failing. Instead, we'll skip large
numbers of them when the factor is large at least.

Also shorten some unnecessary logging.