### PR TITLE
Fix the fuzzer on wasm2c2wasm: emcc must request d8 support now

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -596,6 +596,7 @@ class CompareVMs(TestCaseHandler):
                                os.path.join(self.wasm2c_dir, 'wasm-rt-impl.c'),
                                '-I' + self.wasm2c_dir,
                                '-lm',
+                               '-s', 'ENVIRONMENT=shell',
                                '-s', 'ALLOW_MEMORY_GROWTH']
                 # disable the signal handler: emcc looks like unix, but wasm has
                 # no signals


### PR DESCRIPTION
Emscripten stopped emitting shell support code by default (as most users
run node.js, but here we are literally fuzzing d8).

Fixes #3967