### PR TITLE
[Wasm GC] Handle uses of default values in LocalSubtyping

### DIFF
--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -44,19 +44,19 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
     auto numLocals = func->getNumLocals();
 
     // Compute the local graph. We need to get the list of gets and sets for
-    // for each local, so that we can do the analysis, and also we need to know
+    // each local, so that we can do the analysis, and also we need to know
     // when the default value of a local is used. If the default is actually
     // used then we cannot change that type, as then we might end up with a null
-    // of a different type - that may technically be valid, but it can be
-    // confusing, and errors in the fuzzer. Furthermore, with non-nullable
-    // locals we can get a worse error, where if we change the local type to
+    // of a different type - while all nulls compare equally, it can be
+    // confusing (and errors in the fuzzer). Furthermore, with non-nullable
+    // locals we can get invalid code where if we change the local type to
     // non-nullable then we'd be accessing the default, which is not allowed.
     //
     // TODO: Optimize this, as LocalGraph computes more than we need, and on
     //       more locals than we need.
     LocalGraph localGraph(func);
 
-    // For each local index, we compute all the the sets and gets.
+    // For each local index, compute all the the sets and gets.
     std::vector<std::vector<LocalSet*>> setsForLocal(numLocals);
     std::vector<std::vector<LocalGet*>> getsForLocal(numLocals);
 

--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -77,9 +77,10 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
       auto* get = kv.first;
       auto& sets = kv.second;
       auto index = get->index;
-      if (func->isVar(index) && std::any_of(sets.begin(), sets.end(), [&](LocalSet* set) {
-        return set == nullptr;
-      })) {
+      if (func->isVar(index) &&
+          std::any_of(sets.begin(), sets.end(), [&](LocalSet* set) {
+            return set == nullptr;
+          })) {
         usesDefault.insert(index);
       }
     }

--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -43,7 +43,7 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
 
     auto numLocals = func->getNumLocals();
 
