### PR TITLE
[Wasm GC] Properly validate BrOn*

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2252,10 +2252,10 @@ void FunctionValidator::visitBrOn(BrOn* curr) {
     // casts to.
     shouldBeTrue(
       curr->rtt->type.isRtt(), curr, "br_on_cast rtt must have rtt type");
-    noteBreak(curr->name, curr->getSentType(), curr);
   } else {
     shouldBeTrue(curr->rtt == nullptr, curr, "non-cast BrOn must not have rtt");
   }
+  noteBreak(curr->name, curr->getSentType(), curr);
 }
 
 void FunctionValidator::visitRttCanon(RttCanon* curr) {

--- a/test/spec/br_on_null.wast
+++ b/test/spec/br_on_null.wast
@@ -40,3 +40,17 @@
   (func (param $r (ref func)) (drop (br_on_null 0 (local.get $r))))
   (func (param $r (ref extern)) (drop (br_on_null 0 (local.get $r))))
 )
+
+(assert_invalid
+  (module
+    (type $t (func (result i32)))
+
+    (func $nn (param $r (ref $t)) (result i32)
+      (block $l (ref null $t) ;; br_on_null sends no value; a br to here is bad
+        (return (call_ref (br_on_null $l (local.get $r))))
+      )
+      (i32.const -1)
+    )
+  )
+  "bad break type"
+)

--- a/test/spec/br_on_null.wast
+++ b/test/spec/br_on_null.wast
@@ -42,6 +42,8 @@
 )
 
 (assert_invalid
+  ;; the same module as the first one in this file, but with a type added to
+  ;; the block
   (module
     (type $t (func (result i32)))
 


### PR DESCRIPTION
The `noteBreak` call was in the wrong place, causing us to not note breaks
from BrOnNull for example, which could make validation miss errors.

Noticed in #3926