### PR TITLE
RemoveUnusedBrs::tablify() improvements: handle EqZ and tee

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -172,7 +172,7 @@ IMPORTANT_INITIAL_CONTENTS = [
     # Recently-added or modified passes. These can be added to and pruned
     # frequently.
     os.path.join('lit', 'passes', 'once-reduction.wast'),
-    os.path.join('lit', 'passes', 'remove-unused-brs_enable-multivalue.wast'),
+    os.path.join('passes', 'remove-unused-brs_enable-multivalue.wast'),
 ]
 IMPORTANT_INITIAL_CONTENTS = [os.path.join(shared.get_test_dir('.'), t) for t in IMPORTANT_INITIAL_CONTENTS]
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -172,6 +172,7 @@ IMPORTANT_INITIAL_CONTENTS = [
     # Recently-added or modified passes. These can be added to and pruned
     # frequently.
     os.path.join('lit', 'passes', 'once-reduction.wast'),
+    os.path.join('lit', 'passes', 'remove-unused-brs_enable-multivalue.wast'),
 ]
 IMPORTANT_INITIAL_CONTENTS = [os.path.join(shared.get_test_dir('.'), t) for t in IMPORTANT_INITIAL_CONTENTS]
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1365,6 +1365,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           LocalGet get;
           if (auto* tee = conditionValue->dynCast<LocalSet>()) {
             get.index = tee->index;
+            get.type = getFunction()->getLocalType(get.index);
             conditionValue = &get;
           }
           // if the condition has side effects, we can't replace many

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -1669,6 +1669,71 @@
   )
   (unreachable)
  )
