### PR TITLE
Fix features section handling in the fuzzer

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -123,9 +123,8 @@ ALL_FEATURE_OPTS = ['--all-features', '-all', '--mvp-features', '-mvp']
 def update_feature_opts(wasm):
     global FEATURE_OPTS
     # we will re-compute the features; leave all other things as they are
-    EXTRA = [x for x in FEATURE_OPTS if not x.startswith('--enable') and \
-                                        not x.startswith('--disable') and \
-                                        not x in ALL_FEATURE_OPTS]
+    EXTRA = [x for x in FEATURE_OPTS if not x.startswith('--enable') and
+             not x.startswith('--disable') and x not in ALL_FEATURE_OPTS]
     FEATURE_OPTS = run([in_bin('wasm-opt'), wasm] + FEATURE_OPTS + ['--print-features']).strip().split('\n')
     # filter out '', which can happen if no features are enabled
     FEATURE_OPTS = [x for x in FEATURE_OPTS if x]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -464,7 +464,7 @@ def run_d8_wasm(wasm, liftoff=True):
 
 
 def all_disallowed(features):
-    return not any([('--enable-' + x) in FEATURE_OPTS for x in features])
+    return not any(('--enable-' + x) in FEATURE_OPTS for x in features)
 
 
 class TestCaseHandler:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -464,7 +464,7 @@ def run_d8_wasm(wasm, liftoff=True):
 
 
 def all_disallowed(features):
