### PR TITLE
Add LocalGraph::equivalent

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -56,14 +56,17 @@ def update_example_tests():
             for f in os.environ.get('COMPILER_FLAGS').split(' '):
                 cmd.append(f)
         cmd = [os.environ.get('CXX') or 'g++', '-std=c++' + str(shared.cxx_standard)] + cmd
-        print('link: ', ' '.join(cmd))
-        subprocess.check_call(cmd)
-        print('run...', output_file)
-        proc = subprocess.Popen([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        actual, err = proc.communicate()
-        assert proc.returncode == 0, [proc.returncode, actual, err]
-        with open(expected, 'wb') as o:
-            o.write(actual)
+        try:
+            print('link: ', ' '.join(cmd))
+            subprocess.check_call(cmd)
+            print('run...', output_file)
+            proc = subprocess.Popen([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            actual, err = proc.communicate()
+            assert proc.returncode == 0, [proc.returncode, actual, err]
+            with open(expected, 'wb') as o:
+                o.write(actual)
+        finally:
+            os.remove(output_file)
 
 
 def update_wasm_dis_tests():

--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -56,17 +56,14 @@ def update_example_tests():
             for f in os.environ.get('COMPILER_FLAGS').split(' '):
                 cmd.append(f)
         cmd = [os.environ.get('CXX') or 'g++', '-std=c++' + str(shared.cxx_standard)] + cmd
-        try:
-            print('link: ', ' '.join(cmd))
-            subprocess.check_call(cmd)
-            print('run...', output_file)
-            proc = subprocess.Popen([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            actual, err = proc.communicate()
-            assert proc.returncode == 0, [proc.returncode, actual, err]
-            with open(expected, 'wb') as o:
-                o.write(actual)
-        finally:
-            os.remove(output_file)
+        print('link: ', ' '.join(cmd))
+        subprocess.check_call(cmd)
+        print('run...', output_file)
+        proc = subprocess.Popen([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        actual, err = proc.communicate()
+        assert proc.returncode == 0, [proc.returncode, actual, err]
+        with open(expected, 'wb') as o:
+            o.write(actual)
 
 
 def update_wasm_dis_tests():

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -252,33 +252,33 @@ bool LocalGraph::equivalent(LocalGet* a, LocalGet* b) {
   // there is a single set: if the set did not dominate one of the gets then
   // there would definitely be another set for that get, the zero initialization
   // at the function entry, if nothing else.)
-  if (aSets.size() == 1 && bSets.size() == 1) {
-    auto* aSet = *aSets.begin();
-    auto* bSet = *bSets.begin();
-    if (aSet == bSet) {
-      if (!aSet) {
-        // They are both nullptr, indicating the implicit value for a parameter
-        // or the zero for a local.
-        if (func->isParam(a->index)) {
-          // For parameters to be equivalent they must have the exact same
-          // index.
-          return a->index == b->index;
-        } else {
-          // As locals, they are both of value zero, but must have the right
-          // type as well.
-          return func->getLocalType(a->index) == func->getLocalType(b->index);
-        }
-      } else {
-        // They are both the same actual set.
-        return true;
-      }
-    }
+  if (aSets.size() != 1 || bSets.size() != 1) {
+    // TODO: use a LinearExecutionWalker to find trivially equal gets in basic
+    //       blocks. that plus the above should handle 80% of cases.
+    // TODO: handle chains, merges and other situations
     return false;
   }
-  return false;
-  // TODO: use a LinearExecutionWalker to find trivially equal gets in basic
-  //       blocks. that plus the above should handle 80% of cases.
-  // TODO: handle chains, merges and other situations
+  auto* aSet = *aSets.begin();
+  auto* bSet = *bSets.begin();
+  if (aSet != bSet) {
+    return false;
+  }
+  if (!aSet) {
+    // They are both nullptr, indicating the implicit value for a parameter
+    // or the zero for a local.
+    if (func->isParam(a->index)) {
+      // For parameters to be equivalent they must have the exact same
+      // index.
+      return a->index == b->index;
+    } else {
+      // As locals, they are both of value zero, but must have the right
+      // type as well.
+      return func->getLocalType(a->index) == func->getLocalType(b->index);
+    }
+  } else {
+    // They are both the same actual set.
+    return true;
+  }
 }
 
 void LocalGraph::computeInfluences() {

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -227,7 +227,7 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
 
 // LocalGraph implementation
 
-LocalGraph::LocalGraph(Function* func) {
+LocalGraph::LocalGraph(Function* func) : func(func) {
   LocalGraphInternal::Flower flower(getSetses, locations, func);
 
 #ifdef LOCAL_GRAPH_DEBUG
@@ -242,6 +242,43 @@ LocalGraph::LocalGraph(Function* func) {
   }
   std::cout << "total locations: " << locations.size() << '\n';
 #endif
+}
+
+bool LocalGraph::equivalent(LocalGet* a, LocalGet* b) {
+  auto& aSets = getSetses[a];
+  auto& bSets = getSetses[b];
+  // The simple case of one set dominating two gets easily proves that they must
+  // have the same value. (Note that we can infer dominance from the fact that
+  // there is a single set: if the set did not dominate one of the gets then
+  // there would definitely be another set for that get, the zero initialization
+  // at the function entry, if nothing else.)
+  if (aSets.size() == 1 && bSets.size() == 1) {
+    auto* aSet = *aSets.begin();
+    auto* bSet = *bSets.begin();
+    if (aSet == bSet) {
+      if (!aSet) {
+        // They are both nullptr, indicating the implicit value for a parameter
+        // or the zero for a local.
+        if (func->isParam(a->index)) {
+          // For parameters to be equivalent they must have the exact same
+          // index.
+          return a->index == b->index;
+        } else {
+          // As locals, they are both of value zero, but must have the right
+          // type as well.
+          return func->getLocalType(a->index) == func->getLocalType(b->index);
+        }
+      } else {
+        // They are both the same actual set.
+        return true;
+      }
+    }
+    return false;
+  }
+  return false;
+  // TODO: use a LinearExecutionWalker to find trivially equal gets in basic
+  //       blocks. that plus the above should handle 80% of cases.
+  // TODO: handle chains, merges and other situations
 }
 
 void LocalGraph::computeInfluences() {

--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -48,6 +48,10 @@ struct LocalGraph {
                        // param)
   Locations locations; // where each get and set is (for easy replacing)
 
+  // Checks if two gets are equivalent, that is, definitely have the same
+  // value.
+  bool equivalent(LocalGet* a, LocalGet* b);
+
   // Optional: compute the influence graphs between sets and gets
   // (useful for algorithms that propagate changes).
 
@@ -84,6 +88,7 @@ struct LocalGraph {
   bool isSSA(Index x);
 
 private:
+  Function* func;
   std::set<Index> SSAIndexes;
 };
 

--- a/test/example/local-graph.cpp
+++ b/test/example/local-graph.cpp
@@ -91,7 +91,6 @@ int main() {
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(1, Type::i32);
     foo.body = builder.makeBlock({
-      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
       // two equivalent gets, even though they have a different index, as both
       // use the zero initialized value
       builder.makeDrop(get1),
@@ -103,11 +102,10 @@ int main() {
 
   {
     Function foo;
-    foo.vars = { Type::i32, Type::i32 };
+    foo.vars = { Type::i32, Type::f64 };
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(1, Type::f64);
     foo.body = builder.makeBlock({
-      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
       // two non-equivalent gets as their zero-init value is different
       builder.makeDrop(get1),
       builder.makeDrop(get2),

--- a/test/example/local-graph.cpp
+++ b/test/example/local-graph.cpp
@@ -1,0 +1,122 @@
+// test multiple uses of the threadPool
+
+#include <iostream>
+
+#include <ir/local-graph.h>
+#include <wasm.h>
+#include <wasm-builder.h>
+
+using namespace wasm;
+
+int main() {
+  Module wasm;
+  Builder builder(wasm);
+
+  {
+    Function foo;
+    foo.vars = { Type::i32 };
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(0, Type::i32);
+    foo.body = builder.makeBlock({
+      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
+      // two equivalent gets, as both are preceded by the same single set
+      builder.makeDrop(get1),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  {
+    Function foo;
+    foo.vars = { Type::i32 };
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(0, Type::i32);
+    foo.body = builder.makeBlock({
+      // two non-equivalent gets, as there is a set in between them
+      builder.makeDrop(get1),
+      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  {
+    Function foo;
+    foo.sig = Signature({ Type::i32 }, Type::none);
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(0, Type::i32);
+    foo.body = builder.makeBlock({
+      // two equivalent gets of the same parameter
+      builder.makeDrop(get1),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  {
+    Function foo;
+    foo.sig = Signature({ Type::i32 }, Type::none);
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(0, Type::i32);
+    foo.body = builder.makeBlock({
+      // two non-equivalent gets of the same parameter, as there is a set
+      builder.makeDrop(get1),
+      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  {
+    Function foo;
+    foo.sig = Signature({ Type::i32, Type::i32 }, Type::none);
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(1, Type::i32);
+    foo.body = builder.makeBlock({
+      // two non-equivalent gets as they are of different parameters
+      builder.makeDrop(get1),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  {
+    Function foo;
+    foo.vars = { Type::i32, Type::i32 };
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(1, Type::i32);
+    foo.body = builder.makeBlock({
+      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
+      // two equivalent gets, even though they have a different index, as both
+      // use the zero initialized value
+      builder.makeDrop(get1),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  {
+    Function foo;
+    foo.vars = { Type::i32, Type::i32 };
+    auto* get1 = builder.makeLocalGet(0, Type::i32);
+    auto* get2 = builder.makeLocalGet(1, Type::f64);
+    foo.body = builder.makeBlock({
+      builder.makeLocalSet(0, builder.makeConst(Literal(int32_t(0)))),
+      // two non-equivalent gets as their zero-init value is different
+      builder.makeDrop(get1),
+      builder.makeDrop(get2),
+    });
+    LocalGraph graph(&foo);
+    assert(graph.equivalent(get1, get2));
+  }
+
+  std::cout << "Success." << std::endl;
+
+  return 0;
+}

--- a/test/example/local-graph.cpp
+++ b/test/example/local-graph.cpp
@@ -39,7 +39,7 @@ int main() {
       builder.makeDrop(get2),
     });
     LocalGraph graph(&foo);
-    assert(graph.equivalent(get1, get2));
+    assert(!graph.equivalent(get1, get2));
   }
 
   {
@@ -68,7 +68,7 @@ int main() {
       builder.makeDrop(get2),
     });
     LocalGraph graph(&foo);
-    assert(graph.equivalent(get1, get2));
+    assert(!graph.equivalent(get1, get2));
   }
 
   {
@@ -82,7 +82,7 @@ int main() {
       builder.makeDrop(get2),
     });
     LocalGraph graph(&foo);
-    assert(graph.equivalent(get1, get2));
+    assert(!graph.equivalent(get1, get2));
   }
 
   {
@@ -113,7 +113,7 @@ int main() {
       builder.makeDrop(get2),
     });
     LocalGraph graph(&foo);
-    assert(graph.equivalent(get1, get2));
+    assert(!graph.equivalent(get1, get2));
   }
 
   std::cout << "Success." << std::endl;

--- a/test/example/local-graph.cpp
+++ b/test/example/local-graph.cpp
@@ -1,5 +1,3 @@
-// test multiple uses of the threadPool
-
 #include <iostream>
 
 #include <ir/local-graph.h>

--- a/test/example/local-graph.cpp
+++ b/test/example/local-graph.cpp
@@ -3,8 +3,8 @@
 #include <iostream>
 
 #include <ir/local-graph.h>
-#include <wasm.h>
 #include <wasm-builder.h>
+#include <wasm.h>
 
 using namespace wasm;
 
@@ -14,7 +14,7 @@ int main() {
 
   {
     Function foo;
-    foo.vars = { Type::i32 };
+    foo.vars = {Type::i32};
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(0, Type::i32);
     foo.body = builder.makeBlock({
@@ -29,7 +29,7 @@ int main() {
 
   {
     Function foo;
-    foo.vars = { Type::i32 };
+    foo.vars = {Type::i32};
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(0, Type::i32);
     foo.body = builder.makeBlock({
@@ -44,7 +44,7 @@ int main() {
 
   {
     Function foo;
-    foo.sig = Signature({ Type::i32 }, Type::none);
+    foo.sig = Signature({Type::i32}, Type::none);
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(0, Type::i32);
     foo.body = builder.makeBlock({
@@ -58,7 +58,7 @@ int main() {
 
   {
     Function foo;
-    foo.sig = Signature({ Type::i32 }, Type::none);
+    foo.sig = Signature({Type::i32}, Type::none);
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(0, Type::i32);
     foo.body = builder.makeBlock({
@@ -73,7 +73,7 @@ int main() {
 
   {
     Function foo;
-    foo.sig = Signature({ Type::i32, Type::i32 }, Type::none);
+    foo.sig = Signature({Type::i32, Type::i32}, Type::none);
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(1, Type::i32);
     foo.body = builder.makeBlock({
@@ -87,7 +87,7 @@ int main() {
 
   {
     Function foo;
-    foo.vars = { Type::i32, Type::i32 };
+    foo.vars = {Type::i32, Type::i32};
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(1, Type::i32);
     foo.body = builder.makeBlock({
@@ -102,7 +102,7 @@ int main() {
 
   {
     Function foo;
-    foo.vars = { Type::i32, Type::f64 };
+    foo.vars = {Type::i32, Type::f64};
     auto* get1 = builder.makeLocalGet(0, Type::i32);
     auto* get2 = builder.makeLocalGet(1, Type::f64);
     foo.body = builder.makeBlock({

--- a/test/example/local-graph.txt
+++ b/test/example/local-graph.txt
@@ -1,0 +1,1 @@
+Success.


### PR DESCRIPTION
This compares two `local.get`s and checks whether we are sure they are
equivalent, that is, they contain the same value.

This does not solve the general problem, but uses the existing info to get
a positive answer for the common case where two gets only receive values
by a single set, like
```wat
(local.set $x ..)
(a use.. (local.get $x))
(another use.. (local.get $x))
```
If they only receive values from the same single set, then we know it must
dominate them. The only risk is that the set is "in between" the gets, that is,
that the set occurs after one get and before the other. That can happen in
a loop in theory,
```wat
(loop $loop
  (use (local.get $x))
  (local.set $x ..some new value each iteration..)
  (use (local.get $x))
  (br_if $loop ..)
)
```
Both of those gets receive a value from the set, and they may be different
values, from different loop iterations. But as mentioned in the source code,
this is not a problem since wasm always has a zero-initialization value, and
so the first local.get in that loop would have another set from which it can
receive a value, the function entry. (The only way to avoid that is for this
entire code to be unreachable, in which case nothing matters.)

This will be useful in dead store elimination, which has to use this to reason
about references and pointers in order to be able to do anything useful with
GC and memory.