### PR TITLE
[clang-tidy-diff] Replace readlink -f to inline python script

### DIFF
--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -17,6 +17,7 @@ if [ ! -e "$CLANG_TIDY" ]; then
   exit 1
 fi
 
+# This needs for FreeBSD and Darwin which doesn't support readlink -f command
 function realpath() {
   python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" $CLANG_TIDY;
 }

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -17,7 +17,11 @@ if [ ! -e "$CLANG_TIDY" ]; then
   exit 1
 fi
 
-CLANG_DIR=$(dirname $(dirname $(readlink -f $CLANG_TIDY)))
+function realpath() {
+  python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" $CLANG_TIDY;
+}
+
+CLANG_DIR=$(dirname $(dirname $(realpath $CLANG_TIDY)))
 CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
 if [ ! -e "$CLANG_TIDY_DIFF" ]; then
   echo "Failed to find clang-tidy-diff.py ($CLANG_TIDY_DIFF)"

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -19,7 +19,7 @@ fi
 
 # This needs for FreeBSD and Darwin which doesn't support readlink -f command
 function realpath() {
-  python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" $CLANG_TIDY;
+  python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" $1;
 }
 
 CLANG_DIR=$(dirname $(dirname $(realpath $CLANG_TIDY)))


### PR DESCRIPTION
fix #3985

cc @aheejin @sbc100