### PR TITLE
Implement missing if restructuring

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1111,7 +1111,6 @@ if __name__ == '__main__':
               'speed:', counter / elapsed,
               'iters/sec, ', total_wasm_size / elapsed,
               'wasm_bytes/sec\n')
-        time.sleep(0.5)
         with open(raw_input_data, 'wb') as f:
             f.write(bytes([random.randint(0, 255) for x in range(input_size)]))
         assert os.path.getsize(raw_input_data) == input_size

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1111,6 +1111,7 @@ if __name__ == '__main__':
               'speed:', counter / elapsed,
               'iters/sec, ', total_wasm_size / elapsed,
               'wasm_bytes/sec\n')
+        time.sleep(0.5)
         with open(raw_input_data, 'wb') as f:
             f.write(bytes([random.randint(0, 255) for x in range(input_size)]))
         assert os.path.getsize(raw_input_data) == input_size

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1011,7 +1011,9 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                   list[0] = &nop;
                   auto canReorder = EffectAnalyzer::canReorder(
                     passOptions, features, br->condition, curr);
-                  auto hasSideEffects = EffectAnalyzer(passOptions, features, curr).hasSideEffects();
+                  auto hasSideEffects =
+                    EffectAnalyzer(passOptions, features, curr)
+                      .hasSideEffects();
                   list[0] = old;
                   if (canReorder && !hasSideEffects) {
                     ExpressionManipulator::nop(list[0]);

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -915,7 +915,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
 
       // Restructuring of ifs: if we have
       //   (block $x
-      //     (br_if $x (cond))
+      //     (drop (br_if $x (cond)))
       //     .., no other references to $x
       //   )
       // then we can turn that into (if (!cond) ..).
@@ -925,7 +925,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       // If the block has a return value, we can do something similar, removing
       // the drop from the br_if and putting the if on the outside,
       //   (block $x
-      //     (br_if $x (value) (cond))
+      //     (drop (br_if $x (value) (cond)))
       //     .., no other references to $x
       //     ..final element..
       //   )
@@ -985,7 +985,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                   // may still be able to optimize this, however, by using a
                   // select:
                   //   (block $x
-                  //     (br_if $x (value) (cond))
+                  //     (drop (br_if $x (value) (cond)))
                   //     ..., no other references to $x
                   //     ..final element..
                   //   )

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -974,10 +974,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                 if (!EffectAnalyzer(passOptions, features, br->value)
                        .hasSideEffects()) {
                   // We also need to reorder the condition and the value.
-                  if (EffectAnalyzer::canReorder(passOptions,
-                                                 features,
-                                                 br->condition,
-                                                 br->value)) {
+                  if (EffectAnalyzer::canReorder(
+                        passOptions, features, br->condition, br->value)) {
                     ExpressionManipulator::nop(list[0]);
                     replaceCurrent(
                       builder.makeIf(br->condition, br->value, curr));
@@ -1008,11 +1006,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                   Expression* old = list[0];
                   Nop nop;
                   list[0] = &nop;
-                  auto canReorder = 
-                      EffectAnalyzer::canReorder(passOptions,
-                                                 features,
-                                                 br->condition,
-                                                 curr);
+                  auto canReorder = EffectAnalyzer::canReorder(
+                    passOptions, features, br->condition, curr);
                   list[0] = old;
                   if (canReorder) {
                     ExpressionManipulator::nop(list[0]);

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -986,14 +986,14 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                   // select:
                   //   (block $x
                   //     (br_if $x (value) (cond))
-                  //     .., no other references to $x
+                  //     ..., no other references to $x
                   //     ..final element..
                   //   )
                   // =>
                   //   (select
                   //     (value)
                   //     (block $x
-                  //       .., no other references to $x
+                  //       ..., no other references to $x
                   //       ..final element..
                   //     )
                   //     (cond)
@@ -1005,9 +1005,12 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                   // TODO: we can do this when there *are* other refs to $x,
                   //       with a larger refactoring here.
 
-                  // Test for the conditions with a temporary nop.
+                  // Test for the conditions with a temporary nop instead of the
+                  // br_if.
                   Expression* old = list[0];
                   Nop nop;
+                  // After this assignment, curr is what is left in the block
+                  // after ignoring the br_if.
                   list[0] = &nop;
                   auto canReorder = EffectAnalyzer::canReorder(
                     passOptions, features, br->condition, curr);

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -244,7 +244,6 @@
       )
       ;; and we can't do a select because of effects here
       (call $nothing)
-      ;; the condition cannot be reordered with this
       (i32.const 100)
     )
   )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -27,6 +27,19 @@
     )
   )
 
