### PR TITLE
[Wasm GC] Fix Array initialization of a packed value

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1643,7 +1643,8 @@ public:
       if (init.breaking()) {
         return init;
       }
-      auto value = init.getSingleValue();
+      auto field = curr->type.getHeapType().getArray().element;
+      auto value = truncateForPacking(init.getSingleValue(), field);
       for (Index i = 0; i < num; i++) {
         data[i] = value;
       }

--- a/test/passes/Oz_fuzz-exec_all-features.txt
+++ b/test/passes/Oz_fuzz-exec_all-features.txt
@@ -34,14 +34,16 @@
 [trap cast error]
 [fuzz-exec] calling array-alloc-failure
 [host limit allocation failure]
+[fuzz-exec] calling init-array-packed
+[fuzz-exec] note result: init-array-packed => 213
 (module
  (type $struct (struct (field (mut i32))))
  (type $void_func (func))
  (type $extendedstruct (struct (field (mut i32)) (field f64)))
  (type $bytes (array (mut i8)))
+ (type $int_func (func (result i32)))
  (type $i32_=>_none (func (param i32)))
  (type $anyref_=>_none (func (param anyref)))
- (type $int_func (func (result i32)))
  (import "fuzzing-support" "log-i32" (func $log (param i32)))
  (elem declare func $a-void-func)
  (export "structs" (func $0))
@@ -52,6 +54,7 @@
  (export "br_on_data" (func $6))
  (export "rtt-and-cast-on-func" (func $8))
  (export "array-alloc-failure" (func $9))
+ (export "init-array-packed" (func $10))
  (func $0 (; has Stack IR ;)
   (local $0 (ref null $struct))
   (call $log
@@ -280,6 +283,16 @@
  (func $9 (; has Stack IR ;)
   (nop)
  )
+ (func $10 (; has Stack IR ;) (result i32)
+  (array.get_u $bytes
+   (array.new_with_rtt $bytes
+    (i32.const -43)
+    (i32.const 50)
+    (rtt.canon $bytes)
+   )
+   (i32.const 10)
+  )
+ )
 )
 [fuzz-exec] calling structs
 [LoggingExternalInterface logging 0]
@@ -316,6 +329,8 @@
 [LoggingExternalInterface logging 3]
 [trap cast error]
 [fuzz-exec] calling array-alloc-failure
+[fuzz-exec] calling init-array-packed
+[fuzz-exec] note result: init-array-packed => 213
 ignoring comparison of ExecutionResults!
 [fuzz-exec] calling foo
 [host limit allocation failure]

--- a/test/passes/Oz_fuzz-exec_all-features.wast
+++ b/test/passes/Oz_fuzz-exec_all-features.wast
@@ -241,6 +241,21 @@
    )
   )
  )
+ (func "init-array-packed" (result i32)
+  (local $x (ref null $bytes))
+  (local.set $x
+   (array.new_with_rtt $bytes
+    (i32.const -43) ;; initialize the i8 values with a negative i32
+    (i32.const 50)
+    (rtt.canon $bytes)
+   )
+  )
+  ;; read the value, which should be -43 & 255 ==> 213
+  (array.get_u $bytes
+   (local.get $x)
+   (i32.const 10)
+  )
+ )
 )
 (module
  (type $[mut:i8] (array (mut i8)))


### PR DESCRIPTION
We truncated and extended packed values in get and set, but
not during initialization.

Found by the fuzzer.