### PR TITLE
Ensure cfg-traversal emits blocks in reverse postorder, refactoring try. NFC

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -298,7 +298,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     // Now that we are starting the catches, create the basic blocks that they
     // begin with.
     auto* last = self->currBasicBlock;
-    auto* tryy = (*currp)->dynCast<Try>();
+    auto* tryy = (*currp)->cast<Try>();
     self->processCatchStack.emplace_back();
     auto& entries = self->processCatchStack.back();
     for (Index i = 0; i < tryy->catchBodies.size(); i++) {


### PR DESCRIPTION
Reverse postorder basically just means that a block's immediate dominator
must precede it in the list. That is useful because then algorithms that look at
dominance can simply process the list in order, and the immediate dominator
will have already been seen before each block.

Another way to put it is that in reverse postorder a block's dominators
appear before it in the list, as do all non-loop predecessors. At least in
reducible graphs that is the case, and our IR, like wasm, is reducible.

It is pretty natural to emit reverse postorder on wasm given the
reducibility: simply process the wasm in postorder, and make sure to
create new basic blocks only when reaching their code - that is, do not
create them "ahead of time". We were doing that in a single place, for
try-catch, so this PR refactors that. Specifically it makes us create the
basic blocks for catches right when we reach them, and not earlier.
So the data structure that used to store them becomes a list of things
to connect to them.

This is useful for #4100 , see more details there.