### PR TITLE
[Wasm GC] Properly validate struct.new number of operands

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2299,16 +2299,17 @@ void FunctionValidator::visitStructNew(StructNew* curr) {
                    "struct.new_with_default value type must be defaultable");
     }
   } else {
-    shouldBeEqual(curr->operands.size(),
-                  fields.size(),
-                  curr,
-                  "struct.new must have the right number of operands");
-    // All the fields must have the proper type.
-    for (Index i = 0; i < fields.size(); i++) {
-      shouldBeSubType(curr->operands[i]->type,
-                      fields[i].type,
+    if (shouldBeEqual(curr->operands.size(),
+                      fields.size(),
                       curr,
-                      "struct.new operand must have proper type");
+                      "struct.new must have the right number of operands")) {
+      // All the fields must have the proper type.
+      for (Index i = 0; i < fields.size(); i++) {
+        shouldBeSubType(curr->operands[i]->type,
+                        fields[i].type,
+                        curr,
+                        "struct.new operand must have proper type");
+      }
     }
   }
 }

--- a/test/spec/struct.wast
+++ b/test/spec/struct.wast
@@ -105,3 +105,29 @@
   )
   "invalid rtt"
 )
+
+(assert_invalid
+  (module
+    (type $vec (struct (field (ref func))))
+    (func $test
+      (drop
+        ;; too many arguments
+        (struct.new_with_rtt $vec (i32.const 1) (i32.const 2) (rtt.canon $vec))
+      )
+    )
+  )
+  "invalid numbe of arguments to struct.new"
+)
+
+(assert_invalid
+  (module
+    (type $vec (struct (field (ref func)) (field f64)))
+    (func $test
+      (drop
+        ;; too few arguments
+        (struct.new_with_rtt $vec (i32.const 1) (rtt.canon $vec))
+      )
+    )
+  )
+  "invalid numbe of arguments to struct.new"
+)

--- a/test/spec/struct.wast
+++ b/test/spec/struct.wast
@@ -108,7 +108,7 @@
 
 (assert_invalid
   (module
-    (type $vec (struct (field (ref func))))
+    (type $vec (struct (field i32)))
     (func $test
       (drop
         ;; too many arguments
@@ -116,12 +116,12 @@
       )
     )
   )
-  "invalid numbe of arguments to struct.new"
+  "invalid number of arguments to struct.new"
 )
 
 (assert_invalid
   (module
-    (type $vec (struct (field (ref func)) (field f64)))
+    (type $vec (struct (field i32) (field i32)))
     (func $test
       (drop
         ;; too few arguments
@@ -129,5 +129,5 @@
       )
     )
   )
-  "invalid numbe of arguments to struct.new"
+  "invalid number of arguments to struct.new"
 )


### PR DESCRIPTION
I almost fixed this recently, but forgot that a validation error is not an
early exit...

I wonder if maybe it should be. That would mean more usage of
exceptions in our codebase, and that we'd stop at the first validation
error in all cases, but it would be simpler...