-    return not any([('--enable-' + x) in FEATURE_OPTS for x in features)
+    return not any([('--enable-' + x) in FEATURE_OPTS for x in features])
 
 
 class TestCaseHandler:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -117,6 +117,15 @@ def randomize_feature_opts():
     print('randomized feature opts:', ' '.join(FEATURE_OPTS))
 
 
+def update_feature_opts(wasm):
+    global FEATURE_OPTS
+    # we will re-compute the features; leave all other things as they are
+    EXTRA = filter(lambda x: not x.startswith('--enable') and not x.startswith('--disable') and x != '--all-features',
+                   FEATURE_OPTS)
+    FEATURE_OPTS = run([in_bin('wasm-opt'), wasm] + FEATURE_OPTS + ['--print-features']).strip().split('\n')
+    FEATURE_OPTS += EXTRA
+
+
 def randomize_fuzz_settings():
     # a list of the optimizations to run on the wasm
     global FUZZ_OPTS
@@ -563,7 +572,7 @@ class CompareVMs(TestCaseHandler):
                 if random.random() < 0.5:
                     return False
                 # wasm2c doesn't support most features
-                return all([x in FEATURE_OPTS for x in ['--disable-exception-handling', '--disable-simd', '--disable-threads', '--disable-bulk-memory', '--disable-nontrapping-float-to-int', '--disable-tail-call', '--disable-sign-ext', '--disable-reference-types', '--disable-multivalue', '--disable-gc']])
+                return not any([x in FEATURE_OPTS for x in ['--enable-exception-handling', '--enable-simd', '--enable-threads', '--enable-bulk-memory', '--enable-nontrapping-float-to-int', '--enable-tail-call', '--enable-sign-ext', '--enable-reference-types', '--enable-multivalue', '--enable-gc']])
 
             def run(self, wasm):
                 run([in_bin('wasm-opt'), wasm, '--emit-wasm2c-wrapper=main.c'] + FEATURE_OPTS)
@@ -667,7 +676,7 @@ class CompareVMs(TestCaseHandler):
                 compare(before[vm], after[vm], 'CompareVMs between before and after: ' + vm.name)
 
     def can_run_on_feature_opts(self, feature_opts):
-        return all([x in feature_opts for x in ['--disable-simd', '--disable-exception-handling', '--disable-multivalue']])
+        return not any([x in feature_opts for x in ['--enable-simd', '--enable-exception-handling', '--enable-multivalue']])
 
 
 # Check for determinism - the same command must have the same output.
@@ -805,7 +814,7 @@ class Wasm2JS(TestCaseHandler):
         # specifically for growth here
         if INITIAL_CONTENTS:
             return False
-        return all([x in feature_opts for x in ['--disable-exception-handling', '--disable-simd', '--disable-threads', '--disable-bulk-memory', '--disable-nontrapping-float-to-int', '--disable-tail-call', '--disable-sign-ext', '--disable-reference-types', '--disable-multivalue', '--disable-gc']])
+        return not any([x in feature_opts for x in ['--enable-exception-handling', '--enable-simd', '--enable-threads', '--enable-bulk-memory', '--enable-nontrapping-float-to-int', '--enable-tail-call', '--enable-sign-ext', '--enable-reference-types', '--enable-multivalue', '--enable-gc']])
 
 
 class Asyncify(TestCaseHandler):
@@ -859,7 +868,7 @@ class Asyncify(TestCaseHandler):
         compare(before, after_asyncify, 'Asyncify (before/after_asyncify)')
 
     def can_run_on_feature_opts(self, feature_opts):
-        return all([x in feature_opts for x in ['--disable-exception-handling', '--disable-simd', '--disable-tail-call', '--disable-reference-types', '--disable-multivalue', '--disable-gc']])
+        return not any([x in feature_opts for x in ['--enable-exception-handling', '--enable-simd', '--enable-tail-call', '--enable-reference-types', '--enable-multivalue', '--enable-gc']])
 
 
 # Check that the text format round-trips without error.
@@ -925,6 +934,7 @@ def test_one(random_input, given_wasm):
     wasm_size = os.stat('a.wasm').st_size
     bytes = wasm_size
     print('pre wasm size:', wasm_size)
+    update_feature_opts('a.wasm')
 
     # create a second wasm for handlers that want to look at pairs.
     generate_command = [in_bin('wasm-opt'), 'a.wasm', '-o', 'b.wasm'] + opts + FUZZ_OPTS + FEATURE_OPTS
@@ -1043,10 +1053,10 @@ def randomize_opt_flags():
             if has_flatten:
                 print('avoiding multiple --flatten in a single command, due to exponential overhead')
                 continue
-            if '--disable-exception-handling' not in FEATURE_OPTS:
+            if '--enable-exception-handling' in FEATURE_OPTS:
                 print('avoiding --flatten due to exception catching which does not support it yet')
                 continue
-            if '--disable-multivalue' not in FEATURE_OPTS and '--disable-reference-types' not in FEATURE_OPTS:
+            if '--enable-multivalue' in FEATURE_OPTS and '--enable-reference-types' in FEATURE_OPTS:
                 print('avoiding --flatten due to multivalue + reference types not supporting it (spilling of non-nullable tuples)')
                 continue
             if '--gc' not in FEATURE_OPTS:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -120,9 +120,11 @@ def randomize_feature_opts():
 def update_feature_opts(wasm):
     global FEATURE_OPTS
     # we will re-compute the features; leave all other things as they are
-    EXTRA = filter(lambda x: not x.startswith('--enable') and not x.startswith('--disable') and x != '--all-features',
-                   FEATURE_OPTS)
+    EXTRA = [x for x in FEATURE_OPTS if not x.startswith('--enable') and not x.startswith('--disable') and x != '--all-features']
     FEATURE_OPTS = run([in_bin('wasm-opt'), wasm] + FEATURE_OPTS + ['--print-features']).strip().split('\n')
+    # filter out '', which can happen if no features are enabled
+    FEATURE_OPTS = [x for x in FEATURE_OPTS if x]
+    print(FEATURE_OPTS, EXTRA)
     FEATURE_OPTS += EXTRA
 
 


### PR DESCRIPTION
The features section is additive since #3960. For the fuzzer to know which features
are used, it therefore needs to also scan the features section. To do this,
run `--print-features` to get the total features used from both flags + the
features section.

A result of this is that we now have a list of enabled features instead of
"enable all, then disable". This is actually clearer I think, but it does require
inverting the logic in some places.

May help with #3979 , although I haven't checked yet (cc @MaxGraey ).