### PR TITLE
[wasm-split] Do not add exports of imported memories

### DIFF
--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -266,19 +266,21 @@ void Instrumenter::addProfileExport() {
     }
   }
 
-  // Export the memory if it is not already exported.
-  bool memoryExported = false;
-  for (auto& ex : wasm->exports) {
-    if (ex->kind == ExternalKind::Memory) {
-      memoryExported = true;
-      break;
+  // Export the memory if it is not already exported or imported.
+  if (!wasm->memory.imported()) {
+    bool memoryExported = false;
+    for (auto& ex : wasm->exports) {
+      if (ex->kind == ExternalKind::Memory) {
+        memoryExported = true;
+        break;
+      }
     }
-  }
-  if (!memoryExported) {
-    wasm->addExport(
-      Builder::makeExport("profile-memory",
-                          Names::getValidExportName(*wasm, wasm->memory.name),
-                          ExternalKind::Memory));
+    if (!memoryExported) {
+      wasm->addExport(
+        Builder::makeExport("profile-memory",
+                            Names::getValidExportName(*wasm, wasm->memory.name),
+                            ExternalKind::Memory));
+    }
   }
 }
 

--- a/test/lit/wasm-split/imported-memory.wast
+++ b/test/lit/wasm-split/imported-memory.wast
@@ -1,0 +1,12 @@
+;; RUN: wasm-split --instrument %s -all -S -o - | filecheck %s
+
+;; Check that an imported memory is not exported as "profile-memory"
+
+(module
+  (import "env" "mem" (memory $mem 1 1))
+)
+
+;; CHECK: (import "env" "mem" (memory $mem 1 1))
+;; CHECK: (export "__write_profile" (func $__write_profile))
+
+;; CHECK-NOT: (export "profile-memory" (memory $mem))


### PR DESCRIPTION
We can assume that imported memories (and the profiling data they contain) are
already accessible from the module's environment, so there's no need to export
them. This also avoids needing to add knowledge of "profile-memory" to
Emscripten's library_dylink.js.