### PR TITLE
Create a shasum file for the Windows tarball

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -61,6 +61,8 @@ jobs:
         SHASUM=$PKGNAME.tar.gz.sha256
         mv out/install binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
+        # on Windows, MSYS2 will strip the carriage return from CMake output
+        cmake -E sha256sum $TARBALL > $SHASUM
         echo "::set-output name=tarball::$TARBALL"
         echo "::set-output name=shasum::$SHASUM"
 
@@ -74,13 +76,6 @@ jobs:
         asset_name: ${{ steps.archive.outputs.tarball }}
         asset_content_type: application/gzip
 
-    # We do the shasum as a seprate step because this tool doesn't
-    # exist on windows.
-    - name: shasum
-      id: shasum
-      run: shasum -a 256 ${{ steps.archive.outputs.tarball }} > ${{ steps.archive.outputs.shasum }}
-      if: matrix.os != 'windows-latest'
-
     - name: upload shasum
       uses: actions/upload-release-asset@v1
       env:
@@ -90,7 +85,6 @@ jobs:
         asset_path: ./${{ steps.archive.outputs.shasum }}
         asset_name: ${{ steps.archive.outputs.shasum }}
         asset_content_type: text/plain
-      if: matrix.os != 'windows-latest'
 
   # Build with gcc 6.3 and run tests on Alpine Linux (inside chroot).
   # Note: Alpine uses musl libc.
@@ -137,7 +131,7 @@ jobs:
         ./alpine.sh find install/ -type f -perm -u=x -exec strip {} +
         mv install binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
-        shasum -a 256 $TARBALL > $SHASUM
+        cmake -E sha256sum $TARBALL > $SHASUM
         echo "::set-output name=tarball::$TARBALL"
         echo "::set-output name=shasum::$SHASUM"
 


### PR DESCRIPTION
CMake has a `sha256sum` subcommand that can be used to calculate checksums portably. Use it in the release workflow to create checksums on Windows.

For consistency, use it on macOS and Linux too.