### PR TITLE
[OptimizeInstructions] Transform 64-bit low word masking to wrap + extend unaries

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2314,7 +2314,7 @@ private:
         Bits::getMaxBits(left, this) == 1) {
       return builder.makeUnary(Abstract::getUnary(type, EqZ), left);
     }
-    // bool(x)  ^ 1  ==>  !bool(x)
+    // bool(x) ^ 1  ==>  !bool(x)
     if (matches(curr, binary(Xor, any(&left), ival(1))) &&
         Bits::getMaxBits(left, this) == 1) {
       auto* result = builder.makeUnary(Abstract::getUnary(type, EqZ), left);
@@ -2364,6 +2364,12 @@ private:
       curr->op = EqInt64;
       curr->type = Type::i32;
       return Builder(*getModule()).makeUnary(ExtendUInt32, curr);
+    }
+    // i64(x) & 0x00000000FFFFFFFF   ==>   i64(i32(x))
+    if (matches(curr, binary(And, any(&left), i64(0x00000000FFFFFFFFLL)))) {
+      Builder builder(*getModule());
+      return builder.makeUnary(ExtendUInt32,
+                               builder.makeUnary(WrapInt64, left));
     }
     // (unsigned)x < 0   ==>   i32(0)
     if (matches(curr, binary(LtU, pure(&left), ival(0)))) {

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -9609,6 +9609,13 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.extend_i32_u
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -9805,6 +9812,12 @@
     (drop (i64.div_u
       (local.get $y)
       (i64.const -9223372036854775808)
+    ))
+
+    ;; i64(x) & 0x00000000FFFFFFFF  =>  extend(wrap(x))
+    (drop (i64.and
+      (local.get $y)
+      (i64.const 0x00000000FFFFFFFF)
     ))
 
     ;; (unsigned)x >= 0  =>  i32(1)
@@ -11497,9 +11510,10 @@
 
   ;; CHECK:      (func $sign-and-zero-extention-elimination-2 (param $x i64)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i64.const 4294967295)
+  ;; CHECK-NEXT:   (i64.extend_i32_u
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -11525,10 +11539,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.extend_i32_s
   ;; CHECK-NEXT:    (i32.wrap_i64
-  ;; CHECK-NEXT:     (i64.and
-  ;; CHECK-NEXT:      (local.get $x)
-  ;; CHECK-NEXT:      (i64.const 4294967295)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )


### PR DESCRIPTION
`i64(x) & 0x00000000FFFFFFFF` -> `i64.extend_i32_u(i32.wrap_i64(x))`

This shrinked 5 bytes