### PR TITLE
[clang-format/tidy-diff] Avoid "@{upstream}" for local script branch

### DIFF
--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -8,7 +8,7 @@ if [ -n "$1" ]; then
 elif [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"
 else
-  BRANCH="@{upstream}"
+  BRANCH=""
 fi
 
 MERGE_BASE=$(git merge-base $BRANCH HEAD)

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -8,7 +8,7 @@ if [ -n "$1" ]; then
 elif [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"
 else
-  BRANCH="@{upstream}"
+  BRANCH=""
 fi
 
 CLANG_TIDY=$(which clang-tidy)


### PR DESCRIPTION
`@{upstream}` also caused to problems on non-main branches.
Is it proper fix?