### PR TITLE
[Wasm GC] Fix precomputing of incompatible fallthrough values

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -34,7 +34,6 @@
 #include "pass.h"
 #include "support/learning.h"
 #include "support/permutations.h"
-#include "wasm-builder.h"
 #include "wasm.h"
 #ifdef CFG_PROFILE
 #include "support/timing.h"

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -323,9 +323,10 @@ private:
         // the more specific (in this example, non-nullable) type. But there
         // is a situation where this can cause an issue: RefCast. An attempt to
         // perform a "bad" cast, say of a function to a struct, is a case where
-        // the fallthrough value is different than the actually returned value.
-        // To handle that, if the result has the wrong type, precompute it
-        // without looking through to the fallthrough.
+        // the fallthrough value's type is very different than the actually
+        // returned value's type. To handle that, if we precomputed a value and
+        // if it has the wrong type precompute it again without looking through
+        // to the fallthrough.
         if (values.isConcrete() &&
             !Type::isSubType(values.getType(), set->value->type)) {
           values = precomputeValue(set->value);

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -318,7 +318,7 @@ private:
         // that pass through the value. Normally that does not matter here,
         // for example, (block .. (value)) returns the value unmodified.
         // However, some things change the type, for example RefAsNonNull has
-        // has a non-null type, while its input may be nullable. That does not
+        // a non-null type, while its input may be nullable. That does not
         // matter either, as if we managed to precompute it then the value had
         // the more specific (in this example, non-nullable) type. But there
         // is a situation where this can cause an issue: RefCast. An attempt to

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -326,7 +326,8 @@ private:
         // the fallthrough value is different than the actually returned value.
         // To handle that, if the result has the wrong type, precompute it
         // without looking through to the fallthrough.
-        if (!Type::isSubType(values.getType(), set->value->type)) {
+        if (values.isConcrete() &&
+            !Type::isSubType(values.getType(), set->value->type)) {
           values = precomputeValue(set->value);
         }
         setValues[set] = values;

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -325,8 +325,8 @@ private:
         // perform a "bad" cast, say of a function to a struct, is a case where
         // the fallthrough value's type is very different than the actually
         // returned value's type. To handle that, if we precomputed a value and
-        // if it has the wrong type precompute it again without looking through
-        // to the fallthrough.
+        // if it has the wrong type then precompute it again without looking
+        // through to the fallthrough.
         if (values.isConcrete() &&
             !Type::isSubType(values.getType(), set->value->type)) {
           values = precomputeValue(set->value);

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -454,8 +454,6 @@
    )
   )
   (drop
-   ;; Read from the reference in the local. Precompute should not be confused by
-   ;; the attempt above to store a different type.
    (struct.get $B 0
     (tuple.extract 0
      (local.get $temp)

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -398,7 +398,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $bad-cast-and-get
+ ;; CHECK:      (func $odd-cast-and-get
  ;; CHECK-NEXT:  (local $temp (ref null $B))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.null $B)
@@ -409,11 +409,12 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $bad-cast-and-get
+ (func $odd-cast-and-get
   (local $temp (ref null $B))
   ;; Try to cast a null of A to B. While the types are incompatible, ref.cast
   ;; returns a null when given a null (and the null must have the type that the
-  ;; ref.cast instruction has, that is, the value is a null of type $B).
+  ;; ref.cast instruction has, that is, the value is a null of type $B). So this
+  ;; is an odd cast that "works".
   (local.set $temp
    (ref.cast
     (ref.null $A)
@@ -421,15 +422,15 @@
    )
   )
   (drop
-   ;; Read from the reference in the local. Precompute should not be confused by
-   ;; the attempt above to store a different type.
+   ;; Read from the local, which precompute should set to a null with the proper
+   ;; type.
    (struct.get $B 0
     (local.get $temp)
    )
   )
  )
 
- ;; CHECK:      (func $bad-cast-and-get-tuple
+ ;; CHECK:      (func $odd-cast-and-get-tuple
  ;; CHECK-NEXT:  (local $temp ((ref null $B) i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (tuple.make
@@ -443,7 +444,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $bad-cast-and-get-tuple
+ (func $odd-cast-and-get-tuple
   (local $temp ((ref null $B) i32))
   ;; As above, but with a tuple.
   (local.set $temp
@@ -471,7 +472,7 @@
   (unreachable)
  )
 
- ;; CHECK:      (func $bad-cast-and-get-non-null (param $temp (ref $func-return-i32))
+ ;; CHECK:      (func $odd-cast-and-get-non-null (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.cast
  ;; CHECK-NEXT:    (ref.func $receive-f64)
@@ -484,7 +485,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $bad-cast-and-get-non-null (param $temp (ref $func-return-i32))
+ (func $odd-cast-and-get-non-null (param $temp (ref $func-return-i32))
   ;; Try to cast a function to an incompatible type.
   (local.set $temp
    (ref.cast
@@ -493,8 +494,8 @@
    )
   )
   (drop
-   ;; Call the reference in the local. Precompute should not be confused by the
-   ;; attempt above to store a different type.
+   ;; Read from the local, checking whether precompute set a value there (it
+   ;; should not, as the cast fails).
    (call_ref
     (local.get $temp)
    )

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -6,6 +6,10 @@
  (type $struct (struct (mut i32)))
  (type $empty (struct))
 
+ ;; two incompatible types
+ (type $A (struct (field (mut f32))))
+ (type $B (struct (field (mut f64))))
+
  (import "fuzzing-support" "log-i32" (func $log (param i32)))
 
  ;; CHECK:      (func $test-fallthrough (result i32)
@@ -390,5 +394,73 @@
   ;; this value could be precomputed in principle, however, we currently do not
   ;; precompute GC references, and so nothing will be done.
   (local.get $tempresult)
+ )
+
+ ;; CHECK:      (func $bad-cast-and-get
+ ;; CHECK-NEXT:  (local $temp (ref null $B))
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (ref.null $B)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (struct.get $B 0
+ ;; CHECK-NEXT:    (ref.null $B)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $bad-cast-and-get
+  (local $temp (ref null $B))
+  ;; Try to cast a null of A to B. While the types are incompatible, ref.cast
+  ;; returns a null when given a null (and the null must have the type that the
+  ;; ref.cast instruction has, that is, the value is a null of type $B).
+  (local.set $temp
+   (ref.cast
+    (ref.null $A)
+    (rtt.canon $B)
+   )
+  )
+  (drop
+   ;; Read from the reference in the local. Precompute should not be confused by
+   ;; the attempt above to store a different type.
+   (struct.get $B 0
+    (local.get $temp)
+   )
+  )
+ )
+
+ ;; CHECK:      (func $bad-cast-and-get-tuple
+ ;; CHECK-NEXT:  (local $temp ((ref null $B) i32))
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:    (ref.null $B)
+ ;; CHECK-NEXT:    (i32.const 10)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (struct.get $B 0
+ ;; CHECK-NEXT:    (ref.null $B)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $bad-cast-and-get-tuple
+  (local $temp ((ref null $B) i32))
+  ;; As above, but with a tuple.
+  (local.set $temp
+   (tuple.make
+    (ref.cast
+     (ref.null $A)
+     (rtt.canon $B)
+    )
+    (i32.const 10)
+   )
+  )
+  (drop
+   ;; Read from the reference in the local. Precompute should not be confused by
+   ;; the attempt above to store a different type.
+   (struct.get $B 0
+    (tuple.extract 0
+     (local.get $temp)
+    )
+   )
+  )
  )
 )


### PR DESCRIPTION
Precompute not only computes values, but looks at the fallthrough,

```wat
(local.set 0
  (block
    ..stuff we can ignore..
    ;; the fallthrough we care about - if a value is set to local 0, it is this
    (i32.const 10)
  )
)
```

Normally that is fine, but the fuzzer found a case where it is not: RefCast may
return a different type than the fallthrough, even an incompatible type if we
try to do something bad like cast a function to a struct. As we may then
propagate the value to a place that expects the proper type, this can cause an
error.

To fix this, check if the precomputed value is a proper subtype. If it is not,
then do not look through into the fallthrough, but compute the entire thing.
(In the case of a bad RefCast of a func to a struct, it would then indicate a
trap happens, and we would not precompute the value.)
