### PR TITLE
[fuzz-opt] Better error output for non-deterministic check

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -296,13 +296,16 @@ FUZZ_EXEC_CALL_PREFIX = '[fuzz-exec] calling'
 
 
 # compare two strings, strictly
-def compare(x, y, context):
+def compare(x, y, context, diffonly=False):
     if x != y and x != IGNORE and y != IGNORE:
         message = ''.join([a + '\n' for a in difflib.unified_diff(x.splitlines(), y.splitlines(), fromfile='expected', tofile='actual')])
-        raise Exception(context + " comparison error, expected to have '%s' == '%s', diff:\n\n%s" % (
-            x, y,
-            message
-        ))
+        if diffonly:
+            raise Exception(context + " diff:\n\n%s" % (message))
+        else:
+            raise Exception(context + " comparison error, expected to have '%s' == '%s', diff:\n\n%s" % (
+                x, y,
+                message
+            ))
 
 
 # converts a possibly-signed integer to an unsigned integer
@@ -713,7 +716,14 @@ class CheckDeterminism(TestCaseHandler):
         # check for determinism
         run([in_bin('wasm-opt'), before_wasm, '-o', 'b1.wasm'] + opts)
         run([in_bin('wasm-opt'), before_wasm, '-o', 'b2.wasm'] + opts)
-        assert open('b1.wasm', 'rb').read() == open('b2.wasm', 'rb').read(), 'output must be deterministic'
+        b1 = open('b1.wasm', 'rb').read()
+        b2 = open('b2.wasm', 'rb').read()
+        if (b1 != b2):
+            run([in_bin('wasm-dis'), 'b1.wasm', '-o', 'b1.wat'])
+            run([in_bin('wasm-dis'), 'b2.wasm', '-o', 'b2.wat'])
+            t1 = open('b1.wat', 'r').read()
+            t2 = open('b2.wat', 'r').read()
+            compare(t1, t2, 'Output must be deterministic.\n', True)
 
 
 class Wasm2JS(TestCaseHandler):


### PR DESCRIPTION
When we catches "Output must be deterministic" we can't see any details. This PR fix this and now we can see diff of b1.wasm and b2.wasm files.

Example output: 
```diff
Output must be deterministic.
 diff:

--- expected

+++ actual

@@ -2072,9 +2072,7 @@

          )
          (drop
           (block $label$16 (result funcref)
-           (local.set $10
-            (ref.null func)
-           )
+           (nop)
            (drop
             (call $22
              (f64.const 0.296)
```