### PR TITLE
Revert "Fix Precompute on SIMD"

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -172,8 +172,17 @@ struct Precompute
     if (Properties::isConstantExpression(curr) || curr->is<Nop>()) {
       return;
     }
+    // Until engines implement v128.const and we have SIMD-aware optimizations
+    // that can break large v128.const instructions into smaller consts and
+    // splats, do not try to precompute v128 expressions.
+    if (curr->type.isVector()) {
+      return;
+    }
     // try to evaluate this into a const
     Flow flow = precomputeExpression(curr);
+    if (flow.getType().hasVector()) {
+      return;
+    }
     if (!canEmitConstantFor(flow.values)) {
       return;
     }
@@ -227,12 +236,6 @@ private:
   // Precompute an expression, returning a flow, which may be a constant
   // (that we can replace the expression with if replaceExpression is set).
   Flow precomputeExpression(Expression* curr, bool replaceExpression = true) {
-    // Until engines implement v128.const and we have SIMD-aware optimizations
-    // that can break large v128.const instructions into smaller consts and
-    // splats, do not try to precompute v128 expressions.
-    if (curr->type.isVector()) {
-      return Flow(NONCONSTANT_FLOW);
-    }
     Flow flow;
     try {
       flow =
@@ -245,9 +248,6 @@ private:
     // a type we can emit a constant for.
     if (!flow.breaking() && replaceExpression &&
         !canEmitConstantFor(flow.values)) {
-      return Flow(NONCONSTANT_FLOW);
-    }
-    if (flow.getType().hasVector()) {
       return Flow(NONCONSTANT_FLOW);
     }
     return flow;

--- a/test/passes/precompute_all-features.txt
+++ b/test/passes/precompute_all-features.txt
@@ -1,8 +1,8 @@
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (type $none_=>_v128 (func (result v128)))
  (type $none_=>_f64 (func (result f64)))
+ (type $none_=>_v128 (func (result v128)))
  (type $0 (func (param i32)))
  (type $none_=>_i32_i64 (func (result i32 i64)))
  (type $none_=>_externref (func (result externref)))
@@ -220,13 +220,6 @@
  (func $no-simd-precompute (result v128)
   (i32x4.splat
    (i32.const 0)
-  )
- )
- (func $no-simd-precompute_2 (result v128)
-  (i32x4.extadd_pairwise_i16x8_s
-   (i32x4.splat
-    (i32.const 0)
-   )
   )
  )
  (func $no-simd-precompute-if (result v128)

--- a/test/passes/precompute_all-features.wast
+++ b/test/passes/precompute_all-features.wast
@@ -329,13 +329,6 @@
     (i32.const 0)
    )
   )
-  (func $no-simd-precompute_2 (result v128)
-   (i32x4.extadd_pairwise_i16x8_s
-    (i32x4.splat
-     (i32.const 0)
-    )
-   )
-  )
   (func $no-simd-precompute-if (result v128)
    (return
     (i32x4.splat


### PR DESCRIPTION
Reverts WebAssembly/binaryen#3983

Instead of applying the workaround to avoid precomputing SIMD in more places,
which prevents things we could optimize before, we should probably focus on
making the workaround not needed - that is, implement full SIMD support in the
intepreter (the reason for that PR), and the other TODO in the comment here,

```
    // Until engines implement v128.const and we have SIMD-aware optimizations
    // that can break large v128.const instructions into smaller consts and
    // splats, do not try to precompute v128 expressions.
```