### PR TITLE
Validator: Pass the module along when printing errors, so type names are used

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -31,7 +31,8 @@ namespace wasm {
 static std::ostream& printExpression(Expression* expression,
                                      std::ostream& o,
                                      bool minify = false,
-                                     bool full = false);
+                                     bool full = false,
+                                     Module* wasm = nullptr);
 
 static std::ostream&
 printStackInst(StackInst* inst, std::ostream& o, Function* func = nullptr);
@@ -3039,13 +3040,15 @@ Pass* createPrintStackIRPass() { return new PrintStackIR(); }
 static std::ostream& printExpression(Expression* expression,
                                      std::ostream& o,
                                      bool minify,
-                                     bool full) {
+                                     bool full,
+                                     Module* wasm) {
   if (!expression) {
     o << "(null expression)";
     return o;
   }
   PrintSExpression print(o);
   print.setMinify(minify);
+  print.currModule = wasm;
   if (full || isFullForced()) {
     print.setFull(true);
     o << "[" << expression->type << "] ";
@@ -3213,6 +3216,10 @@ std::ostream& operator<<(std::ostream& o, wasm::Expression& expression) {
 
 std::ostream& operator<<(std::ostream& o, wasm::Expression* expression) {
   return wasm::printExpression(expression, o);
+}
+
+std::ostream& operator<<(std::ostream& o, wasm::ModuleExpression pair) {
+  return wasm::printExpression(pair.second, o, false, false, &pair.first);
 }
 
 std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1945,6 +1945,8 @@ public:
   void clearDebugInfo();
 };
 
+using ModuleExpression = std::pair<Module&, Expression*>;
+
 } // namespace wasm
 
 namespace std {
@@ -1956,6 +1958,8 @@ template<> struct hash<wasm::Address> {
 
 std::ostream& operator<<(std::ostream& o, wasm::Module& module);
 std::ostream& operator<<(std::ostream& o, wasm::Expression& expression);
+std::ostream& operator<<(std::ostream& o, wasm::Expression* expression);
+std::ostream& operator<<(std::ostream& o, wasm::ModuleExpression pair);
 std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst);
 std::ostream& operator<<(std::ostream& o, wasm::StackIR& ir);
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1958,7 +1958,6 @@ template<> struct hash<wasm::Address> {
 
 std::ostream& operator<<(std::ostream& o, wasm::Module& module);
 std::ostream& operator<<(std::ostream& o, wasm::Expression& expression);
-std::ostream& operator<<(std::ostream& o, wasm::Expression* expression);
 std::ostream& operator<<(std::ostream& o, wasm::ModuleExpression pair);
 std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst);
 std::ostream& operator<<(std::ostream& o, wasm::StackIR& ir);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -35,14 +35,15 @@ template<typename T,
          typename std::enable_if<!std::is_base_of<
            Expression,
            typename std::remove_pointer<T>::type>::value>::type* = nullptr>
-inline std::ostream& printModuleComponent(T curr, std::ostream& stream, Module& wasm) {
+inline std::ostream&
+printModuleComponent(T curr, std::ostream& stream, Module& wasm) {
   stream << curr << std::endl;
   return stream;
 }
 
 // Extra overload for Expressions, to print their contents.
-inline std::ostream& printModuleComponent(Expression* curr,
-                                          std::ostream& stream, Module& wasm) {
+inline std::ostream&
+printModuleComponent(Expression* curr, std::ostream& stream, Module& wasm) {
   if (curr) {
     stream << ModuleExpression(wasm, curr) << '\n';
   }


### PR DESCRIPTION
For example, on this invalid wat:
```wat
(module
  (type $vec (struct (field i64)))
  (func $test
    (drop
      (struct.new_with_rtt $vec (i32.const 1) (rtt.canon $vec))
    )
  )
)
```
We used to print:
```
[wasm-validator error in function test] struct.new operand must have proper type, on 
(struct.new_with_rtt ${i64}
 (i32.const 1)
 (rtt.canon ${i64})
)
```
We will now print:
```
[wasm-validator error in function test] struct.new operand must have proper type, on 
(struct.new_with_rtt $vec
 (i32.const 1)
 (rtt.canon $vec)
)
```

Note that `$vec` is used. In real-world examples the autogenerated structural name
can be huge, which this avoids.