### PR TITLE
[Wasm GC] DeadArgumentElimination: Do not refine return types of a function that tail calls

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -335,8 +335,7 @@ struct DAE : public Pass {
       //
       // TODO: Try to optimize in a more holistic manner, see the TODO in
       //       refineReturnTypes() about missing a global optimum.
-      if (!tailCallees.count(name) &&
-          !infoMap[name].hasTailCalls &&
+      if (!tailCallees.count(name) && !infoMap[name].hasTailCalls &&
           refineReturnTypes(func, calls, module)) {
         refinedReturnTypes = true;
       }

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -665,12 +665,6 @@ private:
     }
     assert(refinedType != originalType);
 
-    // The body is unreachable, and there are no returns, so this function
-    // never exits, and there is nothing to optimize.
-    if (refinedType == Type::unreachable) {
-      return false;
-    }
-
     // If the refined type is unreachable then nothing actually returns from
     // this function.
     // TODO: We can propagate that to the outside, and not just for GC.

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -602,6 +602,7 @@
  ;; CHECK-NEXT: )
  (func $tail-call-caller
   (drop
+   ;; Call the tail-calling function so that we try to optimize its return type.
    (call $tail-caller)
   )
  )


### PR DESCRIPTION
Similar to #4025, but when there is a tail call in the function as opposed to
the function is tail-called from somewhere.