### PR TITLE
[Wasm GC] Add a print limit in TypePrinter

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -219,7 +219,6 @@ private:
 
   bool exceededLimit() {
     if (prints >= MaxPrints) {
-      os << "!";
       return true;
     }
     prints++;
@@ -1519,7 +1518,7 @@ bool TypeBounder::lub(const Rtt& a, const Rtt& b, Rtt& out) {
 template<typename T, typename F>
 std::ostream& TypePrinter::printChild(T curr, F printer) {
   if (exceededLimit()) {
-    return os;
+    return os << "..!";
   }
   auto it = depths.find(curr.getID());
   if (it != depths.end()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -219,7 +219,7 @@ private:
 
   bool exceededLimit() {
     if (prints >= MaxPrints) {
-      os << "?";
+      os << "!";
       return true;
     }
     prints++;
@@ -1519,7 +1519,7 @@ bool TypeBounder::lub(const Rtt& a, const Rtt& b, Rtt& out) {
 template<typename T, typename F>
 std::ostream& TypePrinter::printChild(T curr, F printer) {
   if (exceededLimit()) {
-    return os << "..!";
+    return os;
   }
   auto it = depths.find(curr.getID());
   if (it != depths.end()) {


### PR DESCRIPTION
This is similar to the limit in `TypeNamePrinter` in `Print.cpp`. This limit
affects the printed type when debugging with `std::cout << type` etc.,
which just prints the structure and not the name.

This made debugging a recent wasm GC testcase much easier.