### PR TITLE
RemoveUnusedBrs: Optimize if-of-if pattern

### DIFF
--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -405,8 +405,6 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           return;
         }
         Builder builder(*getModule());
-        // Note that we use the br's condition as the select condition.
-        // That keeps the order of the two conditions as it was originally.
         curr->condition =
           builder.makeBinary(AndInt32, curr->condition, child->condition);
         curr->ifTrue = child->ifTrue;

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -391,8 +391,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         if (!child->ifFalse) {
           // If running the child's condition unconditionally is too expensive,
           // give up.
-          if (tooCostlyToRunUnconditionally(
-                getPassOptions(), child->condition)) {
+          if (tooCostlyToRunUnconditionally(getPassOptions(),
+                                            child->condition)) {
             return;
           }
           // Of course we can't do this if the inner if's condition has side

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -388,15 +388,14 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
 
       // if (condition-A) { if (condition-B) .. }
       //   =>
-      // if (condition-A | condition-B) { .. }
+      // if (condition-A & condition-B) { .. }
       if (auto* child = curr->ifTrue->dynCast<If>()) {
         if (child->ifFalse) {
           return;
         }
         // If running the child's condition unconditionally is too expensive,
         // give up.
-        if (tooCostlyToRunUnconditionally(getPassOptions(),
-                                          child->condition)) {
+        if (tooCostlyToRunUnconditionally(getPassOptions(), child->condition)) {
           return;
         }
         // Of course we can't do this if the inner if's condition has side
@@ -409,7 +408,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         // Note that we use the br's condition as the select condition.
         // That keeps the order of the two conditions as it was originally.
         curr->condition =
-          builder.makeBinary(OrInt32, curr->condition, child->condition);
+          builder.makeBinary(AndInt32, curr->condition, child->condition);
         curr->ifTrue = child->ifTrue;
       }
     }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -409,10 +409,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           return;
         }
         Builder builder(*getModule());
-        curr->condition =
-          builder.makeSelect(child->condition,
-                             curr->condition,
-                             builder.makeConst(int32_t(0)));
+        curr->condition = builder.makeSelect(
+          child->condition, curr->condition, builder.makeConst(int32_t(0)));
         curr->ifTrue = child->ifTrue;
       }
     }

