### PR TITLE
Properly handle comparisons of 64-bit ints in wasm2c in the fuzzer.

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -293,8 +293,8 @@ def numbers_are_close_enough(x, y):
         def to_64_bit(a):
             if ' ' not in a:
                 return unsign(int(a), bits=64)
-            low, high = map(lambda x: unsign(int(x), bits=32), a.split(' '))
-            return low + (1 << 32) * high
+            low, high = a.split(' ')
+            return unsign(int(low), 32) + (1 << 32) * unsign(int(high), 32)
 
         return to_64_bit(x) == to_64_bit(y)
     # float() on the strings will handle many minor differences, like

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -294,7 +294,7 @@ def numbers_are_close_enough(x, y):
             if ' ' not in a:
                 return unsign(int(a), bits=64)
             low, high = map(lambda x: unsign(int(x), bits=32), a.split(' '))
-            return low + (2**32) * high
+            return low + (1 << 32) * high
 
         return to_64_bit(x) == to_64_bit(y)
     # float() on the strings will handle many minor differences, like

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -277,7 +277,7 @@ def compare(x, y, context):
 
 # converts a possibly-signed integer to an unsigned integer
 def unsign(x, bits):
-    return x & (2**bits - 1)
+    return x & ((1 << bits) - 1)
 
 
 # numbers are "close enough" if they just differ in printing, as different

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -277,7 +277,7 @@ def compare(x, y, context):
 
 # converts a possibly-signed integer to an unsigned integer
 def unsign(x, bits):
-  return x & (2**bits - 1)
+    return x & (2**bits - 1)
 
 
 # numbers are "close enough" if they just differ in printing, as different


### PR DESCRIPTION
The support code there emits "`low high`" as the result, for example, `25 0` would
be `25` (as the high bits are all 0). This is different than how numbers are reported
in other things we fuzz, so this caused an error.

Fixes #3915