### PR TITLE
Scan module-level code in necessary places

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -289,9 +289,8 @@ struct DAE : public Pass {
     ElementUtils::iterAllElementFunctionNames(
       module, [&](Name name) { infoMap[name].hasUnseenCalls = true; });
     // Check the influence of globals.
-    ModuleUtils::iterDefinedGlobals(*module, [&](Global* glob) {
-      scanner.walk(glob->init);
-    });
+    ModuleUtils::iterDefinedGlobals(
+      *module, [&](Global* glob) { scanner.walk(glob->init); });
     // Scan all the functions.
     scanner.run(runner, module);
     // Combine all the info.

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -280,17 +280,12 @@ struct DAE : public Pass {
       infoMap[func->name];
     }
     DAEScanner scanner(&infoMap);
-    // Check the influence of the table and exports.
+    scanner.walkModuleCode(module);
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
         infoMap[curr->value].hasUnseenCalls = true;
       }
     }
-    ElementUtils::iterAllElementFunctionNames(
-      module, [&](Name name) { infoMap[name].hasUnseenCalls = true; });
-    // Check the influence of globals.
-    ModuleUtils::iterDefinedGlobals(
-      *module, [&](Global* glob) { scanner.walk(glob->init); });
     // Scan all the functions.
     scanner.run(runner, module);
     // Combine all the info.

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -175,24 +175,26 @@ struct FuncCastEmulation : public Pass {
     Signature ABIType(Type(std::vector<Type>(numParams, Type::i64)), Type::i64);
     // Add a thunk for each function in the table, and do the call through it.
     std::unordered_map<Name, Name> funcThunks;
-    ModuleUtils::iterActiveElementSegments(*module, [&](ElementSegment* segment) {
-      for (auto* item : segment->data) {
-        if (auto* ref = item->dynCast<RefFunc>()) {
-          // Update the name.
-          auto& name = ref->func;
-          auto iter = funcThunks.find(name);
-          if (iter == funcThunks.end()) {
-            auto thunk = makeThunk(name, module, numParams);
-            funcThunks[name] = thunk;
-            name = thunk;
-          } else {
-            name = iter->second;
+    ModuleUtils::iterActiveElementSegments(
+      *module, [&](ElementSegment* segment) {
+        for (auto* item : segment->data) {
+          if (auto* ref = item->dynCast<RefFunc>()) {
+            // Update the name.
+            auto& name = ref->func;
+            auto iter = funcThunks.find(name);
+            if (iter == funcThunks.end()) {
+              auto thunk = makeThunk(name, module, numParams);
+              funcThunks[name] = thunk;
+              name = thunk;
+            } else {
+              name = iter->second;
+            }
+            // Update the type.
+            ref->finalize(
+              Type(HeapType(module->getFunction(name)->sig), NonNullable));
           }
-          // Update the type.
-          ref->finalize(Type(HeapType(module->getFunction(name)->sig), NonNullable));
         }
-      }
-    });
+      });
     // update call_indirects
     ParallelFuncCastEmulation(ABIType, numParams).run(runner, module);
   }

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -32,7 +32,6 @@
 
 #include <ir/element-utils.h>
 #include <ir/literal-utils.h>
-#include <ir/module-utils.h>
 #include <pass.h>
 #include <wasm-builder.h>
 #include <wasm.h>
@@ -175,26 +174,17 @@ struct FuncCastEmulation : public Pass {
     Signature ABIType(Type(std::vector<Type>(numParams, Type::i64)), Type::i64);
     // Add a thunk for each function in the table, and do the call through it.
     std::unordered_map<Name, Name> funcThunks;
-    ModuleUtils::iterActiveElementSegments(
-      *module, [&](ElementSegment* segment) {
-        for (auto* item : segment->data) {
-          if (auto* ref = item->dynCast<RefFunc>()) {
-            // Update the name.
-            auto& name = ref->func;
-            auto iter = funcThunks.find(name);
-            if (iter == funcThunks.end()) {
-              auto thunk = makeThunk(name, module, numParams);
-              funcThunks[name] = thunk;
-              name = thunk;
-            } else {
-              name = iter->second;
-            }
-            // Update the type.
-            ref->finalize(
-              Type(HeapType(module->getFunction(name)->sig), NonNullable));
-          }
-        }
-      });
+    ElementUtils::iterAllElementFunctionNames(module, [&](Name& name) {
+      auto iter = funcThunks.find(name);
+      if (iter == funcThunks.end()) {
+        auto thunk = makeThunk(name, module, numParams);
+        funcThunks[name] = thunk;
+        name = thunk;
+      } else {
+        name = iter->second;
+      }
+    });
+
     // update call_indirects
     ParallelFuncCastEmulation(ABIType, numParams).run(runner, module);
   }

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -344,21 +344,13 @@ struct Inlining : public Pass {
       infos[func->name];
     }
     PassRunner runner(module);
-    FunctionInfoScanner(&infos).run(&runner, module);
+    FunctionInfoScanner scanner(&infos);
+    scanner.run(&runner, module);
     // fill in global uses
+    scanner.walkModuleCode(module);
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
         infos[ex->value].usedGlobally = true;
-      }
-    }
-    ElementUtils::iterAllElementFunctionNames(
-      module, [&](Name name) { infos[name].usedGlobally = true; });
-
-    for (auto& global : module->globals) {
-      if (!global->imported()) {
-        for (auto* ref : FindAll<RefFunc>(global->init).list) {
-          infos[ref->func].usedGlobally = true;
-        }
       }
     }
     if (module->start.is()) {

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -21,6 +21,7 @@
 #include <unordered_set>
 
 #include <ir/element-utils.h>
+#include <ir/module-utils.h>
 #include <pass.h>
 #include <wasm.h>
 
@@ -88,6 +89,10 @@ inline void replaceFunctions(PassRunner* runner,
   FunctionRefReplacer(maybeReplace).run(runner, &module);
   // replace in table
   ElementUtils::iterAllElementFunctionNames(&module, maybeReplace);
+  // replace in globals
+  ModuleUtils::iterDefinedGlobals(module, [&](Global* glob) {
+    FunctionRefReplacer(maybeReplace).walk(glob->init);
+  });
 
   // replace in start
   if (module.start.is()) {

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -88,7 +88,7 @@ inline void replaceFunctions(PassRunner* runner,
   // replace direct calls in code both functions and module elements
   FunctionRefReplacer replacer(maybeReplace);
   replacer.run(runner, &module);
-  replacer.walkModuleCode(module);
+  replacer.walkModuleCode(&module);
   // replace in table
   ElementUtils::iterAllElementFunctionNames(&module, maybeReplace);
   // replace in globals

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -85,8 +85,10 @@ inline void replaceFunctions(PassRunner* runner,
       name = iter->second;
     }
   };
-  // replace direct calls
-  FunctionRefReplacer(maybeReplace).run(runner, &module);
+  // replace direct calls in code both functions and module elements
+  FunctionRefReplacer replacer(maybeReplace);
+  replacer.run(runner, &module);
+  replacer.walkModuleCode(module);
   // replace in table
   ElementUtils::iterAllElementFunctionNames(&module, maybeReplace);
   // replace in globals

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -89,12 +89,6 @@ inline void replaceFunctions(PassRunner* runner,
   FunctionRefReplacer replacer(maybeReplace);
   replacer.run(runner, &module);
   replacer.walkModuleCode(&module);
-  // replace in table
-  ElementUtils::iterAllElementFunctionNames(&module, maybeReplace);
-  // replace in globals
-  ModuleUtils::iterDefinedGlobals(module, [&](Global* glob) {
-    FunctionRefReplacer(maybeReplace).walk(glob->init);
-  });
 
   // replace in start
   if (module.start.is()) {

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -272,6 +272,9 @@ struct Walker : public VisitorType {
       if (curr->offset) {
         self->walk(curr->offset);
       }
+      for (auto* item : curr->data) {
+        self->walk(item);
+      }
     }
   }
 

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -259,6 +259,22 @@ struct Walker : public VisitorType {
     self->walkMemory(&module->memory);
   }
 
+  // Walks module-level code, that is, code that is not in functions.
+  void walkModuleCode(Module* module) {
+    // Dispatch statically through the SubType.
+    SubType* self = static_cast<SubType*>(this);
+    for (auto& curr : module->globals) {
+      if (!curr->imported()) {
+        self->walk(curr->init);
+      }
+    }
+    for (auto& curr : module->elementSegments) {
+      if (curr->offset) {
+        self->walk(curr->offset);
+      }
+    }
+  }
+
   // Walk implementation. We don't use recursion as ASTs may be highly
   // nested.
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2851,7 +2851,7 @@ static void validateTables(Module& module, ValidationInfo& info) {
       info.shouldBeTrue(
         table != nullptr, "elem", "elem segment must have a valid table name");
       info.shouldBeTrue(!!segment->offset,
-                        segment,
+                        "elem",
                         "table segment offset should have an offset");
       info.shouldBeEqual(segment->offset->type,
                          Type(Type::i32),
@@ -2865,7 +2865,7 @@ static void validateTables(Module& module, ValidationInfo& info) {
       validator.validate(segment->offset);
     } else {
       info.shouldBeTrue(!segment->offset,
-                        segment,
+                        "elem",
                         "non-table segment offset should have no offset");
     }
     // Avoid double checking items

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2003,8 +2003,8 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   //   curr->type.getHeapType().getSignature()
   // That is blocked on having the ability to create signature types in the C
   // API (for now those users create the type with funcref). This also needs to
-  // be fixed in LegalizeJSInterface and other places that update function
-  // types.
+  // be fixed in LegalizeJSInterface and FuncCastEmulation and other places that
+  // update function types.
   // TODO: check for non-nullability
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1995,19 +1995,8 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   }
   auto* func = getModule()->getFunctionOrNull(curr->func);
   shouldBeTrue(!!func, curr, "function argument of ref.func must exist");
-  if (shouldBeTrue(
-        curr->type.isFunction(), curr, "ref.func must have a function type")) {
-    // TODO: verify it also has a typed function references type,
-    //                    curr->type.getHeapType().isSignature(),
-    // That is blocked on having the ability to create signature types in the C
-    // API. For now those users create the type with funcref.
-    if (curr->type.getHeapType().isSignature()) {
-      shouldBeEqual(curr->type.getHeapType().getSignature(),
-                    func->sig,
-                    curr,
-                    "ref.func must have the right type");
-    }
-  }
+  shouldBeTrue(
+      curr->type.isFunction(), curr, "ref.func must have a function type");
   // TODO: check for non-nullability
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1995,9 +1995,15 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   }
   auto* func = getModule()->getFunctionOrNull(curr->func);
   shouldBeTrue(!!func, curr, "function argument of ref.func must exist");
-  shouldBeTrue(curr->type.isFunction(),
-               curr,
-               "ref.func must have a function reference type");
+  if (shouldBeTrue(curr->type.isFunction() &&
+                   curr->type.getHeapType().isSignature(),
+                   curr,
+                   "ref.func must have a function reference type")) {
+    shouldBeEqual(curr->type.getHeapType().getSignature(),
+                  func->sig,
+                  curr,
+                  "ref.func must have the right type");
+  }
   // TODO: check for non-nullability
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2850,6 +2850,9 @@ static void validateTables(Module& module, ValidationInfo& info) {
       auto table = module.getTableOrNull(segment->table);
       info.shouldBeTrue(
         table != nullptr, "elem", "elem segment must have a valid table name");
+      info.shouldBeTrue(!!segment->offset,
+                        segment,
+                        "table segment offset should have an offset");
       info.shouldBeEqual(segment->offset->type,
                          Type(Type::i32),
                          segment->offset,
@@ -2860,6 +2863,10 @@ static void validateTables(Module& module, ValidationInfo& info) {
                         segment->offset,
                         "table segment offset should be reasonable");
       validator.validate(segment->offset);
+    } else {
+      info.shouldBeTrue(!segment->offset,
+                        segment,
+                        "non-table segment offset should have no offset");
     }
     // Avoid double checking items
     if (module.features.hasReferenceTypes()) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1995,9 +1995,8 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   }
   auto* func = getModule()->getFunctionOrNull(curr->func);
   shouldBeTrue(!!func, curr, "function argument of ref.func must exist");
-  if (shouldBeTrue(curr->type.isFunction(),
-                   curr,
-                   "ref.func must have a function type")) {
+  if (shouldBeTrue(
+        curr->type.isFunction(), curr, "ref.func must have a function type")) {
     // TODO: verify it also has a typed function references type,
     //                    curr->type.getHeapType().isSignature(),
     // That is blocked on having the ability to create signature types in the C

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1995,14 +1995,19 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   }
   auto* func = getModule()->getFunctionOrNull(curr->func);
   shouldBeTrue(!!func, curr, "function argument of ref.func must exist");
-  if (shouldBeTrue(curr->type.isFunction() &&
-                   curr->type.getHeapType().isSignature(),
+  if (shouldBeTrue(curr->type.isFunction(),
                    curr,
-                   "ref.func must have a function reference type")) {
-    shouldBeEqual(curr->type.getHeapType().getSignature(),
-                  func->sig,
-                  curr,
-                  "ref.func must have the right type");
+                   "ref.func must have a function type")) {
+    // TODO: verify it also has a typed function references type,
+    //                    curr->type.getHeapType().isSignature(),
+    // That is blocked on having the ability to create signature types in the C
+    // API. For now those users create the type with funcref.
+    if (curr->type.getHeapType().isSignature()) {
+      shouldBeEqual(curr->type.getHeapType().getSignature(),
+                    func->sig,
+                    curr,
+                    "ref.func must have the right type");
+    }
   }
   // TODO: check for non-nullability
 }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1995,8 +1995,16 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   }
   auto* func = getModule()->getFunctionOrNull(curr->func);
   shouldBeTrue(!!func, curr, "function argument of ref.func must exist");
-  shouldBeTrue(
-      curr->type.isFunction(), curr, "ref.func must have a function type");
+  shouldBeTrue(curr->type.isFunction(),
+               curr,
+               "ref.func must have a function reference type");
+  // TODO: verify it also has a typed function references type, and the right
+  // one,
+  //   curr->type.getHeapType().getSignature()
+  // That is blocked on having the ability to create signature types in the C
+  // API (for now those users create the type with funcref). This also needs to
+  // be fixed in LegalizeJSInterface and other places that update function
+  // types.
   // TODO: check for non-nullability
 }
 

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -893,11 +893,11 @@ void test_core() {
   BinaryenModuleSetFeatures(module, features);
   assert(BinaryenModuleGetFeatures(module) == features);
 
-  // Verify it validates
-  assert(BinaryenModuleValidate(module));
-
   // Print it out
   BinaryenModulePrint(module);
+
+  // Verify it validates
+  assert(BinaryenModuleValidate(module));
 
   // Clean up the module, which owns all the objects we created above
   BinaryenModuleDispose(module);

--- a/test/passes/dae_all-features.txt
+++ b/test/passes/dae_all-features.txt
@@ -292,3 +292,23 @@
   (ref.func $0)
  )
 )
+(module
+ (type $none_=>_none (func))
+ (type $i64 (func (param i64)))
+ (global $global$0 (ref $i64) (ref.func $0))
+ (export "even" (func $1))
+ (func $0 (param $0 i64)
+  (unreachable)
+ )
+ (func $1
+  (call_ref
+   (i64.const 0)
+   (global.get $global$0)
+  )
+ )
+ (func $2
+  (call $0
+   (i64.const 0)
+  )
+ )
+)

--- a/test/passes/dae_all-features.wast
+++ b/test/passes/dae_all-features.wast
@@ -172,3 +172,24 @@
   (ref.func $0)
  )
 )
