### PR TITLE
RemoveUnusedModuleElements: The start function may be imported

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -150,7 +150,7 @@ struct RemoveUnusedModuleElements : public Pass {
     if (module->start.is()) {
       auto startFunction = module->getFunction(module->start);
       // Can be skipped if the start function is empty.
-      if (startFunction->body->is<Nop>()) {
+      if (!startFunction->imported() && startFunction->body->is<Nop>()) {
         module->start.clear();
       } else {
         roots.emplace_back(ModuleElementKind::Function, module->start);

--- a/test/passes/remove-unused-module-elements_all-features.txt
+++ b/test/passes/remove-unused-module-elements_all-features.txt
@@ -272,6 +272,11 @@
  )
 )
 (module
+ (type $none_=>_none (func))
+ (import "env" "start" (func $start))
+ (start $start)
+)
+(module
 )
 (module
 )

--- a/test/passes/remove-unused-module-elements_all-features.wast
+++ b/test/passes/remove-unused-module-elements_all-features.wast
@@ -239,6 +239,10 @@
     (drop (i32.const 0))
   )
 )
+(module ;; imported start cannot be removed
+  (import "env" "start" (func $start))
+  (start $start)
+)
 (module ;; the function and the table can be removed
  (type $0 (func (param f64) (result f64)))
  (table 6 6 funcref)


### PR DESCRIPTION
Without this fix we can segfault, as it has no body.

Fixes #3879
