### PR TITLE
Fix the Switch operand order in LinearExecutionWalker

### DIFF
--- a/src/ir/linear-execution.h
+++ b/src/ir/linear-execution.h
@@ -87,8 +87,8 @@ struct LinearExecutionWalker : public PostWalker<SubType, VisitorType> {
       case Expression::Id::SwitchId: {
         self->pushTask(SubType::doVisitSwitch, currp);
         self->pushTask(SubType::doNoteNonLinear, currp);
-        self->maybePushTask(SubType::scan, &curr->cast<Switch>()->value);
         self->pushTask(SubType::scan, &curr->cast<Switch>()->condition);
+        self->maybePushTask(SubType::scan, &curr->cast<Switch>()->value);
         break;
       }
       case Expression::Id::ReturnId: {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -799,8 +799,8 @@ public:
 
   ArenaVector<Name> targets;
   Name default_;
-  Expression* condition = nullptr;
   Expression* value = nullptr;
+  Expression* condition = nullptr;
 
   void finalize();
 };


### PR DESCRIPTION
This caused no noticeable bugs, but it could in theory in new passes - in fact
in a pass I will open later this week it did.

Also fix the order in wasm.h. That part has no effect, but it is nice to be
consistent. After this PR, everything should match the single source of
truth which is wasm-delegations-fields.h (as that is used in printing, binary
reading/writing, etc., so it has to be correct). Also Switch now matches
the ordering in Break.