### PR TITLE
Do not execute lit tests via an external shell

### DIFF
--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -1,7 +1,7 @@
 import lit.formats
 
 config.name = "Binaryen lit tests"
-config.test_format = lit.formats.ShTest(True)
+config.test_format = lit.formats.ShTest()
 
 config.suffixes = ['.wat', '.wast', '.test']
 


### PR DESCRIPTION
We were previously configuring lit to execute test scripts via an external
shell, which caused lit to look for a bash installation on Windows. To make lit
tests work more "out of the box" on Windows, change the configuration to use
lit's built in shell capabilities instead.