### PR TITLE
Fix type canonicalization bugs

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -71,6 +71,10 @@ struct TypeInfo {
 
   bool isNullable() const { return kind == RefKind && ref.nullable; }
 
+  // If this TypeInfo represents a Type that can be represented more simply, set
+  // `out` to be that simpler Type and return true. For example, this handles
+  // canonicalizing the TypeInfo representing (ref null any) into the BasicType
+  // anyref. It also handles eliminating singleton tuple types.
   bool getCanonical(Type& out) const;
 
   bool operator==(const TypeInfo& other) const;
@@ -114,6 +118,9 @@ struct HeapTypeInfo {
   constexpr bool isArray() const { return kind == ArrayKind; }
   constexpr bool isData() const { return isStruct() || isArray(); }
 
+  // If this HeapTypeInfo represents a HeapType that can be represented more
+  // simply, set `out` to be that simpler HeapType and return true. This handles
+  // turning BasicKind HeapTypes into their corresponding BasicHeapTypes.
   bool getCanonical(HeapType& out) const;
 
   HeapTypeInfo& operator=(const HeapTypeInfo& other);
@@ -318,6 +325,9 @@ bool isTemp(HeapType type) {
   return !type.isBasic() && getHeapTypeInfo(type)->isTemp;
 }
 
+// Given a Type that may or may not be backed by the simplest possible
+// representation, return the equivalent type that is definitely backed by the
+// simplest possible representation.
 Type asCanonical(Type type) {
   if (!type.isBasic()) {
     getTypeInfo(type)->getCanonical(type);
@@ -325,6 +335,9 @@ Type asCanonical(Type type) {
   return type;
 }
 
+// Given a HeapType that may or may not be backed by the simplest possible
+// representation, return the equivalent type that is definitely backed by the
+// simplest possible representation.
 HeapType asCanonical(HeapType type) {
   if (!type.isBasic()) {
     getHeapTypeInfo(type)->getCanonical(type);

--- a/test/example/type-builder.cpp
+++ b/test/example/type-builder.cpp
@@ -103,6 +103,32 @@ void test_canonicalization() {
   assert(built[3] == sig);
 }
 
+// Check that defined basic HeapTypes are handled correctly.
+void test_basic() {
+  std::cout << ";; Test basic\n";
+
+  TypeBuilder builder(6);
+
+  Type anyref = builder.getTempRefType(builder[4], Nullable);
+  Type i31ref = builder.getTempRefType(builder[5], NonNullable);
+
+  builder[0] = Signature(Type::anyref, Type::i31ref);
+  builder[1] = Signature(anyref, Type::i31ref);
+  builder[2] = Signature(Type::anyref, i31ref);
+  builder[3] = Signature(anyref, i31ref);
+  builder[4] = HeapType::any;
+  builder[5] = HeapType::i31;
+
+  std::vector<HeapType> built = builder.build();
+
+  assert(built[0] == HeapType(Signature(Type::anyref, Type::i31ref)));
+  assert(built[1] == built[0]);
+  assert(built[2] == built[1]);
+  assert(built[3] == built[2]);
+  assert(built[4] == HeapType::any);
+  assert(built[5] == HeapType::i31);
+}
+
 void test_recursive() {
   std::cout << ";; Test recursive types\n";
 
@@ -467,8 +493,13 @@ void test_lub() {
 }
 
 int main() {
-  test_builder();
-  test_canonicalization();
-  test_recursive();
-  test_lub();
+  // Run the tests twice to ensure things still work when the global stores are
+  // already populated.
+  for (size_t i = 0; i < 2; ++i) {
+    test_builder();
+    test_canonicalization();
+    test_basic();
+    test_recursive();
+    test_lub();
+  }
 }

--- a/test/example/type-builder.txt
+++ b/test/example/type-builder.txt
@@ -21,6 +21,57 @@ After building types:
 (rtt 0 $array) => (rtt 0 (array (mut externref)))
 
 ;; Test canonicalization
+;; Test basic
+;; Test recursive types
+(func (result (ref null ...1)))
+
+(func (result (ref null ...1)))
+(func (result (ref null ...1)))
+
+(func (result (ref null ...1)))
+(func (result (ref null ...1)))
+(func (result (ref null ...1)))
+(func (result (ref null ...1)))
+(func (result (ref null ...1)))
+
+(func (result (ref null ...1) (ref null (func))))
+(func (result (ref null ...1) (ref null (func))))
+(func)
+(func)
+(func (result (ref null (func (result ...1 (ref null (func)))))))
+(func (result (ref null (func (result ...1 (ref null (func)))))))
+
+(func (result (ref null ...1)))
+(func (result (ref null ...1)))
+
+(func (param anyref) (result (ref null ...1)))
+(func (param anyref) (result (ref null ...1)))
+
+;; Test LUBs
+;; Test TypeBuilder
+Before setting heap types:
+(ref $sig) => [T](ref [T](func))
+(ref $struct) => [T](ref [T](func))
+(ref $array) => [T](ref [T](func))
+(ref null $array) => [T](ref null [T](func))
+(rtt 0 $array) => [T](rtt 0 [T](func))
+
+After setting heap types:
+(ref $sig) => [T](ref [T](func (param [T](ref [T](struct (field [T](ref null [T](array (mut externref))) (mut [T](rtt 0 [T](array (mut externref)))))))) (result [T](ref [T](array (mut externref))) i32)))
+(ref $struct) => [T](ref [T](struct (field [T](ref null [T](array (mut externref))) (mut [T](rtt 0 [T](array (mut externref)))))))
+(ref $array) => [T](ref [T](array (mut externref)))
+(ref null $array) => [T](ref null [T](array (mut externref)))
+(rtt 0 $array) => [T](rtt 0 [T](array (mut externref)))
+
+After building types:
+(ref $sig) => (ref (func (param (ref (struct (field (ref null (array (mut externref))) (mut (rtt 0 (array (mut externref)))))))) (result (ref (array (mut externref))) i32)))
+(ref $struct) => (ref (struct (field (ref null (array (mut externref))) (mut (rtt 0 (array (mut externref)))))))
+(ref $array) => (ref (array (mut externref)))
+(ref null $array) => (ref null (array (mut externref)))
+(rtt 0 $array) => (rtt 0 (array (mut externref)))
+
+;; Test canonicalization
+;; Test basic
 ;; Test recursive types
 (func (result (ref null ...1)))
 

--- a/test/lit/passes/roundtrip-gc-types.wast
+++ b/test/lit/passes/roundtrip-gc-types.wast
@@ -1,0 +1,27 @@
+;; RUN: wasm-opt %s -all --roundtrip -S -o - | filecheck %s
+
+;; Regression test for an issue in which roundtripping failed to reproduce the
+;; original types because type canonicalization was incorrect when the canonical
+;; types already existed in the store.
+
+;; CHECK:      (module
+;; CHECK-NEXT:  (type $A (struct (field (ref $C))))
+;; CHECK-NEXT:  (type $B (func (param (ref $A)) (result (ref $B))))
+;; CHECK-NEXT:  (type $C (struct (field (mut (ref $B)))))
+;; CHECK-NEXT:  (type $D (struct (field (ref $C)) (field (ref $A))))
+;; CHECK-NEXT:  (global $g0 (rtt 0 $A) (rtt.canon $A))
+;; CHECK-NEXT:  (global $g1 (rtt 1 $D) (rtt.sub $D
+;; CHECK-NEXT:   (global.get $g0)
+;; CHECK-NEXT:  ))
+;; CHECK-NEXT: )
+
+(module
+ (type $A (struct (field (ref $C))))
+ (type $B (func (param (ref $A)) (result (ref $B))))
+ (type $C (struct (field (mut (ref $B)))))
+ (type $D (struct (field (ref $C)) (field (ref $A))))
+ (global $g0 (rtt 0 $A) (rtt.canon $A))
+ (global $g1 (rtt 1 $D) (rtt.sub $D
+  (global.get $g0)
+ ))
+)


### PR DESCRIPTION
When canonical heap types were already present in the global store, for example
during the --roundtrip pass, type canonicalization was not working correctly.
The issue was that the GlobalCanonicalizer was replacing temporary HeapTypes
with their canonical equivalents one type at a time, but the act of replacing a
temporary HeapType use with a canonical HeapType use could change the shape of
later HeapTypes, preventing them from being correctly matched with their
canonical counterparts. This PR fixes that problem by computing all the
temporary-to-canonical heap type replacements before executing them.

To avoid a similar problem when canonicalizing Types, one solution would have
been to pre-calculate the replacements before executing them just like with the
HeapTypes, but that would have required either complex bookkeeping or moving
temporary Types into the global store when they are first canonicalized. That
would have been complicated because unlike for temporary HeapTypeInfos, the
unique_pointer to temporary TypeInfos is not readily available. This PR instead
switches back to using pointer-identity based equality and hashing for
TypeInfos, which works because we only ever canonicalize Types with canonical
children. This change should be a nice performance improvement as well.

Another bug this PR fixes is that shape hashing and equality considered
BasicKind HeapTypes to be different from their corresponding BasicHeapTypes,
which meant that canonicalization could produce different types for the same
type definition depending on whether the definition used a TypeBuilder or not.
The fix is to pre-canonicalize BasicHeapTypes (and Types that have them as
children) during shape hashing and equality. The same mechanism is also used to
simplify Store's canonicalization.

Fixes #3736.