### PR TITLE
SetGlobals pass

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -58,6 +58,7 @@ set(passes_SOURCES
   PrintFeatures.cpp
   PrintFunctionMap.cpp
   RoundTrip.cpp
+  SetGlobals.cpp
   StackIR.cpp
   Strip.cpp
   StripTargetFeatures.cpp

--- a/src/passes/SetGlobals.cpp
+++ b/src/passes/SetGlobals.cpp
@@ -20,8 +20,8 @@
 
 #include "pass.h"
 #include "support/string.h"
-#include "wasm.h"
 #include "wasm-builder.h"
+#include "wasm.h"
 
 namespace wasm {
 

--- a/src/passes/SetGlobals.cpp
+++ b/src/passes/SetGlobals.cpp
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-// Removes code from all functions but one, leaving a valid module
-// with (mostly) just the code you want to debug (function-parallel,
-// non-lto) passes on.
+// Assigns values to specified globals. This can be useful to perform a minor
+// customization of an existing wasm file.
 
 #include "pass.h"
 #include "support/string.h"

--- a/src/passes/SetGlobals.cpp
+++ b/src/passes/SetGlobals.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Removes code from all functions but one, leaving a valid module
+// with (mostly) just the code you want to debug (function-parallel,
+// non-lto) passes on.
+
+#include "pass.h"
+#include "support/string.h"
+#include "wasm.h"
+#include "wasm-builder.h"
+
+namespace wasm {
+
+struct SetGlobals : public Pass {
+  void run(PassRunner* runner, Module* module) override {
+    Name input = runner->options.getArgument(
+      "set-globals",
+      "SetGlobals usage:  wasm-opt --pass-arg=set-globals@x=y,z=w");
+
+    // The input is a set of X=Y pairs separated by commas.
+    String::Split pairs(input.str, ",");
+    for (auto& pair : pairs) {
+      String::Split nameAndValue(pair, "=");
+      auto name = nameAndValue[0];
+      auto value = nameAndValue[1];
+      auto* glob = module->getGlobalOrNull(name);
+      if (!glob) {
+        std::cerr << "warning: could not find global: " << name << '\n';
+      }
+      // Parse the input.
+      Literal lit;
+      if (glob->type == Type::i32) {
+        lit = Literal(int32_t(stoi(value)));
+      } else if (glob->type == Type::i64) {
+        lit = Literal(int64_t(stoll(value)));
+      } else {
+        Fatal() << "global's type is not supported: " << name;
+      }
+      // The global now has a value, and is not imported.
+      glob->init = Builder(*module).makeConst(lit);
+      glob->module = glob->base = Name();
+    }
+  }
+};
+
+// declare pass
+
+Pass* createSetGlobalsPass() { return new SetGlobals(); }
+
+} // namespace wasm

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -303,6 +303,9 @@ void PassRegistry::registerPasses() {
   registerPass("safe-heap",
                "instrument loads and stores to check for invalid behavior",
                createSafeHeapPass);
+  registerPass("set-globals",
+               "sets specified globals to specified values",
+               createSetGlobalsPass);
   registerPass("simplify-globals",
                "miscellaneous globals-related optimizations",
                createSimplifyGlobalsPass);

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -102,6 +102,7 @@ Pass* createReReloopPass();
 Pass* createRedundantSetEliminationPass();
 Pass* createRoundTripPass();
 Pass* createSafeHeapPass();
+Pass* createSetGlobalsPass();
 Pass* createSimplifyLocalsPass();
 Pass* createSimplifyGlobalsPass();
 Pass* createSimplifyGlobalsOptimizingPass();

--- a/test/passes/set-globals.passes
+++ b/test/passes/set-globals.passes
@@ -1,0 +1,1 @@
+set-globals_pass-arg=set-globals@foo=1337,bar=42

--- a/test/passes/set-globals.txt
+++ b/test/passes/set-globals.txt
@@ -1,0 +1,4 @@
+(module
+ (global $foo i32 (i32.const 1337))
+ (global $bar i64 (i64.const 42))
+)

--- a/test/passes/set-globals.wast
+++ b/test/passes/set-globals.wast
@@ -1,0 +1,7 @@
+(module
+ ;; an imported i32
+ (import "env" "in" (global $foo i32))
+
+ ;; a defined i64
+ (global $bar i64 (i64.const 1234))
+)


### PR DESCRIPTION
This allows changing a global's value on the commandline in an easy way.

In some toolchains this is useful as the build can contain a global that
indicates something like a logging level, which this can customize.