### PR TITLE
[wasm-split] Add an option to emit only the module names

### DIFF
--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -34,20 +34,33 @@ char getPathSeparator() {
 #endif
 }
 
+static std::string getAllPathSeparators() {
+  // The canonical separator on Windows is `\`, but it also accepts `/`.
+#if defined(WIN32) || defined(_WIN32)
+  return "\\/";
+#else
+  return "/";
+#endif
+}
+
 std::string getDirName(const std::string& path) {
-  auto sep = path.rfind(getPathSeparator());
-  if (sep == std::string::npos) {
-    return "";
+  for (char c : getAllPathSeparators()) {
+    auto sep = path.rfind(c);
+    if (sep != std::string::npos) {
+      return path.substr(0, sep);
+    }
   }
-  return path.substr(0, sep);
+  return "";
 }
 
 std::string getBaseName(const std::string& path) {
-  auto sep = path.rfind(getPathSeparator());
-  if (sep == std::string::npos) {
-    return path;
+  for (char c : getAllPathSeparators()) {
+    auto sep = path.rfind(c);
+    if (sep != std::string::npos) {
+      return path.substr(sep + 1);
+    }
   }
-  return path.substr(sep + 1);
+  return path;
 }
 
 std::string getBinaryenRoot() {

--- a/src/tools/wasm-split.cpp
+++ b/src/tools/wasm-split.cpp
@@ -23,6 +23,7 @@
 #include "pass.h"
 #include "support/file.h"
 #include "support/name.h"
+#include "support/path.h"
 #include "support/utilities.h"
 #include "tool-options.h"
 #include "wasm-builder.h"
@@ -52,6 +53,8 @@ struct WasmSplitOptions : ToolOptions {
   bool symbolMap = false;
 
   bool instrument = false;
+
+  bool emitModuleNames = false;
 
   std::string profileFile;
   std::string profileExport = DEFAULT_PROFILE_EXPORT;
@@ -192,6 +195,13 @@ WasmSplitOptions::WasmSplitOptions()
          [&](Options* o, const std::string& arguments) {
            passOptions.debugInfo = true;
          })
+    .add(
+      "--emit-module-names",
+      "",
+      "Emit module names, even if not emitting the rest of the names section. "
+      "Can help differentiate the modules in stack traces.",
+      Options::Arguments::Zero,
+      [&](Options* o, const std::string& arguments) { emitModuleNames = true; })
     .add("--initial-table",
          "",
          "A hack to ensure the split and instrumented modules have the same "
@@ -500,6 +510,18 @@ void adjustTableSize(Module& wasm, int initialSize) {
   table->initial = initialSize;
 }
 
+void writeModule(Module& wasm,
+                 std::string filename,
+                 const WasmSplitOptions& options) {
+  ModuleWriter writer;
+  writer.setBinary(options.emitBinary);
+  writer.setDebugInfo(options.passOptions.debugInfo);
+  if (options.emitModuleNames) {
+    writer.setEmitModuleName(true);
+  }
+  writer.write(wasm, filename);
+}
+
 void instrumentModule(Module& wasm, const WasmSplitOptions& options) {
   // Check that the profile export name is not already taken
   if (wasm.getExportOrNull(options.profileExport) != nullptr) {
@@ -513,10 +535,7 @@ void instrumentModule(Module& wasm, const WasmSplitOptions& options) {
   adjustTableSize(wasm, options.initialTableSize);
 
   // Write the output modules
-  ModuleWriter writer;
-  writer.setBinary(options.emitBinary);
-  writer.setDebugInfo(options.passOptions.debugInfo);
-  writer.write(wasm, options.output);
+  writeModule(wasm, options.output, options);
 }
 
 // See "wasm-split profile format" above for more information.
@@ -665,12 +684,18 @@ void splitModule(Module& wasm, const WasmSplitOptions& options) {
     writeSymbolMap(*secondary, options.secondaryOutput + ".symbols");
   }
 
-  // Write the output modules
-  ModuleWriter writer;
-  writer.setBinary(options.emitBinary);
-  writer.setDebugInfo(options.passOptions.debugInfo);
-  writer.write(wasm, options.primaryOutput);
-  writer.write(*secondary, options.secondaryOutput);
+  // Set the names of the split modules. This can help differentiate them in
+  // stack traces.
+  if (options.emitModuleNames) {
+    if (!wasm.name) {
+      wasm.name = Path::getBaseName(options.primaryOutput);
+    }
+    secondary->name = Path::getBaseName(options.secondaryOutput);
+  }
+
+  // write the output modules
+  writeModule(wasm, options.primaryOutput, options);
+  writeModule(*secondary, options.secondaryOutput, options);
 }
 
 } // anonymous namespace

--- a/src/tools/wasm-split.cpp
+++ b/src/tools/wasm-split.cpp
@@ -54,6 +54,7 @@ struct WasmSplitOptions : ToolOptions {
 
   bool instrument = false;
 
+  // TODO: Remove this. See the comment in wasm-binary.h.
   bool emitModuleNames = false;
 
   std::string profileFile;
@@ -199,7 +200,9 @@ WasmSplitOptions::WasmSplitOptions()
       "--emit-module-names",
       "",
       "Emit module names, even if not emitting the rest of the names section. "
-      "Can help differentiate the modules in stack traces.",
+      "Can help differentiate the modules in stack traces. This option will be "
+      "removed once simpler ways of naming modules are widely available. See "
+      "https://bugs.chromium.org/p/v8/issues/detail?id=11808.",
       Options::Arguments::Zero,
       [&](Options* o, const std::string& arguments) { emitModuleNames = true; })
     .add("--initial-table",

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1269,6 +1269,11 @@ private:
   std::vector<HeapType> types;
 
   bool debugInfo = true;
+
+  // TODO: Remove `emitModuleName` in the future once there are better ways to
+  // ensure modules have meaningful names in stack traces.For example, using
+  // ObjectURLs works in FireFox, but not Chrome. See
+  // https://bugs.chromium.org/p/v8/issues/detail?id=11808.
   bool emitModuleName = true;
 
   std::ostream* sourceMap = nullptr;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1170,7 +1170,11 @@ public:
     std::vector<Entry> functionBodies;
   } tableOfContents;
 
-  void setNamesSection(bool set) { debugInfo = set; }
+  void setNamesSection(bool set) {
+    debugInfo = set;
+    emitModuleName = set;
+  }
+  void setEmitModuleName(bool set) { emitModuleName = set; }
   void setSourceMap(std::ostream* set, std::string url) {
     sourceMap = set;
     sourceMapUrl = url;
@@ -1265,6 +1269,8 @@ private:
   std::vector<HeapType> types;
 
   bool debugInfo = true;
+  bool emitModuleName = true;
+
   std::ostream* sourceMap = nullptr;
   std::string sourceMapUrl;
   std::string symbolMap;

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -82,7 +82,10 @@ private:
 
 class ModuleWriter : public ModuleIOBase {
   bool binary = true;
+
+  // TODO: Remove `emitModuleName`. See the comment in wasm-binary.h
   bool emitModuleName = false;
+
   std::string symbolMap;
   std::string sourceMapFilename;
   std::string sourceMapUrl;

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -29,7 +29,7 @@ namespace wasm {
 
 class ModuleIOBase {
 protected:
-  bool debugInfo = true;
+  bool debugInfo;
 
 public:
   // Whether we support debug info (the names section).

--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -29,7 +29,7 @@ namespace wasm {
 
 class ModuleIOBase {
 protected:
-  bool debugInfo;
+  bool debugInfo = true;
 
 public:
   // Whether we support debug info (the names section).
@@ -82,6 +82,7 @@ private:
 
 class ModuleWriter : public ModuleIOBase {
   bool binary = true;
+  bool emitModuleName = false;
   std::string symbolMap;
   std::string sourceMapFilename;
   std::string sourceMapUrl;
@@ -99,6 +100,7 @@ public:
   void setSourceMapUrl(std::string sourceMapUrl_) {
     sourceMapUrl = sourceMapUrl_;
   }
+  void setEmitModuleName(bool set) { emitModuleName = set; }
 
   // write text
   void writeText(Module& wasm, Output& output);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -60,7 +60,7 @@ void WasmBinaryWriter::write() {
   writeDataCount();
   writeFunctions();
   writeDataSegments();
-  if (debugInfo) {
+  if (debugInfo || emitModuleName) {
     writeNames();
   }
   if (sourceMap && !sourceMapUrl.empty()) {
@@ -661,11 +661,17 @@ void WasmBinaryWriter::writeNames() {
   writeInlineString(BinaryConsts::UserSections::Name);
 
   // module name
-  if (wasm->name.is()) {
+  if (emitModuleName && wasm->name.is()) {
     auto substart =
       startSubsection(BinaryConsts::UserSections::Subsection::NameModule);
     writeEscapedName(wasm->name.str);
     finishSubsection(substart);
+  }
+
+  if (!debugInfo) {
+    // We were only writing the module name.
+    finishSection(start);
+    return;
   }
 
   // function names

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -137,6 +137,9 @@ void ModuleWriter::writeBinary(Module& wasm, Output& output) {
   WasmBinaryWriter writer(&wasm, buffer);
   // if debug info is used, then we want to emit the names section
   writer.setNamesSection(debugInfo);
+  if (emitModuleName) {
+    writer.setEmitModuleName(true);
+  }
   std::unique_ptr<std::ofstream> sourceMapStream;
   if (sourceMapFilename.size()) {
     sourceMapStream = make_unique<std::ofstream>();

--- a/test/lit/wasm-split/module-names.wast
+++ b/test/lit/wasm-split/module-names.wast
@@ -1,0 +1,24 @@
+;; Check that --emit-module-names without -g strips function names but generates
+;; and keeps the module names.
+
+;; RUN: wasm-split %s --keep-funcs=foo -o1 %t.primary.wasm -o2 %t.secondary.wasm --emit-module-names
+
+;; RUN: wasm-dis %t.primary.wasm -o - | filecheck %s --check-prefix=PRIMARY
+;; RUN: wasm-dis %t.secondary.wasm -o - | filecheck %s --check-prefix=SECONDARY
+
+;; PRIMARY: (module $module-names.wast.tmp.primary.wasm
+;; PRIMARY:   (func $0
+;; PRIMARY-NOT: $foo
+
+;; SECONDARY: (module $module-names.wast.tmp.secondary.wasm
+;; SECONDARY:   (func $0
+;; SECONDARY-NOT: $bar
+
+(module
+  (func $foo
+    (nop)
+  )
+  (func $bar
+    (nop)
+  )
+)


### PR DESCRIPTION
Even when other names are stripped, it can be useful for wasm-split to preserve
the module name so that the split modules can be differentiated in stack traces.
Adding this option to wasm-split requires adding similar options to ModuleWriter
and WasmBinaryWriter.