### PR TITLE
Fix link to Contributing.md

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -3,7 +3,7 @@
 Interested in participating? Please follow
 [the same contributing guidelines as the design repository][].
 
-  [the same contributing guidelines as the design repository]: https://github.com/WebAssembly/design/blob/main/Contributing.md
+  [the same contributing guidelines as the design repository]: https://github.com/WebAssembly/design/blob/master/Contributing.md
 
 Also, please be sure to read [the README.md](README.md) for this repository.
 


### PR DESCRIPTION
The `design` repo is still using `master` for it's default branch.