### PR TITLE
[Wasm GC] Handle call_ref in DeadArgument return refinement

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -688,7 +688,8 @@ private:
         if (targetType == Type::unreachable) {
           continue;
         }
-        if (!processReturnType(targetType.getHeapType().getSignature().results)) {
+        if (!processReturnType(
+              targetType.getHeapType().getSignature().results)) {
           return false;
         }
       }

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -682,6 +682,17 @@ private:
         return false;
       }
     }
+    for (auto* call : FindAll<CallRef>(func->body).list) {
+      if (call->isReturn) {
+        auto targetType = call->target->type;
+        if (targetType == Type::unreachable) {
+          continue;
+        }
+        if (!processReturnType(targetType.getHeapType().getSignature().results)) {
+          return false;
+        }
+      }
+    }
     assert(refinedType != originalType);
 
     // If the refined type is unreachable then nothing actually returns from

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -382,4 +382,53 @@
    (call $tail-caller-indirect-no)
   )
  )
+
+ ;; As above, but with a tail call by function reference.
+ ;; CHECK:      (func $tail-callee-call_ref (result (ref ${}))
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
+ (func $tail-callee-call_ref (result (ref ${}))
+  (unreachable)
+ )
+ ;; CHECK:      (func $tail-caller-call_ref-yes (result (ref ${}))
+ ;; CHECK-NEXT:  (return_call_ref
+ ;; CHECK-NEXT:   (ref.null $return_{})
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $tail-caller-call_ref-yes (result anyref)
+  (return_call_ref (ref.null $return_{}))
+ )
+ ;; CHECK:      (func $tail-caller-call_ref-no (result anyref)
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:   (return
+ ;; CHECK-NEXT:    (ref.null any)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return_call_ref
+ ;; CHECK-NEXT:   (ref.null $return_{})
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $tail-caller-call_ref-no (result anyref)
+  (if (i32.const 1)
+   (return (ref.null any))
+  )
+  (return_call_ref (ref.null $return_{}))
+ )
+ ;; CHECK:      (func $tail-call-caller-call_ref
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (call $tail-caller-call_ref-yes)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (call $tail-caller-call_ref-no)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $tail-call-caller-call_ref
+  (drop
+   (call $tail-caller-call_ref-yes)
+  )
+  (drop
+   (call $tail-caller-call_ref-no)
+  )
+ )
 )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -415,12 +415,28 @@
   )
   (return_call_ref (ref.null $return_{}))
  )
+ ;; CHECK:      (func $tail-caller-call_ref-unreachable
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:   (block
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (ref.null any)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (return)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
  (func $tail-caller-call_ref-unreachable (result anyref)
   (if (i32.const 1)
    (return (ref.null any))
   )
   ;; An unreachable means there is no function signature to even look at. We
   ;; should not hit an assertion on such things.
+  ;; (Note that other DAE optimizations will apply here and remove the return
+  ;; value entirely in the result, together with the drop in the caller below.)
   (return_call_ref (unreachable))
  )
  ;; CHECK:      (func $tail-call-caller-call_ref
@@ -430,6 +446,7 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (call $tail-caller-call_ref-no)
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (call $tail-caller-call_ref-unreachable)
  ;; CHECK-NEXT: )
  (func $tail-call-caller-call_ref
   (drop

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -416,23 +416,11 @@
   (return_call_ref (ref.null $return_{}))
  )
  ;; CHECK:      (func $tail-caller-call_ref-unreachable
- ;; CHECK-NEXT:  (if
- ;; CHECK-NEXT:   (i32.const 1)
- ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (ref.null any)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (return)
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (block
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $tail-caller-call_ref-unreachable (result anyref)
-  (if (i32.const 1)
-   (return (ref.null any))
-  )
   ;; An unreachable means there is no function signature to even look at. We
   ;; should not hit an assertion on such things.
   ;; (Note that other DAE optimizations will apply here and remove the return

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -415,6 +415,14 @@
   )
   (return_call_ref (ref.null $return_{}))
  )
+ (func $tail-caller-call_ref-unreachable (result anyref)
+  (if (i32.const 1)
+   (return (ref.null any))
+  )
+  ;; An unreachable means there is no function signature to even look at. We
+  ;; should not hit an assertion on such things.
+  (return_call_ref (unreachable))
+ )
  ;; CHECK:      (func $tail-call-caller-call_ref
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (call $tail-caller-call_ref-yes)
@@ -429,6 +437,9 @@
   )
   (drop
    (call $tail-caller-call_ref-no)
+  )
+  (drop
+   (call $tail-caller-call_ref-unreachable)
   )
  )
 )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -421,8 +421,6 @@
  (func $tail-caller-call_ref-unreachable (result anyref)
   ;; An unreachable means there is no function signature to even look at. We
   ;; should not hit an assertion on such things.
-  ;; (Note that other DAE optimizations will apply here and remove the return
-  ;; value entirely in the result, together with the drop in the caller below.)
   (return_call_ref (unreachable))
  )
  ;; CHECK:      (func $tail-call-caller-call_ref

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -416,9 +416,7 @@
   (return_call_ref (ref.null $return_{}))
  )
  ;; CHECK:      (func $tail-caller-call_ref-unreachable
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (unreachable)
- ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $tail-caller-call_ref-unreachable (result anyref)
   ;; An unreachable means there is no function signature to even look at. We


### PR DESCRIPTION
This should be the last call type...

If this pattern appears anywhere else (get all the return types) we should
have a helper for it, but it seems to only happen in this one pass.