### PR TITLE
Avoid flatten + multivalue + reference types in the fuzzer

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -988,6 +988,9 @@ def randomize_opt_flags():
             if '--disable-exception-handling' not in FEATURE_OPTS:
                 print('avoiding --flatten due to exception catching which does not support it yet')
                 continue
+            if '--disable-multivalue' not in FEATURE_OPTS and '--disable-reference-types' not in FEATURE_OPTS:
+                print('avoiding --flatten due to multivalue + reference types not supporting it (spilling of non-nullable tuples)')
+                continue
             if INITIAL_CONTENTS and os.path.getsize(INITIAL_CONTENTS) > 2000:
                 print('avoiding --flatten due using a large amount of initial contents, which may blow up')
                 continue

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -342,7 +342,9 @@ struct Flatten
     // top of the file.
     for (auto type : func->vars) {
       if (!type.isDefaultable()) {
-        Fatal() << "Flatten was forced to add a local of a type it cannot handle yet: " << type;
+        Fatal() << "Flatten was forced to add a local of a type it cannot "
+                   "handle yet: "
+                << type;
       }
     }
   }

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -340,7 +340,7 @@ struct Flatten
     TypeUpdating::handleNonNullableLocals(curr, *getModule());
     // We cannot handle non-nullable tuples currently, see the comment at the
     // top of the file.
-    for (auto type : func->vars) {
+    for (auto type : curr->vars) {
       if (!type.isDefaultable()) {
         Fatal() << "Flatten was forced to add a local of a type it cannot "
                    "handle yet: "

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -17,8 +17,27 @@
 //
 // Flattens code into "Flat IR" form. See ir/flat.h.
 //
-// TODO: handle non-nullability
+// TODO: handle non-nullability. for example:
 //
+//      (module
+//       (type $none (func))
+//       (func $foo
+//        (drop
+//         (block (result funcref (ref $none))
+//          (tuple.make
+//           (ref.null func)
+//           (ref.func $foo)
+//          )
+//         )
+//        )
+//       )
+//      )
+//
+// The tuple has a non-nullable type, and so it cannot be set to a local. We
+// would need to split up the tuple and reconstruct it later, but that would
+// require allowing tuple operations in more nested places than Flat IR allows
+// today. For now, error on this; eventually changes in the spec regarding
+// null-nullability may make this easier.
 
 #include <ir/branch-utils.h>
 #include <ir/effects.h>
@@ -319,6 +338,13 @@ struct Flatten
     curr->body = getPreludesWithExpression(originalBody, curr->body);
     // New locals we added may be non-nullable.
     TypeUpdating::handleNonNullableLocals(curr, *getModule());
+    // We cannot handle non-nullable tuples currently, see the comment at the
+    // top of the file.
+    for (auto type : func->vars) {
+      if (!type.isDefaultable()) {
+        Fatal() << "Flatten was forced to add a local of a type it cannot handle yet: " << type;
+      }
+    }
   }
 
 private:


### PR DESCRIPTION
The problem is that a tuple with a non-nullable element cannot be stored
to a local. We'd need to split up the tuple, but that raises questions about
what should be allowed in flat IR (we'd need to allow nested tuple ops
in more places). That combination doesn't seem urgent, so add a clear
error for now, and avoid it in the fuzzer.

Avoids #3759 in the fuzzer