### PR TITLE
Catch bad tuple.extract index in parser

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2527,6 +2527,10 @@ Expression* SExpressionWasmBuilder::makeTupleExtract(Element& s) {
   auto ret = allocator.alloc<TupleExtract>();
   ret->index = atoi(s[1]->str().c_str());
   ret->tuple = parseExpression(s[2]);
+  if (ret->tuple->type != Type::unreachable &&
+      ret->index >= ret->tuple->type.size()) {
+    throw ParseException("Bad index on tuple.extract", s[1]->line, s[1]->col);
+  }
   ret->finalize();
   return ret;
 }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -872,6 +872,7 @@ void TupleExtract::finalize() {
   if (tuple->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
+    assert(index < tuple->type.size());
     type = tuple->type[index];
   }
 }

--- a/test/lit/parse-bad-tuple-extract-index.wast
+++ b/test/lit/parse-bad-tuple-extract-index.wast
@@ -1,0 +1,16 @@
+;; Test that out-of-bounds tuple.extract indices produce parse errors.
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s
+
+;; CHECK: [parse exception: Bad index on tuple.extract (at 9:17)]
+
+(module
+ (func
+  (tuple.extract 2
+   (tuple.make
+    (i32.const 0)
+    (i64.const 1)
+   )
+  )
+ )
+)


### PR DESCRIPTION
Previously an out-of-bounds index would result in an out-of-bounds read during
finalization of the tuple.extract expression.

Fixes #3703.