### PR TITLE
Precompute: Only run a single LocalGraph iteration

### DIFF
--- a/test/passes/precompute-propagate_all-features.txt
+++ b/test/passes/precompute-propagate_all-features.txt
@@ -240,7 +240,12 @@
  (func $multipass (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
   (local $3 i32)
   (nop)
-  (nop)
+  (if
+   (local.get $3)
+   (local.set $2
+    (i32.const 0)
+   )
+  )
   (local.get $2)
  )
  (func $through-fallthrough (param $x i32) (param $y i32) (result i32)

--- a/test/passes/precompute-propagate_all-features.wast
+++ b/test/passes/precompute-propagate_all-features.wast
@@ -141,7 +141,12 @@
   (func $multipass (param $0 i32) (param $1 i32) (param $2 i32) (result i32)
    (local $3 i32)
    (if
-    (local.get $3)
+    (local.get $3) ;; this will be precomputed to 0. after that, the if will be
+                   ;; precomputed to not exist at all. removing the set in the
+                   ;; if body then allows us to optimize the value of $3 in the
+                   ;; if lower down, but we do not do an additional cycle of
+                   ;; this pass automatically as such things are fairly rare,
+                   ;; so that opportunity remains unoptimized in this test.
     (local.set $3 ;; this set is completely removed, allowing later opts
      (i32.const 24)
     )


### PR DESCRIPTION
Precompute has a mode in which it propagates results from `local.set`s to
`local.get`s. That constructs a LocalGraph which is a non-trivial amount of
work. We used to run multiple iterations of this, but investigation shows that
such opportunities are extremely rare, as doing just a single propagation
iteration has no effect on the entire emscripten benchmark suite, nor on
j2cl output. Furthermore, we run this pass twice in the normal pipeline (once
early, once late) so even if there are such opportunities they may be
optimized already. And, `--converge` is a way to get additional iterations of
all passes if a user wants that, so it makes sense not to costly work for more
iterations automatically.

In effect, 99.99% of the time before this pass we would create the LocalGraph
twice: once the first time, then a second time only to see that we can't
actually optimize anything further. This PR makes us only create it once, which
makes `precompute-propagate` 10% faster on j2cl and even faster on other things
like poppler (33%) and LLVM (29%).

See the change in the test suite for an example of a case that does require
more than one iteration to be optimized. Note that even there, we only manage
to get benefit from a second iteration by doing something that overlaps with
another pass (optimizing out an if with condition 0), which shows even more
how unnecessary the extra work was.

See #4165