### PR TITLE
DWARF: Canonicalize tombstone values

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -654,6 +654,19 @@ static bool isTombstone(uint32_t x) {
   return x == 0 || x == uint32_t(-1) || x == uint32_t(-2);
 }
 
+// Return a canonical tombstone value, the same as LLVM's in
+// computeTombstoneAddress().
+static BinaryLocation getTombstone() {
+  // TODO: this may differ in wasm64/DWARF64
+  return uint32_t(-1);
+}
+
+// Fixes up tombstone values to be canonical. This makes us match LLVM as much
+// as possible.
+static BinaryLocation fixTombstoneValue(BinaryLocation location) {
+  return isTombstone(location) ? getTombstone() : location;
+}
+
 // Update debug lines, and update the locationUpdater with debug line offset
 // changes so we can update offsets into the debug line section.
 static void updateDebugLines(llvm::DWARFYAML::Data& data,
@@ -810,6 +823,7 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
             tag == llvm::dwarf::DW_TAG_lexical_block ||
             tag == llvm::dwarf::DW_TAG_label) {
           newValue = locationUpdater.getNewStart(oldValue);
+          newValue = fixTombstoneValue(newValue);
         } else if (tag == llvm::dwarf::DW_TAG_compile_unit) {
           newValue = locationUpdater.getNewFuncStart(oldValue);
           // Per the DWARF spec, "The base address of a compile unit is
@@ -818,6 +832,7 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
             LocationUpdater::OldToNew{oldValue, newValue};
         } else if (tag == llvm::dwarf::DW_TAG_subprogram) {
           newValue = locationUpdater.getNewFuncStart(oldValue);
+          newValue = fixTombstoneValue(newValue);
         } else {
           Fatal() << "unknown tag with low_pc "
                   << llvm::dwarf::TagString(tag).str();
@@ -850,7 +865,9 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
       BinaryLocation oldValue = yamlValue.Value, newValue = 0;
       bool isRelative = attrSpec.Form == llvm::dwarf::DW_FORM_data4;
       if (isRelative) {
-        oldValue += oldLowPC;
+        if (!isTombstone(oldValue) && !isTombstone(oldLowPC)) {
+          oldValue += oldLowPC;
+        }
       }
       if (tag == llvm::dwarf::DW_TAG_GNU_call_site ||
           tag == llvm::dwarf::DW_TAG_inlined_subroutine ||
@@ -865,7 +882,9 @@ static void updateDIE(const llvm::DWARFDebugInfoEntry& DIE,
                 << llvm::dwarf::TagString(tag).str();
       }
       if (isRelative) {
-        newValue -= newLowPC;
+        if (!isTombstone(newValue) && !isTombstone(newLowPC)) {
+          newValue -= newLowPC;
+        }
       }
       yamlValue.Value = newValue;
     });

--- a/test/passes/class_with_dwarf_noprint.bin.txt
+++ b/test/passes/class_with_dwarf_noprint.bin.txt
@@ -336,7 +336,7 @@ Abbrev table for offset: 0x00000000
 
 0x0000011f:     DW_TAG_lexical_block [22] *
                   DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000030)
-                  DW_AT_high_pc [DW_FORM_data4]	(0xffffffd0)
+                  DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
 
 0x00000128:       DW_TAG_variable [21]  
                     DW_AT_location [DW_FORM_sec_offset]	(0x00000046: 

--- a/test/passes/dwarfdump_roundtrip_dwarfdump.bin.txt
+++ b/test/passes/dwarfdump_roundtrip_dwarfdump.bin.txt
@@ -141,7 +141,7 @@ Abbrev table for offset: 0x00000000
               DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
 
 0x00000026:   DW_TAG_subprogram [2]  
-                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
                 DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
                 DW_AT_linkage_name [DW_FORM_strp]	( .debug_str[0x000000c8] = "_Z3foov")
                 DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000d0] = "foo")

--- a/test/passes/fannkuch3_manyopts_dwarf.bin.txt
+++ b/test/passes/fannkuch3_manyopts_dwarf.bin.txt
@@ -2851,7 +2851,7 @@ Abbrev table for offset: 0x00000000
 0x00000278:     DW_TAG_inlined_subroutine [24] *
                   DW_AT_abstract_origin [DW_FORM_ref4]	(cu + 0x01a8 => {0x000001a8} "_ZL8fannkuchi")
                   DW_AT_low_pc [DW_FORM_addr]	(0x00000000000003cb)
