### PR TITLE
[Wasm GC] ConstantFieldPropagation: Ignore copies

### DIFF
--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -253,7 +253,8 @@ struct Scanner : public WalkerPass<PostWalker<Scanner>> {
     }
 
     // Note a write to this field of the struct.
-    noteExpression(curr->value, type.getHeapType(), curr->index, functionSetInfos);
+    noteExpression(
+      curr->value, type.getHeapType(), curr->index, functionSetInfos);
   }
 
 private:
@@ -261,7 +262,10 @@ private:
   FunctionStructValuesMap& functionSetInfos;
 
   // Note a value, checking whether it is a constant or not.
-  void noteExpression(Expression* expr, HeapType type, Index index, FunctionStructValuesMap& valuesMap) {
+  void noteExpression(Expression* expr,
+                      HeapType type,
+                      Index index,
+                      FunctionStructValuesMap& valuesMap) {
     expr =
       Properties::getFallthrough(expr, getPassOptions(), getModule()->features);
 


### PR DESCRIPTION
When looking for all values written to a field, we can ignore
values that are loaded from that same field, i.e., are copied from
something already present there. Such operations never introduce
new values.

This helps by a small but non-zero amount on j2cl.