### PR TITLE
[Optimize Instructions] Combine reinterprets, loads and stores

### DIFF
--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -67,6 +67,11 @@ inline bool hasAnyShift(BinaryOp op) {
          op == RotRInt64;
 }
 
+inline bool hasAnyReinterpret(UnaryOp op) {
+  return op == ReinterpretInt32 || op == ReinterpretInt64 ||
+         op == ReinterpretFloat32 || op == ReinterpretFloat64;
+}
+
 // Provide a wasm type and an abstract op and get the concrete one. For example,
 // you can provide i32 and Add and receive the specific opcode for a 32-bit
 // addition, AddInt32. If the op does not exist, it returns Invalid.

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -26,24 +26,6 @@ namespace wasm {
 
 namespace Properties {
 
-inline int getBits(const Type& type) {
-  if (type.isBasic() && type.isNumber()) {
-    switch (type.getBasic()) {
-      case Type::i32:
-      case Type::f32:
-        return 32;
-      case Type::i64:
-      case Type::f64:
-        return 64;
-      case Type::v128:
-        return 128;
-      default:
-        break;
-    }
-  }
-  return -1;
-}
-
 inline bool emitsBoolean(Expression* curr) {
   if (auto* unary = curr->dynCast<Unary>()) {
     return unary->isRelational();

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -26,6 +26,24 @@ namespace wasm {
 
 namespace Properties {
 
+inline int getBits(const Type& type) {
+  if (type.isBasic() && type.isNumber()) {
+    switch (type.getBasic()) {
+      case Type::i32:
+      case Type::f32:
+        return 32;
+      case Type::i64:
+      case Type::f64:
+        return 64;
+      case Type::v128:
+        return 128;
+      default:
+        break;
+    }
+  }
+  return -1;
+}
+
 inline bool emitsBoolean(Expression* curr) {
   if (auto* unary = curr->dynCast<Unary>()) {
     return unary->isRelational();

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -805,10 +805,10 @@ struct OptimizeInstructions
       }
     }
 
-    // f32.reinterpret_i32(i32.load(x))  =>  f32.load
-    // f64.reinterpret_i64(i64.load(x))  =>  f64.load
-    // i32.reinterpret_f32(f32.load(x))  =>  i32.load
-    // i64.reinterpret_f64(f64.load(x))  =>  i64.load
+    // f32.reinterpret_i32(i32.load(x))  =>  f32.load(x)
+    // f64.reinterpret_i64(i64.load(x))  =>  f64.load(x)
+    // i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
+    // i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
     if (curr->op == ReinterpretInt32 || curr->op == ReinterpretInt64 ||
         curr->op == ReinterpretFloat32 || curr->op == ReinterpretFloat64) {
       if (auto* load = curr->value->dynCast<Load>()) {
@@ -992,10 +992,10 @@ struct OptimizeInstructions
         curr->valueType = Type::i64;
         curr->value = unary->value;
       }
-      // f32.store(f32.reinterpret_i32(x))  =>  i32.load
-      // f64.store(f64.reinterpret_i64(x))  =>  i64.load
-      // i32.store(i32.reinterpret_f32(x))  =>  f32.load
-      // i64.store(i64.reinterpret_f64(x))  =>  f64.load
+      // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
+      // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
+      // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
+      // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
       if (unary->op == ReinterpretInt32 || unary->op == ReinterpretInt64 ||
           unary->op == ReinterpretFloat32 || unary->op == ReinterpretFloat64) {
         switch (unary->type.getBasic()) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -812,7 +812,7 @@ struct OptimizeInstructions
       // f64.reinterpret_i64(i64.reinterpret_f64(x))  =>  x
       if (auto* inner = curr->value->dynCast<Unary>()) {
         if (Abstract::hasAnyReinterpret(inner->op)) {
-          if (inner->type == curr->type) {
+          if (inner->value->type == curr->type) {
             return replaceCurrent(inner->value);
           }
         }
@@ -992,7 +992,6 @@ struct OptimizeInstructions
         // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
         // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
         // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
-        curr->type = unary->value->type;
         curr->valueType = unary->value->type;
         curr->value = unary->value;
       }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -805,16 +805,13 @@ struct OptimizeInstructions
       }
     }
 
-    if (curr->op == ReinterpretInt32 || curr->op == ReinterpretInt64 ||
-        curr->op == ReinterpretFloat32 || curr->op == ReinterpretFloat64) {
+    if (Abstract::hasAnyReinterpret(curr->op)) {
       // i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x
       // i64.reinterpret_f64(f64.reinterpret_i64(x))  =>  x
       // f32.reinterpret_i32(i32.reinterpret_f32(x))  =>  x
       // f64.reinterpret_i64(i64.reinterpret_f64(x))  =>  x
       if (auto* inner = curr->value->dynCast<Unary>()) {
-        if (inner->op == ReinterpretInt32 || inner->op == ReinterpretInt64 ||
-            inner->op == ReinterpretFloat32 ||
-            inner->op == ReinterpretFloat64) {
+        if (Abstract::hasAnyReinterpret(inner->op)) {
           if (inner->type == curr->type) {
             return replaceCurrent(inner->value);
           }
@@ -990,15 +987,12 @@ struct OptimizeInstructions
         // instead of wrapping to 32, just store some of the bits in the i64
         curr->valueType = Type::i64;
         curr->value = unary->value;
-      } else if (unary->op == ReinterpretInt32 ||
-                 unary->op == ReinterpretInt64 ||
-                 unary->op == ReinterpretFloat32 ||
-                 unary->op == ReinterpretFloat64) {
+      } else if (Abstract::hasAnyReinterpret(unary->op)) {
         // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
         // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
         // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
         // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
-        curr->type = unary->value->type;
+        curr->valueType = unary->value->type;
         curr->value = unary->value;
       }
     }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -825,22 +825,8 @@ struct OptimizeInstructions
       // i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
       // i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
       if (auto* load = curr->value->dynCast<Load>()) {
-        switch (load->type.getBasic()) {
-          case Type::i32:
-            load->type = Type::f32;
-            return replaceCurrent(load);
-          case Type::i64:
-            load->type = Type::f64;
-            return replaceCurrent(load);
-          case Type::f32:
-            load->type = Type::i32;
-            return replaceCurrent(load);
-          case Type::f64:
-            load->type = Type::i64;
-            return replaceCurrent(load);
-          default:
-            break;
-        }
+        load->type = curr->type;
+        return replaceCurrent(load);
       }
     }
 
@@ -1011,26 +997,8 @@ struct OptimizeInstructions
       // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
       if (unary->op == ReinterpretInt32 || unary->op == ReinterpretInt64 ||
           unary->op == ReinterpretFloat32 || unary->op == ReinterpretFloat64) {
-        switch (unary->type.getBasic()) {
-          case Type::i32:
-            curr->type = Type::f32;
-            curr->value = unary->value;
-            break;
-          case Type::i64:
-            curr->type = Type::f64;
-            curr->value = unary->value;
-            break;
-          case Type::f32:
-            curr->type = Type::i32;
-            curr->value = unary->value;
-            break;
-          case Type::f64:
-            curr->type = Type::i64;
-            curr->value = unary->value;
-            break;
-          default:
-            break;
-        }
+        curr->type = unary->value->type;
+        curr->value = unary->value;
       }
     }
   }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -992,6 +992,33 @@ struct OptimizeInstructions
         curr->valueType = Type::i64;
         curr->value = unary->value;
       }
+      // f32.store(f32.reinterpret_i32(x))  =>  i32.load
+      // f64.store(f64.reinterpret_i64(x))  =>  i64.load
+      // i32.store(i32.reinterpret_f32(x))  =>  f32.load
+      // i64.store(i64.reinterpret_f64(x))  =>  f64.load
+      if (unary->op == ReinterpretInt32 || unary->op == ReinterpretInt64 ||
+          unary->op == ReinterpretFloat32 || unary->op == ReinterpretFloat64) {
+        switch (unary->type.getBasic()) {
+          case Type::i32:
+            curr->type = Type::f32;
+            curr->value = unary->value;
+            break;
+          case Type::i64:
+            curr->type = Type::f64;
+            curr->value = unary->value;
+            break;
+          case Type::f32:
+            curr->type = Type::i32;
+            curr->value = unary->value;
+            break;
+          case Type::f64:
+            curr->type = Type::i64;
+            curr->value = unary->value;
+            break;
+          default:
+            break;
+        }
+      }
     }
   }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -987,7 +987,8 @@ struct OptimizeInstructions
         // instead of wrapping to 32, just store some of the bits in the i64
         curr->valueType = Type::i64;
         curr->value = unary->value;
-      } else if (Abstract::hasAnyReinterpret(unary->op)) {
+      } else if (Abstract::hasAnyReinterpret(unary->op) &&
+                 curr->bytes * 8 == Properties::getBits(curr->valueType)) {
         // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
         // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
         // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -822,8 +822,10 @@ struct OptimizeInstructions
       // i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
       // i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
       if (auto* load = curr->value->dynCast<Load>()) {
-        load->type = curr->type;
-        return replaceCurrent(load);
+        if (load->bytes * 8 == Properties::getBits(curr->type)) {
+          load->type = curr->type;
+          return replaceCurrent(load);
+        }
       }
     }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -822,8 +822,7 @@ struct OptimizeInstructions
       // i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
       // i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
       if (auto* load = curr->value->dynCast<Load>()) {
-        if (!load->isAtomic &&
-            load->bytes * 8 == Properties::getBits(curr->type)) {
+        if (!load->isAtomic && load->bytes == curr->type.getByteSize()) {
           load->type = curr->type;
           return replaceCurrent(load);
         }
@@ -991,7 +990,7 @@ struct OptimizeInstructions
         curr->valueType = Type::i64;
         curr->value = unary->value;
       } else if (!curr->isAtomic && Abstract::hasAnyReinterpret(unary->op) &&
-                 curr->bytes * 8 == Properties::getBits(curr->valueType)) {
+                 curr->bytes == curr->valueType.getByteSize()) {
         // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
         // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
         // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -990,13 +990,14 @@ struct OptimizeInstructions
         // instead of wrapping to 32, just store some of the bits in the i64
         curr->valueType = Type::i64;
         curr->value = unary->value;
-      }
-      // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
-      // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
-      // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
-      // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
-      if (unary->op == ReinterpretInt32 || unary->op == ReinterpretInt64 ||
-          unary->op == ReinterpretFloat32 || unary->op == ReinterpretFloat64) {
+      } else if (unary->op == ReinterpretInt32 ||
+                 unary->op == ReinterpretInt64 ||
+                 unary->op == ReinterpretFloat32 ||
+                 unary->op == ReinterpretFloat64) {
+        // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
+        // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
+        // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
+        // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
         curr->type = unary->value->type;
         curr->value = unary->value;
       }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -992,6 +992,7 @@ struct OptimizeInstructions
         // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
         // i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
         // i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
+        curr->type = unary->value->type;
         curr->valueType = unary->value->type;
         curr->value = unary->value;
       }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -822,7 +822,8 @@ struct OptimizeInstructions
       // i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
       // i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
       if (auto* load = curr->value->dynCast<Load>()) {
-        if (load->bytes * 8 == Properties::getBits(curr->type)) {
+        if (!load->isAtomic &&
+            load->bytes * 8 == Properties::getBits(curr->type)) {
           load->type = curr->type;
           return replaceCurrent(load);
         }
@@ -989,7 +990,7 @@ struct OptimizeInstructions
         // instead of wrapping to 32, just store some of the bits in the i64
         curr->valueType = Type::i64;
         curr->value = unary->value;
-      } else if (Abstract::hasAnyReinterpret(unary->op) &&
+      } else if (!curr->isAtomic && Abstract::hasAnyReinterpret(unary->op) &&
                  curr->bytes * 8 == Properties::getBits(curr->valueType)) {
         // f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
         // f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)

--- a/test/lit/passes/optimize-instructions-atomics.wast
+++ b/test/lit/passes/optimize-instructions-atomics.wast
@@ -31,4 +31,24 @@
    )
   )
  )
+
+ ;; CHECK:      (func $dont_simplify_reinterpret_atomic_load_store (param $x i32) (param $y f32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (f64.reinterpret_i64
+ ;; CHECK-NEXT:    (i64.atomic.load
+ ;; CHECK-NEXT:     (local.get $x)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (i32.atomic.store
+ ;; CHECK-NEXT:   (i32.const 8)
+ ;; CHECK-NEXT:   (i32.reinterpret_f32
+ ;; CHECK-NEXT:    (local.get $y)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $dont_simplify_reinterpret_atomic_load_store (param $x i32) (param $y f32)
+  (drop (f64.reinterpret_i64 (i64.atomic.load (local.get $x))))         ;; skip
+  (i32.atomic.store (i32.const 8) (i32.reinterpret_f32 (local.get $y))) ;; skip
+ )
 )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12422,29 +12422,33 @@
   ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.store
+  ;; CHECK-NEXT:    (i32.const 8)
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.store
+  ;; CHECK-NEXT:    (i32.const 8)
   ;; CHECK-NEXT:    (local.get $y)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.store
+  ;; CHECK-NEXT:    (i32.const 8)
   ;; CHECK-NEXT:    (local.get $z)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f64.store
+  ;; CHECK-NEXT:    (i32.const 8)
   ;; CHECK-NEXT:    (local.get $w)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
-    (drop (f32.store (f32.reinterpret_i32 (local.get $x))))
-    (drop (f64.store (f64.reinterpret_i64 (local.get $y))))
-    (drop (i32.store (i32.reinterpret_f32 (local.get $z))))
-    (drop (i64.store (i64.reinterpret_f64 (local.get $w))))
+    (drop (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x))))
+    (drop (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $y))))
+    (drop (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $z))))
+    (drop (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $w))))
   )
 )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12414,10 +12414,10 @@
     (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
   )
 
