### PR TITLE
Use TrapsNeverHappen mode in more places in Vacuum

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -180,7 +180,7 @@ public:
   // and gets the result that there are no unremovable side effects, then it
   // must either
   //
-  //  1. Remove any side effects present, if any, so they no longer exists.
+  //  1. Remove any side effects present, if any, so they no longer exist.
   //  2. Keep the code exactly where it is.
   //
   // If instead of 1&2 a pass kept the side effect and also reordered the code

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -103,7 +103,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
       // Check if this expression itself has side effects, ignoring children.
       EffectAnalyzer self(getPassOptions(), *getModule());
       self.visit(curr);
-      if (self.hasSideEffects()) {
+      if (self.hasUnremovableSideEffects()) {
         return curr;
       }
       // The result isn't used, and this has no side effects itself, so we can
@@ -111,7 +111,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
       SmallVector<Expression*, 1> childrenWithEffects;
       for (auto* child : ChildIterator(curr)) {
         if (EffectAnalyzer(getPassOptions(), *getModule(), child)
-              .hasSideEffects()) {
+              .hasUnremovableSideEffects()) {
           childrenWithEffects.push_back(child);
         }
       }
@@ -378,7 +378,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
     }
     if (curr->getResults() == Type::none &&
         !EffectAnalyzer(getPassOptions(), *getModule(), curr->body)
-           .hasSideEffects()) {
+           .hasUnremovableSideEffects()) {
       ExpressionManipulator::nop(curr->body);
     }
   }

--- a/test/lit/passes/vacuum-tnh.wast
+++ b/test/lit/passes/vacuum-tnh.wast
@@ -8,9 +8,7 @@
   (type $struct (struct (field (mut i32))))
 
   ;; CHECK:      (func $drop (param $x i32) (param $y anyref)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (unreachable)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $drop (param $x i32) (param $y anyref)
     ;; A load might trap, normally, but if traps never happen then we can
@@ -39,15 +37,8 @@
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block $block (result i32)
-  ;; CHECK-NEXT:    (local.set $x
-  ;; CHECK-NEXT:     (i32.const 2)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.load
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.const 1)
   ;; CHECK-NEXT: )
@@ -58,7 +49,7 @@
     )
 
     ;; Add to the load an additional specific side effect, of writing to a
-    ;; local.
+    ;; local. We can remove the load, but not the write to a local.
     (drop
       (block (result i32)
         (local.set $x (i32.const 2))
@@ -77,19 +68,11 @@
 
   ;; CHECK:      (func $partial (param $x (ref $struct))
   ;; CHECK-NEXT:  (local $y (ref null $struct))
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.get $struct 0
-  ;; CHECK-NEXT:    (local.tee $y
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (local.set $y
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.get $struct 0
-  ;; CHECK-NEXT:    (local.tee $y
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (local.set $y
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $partial (param $x (ref $struct))

--- a/test/lit/passes/vacuum-tnh.wast
+++ b/test/lit/passes/vacuum-tnh.wast
@@ -100,17 +100,12 @@
     )
   )
 
-  ;; CHECK:      (func $toplevel (param $x (ref $struct))
-  ;; CHECK-NEXT:  (struct.set $struct 0
-  ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK:      (func $toplevel
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
-  (func $toplevel (param $x (ref $struct))
-    ;; A removable side effect at the top level of a function.
-    (struct.set $struct 0
-      (local.get $x)
-      (i32.const 1)
-    )
+  (func $toplevel
+    ;; A removable side effect at the top level of a function. We can turn this
+    ;; into a nop.
+    (unreachable)
   )
 )

--- a/test/lit/passes/vacuum-tnh.wast
+++ b/test/lit/passes/vacuum-tnh.wast
@@ -80,7 +80,7 @@
     ;; The struct.get's side effect can be ignored due to tnh, and the value is
     ;; dropped anyhow, so we can remove it. We cannot remove the local.tee
     ;; inside it, however, so we must only vacuum out the struct.get and
-    ;; nothing more.
+    ;; nothing more. (In addition, a drop of a tee will become a set.)
     (drop
       (struct.get $struct 0
         (local.tee $y


### PR DESCRIPTION
We had already replaced the check on `drop`, but we can also
use that mode on all the other things there, as the pass never
does reorderings of things - it just removes them.

For example, the pass can now remove part of a dropped thing,
```wat
(drop (struct.get (foo)))
=>
(drop (foo))
```
In this example the `struct.get` can be removed, even if the `foo`
can't.