### PR TITLE
[Wasm GC] Handle nondefaultable types in LocalSubtyping

### DIFF
--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -107,10 +107,10 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
           if (!getModule()->features.hasGCNNLocals()) {
             newType = Type(newType.getHeapType(), Nullable);
             // Note that the old type must have been nullable as well, as non-
-            // nullable types cannot be locals without that feature being enabled,
-            // which means that we will not have to do any extra work to handle
-            // non-nullability if we update the type: we are just updating the
-            // heap type, and leaving the type nullable as it was.
+            // nullable types cannot be locals without that feature being
+            // enabled, which means that we will not have to do any extra work
+            // to handle non-nullability if we update the type: we are just
+            // updating the heap type, and leaving the type nullable as it was.
             assert(oldType.isNullable());
           }
         } else if (!newType.isDefaultable()) {

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -214,7 +214,8 @@
   ;; CHECK-NEXT: )
   (func $nondefaultable
     (local $x (anyref anyref))
-    ;; A tuple
+    ;; This tuple is assigned non-nullable values, which means the subtype is
+    ;; nondefaultable, and we must not apply it.
     (local.set $x
       (tuple.make
         (ref.func $i32)

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -202,4 +202,24 @@
       )
     )
   )
+
+  ;; CHECK:      (func $nondefaultable
+  ;; CHECK-NEXT:  (local $x (anyref anyref))
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:    (ref.func $i32)
+  ;; CHECK-NEXT:    (ref.func $i32)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $nondefaultable
+    (local $x (anyref anyref))
+    ;; A tuple
+    (local.set $x
+      (tuple.make
+        (ref.func $i32)
+        (ref.func $i32)
+      )
+    )
+  )
 )


### PR DESCRIPTION
The pass handled non-nullability, but another case is a tuple with nullable
values in it that is assigned non-nullable values, and in general, other stuff
that is nondefaultable (but not non-nullable). Ignore those.