### PR TITLE
[Fuzzer] Don't prompt user when seed is given

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -242,7 +242,7 @@ def init_important_initial_contents():
     print()
 
     # We prompt the user only when there is no seed given. This fuzz_opt.py is
-    # often used with seed in a scirpt called from wasm-reduce, in which case we
+    # often used with seed in a script called from wasm-reduce, in which case we
     # should not pause for a user input.
     if given_seed is None:
         ret = input('Do you want to proceed with these initial contents? (Y/n) ').lower()


### PR DESCRIPTION
Fuzzer shows the initial contents and prompts the user if they want to
proceed after #4173, but when the fuzzer is used within a script called
from `wasm-reduce`, we shouldn't pause for the user input. This shows
the prompt only when there is no seed given.

To do that, we now initialize the important initial contents from
`main`. We used to assign those variables before we start `main`.