### PR TITLE
[Wasm GC] Cache the heap types of functions in binary reading

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1405,6 +1405,14 @@ public:
   Signature getSignatureByFunctionIndex(Index index);
   Signature getSignatureByTypeIndex(Index index);
 
+  // The heap types of functions. This is cached for performance reasons, as
+  // computing the heap type from the signature (stored in functionSignatures)
+  // is not cheap.
+  // TODO: optimize that conversion and remove this
+  std::vector<HeapType> functionTypes;
+
+  HeapType getTypeByFunctionIndex(Index index);
+
   size_t nextLabel;
 
   Name getNextLabel();


### PR DESCRIPTION
This speeds up the loading of a 70MB file from 80 seconds to 26.

Even with this caching, the great majority of time is spent in RefFunc
creation (there are 234,910) of them, so even computing this once per
function is very expensive:

```
- 41.57% wasm::WasmBinaryBuilder::visitRefFunc                                                                                                                 
   - 41.33% wasm::WasmBinaryBuilder::getTypeByFunctionIndex                                                                                                    
      - 41.32% wasm::HeapType::HeapType                                                                                                                        
         - 41.31% wasm::(anonymous namespace)::Store<wasm::(anonymous namespace)::HeapTypeInfo>::canonicalize                                                  
            - 40.99% std::_Hashtable<std::reference_wrapper<wasm::(anonymous namespace)::HeapTypeInfo const>, std::pair<std::reference_wrapper<wasm::(anonymous
               - 26.66% std::_Hashtable<std::reference_wrapper<wasm::(anonymous namespace)::HeapTypeInfo const>, std::pair<std::reference_wrapper<wasm::(anonym
```