### PR TITLE
Apply features from the commandline first

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3974,6 +3974,7 @@ BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize) {
   buffer.resize(inputSize);
   std::copy_n(input, inputSize, buffer.begin());
   try {
+    // TODO: allow providing features in the C API
     WasmBinaryBuilder parser(*wasm, FeatureSet::MVP, buffer);
     parser.read();
   } catch (ParseException& p) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3974,7 +3974,7 @@ BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize) {
   buffer.resize(inputSize);
   std::copy_n(input, inputSize, buffer.begin());
   try {
-    WasmBinaryBuilder parser(*wasm, buffer);
+    WasmBinaryBuilder parser(*wasm, FeatureSet::MVP, buffer);
     parser.read();
   } catch (ParseException& p) {
     p.dump(std::cerr);

--- a/src/passes/RoundTrip.cpp
+++ b/src/passes/RoundTrip.cpp
@@ -33,13 +33,14 @@ struct RoundTrip : public Pass {
   void run(PassRunner* runner, Module* module) override {
     BufferWithRandomAccess buffer;
     // Save features, which would not otherwise make it through a round trip if
-    // the target features section has been stripped.
+    // the target features section has been stripped. We also need them in order
+    // to tell the builder which features to build with.
     auto features = module->features;
     // Write, clear, and read the module
     WasmBinaryWriter(module, buffer).write();
     ModuleUtils::clearModule(*module);
     auto input = buffer.getAsChars();
-    WasmBinaryBuilder parser(*module, input);
+    WasmBinaryBuilder parser(*module, features, input);
     parser.setDWARF(runner->options.debugInfo);
     try {
       parser.read();
@@ -48,8 +49,6 @@ struct RoundTrip : public Pass {
       std::cerr << '\n';
       Fatal() << "error in parsing wasm binary";
     }
-    // Reapply features
-    module->features = features;
   }
 };
 

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -41,7 +41,6 @@ struct ToolOptions : public Options {
            "Disable all non-MVP features",
            Arguments::Zero,
            [this](Options*, const std::string&) {
-             hasFeatureOptions = true;
              enabledFeatures.setMVP();
              disabledFeatures.setAll();
            })
@@ -50,20 +49,14 @@ struct ToolOptions : public Options {
            "Enable all features",
            Arguments::Zero,
            [this](Options*, const std::string&) {
-             hasFeatureOptions = true;
              enabledFeatures.setAll();
              disabledFeatures.setMVP();
            })
       .add("--detect-features",
            "",
-           "Use features from the target features section, or MVP (default)",
+           "(deprecated - this flag does nothing)",
            Arguments::Zero,
-           [this](Options*, const std::string&) {
-             hasFeatureOptions = true;
-             detectFeatures = true;
-             enabledFeatures.setMVP();
-             disabledFeatures.setMVP();
-           })
+           [this](Options*, const std::string&) {})
       .add("--quiet",
            "-q",
            "Emit less verbose output and hide trivial warnings.",
@@ -134,7 +127,6 @@ struct ToolOptions : public Options {
            std::string("Enable ") + description,
            Arguments::Zero,
            [=](Options*, const std::string&) {
-             hasFeatureOptions = true;
              enabledFeatures.set(feature, true);
              disabledFeatures.set(feature, false);
            })
@@ -144,7 +136,6 @@ struct ToolOptions : public Options {
            std::string("Disable ") + description,
            Arguments::Zero,
            [=](Options*, const std::string&) {
-             hasFeatureOptions = true;
              enabledFeatures.set(feature, false);
              disabledFeatures.set(feature, true);
            });
@@ -152,24 +143,11 @@ struct ToolOptions : public Options {
   }
 
   void applyFeatures(Module& module) const {
-    if (hasFeatureOptions) {
-      if (!detectFeatures && module.hasFeaturesSection) {
-        FeatureSet optionsFeatures = FeatureSet::MVP;
-        optionsFeatures.enable(enabledFeatures);
-        optionsFeatures.disable(disabledFeatures);
-        if (!(module.features <= optionsFeatures)) {
-          Fatal() << "features section is not a subset of specified features. "
-                  << "Use --detect-features to resolve.";
-        }
-      }
-      module.features.enable(enabledFeatures);
-      module.features.disable(disabledFeatures);
-    }
+    module.features.enable(enabledFeatures);
+    module.features.disable(disabledFeatures);
   }
 
 private:
-  bool hasFeatureOptions = false;
-  bool detectFeatures = false;
   FeatureSet enabledFeatures = FeatureSet::MVP;
   FeatureSet disabledFeatures = FeatureSet::MVP;
 };

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -56,7 +56,7 @@ struct ToolOptions : public Options {
            "",
            "(deprecated - this flag does nothing)",
            Arguments::Zero,
-           [this](Options*, const std::string&) {})
+           [](Options*, const std::string&) {})
       .add("--quiet",
            "-q",
            "Emit less verbose output and hide trivial warnings.",

--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -99,6 +99,7 @@ int main(int argc, const char* argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   try {
     if (options.debug) {
@@ -114,8 +115,6 @@ int main(int argc, const char* argv[]) {
     p.dump(std::cerr);
     Fatal() << "error in parsing input";
   }
-
-  options.applyFeatures(wasm);
 
   if (options.extra["validate"] != "none") {
     if (options.debug) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -549,6 +549,7 @@ int main(int argc, const char* argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   {
     if (options.debug) {
@@ -562,8 +563,6 @@ int main(int argc, const char* argv[]) {
       Fatal() << "error in parsing input";
     }
   }
-
-  options.applyFeatures(wasm);
 
   if (!WasmValidator().validate(wasm)) {
     std::cout << wasm << '\n';

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -60,6 +60,7 @@ int main(int argc, const char* argv[]) {
     std::cerr << "parsing binary..." << std::endl;
   }
   Module wasm;
+  options.applyFeatures(wasm);
   try {
     ModuleReader().readBinary(options.extra["infile"], wasm, sourceMapFilename);
   } catch (ParseException& p) {
@@ -71,8 +72,6 @@ int main(int argc, const char* argv[]) {
     std::cerr << '\n';
     Fatal() << "error in parsing wasm source mapping";
   }
-
-  options.applyFeatures(wasm);
 
   // TODO: Validation. However, validating would mean that users are forced to
   //       run with  wasm-dis -all  or such, to enable the features (unless the

--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -209,6 +209,7 @@ int main(int argc, const char* argv[]) {
   auto writeOutput = outfile.size() > 0 || !emitBinary;
 
   Module wasm;
+  options.applyFeatures(wasm);
   ModuleReader reader;
   // If we are not writing output then we definitely don't need to read debug
   // info, as it does not affect the metadata we will emit. (However, if we
@@ -238,8 +239,6 @@ int main(int argc, const char* argv[]) {
     std::cerr << '\n';
     Fatal() << "error in parsing wasm source map";
   }
-
-  options.applyFeatures(wasm);
 
   BYN_TRACE_WITH_TYPE("emscripten-dump", "Module before:\n");
   BYN_DEBUG_WITH_TYPE("emscripten-dump", std::cerr << &wasm);

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -504,6 +504,7 @@ int main(int argc, const char* argv[]) {
   auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   {
     if (options.debug) {
@@ -518,8 +519,6 @@ int main(int argc, const char* argv[]) {
       Fatal() << "error in parsing wasm input";
     }
   }
-
-  options.applyFeatures(wasm);
 
   if (options.passOptions.validate) {
     if (!WasmValidator().validate(wasm)) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -217,6 +217,7 @@ int main(int argc, const char* argv[]) {
   options.parse(argc, argv);
 
   Module wasm;
+  options.applyFeatures(wasm);
 
   BYN_TRACE("reading...\n");
 
@@ -259,8 +260,6 @@ int main(int argc, const char* argv[]) {
                  "request for silly amounts of memory)";
     }
 
-    options.applyFeatures(wasm);
-
     if (options.passOptions.validate) {
       if (!WasmValidator().validate(wasm)) {
         exitOnInvalidWasm("error validating input");
@@ -268,7 +267,6 @@ int main(int argc, const char* argv[]) {
     }
   }
   if (translateToFuzz) {
-    options.applyFeatures(wasm);
     TranslateToFuzzReader reader(wasm, options.extra["infile"]);
     if (fuzzPasses) {
       reader.pickPasses(options);

--- a/src/tools/wasm-split.cpp
+++ b/src/tools/wasm-split.cpp
@@ -396,6 +396,7 @@ void WasmSplitOptions::parse(int argc, const char* argv[]) {
 }
 
 void parseInput(Module& wasm, const WasmSplitOptions& options) {
+  options.applyFeatures(wasm);
   ModuleReader reader;
   reader.setProfile(options.profile);
   try {
@@ -408,7 +409,6 @@ void parseInput(Module& wasm, const WasmSplitOptions& options) {
     Fatal() << "error building module, std::bad_alloc (possibly invalid "
                "request for silly amounts of memory)";
   }
-  options.applyFeatures(wasm);
 
   if (options.passOptions.validate && !WasmValidator().validate(wasm)) {
     Fatal() << "error validating input";

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1338,7 +1338,9 @@ class WasmBinaryBuilder {
   std::vector<HeapType> types;
 
 public:
-  WasmBinaryBuilder(Module& wasm, FeatureSet features, const std::vector<char>& input);
+  WasmBinaryBuilder(Module& wasm,
+                    FeatureSet features,
+                    const std::vector<char>& input);
 
   void setDebugInfo(bool value) { debugInfo = value; }
   void setDWARF(bool value) { DWARF = value; }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1338,9 +1338,7 @@ class WasmBinaryBuilder {
   std::vector<HeapType> types;
 
 public:
-  WasmBinaryBuilder(Module& wasm, const std::vector<char>& input)
-    : wasm(wasm), allocator(wasm.allocator), input(input), sourceMap(nullptr),
-      nextDebugLocation(0, {0, 0, 0}), debugLocation() {}
+  WasmBinaryBuilder(Module& wasm, FeatureSet features, const std::vector<char>& input);
 
   void setDebugInfo(bool value) { debugInfo = value; }
   void setDWARF(bool value) { DWARF = value; }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3194,7 +3194,6 @@ void WasmBinaryBuilder::readNames(size_t payloadLen) {
 
 void WasmBinaryBuilder::readFeatures(size_t payloadLen) {
   wasm.hasFeaturesSection = true;
-  wasm.features = FeatureSet::MVP;
 
   auto sectionPos = pos;
   size_t numFeatures = getU32LEB();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1319,7 +1319,9 @@ void WasmBinaryWriter::writeField(const Field& field) {
 
 // reader
 
-WasmBinaryBuilder::WasmBinaryBuilder(Module& wasm, FeatureSet features, const std::vector<char>& input)
+WasmBinaryBuilder::WasmBinaryBuilder(Module& wasm,
+                                     FeatureSet features,
+                                     const std::vector<char>& input)
   : wasm(wasm), allocator(wasm.allocator), input(input), sourceMap(nullptr),
     nextDebugLocation(0, {0, 0, 0}), debugLocation() {
   wasm.features = features;
@@ -3207,8 +3209,7 @@ void WasmBinaryBuilder::readFeatures(size_t payloadLen) {
       throwError("Unrecognized feature policy prefix");
     }
     if (required) {
-      std::cerr
-        << "warning: required features in feature section are ignored";
+      std::cerr << "warning: required features in feature section are ignored";
     }
 
     Name name = getInlineString();
@@ -3250,7 +3251,9 @@ void WasmBinaryBuilder::readFeatures(size_t payloadLen) {
     }
 
     if (disallowed && wasm.features.has(feature)) {
-      std::cerr << "warning: feature " << feature.toString() << " was enabled by the user, but disallowed in the features section.";
+      std::cerr
+        << "warning: feature " << feature.toString()
+        << " was enabled by the user, but disallowed in the features section.";
     }
     if (required || used) {
       wasm.features.enable(feature);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3245,7 +3245,8 @@ void WasmBinaryBuilder::readFeatures(size_t payloadLen) {
                BinaryConsts::UserSections::TypedFunctionReferencesFeature) {
       feature = FeatureSet::TypedFunctionReferences;
     } else {
-      WASM_UNREACHABLE("unknown feature");
+      // Silently ignore unknown features (this may be and old binaryen running
+      // on a new wasm).
     }
 
     if (disallowed && wasm.features.has(feature)) {

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -49,7 +49,9 @@ void ModuleReader::readBinaryData(std::vector<char>& input,
                                   Module& wasm,
                                   std::string sourceMapFilename) {
   std::unique_ptr<std::ifstream> sourceMapStream;
-  WasmBinaryBuilder parser(wasm, input);
+  // Assume that the wasm has had its initial features applied, and use those
+  // while parsing.
+  WasmBinaryBuilder parser(wasm, wasm.features, input);
   parser.setDebugInfo(debugInfo);
   parser.setDWARF(DWARF);
   parser.setSkipFunctionBodies(skipFunctionBodies);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -362,7 +362,8 @@ SExpressionWasmBuilder::SExpressionWasmBuilder(Module& wasm,
         stringToBinary(str, size, data);
       }
     }
-    WasmBinaryBuilder binaryBuilder(wasm, data);
+    // TODO: support applying features here
+    WasmBinaryBuilder binaryBuilder(wasm, FeatureSet::MVP, data);
     binaryBuilder.read();
     return;
   }

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -353,27 +353,19 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
                                '--enable-simd', '--enable-sign-ext',
                                self.input_path('signext_target_feature.wasm')])
 
-    def test_incompatible_features(self):
+    def test_superset_even_without_detect_features(self):
+        # It is ok to enable additional features past what is in the section,
+        # even without passing --detect-features (which is now a no-op).
         path = self.input_path('signext_target_feature.wasm')
-        p = shared.run_process(
+        shared.run_process(
             shared.WASM_OPT + ['--print', '--enable-simd', '-o', os.devnull,
-                               path],
-            check=False, capture_output=True
-        )
-        self.assertNotEqual(p.returncode, 0)
-        self.assertIn('Fatal: features section is not a subset of specified features. ' +
-                      'Use --detect-features to resolve.',
-                      p.stderr)
+                               path])
 
-    def test_incompatible_features_forced(self):
+    def test_superset_with_detect_features(self):
         path = self.input_path('signext_target_feature.wasm')
-        p = shared.run_process(
-            shared.WASM_OPT + ['--print', '--detect-features', '-mvp',
-                               '--enable-simd', '-o', os.devnull, path],
-            check=False, capture_output=True
-        )
-        self.assertNotEqual(p.returncode, 0)
-        self.assertIn('all used features should be allowed', p.stderr)
+        shared.run_process(
+            shared.WASM_OPT + ['--print', '--detect-features',
+                               '--enable-simd', '-o', os.devnull, path])
 
     def test_explicit_detect_features(self):
         self.check_features('signext_target_feature.wasm', ['simd', 'sign-ext'],


### PR DESCRIPTION
As suggested in

https://github.com/WebAssembly/binaryen/pull/3955#issuecomment-871016647

This applies commandline features first. If the features section is present, and
disallows some of them, then we warn. Otherwise, the features can combine
(for example, a wasm may enable feature X because it has to use it, and a user
can simply add the flag for feature Y if they want the optimizer to try to use it;
both flags will then be enabled).

This is important because in some cases we need to know the features before
parsing the wasm, in the case that the wasm does not use the features section.
In particular, non-nullable GC locals have an effect during parsing. (Typed
function references also does, but we found a way to apply its effect all the time,
that is, always use the refined type, and that happened to not break the case
where the feature is disabled - but such a workaround is not possible with
non-nullable locals.)

To make this less error-prone, add a FeatureSet input as a parameter to
WasmBinaryBuilder. That is, when building a module, we must give it the
features to use while doing so.

This will unblock #3955 . That PR will also add a test for the actual usage
of a feature during loading (the test can only be added there, after that PR
unbreaks things).