### PR TITLE
Fix the effects of array.copy

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -659,8 +659,11 @@ private:
       }
     }
     void visitArrayCopy(ArrayCopy* curr) {
+      parent.readsArray = true;
+      parent.writesArray = true;
       // traps when a ref is null, or when out of bounds.
       parent.implicitTrap = true;
+
     }
     void visitRefAs(RefAs* curr) {
       // traps when the arg is not valid

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -663,7 +663,6 @@ private:
       parent.writesArray = true;
       // traps when a ref is null, or when out of bounds.
       parent.implicitTrap = true;
-
     }
     void visitRefAs(RefAs* curr) {
       // traps when the arg is not valid

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1116,6 +1116,20 @@ struct OptimizeInstructions
     }
   }
 
+#if 0
+  void visitCall(Call* curr) {
+    PassOptions options = getPassOptions();
+    if (options.ignoreImplicitTraps || options.trapsNeverHappen) {
+      // 
+      skipNonNullCast
+      skipCastIfValidateWithoutThem. also in LocalSet.
+      // TODO: refactor validator to get the expected type for each child. Then
+      //       use that to remove unneeded casts etc. while things still
+      //       validate, and no unremoabelabe side effects.
+    }
+  }
+#endif
+
   void visitMemoryCopy(MemoryCopy* curr) {
     if (curr->type == Type::unreachable) {
       return;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1116,20 +1116,6 @@ struct OptimizeInstructions
     }
   }
 
-#if 0
-  void visitCall(Call* curr) {
-    PassOptions options = getPassOptions();
-    if (options.ignoreImplicitTraps || options.trapsNeverHappen) {
-      // 
-      skipNonNullCast
-      skipCastIfValidateWithoutThem. also in LocalSet.
-      // TODO: refactor validator to get the expected type for each child. Then
-      //       use that to remove unneeded casts etc. while things still
-      //       validate, and no unremoabelabe side effects.
-    }
-  }
-#endif
-
   void visitMemoryCopy(MemoryCopy* curr) {
     if (curr->type == Type::unreachable) {
       return;

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -599,12 +599,26 @@ void test_cost() {
 void test_effects() {
   PassOptions options;
   Module module;
+
   // Unreachables trap.
   Unreachable unreachable;
   assert_equal(EffectAnalyzer(options, module, &unreachable).trap, true);
+
   // Nops... do not.
   Nop nop;
   assert_equal(EffectAnalyzer(options, module, &nop).trap, false);
+
+  // ArrayCopy can trap, reads arrays, and writes arrays (but not structs).
+  {
+    ArrayCopy arrayCopy(module.allocator);
+    EffectAnalyzer effects(options, module);
+    effects.visit(&arrayCopy);
+    assert_equal(effects.trap, true);
+    assert_equal(effects.readsArray, true);
+    assert_equal(effects.writesArray, true);
+    assert_equal(effects.readsStruct, false);
+    assert_equal(effects.writesStruct, false);
+  }
 }
 
 void test_literals() {


### PR DESCRIPTION
This appeared to be a regression from #4117, however this
was always a bug, and that PR just exposed it. That is,
somehow we forgot to indicate the effects of ArrayCopy, and
after that PR we'd vacuum it out incorrectly.