### PR TITLE
Set an absolute maximum inlining limit

### DIFF
--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -33,11 +33,17 @@ struct Measurer
 
   void visitExpression(Expression* curr) { size++; }
 
+  // Measure the number of expressions.
   static Index measure(Expression* tree) {
     Measurer measurer;
     measurer.walk(tree);
     return measurer.size;
   }
+
+  // A rough estimate of average binary size per expression. The number here is
+  // based on measurements on real-world (MVP) wasm files, on which observed
+  // ratios were 2.2 - 2.8.
+  static constexpr double BytesPerExpr = 2.5;
 };
 
 struct ExpressionAnalyzer {


### PR DESCRIPTION
We have seen some cases in both Chrome and Firefox where
extremely large modules cause overhead,

https://github.com/WebAssembly/binaryen/pull/3730#issuecomment-867939138 (and link therein)
https://github.com/emscripten-core/emscripten/issues/13899#issuecomment-825073344

There is no "right" value to use as a limit here, but pick an
arbitrary one that is very high. (This setting is verified to have
no effect on the emscripten benchmark suite.)