### PR TITLE
Propagate BINARYEN_PASS_DEBUG to lit test commands

### DIFF
--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -1,3 +1,4 @@
+import os
 import lit.formats
 
 config.name = "Binaryen lit tests"
@@ -7,6 +8,8 @@ config.suffixes = ['.wat', '.wast', '.test']
 
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.binaryen_build_root, 'test')
+
+config.environment = dict(os.environ)
 
 # Replace all Binaryen tools with their absolute paths
 bin_dir = os.path.join(config.binaryen_build_root, 'bin')


### PR DESCRIPTION
As well BINARYEN_CORES for good measure. This means that when check.py tries to
run the lit tests with BINARYEN_PASS_DEBUG, this is now correctly reflected in
the tests. Manually validated to catch the bug identified in
#4130 (comment).