### PR TITLE
Fix a new clang warning on implicit Tuple construction

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -377,12 +377,16 @@ struct Tuple {
   Tuple(std::initializer_list<Type> types) : types(types) { validate(); }
   Tuple(const TypeList& types) : types(types) { validate(); }
   Tuple(TypeList&& types) : types(std::move(types)) { validate(); }
+
+  // Allow copies when constructing.
+  Tuple(const Tuple& other) : types(other.types) { validate(); }
+
+  // Prevent accidental copies.
+  Tuple& operator=(const Tuple&) = delete;
+
   bool operator==(const Tuple& other) const { return types == other.types; }
   bool operator!=(const Tuple& other) const { return !(*this == other); }
   std::string toString() const;
-
-  // Prevent accidental copies
-  Tuple& operator=(const Tuple&) = delete;
 
 private:
   void validate() {


### PR DESCRIPTION
Fixes #3838 and current breakage on CI here.

IIUC the warning is that we define a copy assignment operator, but
did not define a copy constructor. Clang wants both to exist now. However,
we delete the copy assignment one, so perhaps we should find a way to
avoid a copy on construction too? That happens here:
```cpp
../src/wasm/wasm-type.cpp:60:51: note: in implicit copy constructor for 'wasm::Tuple' first required here
  TypeInfo(const Tuple& tuple) : kind(TupleKind), tuple(tuple) {}
                                                  ^
```
But I don't see an easy way to remove the copy there, so this PR
defines the copy constructor as clang wants.