### PR TITLE
PostEmscripten: Handle invokes of invalid function pointers. See #14174

### DIFF
--- a/test/passes/post-emscripten.txt
+++ b/test/passes/post-emscripten.txt
@@ -1,14 +1,11 @@
 (module
  (type $i32_f32_=>_none (func (param i32 f32)))
- (type $none_=>_none (func))
  (type $i32_i32_f32_=>_none (func (param i32 i32 f32)))
+ (type $none_=>_none (func))
  (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
  (memory $0 256 256)
  (table $0 7 7 funcref)
- (elem (i32.const 0) $f1 $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
- (func $f1
-  (nop)
- )
+ (elem (i32.const 1) $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
  (func $exc
   (call $other_safe
    (i32.const 42)
@@ -31,6 +28,16 @@
     (i32.const 1)
     (i32.const 1)
    )
+   (i32.const 42)
+   (f32.const 3.141590118408203)
+  )
+  (call $invoke_vif
+   (i32.const 0)
+   (i32.const 42)
+   (f32.const 3.141590118408203)
+  )
+  (call $invoke_vif
+   (i32.const 1337)
    (i32.const 42)
    (f32.const 3.141590118408203)
   )

--- a/test/passes/post-emscripten.wast
+++ b/test/passes/post-emscripten.wast
@@ -3,8 +3,7 @@
   (import "env" "invoke_vif" (func $invoke_vif (param i32 i32 f32)))
   (memory 256 256)
   (table 7 7 funcref)
-  (elem (i32.const 0) $f1 $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
-  (func $f1)
+  (elem (i32.const 1) $exc $other_safe $other_unsafe $deep_safe $deep_unsafe)
   (func $exc
     (call $invoke_vif
       (i32.const 2) ;; other_safe()
@@ -28,6 +27,18 @@
     )
     (call $invoke_vif
       (i32.add (i32.const 1) (i32.const 1)) ;; nonconstant
+      (i32.const 42)
+      (f32.const 3.14159)
+    )
+    ;; there is no function at index 0, so this cannot be optimized
+    (call $invoke_vif
+      (i32.const 0)
+      (i32.const 42)
+      (f32.const 3.14159)
+    )
+    ;; there is no function at index 1337, so this cannot be optimized
+    (call $invoke_vif
+      (i32.const 1337)
       (i32.const 42)
       (f32.const 3.14159)
     )


### PR DESCRIPTION
PostEmscripten will turn an invoke of a constant function
pointer index into a direct call. However, due to UB it is possible to
have invalid function pointers, and we should not crash on that
(and do nothing to optimize, of course).

Mostly whitespace; to avoid deep nesting, I added more
early returns.