### PR TITLE
[NFC] Add a comment in MergeBlocks about subtyping

### DIFF
--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -462,16 +462,17 @@ struct MergeBlocks
           return outer;
         }
         auto* back = block->list.back();
-        if (back->type == Type::unreachable) {
-          // curr is not reachable, dce could remove it; don't try anything
-          // fancy here
+        if (back->type == Type::unreachable ||
+            block->type == Type::unreachable) {
+          // Curr is not reachable, or the block is not. Don't try anything
+          // fancy here and let DCE improve it.
           return outer;
         }
-        // we are going to replace the block with the final element, so they
-        // should be identically typed
-        if (block->type != back->type) {
-          return outer;
-        }
+        // If both types are reachable, then since the block has no breaks to it
+        // (as we've confirmed above), the block's type is exactly that of its
+        // last element.
+        assert(block->type == back->type);
+
         child = back;
         if (outer == nullptr) {
           // reuse the block, move it out

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -473,7 +473,7 @@ struct MergeBlocks
         // block has no breaks (as confirmed above), and so the local-subtyping
         // pass will turn its type into that of its final element, if the final
         // element has a more specialized type. (If we did want to handle that,
-        // we'd need to them run a ReFinalize after everything, which would add
+        // we'd need to then run a ReFinalize after everything, which would add
         // more complexity here.)
         if (block->type != back->type) {
           return outer;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -464,8 +464,8 @@ struct MergeBlocks
         auto* back = block->list.back();
         if (back->type == Type::unreachable ||
             block->type == Type::unreachable) {
-          // Curr is not reachable, or the block is not. Don't try anything
-          // fancy here and let DCE improve it.
+          // If either the block is unreachable or the final element is then let
+          // DCE improve things rather than try anything complex here.
           return outer;
         }
         // If both types are reachable, then since the block has no breaks to it


### PR DESCRIPTION
Followup to #4137 , I looked into the idea @tlively had but I
realized it is actually not necessary for a non-obvious reason.
This PR adds a comment.