### PR TITLE
BranchUtils additions

### DIFF
--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -96,9 +96,9 @@ void operateOnScopeNameUsesAndSentValues(Expression* expr, T func) {
     // There isn't a delegate mechanism for getting a sent value, so do a direct
     // if-else chain. This will need to be updated with new br variants.
     if (auto* br = expr->dynCast<Break>()) {
-      func(name, br->value ? br->value : nullptr);
+      func(name, br->value);
     } else if (auto* sw = expr->dynCast<Switch>()) {
-      func(name, sw->value ? sw->value : nullptr);
+      func(name, sw->value);
     } else if (auto* br = expr->dynCast<BrOn>()) {
       func(name, br->ref);
     } else {

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -352,7 +352,7 @@ public:
   }
 };
 
-// Provides a map of branch target names to the expression that corresponds to
+// Provides a map of branch target names to the expressions that branch to
 // them.
 struct BranchTargets {
   BranchTargets(Expression* expr) { inner.walk(expr); }

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -69,22 +69,31 @@ template<typename T> void operateOnScopeNameUses(Expression* expr, T func) {
 #include "wasm-delegations-fields.h"
 }
 
-// Similar to operateOnScopeNameUses, but also passes in the type that is sent
-// if the branch is taken. The type is none if there is no value.
+// Similar to operateOnScopeNameUses, but also passes in the expression that is
+// sent if the branch is taken. nullptr is given if there is no value.
 template<typename T>
-void operateOnScopeNameUsesAndSentTypes(Expression* expr, T func) {
+void operateOnScopeNameUsesAndSentValues(Expression* expr, T func) {
   operateOnScopeNameUses(expr, [&](Name& name) {
     // There isn't a delegate mechanism for getting a sent value, so do a direct
     // if-else chain. This will need to be updated with new br variants.
     if (auto* br = expr->dynCast<Break>()) {
-      func(name, br->value ? br->value->type : Type::none);
+      func(name, br->value ? br->value : nullptr);
     } else if (auto* sw = expr->dynCast<Switch>()) {
-      func(name, sw->value ? sw->value->type : Type::none);
+      func(name, sw->value ? sw->value : nullptr);
     } else if (auto* br = expr->dynCast<BrOn>()) {
-      func(name, br->getCastType());
+      func(name, br->ref);
     } else {
       assert(expr->is<Try>() || expr->is<Rethrow>()); // delegate or rethrow
     }
+  });
+}
+
+// Similar to operateOnScopeNameUses, but also passes in the type that is sent
+// if the branch is taken. The type is none if there is no value.
+template<typename T>
+void operateOnScopeNameUsesAndSentTypes(Expression* expr, T func) {
+  operateOnScopeNameUsesAndSentValues(expr, [&](Name& name, Expression* value) {
+    func(name, value ? value->type : Type::none);
   });
 }
 
@@ -331,6 +340,27 @@ public:
 #endif
     return result;
   }
+};
+
+// Provides a map of branch target names to the expression that corresponds to
+// them.
+struct BranchTargets {
+  BranchTargets(Expression* expr) { inner.walk(expr); }
+
+  Expression* getTarget(Name name) { return inner.map[name]; }
+
+private:
+  struct Inner : public PostWalker<Inner, UnifiedExpressionVisitor<Inner>> {
+    void visitExpression(Expression* curr) {
+      operateOnScopeNameDefs(curr, [&](Name name) {
+        if (name.is()) {
+          map[name] = curr;
+        }
+      });
+    }
+
+    std::map<Name, Expression*> map;
+  } inner;
 };
 
 } // namespace BranchUtils


### PR DESCRIPTION
Add `operateOnScopeNameUsesAndSentValues` which is like the
existing utilities, but provides the child expression that is sent as a
value on the branch.

Also provide a `BranchTargets` utility that maps target names to the
control flow structure for them.

Both will be used and tested in escape analysis.