+  ;; CHECK:      (func $restructure-br_if (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (if (result i32)
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 100)
+  ;; CHECK-NEXT:   (block $x (result i32)
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 200)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 300)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $restructure-br_if (param $x i32) (result i32)
     ;; this block+br_if can be turned into an if.
     (block $x (result i32)
@@ -43,6 +56,22 @@
 
   (func $nothing)
 
+  ;; CHECK:      (func $restructure-br_if-condition-reorderable (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (if (result i32)
+  ;; CHECK-NEXT:   (block $block (result i32)
+  ;; CHECK-NEXT:    (call $nothing)
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 100)
+  ;; CHECK-NEXT:   (block $x (result i32)
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 200)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 300)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $restructure-br_if-condition-reorderable (param $x i32) (result i32)
     (block $x (result i32)
       (drop
@@ -60,6 +89,25 @@
     )
   )
 
+  ;; CHECK:      (func $restructure-br_if-value-effectful (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (select
+  ;; CHECK-NEXT:   (block $block (result i32)
+  ;; CHECK-NEXT:    (call $nothing)
+  ;; CHECK-NEXT:    (i32.const 100)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (block $x (result i32)
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 200)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 300)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (block $block0 (result i32)
+  ;; CHECK-NEXT:    (call $nothing)
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $restructure-br_if-value-effectful (param $x i32) (result i32)
     (block $x (result i32)
       (drop
@@ -83,6 +131,24 @@
     )
   )
 
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-1 (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (block $x (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $x
+  ;; CHECK-NEXT:     (block $block (result i32)
+  ;; CHECK-NEXT:      (call $nothing)
+  ;; CHECK-NEXT:      (i32.const 100)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block $block1 (result i32)
+  ;; CHECK-NEXT:      (call $nothing)
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $nothing)
+  ;; CHECK-NEXT:   (i32.const 300)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $restructure-br_if-value-effectful-corner-case-1 (param $x i32) (result i32)
     (block $x (result i32)
       (drop
@@ -103,10 +169,33 @@
     )
   )
 
+  ;; CHECK:      (func $get-i32 (result i32)
+  ;; CHECK-NEXT:  (i32.const 400)
+  ;; CHECK-NEXT: )
   (func $get-i32 (result i32)
     (i32.const 400)
   )
 
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-2 (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (block $x (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $x
+  ;; CHECK-NEXT:     (block $block (result i32)
+  ;; CHECK-NEXT:      (call $nothing)
+  ;; CHECK-NEXT:      (i32.const 100)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block $block2 (result i32)
+  ;; CHECK-NEXT:      (call $nothing)
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 300)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $get-i32)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $restructure-br_if-value-effectful-corner-case-2 (param $x i32) (result i32)
     (block $x (result i32)
       (drop

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -215,4 +215,72 @@
       (call $get-i32)
     )
   )
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-3 (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (block $x (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $x
+  ;; CHECK-NEXT:     (block $block (result i32)
+  ;; CHECK-NEXT:      (call $nothing)
+  ;; CHECK-NEXT:      (i32.const 100)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $nothing)
+  ;; CHECK-NEXT:   (i32.const 100)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-value-effectful-corner-case-3 (param $x i32) (result i32)
+    (block $x (result i32)
+      (drop
+        (br_if $x
+          ;; we can't do an if because of effects here
+          (block (result i32)
+            (call $nothing)
+            (i32.const 100)
+          )
+          (local.get $x)
+        )
+      )
+      ;; and we can't do a select because of effects here
+      (call $nothing)
+      ;; the condition cannot be reordered with this
+      (i32.const 100)
+    )
+  )
+
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-4 (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (block $x (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $x
+  ;; CHECK-NEXT:     (block $block (result i32)
+  ;; CHECK-NEXT:      (call $nothing)
+  ;; CHECK-NEXT:      (i32.const 100)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 300)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $get-i32)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-value-effectful-corner-case-4 (param $x i32) (result i32)
+    (block $x (result i32)
+      (drop
+        (br_if $x
+          ;; we can't do an if because of effects here
+          (block (result i32)
+            (call $nothing)
+            (i32.const 100)
+          )
+          (local.get $x)
+        )
+      )
+      (drop (i32.const 300))
+      ;; and we can't do a select because of effects here
+      (call $get-i32)
+    )
+  )
 )

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -1988,17 +1988,16 @@
    )
   )
  )
- (func $drop-restructure-if-bad (param $x i32) (param $y i32) (result i32)
-  (block $label$2 (result i32)
-   (drop
-    (br_if $label$2
-     (local.tee $y
-      (local.get $x)
-     )
-     (local.get $y)
-    )
+ (func $drop-restructure-select (param $x i32) (param $y i32) (result i32)
+  (select
+   (local.tee $y
+    (local.get $x)
    )
-   (i32.const 0)
+   (block $label$2 (result i32)
+    (nop)
+    (i32.const 0)
+   )
+   (local.get $y)
   )
  )
  (func $drop-restructure-if-bad-2 (param $x i32) (param $y i32) (result i32)

--- a/test/passes/remove-unused-brs_enable-multivalue.wast
+++ b/test/passes/remove-unused-brs_enable-multivalue.wast
@@ -1615,7 +1615,7 @@
     (i32.const 0)
    )
   )
-  (func $drop-restructure-if-bad (param $x i32) (param $y i32) (result i32)
+  (func $drop-restructure-select (param $x i32) (param $y i32) (result i32)
    (block $label$2 (result i32)
     (drop
      (br_if $label$2


### PR DESCRIPTION
The existing restructuring code could turn a block+br_if into an if in
simple cases, but it had some TODOs that I noticed were helpful on
GC benchmarks.

One limitation was that we need to reorder the condition and the value,
```wat
(block
  (br_if
    (value)
    (condition)
  )
  (...)
)
=>
(if
  (condition)
  (value)
  (...)
)
```
The old code checked for side effects in the condition. But it is ok for it
to have side effects if they can be reordered with the value (for example,
if the value is a constant then it definitely does not care about side effects
in the condition).

The other missing TODO is to use a select when we can't use an if:
```wat
(block
  (br_if
    (value)
    (condition)
  )
  (...)
)
=>
(select
  (value)
  (...)
  (condition)
)
```
In this case we do not reorder the condition and the value, but we do
reorder the condition with the rest of the block.