--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -460,42 +460,41 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (if (result i32)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 2)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (block (result i32)
-  ;; CHECK-NEXT:          (i32.store
-  ;; CHECK-NEXT:           (global.get $__asyncify_data)
-  ;; CHECK-NEXT:           (i32.sub
-  ;; CHECK-NEXT:            (i32.load
-  ;; CHECK-NEXT:             (global.get $__asyncify_data)
-  ;; CHECK-NEXT:            )
-  ;; CHECK-NEXT:            (i32.const 4)
-  ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.load
-  ;; CHECK-NEXT:           (i32.load
-  ;; CHECK-NEXT:            (global.get $__asyncify_data)
-  ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (local.get $1)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:       (i32.eq
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:         (i32.const 2)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (block (result i32)
+  ;; CHECK-NEXT:         (i32.store
+  ;; CHECK-NEXT:          (global.get $__asyncify_data)
+  ;; CHECK-NEXT:          (i32.sub
+  ;; CHECK-NEXT:           (i32.load
+  ;; CHECK-NEXT:            (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:           (i32.const 4)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (i32.load
+  ;; CHECK-NEXT:          (i32.load
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -538,43 +537,20 @@
   ;; CHECK:      (func $calls-import2-if-else (param $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (i32.eq
-  ;; CHECK-NEXT:    (global.get $__asyncify_state)
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (i32.store
-  ;; CHECK-NEXT:     (global.get $__asyncify_data)
-  ;; CHECK-NEXT:     (i32.sub
-  ;; CHECK-NEXT:      (i32.load
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 4)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.load
-  ;; CHECK-NEXT:      (i32.load
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (block (result i32)
-  ;; CHECK-NEXT:         (if
+  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (local.tee $1
+  ;; CHECK-NEXT:        (select
+  ;; CHECK-NEXT:         (if (result i32)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 2)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (block
+  ;; CHECK-NEXT:          (block (result i32)
   ;; CHECK-NEXT:           (i32.store
   ;; CHECK-NEXT:            (global.get $__asyncify_data)
   ;; CHECK-NEXT:            (i32.sub
@@ -584,25 +560,14 @@
   ;; CHECK-NEXT:             (i32.const 4)
   ;; CHECK-NEXT:            )
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (local.set $2
+  ;; CHECK-NEXT:           (i32.load
   ;; CHECK-NEXT:            (i32.load
-  ;; CHECK-NEXT:             (i32.load
-  ;; CHECK-NEXT:              (global.get $__asyncify_data)
-  ;; CHECK-NEXT:             )
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
   ;; CHECK-NEXT:            )
   ;; CHECK-NEXT:           )
   ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (local.get $2)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.or
-  ;; CHECK-NEXT:       (local.tee $1
-  ;; CHECK-NEXT:        (select
-  ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (local.get $0)
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:        )
@@ -611,6 +576,37 @@
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:       (block (result i32)
+  ;; CHECK-NEXT:        (if
+  ;; CHECK-NEXT:         (i32.eq
+  ;; CHECK-NEXT:          (global.get $__asyncify_state)
+  ;; CHECK-NEXT:          (i32.const 2)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (block
+  ;; CHECK-NEXT:          (i32.store
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           (i32.sub
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:            (i32.const 4)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (local.set $2
+  ;; CHECK-NEXT:           (i32.load
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -629,7 +625,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
+  ;; CHECK-NEXT:     (select
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $1)
@@ -639,6 +635,7 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (select
   ;; CHECK-NEXT:       (i32.eq
   ;; CHECK-NEXT:        (local.get $2)
@@ -733,10 +730,8 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (local.tee $2
   ;; CHECK-NEXT:        (select
@@ -750,20 +745,15 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (global.get $__asyncify_state)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (return
   ;; CHECK-NEXT:      (i32.const 1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $2)
@@ -772,6 +762,11 @@
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -827,67 +822,37 @@
   ;; CHECK:      (func $calls-import2-if-else-oneside2 (param $0 i32) (result i32)
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (i32.eq
-  ;; CHECK-NEXT:    (global.get $__asyncify_state)
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (i32.store
-  ;; CHECK-NEXT:     (global.get $__asyncify_data)
-  ;; CHECK-NEXT:     (i32.sub
-  ;; CHECK-NEXT:      (i32.load
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 4)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.load
-  ;; CHECK-NEXT:      (i32.load
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (if (result i32)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 2)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (block (result i32)
-  ;; CHECK-NEXT:          (i32.store
-  ;; CHECK-NEXT:           (global.get $__asyncify_data)
-  ;; CHECK-NEXT:           (i32.sub
-  ;; CHECK-NEXT:            (i32.load
-  ;; CHECK-NEXT:             (global.get $__asyncify_data)
-  ;; CHECK-NEXT:            )
-  ;; CHECK-NEXT:            (i32.const 4)
-  ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.load
-  ;; CHECK-NEXT:           (i32.load
-  ;; CHECK-NEXT:            (global.get $__asyncify_data)
-  ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (local.get $2)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (local.tee $1
   ;; CHECK-NEXT:        (select
-  ;; CHECK-NEXT:         (local.get $1)
+  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:          (i32.eq
+  ;; CHECK-NEXT:           (global.get $__asyncify_state)
+  ;; CHECK-NEXT:           (i32.const 2)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (block (result i32)
+  ;; CHECK-NEXT:           (i32.store
+  ;; CHECK-NEXT:            (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            (i32.sub
+  ;; CHECK-NEXT:             (i32.load
+  ;; CHECK-NEXT:              (global.get $__asyncify_data)
+  ;; CHECK-NEXT:             )
+  ;; CHECK-NEXT:             (i32.const 4)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:           (i32.load
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (local.get $1)
+  ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:         (local.get $0)
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:        )
@@ -896,6 +861,33 @@
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:         (i32.const 2)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (block (result i32)
+  ;; CHECK-NEXT:         (i32.store
+  ;; CHECK-NEXT:          (global.get $__asyncify_data)
+  ;; CHECK-NEXT:          (i32.sub
+  ;; CHECK-NEXT:           (i32.load
+  ;; CHECK-NEXT:            (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:           (i32.const 4)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (i32.load
+  ;; CHECK-NEXT:          (i32.load
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -914,10 +906,8 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $1)
@@ -927,6 +917,7 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (global.get $__asyncify_state)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (return
   ;; CHECK-NEXT:      (i32.const 2)

--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -460,7 +460,7 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
   ;; CHECK-NEXT:        (if (result i32)
@@ -565,7 +565,7 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
   ;; CHECK-NEXT:        (block (result i32)
@@ -629,7 +629,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $1)
@@ -733,7 +733,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
@@ -756,7 +756,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
   ;; CHECK-NEXT:        (local.get $1)
@@ -854,7 +854,7 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
   ;; CHECK-NEXT:        (if (result i32)
@@ -914,7 +914,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )

--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -460,54 +460,52 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eq
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      (i32.const 2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (i32.store
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:       (i32.sub
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:         (global.get $__asyncify_data)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 4)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.set $1
-  ;; CHECK-NEXT:       (i32.load
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:         (global.get $__asyncify_data)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
-  ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:      (i32.eq
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:         (i32.eq
+  ;; CHECK-NEXT:          (global.get $__asyncify_state)
+  ;; CHECK-NEXT:          (i32.const 2)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (block (result i32)
+  ;; CHECK-NEXT:          (i32.store
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           (i32.sub
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:            (i32.const 4)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (i32.load
+  ;; CHECK-NEXT:           (i32.load
+  ;; CHECK-NEXT:            (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (local.get $1)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (i32.const 0)
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (call $import)
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (br_if $__asyncify_unwind
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 1)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block
+  ;; CHECK-NEXT:      (call $import)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_if $__asyncify_unwind
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
@@ -567,62 +565,64 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eq
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      (i32.const 2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (i32.store
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:       (i32.sub
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:         (global.get $__asyncify_data)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 4)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.set $2
-  ;; CHECK-NEXT:       (i32.load
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:         (global.get $__asyncify_data)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
-  ;; CHECK-NEXT:      (local.tee $1
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.eq
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:        (block (result i32)
+  ;; CHECK-NEXT:         (if
+  ;; CHECK-NEXT:          (i32.eq
+  ;; CHECK-NEXT:           (global.get $__asyncify_state)
+  ;; CHECK-NEXT:           (i32.const 2)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (block
+  ;; CHECK-NEXT:           (i32.store
+  ;; CHECK-NEXT:            (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            (i32.sub
+  ;; CHECK-NEXT:             (i32.load
+  ;; CHECK-NEXT:              (global.get $__asyncify_data)
+  ;; CHECK-NEXT:             )
+  ;; CHECK-NEXT:             (i32.const 4)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:           (local.set $2
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (i32.load
+  ;; CHECK-NEXT:              (global.get $__asyncify_data)
+  ;; CHECK-NEXT:             )
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (local.get $2)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (i32.const 0)
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (call $import3
-  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (local.tee $1
+  ;; CHECK-NEXT:        (select
+  ;; CHECK-NEXT:         (local.get $1)
+  ;; CHECK-NEXT:         (local.get $0)
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (br_if $__asyncify_unwind
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 1)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block
+  ;; CHECK-NEXT:      (call $import3
+  ;; CHECK-NEXT:       (i32.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_if $__asyncify_unwind
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
@@ -630,15 +630,15 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.eq
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (select
   ;; CHECK-NEXT:       (i32.eq
   ;; CHECK-NEXT:        (local.get $2)
@@ -647,17 +647,17 @@
   ;; CHECK-NEXT:       (i32.const 1)
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (call $import3
-  ;; CHECK-NEXT:        (i32.const 2)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (br_if $__asyncify_unwind
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block
+  ;; CHECK-NEXT:      (call $import3
+  ;; CHECK-NEXT:       (i32.const 2)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_if $__asyncify_unwind
+  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 1)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 1)
-  ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
@@ -734,38 +734,29 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
-  ;; CHECK-NEXT:      (local.tee $2
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $2)
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.eq
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (return
-  ;; CHECK-NEXT:       (i32.const 1)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (local.tee $2
+  ;; CHECK-NEXT:        (select
+  ;; CHECK-NEXT:         (local.get $2)
+  ;; CHECK-NEXT:         (local.get $0)
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (return
+  ;; CHECK-NEXT:      (i32.const 1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (local.get $2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.eq
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
   ;; CHECK-NEXT:        (local.get $1)
@@ -773,17 +764,26 @@
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (call $import3
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (br_if $__asyncify_unwind
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 1)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block
+  ;; CHECK-NEXT:      (call $import3
+  ;; CHECK-NEXT:       (i32.const 2)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_if $__asyncify_unwind
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
@@ -854,62 +854,60 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eq
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      (i32.const 2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (i32.store
-  ;; CHECK-NEXT:       (global.get $__asyncify_data)
-  ;; CHECK-NEXT:       (i32.sub
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:         (global.get $__asyncify_data)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 4)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.set $2
-  ;; CHECK-NEXT:       (i32.load
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:         (global.get $__asyncify_data)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
-  ;; CHECK-NEXT:      (local.tee $1
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.eq
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:         (i32.eq
+  ;; CHECK-NEXT:          (global.get $__asyncify_state)
+  ;; CHECK-NEXT:          (i32.const 2)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (block (result i32)
+  ;; CHECK-NEXT:          (i32.store
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           (i32.sub
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:            (i32.const 4)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (i32.load
+  ;; CHECK-NEXT:           (i32.load
+  ;; CHECK-NEXT:            (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (local.get $2)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (i32.const 0)
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (call $import3
-  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (local.tee $1
+  ;; CHECK-NEXT:        (select
+  ;; CHECK-NEXT:         (local.get $1)
+  ;; CHECK-NEXT:         (local.get $0)
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (br_if $__asyncify_unwind
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:         (i32.eq
-  ;; CHECK-NEXT:          (global.get $__asyncify_state)
-  ;; CHECK-NEXT:          (i32.const 1)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block
+  ;; CHECK-NEXT:      (call $import3
+  ;; CHECK-NEXT:       (i32.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_if $__asyncify_unwind
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:        (i32.eq
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
@@ -918,20 +916,20 @@
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.or
   ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.eq
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (i32.const 2)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eq
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (return
-  ;; CHECK-NEXT:       (i32.const 2)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (return
+  ;; CHECK-NEXT:      (i32.const 2)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -439,7 +439,7 @@
     )
   )
 
-  ;; CHECK:      (func $if-of-if-but-else
+  ;; CHECK:      (func $if-of-if-but-inner-else
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (local.tee $x
@@ -447,12 +447,12 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (if
   ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (call $if-of-if-but-else)
+  ;; CHECK-NEXT:    (call $if-of-if-but-inner-else)
   ;; CHECK-NEXT:    (call $if-of-if)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $if-of-if-but-else
+  (func $if-of-if-but-inner-else
     (local $x i32)
     ;; The inner if has an else. For now, leave this unoptimized.
     (if
@@ -461,9 +461,37 @@
       )
       (if
         (local.get $x)
-        (call $if-of-if-but-else)
+        (call $if-of-if-but-inner-else)
         (call $if-of-if)
       )
+    )
+  )
+
+  ;; CHECK:      (func $if-of-if-but-outer-else
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.tee $x
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (call $if-of-if-but-outer-else)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $if-of-if)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-of-if-but-outer-else
+    (local $x i32)
+    ;; The outer if has an else. For now, leave this unoptimized.
+    (if
+      (local.tee $x
+        (i32.const 1)
+      )
+      (if
+        (local.get $x)
+        (call $if-of-if-but-outer-else)
+      )
+      (call $if-of-if)
     )
   )
 )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -339,7 +339,7 @@
   ;; CHECK:      (func $if-of-if
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (i32.or
+  ;; CHECK-NEXT:   (i32.and
   ;; CHECK-NEXT:    (local.tee $x
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -335,4 +335,135 @@
       )
     )
   )
+
+  ;; CHECK:      (func $if-of-if
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.or
+  ;; CHECK-NEXT:    (local.tee $x
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $if-of-if)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-of-if
+    (local $x i32)
+    ;; The outer if has side effects in the condition while the inner one does
+    ;; not, which means we can fold them.
+    (if
+      (local.tee $x
+        (i32.const 1)
+      )
+      (if
+        (local.get $x)
+        (call $if-of-if)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $if-of-if-but-side-effects
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.tee $x
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.tee $x
+  ;; CHECK-NEXT:     (i32.const 2)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (call $if-of-if-but-side-effects)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-of-if-but-side-effects
+    (local $x i32)
+    ;; The inner if has side effects in the condition, which prevents this
+    ;; optimization.
+    (if
+      (local.tee $x
+        (i32.const 1)
+      )
+      (if
+        (local.tee $x
+          (i32.const 2)
+        )
+        (call $if-of-if-but-side-effects)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $if-of-if-but-too-costly
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.tee $x
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (i32.eqz
+  ;; CHECK-NEXT:         (i32.eqz
+  ;; CHECK-NEXT:          (i32.eqz
+  ;; CHECK-NEXT:           (i32.eqz
+  ;; CHECK-NEXT:            (local.get $x)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (call $if-of-if-but-too-costly)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-of-if-but-too-costly
+    (local $x i32)
+    ;; The inner if's condition has no effects, but it is very costly, so do not
+    ;; run it unconditionally - leave this unoptimized.
+    (if
+      (local.tee $x
+        (i32.const 1)
+      )
+      (if
+        (i32.eqz (i32.eqz (i32.eqz (i32.eqz (i32.eqz (i32.eqz (i32.eqz (i32.eqz
+          (local.get $x)
+        ))))))))
+        (call $if-of-if-but-too-costly)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $if-of-if-but-else
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.tee $x
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (call $if-of-if-but-else)
+  ;; CHECK-NEXT:    (call $if-of-if)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-of-if-but-else
+    (local $x i32)
+    ;; The inner if has an else. For now, leave this unoptimized.
+    (if
+      (local.tee $x
+        (i32.const 1)
+      )
+      (if
+        (local.get $x)
+        (call $if-of-if-but-else)
+        (call $if-of-if)
+      )
+    )
+  )
 )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -339,10 +339,11 @@
   ;; CHECK:      (func $if-of-if
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:   (select
   ;; CHECK-NEXT:    (local.tee $x
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (call $if-of-if)


### PR DESCRIPTION
```js
if (A) {
  if (B) {
    C
  }
}
=>
if (A ? B : 0) {
  C
}
```
when B has no side effects, and is fast enough to consider running
unconditionally. In that case, we replace an `if` with a `select` and a
zero, which is the same size, but should be faster and may be
further optimized.

As suggested by @MaxGraey in #4168 (thanks!)

An asyncify test happens to be helped by this; the diff there is
mostly whitespace. Proper new testing appears after that in the
`lit` test for this.