### PR TITLE
Make static buffers in numToString thread local

### DIFF
--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -947,8 +947,9 @@ struct JSPrinter {
     bool integer = wasm::isInteger(d);
 #define BUFFERSIZE 1000
     // f is normal, e is scientific for float, x for integer
-    char full_storage_f[BUFFERSIZE];
-    char full_storage_e[BUFFERSIZE];
+    // These need to be thread-local because they are returned.
+    thread_local char full_storage_f[BUFFERSIZE];
+    thread_local char full_storage_e[BUFFERSIZE];
     // full has one more char, for a possible '-'
     char* storage_f = full_storage_f + 1;
     char* storage_e = full_storage_e + 1;

--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -947,8 +947,8 @@ struct JSPrinter {
     bool integer = wasm::isInteger(d);
 #define BUFFERSIZE 1000
     // f is normal, e is scientific for float, x for integer
-    char full_storage_f[BUFFERSIZE] = {};
-    char full_storage_e[BUFFERSIZE] = {};
+    char full_storage_f[BUFFERSIZE];
+    char full_storage_e[BUFFERSIZE];
     // full has one more char, for a possible '-'
     char* storage_f = full_storage_f + 1;
     char* storage_e = full_storage_e + 1;
@@ -958,7 +958,7 @@ struct JSPrinter {
       char* buffer = e ? storage_e : storage_f;
       double temp;
       if (!integer) {
-        char format[6] = {};
+        char format[6];
         for (int i = 0; i <= 18; i++) {
           format[0] = '%';
           format[1] = '.';

--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -947,17 +947,18 @@ struct JSPrinter {
     bool integer = wasm::isInteger(d);
 #define BUFFERSIZE 1000
     // f is normal, e is scientific for float, x for integer
-    thread_local char full_storage_f[BUFFERSIZE], full_storage_e[BUFFERSIZE];
+    char full_storage_f[BUFFERSIZE] = {};
+    char full_storage_e[BUFFERSIZE] = {};
     // full has one more char, for a possible '-'
-    thread_local char *storage_f = full_storage_f + 1,
-                      *storage_e = full_storage_e + 1;
+    char* storage_f = full_storage_f + 1;
+    char* storage_e = full_storage_e + 1;
     auto err_f = std::numeric_limits<double>::quiet_NaN();
     auto err_e = std::numeric_limits<double>::quiet_NaN();
     for (int e = 0; e <= 1; e++) {
       char* buffer = e ? storage_e : storage_f;
       double temp;
       if (!integer) {
-        thread_local char format[6];
+        char format[6] = {};
         for (int i = 0; i <= 18; i++) {
           format[0] = '%';
           format[1] = '.';

--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -947,17 +947,17 @@ struct JSPrinter {
     bool integer = wasm::isInteger(d);
 #define BUFFERSIZE 1000
     // f is normal, e is scientific for float, x for integer
-    static char full_storage_f[BUFFERSIZE], full_storage_e[BUFFERSIZE];
+    thread_local char full_storage_f[BUFFERSIZE], full_storage_e[BUFFERSIZE];
     // full has one more char, for a possible '-'
-    static char *storage_f = full_storage_f + 1,
-                *storage_e = full_storage_e + 1;
+    thread_local char *storage_f = full_storage_f + 1,
+                      *storage_e = full_storage_e + 1;
     auto err_f = std::numeric_limits<double>::quiet_NaN();
     auto err_e = std::numeric_limits<double>::quiet_NaN();
     for (int e = 0; e <= 1; e++) {
       char* buffer = e ? storage_e : storage_f;
       double temp;
       if (!integer) {
-        static char format[6];
+        thread_local char format[6];
         for (int i = 0; i <= 18; i++) {
           format[0] = '%';
           format[1] = '.';


### PR DESCRIPTION
Validation is performed on multiple threads at once and when there are multiple
validation failures, those threads can all end up in `numToString` at the same
time as they construct their respective error messages. Previously the threads
would race on their access to the snprintf buffers, sometimes leading to
segfaults. Fix the data races by making the buffers thread local.