### PR TITLE
Fix 'example' tests in check.py

### DIFF
--- a/check.py
+++ b/check.py
@@ -277,16 +277,16 @@ def run_validator_tests():
     support.run_command(cmd, expected_status=1)
 
 
-def run_gcc_tests():
-    print('\n[ checking native gcc testcases...]\n')
+def run_example_tests():
+    print('\n[ checking native example testcases...]\n')
     if not shared.NATIVECC or not shared.NATIVEXX:
         shared.fail_with_error('Native compiler (e.g. gcc/g++) was not found in PATH!')
         return
     # windows + gcc will need some work
-    if shared.skip_if_on_windows('gcc'):
+    if shared.skip_if_on_windows('example'):
         return
 
-    for t in sorted(os.listdir(shared.get_test_dir('example'))):
+    for t in shared.get_tests(shared.get_test_dir('example')):
         output_file = 'example'
         cmd = ['-I' + os.path.join(shared.options.binaryen_root, 't'), '-g', '-pthread', '-o', output_file]
         if not t.endswith(('.c', '.cpp')):
@@ -358,7 +358,7 @@ TEST_SUITES = OrderedDict([
     ('lld', lld.test_wasm_emscripten_finalize),
     ('wasm2js', wasm2js.test_wasm2js),
     ('validator', run_validator_tests),
-    ('gcc', run_gcc_tests),
+    ('example', run_example_tests),
     ('unit', run_unittest),
     ('binaryenjs', binaryenjs.test_binaryen_js),
     ('binaryenjs_wasm', binaryenjs.test_binaryen_wasm),


### PR DESCRIPTION
Rename the test suite from 'gcc' to 'example' to match the name in
auto_update_tests.py. Also retrieve the tests to run using `shared.get_tests`,
which properly applies the --filter argument, again to match
auto_update_tests.py.