### PR TITLE
RefFunc: Validate that the type is non-nullable, and avoid possible bugs in the builder

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3480,9 +3480,8 @@ BinaryenAddPassiveElementSegment(BinaryenModuleRef module,
     if (func == nullptr) {
       Fatal() << "invalid function '" << funcNames[i] << "'.";
     }
-    Type type(HeapType(func->sig), Nullable);
     segment->data.push_back(
-      Builder(*(Module*)module).makeRefFunc(funcNames[i], type));
+      Builder(*(Module*)module).makeRefFunc(funcNames[i], func->sig));
   }
   return ((Module*)module)->addElementSegment(std::move(segment));
 }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3462,9 +3462,8 @@ BinaryenAddActiveElementSegment(BinaryenModuleRef module,
     if (func == nullptr) {
       Fatal() << "invalid function '" << funcNames[i] << "'.";
     }
-    Type type(HeapType(func->sig), Nullable);
     segment->data.push_back(
-      Builder(*(Module*)module).makeRefFunc(funcNames[i], type));
+      Builder(*(Module*)module).makeRefFunc(funcNames[i], func->sig));
   }
   return ((Module*)module)->addElementSegment(std::move(segment));
 }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1259,9 +1259,10 @@ BinaryenExpressionRef BinaryenRefAs(BinaryenModuleRef module,
 
 BinaryenExpressionRef
 BinaryenRefFunc(BinaryenModuleRef module, const char* func, BinaryenType type) {
+  // TODO: consider changing the C API to receive a heap type
   Type type_(type);
   return static_cast<Expression*>(
-    Builder(*(Module*)module).makeRefFunc(func, type_));
+    Builder(*(Module*)module).makeRefFunc(func, type_.getHeapType()));
 }
 
 BinaryenExpressionRef BinaryenRefEq(BinaryenModuleRef module,

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -105,8 +105,7 @@ template<class F> void forEachElement(Module& module, F f) {
 
 static RefFunc* makeRefFunc(Module& wasm, Function* func) {
   // FIXME: make the type NonNullable when we support it!
-  return Builder(wasm).makeRefFunc(func->name,
-                                   Type(HeapType(func->sig), Nullable));
+  return Builder(wasm).makeRefFunc(func->name, func->sig);
 }
 
 struct TableSlotManager {

--- a/src/ir/table-utils.h
+++ b/src/ir/table-utils.h
@@ -87,9 +87,7 @@ inline Index append(Table& table, Name name, Module& wasm) {
 
   auto* func = wasm.getFunctionOrNull(name);
   assert(func != nullptr && "Cannot append non-existing function to a table.");
-  // FIXME: make the type NonNullable when we support it!
-  auto type = Type(HeapType(func->sig), Nullable);
-  segment->data.push_back(Builder(wasm).makeRefFunc(name, type));
+  segment->data.push_back(Builder(wasm).makeRefFunc(name, func->sig));
   table.initial = table.initial + 1;
   return tableIndex;
 }

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -735,7 +735,7 @@ private:
     }
     // add some to an elem segment
     while (oneIn(3) && !finishedInput) {
-      auto type = Type(HeapType(func->sig), Nullable);
+      auto type = Type(HeapType(func->sig), NonNullable);
       std::vector<ElementSegment*> compatibleSegments;
       ModuleUtils::iterActiveElementSegments(
         wasm, [&](ElementSegment* segment) {
@@ -744,8 +744,7 @@ private:
           }
         });
       auto& randomElem = compatibleSegments[upTo(compatibleSegments.size())];
-      // FIXME: make the type NonNullable when we support it!
-      randomElem->data.push_back(builder.makeRefFunc(func->name, type));
+      randomElem->data.push_back(builder.makeRefFunc(func->name, func->sig));
     }
     numAddedFunctions++;
     return func;
@@ -1520,10 +1519,9 @@ private:
     for (const auto& type : target->sig.params) {
       args.push_back(make(type));
     }
-    auto targetType = Type(HeapType(target->sig), NonNullable);
     // TODO: half the time make a completely random item with that type.
     return builder.makeCallRef(
-      builder.makeRefFunc(target->name, targetType), args, type, isReturn);
+      builder.makeRefFunc(target->name, target->sig), args, type, isReturn);
   }
 
   Expression* makeLocalGet(Type type) {
@@ -2112,8 +2110,7 @@ private:
         if (!wasm.functions.empty() && !oneIn(wasm.functions.size())) {
           target = pick(wasm.functions).get();
         }
-        auto type = Type(HeapType(target->sig), Nullable);
-        return builder.makeRefFunc(target->name, type);
+        return builder.makeRefFunc(target->name, target->sig);
       }
       if (type == Type::i31ref) {
         return builder.makeI31New(makeConst(Type::i32));
@@ -2157,7 +2154,7 @@ private:
         sig,
         {},
         builder.makeUnreachable()));
