### PR TITLE
Use standard type traversal in module-utils.h

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -204,6 +204,9 @@ public:
   // Returns true if left is a subtype of right. Subtype includes itself.
   static bool isSubType(Type left, Type right);
 
+  // Return the ordered HeapType children, looking through child Types.
+  std::vector<HeapType> getHeapTypeChildren();
+
   // Computes the least upper bound from the type lattice.
   // If one of the type is unreachable, the other type becomes the result. If
   // the common supertype does not exist, returns none, a poison value.
@@ -361,10 +364,14 @@ public:
 
   // Order heap types by some notion of simplicity.
   bool operator<(const HeapType& other) const;
-  std::string toString() const;
 
   // Returns true if left is a subtype of right. Subtype includes itself.
   static bool isSubType(HeapType left, HeapType right);
+
+  // Return the ordered HeapType children, looking through child Types.
+  std::vector<HeapType> getHeapTypeChildren();
+
+  std::string toString() const;
 };
 
 typedef std::vector<Type> TypeList;


### PR DESCRIPTION
Add new public `getHeapTypeChildren` methods to Type and HeapType, implemented
in using the standard machinery from #3844, and use them to simplify
`ModuleUtils::collectHeapTypes`.

Now that the type traversal code in wasm-type.cpp is not just used in
canonicalization, move it to a more appropriate place in the file. Also, since
the only users of `HeapTypePathWalker` were using it to visit top-level children
only, replace that with a more specialized `HeapTypeChildWalker` to reduce code
duplication.