### PR TITLE
Allow only computing necessary influences in LocalGraph. NFC

### DIFF
--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -284,7 +284,7 @@ bool LocalGraph::equivalent(LocalGet* a, LocalGet* b) {
 void LocalGraph::computeSetInfluences() {
   for (auto& pair : locations) {
     auto* curr = pair.first;
-    if (auto* get = curr->cast<LocalGet>()) {
+    if (auto* get = curr->dynCast<LocalGet>()) {
       for (auto* set : getSetses[get]) {
         setInfluences[set].insert(get);
       }

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -281,18 +281,24 @@ bool LocalGraph::equivalent(LocalGet* a, LocalGet* b) {
   }
 }
 
-void LocalGraph::computeInfluences() {
+void LocalGraph::computeSetInfluences() {
+  for (auto& pair : locations) {
+    auto* curr = pair.first;
+    if (auto* get = curr->cast<LocalGet>()) {
+      for (auto* set : getSetses[get]) {
+        setInfluences[set].insert(get);
+      }
+    }
+  }
+}
+
+void LocalGraph::computeGetInfluences() {
   for (auto& pair : locations) {
     auto* curr = pair.first;
     if (auto* set = curr->dynCast<LocalSet>()) {
       FindAll<LocalGet> findAll(set->value);
       for (auto* get : findAll.list) {
         getInfluences[get].insert(set);
-      }
-    } else {
-      auto* get = curr->cast<LocalGet>();
-      for (auto* set : getSetses[get]) {
-        setInfluences[set].insert(get);
       }
     }
   }

--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -55,7 +55,13 @@ struct LocalGraph {
   // Optional: compute the influence graphs between sets and gets
   // (useful for algorithms that propagate changes).
 
-  void computeInfluences();
+  void computeSetInfluences();
+  void computeGetInfluences();
+
+  void computeInfluences() {
+    computeSetInfluences();
+    computeGetInfluences();
+  }
 
   // for each get, the sets whose values are influenced by that get
   std::unordered_map<LocalGet*, std::unordered_set<LocalSet*>> getInfluences;

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -192,7 +192,7 @@ struct MergeLocals
       // the live range unless we are definitely removing a conflict, same
       // logic as before).
       LocalGraph postGraph(func);
-      postGraph.computeInfluences();
+      postGraph.computeSetInfluences();
       for (auto& pair : optimizedToCopy) {
         auto* copy = pair.first;
         auto* trivial = pair.second;

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -277,7 +277,7 @@ struct OptimizeAddedConstants
       propagatable.clear();
       if (propagate) {
         localGraph = make_unique<LocalGraph>(func);
-        localGraph->computeInfluences();
+        localGraph->computeSetInfluences();
         localGraph->computeSSAIndexes();
         findPropagatable();
       }

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -90,7 +90,7 @@ struct SSAify : public Pass {
     module = module_;
     func = func_;
     LocalGraph graph(func);
-    graph.computeInfluences();
+    graph.computeSetInfluences();
     graph.computeSSAIndexes();
     // create new local indexes, one for each set
     createNewIndexes(graph);

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -112,7 +112,7 @@ private:
     // TODO: we can do this a lot faster, as we just care about linear
     //       control flow.
     LocalGraph localGraph(func);
-    localGraph.computeInfluences();
+    localGraph.computeSetInfluences();
     // We maintain a stack of relevant values. This contains:
     //  * a null for each actual value that the value stack would have
     //  * an index of each LocalSet that *could* be on the value


### PR DESCRIPTION
Some passes need `setInfluences` but not `getInfluences`, but were
computing them nonetheless.

(To verify correctness, can see that there is no reference to
`getInfluences` in the modified passes.)

This makes e.g. MergeLocals 12% faster. It will also help use LocalGraph
in new passes with less worries about speed.