### PR TITLE
[Wasm GC] Fix printing of unreachable Array operations

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1977,6 +1977,10 @@ struct PrintExpressionContents
     TypeNamePrinter(o, wasm).print(curr->rtt->type.getHeapType());
   }
   void visitArrayGet(ArrayGet* curr) {
+    if (curr->ref->type == Type::unreachable) {
+      printUnreachableReplacement();
+      return;
+    }
     const auto& element = curr->ref->type.getHeapType().getArray().element;
     if (element.type == Type::i32 && element.packedType != Field::not_packed) {
       if (curr->signed_) {
@@ -1990,6 +1994,10 @@ struct PrintExpressionContents
     TypeNamePrinter(o, wasm).print(curr->ref->type.getHeapType());
   }
   void visitArraySet(ArraySet* curr) {
+    if (curr->ref->type == Type::unreachable) {
+      printUnreachableReplacement();
+      return;
+    }
     printMedium(o, "array.set ");
     TypeNamePrinter(o, wasm).print(curr->ref->type.getHeapType());
   }
@@ -2370,6 +2378,20 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
     visitExpression(curr);
   }
   void visitStructGet(StructGet* curr) {
+    if (curr->ref->type == Type::unreachable) {
+      printUnreachableReplacement(curr);
+      return;
+    }
+    visitExpression(curr);
+  }
+  void visitArraySet(ArraySet* curr) {
+    if (curr->ref->type == Type::unreachable) {
+      printUnreachableReplacement(curr);
+      return;
+    }
+    visitExpression(curr);
+  }
+  void visitArrayGet(ArrayGet* curr) {
     if (curr->ref->type == Type::unreachable) {
       printUnreachableReplacement(curr);
       return;

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -272,4 +272,37 @@
   (func $unreachables-4
     (struct.set $struct.C 0 (unreachable) (f32.const 1))
   )
+  (func $unreachables-array-1
+    (array.get $vector
+      (unreachable)
+      (i32.const 2)
+    )
+  )
+  (func $unreachables-array-2
+    (array.get $vector
+      (ref.null $vector)
+      (unreachable)
+    )
+  )
+  (func $unreachables-array-3
+    (array.set $vector
+      (unreachable)
+      (i32.const 2)
+      (f64.const 2.18281828)
+    )
+  )
+  (func $unreachables-array-4
+    (array.set $vector
+      (ref.null $vector)
+      (unreachable)
+      (f64.const 2.18281828)
+    )
+  )
+  (func $unreachables-array-5
+    (array.set $vector
+      (ref.null $vector)
+      (i32.const 2)
+      (unreachable)
+    )
+  )
 )

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -1,10 +1,10 @@
 (module
  (type $struct.A (struct (field i32) (field f32) (field $named f64)))
- (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
  (type $none_=>_none (func))
+ (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
+ (type $vector (array (mut f64)))
  (type $grandchild (struct (field i32) (field i64)))
  (type $struct.C (struct (field $named-mut (mut f32))))
- (type $vector (array (mut f64)))
  (type $matrix (array (mut (ref null $vector))))
  (type $anyref_=>_none (func (param anyref)))
  (type $parent (struct ))
@@ -340,6 +340,49 @@
    (drop
     (f32.const 1)
    )
+  )
+ )
+ (func $unreachables-array-1
+  (block ;; (replaces something unreachable we can't emit)
+   (drop
+    (unreachable)
+   )
+   (drop
+    (i32.const 2)
+   )
+  )
+ )
+ (func $unreachables-array-2
+  (array.get $vector
+   (ref.null $vector)
+   (unreachable)
+  )
+ )
+ (func $unreachables-array-3
+  (block ;; (replaces something unreachable we can't emit)
+   (drop
+    (unreachable)
+   )
+   (drop
+    (i32.const 2)
+   )
+   (drop
+    (f64.const 2.18281828)
+   )
+  )
+ )
+ (func $unreachables-array-4
+  (array.set $vector
+   (ref.null $vector)
+   (unreachable)
+   (f64.const 2.18281828)
+  )
+ )
+ (func $unreachables-array-5
+  (array.set $vector
+   (ref.null $vector)
+   (i32.const 2)
+   (unreachable)
   )
  )
 )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -1,9 +1,9 @@
 (module
  (type $struct.A (struct (field i32) (field f32) (field $named f64)))
- (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
  (type $none_=>_none (func))
- (type $grandchild (struct (field i32) (field i64)))
+ (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
  (type $vector (array (mut f64)))
+ (type $grandchild (struct (field i32) (field i64)))
  (type $matrix (array (mut (ref null $vector))))
  (type $struct.C (struct (field $named-mut (mut f32))))
  (type $anyref_=>_none (func (param anyref)))
@@ -319,6 +319,33 @@
   (unreachable)
  )
  (func $unreachables-4
+  (unreachable)
+ )
+ (func $unreachables-array-1
+  (unreachable)
+ )
+ (func $unreachables-array-2
+  (drop
+   (ref.null $vector)
+  )
+  (unreachable)
+ )
+ (func $unreachables-array-3
+  (unreachable)
+ )
+ (func $unreachables-array-4
+  (drop
+   (ref.null $vector)
+  )
+  (unreachable)
+ )
+ (func $unreachables-array-5
+  (drop
+   (ref.null $vector)
+  )
+  (drop
+   (i32.const 2)
+  )
   (unreachable)
  )
 )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -1,9 +1,9 @@
 (module
  (type ${i32_f32_f64} (struct (field i32) (field f32) (field f64)))
- (type ${i8_mut:i16_ref|{i32_f32_f64}|_mut:ref|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref ${i32_f32_f64})) (field (mut (ref ${i32_f32_f64})))))
  (type $none_=>_none (func))
- (type ${i32_i64} (struct (field i32) (field i64)))
+ (type ${i8_mut:i16_ref|{i32_f32_f64}|_mut:ref|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref ${i32_f32_f64})) (field (mut (ref ${i32_f32_f64})))))
  (type $[mut:f64] (array (mut f64)))
+ (type ${i32_i64} (struct (field i32) (field i64)))
  (type $[mut:ref?|[mut:f64]|] (array (mut (ref null $[mut:f64]))))
  (type ${mut:f32} (struct (field (mut f32))))
  (type $anyref_=>_none (func (param anyref)))
@@ -319,6 +319,33 @@
   (unreachable)
  )
  (func $11
+  (unreachable)
+ )
+ (func $12
+  (unreachable)
+ )
+ (func $13
+  (drop
+   (ref.null $[mut:f64])
+  )
+  (unreachable)
+ )
+ (func $14
+  (unreachable)
+ )
+ (func $15
+  (drop
+   (ref.null $[mut:f64])
+  )
+  (unreachable)
+ )
+ (func $16
+  (drop
+   (ref.null $[mut:f64])
+  )
+  (drop
+   (i32.const 2)
+  )
   (unreachable)
  )
 )


### PR DESCRIPTION
Similar to struct operations, if the reference is unreachable then we do
not know the heap type, and cannot print the full expression.