-  ;; f32.store(f32.reinterpret_i32(x))  =>  i32.load
-  ;; f64.store(f64.reinterpret_i64(x))  =>  i64.load
-  ;; i32.store(i32.reinterpret_f32(x))  =>  f32.load
-  ;; i64.store(i64.reinterpret_f64(x))  =>  f64.load
+  ;; f32.store(f32.reinterpret_i32(x))  =>  i32.store
+  ;; f64.store(f64.reinterpret_i64(x))  =>  i64.store
+  ;; i32.store(i32.reinterpret_f32(x))  =>  f32.store
+  ;; i64.store(i64.reinterpret_f64(x))  =>  f64.store
 
   ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
   ;; CHECK-NEXT:  (drop

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12425,23 +12425,37 @@
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i64.store
-  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (i32.const 16)
   ;; CHECK-NEXT:   (local.get $y)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (f32.store
-  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (i32.const 24)
   ;; CHECK-NEXT:   (local.get $z)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (f64.store
-  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (i32.const 32)
   ;; CHECK-NEXT:   (local.get $w)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (i32.store8
+  ;; CHECK-NEXT:   (i32.const 40)
+  ;; CHECK-NEXT:   (i32.reinterpret_f32
+  ;; CHECK-NEXT:    (local.get $z)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (i64.store32
+  ;; CHECK-NEXT:   (i32.const 44)
+  ;; CHECK-NEXT:   (i64.reinterpret_f64
+  ;; CHECK-NEXT:    (local.get $w)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
     (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x)))
-    (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $y)))
-    (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $z)))
-    (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $w)))
+    (f64.store (i32.const 16) (f64.reinterpret_i64 (local.get $y)))
+    (i32.store (i32.const 24) (i32.reinterpret_f32 (local.get $z)))
+    (i64.store (i32.const 32) (i64.reinterpret_f64 (local.get $w)))
+    (i32.store8 (i32.const 40) (i32.reinterpret_f32 (local.get $z)))  ;; skip
+    (i64.store32 (i32.const 44) (i64.reinterpret_f64 (local.get $w))) ;; skip
   )
 
   ;; i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12406,12 +12406,28 @@
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.reinterpret_i32
+  ;; CHECK-NEXT:    (f32.load8_s
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.reinterpret_i64
+  ;; CHECK-NEXT:    (i64.load32_u
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $simplify_reinterpret_and_load (param $x i32)
     (drop (f32.reinterpret_i32 (i32.load (local.get $x))))
     (drop (f64.reinterpret_i64 (i64.load (local.get $x))))
     (drop (i32.reinterpret_f32 (f32.load (local.get $x))))
     (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
+    (drop (f32.reinterpret_i32 (i32.load8_s (local.get $x))))  ;; skip
+    (drop (f64.reinterpret_i64 (i64.load32_u (local.get $x)))) ;; skip
   )
 
   ;; f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12408,7 +12408,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.reinterpret_i32
-  ;; CHECK-NEXT:    (f32.load8_s
+  ;; CHECK-NEXT:    (i32.load8_s
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12419,44 +12419,29 @@
   ;; i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
   ;; i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
 
-  ;; CHECK:      (func $simplify_store_and_reinterpret_i32 (param $x i32)
+  ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
   ;; CHECK-NEXT:  (i32.store
   ;; CHECK-NEXT:   (i32.const 8)
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $simplify_store_and_reinterpret_i32 (param $x i32)
-    (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x)))
-  )
-
-  ;; CHECK:      (func $simplify_store_and_reinterpret_i64 (param $x i64)
   ;; CHECK-NEXT:  (i64.store
   ;; CHECK-NEXT:   (i32.const 8)
-  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (local.get $y)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $simplify_store_and_reinterpret_i64 (param $x i64)
-    (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $x)))
-  )
-
-  ;; CHECK:      (func $simplify_store_and_reinterpret_f32 (param $x f32)
   ;; CHECK-NEXT:  (f32.store
   ;; CHECK-NEXT:   (i32.const 8)
-  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (local.get $z)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $simplify_store_and_reinterpret_f32 (param $x f32)
-    (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $x)))
-  )
-
-  ;; CHECK:      (func $simplify_store_and_reinterpret_f64 (param $x f64)
   ;; CHECK-NEXT:  (f64.store
   ;; CHECK-NEXT:   (i32.const 8)
-  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (local.get $w)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $simplify_store_and_reinterpret_f64 (param $x f64)
-    (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $x)))
+  (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
+    (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x)))
+    (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $y)))
+    (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $z)))
+    (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $w)))
   )
 
   ;; i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12414,9 +12414,37 @@
     (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
   )
 
