### PR TITLE
UniqueDeferredQueue improvements

### DIFF
--- a/src/support/unique_deferring_queue.h
+++ b/src/support/unique_deferring_queue.h
@@ -57,6 +57,32 @@ template<typename T> struct UniqueDeferredQueue {
       // skip this one, keep going
     }
   }
+
+  void clear() {
+    while (!data.empty()) {
+      data.pop();
+    }
+    count.clear();
+  }
+};
+
+// As UniqueDeferredQueue, but once an item has been processed through the queue
+// (that is, popped) it will be ignored from then on in later pushes.
+template<typename T>
+struct UniqueNonrepeatingDeferredQueue : UniqueDeferredQueue<T> {
+  std::unordered_set<T> processed;
+
+  void push(T item) {
+    if (!processed.count(item)) {
+      UniqueDeferredQueue<T>::push(item);
+    }
+  }
+
+  T pop() {
+    T ret = UniqueDeferredQueue<T>::pop();
+    processed.insert(ret);
+    return ret;
+  }
 };
 
 } // namespace wasm

--- a/src/support/unique_deferring_queue.h
+++ b/src/support/unique_deferring_queue.h
@@ -25,6 +25,7 @@
 
 #include <queue>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace wasm {
 

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -612,6 +612,9 @@ void test_queue() {
     queue.push(1);
     // We never repeat values in this queue, so the last push of 1 is ignored.
     assert_equal(queue.empty(), true);
+    // But new values work.
+    queue.push(2);
+    assert_equal(queue.pop(), 2);
   }
 }
 


### PR DESCRIPTION
Add `clear()`.

Add `UniqueNonrepeatingDeferredQueue` which also has the property
that it never repeats values in the output.

Also add unit tests.

This will be used in dead store elimination.