### PR TITLE
Optimize LocalCSE hash computations using a stack. NFC

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -316,7 +316,7 @@ inline Index getNumChildren(Expression* curr) {
 #define DELEGATE_ID curr->_id
 
 #define DELEGATE_START(id)                                                     \
-  auto* cast = curr->cast<id>();                                             \
+  auto* cast = curr->cast<id>();                                               \
   WASM_UNUSED(cast);
 
 #define DELEGATE_GET_FIELD(id, name) cast->name
@@ -325,7 +325,7 @@ inline Index getNumChildren(Expression* curr) {
 
 #define DELEGATE_FIELD_OPTIONAL_CHILD(id, name)                                \
   if (cast->name) {                                                            \
-    ret++; \
+    ret++;                                                                     \
   }
 
 #define DELEGATE_FIELD_INT(id, name)

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -310,6 +310,41 @@ inline Expression* getFallthrough(Expression* curr,
   }
 }
 
+inline Index getNumChildren(Expression* curr) {
+  Index ret = 0;
+
+#define DELEGATE_ID curr->_id
+
+#define DELEGATE_START(id)                                                     \
+  auto* cast = curr->cast<id>();                                             \
+  WASM_UNUSED(cast);
+
+#define DELEGATE_GET_FIELD(id, name) cast->name
+
+#define DELEGATE_FIELD_CHILD(id, name) ret++;
+
+#define DELEGATE_FIELD_OPTIONAL_CHILD(id, name)                                \
+  if (cast->name) {                                                            \
+    ret++; \
+  }
+
+#define DELEGATE_FIELD_INT(id, name)
+#define DELEGATE_FIELD_INT_ARRAY(id, name)
+#define DELEGATE_FIELD_LITERAL(id, name)
+#define DELEGATE_FIELD_NAME(id, name)
+#define DELEGATE_FIELD_NAME_VECTOR(id, name)
+#define DELEGATE_FIELD_SCOPE_NAME_DEF(id, name)
+#define DELEGATE_FIELD_SCOPE_NAME_USE(id, name)
+#define DELEGATE_FIELD_SCOPE_NAME_USE_VECTOR(id, name)
+#define DELEGATE_FIELD_SIGNATURE(id, name)
+#define DELEGATE_FIELD_TYPE(id, name)
+#define DELEGATE_FIELD_ADDRESS(id, name)
+
+#include "wasm-delegations-fields.def"
+
+  return ret;
+}
+
 // Returns whether the resulting value here must fall through without being
 // modified. For example, a tee always does so. That is, this returns false if
 // and only if the return value may have some computation performed on it to

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -240,7 +240,7 @@ struct Scanner
     //
     // Note that we must compute the hash first, as we need it even for things
     // that are not isRelevant() (if they are the children of a relevant thing).
-    auto numChildren = getNumChildren(curr);
+    auto numChildren = Properties::getNumChildren(curr);
     auto hash = ExpressionAnalyzer::shallowHash(curr);
     for (Index i = 0; i < numChildren; i++) {
       if (activeHashes.empty()) {


### PR DESCRIPTION
Before, we'd compute the hash of a child, then store that in a map, then
the parent would find the child's hash in the map using the pointer to the
child. But as we do a simple postorder walk, we can use a stack, and
avoid hashing the child pointers.

This makes it 10% faster or so.