### PR TITLE
[Wasm GC] Do not inline a function with an RTT parameter

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -21,7 +21,13 @@ namespace wasm {
 
 namespace TypeUpdating {
 
-void handleNonNullableLocals(Function* func, Module& wasm) {
+bool canHandleAsLocal(Type type) {
+  // Defaultable types are always ok. For non-nullable types, we can handle them
+  // using defaultable ones + ref.as_non_nulls.
+  return type.isDefaultable() || type.isRef();
+}
+
+void handleNonDefaultableLocals(Function* func, Module& wasm) {
   // Check if this is an issue.
   bool hasNonNullable = false;
   for (auto type : func->vars) {

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -307,10 +307,15 @@ struct TypeUpdater
 
 namespace TypeUpdating {
 
+// Checks whether a type is valid as a local, or whether
+// handleNonDefaultableLocals() can handle it if not.
+bool canHandleAsLocal(Type type);
+
 // Finds non-nullable locals, which are currently not supported, and handles
 // them. Atm this turns them into nullable ones, and adds ref.as_non_null on
 // their uses (which keeps the type of the users identical).
-void handleNonNullableLocals(Function* func, Module& wasm);
+// This may also handle other types of nondefaultable locals in the future.
+void handleNonDefaultableLocals(Function* func, Module& wasm);
 
 } // namespace TypeUpdating
 

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -383,7 +383,7 @@ struct DAE : public Pass {
             // Wonderful, nothing stands in our way! Do it.
             // TODO: parallelize this?
             removeParameter(func, i, calls);
-            TypeUpdating::handleNonNullableLocals(func, *module);
+            TypeUpdating::handleNonDefaultableLocals(func, *module);
             changed.insert(func);
           }
         }

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -337,7 +337,7 @@ struct Flatten
     // the body may have preludes
     curr->body = getPreludesWithExpression(originalBody, curr->body);
     // New locals we added may be non-nullable.
-    TypeUpdating::handleNonNullableLocals(curr, *getModule());
+    TypeUpdating::handleNonDefaultableLocals(curr, *getModule());
     // We cannot handle non-nullable tuples currently, see the comment at the
     // top of the file.
     for (auto type : curr->vars) {

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -100,7 +100,7 @@ struct SSAify : public Pass {
     // add prepends to function
     addPrepends();
     // Handle non-nullability in new locals we added.
-    TypeUpdating::handleNonNullableLocals(func, *module);
+    TypeUpdating::handleNonDefaultableLocals(func, *module);
   }
 
   void createNewIndexes(LocalGraph& graph) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2186,7 +2186,7 @@ void WasmBinaryBuilder::readFunctions() {
       }
     }
 
-    TypeUpdating::handleNonNullableLocals(func, wasm);
+    TypeUpdating::handleNonDefaultableLocals(func, wasm);
 
     std::swap(func->epilogLocation, debugLocation);
     currFunction = nullptr;

--- a/test/passes/inlining_all-features.txt
+++ b/test/passes/inlining_all-features.txt
@@ -125,3 +125,16 @@
   )
  )
 )
+(module
+ (type $struct (struct ))
+ (type $none_=>_none (func))
+ (type $rtt_$struct_=>_none (func (param (rtt $struct))))
+ (func $0 (param $rtt (rtt $struct))
+  (nop)
+ )
+ (func $1
+  (call $0
+   (rtt.canon $struct)
+  )
+ )
+)

--- a/test/passes/inlining_all-features.wast
+++ b/test/passes/inlining_all-features.wast
@@ -101,3 +101,14 @@
   )
  )
 )
+;; never inline an rtt parameter, as those cannot be handled as locals
+(module
+ (type $struct (struct))
+ (func $0 (param $rtt (rtt $struct))
+ )
+ (func $1
+  (call $0
+   (rtt.canon $struct)
+  )
+ )
+)


### PR DESCRIPTION
Inlined parameters become locals, and rtts cannot be handled as locals, unlike
non-nullable values which we can at least fix up. So do not inline functions with
rtt params.