### PR TITLE
Run spec test all at once after binary transform

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -424,7 +424,6 @@ SPEC_TESTS_TO_SKIP = [
     'utf8-invalid-encoding.wast',
 
     # 'register' command
-    'imports.wast',
     'linking.wast',
 
     # Misc. unsupported constructs

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -145,7 +145,7 @@ def split_wast(wastFile):
             ret += [(chunk, [])]
         elif chunk.startswith('(assert_invalid'):
             continue
-        elif chunk.startswith(('(assert', '(invoke')):
+        elif chunk.startswith(('(assert', '(invoke', '(register')):
             # ret may be empty if there are some asserts before the first
             # module. in that case these are asserts *without* a module, which
             # are valid (they may check something that doesn't refer to a module

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2422,23 +2422,24 @@ private:
   protected:
     // Returns the instance that defines the memory used by this one.
     SubType* getMemoryInstance() {
-      if (instance.wasm.memory.imported()) {
-        return instance.linkedInstances.at(instance.wasm.memory.module).get();
-      } else {
-        return static_cast<SubType*>(&instance);
+      SubType* inst = static_cast<SubType*>(&instance);
+      while (inst->wasm.memory.imported()) {
+        inst = inst->linkedInstances.at(inst->wasm.memory.module).get();
       }
+      return inst;
     }
 
     // Returns a reference to the current value of a potentially imported global
     Literals& getGlobal(Name name) {
-      auto* global = instance.wasm.getGlobal(name);
-      if (global->imported()) {
-        auto inst = instance.linkedInstances.at(global->module);
+      SubType* inst = static_cast<SubType*>(&instance);
+      auto* global = inst->wasm.getGlobal(name);
+      while (global->imported()) {
+        inst = inst->linkedInstances.at(global->module).get();
         Export* globalExport = inst->wasm.getExport(global->base);
-        return inst->globals[globalExport->value];
-      } else {
-        return instance.globals[name];
+        global = inst->wasm.getGlobal(globalExport->value);
       }
+
+      return inst->globals[global->name];
     }
 
   public:

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2422,7 +2422,7 @@ private:
   protected:
     // Returns the instance that defines the memory used by this one.
     SubType* getMemoryInstance() {
-      SubType* inst = static_cast<SubType*>(&instance);
+      auto* inst = instance.self();
       while (inst->wasm.memory.imported()) {
         inst = inst->linkedInstances.at(inst->wasm.memory.module).get();
       }
@@ -2431,7 +2431,7 @@ private:
 
     // Returns a reference to the current value of a potentially imported global
     Literals& getGlobal(Name name) {
-      SubType* inst = static_cast<SubType*>(&instance);
+      auto* inst = instance.self();
       auto* global = inst->wasm.getGlobal(name);
       while (global->imported()) {
         inst = inst->linkedInstances.at(global->module).get();

--- a/test/spec/imports.wast
+++ b/test/spec/imports.wast
@@ -10,9 +10,13 @@
   (func (export "func-i64->i64") (param i64) (result i64) (local.get 0))
   (global (export "global-i32") i32 (i32.const 55))
   (global (export "global-f32") f32 (f32.const 44))
+  ;;; FIXME: Exporting a mutable global is currently not supported. Make mutable
+  ;;; when support is added.
+  (global (export "global-mut-i64") i64 (i64.const 66))
   (table (export "table-10-inf") 10 funcref)
-  ;; (table (export "table-10-20") 10 20 funcref)
+  (table (export "table-10-20") 10 20 funcref)
   (memory (export "memory-2-inf") 2)
+  ;; Multiple memories are not yet supported
   ;; (memory (export "memory-2-4") 2 4)
 )
 
@@ -43,9 +47,12 @@
 
   (func (export "p1") (import "spectest" "print_i32") (param i32))
   (func $p (export "p2") (import "spectest" "print_i32") (param i32))
-  (func (export "p3") (export "p4") (import "spectest" "print_i32") (param i32))
+  (func (import "spectest" "print_i32") (param i32))
   (func (export "p5") (import "spectest" "print_i32") (type 0))
   (func (export "p6") (import "spectest" "print_i32") (type 0) (param i32) (result))
+
+  ;; (export "p3" (func $print_i32))
+  ;; (export "p4" (func $print_i32))
 
   (import "spectest" "print_i32" (func (type $forward)))
   (func (import "spectest" "print_i32") (type $forward))
@@ -94,6 +101,26 @@
   )
   "unknown type"
 )
+
+;; Export sharing name with import
+(module
+  (import "spectest" "print_i32" (func $imported_print (param i32)))
+  (func (export "print_i32") (param $i i32)
+    (call $imported_print (local.get $i))
+  )
+)
+
+(assert_return (invoke "print_i32" (i32.const 13)))
+
+;; Export sharing name with import
+(module
+  (import "spectest" "print_i32" (func $imported_print (param i32)))
+  (func (export "print_i32") (param $i i32) (param $j i32) (result i32)
+    (i32.add (local.get $i) (local.get $j))
+  )
+)
+
+(assert_return (invoke "print_i32" (i32.const 5) (i32.const 11)) (i32.const 16))
 
 (module (import "test" "func" (func)))
 (module (import "test" "func-i32" (func (param i32))))
@@ -230,6 +257,7 @@
 
 (module (import "test" "global-i32" (global i32)))
 (module (import "test" "global-f32" (global f32)))
+(module (import "test" "global-mut-i64" (global (mut i64))))
 
 (assert_unlinkable
   (module (import "test" "unknown" (global i32)))
@@ -238,6 +266,55 @@
 (assert_unlinkable
   (module (import "spectest" "unknown" (global i32)))
   "unknown import"
+)
+
+(assert_unlinkable
+  (module (import "test" "global-i32" (global i64)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-i32" (global f32)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-i32" (global f64)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-i32" (global (mut i32))))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-f32" (global i32)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-f32" (global i64)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-f32" (global f64)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-f32" (global (mut f32))))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-mut-i64" (global (mut i32))))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-mut-i64" (global (mut f32))))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-mut-i64" (global (mut f64))))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "global-mut-i64" (global i64)))
+  "incompatible import type"
 )
 
 (assert_unlinkable
@@ -270,11 +347,11 @@
 
 (module
   (type (func (result i32)))
-  (import "spectest" "table" (table 10 20 funcref))
-  (elem (i32.const 1) $f $g)
+  (import "spectest" "table" (table $tab 10 20 funcref))
+  (elem (table $tab) (i32.const 1) func $f $g)
 
   (func (export "call") (param i32) (result i32)
-    (call_indirect (type 0) (local.get 0))
+    (call_indirect $tab (type 0) (local.get 0))
   )
   (func $f (result i32) (i32.const 11))
   (func $g (result i32) (i32.const 22))
@@ -289,11 +366,11 @@
 
 (module
   (type (func (result i32)))
-  (table (import "spectest" "table") 10 20 funcref)
-  (elem (i32.const 1) $f $g)
+  (table $tab (import "spectest" "table") 10 20 funcref)
+  (elem (table $tab) (i32.const 1) func $f $g)
 
   (func (export "call") (param i32) (result i32)
-    (call_indirect (type 0) (local.get 0))
+    (call_indirect $tab (type 0) (local.get 0))
   )
   (func $f (result i32) (i32.const 11))
   (func $g (result i32) (i32.const 22))
@@ -306,22 +383,25 @@
 (assert_trap (invoke "call" (i32.const 100)) "undefined element")
 
 
-(assert_invalid
-  (module (import "" "" (table 10 funcref)) (import "" "" (table 10 funcref)))
-  "multiple tables"
-)
-(assert_invalid
-  (module (import "" "" (table 10 funcref)) (table 10 funcref))
-  "multiple tables"
-)
-(assert_invalid
-  (module (table 10 funcref) (table 10 funcref))
-  "multiple tables"
+(module
+  (import "spectest" "table" (table 0 funcref))
+  (import "spectest" "table" (table 0 funcref))
+  (table 10 funcref)
+  (table 10 funcref)
 )
 
 (module (import "test" "table-10-inf" (table 10 funcref)))
 (module (import "test" "table-10-inf" (table 5 funcref)))
 (module (import "test" "table-10-inf" (table 0 funcref)))
+(module (import "test" "table-10-20" (table 10 funcref)))
+(module (import "test" "table-10-20" (table 5 funcref)))
+(module (import "test" "table-10-20" (table 0 funcref)))
+(module (import "test" "table-10-20" (table 10 20 funcref)))
+(module (import "test" "table-10-20" (table 5 20 funcref)))
+(module (import "test" "table-10-20" (table 0 20 funcref)))
+(module (import "test" "table-10-20" (table 10 25 funcref)))
+(module (import "test" "table-10-20" (table 5 25 funcref)))
+(module (import "test" "table-10-20" (table 0 25 funcref)))
 (module (import "spectest" "table" (table 10 funcref)))
 (module (import "spectest" "table" (table 5 funcref)))
 (module (import "spectest" "table" (table 0 funcref)))
@@ -346,6 +426,14 @@
 )
 (assert_unlinkable
   (module (import "test" "table-10-inf" (table 10 20 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table-10-20" (table 12 20 funcref)))
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module (import "test" "table-10-20" (table 10 18 funcref)))
   "incompatible import type"
 )
 (assert_unlinkable
@@ -380,7 +468,7 @@
 
 (module
   (import "spectest" "memory" (memory 1 2))
-  (data (i32.const 10) "\10")
+  (data (memory 0) (i32.const 10) "\10")
 
   (func (export "load") (param i32) (result i32) (i32.load (local.get 0)))
 )
@@ -392,7 +480,7 @@
 
 (module
   (memory (import "spectest" "memory") 1 2)
-  (data (i32.const 10) "\10")
+  (data (memory 0) (i32.const 10) "\10")
 
   (func (export "load") (param i32) (result i32) (i32.load (local.get 0)))
 )
@@ -493,6 +581,27 @@
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
 (assert_return (invoke "grow" (i32.const 1)) (i32.const -1))
 (assert_return (invoke "grow" (i32.const 0)) (i32.const 2))
+
+(module $Mgm
+  (memory (export "memory") 1) ;; initial size is 1
+  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+)
+(register "grown-memory" $Mgm)
+(assert_return (invoke $Mgm "grow") (i32.const 1)) ;; now size is 2
+(module $Mgim1
+  ;; imported memory limits should match, because external memory size is 2 now
+  (memory (import "grown-memory" "memory") 2)
+  (export "memory" (memory 0))
+  (func (export "grow") (result i32) (memory.grow (i32.const 1)))
+)
+(register "grown-imported-memory" $Mgim1)
+(assert_return (invoke $Mgim1 "grow") (i32.const 2)) ;; now size is 3
+(module $Mgim2
+  ;; imported memory limits should match, because external memory size is 3 now
+  (import "grown-imported-memory" "memory" (memory 3))
+  (func (export "size") (result i32) (memory.size))
+)
+(assert_return (invoke $Mgim2 "size") (i32.const 3))
 
 
 ;; Syntax errors


### PR DESCRIPTION
#3792 added support for module linking and `(register` command to
`wasm-shell`, but forgot about three problems:

1. Splitting spec tests prevents linking test modules together.
2. Registered modules may still be used in assertions or an `invoke`
3. Modules may re-export imported objects

This PR appends transformed modules after binary checks to a `spec.wast`
file, plus assertion tests and register commands. Then runs `wasm-shell`
on the whole file. It also keeps both the module name and its registered
name available in `wasm-shell` for use in shell commands and linked
modules. Furthermore, it correctly finds the module where an object is
defined even if it is imported and re-exported several times.

The updated version of `imports.wast` spec test is enabled to verify the
fixes.