### PR TITLE
[Wasm GC] Fix the type of ref.as_func, which should be non-nullable

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1028,7 +1028,7 @@ void RefAs::finalize() {
       type = Type(value->type.getHeapType(), NonNullable);
       break;
     case RefAsFunc:
-      type = Type::funcref;
+      type = Type(HeapType::func, NonNullable);
       break;
     case RefAsData:
       type = Type::dataref;


### PR DESCRIPTION
It's easy to make a mistake like this because the spec varies on whether
a basic type is nullable or not (funcref is nullable, dataref and i31ref are not)...

It's not easy to test this - perhaps a contrived test could depend on it in
an optimization, but I'm not sure if it's worth it.