+ (func $br-to-table-initial-tee (param $a i32)
+  (block $x
+   (block $y
+    (block $z
+     (br_if $x
+      (i32.eq
+       (local.tee $a
+        (i32.const 99)
+       )
+       (i32.const 10)
+      )
+     )
+     (br_if $y
+      (i32.eq
+       (local.get $a)
+       (i32.const 11)
+      )
+     )
+     (br_if $z
+      (i32.eq
+       (local.get $a)
+       (i32.const 12)
+      )
+     )
+     (unreachable)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (unreachable)
+ )
+ (func $br-to-table-initial-tee-wrong-index (param $a i32)
+  (local $b i32)
+  (block $x
+   (block $y
+    (block $z
+     (br_if $x
+      (i32.eq
+       (local.tee $a
+        (i32.const 99)
+       )
+       (i32.const 10)
+      )
+     )
+     (br_if $y
+      (i32.eq
+       (local.get $b)
+       (i32.const 11)
+      )
+     )
+     (br_if $z
+      (i32.eq
+       (local.get $b)
+       (i32.const 12)
+      )
+     )
+     (unreachable)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (unreachable)
+ )
  (func $tiny-switch
   (if
    (i32.const 0)

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -1673,24 +1673,16 @@
   (block $x
    (block $y
     (block $z
-     (br_if $x
-      (i32.eq
-       (local.tee $a
-        (i32.const 99)
+     (nop)
+     (nop)
+     (block $tablify|0
+      (br_table $x $y $z $tablify|0
+       (i32.sub
+        (local.tee $a
+         (i32.const 99)
+        )
+        (i32.const 10)
        )
-       (i32.const 10)
-      )
-     )
-     (br_if $y
-      (i32.eq
-       (local.get $a)
-       (i32.const 11)
-      )
-     )
-     (br_if $z
-      (i32.eq
-       (local.get $a)
-       (i32.const 12)
       )
      )
      (unreachable)

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -1679,7 +1679,10 @@
       (br_table $x $y $z $tablify|0
        (i32.sub
         (local.tee $a
-         (i32.const 99)
+         (i32.add
+          (i32.const 10)
+          (i32.const 1)
+         )
         )
         (i32.const 10)
        )
@@ -1716,6 +1719,49 @@
       (i32.eq
        (local.get $b)
        (i32.const 12)
+      )
+     )
+     (unreachable)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (unreachable)
+ )
+ (func $br-to-table-eqz (param $a i32)
+  (block $x
+   (block $y
+    (block $z
+     (nop)
+     (nop)
+     (block $tablify|0
+      (br_table $x $y $z $tablify|0
+       (local.get $a)
+      )
+     )
+     (unreachable)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+  (unreachable)
+ )
+ (func $br-to-table-tee-eqz (param $a i32)
+  (block $x
+   (block $y
+    (block $z
+     (nop)
+     (nop)
+     (block $tablify|0
+      (br_table $x $y $z $tablify|0
+       (local.tee $a
+        (i32.add
+         (i32.const 0)
+         (i32.const 1)
+        )
+       )
       )
      )
      (unreachable)

--- a/test/passes/remove-unused-brs_enable-multivalue.wast
+++ b/test/passes/remove-unused-brs_enable-multivalue.wast
@@ -1353,6 +1353,49 @@
     )
     (unreachable)
   )
+  (func $br-to-table-initial-tee (param $a i32)
+    (block $x
+      (block $y
+        (block $z
+          (br_if $x
+            (i32.eq
+              (local.tee $a (i32.const 99))
+              (i32.const 10)
+            )
+          )
+          (br_if $y (i32.eq (local.get $a) (i32.const 11)))
+          (br_if $z (i32.eq (local.get $a) (i32.const 12)))
+          (unreachable)
+        )
+        (unreachable)
+      )
+      (unreachable)
+    )
+    (unreachable)
+  )
+  (func $br-to-table-initial-tee-wrong-index (param $a i32)
+    (local $b i32)
+    (block $x
+      (block $y
+        (block $z
+          (br_if $x
+            (i32.eq
+              (local.tee $a (i32.const 99))
+              (i32.const 10)
+            )
+          )
+          ;; The subsequent conditions use a different local, $b, so we cannot
+          ;; optimize here.
+          (br_if $y (i32.eq (local.get $b) (i32.const 11)))
+          (br_if $z (i32.eq (local.get $b) (i32.const 12)))
+          (unreachable)
+        )
+        (unreachable)
+      )
+      (unreachable)
+    )
+    (unreachable)
+  )
   (func $tiny-switch
     (block $x
       (block $y

--- a/test/passes/remove-unused-brs_enable-multivalue.wast
+++ b/test/passes/remove-unused-brs_enable-multivalue.wast
@@ -1359,7 +1359,12 @@
         (block $z
           (br_if $x
             (i32.eq
-              (local.tee $a (i32.const 99))
+              (local.tee $a
+                (i32.add
+                  (i32.const 10)
+                  (i32.const 1)
+                )
+              )
               (i32.const 10)
             )
           )
@@ -1388,6 +1393,45 @@
           ;; optimize here.
           (br_if $y (i32.eq (local.get $b) (i32.const 11)))
           (br_if $z (i32.eq (local.get $b) (i32.const 12)))
+          (unreachable)
+        )
+        (unreachable)
+      )
+      (unreachable)
+    )
+    (unreachable)
+  )
+  (func $br-to-table-eqz (param $a i32)
+    (block $x
+      (block $y
+        (block $z
+          (br_if $x (i32.eqz (local.get $a)))
+          (br_if $y (i32.eq (local.get $a) (i32.const 1)))
+          (br_if $z (i32.eq (local.get $a) (i32.const 2)))
+          (unreachable)
+        )
+        (unreachable)
+      )
+      (unreachable)
+    )
+    (unreachable)
+  )
+  (func $br-to-table-tee-eqz (param $a i32)
+    (block $x
+      (block $y
+        (block $z
+          (br_if $x
+            (i32.eqz
+              (local.tee $a
+                (i32.add
+                  (i32.const 0)
+                  (i32.const 1)
+                )
+              )
+            )
+          )
+          (br_if $y (i32.eq (local.get $a) (i32.const 1)))
+          (br_if $z (i32.eq (local.get $a) (i32.const 2)))
           (unreachable)
         )
         (unreachable)


### PR DESCRIPTION
`tablify()` attempts to turns a sequence of `br_if`s into a single
`br_table`. This PR adds some flexibility to the specific pattern it
looks for, specifically:

* Accept `i32.eqz` as a comparison to zero, and not just to look
  for `i32.eq` against a constant.
* Allow the first condition to be a `tee`. If it is, compare later
  conditions to `local.get` of that local.

This will allow more `br_table`s to be emitted in j2cl output.