### PR TITLE
Emit imported functions first in symbol maps

### DIFF
--- a/src/passes/PrintFunctionMap.cpp
+++ b/src/passes/PrintFunctionMap.cpp
@@ -24,6 +24,7 @@
 // 2:baz
 //
 
+#include "ir/module-utils.h"
 #include "pass.h"
 #include "support/file.h"
 #include "wasm.h"
@@ -40,9 +41,11 @@ struct PrintFunctionMap : public Pass {
     Output output(outFile, Flags::Text);
     auto& o = output.getStream();
     Index i = 0;
-    for (auto& func : module->functions) {
+    auto write = [&](Function* func) {
       o << i++ << ':' << func->name.str << '\n';
-    }
+    };
+    ModuleUtils::iterImportedFunctions(*module, write);
+    ModuleUtils::iterDefinedFunctions(*module, write);
   }
 };
 

--- a/test/lit/wasm-split/symbolmap.wast
+++ b/test/lit/wasm-split/symbolmap.wast
@@ -3,7 +3,9 @@
 ;; RUN: filecheck %s --check-prefix SECONDARY-MAP < %t.2.wasm.symbols
 ;; RUN: wasm-dis %t.1.wasm | filecheck %s --check-prefix PRIMARY
 
-;; PRIMARY-MAP: 0:bar
+;; PRIMARY-MAP: 0:placeholder_0
+;; PRIMARY-MAP: 1:placeholder_2
+;; PRIMARY-MAP: 2:bar
 
 ;; SECONDARY-MAP: 0:baz
 ;; SECONDARY-MAP: 1:foo
@@ -12,6 +14,8 @@
 ;; PRIMARY: (func $0
 
 (module
+  (table $table 3 3 funcref)
+  (elem $table (i32.const 0) $foo $bar $baz)
   (func $foo
     (nop)
   )


### PR DESCRIPTION
Imported functions come first when modules are emitted, so to ensure the
function indices are correct, they need to come first in the symbol maps. We
never noticed this bug before because imported functions are always the first
functions when a module is parsed, so the bug never mattered in practice.
However, wasm-split adds new imported functions after parsing and these were
causing the symbol map indices to be incorrect.