### PR TITLE
Reduce more carefully when it looks like we are failing

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1045,7 +1045,7 @@ struct Reducer
     if (WasmValidator().validate(
           *module, WasmValidator::Globally | WasmValidator::Quiet) &&
         writeAndTestReduction()) {
-      std::cerr << "|      removed " << names.size() << " functions\n";
+      std::cerr << "|        removed " << names.size() << " functions\n";
       return true;
     } else {
       loadWorking(); // restore it from orbit
@@ -1353,8 +1353,8 @@ int main(int argc, const char* argv[]) {
         // stop
         stopping = true;
       } else {
-        // just try to remove all we can and finish up
-        factor = 1;
+        // decrease the factor quickly
+        factor = (factor + 1) / 2; // stable on 1
       }
     }
     lastPostPassesSize = newSize;


### PR DESCRIPTION
Instead of skipping to the end, move quickly towards the end. This is
sometimes more efficient (as jumping from a big factor to a factor of 1
can skip over big opportunities to remove code all at once instead of
once instruction at a time).