### PR TITLE
Store signatures as HeapTypes when parsing binaries

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1401,11 +1401,11 @@ public:
   // The signatures of each function, including imported functions, given in the
   // import and function sections. Store HeapTypes instead of Signatures because
   // reconstructing the HeapTypes from the Signatures is expensive.
-  std::vector<HeapType> functionSignatures;
+  std::vector<HeapType> functionTypes;
 
   void readFunctionSignatures();
-  HeapType getSignatureByFunctionIndex(Index index);
-  HeapType getSignatureByTypeIndex(Index index);
+  HeapType getTypeByFunctionIndex(Index index);
+  HeapType getSigTypeByIndex(Index index);
 
   size_t nextLabel;
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1404,8 +1404,10 @@ public:
   std::vector<HeapType> functionTypes;
 
   void readFunctionSignatures();
+  HeapType getTypeByIndex(Index index);
   HeapType getTypeByFunctionIndex(Index index);
-  HeapType getSigTypeByIndex(Index index);
+  Signature getSignatureByTypeIndex(Index index);
+  Signature getSignatureByFunctionIndex(Index index);
 
   size_t nextLabel;
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1398,12 +1398,14 @@ public:
                           Address defaultIfNoMax);
   void readImports();
 
-  // The signatures of each function, given in the function section
-  std::vector<Signature> functionSignatures;
+  // The signatures of each function, including imported functions, given in the
+  // import and function sections. Store HeapTypes instead of Signatures because
+  // reconstructing the HeapTypes from the Signatures is expensive.
+  std::vector<HeapType> functionSignatures;
 
   void readFunctionSignatures();
-  Signature getSignatureByFunctionIndex(Index index);
-  Signature getSignatureByTypeIndex(Index index);
+  HeapType getSignatureByFunctionIndex(Index index);
+  HeapType getSignatureByTypeIndex(Index index);
 
   size_t nextLabel;
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2139,7 +2139,7 @@ void WasmBinaryBuilder::readFunctions() {
 
     auto* func = new Function;
     func->name = Name::fromInt(i);
-    func->sig = getSignatureByFunctionIndex(i);
+    func->sig = getSignatureByFunctionIndex(functionImports.size() + i);
     currFunction = func;
 
     if (DWARF) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6053,7 +6053,11 @@ void WasmBinaryBuilder::visitRefIs(RefIs* curr, uint8_t code) {
 void WasmBinaryBuilder::visitRefFunc(RefFunc* curr) {
   BYN_TRACE("zz node: RefFunc\n");
   Index index = getU32LEB();
-  // We don't know function names yet.
+  // We don't know function names yet, so record this use to be updated later.
+  // Note that we do not need to check that 'index' is in bounds, as that will
+  // be verified in the next line. (Also, note that functionRefs[index] may
+  // write to an odd place in the functionRefs map if index is invalid, but that
+  // is harmless.)
   functionRefs[index].push_back(curr);
   // To support typed function refs, we give the reference not just a general
   // funcref, but a specific subtype with the actual signature.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2139,7 +2139,7 @@ void WasmBinaryBuilder::readFunctions() {
 
     auto* func = new Function;
     func->name = Name::fromInt(i);
-    func->sig = functionTypes[functionImports.size() + i].getSignature();
+    func->sig = getSignatureByFunctionIndex(i);
     currFunction = func;
 
     if (DWARF) {


### PR DESCRIPTION
When parsing func.ref instructions, we need to get the HeapType corresponding to
the referenced function's signature. Since constructing HeapTypes from
Signatures can be expensive under equirecursive typing, keep track of the
original function signature HeapTypes directly during parsing rather than
storing them as Signatures.

@kripken, what do you think about this as an alternative to #3925? IMO it would be good to avoid adding more state to binary parsing if possible. The possible downside of this approach is that it will not deduplicate signature HeapTypes in a nominal system. If that's something we want to do, we will have to either go with the caching approach or possibly perform the deduplication in `ModuleUtils::collectHeapTypes`. Without knowing more about the semantics of a nominally typed GC proposal, though, I don't know if we will even want to deduplicate signature types, so I'm inclined to not worry about that right now.