### PR TITLE
Fuzzing: Minor execution-results.h fixes

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -223,7 +223,8 @@ struct ExecutionResults {
       for (const auto& param : func->sig.params) {
         // zeros in arguments TODO: more?
         if (!param.isDefaultable()) {
-          std::cout << "[trap fuzzer can only send nullable parameters to exports]\n";
+          std::cout
+            << "[trap fuzzer can only send defaultable parameters to exports]\n";
         }
         arguments.push_back(Literal::makeZero(param));
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -44,8 +44,20 @@ struct LoggingExternalInterface : public ShellExternalInterface {
       std::cout << "[LoggingExternalInterface logging";
       loggings.push_back(Literal()); // buffer with a None between calls
       for (auto argument : arguments) {
-        std::cout << ' ' << argument;
-        loggings.push_back(argument);
+        if (argument.type == Type::i64) {
+          // To avoid JS legalization changing logging results, treat a logging
+          // of an i64 as two i32s (which is what legalization would turn us
+          // into).
+          auto low = Literal(int32_t(argument.getInteger()));
+          auto high = Literal(int32_t(argument.getInteger() >> int32_t(32)));
+          std::cout << ' ' << low;
+          loggings.push_back(low);
+          std::cout << ' ' << high;
+          loggings.push_back(high);
+        } else {
+          std::cout << ' ' << argument;
+          loggings.push_back(argument);
+        }
       }
       std::cout << "]\n";
       return {};
@@ -97,8 +109,17 @@ struct ExecutionResults {
           results[exp->name] = ret;
           // ignore the result if we hit an unreachable and returned no value
           if (ret.size() > 0) {
-            std::cout << "[fuzz-exec] note result: " << exp->name << " => "
-                      << ret << '\n';
+            std::cout << "[fuzz-exec] note result: " << exp->name << " => ";
+            auto resultType = func->sig.results;
+            if (resultType.isRef()) {
+              // Don't print reference values, as funcref(N) contains an index
+              // for example, which is not guaranteed to remain identical after
+              // optimizations.
+              std::cout << resultType;
+            } else {
+              std::cout << ret;
+            }
+            std::cout << '\n';
           }
         } else {
           // no result, run it anyhow (it might modify memory etc.)
@@ -202,6 +223,9 @@ struct ExecutionResults {
       // call the method
       for (const auto& param : func->sig.params) {
         // zeros in arguments TODO: more?
+        if (!param.isDefaultable()) {
+          std::cout << "[trap fuzzer cannot provide a non-null export param'\n";
+        }
         arguments.push_back(Literal::makeZero(param));
       }
       return instance.callFunction(func->name, arguments);

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -115,11 +115,10 @@ struct ExecutionResults {
               // Don't print reference values, as funcref(N) contains an index
               // for example, which is not guaranteed to remain identical after
               // optimizations.
-              std::cout << resultType;
+              std::cout << resultType << '\n';
             } else {
-              std::cout << ret;
+              std::cout << ret << '\n';
             }
-            std::cout << '\n';
           }
         } else {
           // no result, run it anyhow (it might modify memory etc.)

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -223,8 +223,8 @@ struct ExecutionResults {
       for (const auto& param : func->sig.params) {
         // zeros in arguments TODO: more?
         if (!param.isDefaultable()) {
-          std::cout
-            << "[trap fuzzer can only send defaultable parameters to exports]\n";
+          std::cout << "[trap fuzzer can only send defaultable parameters to "
+                       "exports]\n";
         }
         arguments.push_back(Literal::makeZero(param));
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -223,7 +223,7 @@ struct ExecutionResults {
       for (const auto& param : func->sig.params) {
         // zeros in arguments TODO: more?
         if (!param.isDefaultable()) {
-          std::cout << "[trap fuzzer cannot provide a non-null export param'\n";
+          std::cout << "[trap fuzzer can only send nullable parameters to exports]\n";
         }
         arguments.push_back(Literal::makeZero(param));
       }

--- a/test/passes/fuzz-exec_all-features.txt
+++ b/test/passes/fuzz-exec_all-features.txt
@@ -208,7 +208,7 @@
 [fuzz-exec] calling rmw-reads-modifies-and-writes-asymmetrical
 [LoggingExternalInterface logging 214]
 [fuzz-exec] calling func
-[fuzz-exec] note result: func => funcref(func)
+[fuzz-exec] note result: func => funcref
 (module
  (type $none_=>_funcref (func (result funcref)))
  (elem declare func $func)
@@ -218,5 +218,5 @@
  )
 )
 [fuzz-exec] calling func
-[fuzz-exec] note result: func => funcref(func)
+[fuzz-exec] note result: func => funcref
 [fuzz-exec] comparing func

--- a/test/passes/simplify-globals_all-features_fuzz-exec.txt
+++ b/test/passes/simplify-globals_all-features_fuzz-exec.txt
@@ -1,5 +1,5 @@
 [fuzz-exec] calling export
-[fuzz-exec] note result: export => funcref(0)
+[fuzz-exec] note result: export => funcref
 (module
  (type $f32_i31ref_i64_f64_funcref_=>_none (func (param f32 i31ref i64 f64 funcref)))
  (type $none_=>_funcref (func (result funcref)))
@@ -17,5 +17,5 @@
  )
 )
 [fuzz-exec] calling export
-[fuzz-exec] note result: export => funcref(0)
+[fuzz-exec] note result: export => funcref
 [fuzz-exec] comparing export


### PR DESCRIPTION
* Log out an i64 as two i32s. That keeps the output consistent regardless of
  whether we legalize.
* Do not print a reference result. The printed value cannot be compared, as
  `funcref(10)` (where 10 is the index of the function) is not guaranteed to be
  the same after opts.
* Trap when trying to call an export with a nondefaultable type (instead of
  asserting when trying to create zeros for it).