### PR TITLE
Fix assert on access of empty vector

### DIFF
--- a/third_party/llvm-project/DWARFVisitor.cpp
+++ b/third_party/llvm-project/DWARFVisitor.cpp
@@ -135,7 +135,7 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
           case dwarf::DW_FORM_block:
             onValue((uint64_t)FormVal->BlockData.size(), true);
             onValue(
-                MemoryBufferRef(StringRef((const char *)&FormVal->BlockData[0],
+                MemoryBufferRef(StringRef((const char *)FormVal->BlockData.data(),
                                           FormVal->BlockData.size()),
                                 ""));
             break;
@@ -143,7 +143,7 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
             auto writeSize = FormVal->BlockData.size();
             onValue((uint8_t)writeSize);
             onValue(
-                MemoryBufferRef(StringRef((const char *)&FormVal->BlockData[0],
+                MemoryBufferRef(StringRef((const char *)FormVal->BlockData.data(),
                                           FormVal->BlockData.size()),
                                 ""));
             break;
@@ -152,7 +152,7 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
             auto writeSize = FormVal->BlockData.size();
             onValue((uint16_t)writeSize);
             onValue(
-                MemoryBufferRef(StringRef((const char *)&FormVal->BlockData[0],
+                MemoryBufferRef(StringRef((const char *)FormVal->BlockData.data(),
                                           FormVal->BlockData.size()),
                                 ""));
             break;
@@ -161,7 +161,7 @@ template <typename T> void DWARFYAML::VisitorImpl<T>::traverseDebugInfo() {
             auto writeSize = FormVal->BlockData.size();
             onValue((uint32_t)writeSize);
             onValue(
-                MemoryBufferRef(StringRef((const char *)&FormVal->BlockData[0],
+                MemoryBufferRef(StringRef((const char *)FormVal->BlockData.data(),
                                           FormVal->BlockData.size()),
                                 ""));
             break;


### PR DESCRIPTION
(on VS2019)
Triggered by:
wasm-emscripten-finalize --minimize-wasm-changes -g --bigint --no-dyncalls --dwarf test_asan_api.wasm -o test_asan_api.wasm --detect-features