### PR TITLE
[Wasm GC] Fix StructSet::finalize on an unreachable value

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -977,7 +977,7 @@ void StructGet::finalize() {
 }
 
 void StructSet::finalize() {
-  if (ref->type == Type::unreachable) {
+  if (ref->type == Type::unreachable || value->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
     type = Type::none;

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -258,12 +258,18 @@
       )
     )
   )
-  (func $unreachables
+  (func $unreachables-1
     (drop
-      (struct.get $struct.A 0 (unreachable))
+      (struct.get $struct.C 0 (unreachable))
     )
-    (drop
-      (struct.set $struct.A 0 (unreachable) (unreachable))
-    )
+  )
+  (func $unreachables-2
+    (struct.set $struct.C 0 (ref.null $struct.C) (unreachable))
+  )
+  (func $unreachables-3
+    (struct.set $struct.C 0 (unreachable) (unreachable))
+  )
+  (func $unreachables-4
+    (struct.set $struct.C 0 (unreachable) (f32.const 1))
   )
 )

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -1,14 +1,14 @@
 (module
  (type $struct.A (struct (field i32) (field f32) (field $named f64)))
  (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
+ (type $none_=>_none (func))
  (type $grandchild (struct (field i32) (field i64)))
+ (type $struct.C (struct (field $named-mut (mut f32))))
  (type $vector (array (mut f64)))
  (type $matrix (array (mut (ref null $vector))))
  (type $anyref_=>_none (func (param anyref)))
  (type $parent (struct ))
  (type $child (struct (field i32)))
- (type $struct.C (struct (field $named-mut (mut f32))))
- (type $none_=>_none (func))
  (type $nested-child-struct (struct (field (mut (ref $child)))))
  (type $rtt_1_$parent_=>_none (func (param (rtt 1 $parent))))
  (type $rtt_$parent_=>_none (func (param (rtt $parent))))
@@ -307,17 +307,29 @@
    )
   )
  )
- (func $unreachables
+ (func $unreachables-1
   (drop
    (block 
     (unreachable)
    )
   )
-  (drop
-   (block 
-    (unreachable)
-    (unreachable)
-   )
+ )
+ (func $unreachables-2
+  (struct.set $struct.C $named-mut
+   (ref.null $struct.C)
+   (unreachable)
+  )
+ )
+ (func $unreachables-3
+  (block 
+   (unreachable)
+   (unreachable)
+  )
+ )
+ (func $unreachables-4
+  (block 
+   (unreachable)
+   (f32.const 1)
   )
  )
 )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -1,14 +1,14 @@
 (module
  (type $struct.A (struct (field i32) (field f32) (field $named f64)))
  (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
+ (type $none_=>_none (func))
  (type $grandchild (struct (field i32) (field i64)))
  (type $vector (array (mut f64)))
  (type $matrix (array (mut (ref null $vector))))
+ (type $struct.C (struct (field $named-mut (mut f32))))
  (type $anyref_=>_none (func (param anyref)))
  (type $parent (struct ))
  (type $child (struct (field i32)))
- (type $struct.C (struct (field $named-mut (mut f32))))
- (type $none_=>_none (func))
  (type $nested-child-struct (struct (field (mut (ref $child)))))
  (type $rtt_1_$parent_=>_none (func (param (rtt 1 $parent))))
  (type $rtt_$parent_=>_none (func (param (rtt $parent))))
@@ -306,7 +306,19 @@
    )
   )
  )
- (func $unreachables
+ (func $unreachables-1
+  (unreachable)
+ )
+ (func $unreachables-2
+  (drop
+   (ref.null $struct.C)
+  )
+  (unreachable)
+ )
+ (func $unreachables-3
+  (unreachable)
+ )
+ (func $unreachables-4
   (unreachable)
  )
 )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -1,14 +1,14 @@
 (module
  (type ${i32_f32_f64} (struct (field i32) (field f32) (field f64)))
  (type ${i8_mut:i16_ref|{i32_f32_f64}|_mut:ref|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref ${i32_f32_f64})) (field (mut (ref ${i32_f32_f64})))))
+ (type $none_=>_none (func))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type $[mut:f64] (array (mut f64)))
  (type $[mut:ref?|[mut:f64]|] (array (mut (ref null $[mut:f64]))))
+ (type ${mut:f32} (struct (field (mut f32))))
  (type $anyref_=>_none (func (param anyref)))
  (type ${} (struct ))
  (type ${i32} (struct (field i32)))
- (type ${mut:f32} (struct (field (mut f32))))
- (type $none_=>_none (func))
  (type ${mut:ref|{i32}|} (struct (field (mut (ref ${i32})))))
  (type $rtt_1_{}_=>_none (func (param (rtt 1 ${}))))
  (type $rtt_{}_=>_none (func (param (rtt ${}))))
@@ -307,6 +307,18 @@
   )
  )
  (func $8
+  (unreachable)
+ )
+ (func $9
+  (drop
+   (ref.null ${mut:f32})
+  )
+  (unreachable)
+ )
+ (func $10
+  (unreachable)
+ )
+ (func $11
   (unreachable)
  )
 )


### PR DESCRIPTION
Also improve the testing: put each unreachable expression in its
own function (as otherwise everything after the first is dead).