### PR TITLE
Fuzzer: Use NameTypes in RoundTrip

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -886,7 +886,11 @@ class RoundtripText(TestCaseHandler):
     frequency = 0.05
 
     def handle(self, wasm):
-        run([in_bin('wasm-dis'), wasm, '-o', 'a.wast'])
+        # use name-types because in wasm GC we can end up truncating the default
+        # names which are very long, causing names to collide and the wast to be
+        # invalid
+        # FIXME: run name-types by default during load?
+        run([in_bin('wasm-opt'), wasm, '--name-types', '-S', '-o', 'a.wast'] + FEATURE_OPTS)
         run([in_bin('wasm-opt'), 'a.wast'] + FEATURE_OPTS)
 
 


### PR DESCRIPTION
This works around the issue with wasm gc types sometimes getting
truncated (as the default names can be very long or even infinitely
recursive). If the truncation leads to name collision, the wast is not
valid.

Should we run name-types during load of a file using wasm GC? I
think you had some other idea here @tlively but I don't remember
what.