### PR TITLE
Fuzzer: Fix handling of features with initial contents

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -255,7 +255,16 @@ def pick_initial_contents():
 
     # the given wasm may not work with the chosen feature opts. for example, if
     # we pick atomics.wast but want to run with --disable-atomics, then we'd
-    # error. test the wasm.
+    # error, so we need to test the wasm. first, make sure it doesn't have a
+    # features section, as that would enable a feature that we might want to
+    # be disabled, and our test would not error as we want it to.
+    if test_name.endswith('.wasm'):
+        temp_test_name = 'initial.wasm'
+        run([in_bin('wasm-opt'), test_name, '-all', '--strip-target-features',
+             '-o', temp_test_name])
+        test_name = temp_test_name
+
+    # next, test the wasm.
     try:
         run([in_bin('wasm-opt'), test_name] + FEATURE_OPTS,
             stderr=subprocess.PIPE,

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -260,8 +260,14 @@ def pick_initial_contents():
     # be disabled, and our test would not error as we want it to.
     if test_name.endswith('.wasm'):
         temp_test_name = 'initial.wasm'
-        run([in_bin('wasm-opt'), test_name, '-all', '--strip-target-features',
-             '-o', temp_test_name])
+        try:
+            run([in_bin('wasm-opt'), test_name, '-all', '--strip-target-features',
+                 '-o', temp_test_name])
+        except:
+            # the input can be invalid if e.g. it is raw data that is used with
+            # -ttf as fuzzer input
+            print('(initial contents are not valid wasm, ignoring)')
+            return
         test_name = temp_test_name
 
     # next, test the wasm.

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -263,7 +263,7 @@ def pick_initial_contents():
         try:
             run([in_bin('wasm-opt'), test_name, '-all', '--strip-target-features',
                  '-o', temp_test_name])
-        except:
+        except Exception:
             # the input can be invalid if e.g. it is raw data that is used with
             # -ttf as fuzzer input
             print('(initial contents are not valid wasm, ignoring)')


### PR DESCRIPTION
Now that the features section adds on top of the commandline arguments,
it means the way we test if initial contents are ok to use will not work if
the wasm has a features section - as it will enable a feature, even if
we wanted to see if the wasm can work without that feature. To fix this,
strip the features section there.