### PR TITLE
Use STATIC instead of OBJECT for wasm-split-lib

### DIFF
--- a/src/tools/wasm-split/CMakeLists.txt
+++ b/src/tools/wasm-split/CMakeLists.txt
@@ -4,7 +4,7 @@ set(wasm_split_SOURCES
   instrumenter.cpp
   ${wasm_split_HEADERS}
 )
-add_library(wasm-split-lib STATIC ${wasm_split_SOURCES})
+add_library(wasm-split-lib OBJECT ${wasm_split_SOURCES})
 
-binaryen_add_executable(wasm-split wasm-split.cpp)
+binaryen_add_executable(wasm-split wasm-split.cpp $<TARGET_OBJECTS:wasm-split-lib>)
 target_link_libraries(wasm-split wasm-split-lib)

--- a/src/tools/wasm-split/CMakeLists.txt
+++ b/src/tools/wasm-split/CMakeLists.txt
@@ -4,7 +4,7 @@ set(wasm_split_SOURCES
   instrumenter.cpp
   ${wasm_split_HEADERS}
 )
-add_library(wasm-split-lib OBJECT ${wasm_split_SOURCES})
+add_library(wasm-split-lib STATIC ${wasm_split_SOURCES})
 
 binaryen_add_executable(wasm-split wasm-split.cpp)
 target_link_libraries(wasm-split wasm-split-lib)


### PR DESCRIPTION
In an attempt to fix https://github.com/emscripten-core/emsdk/issues/886.