### PR TITLE
[Wasm GC] Optimize static (rtt-free) operations

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1454,6 +1454,18 @@ struct OptimizeInstructions
           // Skip the parent.
           replaceCurrent(child);
           return;
+        } else {
+          // The types are not compatible, so if the input is not null, this
+          // will trap.
+          if (!curr->type.isNullable()) {
+            // Make sure to emit a block with the same type as us; leave
+            // updating types for other passes.
+            replaceCurrent(builder.makeBlock({
+              builder.makeDrop(child->ref),
+              builder.makeUnreachable()
+            }, curr->type));
+            return;
+          }
         }
       }
     }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1334,104 +1334,106 @@ struct OptimizeInstructions
     Builder builder(*getModule());
     auto passOptions = getPassOptions();
 
-    // TODO: If no rtt, this is a static cast, and if the type matches then it
-    //       will definitely succeed. The opts below could be expanded for that.
-    if (curr->rtt) {
+    auto fallthrough =
+      Properties::getFallthrough(curr->ref, getPassOptions(), *getModule());
 
-      auto fallthrough =
-        Properties::getFallthrough(curr->ref, getPassOptions(), *getModule());
-
-      // If the value is a null, it will just flow through, and we do not need
-      // the cast. However, if that would change the type, then things are less
-      // simple: if the original type was non-nullable, replacing it with a null
-      // would change the type, which can happen in e.g.
-      //   (ref.cast (ref.as_non_null (.. (ref.null)
-      if (fallthrough->is<RefNull>()) {
-        // Replace the expression with drops of the inputs, and a null. Note
-        // that we provide a null of the type the outside expects - that of the
-        // rtt, which is what was cast to.
-        Expression* rep = builder.makeBlock(
+    // If the value is a null, it will just flow through, and we do not need
+    // the cast. However, if that would change the type, then things are less
+    // simple: if the original type was non-nullable, replacing it with a null
+    // would change the type, which can happen in e.g.
+    //   (ref.cast (ref.as_non_null (.. (ref.null)
+    if (fallthrough->is<RefNull>()) {
+      // Replace the expression with drops of the inputs, and a null. Note
+      // that we provide a null of the previous type, so that we do not alter
+      // the type received by our parent.
+      Expression* rep;
+      if (curr->rtt) {
+        rep = builder.makeBlock(
           {builder.makeDrop(curr->ref),
            builder.makeDrop(curr->rtt),
            builder.makeRefNull(curr->rtt->type.getHeapType())});
-        if (curr->ref->type.isNonNullable()) {
-          // Avoid a type change by forcing to be non-nullable. In practice,
-          // this would have trapped before we get here, so this is just for
-          // validation.
-          rep = builder.makeRefAs(RefAsNonNull, rep);
-        }
-        replaceCurrent(rep);
-        return;
-        // TODO: The optimal ordering of this and the other ref.as_non_null
-        //       stuff later down in this functions is unclear and may be worth
-        //       looking into.
+      } else {
+        rep = builder.makeBlock(
+          {builder.makeDrop(curr->ref),
+           builder.makeRefNull(curr->getIntendedType())});
       }
-
-      // For the cast to be able to succeed, the value being cast must be a
-      // subtype of the desired type, as RTT subtyping is a subset of static
-      // subtyping. For example, trying to cast an array to a struct would be
-      // incompatible.
-      if (!canBeCastTo(curr->ref->type.getHeapType(),
-                       curr->rtt->type.getHeapType())) {
-        // This cast cannot succeed. If the input is not a null, it will
-        // definitely trap.
-        if (fallthrough->type.isNonNullable()) {
-          // Make sure to emit a block with the same type as us; leave updating
-          // types for other passes.
-          replaceCurrent(builder.makeBlock({builder.makeDrop(curr->ref),
-                                            builder.makeDrop(curr->rtt),
-                                            builder.makeUnreachable()},
-                                           curr->type));
-          return;
-        }
-        // Otherwise, we are not sure what it is, and need to wait for runtime
-        // to see if it is a null or not. (We've already handled the case where
-        // we can see the value is definitely a null at compile time, earlier.)
+      if (curr->ref->type.isNonNullable()) {
+        // Avoid a type change by forcing to be non-nullable. In practice,
+        // this would have trapped before we get here, so this is just for
+        // validation.
+        rep = builder.makeRefAs(RefAsNonNull, rep);
       }
+      replaceCurrent(rep);
+      return;
+      // TODO: The optimal ordering of this and the other ref.as_non_null
+      //       stuff later down in this functions is unclear and may be worth
+      //       looking into.
+    }
 
-      if (passOptions.ignoreImplicitTraps || passOptions.trapsNeverHappen) {
-        // Aside from the issue of type incompatibility as mentioned above, the
-        // cast can trap if the types *are* compatible but it happens to be the
-        // case at runtime that the value is not of the desired subtype. If we
-        // do not consider such traps possible, we can ignore that. Note,
-        // though, that we cannot do this if we cannot replace the current type
-        // with the reference's type.
-        if (HeapType::isSubType(curr->ref->type.getHeapType(),
-                                curr->rtt->type.getHeapType())) {
-          replaceCurrent(getResultOfFirst(curr->ref,
+    // For the cast to be able to succeed, the value being cast must be a
+    // subtype of the desired type, as RTT subtyping is a subset of static
+    // subtyping. For example, trying to cast an array to a struct would be
+    // incompatible.
+    if (!canBeCastTo(curr->ref->type.getHeapType(),
+                     curr->rtt->type.getHeapType())) {
+      // This cast cannot succeed. If the input is not a null, it will
+      // definitely trap.
+      if (fallthrough->type.isNonNullable()) {
+        // Make sure to emit a block with the same type as us; leave updating
+        // types for other passes.
+        replaceCurrent(builder.makeBlock({builder.makeDrop(curr->ref),
                                           builder.makeDrop(curr->rtt),
-                                          getFunction(),
-                                          getModule(),
-                                          passOptions));
-          return;
-        }
+                                          builder.makeUnreachable()},
+                                         curr->type));
+        return;
       }
+      // Otherwise, we are not sure what it is, and need to wait for runtime
+      // to see if it is a null or not. (We've already handled the case where
+      // we can see the value is definitely a null at compile time, earlier.)
+    }
 
-      // Repeated identical ref.cast operations are unnecessary, if using the
-      // exact same rtt - the result will be the same. Find the immediate child
-      // cast, if there is one, and see if it is identical.
-      // TODO: Look even further through incompatible casts?
-      auto* ref = curr->ref;
-      while (!ref->is<RefCast>()) {
-        auto* last = ref;
-        // RefCast falls through the value, so instead of calling
-        // getFallthrough() to look through all fallthroughs, we must iterate
-        // manually. Keep going until we reach either the end of things
-        // falling-through, or a cast.
-        ref =
-          Properties::getImmediateFallthrough(ref, passOptions, *getModule());
-        if (ref == last) {
-          break;
-        }
+    if (passOptions.ignoreImplicitTraps || passOptions.trapsNeverHappen) {
+      // Aside from the issue of type incompatibility as mentioned above, the
+      // cast can trap if the types *are* compatible but it happens to be the
+      // case at runtime that the value is not of the desired subtype. If we
+      // do not consider such traps possible, we can ignore that. Note,
+      // though, that we cannot do this if we cannot replace the current type
+      // with the reference's type.
+      if (HeapType::isSubType(curr->ref->type.getHeapType(),
+                              curr->rtt->type.getHeapType())) {
+        replaceCurrent(getResultOfFirst(curr->ref,
+                                        builder.makeDrop(curr->rtt),
+                                        getFunction(),
+                                        getModule(),
+                                        passOptions));
+        return;
       }
-      if (auto* child = ref->dynCast<RefCast>()) {
-        // Check if the casts are identical.
-        if (ExpressionAnalyzer::equal(curr->rtt, child->rtt) &&
-            !EffectAnalyzer(passOptions, *getModule(), curr->rtt)
-               .hasSideEffects()) {
-          replaceCurrent(curr->ref);
-          return;
-        }
+    }
+
+    // Repeated identical ref.cast operations are unnecessary, if using the
+    // exact same rtt - the result will be the same. Find the immediate child
+    // cast, if there is one, and see if it is identical.
+    // TODO: Look even further through incompatible casts?
+    auto* ref = curr->ref;
+    while (!ref->is<RefCast>()) {
+      auto* last = ref;
+      // RefCast falls through the value, so instead of calling
+      // getFallthrough() to look through all fallthroughs, we must iterate
+      // manually. Keep going until we reach either the end of things
+      // falling-through, or a cast.
+      ref =
+        Properties::getImmediateFallthrough(ref, passOptions, *getModule());
+      if (ref == last) {
+        break;
+      }
+    }
+    if (auto* child = ref->dynCast<RefCast>()) {
+      // Check if the casts are identical.
+      if (ExpressionAnalyzer::equal(curr->rtt, child->rtt) &&
+          !EffectAnalyzer(passOptions, *getModule(), curr->rtt)
+             .hasSideEffects()) {
+        replaceCurrent(curr->ref);
+        return;
       }
     }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1372,8 +1372,7 @@ struct OptimizeInstructions
     // subtype of the desired type, as RTT subtyping is a subset of static
     // subtyping. For example, trying to cast an array to a struct would be
     // incompatible.
-    if (!canBeCastTo(curr->ref->type.getHeapType(),
-                     intendedType)) {
+    if (!canBeCastTo(curr->ref->type.getHeapType(), intendedType)) {
       // This cast cannot succeed. If the input is not a null, it will
       // definitely trap.
       if (fallthrough->type.isNonNullable()) {
@@ -1402,8 +1401,7 @@ struct OptimizeInstructions
       // though, that we cannot do this if we cannot replace the current type
       // with the reference's type.) We can also do this if this is a static
       // cast: in that case, all we need to know about are the types.
-      if (HeapType::isSubType(curr->ref->type.getHeapType(),
-                              intendedType)) {
+      if (HeapType::isSubType(curr->ref->type.getHeapType(), intendedType)) {
         if (curr->rtt) {
           replaceCurrent(getResultOfFirst(curr->ref,
                                           builder.makeDrop(curr->rtt),
@@ -1427,8 +1425,7 @@ struct OptimizeInstructions
       // getFallthrough() to look through all fallthroughs, we must iterate
       // manually. Keep going until we reach either the end of things
       // falling-through, or a cast.
-      ref =
-        Properties::getImmediateFallthrough(ref, passOptions, *getModule());
+      ref = Properties::getImmediateFallthrough(ref, passOptions, *getModule());
       if (ref == last) {
         break;
       }
@@ -1460,10 +1457,9 @@ struct OptimizeInstructions
           if (!curr->type.isNullable()) {
             // Make sure to emit a block with the same type as us; leave
             // updating types for other passes.
-            replaceCurrent(builder.makeBlock({
-              builder.makeDrop(child->ref),
-              builder.makeUnreachable()
-            }, curr->type));
+            replaceCurrent(builder.makeBlock(
+              {builder.makeDrop(child->ref), builder.makeUnreachable()},
+              curr->type));
             return;
           }
         }
@@ -1511,8 +1507,7 @@ struct OptimizeInstructions
     auto intendedType = curr->getIntendedType();
 
     // See above in RefCast.
-    if (!canBeCastTo(refType,
-                     intendedType)) {
+    if (!canBeCastTo(refType, intendedType)) {
       // This test cannot succeed, and will definitely return 0.
       std::vector<Expression*> items;
       items.push_back(builder.makeDrop(curr->ref));
@@ -1527,10 +1522,8 @@ struct OptimizeInstructions
     if (!curr->rtt && curr->ref->type.isNonNullable() &&
         HeapType::isSubType(refType, intendedType)) {
       // This static test will definitely succeed.
-      replaceCurrent(builder.makeBlock({
-        builder.makeDrop(curr->ref),
-        builder.makeConst(int32_t(1))
-      }));
+      replaceCurrent(builder.makeBlock(
+        {builder.makeDrop(curr->ref), builder.makeConst(int32_t(1))}));
       return;
     }
   }

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -263,8 +263,7 @@ void test_features() {
   printf("BinaryenFeatureMemory64: %d\n", BinaryenFeatureMemory64());
   printf("BinaryenFeatureTypedFunctionReferences: %d\n",
          BinaryenFeatureTypedFunctionReferences());
-  printf("BinaryenFeatureRelaxedSIMD: %d\n",
-         BinaryenFeatureRelaxedSIMD());
+  printf("BinaryenFeatureRelaxedSIMD: %d\n", BinaryenFeatureRelaxedSIMD());
   printf("BinaryenFeatureAll: %d\n", BinaryenFeatureAll());
 }
 

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -15,10 +15,10 @@
   ))
 
   ;; CHECK:      (type $A (struct (field i32)))
+  ;; NOMNL:      (type $A (struct (field i32)))
+  (type $A (struct (field i32)))
 
   ;; CHECK:      (type $array (array (mut i8)))
-  ;; NOMNL:      (type $A (struct (field i32)))
-
   ;; NOMNL:      (type $array (array (mut i8)))
   (type $array (array (mut i8)))
 
@@ -29,8 +29,6 @@
   ;; CHECK:      (type $B-child (struct (field i32) (field i32) (field f32) (field i64)))
   ;; NOMNL:      (type $B-child (struct (field i32) (field i32) (field f32) (field i64)) (extends $B))
   (type $B-child (struct (field i32) (field i32) (field f32) (field i64)) (extends $B))
-
-  (type $A (struct (field i32)))
 
   ;; CHECK:      (type $empty (struct ))
   ;; NOMNL:      (type $empty (struct ))

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2222,12 +2222,11 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (ref.cast_static $struct
-  ;; CHECK-NEXT:     (ref.cast_static $array
-  ;; CHECK-NEXT:      (local.get $x)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -2240,12 +2239,11 @@
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.as_non_null
-  ;; NOMNL-NEXT:    (ref.cast_static $struct
-  ;; NOMNL-NEXT:     (ref.cast_static $array
-  ;; NOMNL-NEXT:      (local.get $x)
-  ;; NOMNL-NEXT:     )
+  ;; NOMNL-NEXT:   (block (result (ref $struct))
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.get $x)
   ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (unreachable)
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2340,6 +2340,51 @@
     )
   )
 
+  ;; CHECK:      (func $ref-cast-static-very-many (param $x eqref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-very-many (param $x eqref)
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-very-many (param $x eqref)
+    ;; We should optimize an arbitrarily-long long sequence of static casts.
+    (drop
+      (ref.cast_static $A
+        (ref.cast_static $B
+          (ref.cast_static $B-child
+            (ref.cast_static $A
+              (ref.cast_static $A
+                (ref.cast_static $B-child
+                  (ref.cast_static $B-child
+                    (ref.cast_static $B
+                      (ref.cast_static $B
+                        (ref.cast_static $B
+                          (ref.cast_static $B-child
+                            (ref.cast_static $A
+                              (local.get $x)
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+
   ;; CHECK:      (func $ref-cast-static-squared-impossible (param $x eqref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast_static $struct

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2088,16 +2088,12 @@
     )
   )
 
-  ;; CHECK:      (func $ref-cast-static-non-null (param $a (ref $A)) (param $b (ref $B))
+  ;; CHECK:      (func $ref-cast-static-general (param $a (ref null $A)) (param $b (ref null $B))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_static $A
-  ;; CHECK-NEXT:    (local.get $a)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_static $A
-  ;; CHECK-NEXT:    (local.get $b)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $b)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast_static $B
@@ -2105,23 +2101,17 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_static $A
-  ;; CHECK-NEXT:    (local.tee $a
-  ;; CHECK-NEXT:     (local.get $a)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (local.tee $a
+  ;; CHECK-NEXT:    (local.get $a)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $ref-cast-static-non-null (param $a (ref $A)) (param $b (ref $B))
+  ;; NOMNL:      (func $ref-cast-static-general (param $a (ref null $A)) (param $b (ref null $B))
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast_static $A
-  ;; NOMNL-NEXT:    (local.get $a)
-  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:   (local.get $a)
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast_static $A
-  ;; NOMNL-NEXT:    (local.get $b)
-  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:   (local.get $b)
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.cast_static $B
@@ -2129,15 +2119,14 @@
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast_static $A
-  ;; NOMNL-NEXT:    (local.tee $a
-  ;; NOMNL-NEXT:     (local.get $a)
-  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:   (local.tee $a
+  ;; NOMNL-NEXT:    (local.get $a)
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
-  (func $ref-cast-static-non-null (param $a (ref $A)) (param $b (ref $B))
-    ;; Casting nulls results in a null.
+  (func $ref-cast-static-general (param $a (ref null $A)) (param $b (ref null $B))
+    ;; In the general case, a static cast of something simply succeeds if the
+    ;; type is a subtype.
     (drop
       (ref.cast_static $A
         (local.get $a)
@@ -2148,6 +2137,7 @@
         (local.get $b)
       )
     )
+    ;; This is the only one that we cannot know for sure will succeed.
     (drop
       (ref.cast_static $B
         (local.get $a)

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2152,4 +2152,118 @@
       )
     )
   )
+
+  ;; CHECK:      (func $ref-cast-static-squared (param $x eqref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $A
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-squared (param $x eqref)
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $A
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-squared (param $x eqref)
+    ;; Identical ref.casts can be folded together.
+    (drop
+      (ref.cast_static $A
+        (ref.cast_static $A
+          (local.get $x)
+        )
+      )
+    )
+    ;; When subtypes exist, we only need the stricter one.
+    (drop
+      (ref.cast_static $A
+        (ref.cast_static $B
+          (local.get $x)
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $B
+        (ref.cast_static $A
+          (local.get $x)
+        )
+      )
+    )
+  )
+
+  ;; CHECK:      (func $ref-cast-static-squared-impossible (param $x eqref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $struct
+  ;; CHECK-NEXT:    (ref.cast_static $array
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (ref.cast_static $struct
+  ;; CHECK-NEXT:     (ref.cast_static $array
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-squared-impossible (param $x eqref)
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $struct
+  ;; NOMNL-NEXT:    (ref.cast_static $array
+  ;; NOMNL-NEXT:     (local.get $x)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.as_non_null
+  ;; NOMNL-NEXT:    (ref.cast_static $struct
+  ;; NOMNL-NEXT:     (ref.cast_static $array
+  ;; NOMNL-NEXT:      (local.get $x)
+  ;; NOMNL-NEXT:     )
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-squared-impossible (param $x eqref)
+    ;; Impossible casts will trap unless the input is null.
+    (drop
+      (ref.cast_static $struct
+        (ref.cast_static $array
+          (local.get $x)
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $struct
+        (ref.cast_static $array
+          (ref.as_non_null (local.get $x))
+        )
+      )
+    )
+  )
 )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2058,4 +2058,102 @@
       )
     )
   )
+
+  ;; CHECK:      (func $ref-cast-static-impossible (param $func funcref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static data
+  ;; CHECK-NEXT:    (local.get $func)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-impossible (param $func funcref)
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static data
+  ;; NOMNL-NEXT:    (local.get $func)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-impossible (param $func funcref)
+    ;; A funcref cannot be cast to data, so this will trap.
+    (drop
+      (ref.cast_static data
+        (local.get $func)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $ref-cast-static-non-null (param $a (ref $A)) (param $b (ref $B))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $A
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $A
+  ;; CHECK-NEXT:    (local.get $b)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $A
+  ;; CHECK-NEXT:    (local.tee $a
+  ;; CHECK-NEXT:     (local.get $a)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-non-null (param $a (ref $A)) (param $b (ref $B))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $A
+  ;; NOMNL-NEXT:    (local.get $a)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $A
+  ;; NOMNL-NEXT:    (local.get $b)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B
+  ;; NOMNL-NEXT:    (local.get $a)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $A
+  ;; NOMNL-NEXT:    (local.tee $a
+  ;; NOMNL-NEXT:     (local.get $a)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-non-null (param $a (ref $A)) (param $b (ref $B))
+    ;; Casting nulls results in a null.
+    (drop
+      (ref.cast_static $A
+        (local.get $a)
+      )
+    )
+    (drop
+      (ref.cast_static $A
+        (local.get $b)
+      )
+    )
+    (drop
+      (ref.cast_static $B
+        (local.get $a)
+      )
+    )
+    ;; A fallthrough works too.
+    (drop
+      (ref.cast_static $A
+        (local.tee $a
+          (local.get $a)
+        )
+      )
+    )
+  )
 )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2296,11 +2296,14 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
   (func $ref-test-static-same-type (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+    ;; A nullable value cannot be optimized here even though it is the same
+    ;; type.
     (drop
       (ref.test_static $A
         (local.get $nullable)
       )
     )
+    ;; But if it is non-nullable, it must succeed.
     (drop
       (ref.test_static $A
         (local.get $non-nullable)
@@ -2339,6 +2342,7 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
   (func $ref-test-static-subtype (param $nullable (ref null $B)) (param $non-nullable (ref $B))
+    ;; As above, but the input is a subtype, so the same things happen.
     (drop
       (ref.test_static $A
         (local.get $nullable)
@@ -2376,6 +2380,8 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
   (func $ref-test-static-supertype (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+    ;; As above, but the input is a supertype. We can't know at compile time
+    ;; what to do here.
     (drop
       (ref.test_static $B
         (local.get $nullable)
@@ -2425,6 +2431,7 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
   (func $ref-test-static-impossible (param $nullable (ref null $array)) (param $non-nullable (ref $array))
+    ;; Testing an impossible cast will definitely fail.
     (drop
       (ref.test_static $struct
         (local.get $nullable)

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -26,6 +26,10 @@
   ;; NOMNL:      (type $B (struct (field i32) (field i32) (field f32)) (extends $A))
   (type $B (struct (field i32) (field i32) (field f32)) (extends $A))
 
+  ;; CHECK:      (type $B-child (struct (field i32) (field i32) (field f32) (field i64)))
+  ;; NOMNL:      (type $B-child (struct (field i32) (field i32) (field f32) (field i64)) (extends $B))
+  (type $B-child (struct (field i32) (field i32) (field f32) (field i64)) (extends $B))
+
   (type $A (struct (field i32)))
 
   ;; CHECK:      (type $empty (struct ))
@@ -2208,6 +2212,129 @@
       (ref.cast_static $B
         (ref.cast_static $A
           (local.get $x)
+        )
+      )
+    )
+  )
+
+  ;; CHECK:      (func $ref-cast-static-many (param $x eqref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast_static $B-child
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-many (param $x eqref)
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.cast_static $B-child
+  ;; NOMNL-NEXT:    (local.get $x)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-many (param $x eqref)
+    ;; We should optimize a long sequence of static casts when we can. All six
+    ;; orderings of these casts should collapse into the strictest one.
+    (drop
+      (ref.cast_static $A
+        (ref.cast_static $B
+          (ref.cast_static $B-child
+            (local.get $x)
+          )
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $A
+        (ref.cast_static $B-child
+          (ref.cast_static $B
+            (local.get $x)
+          )
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $B
+        (ref.cast_static $A
+          (ref.cast_static $B-child
+            (local.get $x)
+          )
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $B
+        (ref.cast_static $B-child
+          (ref.cast_static $A
+            (local.get $x)
+          )
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $B-child
+        (ref.cast_static $A
+          (ref.cast_static $B
+            (local.get $x)
+          )
+        )
+      )
+    )
+    (drop
+      (ref.cast_static $B-child
+        (ref.cast_static $B
+          (ref.cast_static $A
+            (local.get $x)
+          )
         )
       )
     )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -14,7 +14,11 @@
     (field $i64 (mut i64))
   ))
 
+  ;; CHECK:      (type $A (struct (field i32)))
+
   ;; CHECK:      (type $array (array (mut i8)))
+  ;; NOMNL:      (type $A (struct (field i32)))
+
   ;; NOMNL:      (type $array (array (mut i8)))
   (type $array (array (mut i8)))
 
@@ -22,8 +26,6 @@
   ;; NOMNL:      (type $B (struct (field i32) (field i32) (field f32)) (extends $A))
   (type $B (struct (field i32) (field i32) (field f32)) (extends $A))
 
-  ;; CHECK:      (type $A (struct (field i32)))
-  ;; NOMNL:      (type $A (struct (field i32)))
   (type $A (struct (field i32)))
 
   ;; CHECK:      (type $empty (struct ))
@@ -1953,5 +1955,107 @@
        (rtt.canon $struct)
      )
    )
+  )
+
+  ;; CHECK:      (func $ref-cast-static-null
+  ;; CHECK-NEXT:  (local $a (ref null $A))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result (ref null $A))
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.null $A)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result (ref null $A))
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.null $B)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result (ref null $B))
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.null $A)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null $B)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result (ref null $A))
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $a
+  ;; CHECK-NEXT:      (ref.null $A)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-static-null
+  ;; NOMNL-NEXT:  (local $a (ref null $A))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result (ref null $A))
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (ref.null $A)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (ref.null $A)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result (ref null $A))
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (ref.null $B)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (ref.null $A)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result (ref null $B))
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (ref.null $A)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (ref.null $B)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result (ref null $A))
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.tee $a
+  ;; NOMNL-NEXT:      (ref.null $A)
+  ;; NOMNL-NEXT:     )
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (ref.null $A)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-cast-static-null
+    (local $a (ref null $A))
+    ;; Casting nulls results in a null.
+    (drop
+      (ref.cast_static $A
+        (ref.null $A)
+      )
+    )
+    (drop
+      (ref.cast_static $A
+        (ref.null $B)
+      )
+    )
+    (drop
+      (ref.cast_static $B
+        (ref.null $A)
+      )
+    )
+    ;; A fallthrough works too.
+    (drop
+      (ref.cast_static $A
+        (local.tee $a
+          (ref.null $A)
+        )
+      )
+    )
   )
 )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2264,4 +2264,176 @@
       )
     )
   )
+
+  ;; CHECK:      (func $ref-test-static-same-type (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.test_static $A
+  ;; CHECK-NEXT:    (local.get $nullable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $non-nullable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-test-static-same-type (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.test_static $A
+  ;; NOMNL-NEXT:    (local.get $nullable)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result i32)
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.get $non-nullable)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (i32.const 1)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-test-static-same-type (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+    (drop
+      (ref.test_static $A
+        (local.get $nullable)
+      )
+    )
+    (drop
+      (ref.test_static $A
+        (local.get $non-nullable)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $ref-test-static-subtype (param $nullable (ref null $B)) (param $non-nullable (ref $B))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.test_static $A
+  ;; CHECK-NEXT:    (local.get $nullable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $non-nullable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-test-static-subtype (param $nullable (ref null $B)) (param $non-nullable (ref $B))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.test_static $A
+  ;; NOMNL-NEXT:    (local.get $nullable)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result i32)
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.get $non-nullable)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (i32.const 1)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-test-static-subtype (param $nullable (ref null $B)) (param $non-nullable (ref $B))
+    (drop
+      (ref.test_static $A
+        (local.get $nullable)
+      )
+    )
+    (drop
+      (ref.test_static $A
+        (local.get $non-nullable)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $ref-test-static-supertype (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.test_static $B
+  ;; CHECK-NEXT:    (local.get $nullable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.test_static $B
+  ;; CHECK-NEXT:    (local.get $non-nullable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-test-static-supertype (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.test_static $B
+  ;; NOMNL-NEXT:    (local.get $nullable)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.test_static $B
+  ;; NOMNL-NEXT:    (local.get $non-nullable)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-test-static-supertype (param $nullable (ref null $A)) (param $non-nullable (ref $A))
+    (drop
+      (ref.test_static $B
+        (local.get $nullable)
+      )
+    )
+    (drop
+      (ref.test_static $B
+        (local.get $non-nullable)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $ref-test-static-impossible (param $nullable (ref null $array)) (param $non-nullable (ref $array))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $nullable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $non-nullable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-test-static-impossible (param $nullable (ref null $array)) (param $non-nullable (ref $array))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result i32)
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.get $nullable)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (i32.const 0)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (block (result i32)
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.get $non-nullable)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (i32.const 0)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
+  (func $ref-test-static-impossible (param $nullable (ref null $array)) (param $non-nullable (ref $array))
+    (drop
+      (ref.test_static $struct
+        (local.get $nullable)
+      )
+    )
+    (drop
+      (ref.test_static $struct
+        (local.get $non-nullable)
+      )
+    )
+  )
 )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2061,7 +2061,7 @@
 
   ;; CHECK:      (func $ref-cast-static-impossible (param $func (ref func))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result dataref)
+  ;; CHECK-NEXT:   (block (result (ref $struct))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $func)
   ;; CHECK-NEXT:    )
@@ -2071,7 +2071,7 @@
   ;; CHECK-NEXT: )
   ;; NOMNL:      (func $ref-cast-static-impossible (param $func (ref func))
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (block (result dataref)
+  ;; NOMNL-NEXT:   (block (result (ref $struct))
   ;; NOMNL-NEXT:    (drop
   ;; NOMNL-NEXT:     (local.get $func)
   ;; NOMNL-NEXT:    )
@@ -2080,9 +2080,9 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
   (func $ref-cast-static-impossible (param $func (ref func))
-    ;; A func cannot be cast to data, so this will trap.
+    ;; A func cannot be cast to a struct, so this will trap.
     (drop
-      (ref.cast_static data
+      (ref.cast_static $struct
         (local.get $func)
       )
     )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2059,22 +2059,28 @@
     )
   )
 
-  ;; CHECK:      (func $ref-cast-static-impossible (param $func funcref)
+  ;; CHECK:      (func $ref-cast-static-impossible (param $func (ref func))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_static data
-  ;; CHECK-NEXT:    (local.get $func)
+  ;; CHECK-NEXT:   (block (result dataref)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $func)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $ref-cast-static-impossible (param $func funcref)
+  ;; NOMNL:      (func $ref-cast-static-impossible (param $func (ref func))
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast_static data
-  ;; NOMNL-NEXT:    (local.get $func)
+  ;; NOMNL-NEXT:   (block (result dataref)
+  ;; NOMNL-NEXT:    (drop
+  ;; NOMNL-NEXT:     (local.get $func)
+  ;; NOMNL-NEXT:    )
+  ;; NOMNL-NEXT:    (unreachable)
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
-  (func $ref-cast-static-impossible (param $func funcref)
-    ;; A funcref cannot be cast to data, so this will trap.
+  (func $ref-cast-static-impossible (param $func (ref func))
+    ;; A func cannot be cast to data, so this will trap.
     (drop
       (ref.cast_static data
         (local.get $func)

--- a/test/passes/Oz_fuzz-exec_all-features.txt
+++ b/test/passes/Oz_fuzz-exec_all-features.txt
@@ -533,17 +533,10 @@
    (i32.const 0)
   )
   (call $log
-   (ref.test_static $struct
-    (array.new $bytes
-     (i32.const 20)
-     (i32.const 10)
-    )
-   )
+   (i32.const 0)
   )
   (call $log
-   (ref.test_static $struct
-    (struct.new_default $struct)
-   )
+   (i32.const 1)
   )
   (call $log
    (ref.test_static $extendedstruct
@@ -551,9 +544,7 @@
    )
   )
   (call $log
-   (ref.test_static $struct
-    (struct.new_default $extendedstruct)
-   )
+   (i32.const 1)
   )
  )
  (func $29 (; has Stack IR ;)


### PR DESCRIPTION
Now that they are all implemented, we can optimize them. This removes the
big `if` that ignored static operations, and implements things for them.

In general this matches the existing rtt-using case, but there are a few things
we can do better, which this does:

* A cast of a subtype to a type always succeeds.
* A test of a subtype to a type is always 1 (if non-nullable).
* Repeated static casts can leave just the most demanding of them.

(diff without whitespace is smaller)