### PR TITLE
[Wasm GC] Refine return types

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -623,7 +623,7 @@ private:
     }
 
     Type originalType = func->getResults();
-    if (!originalType.isRef()) {
+    if (!originalType.hasRef()) {
       // Nothing to refine.
       return false;
     }

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -615,6 +615,10 @@ private:
   // function subtyping in indirect calls. TODO: relax this when possible
   //
   // Returns whether we optimized.
+  //
+  // TODO: We may be missing a global optimum here, as if a function calls
+  //       itself and returns that value, then we would not do any change here,
+  //       as one of the return values is exactly what it already is.
   bool refineReturnTypes(Function* func,
                          const std::vector<Call*>& calls,
                          Module* module) {

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -616,9 +616,11 @@ private:
   //
   // Returns whether we optimized.
   //
-  // TODO: We may be missing a global optimum here, as if a function calls
+  // TODO: We may be missing a global optimum here, as e.g. if a function calls
   //       itself and returns that value, then we would not do any change here,
-  //       as one of the return values is exactly what it already is.
+  //       as one of the return values is exactly what it already is. Similar
+  //       unoptimality can happen with multiple functions, more local code in
+  //       the middle, etc.
   bool refineReturnTypes(Function* func,
                          const std::vector<Call*>& calls,
                          Module* module) {

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -328,8 +328,8 @@ struct DAE : public Pass {
       // where possible.
       refineArgumentTypes(func, calls, module);
       // Refine return types as well.
-      refinedReturnTypes = refinedReturnTypes ||
-                           refineReturnTypes(func, calls, module);
+      refinedReturnTypes =
+        refinedReturnTypes || refineReturnTypes(func, calls, module);
       // Check if all calls pass the same constant for a particular argument.
       for (Index i = 0; i < numParams; i++) {
         Literal value;

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -9,10 +9,11 @@
  (type ${i32} (struct (field i32)))
  ;; CHECK:      (type ${i32_i64} (struct (field i32) (field i64)))
 
+ ;; CHECK:      (type ${i32_f32} (struct (field i32) (field f32)))
+
  ;; CHECK:      (type ${f64} (struct (field f64)))
  (type ${f64} (struct (field f64)))
  (type ${i32_i64} (struct (field i32) (field i64)))
- ;; CHECK:      (type ${i32_f32} (struct (field i32) (field f32)))
  (type ${i32_f32} (struct (field i32) (field f32)))
 
  ;; CHECK:      (func $foo
@@ -486,5 +487,31 @@
   )
   ;; The refined return value is limited by this value.
   (ref.null data)
+ )
+
+ ;; CHECK:      (func $refine-return-many-middle (result (ref null ${i32}))
+ ;; CHECK-NEXT:  (local $temp anyref)
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (call $refine-return-many-middle)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:   (return
+ ;; CHECK-NEXT:    (ref.null ${i32_i64})
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (ref.null ${i32_f32})
+ ;; CHECK-NEXT: )
+ (func $refine-return-many-middle (result anyref)
+  (local $temp anyref)
+  (local.set $temp (call $refine-return-many-middle))
+
+  ;; Return two different struct types, with an LUB that is not equal to either
+  ;; of them.
+  (if
+   (i32.const 1)
+   (return (ref.null ${i32_i64}))
+  )
+  (ref.null ${i32_f32})
  )
 )

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -419,10 +419,10 @@
   (ref.null func)
  )
 
- ;; CHECK:      (func $refine-return-many-partial (result anyref)
+ ;; CHECK:      (func $refine-return-many-blocked (result anyref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (call $refine-return-many-partial)
+ ;; CHECK-NEXT:   (call $refine-return-many-blocked)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (i32.const 1)
@@ -438,9 +438,9 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (ref.null func)
  ;; CHECK-NEXT: )
- (func $refine-return-many-partial (result anyref)
+ (func $refine-return-many-blocked (result anyref)
   (local $temp anyref)
-  (local.set $temp (call $refine-return-many-partial))
+  (local.set $temp (call $refine-return-many-blocked))
 
   (if
    (i32.const 1)
@@ -448,16 +448,16 @@
   )
   (if
    (i32.const 2)
-   ;; The refined return value is limited by this return.
+   ;; The refined return value is blocked by this return.
    (return (ref.null data))
   )
   (ref.null func)
  )
 
- ;; CHECK:      (func $refine-return-many-partial-2 (result anyref)
+ ;; CHECK:      (func $refine-return-many-blocked-2 (result anyref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (call $refine-return-many-partial-2)
+ ;; CHECK-NEXT:   (call $refine-return-many-blocked-2)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (i32.const 1)
@@ -473,9 +473,9 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (ref.null data)
  ;; CHECK-NEXT: )
- (func $refine-return-many-partial-2 (result anyref)
+ (func $refine-return-many-blocked-2 (result anyref)
   (local $temp anyref)
-  (local.set $temp (call $refine-return-many-partial-2))
+  (local.set $temp (call $refine-return-many-blocked-2))
 
   (if
    (i32.const 1)
@@ -485,7 +485,7 @@
    (i32.const 2)
    (return (ref.null func))
   )
-  ;; The refined return value is limited by this value.
+  ;; The refined return value is blocked by this value.
   (ref.null data)
  )
 
@@ -513,5 +513,32 @@
    (return (ref.null ${i32_i64}))
   )
   (ref.null ${i32_f32})
+ )
+
+ ;; We can refine the return types of tuples.
+ ;; CHECK:      (func $refine-return-tuple (result funcref i32)
+ ;; CHECK-NEXT:  (local $temp anyref)
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:    (call $refine-return-tuple)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:   (ref.null func)
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $refine-return-tuple (result anyref i32)
+  (local $temp anyref)
+  (local.set $temp
+   (tuple.extract 0
+    (call $refine-return-tuple)
+   )
+  )
+
+  (tuple.make
+   (ref.null func)
+   (i32.const 1)
+  )
  )
 )


### PR DESCRIPTION
Corresponds to #4014 which did the same for parameter types. This sees
whether the return types actually returned from a function allow us to use
a more specific type for the function's return. If so, we update that type, as
well as calls to the function.