### PR TITLE
[Wasm GC] Remove I31New from isSingleConstantExpression. NFC

### DIFF
--- a/src/ir/global-utils.h
+++ b/src/ir/global-utils.h
@@ -64,7 +64,7 @@ inline bool canInitializeGlobal(const Expression* curr) {
   }
   return Properties::isSingleConstantExpression(curr) ||
          curr->is<GlobalGet>() || curr->is<RttCanon>() || curr->is<RttSub>() ||
-         curr->is<StructNew>();
+         curr->is<StructNew>() || curr->is<ArrayNew>() || curr->is<I31New>();
 }
 
 } // namespace GlobalUtils

--- a/src/ir/global-utils.h
+++ b/src/ir/global-utils.h
@@ -63,9 +63,9 @@ inline bool canInitializeGlobal(Expression* curr) {
     }
     return true;
   }
-  if (Properties::isSingleConstantExpression(curr) ||
-      curr->is<GlobalGet>() || curr->is<RttCanon>() || curr->is<RttSub>() ||
-      curr->is<StructNew>() || curr->is<ArrayNew>() || curr->is<I31New>()) {
+  if (Properties::isSingleConstantExpression(curr) || curr->is<GlobalGet>() ||
+      curr->is<RttCanon>() || curr->is<RttSub>() || curr->is<StructNew>() ||
+      curr->is<ArrayNew>() || curr->is<I31New>()) {
     for (auto* child : ChildIterator(curr)) {
       if (!canInitializeGlobal(child)) {
         return false;

--- a/src/ir/global-utils.h
+++ b/src/ir/global-utils.h
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "ir/iteration.h"
 #include "ir/module-utils.h"
 #include "literal.h"
 #include "wasm.h"
@@ -53,7 +54,7 @@ getGlobalInitializedToImport(Module& wasm, Name module, Name base) {
   return ret;
 }
 
-inline bool canInitializeGlobal(const Expression* curr) {
+inline bool canInitializeGlobal(Expression* curr) {
   if (auto* tuple = curr->dynCast<TupleMake>()) {
     for (auto* op : tuple->operands) {
       if (!canInitializeGlobal(op)) {
@@ -62,9 +63,17 @@ inline bool canInitializeGlobal(const Expression* curr) {
     }
     return true;
   }
-  return Properties::isSingleConstantExpression(curr) ||
-         curr->is<GlobalGet>() || curr->is<RttCanon>() || curr->is<RttSub>() ||
-         curr->is<StructNew>() || curr->is<ArrayNew>() || curr->is<I31New>();
+  if (Properties::isSingleConstantExpression(curr) ||
+      curr->is<GlobalGet>() || curr->is<RttCanon>() || curr->is<RttSub>() ||
+      curr->is<StructNew>() || curr->is<ArrayNew>() || curr->is<I31New>()) {
+    for (auto* child : ChildIterator(curr)) {
+      if (!canInitializeGlobal(child)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
 }
 
 } // namespace GlobalUtils

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -84,11 +84,12 @@ inline bool isNamedControlFlow(Expression* curr) {
 
 // A constant expression is something like a Const: it has a fixed value known
 // at compile time, and passes that propagate constants can try to propagate it.
-// Constant expressions are also allowed in global initializers in wasm.
+// Constant expressions are also allowed in global initializers in wasm. Also
+// when two constant expressions compare equal at compile time, their values at
+// runtime will be equal as well.
 // TODO: look into adding more things here like RttCanon.
 inline bool isSingleConstantExpression(const Expression* curr) {
-  return curr->is<Const>() || curr->is<RefNull>() || curr->is<RefFunc>() ||
-         (curr->is<I31New>() && curr->cast<I31New>()->value->is<Const>());
+  return curr->is<Const>() || curr->is<RefNull>() || curr->is<RefFunc>();
 }
 
 inline bool isConstantExpression(const Expression* curr) {


### PR DESCRIPTION
We have a not-very-clear distinction between

isSingleConstantExpression

and

canInitializeGlobal

To make it useful, the former should mean a constant expression:
something that is a simple constant like a number or a ref.func, that
will always be the same value at runtime. That means we should
move the I31 constructor from there to the second function. After that,
the I31 constructor is no longer in a weird place, and is alongside its
sibling constructors for other GC things.

This is NFC, but perhaps it also fixes a bug in a pass that uses
isSingleConstantExpression incorrectly. I was unable to find such
a bug, however. After this PR, I think we can use
isSingleConstantExpression in more places (like in an upcoming
GC type LTO pass I am working on, that wants to propagate
constant values).

Also add ArrayNew alongside StructNew and I31New.