### PR TITLE
wasm-reduce: Always decrease the factor

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1359,13 +1359,18 @@ int main(int argc, const char* argv[]) {
     }
     lastPostPassesSize = newSize;
 
-    // if destructive reductions lead to useful proportionate pass reductions,
-    // keep going at the same factor, as pass reductions are far faster
+    // If destructive reductions lead to useful proportionate pass reductions,
+    // keep going at the same factor, as pass reductions are far faster.
     std::cerr << "|  pass progress: " << passProgress
               << ", last destructive: " << lastDestructiveReductions << '\n';
     if (passProgress >= 4 * lastDestructiveReductions) {
-      // don't change
       std::cerr << "|  progress is good, do not quickly decrease factor\n";
+      // While the amount of pass reductions is proportionately high, we do
+      // still want to reduce the factor by some amount. If we do not then there
+      // is a risk that both pass and destructive reductions are very low, and
+      // we get "stuck" cycling through them. In that case we simply need to do
+      // more destructive reductions to make real progress. For that reason,
+      // decrease the factor by some small percentage.
       factor = std::max(1, (factor * 9) / 10);
     } else {
       if (factor > 10) {

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1366,6 +1366,7 @@ int main(int argc, const char* argv[]) {
     if (passProgress >= 4 * lastDestructiveReductions) {
       // don't change
       std::cerr << "|  progress is good, do not quickly decrease factor\n";
+      factor = std::max(1, (factor * 9) / 10);
     } else {
       if (factor > 10) {
         factor = (factor / 3) + 1;


### PR DESCRIPTION
When things go well, the reducer shrinks the factor by 50% or more, but
when things are slow it kept the factor unchanged. That is annoying in
some cases where you really have no benefit from reduction until the
factor gets small. So this at least reduces it by 10% in each iteration.

On the large wasm GC testcase I recently reduced this helped a lot. I
don't have a guarantee it will help elsewhere, though... but seems low risk.