### PR TITLE
[Optimize Instructions] Simplify zero/sign extentions (special case)

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -843,21 +843,22 @@ struct OptimizeInstructions
       {
         if (getModule()->features.hasSignExt()) {
           // i64.extend_i32_s(i32.wrap_i64(x))  =>  i64.extend32_s(x)
-          // or
-          // i64.extend_i32_u(i32.wrap_i64(x))  =>  i64.extend32_s(x)
-          //   where maxBits(x) <= 31
           Unary* inner;
           Expression* x;
           if (matches(curr,
-                      unary(ExtendSInt32, unary(&inner, WrapInt64, any(&x)))) ||
-              (matches(
-                 curr,
-                 unary(ExtendUInt32, unary(&inner, WrapInt64, any(&x)))) &&
-               Bits::getMaxBits(x, this) <= 31)) {
+                      unary(ExtendSInt32, unary(&inner, WrapInt64, any(&x))))) {
             inner->op = ExtendS32Int64;
             inner->type = Type::i64;
             inner->value = x;
             return replaceCurrent(inner);
+          }
+
+          // i64.extend_i32_u(i32.wrap_i64(x))  =>  x
+          //   where maxBits(x) <= 31
+          if (matches(curr,
+                      unary(ExtendUInt32, unary(&inner, WrapInt64, any(&x)))) &&
+              Bits::getMaxBits(x, this) <= 31) {
+            return replaceCurrent(x);
           }
         }
       }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -846,10 +846,9 @@ struct OptimizeInstructions
         //
         // i64.extend_i32_u(i32.wrap_i64(x))  =>  x
         //   where maxBits(x) <= 32
-        Unary* inner;
         Expression* x;
         UnaryOp unaryOp;
