### PR TITLE
Nominal subtyping

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -550,9 +550,16 @@ struct TypeBuilder {
   Type getTempRefType(HeapType heapType, Nullability nullable);
   Type getTempRttType(Rtt rtt);
 
+  // In nominal mode, declare the HeapType being built at index `i` to be an
+  // immediate subtype of the HeapType being built at index `j`. Does nothing in
+  // equirecursive mode.
+  void setSubType(size_t i, size_t j);
+
   // Returns all of the newly constructed heap types. May only be called once
   // all of the heap types have been initialized with `setHeapType`. In nominal
-  // mode, all of the constructed HeapTypes will be fresh and distinct.
+  // mode, all of the constructed HeapTypes will be fresh and distinct. In
+  // nominal mode, will also produce a fatal error if the declared subtype
+  // relationships are not valid.
   std::vector<HeapType> build();
 
   // Utility for ergonomically using operator[] instead of explicit setHeapType
@@ -579,6 +586,11 @@ struct TypeBuilder {
     }
     Entry& operator=(Array array) {
       builder.setHeapType(index, array);
+      return *this;
+    }
+    Entry& subTypeOf(Entry other) {
+      assert(&builder == &other.builder);
+      builder.setSubType(index, other.index);
       return *this;
     }
   };

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -770,7 +770,8 @@ TypeID Store<Info>::doInsert(std::unique_ptr<Info>&& info) {
 }
 
 // For nominal mode, explicitly track all the subtype relations. Each HeapType
-// can have only one immediate supertype. TODO:
+// can have only one immediate supertype. The lock guards all accesses to
+// `nominalSuperTypes` since it is shared between threads.
 std::unordered_map<HeapType, HeapType> nominalSuperTypes;
 std::mutex nominalSuperTypesLock;
 

--- a/test/example/type-builder-nominal.txt
+++ b/test/example/type-builder-nominal.txt
@@ -44,6 +44,7 @@ After building types:
 (func (result (ref null ...1)))
 (func (result (ref null (func (result ...1)))))
 
+;; Test subtyping
 ;; Test TypeBuilder
 Before setting heap types:
 (ref $sig) => (ref [T](func))
@@ -90,3 +91,4 @@ After building types:
 (func (result (ref null ...1)))
 (func (result (ref null (func (result ...1)))))
 
+;; Test subtyping


### PR DESCRIPTION
Add methods to the TypeBuilder interface to declare subtyping relationships
between the built types. These relationships are validated and recorded globally
as part of type building. If the relationships are not valid, a fatal error is
produced. In the future, it would be better to report the error to the
TypeBuilder client code, but this behavior is sufficient for now. Also updates
SubTyper and TypeBounder to be aware of nominal mode so that subtyping and LUBs
are correctly calculated.

Tests of the failing behavior will be added in a future PR that exposes this
functionality to the command line, since the current `example` testing
infrastructure cannot handle testing fatal errors.