-  ;; TODO:
   ;; f32.store(f32.reinterpret_i32(x))  =>  i32.load
   ;; f64.store(f64.reinterpret_i64(x))  =>  i64.load
   ;; i32.store(i32.reinterpret_f32(x))  =>  f32.load
   ;; i64.store(i64.reinterpret_f64(x))  =>  f64.load
+
+  ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.store
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.store
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.store
+  ;; CHECK-NEXT:    (local.get $z)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.store
+  ;; CHECK-NEXT:    (local.get $w)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
+    (drop (f32.store (f32.reinterpret_i32 (local.get $x))))
+    (drop (f64.store (f64.reinterpret_i64 (local.get $y))))
+    (drop (i32.store (i32.reinterpret_f32 (local.get $z))))
+    (drop (i64.store (i64.reinterpret_f64 (local.get $w))))
+  )
 )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12420,35 +12420,52 @@
   ;; i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
 
   ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.store
-  ;; CHECK-NEXT:    (i32.const 8)
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (i32.store
+  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.store
-  ;; CHECK-NEXT:    (i32.const 8)
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (i64.store
+  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (local.get $y)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.store
-  ;; CHECK-NEXT:    (i32.const 8)
-  ;; CHECK-NEXT:    (local.get $z)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (f32.store
+  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (local.get $z)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.store
-  ;; CHECK-NEXT:    (i32.const 8)
-  ;; CHECK-NEXT:    (local.get $w)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (f64.store
+  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (local.get $w)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
-    (drop (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x))))
-    (drop (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $y))))
-    (drop (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $z))))
-    (drop (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $w))))
+    (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x)))
+    (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $y)))
+    (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $z)))
+    (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $w)))
   )