-        if (matches(curr, unary(&unaryOp, unary(&inner, WrapInt64, any(&x))))) {
+        if (matches(curr, unary(&unaryOp, unary(WrapInt64, any(&x))))) {
           if (unaryOp == ExtendSInt32 || unaryOp == ExtendUInt32) {
             auto maxBits = Bits::getMaxBits(x, this);
             if ((unaryOp == ExtendSInt32 && maxBits <= 31) ||

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -845,6 +845,7 @@ struct OptimizeInstructions
           Unary* inner;
           Expression* x;
           // i64.extend_i32_u(i32.wrap_i64(x))  =>  x
+          // i64.extend_i32_s(i32.wrap_i64(x))  =>  x
           //   where maxBits(x) <= 31
           if ((matches(
                  curr,

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -845,7 +845,7 @@ struct OptimizeInstructions
           // i64.extend_i32_s(i32.wrap_i64(x))  =>  i64.extend32_s(x)
           // or
           // i64.extend_i32_u(i32.wrap_i64(x))  =>  i64.extend32_s(x)
-          //    where maxBits(x) <= 31
+          //   where maxBits(x) <= 31
           Unary* inner;
           Expression* x;
           if (matches(curr,

--- a/test/lit/passes/optimize-instructions-sign-ext.wast
+++ b/test/lit/passes/optimize-instructions-sign-ext.wast
@@ -62,33 +62,4 @@
     (drop (i64.shr_s (i64.shl (local.get $x) (i64.const 16)) (i64.const 16))) ;; skip
     (drop (i64.extend_i32_s (i32.wrap_i64 (local.get $x))))
   )
-
-  ;; i64.extend_i32_u(i32.wrap_i64(x))  =>  x where maxBits(x) <= 31
-
-  ;; CHECK:      (func $i64-zero-sign-special-extentions (param $x i64)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i64.const 2147483647)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i64.const 2147483647)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.extend_i32_u
-  ;; CHECK-NEXT:    (i32.wrap_i64
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $i64-zero-sign-special-extentions (param $x i64)
-    (drop (i64.extend_i32_u (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
-    (drop (i64.extend_i32_s (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
-    (drop (i64.extend_i32_u (i32.wrap_i64 (local.get $x)))) ;; skip
-  )
 )

--- a/test/lit/passes/optimize-instructions-sign-ext.wast
+++ b/test/lit/passes/optimize-instructions-sign-ext.wast
@@ -65,7 +65,13 @@
 
   ;; i64.extend_i32_u(i32.wrap_i64(x))  =>  x where maxBits(x) <= 31
 
-  ;; CHECK:      (func $i64-zero-special-extention (param $x i64)
+  ;; CHECK:      (func $i64-zero-sign-special-extentions (param $x i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i64.const 2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.and
   ;; CHECK-NEXT:    (local.get $x)
@@ -80,8 +86,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $i64-zero-special-extention (param $x i64)
+  (func $i64-zero-sign-special-extentions (param $x i64)
     (drop (i64.extend_i32_u (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
+    (drop (i64.extend_i32_s (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
     (drop (i64.extend_i32_u (i32.wrap_i64 (local.get $x)))) ;; skip
   )
 )

--- a/test/lit/passes/optimize-instructions-sign-ext.wast
+++ b/test/lit/passes/optimize-instructions-sign-ext.wast
@@ -62,4 +62,28 @@
     (drop (i64.shr_s (i64.shl (local.get $x) (i64.const 16)) (i64.const 16))) ;; skip
     (drop (i64.extend_i32_s (i32.wrap_i64 (local.get $x))))
   )
+
+  ;; i64.extend_i32_u(i32.wrap_i64(x))  =>  i64.extend32_s(x) where maxBits(x) <= 31
+
+  ;; CHECK:      (func $i64-zero-special-extention (param $x i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.extend32_s
+  ;; CHECK-NEXT:    (i64.and
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:     (i64.const 2147483647)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.extend_i32_u
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $i64-zero-special-extention (param $x i64)
+    (drop (i64.extend_i32_u (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
+    (drop (i64.extend_i32_u (i32.wrap_i64 (local.get $x)))) ;; skip
+  )
 )

--- a/test/lit/passes/optimize-instructions-sign-ext.wast
+++ b/test/lit/passes/optimize-instructions-sign-ext.wast
@@ -63,15 +63,13 @@
     (drop (i64.extend_i32_s (i32.wrap_i64 (local.get $x))))
   )
 
-  ;; i64.extend_i32_u(i32.wrap_i64(x))  =>  i64.extend32_s(x) where maxBits(x) <= 31
+  ;; i64.extend_i32_u(i32.wrap_i64(x))  =>  x where maxBits(x) <= 31
 
   ;; CHECK:      (func $i64-zero-special-extention (param $x i64)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.extend32_s
-  ;; CHECK-NEXT:    (i64.and
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:     (i64.const 2147483647)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i64.const 2147483647)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -11252,7 +11252,7 @@
   ;; i32.wrap_i64(i64.extend_i32_s(x))  ==>  x
   ;; i32.wrap_i64(i64.extend_i32_u(x))  ==>  x
 
-  ;; CHECK:      (func $sign-and-zero-extention-elimination (param $x i32)
+  ;; CHECK:      (func $sign-and-zero-extention-elimination-1 (param $x i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
@@ -11260,9 +11260,38 @@
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $sign-and-zero-extention-elimination (param $x i32)
+  (func $sign-and-zero-extention-elimination-1 (param $x i32)
     (drop (i32.wrap_i64 (i64.extend_i32_s (local.get $x))))
     (drop (i32.wrap_i64 (i64.extend_i32_u (local.get $x))))
+  )
+  ;; i64.extend_i32_u(i32.wrap_i64(x))  =>  x,  where maxBits(x) <= 32
+  ;; i64.extend_i32_s(i32.wrap_i64(x))  =>  x,  where maxBits(x) <= 31
+
+  ;; CHECK:      (func $sign-and-zero-extention-elimination-2 (param $x i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i64.const 4294967295)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i64.const 2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.extend_i32_u
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $sign-and-zero-extention-elimination-2 (param $x i64)
+    (drop (i64.extend_i32_u (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x00000000FFFFFFFF)))))
+    (drop (i64.extend_i32_s (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
+    (drop (i64.extend_i32_u (i32.wrap_i64 (local.get $x)))) ;; skip
   )
   ;; CHECK:      (func $optimize-shifts (param $x i32) (param $y i32) (param $z i64) (param $w i64)
   ;; CHECK-NEXT:  (drop

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -11287,11 +11287,31 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.extend_i32_s
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.extend_i32_s
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (i64.and
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:      (i64.const 4294967295)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $sign-and-zero-extention-elimination-2 (param $x i64)
     (drop (i64.extend_i32_u (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x00000000FFFFFFFF)))))
     (drop (i64.extend_i32_s (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x000000007FFFFFFF)))))
+
     (drop (i64.extend_i32_u (i32.wrap_i64 (local.get $x)))) ;; skip
+    (drop (i64.extend_i32_s (i32.wrap_i64 (local.get $x)))) ;; skip
+    (drop (i64.extend_i32_s (i32.wrap_i64 (i64.and (local.get $x) (i64.const 0x00000000FFFFFFFF))))) ;; skip
   )
   ;; CHECK:      (func $optimize-shifts (param $x i32) (param $y i32) (param $z i64) (param $w i64)
   ;; CHECK-NEXT:  (drop


### PR DESCRIPTION
For signed or unsigned extension to 64-bits after lowering from partially filled 64-bit arguments:
```rust
i64.extend_i32_u(i32.wrap_i64(x))  =>  x   // where maxBits(x) <= 32
i64.extend_i32_s(i32.wrap_i64(x))  =>  x   // where maxBits(x) <= 31
```