### PR TITLE
[Wasm GC] Fix canMakeZero on tuples

### DIFF
--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -32,9 +32,22 @@ inline Expression* makeFromInt32(int32_t x, Type type, Module& wasm) {
 }
 
 inline bool canMakeZero(Type type) {
-  // We can make a "zero" - a 0, or a null, or a trivial rtt, etc. - for pretty
-  // much anything except a non-nullable reference type.
-  return !type.isRef() || type.isNullable();
+  if (type.isRef() && !type.isNullable()) {
+    return false;
+  }
+  if (type.isTuple()) {
+    for (auto t : type) {
+      if (!canMakeZero(t)) {
+        return false;
+      }
+    }
+  }
+  if (type.isFunction()) {
+    // Making a "zero" function is possible, but requires global knowledge - a
+    // function, and of the right type - so skip that.
+    return false;
+  }
+  return true;
 }
 
 inline Expression* makeZero(Type type, Module& wasm) {

--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -42,11 +42,6 @@ inline bool canMakeZero(Type type) {
       }
     }
   }
-  if (type.isFunction()) {
-    // Making a "zero" function is possible, but requires global knowledge - a
-    // function, and of the right type - so skip that.
-    return false;
-  }
   return true;
 }
 

--- a/test/passes/vacuum_all-features.txt
+++ b/test/passes/vacuum_all-features.txt
@@ -494,3 +494,10 @@
   (nop)
  )
 )
+(module
+ (type $none_=>_none (func))
+ (global $global$0 (mut i32) (i32.const 10))
+ (func $1
+  (nop)
+ )
+)

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -885,3 +885,31 @@
   )
  )
 )
+(module
+ (global $global$0 (mut i32) (i32.const 10))
+ (func $1
+  (drop
+   (block $block (result funcref i32)
+    ;; we can vaccum out all parts of this block: the br_if is not taken, there
+    ;; is a nop, and the tuple at the end goes to a dropped block anyhow. in
+    ;; all those cases, be careful with non-nullable types. (this test verifies
+    ;; we do not create a ref.null of a function or anything invalid like that,
+    ;; in the intermediate steps along the way)
+    (drop
+     (br_if $block
+      (tuple.make
+       (ref.func $1)
+       (i32.const 0)
+      )
+      (i32.const 0)
+     )
+    )
+    (nop)
+    (tuple.make
+     (ref.func $1)
+     (i32.const 1)
+    )
+   )
+  )
+ )
+)

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -891,10 +891,10 @@
   (drop
    (block $block (result funcref i32)
     ;; we can vaccum out all parts of this block: the br_if is not taken, there
-    ;; is a nop, and the tuple at the end goes to a dropped block anyhow. in
-    ;; all those cases, be careful with non-nullable types. (this test verifies
-    ;; we do not create a ref.null of a function or anything invalid like that,
-    ;; in the intermediate steps along the way)
+    ;; is a nop, and the tuple at the end goes to a dropped block anyhow. this
+    ;; test specifically verifies handling of tuples containing non-nullable
+    ;; types, for which we try to create a zero in an intermediate step along
+    ;; the way.
     (drop
      (br_if $block
       (tuple.make


### PR DESCRIPTION
We can't make a zero tuple if any field cannot be a zero.
