### PR TITLE
[EH] Change Walker::TaskFunc back to function pointer

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -311,10 +311,6 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     self->catchIndexStack.push_back(0);
   }
 
-  static void incrementCatchIndex(SubType* self, Expression** currp) {
-    self->catchIndexStack.back()++;
-  }
-
   static void doStartCatch(SubType* self, Expression** currp) {
     // Get the block that starts this catch
     self->currBasicBlock =
@@ -325,6 +321,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     // We are done with this catch; set the block that ends it
     self->processCatchStack.back()[self->catchIndexStack.back()] =
       self->currBasicBlock;
+    self->catchIndexStack.back()++;
   }
 
   static void doEndTry(SubType* self, Expression** currp) {
@@ -394,7 +391,6 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
         self->pushTask(SubType::doEndTry, currp);
         auto& catchBodies = curr->cast<Try>()->catchBodies;
         for (Index i = 0; i < catchBodies.size(); i++) {
-          self->pushTask(incrementCatchIndex, currp);
           self->pushTask(doEndCatch, currp);
           self->pushTask(SubType::scan, &catchBodies[i]);
           self->pushTask(doStartCatch, currp);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -282,7 +282,7 @@ struct Walker : public VisitorType {
   // nested.
 
   // Tasks receive the this pointer and a pointer to the pointer to operate on
-  using TaskFunc = std::function<void(SubType*, Expression**)>;
+  typedef void (*TaskFunc)(SubType*, Expression**);
 
   struct Task {
     TaskFunc func;

--- a/test/passes/rse_all-features.txt
+++ b/test/passes/rse_all-features.txt
@@ -4,6 +4,7 @@
  (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_f64_=>_none (func (param i32 f64)))
  (event $e (attr 0) (param i32))
+ (event $e2 (attr 0) (param))
  (func $basic (param $x i32) (param $y f64)
   (local $a f32)
   (local $b i64)
@@ -642,6 +643,86 @@
    )
   )
   (local.set $x
+   (i32.const 1)
+  )
+ )
+ (func $nested-catch1
+  (local $x i32)
+  (try $try
+   (do
+    (throw $e
+     (i32.const 0)
+    )
+   )
+   (catch $e
+    (drop
+     (pop i32)
+    )
+   )
+   (catch $e2
+    (try $try6
+     (do
+      (throw $e
+       (i32.const 0)
+      )
+     )
+     (catch $e
+      (drop
+       (pop i32)
+      )
+     )
+     (catch $e2
+      (local.set $x
+       (i32.const 1)
+      )
+     )
+    )
+   )
+  )
+  (local.set $x
+   (i32.const 1)
+  )
+ )
+ (func $nested-catch2
+  (local $x i32)
+  (try $try
+   (do
+    (throw $e
+     (i32.const 0)
+    )
+   )
+   (catch $e
+    (drop
+     (pop i32)
+    )
+    (local.set $x
+     (i32.const 1)
+    )
+   )
+   (catch_all
+    (try $try7
+     (do
+      (throw $e
+       (i32.const 0)
+      )
+     )
+     (catch $e
+      (drop
+       (pop i32)
+      )
+      (local.set $x
+       (i32.const 1)
+      )
+     )
+     (catch_all
+      (local.set $x
+       (i32.const 1)
+      )
+     )
+    )
+   )
+  )
+  (drop
    (i32.const 1)
   )
  )

--- a/test/passes/rse_all-features.wast
+++ b/test/passes/rse_all-features.wast
@@ -441,7 +441,8 @@
       )
     )
     ;; This should NOT be dropped because the exception might not be caught by
-    ;; the inner catches, and the local.set may not run.
+    ;; the inner catches, and the local.set above us may not have run, and
+    ;; other possible code paths do not even set the local.
     (local.set $x (i32.const 1))
   )
   (func $nested-catch2

--- a/test/passes/rse_all-features.wast
+++ b/test/passes/rse_all-features.wast
@@ -288,6 +288,7 @@
   )
 
   (event $e (attr 0) (param i32))
+  (event $e2 (attr 0))
   (func $try1
     (local $x i32)
     (try
@@ -414,6 +415,62 @@
     )
     ;; Unlike nested-try2, the exception may not be caught by the inner catch,
     ;; so the local.set may not run. So this should NOT be dropped.
+    (local.set $x (i32.const 1))
+  )
+  (func $nested-catch1
+    (local $x i32)
+    (try
+      (do
+        (throw $e (i32.const 0))
+      )
+      (catch $e
+        (drop (pop i32))
+      )
+      (catch $e2
+        (try
+          (do
+            (throw $e (i32.const 0))
+          )
+          (catch $e
+            (drop (pop i32))
+          )
+          (catch $e2
+            (local.set $x (i32.const 1))
+          )
+        )
+      )
+    )
+    ;; This should NOT be dropped because the exception might not be caught by
+    ;; the inner catches, and the local.set may not run.
+    (local.set $x (i32.const 1))
+  )
+  (func $nested-catch2
+    (local $x i32)
+    (try
+      (do
+        (throw $e (i32.const 0))
+      )
+      (catch $e
+        (drop (pop i32))
+        (local.set $x (i32.const 1))
+      )
+      (catch_all
+        (try
+          (do
+            (throw $e (i32.const 0))
+          )
+          (catch $e
+            (drop (pop i32))
+            (local.set $x (i32.const 1))
+          )
+          (catch_all
+            (local.set $x (i32.const 1))
+          )
+        )
+      )
+    )
+    ;; This should be dropped because the exception is guaranteed to be caught
+    ;; by one of the catches and it will set the local to 1.
     (local.set $x (i32.const 1))
   )
 )


### PR DESCRIPTION
[`Walker::TaskFunc`](https://github.com/WebAssembly/binaryen/blob/35f9da76d53401ba4de054f4db631ce4177b32f1/src/wasm-traversal.h#L285) has changed from a function pointer to
`std::function` in #3494, mainly to make the EH support for `CFGWalker`
easier. We didn't notice much performance difference then, but it was
recently reported that it creased binaryen.js code size and performance.
This changes `Walker::TaskFunc` back to a function pointer and does a
little more work to manage catch index in `CFGWalker` side.

Hopefully fixes #3857.

cc @MaxGraey