### PR TITLE
[OptimizeInstructions] canonicalize extacting sign bit (x >>> (31|63)) to relational x < 0

### DIFF
--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -1345,6 +1345,34 @@
     (drop (i32.and (local.get $y) (local.get $x)))
     (drop (i32.and (local.get $y) (local.tee $x (i32.const -4))))
   )
+  ;; CHECK:      (func $canonicalize-unsigned-shifts-to-relationals (param $x i32) (param $y i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.lt_s
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.lt_s
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $canonicalize-unsigned-shifts-to-relationals (param $x i32) (param $y i64)
+    ;; i32(x) >>> 31   ==>   x < 0
+    (drop (i32.shr_u
+      (local.get $x)
+      (i32.const 31)
+    ))
+    ;; i32(i64(x) >>> 63)   ==>   x < 0
+    (drop (i32.wrap_i64
+      (i64.shr_u
+        (local.get $y)
+        (i64.const 63)
+      )
+    ))
+  )
   ;; CHECK:      (func $canonicalize-block-var (param $x i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
@@ -2683,12 +2711,12 @@
     )
   )
   ;; CHECK:      (func $sext-24-shr_s-and-masked-sign (result i32)
-  ;; CHECK-NEXT:  (i32.shr_u
+  ;; CHECK-NEXT:  (i32.lt_u
   ;; CHECK-NEXT:   (i32.and
   ;; CHECK-NEXT:    (i32.const -1)
   ;; CHECK-NEXT:    (i32.const 2147483647)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (i32.const 31)
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $sext-24-shr_s-and-masked-sign (result i32)
@@ -6593,9 +6621,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (call $div-32-power-2
-  ;; CHECK-NEXT:    (i32.shr_u
+  ;; CHECK-NEXT:    (i32.lt_s
   ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:     (i32.const 31)
+  ;; CHECK-NEXT:     (i32.const 0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -8934,35 +8962,27 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.wrap_i64
-  ;; CHECK-NEXT:    (i64.shr_u
-  ;; CHECK-NEXT:     (local.get $y)
-  ;; CHECK-NEXT:     (i64.const 63)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i64.lt_s
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (i32.shr_u
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:     (i32.const 31)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i32.ge_s
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.eqz
-  ;; CHECK-NEXT:    (i64.shr_u
-  ;; CHECK-NEXT:     (local.get $y)
-  ;; CHECK-NEXT:     (i64.const 63)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i64.ge_s
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.eqz
-  ;; CHECK-NEXT:    (i64.shr_u
-  ;; CHECK-NEXT:     (local.get $y)
-  ;; CHECK-NEXT:     (i64.const 63)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i64.ge_s
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -9835,9 +9855,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.shr_u
+  ;; CHECK-NEXT:   (i32.lt_s
   ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i32.const 31)
+  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop


### PR DESCRIPTION
Canonicalize unsigned shift by 31 or 63 to relational operation
```rust
u32(x) >> 31        ->   i32(x) < 0
i32(u64(x) >> 63)   ->   i64(x) < 0
```
LLVM usually optimize `x < 0` into unsigned shift to MSB: https://godbolt.org/z/PTWK65vza

In this PR we revert this back to more canonical form which important for some transforms like [this](https://github.com/WebAssembly/binaryen/pull/4154)

