### PR TITLE
wasm-reduce: Avoid a crash where function names change after tryToRemoveFunctions()

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -890,9 +890,10 @@ struct Reducer
       if (names.size() == 0) {
         continue;
       }
-      // Try to remove functions, and if that fails, try to at least empty out
-      // their bodies.
-      justReduced = tryToRemoveFunctions(names) || tryToEmptyFunctions(names);
+      // Try to remove functions and/or empty them. Note that
+      // tryToRemoveFunctions() will reload the module if it fails, which means
+      // function names may change - for that reason, run it second.
+      justReduced = tryToEmptyFunctions(names) || tryToRemoveFunctions(names);
       if (justReduced) {
         noteReduction(names.size());
         i += skip;


### PR DESCRIPTION
`tryToRemoveFunctions()` will reload the wasm from binary if it fails to
optimize, and without the names section we don't have a guarantee on the
names being the same after that. And then `tryToEmptyFunctions` would
look for a name, and crash.

In the reverse order there is no risk, as `tryToEmptyFunctions` does not
reload the wasm from binary, it carefully undoes what it tried to do when
it fails.