### PR TITLE
Fix signed_ field initialization in Load

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -876,7 +876,7 @@ public:
   Load(MixedArena& allocator) {}
 
   uint8_t bytes;
-  bool signed_;
+  bool signed_ = false;
   Address offset;
   Address align;
   bool isAtomic;
@@ -1335,7 +1335,7 @@ public:
   I31Get(MixedArena& allocator) {}
 
   Expression* i31;
-  bool signed_;
+  bool signed_ = false;
 
   void finalize();
 };

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4041,12 +4041,6 @@ bool WasmBinaryBuilder::maybeVisitLoad(Expression*& out,
   Load* curr;
   auto allocate = [&]() {
     curr = allocator.alloc<Load>();
-    // The signed field does not matter in some cases (where the size of the
-    // load is equal to the size of the type, in which case we do not extend),
-    // but give it a default value nonetheless, to make hashing and other code
-    // simpler, so that they do not need to consider whether the sign matters or
-    // not.
-    curr->signed_ = false;
   };
   if (!isAtomic) {
     switch (code) {


### PR DESCRIPTION
This was being set in the creation of Loads in the binary reader, but
forgotten in the SIMD logic - which ends up creating a Load with
type v128, and `signed_` was uninitialized.

Very hard to test this, but I saw it "break" hash value computation
which is how I noticed this.

Also initialize the I31 sign field. Now all of them in wasm.h are
properly initialized.