### PR TITLE
Disallow flatten + GC in the fuzzer due to RTTs

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -991,6 +991,9 @@ def randomize_opt_flags():
             if '--disable-multivalue' not in FEATURE_OPTS and '--disable-reference-types' not in FEATURE_OPTS:
                 print('avoiding --flatten due to multivalue + reference types not supporting it (spilling of non-nullable tuples)')
                 continue
+            if '--gc' not in FEATURE_OPTS:
+                print('avoiding --flatten due to GC not supporting it (spilling of RTTs)')
+                continue
             if INITIAL_CONTENTS and os.path.getsize(INITIAL_CONTENTS) > 2000:
                 print('avoiding --flatten due using a large amount of initial contents, which may blow up')
                 continue


### PR DESCRIPTION
RTTs are not defaultable, and we cannot spill them to locals.