### PR TITLE
[Wasm GC] Fix printing of more unreachable struct/array instructions

### DIFF
--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -356,6 +356,20 @@
       (unreachable)
     )
   )
+  (func $unreachables-array-6
+    (drop
+      (array.len $vector
+        (unreachable)
+      )
+    )
+  )
+  (func $unreachables-7
+    (drop
+      (struct.new_default_with_rtt $struct.A
+        (unreachable)
+      )
+    )
+  )
   (func $array-copy (param $x (ref $vector)) (param $y (ref null $vector))
     (array.copy $vector $vector
       (local.get $x)

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -1,8 +1,8 @@
 (module
  (type $struct.A (struct (field i32) (field f32) (field $named f64)))
+ (type $none_=>_none (func))
  (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
  (type $vector (array (mut f64)))
- (type $none_=>_none (func))
  (type $grandchild (struct (field i32) (field i64)))
  (type $struct.C (struct (field $named-mut (mut f32))))
  (type $matrix (array (mut (ref null $vector))))
@@ -443,6 +443,20 @@
    (ref.null $vector)
    (i32.const 2)
    (unreachable)
+  )
+ )
+ (func $unreachables-array-6
+  (drop
+   (block
+    (unreachable)
+   )
+  )
+ )
+ (func $unreachables-7
+  (drop
+   (block
+    (unreachable)
+   )
   )
  )
  (func $array-copy (param $x (ref $vector)) (param $y (ref null $vector))

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -1,8 +1,8 @@
 (module
  (type $struct.A (struct (field i32) (field f32) (field $named f64)))
+ (type $none_=>_none (func))
  (type $struct.B (struct (field i8) (field (mut i16)) (field (ref $struct.A)) (field (mut (ref $struct.A)))))
  (type $vector (array (mut f64)))
- (type $none_=>_none (func))
  (type $grandchild (struct (field i32) (field i64)))
  (type $matrix (array (mut (ref null $vector))))
  (type $struct.C (struct (field $named-mut (mut f32))))
@@ -406,6 +406,12 @@
   (drop
    (i32.const 2)
   )
+  (unreachable)
+ )
+ (func $unreachables-array-6
+  (unreachable)
+ )
+ (func $unreachables-7
   (unreachable)
  )
  (func $array-copy (param $x (ref $vector)) (param $y (ref null $vector))

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -1,8 +1,8 @@
 (module
  (type ${i32_f32_f64} (struct (field i32) (field f32) (field f64)))
+ (type $none_=>_none (func))
  (type ${i8_mut:i16_ref|{i32_f32_f64}|_mut:ref|{i32_f32_f64}|} (struct (field i8) (field (mut i16)) (field (ref ${i32_f32_f64})) (field (mut (ref ${i32_f32_f64})))))
  (type $[mut:f64] (array (mut f64)))
- (type $none_=>_none (func))
  (type ${i32_i64} (struct (field i32) (field i64)))
  (type $[mut:ref?|[mut:f64]|] (array (mut (ref null $[mut:f64]))))
  (type ${mut:f32} (struct (field (mut f32))))
@@ -408,7 +408,13 @@
   )
   (unreachable)
  )
- (func $17 (param $0 (ref $[mut:f64])) (param $1 (ref null $[mut:f64]))
+ (func $17
+  (unreachable)
+ )
+ (func $18
+  (unreachable)
+ )
+ (func $19 (param $0 (ref $[mut:f64])) (param $1 (ref null $[mut:f64]))
   (array.copy $[mut:f64] $[mut:f64]
    (local.get $0)
    (i32.const 11)


### PR DESCRIPTION
We were missing StructNew and ArrayLen.