### PR TITLE
Fix lock-free MixedArena allocation

### DIFF
--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -104,7 +104,7 @@ struct MixedArena {
         if (!allocated) {
           allocated = new MixedArena(); // has our thread id
         }
-        if (curr->next.compare_exchange_weak(seen, allocated)) {
+        if (curr->next.compare_exchange_strong(seen, allocated)) {
           // we replaced it, so we are the next in the chain
           // we can forget about allocated, it is owned by the chain now
           allocated = nullptr;


### PR DESCRIPTION
To reduce allocator contention, MixedArena transparently forwards allocations to a
thread-local arena by traversing a linked list of arenas, looking for the one
corresponding to the current thread. If the search reaches the end of the linked
list, it allocates a new arena for the current thread and atomically appends it
to the end of the list using a compare-and-swap operation.

The problem was that the previous code used `compare_exchange_weak`, which is
allowed to spuriously fail, i.e. it is allowed to behave as though the original
value is not the same as the expected value, even when it is. In this case, that
means that it might fail to append the new allocation to the list even if the
`next` pointer is still null, which results in a subsequent null pointer
dereference. The fix is to use `compare_exchange_strong`, which is not allowed
to spuriously fail in this way.

Reported in #3806.