### PR TITLE
[Wasm GC] Allow tail call subtyping in DeadArgumentElimination

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -327,14 +327,8 @@ struct DAE : public Pass {
       // affect whether an argument is used or not, it just refines the type
       // where possible.
       refineArgumentTypes(func, calls, module);
-      // Refine return types as well, if we can. We cannot do so if this
-      // function is tail-called, because then the return type must match that
-      // of the function doing a tail call of it - we cannot change just one of
-      // them.
-      //
-      // TODO: Try to optimize in a more holistic manner, see the TODO in
-      //       refineReturnTypes() about missing a global optimum.
-      if (!tailCallees.count(name) && refineReturnTypes(func, calls, module)) {
+      // Refine return types as well.
+      if (refineReturnTypes(func, calls, module)) {
         refinedReturnTypes = true;
       }
       // Check if all calls pass the same constant for a particular argument.

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -588,7 +588,7 @@
  (func $do-return-call (result funcref)
   (return_call $return-ref-func)
  )
- ;; CHECK:      (func $return-ref-func (result funcref)
+ ;; CHECK:      (func $return-ref-func (result (ref $none_=>_funcref))
  ;; CHECK-NEXT:  (ref.func $do-return-call)
  ;; CHECK-NEXT: )
  (func $return-ref-func (result funcref)

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -580,8 +580,8 @@
 
  ;; This function does a return call of the one after it. The one after it
  ;; returns a ref.func of this one. They both begin by returning a funcref;
- ;; after refining the return type, they will no longer have an identical type,
- ;; but that is ok as subtyping is allowed with tail calls.
+ ;; after refining the return type of the second function, it will have a more
+ ;; specific type (which is ok as subtyping is allowed with tail calls).
  ;; CHECK:      (func $do-return-call (result funcref)
  ;; CHECK-NEXT:  (return_call $return-ref-func)
  ;; CHECK-NEXT: )

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -579,9 +579,9 @@
  )
 
  ;; This function does a return call of the one after it. The one after it
- ;; returns a ref.func of this one. They both begin by returning a funcref; if
- ;; we refine the return type of the latter (which ref.func allows us to do)
- ;; then the return type would not match, and we would get a validation error.
+ ;; returns a ref.func of this one. They both begin by returning a funcref;
+ ;; after refining the return type, they will no longer have an identical type,
+ ;; but that is ok as subtyping is allowed with tail calls.
  ;; CHECK:      (func $do-return-call (result funcref)
  ;; CHECK-NEXT:  (return_call $return-ref-func)
  ;; CHECK-NEXT: )


### PR DESCRIPTION
Partially reverts #4025, removing the code and updates the test to show
we do the optimization.