### PR TITLE
Properly error on bad function names in text format

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -191,6 +191,7 @@ private:
   bool isType(cashew::IString str) {
     return stringToType(str, true) != Type::none;
   }
+  HeapType getFunctionType(Name name, Element& s);
 
 public:
   Expression* parseExpression(Element* s) { return parseExpression(*s); }


### PR DESCRIPTION
Without this we hit an assert which is not that helpful.