### PR TITLE
Fix fuzzer on creating a function with a heaptype of just 'func'

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2115,8 +2115,8 @@ private:
       if (heapType.isSignature()) {
         sig = heapType.getSignature();
       } else {
-        assert(heapType == HeapType::func);
-        // The specific signature does not matter.
+        // This is something like funcref or externref, and so the specific
+        // signature does not matter.
         sig = Signature(Type::none, Type::none);
       }
       auto* func = wasm.addFunction(builder.makeFunction(

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2118,6 +2118,9 @@ private:
         // This is something like funcref or externref, and so the specific
         // signature does not matter.
         sig = Signature(Type::none, Type::none);
+        // When we set the type of the ref.func, it must be funcref and not
+        // externref or such.
+        type = Type::funcref;
       }
       auto* func = wasm.addFunction(builder.makeFunction(
         Names::getValidFunctionName(wasm, "ref_func_target"),

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2110,9 +2110,18 @@ private:
         return builder.makeRefNull(type);
       }
       // Last resort: create a function.
+      auto heapType = type.getHeapType();
+      Signature sig;
+      if (heapType.isSignature()) {
+        sig = heapType.getSignature();
+      } else {
+        assert(heapType == HeapType::func);
+        // The specific signature does not matter.
+        sig = Signature(Type::none, Type::none);
+      }
       auto* func = wasm.addFunction(builder.makeFunction(
         Names::getValidFunctionName(wasm, "ref_func_target"),
-        type.getHeapType().getSignature(),
+        sig,
         {},
         builder.makeUnreachable()));
       return builder.makeRefFunc(func->name, type);

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2077,9 +2077,9 @@ private:
     if (type.isRef()) {
       assert(wasm.features.hasReferenceTypes());
       // Check if we can use ref.func.
-      // 'func' is the pointer to the last created function and can be null when
-      // we set up globals (before we create any functions), in which case we
-      // can't use ref.func.
+      // 'funcContext->func' is the pointer to the last created function and can
+      // be null when we set up globals (before we create any functions), in
+      // which case we can't use ref.func.
       if (type == Type::funcref && funcContext && oneIn(2)) {
         // First set to target to the last created function, and try to select
         // among other existing function if possible


### PR DESCRIPTION
Without this the fuzzer calls `getSignature` on `HeapType::func` which asserts.