### PR TITLE
Add space between options in --help text

### DIFF
--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -79,6 +79,7 @@ Options::Options(const std::string& command, const std::string& description)
             std::max(optionWidth, o.longName.size() + o.shortName.size());
         }
         for (const auto& o : options) {
+          std::cout << '\n';
           bool long_n_short = o.longName.size() != 0 && o.shortName.size() != 0;
           size_t pad = 1 + optionWidth - o.longName.size() - o.shortName.size();
           std::cout << "  " << o.longName << (long_n_short ? ',' : ' ')

--- a/test/lit/wasm-split/help.test
+++ b/test/lit/wasm-split/help.test
@@ -13,42 +13,56 @@ CHECK-NEXT: Options:
 
 CHECK:        --split                              Split an input module into two output
 CHECK-NEXT:                                        modules. The default mode.
+CHECK-NEXT:
 CHECK-NEXT:   --instrument                         Instrument an input module to allow it to
 CHECK-NEXT:                                        generate a profile that can be used to
 CHECK-NEXT:                                        guide splitting.
+CHECK-NEXT:
 CHECK-NEXT:   --merge-profiles                     Merge multiple profiles for the same
 CHECK-NEXT:                                        module into a single profile.
+CHECK-NEXT:
 CHECK-NEXT:   --profile                            [split] The profile to use to guide
 CHECK-NEXT:                                        splitting.
+CHECK-NEXT:
 CHECK-NEXT:   --keep-funcs                         [split] Comma-separated list of functions
 CHECK-NEXT:                                        to keep in the primary module, regardless
 CHECK-NEXT:                                        of any profile.
+CHECK-NEXT:
 CHECK-NEXT:   --split-funcs                        [split] Comma-separated list of functions
 CHECK-NEXT:                                        to split into the secondary module,
 CHECK-NEXT:                                        regardless of any profile. If there is no
 CHECK-NEXT:                                        profile, then this defaults to all
 CHECK-NEXT:                                        functions defined in the module.
+CHECK-NEXT:
 CHECK-NEXT:   --primary-output,-o1                 [split] Output file for the primary
 CHECK-NEXT:                                        module.
+CHECK-NEXT:
 CHECK-NEXT:   --secondary-output,-o2               [split] Output file for the secondary
 CHECK-NEXT:                                        module.
+CHECK-NEXT:
 CHECK-NEXT:   --symbolmap                          [split] Write a symbol map file for each
 CHECK-NEXT:                                        of the output modules.
+CHECK-NEXT:
 CHECK-NEXT:   --placeholdermap                     [split] Write a file mapping placeholder
 CHECK-NEXT:                                        indices to the function names.
+CHECK-NEXT:
 CHECK-NEXT:   --import-namespace                   [split] The namespace from which to
 CHECK-NEXT:                                        import objects from the primary module
 CHECK-NEXT:                                        into the secondary module.
+CHECK-NEXT:
 CHECK-NEXT:   --placeholder-namespace              [split] The namespace from which to
 CHECK-NEXT:                                        import placeholder functions into the
 CHECK-NEXT:                                        primary module.
+CHECK-NEXT:
 CHECK-NEXT:   --export-prefix                      [split] An identifying prefix to prepend
 CHECK-NEXT:                                        to new export names created by module
 CHECK-NEXT:                                        splitting.
+CHECK-NEXT:
 CHECK-NEXT:   --profile-export                     [instrument] The export name of the
 CHECK-NEXT:                                        function the embedder calls to write the
 CHECK-NEXT:                                        profile into memory. Defaults to
 CHECK-NEXT:                                        `__write_profile`.
+CHECK-NEXT:
 CHECK-NEXT:   --emit-module-names                  [split, instrument] Emit module names,
 CHECK-NEXT:                                        even if not emitting the rest of the
 CHECK-NEXT:                                        names section. Can help differentiate the
@@ -56,17 +70,23 @@ CHECK-NEXT:                                        modules in stack traces. This
 CHECK-NEXT:                                        be removed once simpler ways of naming
 CHECK-NEXT:                                        modules are widely available. See
 CHECK-NEXT:                                        https://bugs.chromium.org/p/v8/issues/detail?id=11808.
+CHECK-NEXT:
 CHECK-NEXT:   --initial-table                      [split, instrument] A hack to ensure the
 CHECK-NEXT:                                        split and instrumented modules have the
 CHECK-NEXT:                                        same table size when using Emscripten's
 CHECK-NEXT:                                        SPLIT_MODULE mode with dynamic linking.
 CHECK-NEXT:                                        TODO: Figure out a more elegant solution
 CHECK-NEXT:                                        for that use case and remove this.
+CHECK-NEXT:
 CHECK-NEXT:   --emit-text,-S                       [split, instrument] Emit text instead of
 CHECK-NEXT:                                        binary for the output file or files.
+CHECK-NEXT:
 CHECK-NEXT:   --debuginfo,-g                       [split, instrument] Emit names section in
 CHECK-NEXT:                                        wasm binary (or full debuginfo in wast)
+CHECK-NEXT:
 CHECK-NEXT:   --output,-o                          [instrument, merge-profiles] Output file.
+CHECK-NEXT:
 CHECK-NEXT:   --verbose,-v                         Verbose output mode. Prints the functions
 CHECK-NEXT:                                        that will be kept and split out when
 CHECK-NEXT:                                        splitting a module.
+CHECK-NEXT:


### PR DESCRIPTION
Improve the legibility of the option documentation by adding vertical space
between options. This is particularly helpful to delimit the text of options
with longer explanations.