### PR TITLE
[NFC] Inlining: Track names over multiple iterations, not pointers

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -360,7 +360,11 @@ struct Inlining : public Pass {
     // call. This is typically recursion, which to some extent can help, but
     // then like loop unrolling it loses its benefit quickly, so set a limit
     // here.
-    std::unordered_map<Function*, Index> iterationsInlinedInto;
+    //
+    // (Track names here, and not Function pointers, as we can remove functions
+    // while inlining, and it may be confusing during debugging to have a
+    // pointer to something that was removed.)
+    std::unordered_map<Name, Index> iterationsInlinedInto;
 
     const size_t MaxIterationsForFunc = 5;
 
@@ -384,7 +388,7 @@ struct Inlining : public Pass {
 #endif
 
       for (auto* func : inlinedInto) {
-        if (++iterationsInlinedInto[func] >= MaxIterationsForFunc) {
+        if (++iterationsInlinedInto[func->name] >= MaxIterationsForFunc) {
           return;
         }
       }


### PR DESCRIPTION
It can be confusing during debugging to keep a map of pointers when
we might have removed some of those functions from the module
meanwhile (if you iterate over it in some additional debug logging).
This change has no observable effect, however, as no bug could have
actually occurred in practice given that nothing is done with the
pointers in the actual code.