### PR TITLE
[wasm-split] Add a --symbolmap option

### DIFF
--- a/src/tools/wasm-split.cpp
+++ b/src/tools/wasm-split.cpp
@@ -661,8 +661,8 @@ void splitModule(Module& wasm, const WasmSplitOptions& options) {
   adjustTableSize(*secondary, options.initialTableSize);
 
   if (options.symbolMap) {
-    writeSymbolMap(wasm, options.primaryOutput + ".symbolmap");
-    writeSymbolMap(*secondary, options.secondaryOutput + ".symbolmap");
+    writeSymbolMap(wasm, options.primaryOutput + ".symbols");
+    writeSymbolMap(*secondary, options.secondaryOutput + ".symbols");
   }
 
   // Write the output modules

--- a/src/tools/wasm-split.cpp
+++ b/src/tools/wasm-split.cpp
@@ -20,6 +20,7 @@
 #include "ir/module-splitting.h"
 #include "ir/module-utils.h"
 #include "ir/names.h"
+#include "pass.h"
 #include "support/file.h"
 #include "support/name.h"
 #include "support/utilities.h"

--- a/test/lit/wasm-split/invalid-options.wast
+++ b/test/lit/wasm-split/invalid-options.wast
@@ -13,6 +13,10 @@
 ;; RUN: not wasm-split %s --instrument -o2 %t 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-OUT2
 
+;; --instrument cannot be used with --symbolmap
+;; RUN: not wasm-split %s --instrument --symbolmap 2>&1 \
+;; RUN:   | filecheck %s --check-prefix INSTRUMENT-SYMBOLMAP
+
 ;; --instrument cannot be used with --import-namespace
 ;; RUN: not wasm-split %s --instrument --import-namespace=foo 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-IMPORT-NS
@@ -46,6 +50,8 @@
 ;; INSTRUMENT-OUT1: error: primary output cannot be used with --instrument
 
 ;; INSTRUMENT-OUT2: error: secondary output cannot be used with --instrument
+
+;; INSTRUMENT-SYMBOLMAP: error: --symbolmap cannot be used with --instrument
 
 ;; INSTRUMENT-IMPORT-NS: error: --import-namespace cannot be used with --instrument
 

--- a/test/lit/wasm-split/symbolmap.wast
+++ b/test/lit/wasm-split/symbolmap.wast
@@ -1,11 +1,15 @@
 ;; RUN: wasm-split %s --keep-funcs=bar -o1 %t.1.wasm -o2 %t.2.wasm --symbolmap
-;; RUN: filecheck %s --check-prefix PRIMARY < %t.1.wasm.symbolmap
-;; RUN: filecheck %s --check-prefix SECONDARY < %t.2.wasm.symbolmap
+;; RUN: filecheck %s --check-prefix PRIMARY-MAP < %t.1.wasm.symbolmap
+;; RUN: filecheck %s --check-prefix SECONDARY-MAP < %t.2.wasm.symbolmap
+;; RUN: wasm-dis %t.1.wasm | filecheck %s --check-prefix PRIMARY
 
-;; PRIMARY: 0:bar
+;; PRIMARY-MAP: 0:bar
 
-;; SECONDARY: 0:baz
-;; SECONDARY: 1:foo
+;; SECONDARY-MAP: 0:baz
+;; SECONDARY-MAP: 1:foo
+
+;; Check that the names have been stripped.
+;; PRIMARY: (func $0
 
 (module
   (func $foo

--- a/test/lit/wasm-split/symbolmap.wast
+++ b/test/lit/wasm-split/symbolmap.wast
@@ -1,6 +1,6 @@
 ;; RUN: wasm-split %s --keep-funcs=bar -o1 %t.1.wasm -o2 %t.2.wasm --symbolmap
-;; RUN: filecheck %s --check-prefix PRIMARY-MAP < %t.1.wasm.symbolmap
-;; RUN: filecheck %s --check-prefix SECONDARY-MAP < %t.2.wasm.symbolmap
+;; RUN: filecheck %s --check-prefix PRIMARY-MAP < %t.1.wasm.symbols
+;; RUN: filecheck %s --check-prefix SECONDARY-MAP < %t.2.wasm.symbols
 ;; RUN: wasm-dis %t.1.wasm | filecheck %s --check-prefix PRIMARY
 
 ;; PRIMARY-MAP: 0:bar

--- a/test/lit/wasm-split/symbolmap.wast
+++ b/test/lit/wasm-split/symbolmap.wast
@@ -1,0 +1,20 @@
+;; RUN: wasm-split %s --keep-funcs=bar -o1 %t.1.wasm -o2 %t.2.wasm --symbolmap
+;; RUN: filecheck %s --check-prefix PRIMARY < %t.1.wasm.symbolmap
+;; RUN: filecheck %s --check-prefix SECONDARY < %t.2.wasm.symbolmap
+
+;; PRIMARY: 0:bar
+
+;; SECONDARY: 0:baz
+;; SECONDARY: 1:foo
+
+(module
+  (func $foo
+    (nop)
+  )
+  (func $bar
+    (nop)
+  )
+  (func $baz
+    (nop)
+  )
+)


### PR DESCRIPTION
The new option emits a symbol map file for each of the split modules. The file
names are created by appending ".symbolmap" to each of the Wasm output file
names.