### PR TITLE
Implement interpretation of i64x2.bitmask

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -570,6 +570,7 @@ public:
   Literal extMulHighUI32x4(const Literal& other) const;
   Literal absI64x2() const;
   Literal negI64x2() const;
+  Literal bitmaskI64x2() const;
   Literal allTrueI64x2() const;
   Literal shlI64x2(const Literal& other) const;
   Literal shrSI64x2(const Literal& other) const;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -500,7 +500,7 @@ public:
       case AllTrueVecI64x2:
         return value.allTrueI64x2();
       case BitmaskVecI64x2:
-        WASM_UNREACHABLE("unimp");
+        return value.bitmaskI64x2();
       case AbsVecF32x4:
         return value.absF32x4();
       case NegVecF32x4:

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -1868,6 +1868,16 @@ Literal Literal::bitmaskI32x4() const {
 Literal Literal::allTrueI64x2() const {
   return all_true<2, &Literal::getLanesI64x2>(*this);
 }
+Literal Literal::bitmaskI64x2() const {
+  uint32_t result = 0;
+  LaneArray<2> lanes = getLanesI64x2();
+  for (size_t i = 0; i < 2; ++i) {
+    if (lanes[i].geti64() & (1ll << 63)) {
+      result = result | (1 << i);
+    }
+  }
+  return Literal(result);
+}
 
 template<int Lanes,
          LaneArray<Lanes> (Literal::*IntoLanes)() const,

--- a/test/spec/simd.wast
+++ b/test/spec/simd.wast
@@ -824,7 +824,8 @@
 
 ;; i64x2 arithmetic
 (assert_return (invoke "i64x2.neg" (v128.const i64x2 0x8000000000000000 42)) (v128.const i64x2 0x8000000000000000 -42))
-;; TODO: test i64x2.bitmask
+(assert_return (invoke "i64x2.bitmask" (v128.const i64x2 0x8000000000000000 42)) (i32.const 1))
+(assert_return (invoke "i64x2.bitmask" (v128.const i64x2 1 -1)) (i32.const 2))
 (assert_return (invoke "i64x2.shl" (v128.const i64x2 1 0x8000000000000000) (i32.const 1)) (v128.const i64x2 2 0))
 (assert_return (invoke "i64x2.shl" (v128.const i64x2 1 0x8000000000000000) (i32.const 64)) (v128.const i64x2 1 0x8000000000000000))
 (assert_return (invoke "i64x2.shr_s" (v128.const i64x2 1 0x8000000000000000) (i32.const 1)) (v128.const i64x2 0 0xc000000000000000))


### PR DESCRIPTION
Like a few other SIMD operations, this i64x2.bitmask had not been implemented in
the interpreter yet. Unlike the others, i64x2.bitmask has type i32 rather than
type v128, so Precompute was not skipping it, leading to a crash, as in
https://github.com/emscripten-core/emscripten/issues/14629. Fix the problem by
implementing i64x2.bitmask in the interpreter.