-                  DW_AT_high_pc [DW_FORM_data4]	(0xfffffc35)
+                  DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
                   DW_AT_call_file [DW_FORM_data1]	("/usr/local/google/home/azakai/Dev/emscripten/tests/fannkuch.cpp")
                   DW_AT_call_line [DW_FORM_data1]	(159)
                   DW_AT_call_column [DW_FORM_data1]	(0x29)

--- a/test/passes/fib2_dwarf.bin.txt
+++ b/test/passes/fib2_dwarf.bin.txt
@@ -453,7 +453,7 @@ Abbrev table for offset: 0x00000000
                 DW_AT_external [DW_FORM_flag_present]	(true)
 
 0x0000009a:     DW_TAG_GNU_call_site [7]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
 
 0x0000009f:     NULL
 

--- a/test/passes/fib2_emptylocspan_dwarf.bin.txt
+++ b/test/passes/fib2_emptylocspan_dwarf.bin.txt
@@ -453,7 +453,7 @@ Abbrev table for offset: 0x00000000
                 DW_AT_external [DW_FORM_flag_present]	(true)
 
 0x0000009a:     DW_TAG_GNU_call_site [7]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
 
 0x0000009f:     NULL
 

--- a/test/passes/ignore_missing_func_dwarf.bin.txt
+++ b/test/passes/ignore_missing_func_dwarf.bin.txt
@@ -668,7 +668,7 @@ Abbrev table for offset: 0x00000000
 0x00000074:     NULL
 
 0x00000075:   DW_TAG_subprogram [6] *
-                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
                 DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
                 DW_AT_linkage_name [DW_FORM_strp]	( .debug_str[0x000000d2] = "_Z6unusedi")
                 DW_AT_name [DW_FORM_strp]	( .debug_str[0x000000dd] = "unused")

--- a/test/passes/inlined_to_start_dwarf.bin.txt
+++ b/test/passes/inlined_to_start_dwarf.bin.txt
@@ -120,7 +120,7 @@ Abbrev table for offset: 0x00000000
                  [0x00000013, 0x0000001b))
 
 0x00000026:   DW_TAG_subprogram [2] *
-                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
                 DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
                 DW_AT_frame_base [DW_FORM_exprloc]	(DW_OP_WASM_location 0x3 +0, <decoding error> 00 00 9f)
                 DW_AT_GNU_all_call_sites [DW_FORM_flag_present]	(true)
@@ -260,7 +260,7 @@ Abbrev table for offset: 0x00000000
                   DW_AT_type [DW_FORM_ref4]	(cu + 0x0071 => {0x00000071} "int")
 
 0x00000129:     DW_TAG_GNU_call_site [13]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
 
 0x0000012e:     NULL
 

--- a/test/passes/reverse_dwarf_abbrevs.bin.txt
+++ b/test/passes/reverse_dwarf_abbrevs.bin.txt
@@ -50,7 +50,7 @@ Abbrev table for offset: 0x00000000
               DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
 
 0x00000026:   DW_TAG_subprogram [3] *
-                DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
                 DW_AT_high_pc [DW_FORM_data4]	(0x00000000)
                 DW_AT_frame_base [DW_FORM_exprloc]	(DW_OP_WASM_location 0x3 +0, <decoding error> 00 00 9f)
                 DW_AT_GNU_all_call_sites [DW_FORM_flag_present]	(true)
@@ -61,7 +61,7 @@ Abbrev table for offset: 0x00000000
                 DW_AT_external [DW_FORM_flag_present]	(true)
 
 0x00000041:     DW_TAG_GNU_call_site [2]  
-                  DW_AT_low_pc [DW_FORM_addr]	(0x0000000000000000)
+                  DW_AT_low_pc [DW_FORM_addr]	(0x00000000ffffffff)
 
 0x00000046:     NULL
 


### PR DESCRIPTION
This uses LLVM-style tombstone values in more places, and avoids
doing math on tombstone values incorrectly. This reduces a large
amount of dwarfdump verification errors that currently happen even on
hello world.

cc @pfaffe 