### PR TITLE
Print parse errors in reducer and roundtrip

### DIFF
--- a/src/passes/RoundTrip.cpp
+++ b/src/passes/RoundTrip.cpp
@@ -41,7 +41,13 @@ struct RoundTrip : public Pass {
     auto input = buffer.getAsChars();
     WasmBinaryBuilder parser(*module, input);
     parser.setDWARF(runner->options.debugInfo);
-    parser.read();
+    try {
+      parser.read();
+    } catch (ParseException& p) {
+      p.dump(std::cerr);
+      std::cerr << '\n';
+      Fatal() << "error in parsing wasm binary";
+    }
     // Reapply features
     module->features = features;
   }

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -347,7 +347,13 @@ struct Reducer
   void loadWorking() {
     module = make_unique<Module>();
     ModuleReader reader;
-    reader.read(working, *module);
+    try {
+      reader.read(working, *module);
+    } catch (ParseException& p) {
+      p.dump(std::cerr);
+      std::cerr << '\n';
+      Fatal() << "error in parsing working wasm binary";
+    }
     // If there is no features section, assume we may need them all (without
     // this, a module with no features section but that uses e.g. atomics and
     // bulk memory would not work).


### PR DESCRIPTION
Without this, crashes from things like #3736 simply get reported as
"a parse exception was thrown" with no detail.