### PR TITLE
Rename emscripten metadata key to signal new unmangled names

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -423,7 +423,7 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata() {
   });
   meta << "\n  ],\n";
 
-  meta << "  \"externs\": [";
+  meta << "  \"globalImports\": [";
   commaFirst = true;
   ModuleUtils::iterImportedGlobals(wasm, [&](Global* import) {
     meta << nextElement() << '"' << import->base.str << '"';

--- a/test/lld/basic_safe_stack.wat.out
+++ b/test/lld/basic_safe_stack.wat.out
@@ -91,7 +91,7 @@
   "declares": [
     "__handle_stack_overflow"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/duplicate_imports.wat.out
+++ b/test/lld/duplicate_imports.wat.out
@@ -72,7 +72,7 @@
   "declares": [
     "puts"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -78,7 +78,7 @@
   "declares": [
     "emscripten_asm_const_int"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm.wat.out
+++ b/test/lld/em_asm.wat.out
@@ -80,7 +80,7 @@
   "declares": [
     "emscripten_asm_const_int"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm64.wat.out
+++ b/test/lld/em_asm64.wat.out
@@ -80,7 +80,7 @@
   "declares": [
     "emscripten_asm_const_int"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm_O0.wat.out
+++ b/test/lld/em_asm_O0.wat.out
@@ -103,7 +103,7 @@
   "declares": [
     "emscripten_asm_const_int"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm_main_thread.wat.out
+++ b/test/lld/em_asm_main_thread.wat.out
@@ -204,7 +204,7 @@
   "declares": [
     "emscripten_asm_const_int_sync_on_main_thread"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm_pthread.wasm.out
+++ b/test/lld/em_asm_pthread.wasm.out
@@ -12867,7 +12867,7 @@
     "fd_write",
     "setTempRet0"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/em_asm_shared.wat.out
+++ b/test/lld/em_asm_shared.wat.out
@@ -105,7 +105,7 @@
   "declares": [
     "emscripten_asm_const_int"
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__memory_base",
     "__table_base",

--- a/test/lld/em_asm_table.wat.out
+++ b/test/lld/em_asm_table.wat.out
@@ -37,7 +37,7 @@
     "emscripten_log",
     "emscripten_asm_const_int"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "dynCall_vii",

--- a/test/lld/em_js_O0.wat.out
+++ b/test/lld/em_js_O0.wat.out
@@ -18,7 +18,7 @@
   "tableSize": 0,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
   ],

--- a/test/lld/hello_world.passive.wat.out
+++ b/test/lld/hello_world.passive.wat.out
@@ -44,7 +44,7 @@
   "declares": [
     "puts"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/hello_world.wat.mem.out
+++ b/test/lld/hello_world.wat.mem.out
@@ -32,7 +32,7 @@
   "declares": [
     "puts"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/hello_world.wat.out
+++ b/test/lld/hello_world.wat.out
@@ -33,7 +33,7 @@
   "declares": [
     "puts"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/init.wat.out
+++ b/test/lld/init.wat.out
@@ -44,7 +44,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/longjmp.wat.out
+++ b/test/lld/longjmp.wat.out
@@ -151,7 +151,7 @@
     "setTempRet0",
     "free"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/main_module.wat.out
+++ b/test/lld/main_module.wat.out
@@ -60,7 +60,7 @@
   "declares": [
     "puts"
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__memory_base",
     "__table_base",

--- a/test/lld/main_module_table.wat.out
+++ b/test/lld/main_module_table.wat.out
@@ -15,7 +15,7 @@
   "tableSize": 0,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__stdio_write"
   ],

--- a/test/lld/main_module_table_2.wat.out
+++ b/test/lld/main_module_table_2.wat.out
@@ -16,7 +16,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__stdio_write"
   ],

--- a/test/lld/main_module_table_3.wat.out
+++ b/test/lld/main_module_table_3.wat.out
@@ -16,7 +16,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__stdio_write"
   ],

--- a/test/lld/main_module_table_4.wat.out
+++ b/test/lld/main_module_table_4.wat.out
@@ -17,7 +17,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__stdio_write",
     "__table_base"

--- a/test/lld/main_module_table_5.wat.out
+++ b/test/lld/main_module_table_5.wat.out
@@ -31,7 +31,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__stdio_write",
     "__table_base"

--- a/test/lld/recursive.wat.out
+++ b/test/lld/recursive.wat.out
@@ -90,7 +90,7 @@
   "declares": [
     "iprintf"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/recursive_safe_stack.wat.out
+++ b/test/lld/recursive_safe_stack.wat.out
@@ -180,7 +180,7 @@
     "printf",
     "__handle_stack_overflow"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/reserved_func_ptr.wat.out
+++ b/test/lld/reserved_func_ptr.wat.out
@@ -125,7 +125,7 @@
   "declares": [
     "_Z4atoiPKc"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/safe_stack_standalone-wasm.wat.out
+++ b/test/lld/safe_stack_standalone-wasm.wat.out
@@ -178,7 +178,7 @@
   "declares": [
     "printf"
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "__wasm_call_ctors",

--- a/test/lld/shared.wat.out
+++ b/test/lld/shared.wat.out
@@ -57,7 +57,7 @@
   "declares": [
     "puts"
   ],
-  "externs": [
+  "globalImports": [
     "__memory_base",
     "__table_base",
     "external_var",

--- a/test/lld/shared_add_to_table.wasm.out
+++ b/test/lld/shared_add_to_table.wasm.out
@@ -75,7 +75,7 @@
   "declares": [
     "_Z16waka_func_theirsi"
   ],
-  "externs": [
+  "globalImports": [
     "__stack_pointer",
     "__memory_base",
     "__table_base",

--- a/test/lld/shared_longjmp.wat.out
+++ b/test/lld/shared_longjmp.wat.out
@@ -160,7 +160,7 @@
     "setTempRet0",
     "free"
   ],
-  "externs": [
+  "globalImports": [
     "__memory_base",
     "__table_base",
     "__THREW__",

--- a/test/lld/standalone-wasm-with-start.wat.out
+++ b/test/lld/standalone-wasm-with-start.wat.out
@@ -23,7 +23,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "_start"

--- a/test/lld/standalone-wasm.wat.out
+++ b/test/lld/standalone-wasm.wat.out
@@ -27,7 +27,7 @@
   "tableSize": 1,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "main"

--- a/test/lld/standalone-wasm2.wat.out
+++ b/test/lld/standalone-wasm2.wat.out
@@ -24,7 +24,7 @@
   "tableSize": 0,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
     "main"

--- a/test/lld/standalone-wasm3.wat.out
+++ b/test/lld/standalone-wasm3.wat.out
@@ -17,7 +17,7 @@
   "tableSize": 0,
   "declares": [
   ],
-  "externs": [
+  "globalImports": [
   ],
   "exports": [
   ],


### PR DESCRIPTION
Turns out just removing the mangling wasn't enough for
emscripten to support both before and after versions.

See https://github.com/WebAssembly/binaryen/pull/3785