### PR TITLE
[Wasm GC] Enable more GC fuzzing

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -36,7 +36,6 @@ assert sys.version_info.major == 3, 'requires Python 3!'
 # parameters
 
 # feature options that are always passed to the tools.
-# * multivalue: https://github.com/WebAssembly/binaryen/issues/2770
 CONSTANT_FEATURE_OPTS = ['--all-features']
 
 INPUT_SIZE_MIN = 1024
@@ -213,8 +212,6 @@ def pick_initial_contents():
         '--disable-exception-handling',
         # has not been fuzzed in general yet
         '--disable-memory64',
-        # has not been fuzzed in general yet
-        '--disable-gc',
         # DWARF is incompatible with multivalue atm; it's more important to
         # fuzz multivalue since we aren't actually fuzzing DWARF here
         '--strip-dwarf',
@@ -581,8 +578,12 @@ class CompareVMs(TestCaseHandler):
                 # NaNs can differ from wasm VMs
                 return not NANS
 
-        self.vms = [BinaryenInterpreter(), D8(), D8Liftoff(), D8TurboFan(),
-                    Wasm2C(), Wasm2C2Wasm()]
+        self.vms = [BinaryenInterpreter(),
+                    D8(),
+                    D8Liftoff(),
+                    D8TurboFan(),
+                    Wasm2C(),
+                    Wasm2C2Wasm()]
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):
         before = self.run_vms(before_wasm)
@@ -616,7 +617,7 @@ class CompareVMs(TestCaseHandler):
                 compare(before[vm], after[vm], 'CompareVMs between before and after: ' + vm.name)
 
     def can_run_on_feature_opts(self, feature_opts):
-        return all([x in feature_opts for x in ['--disable-simd', '--disable-reference-types', '--disable-exception-handling', '--disable-multivalue', '--disable-gc']])
+        return all([x in feature_opts for x in ['--disable-simd', '--disable-exception-handling', '--disable-multivalue']])
 
 
 # Check for determinism - the same command must have the same output.


### PR DESCRIPTION
The fuzzer doesn't generate much GC code yet, but it does fuzz things in
the test suite and adds fuzz to them. This PR allows GC when using initial
content, and also in CompareVMs, both of which have been fuzzed for
days locally for me with no issues.