### PR TITLE
[OptimizeInstruction] Simplify (x + 0.0) + 0.0 rule

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2471,6 +2471,17 @@ private:
         return curr->left;
       }
     }
+    {
+      // (x + 0.0) + 0.0   ==>   x + 0.0
+      double c1, c2;
+      Binary* inner;
+      if (matches(
+            curr,
+            binary(Add, binary(&inner, Add, any(), fval(&c1)), fval(&c2))) &&
+          c1 == 0.0 && c2 == 0.0 && !std::signbit(c1) && !std::signbit(c2)) {
+        return inner;
+      }
+    }
     // -x * fval(C)   ==>   x * -C
     // -x / fval(C)   ==>   x / -C
     if (matches(curr, binary(Mul, unary(Neg, any(&left)), fval())) ||

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -9029,6 +9029,18 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:    (local.get $fx)
+  ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:    (local.get $fy)
+  ;; CHECK-NEXT:    (f64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.sub
   ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:    (local.get $fx)
@@ -9077,6 +9089,21 @@
     (drop (f64.add
       (local.get $fy)
       (f64.const -0)
+    ))
+    ;; (x + 0.0) + 0.0   ==>   x + 0.0
+    (drop (f32.add
+      (f32.add
+        (local.get $fx)
+        (f32.const 0)
+      )
+      (f32.const 0)
+    ))
+    (drop (f64.add
+      (f64.add
+        (local.get $fy)
+        (f64.const 0)
+      )
+      (f64.const 0)
     ))
     ;; x - (-0.0)   ==>   x + 0.0
     (drop (f32.sub


### PR DESCRIPTION
We can't simplify `x + 0.0` even in `fast-math` mode. But we can  always simplify `(x + 0.0) + 0.0` into `x + 0.0`.
```
(-0.0 + 0.0) + 0.0   equivalent to  (-0.0 + 0.0)
```