+(module
+ (type $i64 (func (param i64)))
+ (global $global$0 (ref $i64) (ref.func $0))
+ (export "even" (func $1))
+ ;; the argument to this function cannot be removed due to the ref.func of it
+ ;; in a global
+ (func $0 (param $0 i64)
+  (unreachable)
+ )
+ (func $1
+  (call_ref
+   (i64.const 0)
+   (global.get $global$0)
+  )
+ )
+ (func $2
+  (call $0
+   (i64.const 0)
+  )
+ )
+)

--- a/test/passes/duplicate-function-elimination_all-features.txt
+++ b/test/passes/duplicate-function-elimination_all-features.txt
@@ -19,3 +19,16 @@
   (nop)
  )
 )
+(module
+ (type $func (func (result i32)))
+ (global $global$0 (ref $func) (ref.func $foo))
+ (export "export" (func $2))
+ (func $foo (result i32)
+  (unreachable)
+ )
+ (func $2 (result i32)
+  (call_ref
+   (global.get $global$0)
+  )
+ )
+)

--- a/test/passes/duplicate-function-elimination_all-features.wast
+++ b/test/passes/duplicate-function-elimination_all-features.wast
@@ -21,3 +21,21 @@
  (func $foo ;; happens to share a name with the memory
  )
 )
+;; renaming after deduplication must update ref.funcs in globals
+(module
+ (type $func (func (result i32)))
+ (global $global$0 (ref $func) (ref.func $bar))
+ ;; These two identical functions can be merged. The ref.func in the global must
+ ;; be updated accordingly.
+ (func $foo (result i32)
+  (unreachable)
+ )
+ (func $bar (result i32)
+  (unreachable)
+ )
+ (func "export" (result i32)
+  (call_ref
+   (global.get $global$0)
+  )
+ )
+)


### PR DESCRIPTION
Several old passes like DeadArgumentElimination and DuplicateFunctionElimination
need to look at all `ref.func`s, and they scanned functions for that, but that is not
enough as such an instruction might appear in a global initializer. To fix this, add a
`walkModuleCode` method.

`walkModuleCode` is useful when doing the pattern of creating a function-parallel
pass to scan functions quickly, but we also want to do the same scanning of code
at the module level. This allows doing so in a single line.

(It is also possible to just do `walk()` on the entire module, which will find all code,
but that is not function-parallel. Perhaps we should have a `walkParallel()` option
to simplify this further in a followup, and that would call `walkModuleCode` afterwards
etc.)

Also add some missing validation and comments in the validator about issues that
I noticed in relation to the new testcases here.