### PR TITLE
[OptimizeForJS] Avoid 64-bit integer storage if it's possible

### DIFF
--- a/src/passes/OptimizeForJS.cpp
+++ b/src/passes/OptimizeForJS.cpp
@@ -65,6 +65,24 @@ struct OptimizeForJSPass : public WalkerPass<PostWalker<OptimizeForJSPass>> {
             builder.makeLocalGet(temp.index, type),
             builder.makeConst(Literal::makeOne(type.getBasic())))))));
   }
+
+  void visitStore(Store* curr) {
+    // i64.store(x, C)   ==>   f64.store(x, reinterpret<f64>(C)),
+    //    if reinterpret<f64>(C) != NaN
+    //
+    // Regarding 0x8000000000000000. Closure Compiler preserve -0.0
+    // so it should be safe but make sure your minifactor does not
+    // turn -0.0 into +0.0.
+    if (curr->valueType == Type::i64) {
+      if (auto* c = curr->value->dynCast<Const>()) {
+        double value = c->value.reinterpretf64();
+        if (!std::isnan(value)) {
+          curr->valueType = Type::f64;
+          c->set(Literal(value));
+        }
+      }
+    }
+  }
 };
 
 Pass* createOptimizeForJSPass() { return new OptimizeForJSPass(); }

--- a/test/lit/passes/optimize-for-js.wast
+++ b/test/lit/passes/optimize-for-js.wast
@@ -3,6 +3,7 @@
 ;; RUN:  | filecheck %s
 
 (module
+ (memory 0)
  ;; CHECK:      (func $is-power-of-2_32 (param $x i32) (result i32)
  ;; CHECK-NEXT:  (i32.and
  ;; CHECK-NEXT:   (i32.eqz
@@ -79,5 +80,62 @@
    (i64.popcnt (local.get $x))
    (i64.const 1)
   )
+ )
+
+ ;; i64.store(ptr, C)   ->   f64.store(ptr, reinterpret<f64>(C))
+
+ ;; CHECK:      (func $store-const-zero (param $ptr i32)
+ ;; CHECK-NEXT:  (f64.store
+ ;; CHECK-NEXT:   (local.get $ptr)
+ ;; CHECK-NEXT:   (f64.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $store-const-zero (param $ptr i32)
+  (i64.store (local.get $ptr) (i64.const 0))
+ )
+ ;; CHECK:      (func $store-const-one (param $ptr i32)
+ ;; CHECK-NEXT:  (f64.store
+ ;; CHECK-NEXT:   (local.get $ptr)
+ ;; CHECK-NEXT:   (f64.const 5e-324)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $store-const-one (param $ptr i32)
+  (i64.store (local.get $ptr) (i64.const 1))
+ )
+ ;; CHECK:      (func $store-const-smin (param $ptr i32)
+ ;; CHECK-NEXT:  (f64.store
+ ;; CHECK-NEXT:   (local.get $ptr)
+ ;; CHECK-NEXT:   (f64.const -0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $store-const-smin (param $ptr i32)
+  (i64.store (local.get $ptr) (i64.const 0x8000000000000000))
+ )
+ ;; CHECK:      (func $store-unsafe-const-1_skip (param $ptr i32)
+ ;; CHECK-NEXT:  (i64.store
+ ;; CHECK-NEXT:   (local.get $ptr)
+ ;; CHECK-NEXT:   (i64.const -1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $store-unsafe-const-1_skip (param $ptr i32)
+  (i64.store (local.get $ptr) (i64.const -1)) ;; will be NaN
+ )
+ ;; CHECK:      (func $store-unsafe-const-2_skip (param $ptr i32)
+ ;; CHECK-NEXT:  (i64.store
+ ;; CHECK-NEXT:   (local.get $ptr)
+ ;; CHECK-NEXT:   (i64.const -2)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $store-unsafe-const-2_skip (param $ptr i32)
+  (i64.store (local.get $ptr) (i64.const -2))
+ )
+ ;; CHECK:      (func $store-non-const_skip (param $ptr i32) (param $x i64)
+ ;; CHECK-NEXT:  (i64.store
+ ;; CHECK-NEXT:   (local.get $ptr)
+ ;; CHECK-NEXT:   (local.get $x)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $store-non-const_skip (param $ptr i32) (param $x i64)
+  (i64.store (local.get $ptr) (local.get $x))
  )
 )

--- a/test/wasm2js/unaligned.2asm.js.opt
+++ b/test/wasm2js/unaligned.2asm.js.opt
@@ -76,17 +76,6 @@ function asmFunc(env) {
  }
  
  function $5() {
-  HEAP8[0] = 0;
-  HEAP8[1] = 0;
-  HEAP8[2] = 0;
-  HEAP8[3] = 0;
-  HEAP8[4] = 0;
-  HEAP8[5] = 0;
-  HEAP8[6] = 0;
-  HEAP8[7] = 0;
- }
- 
- function $7() {
   var $0_1 = 0, $1 = 0;
   wasm2js_scratch_store_f64(0.0);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
@@ -122,7 +111,7 @@ function asmFunc(env) {
   "i32_store": $4, 
   "i64_store": $5, 
   "f32_store": $4, 
-  "f64_store": $7
+  "f64_store": $5
  };
 }
 


### PR DESCRIPTION
Fix: https://github.com/emscripten-core/emscripten/issues/13365