### PR TITLE
Tiny code cleanups. NFC

### DIFF
--- a/src/ir/iteration.h
+++ b/src/ir/iteration.h
@@ -18,7 +18,6 @@
 #define wasm_ir_iteration_h
 
 #include "ir/properties.h"
-#include "wasm-traversal.h"
 #include "wasm.h"
 
 namespace wasm {

--- a/src/wasm-delegations-fields.def
+++ b/src/wasm-delegations-fields.def
@@ -298,7 +298,7 @@ switch (DELEGATE_ID) {
     DELEGATE_FIELD_CHILD(AtomicCmpxchg, ptr);
     DELEGATE_FIELD_INT(AtomicCmpxchg, bytes);
     DELEGATE_FIELD_ADDRESS(AtomicCmpxchg, offset);
-    DELEGATE_END(AtomicCmpxchgId);
+    DELEGATE_END(AtomicCmpxchg);
     break;
   }
   case Expression::Id::AtomicWaitId: {


### PR DESCRIPTION
Remove an unnecessary include, and fix a typo in a macro
declaration (that macro is not tested as it seems nothing uses
`DELEGATE_END` yet, but I may be soon).