### PR TITLE
Do not crash in ExtractFunction if an export already exists

### DIFF
--- a/src/passes/ExtractFunction.cpp
+++ b/src/passes/ExtractFunction.cpp
@@ -46,6 +46,7 @@ static void extract(PassRunner* runner, Module* module, Name name) {
 
   // Leave just one export, for the thing we want.
   module->exports.clear();
+  module->updateMaps();
   module->addExport(Builder::makeExport(name, name, ExternalKind::Function));
 
   // Remove unneeded things.

--- a/test/lit/passes/extract-function.wast
+++ b/test/lit/passes/extract-function.wast
@@ -68,7 +68,9 @@
   ;; CHECK:      (elem $0 (i32.const 0) $other)
   (elem $0 (table $t) (i32.const 0) func $other)
 
+  ;; Test that an existing export does not cause us to crash.
   ;; CHECK:      (export "foo" (func $foo))
+  (export "foo" (func $foo))
 
   ;; CHECK:      (func $foo
   ;; CHECK-NEXT:  (call_indirect (type $none)


### PR DESCRIPTION
We just cleared the list of exports, but the exportMap was still populated, so
the data was in an inconsistent state. We should perhaps have `clearExport()`
etc. methods. If those sound good I can add them as a followup.

This fixes the case of running `--extract-function` multiple times on a file (which
is usually not useful, unless one of the passes you are debugging adds new
functions to the file - which some do).