### PR TITLE
[NFC] Move InsertOrdered{Set,Map} into a new header

### DIFF
--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -37,6 +37,7 @@ http://doi.acm.org/10.1145/2048147.2048224
 #include <memory>
 #include <set>
 
+#include "support/insert_ordered.h"
 #include "wasm-builder.h"
 #include "wasm.h"
 
@@ -121,119 +122,6 @@ struct Branch {
   // Emits code for branch
   wasm::Expression*
   Render(RelooperBuilder& Builder, Block* Target, bool SetLabel);
-};
-
-// like std::set, except that begin() -> end() iterates in the
-// order that elements were added to the set (not in the order
-// of operator<(T, T))
-template<typename T> struct InsertOrderedSet {
-  std::map<T, typename std::list<T>::iterator> Map;
-  std::list<T> List;
-
-  typedef typename std::list<T>::iterator iterator;
-  iterator begin() { return List.begin(); }
-  iterator end() { return List.end(); }
-
-  void erase(const T& val) {
-    auto it = Map.find(val);
-    if (it != Map.end()) {
-      List.erase(it->second);
-      Map.erase(it);
-    }
-  }
-
-  void erase(iterator position) {
-    Map.erase(*position);
-    List.erase(position);
-  }
-
-  // cheating a bit, not returning the iterator
-  void insert(const T& val) {
-    auto it = Map.find(val);
-    if (it == Map.end()) {
-      List.push_back(val);
-      Map.insert(std::make_pair(val, --List.end()));
-    }
-  }
-
-  size_t size() const { return Map.size(); }
-  bool empty() const { return Map.empty(); }
-
-  void clear() {
-    Map.clear();
-    List.clear();
-  }
-
-  size_t count(const T& val) const { return Map.count(val); }
-
-  InsertOrderedSet() = default;
-  InsertOrderedSet(const InsertOrderedSet& other) { *this = other; }
-  InsertOrderedSet& operator=(const InsertOrderedSet& other) {
-    clear();
-    for (auto i : other.List) {
-      insert(i); // inserting manually creates proper iterators
-    }
-    return *this;
-  }
-};
-
-// like std::map, except that begin() -> end() iterates in the
-// order that elements were added to the map (not in the order
-// of operator<(Key, Key))
-template<typename Key, typename T> struct InsertOrderedMap {
-  std::map<Key, typename std::list<std::pair<Key, T>>::iterator> Map;
-  std::list<std::pair<Key, T>> List;
-
-  T& operator[](const Key& k) {
-    auto it = Map.find(k);
-    if (it == Map.end()) {
-      List.push_back(std::make_pair(k, T()));
-      auto e = --List.end();
-      Map.insert(std::make_pair(k, e));
-      return e->second;
-    }
-    return it->second->second;
-  }
-
-  typedef typename std::list<std::pair<Key, T>>::iterator iterator;
-  iterator begin() { return List.begin(); }
-  iterator end() { return List.end(); }
-
-  void erase(const Key& k) {
-    auto it = Map.find(k);
-    if (it != Map.end()) {
-      List.erase(it->second);
-      Map.erase(it);
-    }
-  }
-
-  void erase(iterator position) { erase(position->first); }
-
-  void clear() {
-    Map.clear();
-    List.clear();
-  }
-
-  void swap(InsertOrderedMap<Key, T>& Other) {
-    Map.swap(Other.Map);
-    List.swap(Other.List);
-  }
-
-  size_t size() const { return Map.size(); }
-  bool empty() const { return Map.empty(); }
-  size_t count(const Key& k) const { return Map.count(k); }
-
-  InsertOrderedMap() = default;
-  InsertOrderedMap(InsertOrderedMap& other) {
-    abort(); // TODO, watch out for iterators
-  }
-  InsertOrderedMap& operator=(const InsertOrderedMap& other) {
-    abort(); // TODO, watch out for iterators
-  }
-  bool operator==(const InsertOrderedMap& other) {
-    return Map == other.Map && List == other.List;
-  }
-  bool operator!=(const InsertOrderedMap& other) { return !(*this == other); }
 };
 
 typedef InsertOrderedSet<Block*> BlockSet;

