### PR TITLE
Fuzzer: Do not fuzz multivalue testcases in initial contents

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -214,7 +214,7 @@ def pick_initial_contents():
         '--disable-memory64',
         # avoid multivalue for now due to bad interactions with gc rtts in
         # stacky code. for example, this fails to roundtrip as the tuple code
-        # ends up creating stack binary code that needs to spill rtts to locals,
+        # ends up creating stacky binary code that needs to spill rtts to locals,
         # which is not allowed:
         #
         # (module

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -212,6 +212,27 @@ def pick_initial_contents():
         '--disable-exception-handling',
         # has not been fuzzed in general yet
         '--disable-memory64',
+        # avoid multivalue for now due to bad interactions with gc rtts in
+        # stacky code. for example, this fails to roundtrip as the tuple code
+        # ends up creating stack binary code that needs to spill rtts to locals,
+        # which is not allowed:
+        #
+        # (module
+        #  (type $other (struct))
+        #  (func $foo (result (rtt $other))
+        #   (select
+        #    (rtt.canon $other)
+        #    (rtt.canon $other)
+        #    (tuple.extract 1
+        #     (tuple.make
+        #      (i32.const 0)
+        #      (i32.const 0)
+        #     )
+        #    )
+        #   )
+        #  )
+        # )
+        '--disable-multivalue',
         # DWARF is incompatible with multivalue atm; it's more important to
         # fuzz multivalue since we aren't actually fuzzing DWARF here
         '--strip-dwarf',


### PR DESCRIPTION
There is a conflict between multivalue and GC, see the details in the
comment. There isn't a good way to get the fuzzer to avoid the combination
of them, and GC is more urgent, so disable multivalue in that area for now.

(This does not disable all multivalue fuzzing - the fuzzer can still emit stuff.
This just disables initial content from test suite having multivalue, which
is enough for now, until the fuzzer can emit more GC things, and then we'll
need to do more.)