-)
+
+  ;; i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x
+  ;; i64.reinterpret_f64(f64.reinterpret_i64(x))  =>  x
+  ;; f32.reinterpret_i32(i32.reinterpret_f32(x))  =>  x
+  ;; f64.reinterpret_i64(i64.reinterpret_f64(x))  =>  x
+
+  ;; CHECK:      (func $eliminate_reinterpret_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $y)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $z)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $w)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $eliminate_reinterpret_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
+    (drop (i32.reinterpret_f32 (f32.reinterpret_i32 (local.get $x))))
+    (drop (i64.reinterpret_f64 (f64.reinterpret_i64 (local.get $y))))
+    (drop (f32.reinterpret_i32 (i32.reinterpret_f32 (local.get $z))))
+    (drop (f64.reinterpret_i64 (i64.reinterpret_f64 (local.get $w))))
+  )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12379,4 +12379,38 @@
       )
     )
   )
+
+  ;; f32.reinterpret_i32(i32.load(x))  =>  f32.load
+  ;; f64.reinterpret_i64(i64.load(x))  =>  f64.load
+  ;; i32.reinterpret_f32(f32.load(x))  =>  i32.load
+  ;; i64.reinterpret_f64(f64.load(x))  =>  i64.load
+
+  ;; CHECK:      (func $simplify_reinterpret_and_load (param $x i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.load
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.load
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.load
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.load
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $simplify_reinterpret_and_load (param $x i32)
+    (drop (f32.reinterpret_i32 (i32.load (local.get $x))))
+    (drop (f64.reinterpret_i64 (i64.load (local.get $x))))
+    (drop (i32.reinterpret_f32 (f32.load (local.get $x))))
+    (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
+  )
 )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12419,29 +12419,44 @@
   ;; i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
   ;; i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
 
-  ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
+  ;; CHECK:      (func $simplify_store_and_reinterpret_i32 (param $x i32)
   ;; CHECK-NEXT:  (i32.store
   ;; CHECK-NEXT:   (i32.const 8)
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $simplify_store_and_reinterpret_i32 (param $x i32)
+    (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x)))
+  )
+
+  ;; CHECK:      (func $simplify_store_and_reinterpret_i64 (param $x i64)
   ;; CHECK-NEXT:  (i64.store
   ;; CHECK-NEXT:   (i32.const 8)
-  ;; CHECK-NEXT:   (local.get $y)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (f32.store
-  ;; CHECK-NEXT:   (i32.const 8)
-  ;; CHECK-NEXT:   (local.get $z)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (f64.store
-  ;; CHECK-NEXT:   (i32.const 8)
-  ;; CHECK-NEXT:   (local.get $w)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
-    (f32.store (i32.const 8) (f32.reinterpret_i32 (local.get $x)))
-    (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $y)))
-    (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $z)))
-    (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $w)))
+  (func $simplify_store_and_reinterpret_i64 (param $x i64)
+    (f64.store (i32.const 8) (f64.reinterpret_i64 (local.get $x)))
+  )
+
+  ;; CHECK:      (func $simplify_store_and_reinterpret_f32 (param $x f32)
+  ;; CHECK-NEXT:  (f32.store
+  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $simplify_store_and_reinterpret_f32 (param $x f32)
+    (i32.store (i32.const 8) (i32.reinterpret_f32 (local.get $x)))
+  )
+
+  ;; CHECK:      (func $simplify_store_and_reinterpret_f64 (param $x f64)
+  ;; CHECK-NEXT:  (f64.store
+  ;; CHECK-NEXT:   (i32.const 8)
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $simplify_store_and_reinterpret_f64 (param $x f64)
+    (i64.store (i32.const 8) (i64.reinterpret_f64 (local.get $x)))
   )
 
   ;; i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12426,8 +12426,8 @@
     (drop (f64.reinterpret_i64 (i64.load (local.get $x))))
     (drop (i32.reinterpret_f32 (f32.load (local.get $x))))
     (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
-    (drop (f32.reinterpret_i32 (i32.load8_s (local.get $x))))  ;; skip
-    (drop (f64.reinterpret_i64 (i64.load32_u (local.get $x)))) ;; skip
+    (drop (f32.reinterpret_i32 (i32.load8_s (local.get $x))))     ;; skip
+    (drop (f64.reinterpret_i64 (i64.load32_u (local.get $x))))    ;; skip
   )
 
   ;; f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
@@ -12470,8 +12470,8 @@
     (f64.store (i32.const 16) (f64.reinterpret_i64 (local.get $y)))
     (i32.store (i32.const 24) (i32.reinterpret_f32 (local.get $z)))
     (i64.store (i32.const 32) (i64.reinterpret_f64 (local.get $w)))
-    (i32.store8 (i32.const 40) (i32.reinterpret_f32 (local.get $z)))  ;; skip
-    (i64.store32 (i32.const 44) (i64.reinterpret_f64 (local.get $w))) ;; skip
+    (i32.store8 (i32.const 40) (i32.reinterpret_f32 (local.get $z)))       ;; skip
+    (i64.store32 (i32.const 44) (i64.reinterpret_f64 (local.get $w)))      ;; skip
   )
 
   ;; i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12413,4 +12413,10 @@
     (drop (i32.reinterpret_f32 (f32.load (local.get $x))))
     (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
   )
+
+  ;; TODO:
+  ;; f32.store(f32.reinterpret_i32(x))  =>  i32.load
+  ;; f64.store(f64.reinterpret_i64(x))  =>  i64.load
+  ;; i32.store(i32.reinterpret_f32(x))  =>  f32.load
+  ;; i64.store(i64.reinterpret_f64(x))  =>  f64.load
 )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12469,3 +12469,4 @@
     (drop (f32.reinterpret_i32 (i32.reinterpret_f32 (local.get $z))))
     (drop (f64.reinterpret_i64 (i64.reinterpret_f64 (local.get $w))))
   )