-    // Compute the local graph. We need is to get the list of gets and sets for
+    // Compute the local graph. We need to get the list of gets and sets for
     // for each local, so that we can do the analysis, and also we need to know
     // when the default value of a local is used. If the default is actually
     // used then we cannot change that type, as then we might end up with a null

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -352,7 +352,7 @@ private:
             if (getFunction()->isVar(get->index)) {
               auto localType = getFunction()->getLocalType(get->index);
               if (localType.isNonNullable()) {
-                Fatal() << "Non-nullable locals accessing the default value in "
+                Fatal() << "Non-nullable local accessing the default value in "
                         << getFunction()->name << " (" << get->index << ')';
               }
               curr = Literal::makeZeros(localType);

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -351,8 +351,10 @@ private:
           if (set == nullptr) {
             if (getFunction()->isVar(get->index)) {
               auto localType = getFunction()->getLocalType(get->index);
-              assert(!localType.isNonNullable() &&
-                     "Non-nullable locals must not use the default value");
+              if (localType.isNonNullable()) {
+                Fatal() << "Non-nullable locals accessing the default value in "
+                        << getFunction()->name << " (" << get->index << ')';
+              }
               curr = Literal::makeZeros(localType);
             } else {
               // it's a param, so it's hopeless

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -146,7 +146,7 @@ struct ExecutionResults {
   bool areEqual(Literal a, Literal b) {
     // We allow nulls to have different types (as they compare equal regardless)
     // but anything else must have an identical type.
-    if (a.type != b.type && !a.isNull() && !b.isNull()) {
+    if (a.type != b.type && !(a.isNull() && b.isNull())) {
       std::cout << "types not identical! " << a << " != " << b << '\n';
       return false;
     }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -145,8 +145,7 @@ struct ExecutionResults {
 
   bool areEqual(Literal a, Literal b) {
     if (a.type != b.type) {
-      std::cout << "types not identical! " << a.type << " != " << b.type
-                << '\n';
+      std::cout << "types not identical! " << a << " != " << b << '\n';
       return false;
     }
     if (a.type.isRef()) {

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -144,7 +144,9 @@ struct ExecutionResults {
   }
 
   bool areEqual(Literal a, Literal b) {
-    if (a.type != b.type) {
+    // We allow nulls to have different types (as they compare equal regardless)
+    // but anything else must have an identical type.
+    if (a.type != b.type && !a.isNull() && !b.isNull()) {
       std::cout << "types not identical! " << a << " != " << b << '\n';
       return false;
     }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -145,7 +145,8 @@ struct ExecutionResults {
 
   bool areEqual(Literal a, Literal b) {
     if (a.type != b.type) {
-      std::cout << "types not identical! " << a << " != " << b << '\n';
+      std::cout << "types not identical! " << a.type << " != " << b.type
+                << '\n';
       return false;
     }
     if (a.type.isRef()) {

--- a/test/lit/passes/local-subtyping-nn.wast
+++ b/test/lit/passes/local-subtyping-nn.wast
@@ -20,6 +20,9 @@
   ;; CHECK-NEXT:  (local.set $y
   ;; CHECK-NEXT:   (ref.func $i32)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $non-nullable
     (local $x (ref null $struct))
@@ -28,10 +31,44 @@
     (local.set $x
       (ref.as_non_null (ref.null $struct))
     )
-    ;; x is assigned a value that is non-nullable, and also allows a more
+    ;; y is assigned a value that is non-nullable, and also allows a more
     ;; specific heap type.
     (local.set $y
       (ref.func $i32)
+    )
+    ;; Verify that the presence of a get does not alter things.
+    (drop
+      (local.get $x)
+    )
+  )
+
+  ;; CHECK:      (func $uses-default (param $i i32)
+  ;; CHECK-NEXT:  (local $x (ref null $struct))
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.get $i)
+  ;; CHECK-NEXT:   (local.set $x
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (ref.null $struct)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $uses-default (param $i i32)
+    (local $x (ref null $struct))
+    (if
+      (local.get $i)
+      ;; The only set to this local uses a non-nullable type.
+      (local.set $x
+        (ref.as_non_null (ref.null $struct))
+      )
+    )
+    (drop
+      ;; This get may use the null value, and so we should not alter the
+      ;; type of the local to be non-nullable
+      (local.get $x)
     )
   )
 )

--- a/test/lit/passes/local-subtyping-nn.wast
+++ b/test/lit/passes/local-subtyping-nn.wast
@@ -57,7 +57,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $uses-default (param $i i32)
-    (local $x (ref null $struct))
+    (local $x (ref null any))
     (if
       (local.get $i)
       ;; The only set to this local uses a non-nullable type.
@@ -66,8 +66,8 @@
       )
     )
     (drop
-      ;; This get may use the null value, and so we should not alter the
-      ;; type of the local to be non-nullable
+      ;; This get may use the null value, so we can refine the heap type but not
+      ;; alter nullability.
       (local.get $x)
     )
   )

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -225,7 +225,7 @@
   )
 
   ;; CHECK:      (func $uses-default (param $i i32)
-  ;; CHECK-NEXT:  (local $x anyref)
+  ;; CHECK-NEXT:  (local $x (ref null $i32_=>_none))
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (local.get $i)
   ;; CHECK-NEXT:   (local.set $x
@@ -244,8 +244,8 @@
       (local.set $x (ref.func $uses-default))
     )
     (drop
-      ;; This get may use the default value, and so we should not alter the
-      ;; type of the local.
+      ;; This get may use the default value, but it is ok to have a null of a
+      ;; more refined type in the local.
       (local.get $x)
     )
   )

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -223,4 +223,30 @@
       )
     )
   )
+
+  ;; CHECK:      (func $uses-default (param $i i32)
+  ;; CHECK-NEXT:  (local $x anyref)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.get $i)
+  ;; CHECK-NEXT:   (local.set $x
+  ;; CHECK-NEXT:    (ref.func $uses-default)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $uses-default (param $i i32)
+    (local $x anyref)
+    (if
+      (local.get $i)
+      ;; The only set to this local uses a more specific type than anyref.
+      (local.set $x (ref.func $uses-default))
+    )
+    (drop
+      ;; This get may use the default value, and so we should not alter the
+      ;; type of the local.
+      (local.get $x)
+    )
+  )
 )


### PR DESCRIPTION
If the default value is used, it is better to not change the local type. See
details in the comment.
