### PR TITLE
Add a shallowHash() method

### DIFF
--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -85,6 +85,9 @@ struct ExpressionAnalyzer {
   // hash an expression, ignoring superficial details like specific internal
   // names
   static size_t hash(Expression* curr);
+
+  // hash an expression, ignoring child nodes.
+  static size_t shallowHash(Expression* curr);
 };
 
 // Re-Finalizes all node types. This can be run after code was modified in

--- a/test/example/hash.cpp
+++ b/test/example/hash.cpp
@@ -11,6 +11,14 @@ using namespace wasm;
 #define assertNotEqual(left, right)                                            \
   assert(ExpressionAnalyzer::hash(&left) != ExpressionAnalyzer::hash(&right));
 
+#define assertShallowEqual(left, right)                                        \
+  assert(ExpressionAnalyzer::shallowHash(&left) ==                             \
+         ExpressionAnalyzer::shallowHash(&right));
+
+#define assertShallowNotEqual(left, right)                                     \
+  assert(ExpressionAnalyzer::shallowHash(&left) !=                             \
+         ExpressionAnalyzer::shallowHash(&right));
+
 int main() {
   {
     Const x, y;
@@ -33,7 +41,7 @@ int main() {
     assertNotEqual(x, y);
   }
   {
-    // Nested child.
+    // Nested identical child.
     Drop dx, dy;
     Const x, y;
     x.set(Literal(int32_t(10)));
@@ -43,7 +51,17 @@ int main() {
     assertEqual(dx, dy);
   }
   {
-    // Nested child.
+    // Nested identical child, checked shallowly.
+    Drop dx, dy;
+    Const x, y;
+    x.set(Literal(int32_t(10)));
+    y.set(Literal(int32_t(10)));
+    dx.value = &x;
+    dy.value = &y;
+    assertShallowEqual(dx, dy);
+  }
+  {
+    // Nested different child.
     Drop dx, dy;
     Const x, y;
     x.set(Literal(int32_t(10)));
@@ -51,6 +69,17 @@ int main() {
     dx.value = &x;
     dy.value = &y;
     assertNotEqual(dx, dy);
+  }
+  {
+    // Nested different child, checked shallowly (so we ignore the difference,
+    // and return equal).
+    Drop dx, dy;
+    Const x, y;
+    x.set(Literal(int32_t(10)));
+    y.set(Literal(int32_t(11)));
+    dx.value = &x;
+    dy.value = &y;
+    assertShallowEqual(dx, dy);
   }
   MixedArena arena;
   {


### PR DESCRIPTION
This adds and tests the new method. It will be used in a new pass later, where
computing shallow hashes allows it to be done in linear time.

99% of the diff is whitespace.
