### PR TITLE
Fix nondefaultability of Tuple types

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -673,8 +673,9 @@ private:
     Index numVars = upToSquared(MAX_VARS);
     for (Index i = 0; i < numVars; i++) {
       auto type = getConcreteType();
-      if (type.isRef() && !type.isNullable()) {
-        // We can't use a nullable type as a var, which is null-initialized.
+      if (!type.isDefaultable()) {
+        // We can't use a nondefaultable type as a var, as those must be
+        // initialized to some default value.
         continue;
       }
       funcContext->typeLocals[type].push_back(params.size() +

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -587,6 +587,14 @@ bool Type::isDefaultable() const {
   // A variable can get a default value if its type is concrete (unreachable
   // and none have no values, hence no default), and if it's a reference, it
   // must be nullable.
+  if (isTuple()) {
+    for (auto t : *this) {
+      if (!t.isDefaultable()) {
+        return false;
+      }
+    }
+    return true;
+  }
   return isConcrete() && (!isRef() || isNullable()) && !isRtt();
 }
 

--- a/test/spec/tuples.wast
+++ b/test/spec/tuples.wast
@@ -1,0 +1,9 @@
+(assert_invalid
+  (module
+    (func $foo
+      (local $temp ((ref func) i32))
+    )
+  )
+  "var must be defaultable"
+)
+


### PR DESCRIPTION
This looks like a pre-existing issue to https://github.com/WebAssembly/binaryen/pull/3731, but
the testcase only fails on that PR for a reason I did not investigate in
depth, so it should land first.

Also fix the check for nondefaultability in the fuzzer.