### PR TITLE
[Wasm GC] Skip DeadArgumentElimination of an RTT parameter

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -383,8 +383,8 @@ struct DAE : public Pass {
           // replace the parameter with a local).
           // TODO: if there are no references at all, we can avoid creating a
           //       local
-          bool typeIsValid = TypeUpdating::canHandleAsLocal(
-            func->getLocalType(i));
+          bool typeIsValid =
+            TypeUpdating::canHandleAsLocal(func->getLocalType(i));
           if (callParamAreValid && typeIsValid) {
             // Wonderful, nothing stands in our way! Do it.
             // TODO: parallelize this?

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -373,13 +373,19 @@ struct DAE : public Pass {
           // Great, it's not used. Check if none of the calls has a param with
           // side effects, as that would prevent us removing them (flattening
           // should have been done earlier).
-          bool canRemove =
+          bool callParamAreValid =
             std::none_of(calls.begin(), calls.end(), [&](Call* call) {
               auto* operand = call->operands[i];
               return EffectAnalyzer(runner->options, module->features, operand)
                 .hasSideEffects();
             });
-          if (canRemove) {
+          // The type must be valid for us to handle as a local (since we
+          // replace the parameter with a local).
+          // TODO: if there are no references at all, we can avoid creating a
+          //       local
+          bool typeIsValid = TypeUpdating::canHandleAsLocal(
+            func->getLocalType(i));
+          if (callParamAreValid && typeIsValid) {
             // Wonderful, nothing stands in our way! Do it.
             // TODO: parallelize this?
             removeParameter(func, i, calls);

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -373,7 +373,7 @@ struct DAE : public Pass {
           // Great, it's not used. Check if none of the calls has a param with
           // side effects, as that would prevent us removing them (flattening
           // should have been done earlier).
-          bool callParamAreValid =
+          bool callParamsAreValid =
             std::none_of(calls.begin(), calls.end(), [&](Call* call) {
               auto* operand = call->operands[i];
               return EffectAnalyzer(runner->options, module->features, operand)
@@ -385,7 +385,7 @@ struct DAE : public Pass {
           //       local
           bool typeIsValid =
             TypeUpdating::canHandleAsLocal(func->getLocalType(i));
-          if (callParamAreValid && typeIsValid) {
+          if (callParamsAreValid && typeIsValid) {
             // Wonderful, nothing stands in our way! Do it.
             // TODO: parallelize this?
             removeParameter(func, i, calls);

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -2,6 +2,8 @@
 ;; RUN: wasm-opt %s -all --dae -S -o - | filecheck %s
 
 (module
+ (type ${} (struct))
+
  ;; CHECK:      (func $foo
  ;; CHECK-NEXT:  (call $bar)
  ;; CHECK-NEXT: )
@@ -44,6 +46,24 @@
   ;; so the correctness in this case is visible in the output)
   (local.tee $0
    (unreachable)
+  )
+ )
+ ;; a function that gets an rtt that is never used. we cannot create a local for
+ ;; that parameter, as it is not defaultable, so do not remove the parameter.
+ ;; CHECK:      (func $get-rtt (param $0 (rtt ${}))
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT: )
+ (func $get-rtt (param $0 (rtt ${}))
+  (nop)
+ )
+ ;; CHECK:      (func $send-rtt
+ ;; CHECK-NEXT:  (call $get-rtt
+ ;; CHECK-NEXT:   (rtt.canon ${})
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $send-rtt
+  (call $get-rtt
+   (rtt.canon ${})
   )
  )
 )


### PR DESCRIPTION
We could more carefully see when a local is not needed there, but atm
we always add one, and that doesn't work for something nondefaultable.