### PR TITLE
[EH] Allow catch/delegate-less trys

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6077,12 +6077,6 @@ void WasmBinaryBuilder::visitTryOrTryInBlock(Expression*& out) {
     return;
   }
 
-  if (lastSeparator != BinaryConsts::Catch &&
-      lastSeparator != BinaryConsts::CatchAll &&
-      lastSeparator != BinaryConsts::Delegate) {
-    throwError("try scope should contain only catch/catch_all/delegate");
-  }
-
   Builder builder(wasm);
   // A nameless label shared by all catch body blocks
   Name catchLabel = getNextLabel();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6069,10 +6069,18 @@ void WasmBinaryBuilder::visitTryOrTryInBlock(Expression*& out) {
   // blocks instead.
   curr->type = getType();
   curr->body = getBlockOrSingleton(curr->type);
+
+  // try without catch or delegate
+  if (lastSeparator == BinaryConsts::End) {
+    curr->finalize();
+    out = curr;
+    return;
+  }
+
   if (lastSeparator != BinaryConsts::Catch &&
       lastSeparator != BinaryConsts::CatchAll &&
       lastSeparator != BinaryConsts::Delegate) {
-    throwError("No catch instruction within a try scope");
+    throwError("try scope should contain only catch/catch_all/delegate");
   }
 
   Builder builder(wasm);
@@ -6189,7 +6197,7 @@ void WasmBinaryBuilder::visitTryOrTryInBlock(Expression*& out) {
   //     (catch $e
   //       (block   ;; Now this can be deleted when writing binary
   //         ...
-  //         (br $label0)
+  //         (br $label)
   //       )
   //     )
   //   )

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2470,9 +2470,6 @@ Expression* SExpressionWasmBuilder::makeTry(Element& s) {
     throw ParseException(
       "there should be at most one catch_all block at the end", s.line, s.col);
   }
-  if (ret->catchBodies.empty() && !ret->isDelegate()) {
-    throw ParseException("no catch bodies or delegate", s.line, s.col);
-  }
 
   ret->finalize(type);
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2078,9 +2078,6 @@ void FunctionValidator::visitTry(Try* curr) {
   shouldBeFalse(curr->isCatch() && curr->isDelegate(),
                 curr,
                 "try cannot have both catch and delegate at the same time");
-  shouldBeTrue(curr->isCatch() || curr->isDelegate(),
-               curr,
-               "try should have either catches or a delegate");
 
   if (curr->isDelegate()) {
     noteDelegate(curr->delegateTarget, curr);

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -131,6 +131,13 @@
         )
       )
     )
+
+    ;; try without catch or delegate
+    (try
+      (do
+        (throw $e-i32 (i32.const 0))
+      )
+    )
   )
 
   (func $delegate-test

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -170,6 +170,13 @@
     )
    )
   )
+  (try $try10
+   (do
+    (throw $e-i32
+     (i32.const 0)
+    )
+   )
+  )
  )
  (func $delegate-test
   (try $l0
@@ -180,7 +187,7 @@
      )
      (delegate $l0)
     )
-    (try $try10
+    (try $try11
      (do
       (call $foo)
      )
@@ -191,24 +198,24 @@
     (nop)
    )
   )
-  (block $l014
-   (try $l011
+  (block $l015
+   (try $l012
     (do
-     (try $try12
-      (do
-       (br_if $l014
-        (i32.const 1)
-       )
-      )
-      (delegate $l011)
-     )
      (try $try13
       (do
-       (br_if $l014
+       (br_if $l015
         (i32.const 1)
        )
       )
-      (delegate $l011)
+      (delegate $l012)
+     )
+     (try $try14
+      (do
+       (br_if $l015
+        (i32.const 1)
+       )
+      )
+      (delegate $l012)
      )
     )
     (catch_all
@@ -216,18 +223,18 @@
     )
    )
   )
-  (try $l015
+  (try $l016
    (do
-    (try $try16
+    (try $try17
      (do
       (call $foo)
      )
-     (delegate $l015)
+     (delegate $l016)
     )
    )
    (delegate 0)
   )
-  (try $try17
+  (try $try18
    (do
     (nop)
    )
@@ -251,8 +258,8 @@
     (rethrow $l0)
    )
   )
-  (block $l019
-   (try $l018
+  (block $l020
+   (try $l019
     (do
      (call $foo)
     )
@@ -260,14 +267,14 @@
      (drop
       (pop i32)
      )
-     (rethrow $l018)
+     (rethrow $l019)
     )
     (catch_all
-     (br $l019)
+     (br $l020)
     )
    )
   )
-  (try $l020
+  (try $l021
    (do
     (call $foo)
    )
@@ -280,20 +287,20 @@
       (drop
        (pop i32)
       )
-      (rethrow $l020)
+      (rethrow $l021)
      )
      (catch_all
-      (rethrow $l020)
+      (rethrow $l021)
      )
     )
    )
   )
-  (try $l021
+  (try $l022
    (do
     (call $foo)
    )
    (catch_all
-    (try $try22
+    (try $try23
      (do
       (call $foo)
      )
@@ -302,25 +309,25 @@
        (pop i32)
       )
       (block $b0
-       (rethrow $l021)
+       (rethrow $l022)
       )
      )
      (catch_all
       (block $b1
-       (rethrow $l021)
+       (rethrow $l022)
       )
      )
     )
    )
   )
-  (try $l023
+  (try $l024
    (do
     (call $foo)
    )
    (catch_all
-    (try $try24
+    (try $try25
      (do
-      (rethrow $l023)
+      (rethrow $l024)
      )
      (catch_all
       (nop)
@@ -328,14 +335,14 @@
     )
    )
   )
-  (try $l025
+  (try $l026
    (do
     (call $foo)
    )
    (catch_all
-    (try $try26
+    (try $try27
      (do
-      (rethrow $l025)
+      (rethrow $l026)
      )
      (catch_all
       (nop)

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -195,6 +195,13 @@
     )
    )
   )
+  (try
+   (do
+    (throw $event$0
+     (i32.const 0)
+    )
+   )
+  )
  )
  (func $delegate-test
   (try $label$9

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -195,6 +195,13 @@
     )
    )
   )
+  (try
+   (do
+    (throw $event$0
+     (i32.const 0)
+    )
+   )
+  )
  )
  (func $3
   (try $label$9


### PR DESCRIPTION
This removes the restriction that `try` should have at least one
`catch`/`catch_all`/`delegate`. See WebAssembly/exception-handling#157.