### PR TITLE
Use UniqueDeferringQueue in Precompute

### DIFF
--- a/src/support/unique_deferring_queue.h
+++ b/src/support/unique_deferring_queue.h
@@ -23,6 +23,7 @@
 #ifndef wasm_support_unique_deferring_queue_h
 #define wasm_support_unique_deferring_queue_h
 
+#include <cassert>
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
This makes the code a little shorter, and more consistent with other
similar queue situations we have in the codebase.