### PR TITLE
[Wasm GC] Implement CFGWalker support for BrOn*

### DIFF
--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -3,6 +3,9 @@
 ;; RUN:   | filecheck %s
 
 (module
+ (type $array (array (mut i8)))
+ (global $global (ref null $array) (ref.null $array))
+
  ;; CHECK:      (func $test-dead-get-non-nullable (param $0 dataref)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (drop
@@ -16,6 +19,42 @@
    ;; function). Normally we replace such gets with nops as best we can, but in
    ;; this case the type is non-nullable, so we must leave it alone.
    (local.get $func)
+  )
+ )
+
+ ;; CHECK:      (func $br_on_null (param $0 (ref null $array)) (result (ref null $array))
+ ;; CHECK-NEXT:  (block $label$1 (result (ref null $array))
+ ;; CHECK-NEXT:   (block $label$2
+ ;; CHECK-NEXT:    (br $label$1
+ ;; CHECK-NEXT:     (br_on_null $label$2
+ ;; CHECK-NEXT:      (local.get $0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $0
+ ;; CHECK-NEXT:    (global.get $global)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $br_on_null (param $ref (ref null $array)) (result (ref null $array))
+  (local $1 (ref null $array))
+  (block $label$1 (result (ref null $array))
+   (block $label$2
+    (br $label$1
+     ;; Test that we properly model the basic block connections around a
+     ;; BrOnNull. There should be a branch to $label$2, and also a fallthrough.
+     ;; As a result, the local.set below is reachable, and should not be
+     ;; eliminated (turned into a drop).
+     (br_on_null $label$2
+      (local.get $ref)
+     )
+    )
+   )
+   (local.set $1
+    (global.get $global)
+   )
+   (local.get $1)
   )
  )
 )


### PR DESCRIPTION
Without adding logic there, it simply ignored the branch, which could
lead to bad optimizations (thinking code is unreachable when it was).

There isn't a trivial way to add a static error to force us to add new
classes to CFGWalker. But this PR generalizes the code there to
handle all branches and all unreachable instructions in a generic
way. The only thing we'll need to remember to do in the future is to
add control flow structures. (And normally the fuzzer should quickly
find such bugs, but we don't have full fuzzing enabled for GC yet.)

Fixes #3907