### PR TITLE
Fix DeadArgumentElimination pass on non-nullable locals

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -41,6 +41,7 @@
 #include "ir/effects.h"
 #include "ir/element-utils.h"
 #include "ir/module-utils.h"
+#include "ir/type-updating.h"
 #include "pass.h"
 #include "passes/opt-utils.h"
 #include "support/sorted_vector.h"
@@ -382,6 +383,7 @@ struct DAE : public Pass {
             // Wonderful, nothing stands in our way! Do it.
             // TODO: parallelize this?
             removeParameter(func, i, calls);
+            TypeUpdating::handleNonNullableLocals(func, *module);
             changed.insert(func);
           }
         }

--- a/test/passes/dae_all-features.txt
+++ b/test/passes/dae_all-features.txt
@@ -312,3 +312,13 @@
   )
  )
 )
+(module
+ (type $none_=>_none (func))
+ (func $0
+  (local $0 (ref null i31))
+  (nop)
+ )
+ (func $1
+  (call $0)
+ )
+)

--- a/test/passes/dae_all-features.wast
+++ b/test/passes/dae_all-features.wast
@@ -193,3 +193,14 @@
   )
  )
 )
+(module
+ ;; a removable non-nullable parameter
+ (func $0 (param $x i31ref)
+  (nop)
+ )
+ (func $1
+  (call $0
+   (i31.new (i32.const 0))
+  )
+ )
+)


### PR DESCRIPTION
In this case, there is a natural place to fix things up right after
removing a parameter (which is where a local gets added). Doing it
there avoids doing work on all functions unnecessarily.

Note that we could do something even simpler here than calling
the generic code: the parameter was not used, so the new local
is not used, and we could just change the type of the local or not
add it at all. Those would be slightly more code though, and add
complexity to the parameter removal method itself.