### PR TITLE
wasm-emscripten: Remove unused EM_ASM_PREFIX and STACK_INIT

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -33,10 +33,7 @@
 
 namespace wasm {
 
-cashew::IString EM_ASM_PREFIX("emscripten_asm_const");
 cashew::IString EM_JS_PREFIX("__em_js__");
-
-static Name STACK_INIT("stack$init");
 
 void addExportedFunction(Module& wasm, Function* function) {
   wasm.addFunction(function);
@@ -429,9 +426,7 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata() {
   meta << "  \"externs\": [";
   commaFirst = true;
   ModuleUtils::iterImportedGlobals(wasm, [&](Global* import) {
-    if (!(import->module == ENV && import->name == STACK_INIT)) {
-      meta << nextElement() << "\"_" << import->base.str << '"';
-    }
+    meta << nextElement() << "\"_" << import->base.str << '"';
   });
   meta << "\n  ],\n";
 


### PR DESCRIPTION
I'm not sure what `stack$init` is but I don't think its been
used for many years.