### PR TITLE
Fuzzer: Ignore our current bug with the type of br_if

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -351,7 +351,12 @@ def fix_spec_output(out):
 def run_vm(cmd):
     # ignore some vm assertions, if bugs have already been filed
     known_issues = [
-        'local count too large',    # ignore this; can be caused by flatten, ssa, etc. passes
+        # can be caused by flatten, ssa, etc. passes
+        'local count too large',
+        # https://github.com/WebAssembly/binaryen/issues/3767
+        # note that this text is a little too broad, but the problem is rare
+        # enough that it's unlikely to hide an unrelated issue
+        'found br_if of type',
     ]
     try:
         return run(cmd)


### PR DESCRIPTION
We give `br_if` a too specific type: https://github.com/WebAssembly/binaryen/issues/3767

This is only noticeable with GC, and in rare cases where the type of `br_if`
is actually used - which realistically it never is, so really just fuzzer testcases.