+)

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -12380,10 +12380,10 @@
     )
   )
 
-  ;; f32.reinterpret_i32(i32.load(x))  =>  f32.load
-  ;; f64.reinterpret_i64(i64.load(x))  =>  f64.load
-  ;; i32.reinterpret_f32(f32.load(x))  =>  i32.load
-  ;; i64.reinterpret_f64(f64.load(x))  =>  i64.load
+  ;; f32.reinterpret_i32(i32.load(x))  =>  f32.load(x)
+  ;; f64.reinterpret_i64(i64.load(x))  =>  f64.load(x)
+  ;; i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
+  ;; i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
 
   ;; CHECK:      (func $simplify_reinterpret_and_load (param $x i32)
   ;; CHECK-NEXT:  (drop
@@ -12414,10 +12414,10 @@
     (drop (i64.reinterpret_f64 (f64.load (local.get $x))))
   )
 
-  ;; f32.store(f32.reinterpret_i32(x))  =>  i32.store
-  ;; f64.store(f64.reinterpret_i64(x))  =>  i64.store
-  ;; i32.store(i32.reinterpret_f32(x))  =>  f32.store
-  ;; i64.store(i64.reinterpret_f64(x))  =>  f64.store
+  ;; f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
+  ;; f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
+  ;; i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
+  ;; i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
 
   ;; CHECK:      (func $simplify_store_and_reinterpret (param $x i32) (param $y i64) (param $z f32) (param $w f64)
   ;; CHECK-NEXT:  (drop

--- a/test/wasm2js/reinterpret.2asm.js.opt
+++ b/test/wasm2js/reinterpret.2asm.js.opt
@@ -21,14 +21,6 @@
     f64ScratchView[0] = value;
   }
       
-  function wasm2js_scratch_store_f32(value) {
-    f32ScratchView[2] = value;
-  }
-      
-  function wasm2js_scratch_load_f32() {
-    return f32ScratchView[2];
-  }
-      
 function asmFunc(env) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -45,7 +37,7 @@ function asmFunc(env) {
  var infinity = Infinity;
  function $1($0) {
   $0 = $0 | 0;
-  return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(2)) | 0) == ($0 | 0) | 0;
+  return 1;
  }
  
  function legalstub$2($0, $1_1) {


### PR DESCRIPTION
FIx #3973

```rust
f32.reinterpret_i32(i32.load(x))  =>  f32.load(x)
f64.reinterpret_i64(i64.load(x))  =>  f64.load(x)
i32.reinterpret_f32(f32.load(x))  =>  i32.load(x)
i64.reinterpret_f64(f64.load(x))  =>  i64.load(x)
```

```rust
f32.store(y, f32.reinterpret_i32(x))  =>  i32.store(y, x)
f64.store(y, f64.reinterpret_i64(x))  =>  i64.store(y, x)
i32.store(y, i32.reinterpret_f32(x))  =>  f32.store(y, x)
i64.store(y, i64.reinterpret_f64(x))  =>  f64.store(y, x)
```

```rust
i32.reinterpret_f32(f32.reinterpret_i32(x))  =>  x
i64.reinterpret_f64(f64.reinterpret_i64(x))  =>  x
f32.reinterpret_i32(i32.reinterpret_f32(x))  =>  x
f64.reinterpret_i64(i64.reinterpret_f64(x))  =>  x
```