--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// like std::set, except that begin() -> end() iterates in the
+// order that elements were added to the set (not in the order
+// of operator<(T, T))
+template<typename T> struct InsertOrderedSet {
+  std::map<T, typename std::list<T>::iterator> Map;
+  std::list<T> List;
+
+  typedef typename std::list<T>::iterator iterator;
+  iterator begin() { return List.begin(); }
+  iterator end() { return List.end(); }
+
+  void erase(const T& val) {
+    auto it = Map.find(val);
+    if (it != Map.end()) {
+      List.erase(it->second);
+      Map.erase(it);
+    }
+  }
+
+  void erase(iterator position) {
+    Map.erase(*position);
+    List.erase(position);
+  }
+
+  // cheating a bit, not returning the iterator
+  void insert(const T& val) {
+    auto it = Map.find(val);
+    if (it == Map.end()) {
+      List.push_back(val);
+      Map.insert(std::make_pair(val, --List.end()));
+    }
+  }
+
+  size_t size() const { return Map.size(); }
+  bool empty() const { return Map.empty(); }
+
+  void clear() {
+    Map.clear();
+    List.clear();
+  }
+
+  size_t count(const T& val) const { return Map.count(val); }
+
+  InsertOrderedSet() = default;
+  InsertOrderedSet(const InsertOrderedSet& other) { *this = other; }
+  InsertOrderedSet& operator=(const InsertOrderedSet& other) {
+    clear();
+    for (auto i : other.List) {
+      insert(i); // inserting manually creates proper iterators
+    }
+    return *this;
+  }
+};
+
+// like std::map, except that begin() -> end() iterates in the
+// order that elements were added to the map (not in the order
+// of operator<(Key, Key))
+template<typename Key, typename T> struct InsertOrderedMap {
+  std::map<Key, typename std::list<std::pair<Key, T>>::iterator> Map;
+  std::list<std::pair<Key, T>> List;
+
+  T& operator[](const Key& k) {
+    auto it = Map.find(k);
+    if (it == Map.end()) {
+      List.push_back(std::make_pair(k, T()));
+      auto e = --List.end();
+      Map.insert(std::make_pair(k, e));
+      return e->second;
+    }
+    return it->second->second;
+  }
+
+  typedef typename std::list<std::pair<Key, T>>::iterator iterator;
+  iterator begin() { return List.begin(); }
+  iterator end() { return List.end(); }
+
+  void erase(const Key& k) {
+    auto it = Map.find(k);
+    if (it != Map.end()) {
+      List.erase(it->second);
+      Map.erase(it);
+    }
+  }
+
+  void erase(iterator position) { erase(position->first); }
+
+  void clear() {
+    Map.clear();
+    List.clear();
+  }
+
+  void swap(InsertOrderedMap<Key, T>& Other) {
+    Map.swap(Other.Map);
+    List.swap(Other.List);
+  }
+
+  size_t size() const { return Map.size(); }
+  bool empty() const { return Map.empty(); }
+  size_t count(const Key& k) const { return Map.count(k); }
+
+  InsertOrderedMap() = default;
+  InsertOrderedMap(InsertOrderedMap& other) {
+    abort(); // TODO, watch out for iterators
+  }
+  InsertOrderedMap& operator=(const InsertOrderedMap& other) {
+    abort(); // TODO, watch out for iterators
+  }
+  bool operator==(const InsertOrderedMap& other) {
+    return Map == other.Map && List == other.List;
+  }
+  bool operator!=(const InsertOrderedMap& other) { return !(*this == other); }
+};

--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -15,6 +15,7 @@
  */
 
 #include <list>
+#include <stddef.h>
 #include <unordered_map>
 
 // like std::set, except that begin() -> end() iterates in the

--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -18,6 +18,8 @@
 #include <stddef.h>
 #include <unordered_map>
 
+#include "support/utilities.h"
+
 // like std::set, except that begin() -> end() iterates in the
 // order that elements were added to the set (not in the order
 // of operator<(T, T))
@@ -120,10 +122,12 @@ template<typename Key, typename T> struct InsertOrderedMap {
 
   InsertOrderedMap() = default;
   InsertOrderedMap(InsertOrderedMap& other) {
-    abort(); // TODO, watch out for iterators
+    // TODO, watch out for iterators.
+    WASM_UNREACHABLE("unimp");
   }
   InsertOrderedMap& operator=(const InsertOrderedMap& other) {
-    abort(); // TODO, watch out for iterators
+    // TODO, watch out for iterators.
+    WASM_UNREACHABLE("unimp");
   }
   bool operator==(const InsertOrderedMap& other) {
     return Map == other.Map && List == other.List;

--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+#include <list>
+#include <unordered_map>
+
 // like std::set, except that begin() -> end() iterates in the
 // order that elements were added to the set (not in the order
 // of operator<(T, T))
 template<typename T> struct InsertOrderedSet {
-  std::map<T, typename std::list<T>::iterator> Map;
+  std::unordered_map<T, typename std::list<T>::iterator> Map;
   std::list<T> List;
 
   typedef typename std::list<T>::iterator iterator;
@@ -72,7 +75,7 @@ template<typename T> struct InsertOrderedSet {
 // order that elements were added to the map (not in the order
 // of operator<(Key, Key))
 template<typename Key, typename T> struct InsertOrderedMap {
-  std::map<Key, typename std::list<std::pair<Key, T>>::iterator> Map;
+  std::unordered_map<Key, typename std::list<std::pair<Key, T>>::iterator> Map;
   std::list<std::pair<Key, T>> List;
 
   T& operator[](const Key& k) {


### PR DESCRIPTION
Move the `InsertOrderedSet` and `InsertOrderedMap` implementations out of
Relooper.h and into a new insert_ordered.h so they can be used more widely. Only
changes the implementation code to use unordered_maps.