### PR TITLE
Avoid an unnecessary copy in Directize

### DIFF
--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -94,7 +94,7 @@ struct FunctionDirectizer : public WalkerPass<PostWalker<FunctionDirectizer>> {
   }
 
 private:
-  const std::unordered_map<Name, TableUtils::FlatTable> tables;
+  const std::unordered_map<Name, TableUtils::FlatTable>& tables;
 
   bool changedTypes = false;
 


### PR DESCRIPTION
We assign a `const&` to there, and were copying it...