-      return builder.makeRefFunc(func->name, type);
+      return builder.makeRefFunc(func->name, heapType);
     }
     if (type.isRtt()) {
       return builder.makeRtt(type);

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -2132,7 +2132,7 @@ private:
       // TODO: randomize the order
       for (auto& func : wasm.functions) {
         if (type == Type(HeapType(func->sig), NonNullable)) {
-          return builder.makeRefFunc(func->name, type);
+          return builder.makeRefFunc(func->name, func->sig);
         }
       }
       // We failed to find a function, so create a null reference if we can.

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -618,10 +618,10 @@ public:
     ret->finalize();
     return ret;
   }
-  RefFunc* makeRefFunc(Name func, Type type) {
+  RefFunc* makeRefFunc(Name func, HeapType heapType) {
     auto* ret = wasm.allocator.alloc<RefFunc>();
     ret->func = func;
-    ret->finalize(type);
+    ret->finalize(Type(heapType, NonNullable));
     return ret;
   }
   RefEq* makeRefEq(Expression* left, Expression* right) {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -870,7 +870,7 @@ public:
       return makeRefNull(type);
     }
     if (type.isFunction()) {
-      return makeRefFunc(value.getFunc(), type);
+      return makeRefFunc(value.getFunc(), type.getHeapType());
     }
     if (type.isRtt()) {
       return makeRtt(value.type);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2856,8 +2856,7 @@ void WasmBinaryBuilder::readElementSegments() {
         Index index = getU32LEB();
         auto sig = getSignatureByFunctionIndex(index);
         // Use a placeholder name for now
-        auto* refFunc = Builder(wasm).makeRefFunc(
-          Name::fromInt(index), sig);
+        auto* refFunc = Builder(wasm).makeRefFunc(Name::fromInt(index), sig);
         functionRefs[index].push_back(refFunc);
         segmentData.push_back(refFunc);
       }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2857,7 +2857,7 @@ void WasmBinaryBuilder::readElementSegments() {
         auto sig = getSignatureByFunctionIndex(index);
         // Use a placeholder name for now
         auto* refFunc = Builder(wasm).makeRefFunc(
-          Name::fromInt(index), Type(HeapType(sig), Nullable));
+          Name::fromInt(index), sig);
         functionRefs[index].push_back(refFunc);
         segmentData.push_back(refFunc);
       }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3354,8 +3354,8 @@ ElementSegment* SExpressionWasmBuilder::parseElemFinish(
   } else {
     for (; i < s.size(); i++) {
       auto func = getFunctionName(*s[i]);
-      segment->data.push_back(Builder(wasm).makeRefFunc(
-        func, functionSignatures[func]));
+      segment->data.push_back(
+        Builder(wasm).makeRefFunc(func, functionSignatures[func]));
     }
   }
   return wasm.addElementSegment(std::move(segment));

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3355,7 +3355,7 @@ ElementSegment* SExpressionWasmBuilder::parseElemFinish(
     for (; i < s.size(); i++) {
       auto func = getFunctionName(*s[i]);
       segment->data.push_back(Builder(wasm).makeRefFunc(
-        func, Type(HeapType(functionSignatures[func]), Nullable)));
+        func, functionSignatures[func]);
     }
   }
   return wasm.addElementSegment(std::move(segment));

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3355,7 +3355,7 @@ ElementSegment* SExpressionWasmBuilder::parseElemFinish(
     for (; i < s.size(); i++) {
       auto func = getFunctionName(*s[i]);
       segment->data.push_back(Builder(wasm).makeRefFunc(
-        func, functionSignatures[func]);
+        func, functionSignatures[func]));
     }
   }
   return wasm.addElementSegment(std::move(segment));

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2001,6 +2001,9 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   shouldBeTrue(curr->type.isFunction(),
                curr,
                "ref.func must have a function reference type");
+  shouldBeTrue(!curr->type.isNullable(),
+               curr,
+               "ref.func must have non-nullable type");
   // TODO: verify it also has a typed function references type, and the right
   // one,
   //   curr->type.getHeapType().getSignature()

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2001,9 +2001,8 @@ void FunctionValidator::visitRefFunc(RefFunc* curr) {
   shouldBeTrue(curr->type.isFunction(),
                curr,
                "ref.func must have a function reference type");
-  shouldBeTrue(!curr->type.isNullable(),
-               curr,
-               "ref.func must have non-nullable type");
+  shouldBeTrue(
+    !curr->type.isNullable(), curr, "ref.func must have non-nullable type");
   // TODO: verify it also has a typed function references type, and the right
   // one,
   //   curr->type.getHeapType().getSignature()

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -1448,7 +1448,9 @@ console.log("# RefFunc");
   assert(theRefFunc instanceof binaryen.RefFunc);
   assert(theRefFunc instanceof binaryen.Expression);
   assert(theRefFunc.func === func);
-  assert(theRefFunc.type === binaryen.funcref);
+  // TODO: check the type. the type is (ref func), that is, a non-nullable func,
+  //       which differs from funcref. we don't have the ability to create such
+  //       a type in the C/JS APIs yet.
 
   theRefFunc.func = func = "b";
   assert(theRefFunc.func === func);


### PR DESCRIPTION
The builder can receive a HeapType so that callers don't need to set non-nullability
themselves.

Not NFC as some of the callers were in fact still making it nullable.