### PR TITLE
Wasm2JS fuzzing: Emit null for reference type params instead of 0

### DIFF
--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -103,7 +103,7 @@ static std::string generateJSWrapper(Module& wasm) {
     }
     ret += std::string("instance.exports.") + exp->name.str + "(";
     bool first = true;
-    for (const auto param : func->sig.params) {
+    for (auto param : func->sig.params) {
       // zeros in arguments TODO more?
       if (first) {
         first = false;

--- a/src/tools/js-wrapper.h
+++ b/src/tools/js-wrapper.h
@@ -103,16 +103,20 @@ static std::string generateJSWrapper(Module& wasm) {
     }
     ret += std::string("instance.exports.") + exp->name.str + "(";
     bool first = true;
-    for (const auto& param : func->sig.params) {
+    for (const auto param : func->sig.params) {
       // zeros in arguments TODO more?
       if (first) {
         first = false;
       } else {
         ret += ", ";
       }
-      ret += "0";
-      if (param == Type::i64) {
-        ret += ", 0";
+      if (param.isRef()) {
+        ret += "null";
+      } else {
+        ret += "0";
+        if (param == Type::i64) {
+          ret += ", 0";
+        }
       }
     }
     ret += ")";


### PR DESCRIPTION
VMs will not convert a 0 or `undefined` from JS into a wasm null reference - it must be `null`.