### PR TITLE
[wasm-split] Disallow mixing --profile, --keep-funcs, and --split-funcs

### DIFF
--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -35,21 +35,18 @@
 ;; CHECK-NEXT:                                        splitting.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --keep-funcs                         [split] Comma-separated list of functions
-;; CHECK-NEXT:                                        to keep in the primary module, regardless
-;; CHECK-NEXT:                                        of any profile. You can also pass a file
-;; CHECK-NEXT:                                        with a list of functions separated by new
-;; CHECK-NEXT:                                        lines. To do this, prepend @ before
-;; CHECK-NEXT:                                        filename (--keep-funcs @myfile)
+;; CHECK-NEXT:                                        to keep in the primary module. The rest
+;; CHECK-NEXT:                                        will be split out. Cannot be used with
+;; CHECK-NEXT:                                        --profile or --split-funcs. You can also
+;; CHECK-NEXT:                                        pass a file with one function per line by
+;; CHECK-NEXT:                                        passing @filename.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --split-funcs                        [split] Comma-separated list of functions
-;; CHECK-NEXT:                                        to split into the secondary module,
-;; CHECK-NEXT:                                        regardless of any profile. If there is no
-;; CHECK-NEXT:                                        profile, then this defaults to all
-;; CHECK-NEXT:                                        functions defined in the module. You can
-;; CHECK-NEXT:                                        also pass a file with a list of functions
-;; CHECK-NEXT:                                        separated by new lines. To do this,
-;; CHECK-NEXT:                                        prepend @ before filename (--split-funcs
-;; CHECK-NEXT:                                        @myfile)
+;; CHECK-NEXT:                                        to split out to the secondary module. The
+;; CHECK-NEXT:                                        rest will be kept. Cannot be used with
+;; CHECK-NEXT:                                        --profile or --keep-funcs. You can also
+;; CHECK-NEXT:                                        pass a file with one function per line by
+;; CHECK-NEXT:                                        passing @filename.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --primary-output,-o1                 [split] Output file for the primary
 ;; CHECK-NEXT:                                        module.

--- a/test/lit/wasm-split/basic.wast
+++ b/test/lit/wasm-split/basic.wast
@@ -41,6 +41,12 @@
 ;; RUN: wasm-dis %t.both.1.wasm | filecheck %s --check-prefix KEEP-BOTH-PRIMARY
 ;; RUN: wasm-dis %t.both.2.wasm | filecheck %s --check-prefix KEEP-BOTH-SECONDARY
 
+;; Also check the inverse workflow using --keep-all and --split-funcs
+;; RUN: wasm-split %s --export-prefix='%' -g -o1 %t.split-bar.1.wasm -o2 %t.split-bar.2.wasm --split-funcs=bar -v 2>&1 \
+;; RUN:     | filecheck %s --check-prefix KEEP-FOO
+;; RUN: wasm-dis %t.split-bar.1.wasm | filecheck %s --check-prefix KEEP-FOO-PRIMARY
+;; RUN: wasm-dis %t.split-bar.2.wasm | filecheck %s --check-prefix KEEP-FOO-SECONDARY
+
 (module
  (table $table 1 1 funcref)
  (elem (i32.const 0) $foo)

--- a/test/lit/wasm-split/invalid-options.wast
+++ b/test/lit/wasm-split/invalid-options.wast
@@ -53,6 +53,18 @@
 ;; RUN: not wasm-split %s --merge-profiles -g 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix MERGE-DEBUGINFO
 
+;; --profile cannot be used with --keep-funcs
+;; RUN: not wasm-split %s --profile=foo --keep-funcs=foo 2>&1 \
+;; RUN:   | filecheck %s --check-prefix PROFILE-KEEP
+
+;; --profile cannot be used with --split-funcs
+;; RUN: not wasm-split %s --profile=foo --split-funcs=foo 2>&1 \
+;; RUN:   | filecheck %s --check-prefix PROFILE-SPLIT
+
+;; --keep-funcs cannot be used with --split-funcs
+;; RUN: not wasm-split %s  --keep-funcs=foo --split-funcs=foo 2>&1 \
+;; RUN:   | filecheck %s --check-prefix KEEP-SPLIT
+
 ;; INSTRUMENT-PROFILE: error: Option --profile cannot be used in instrument mode.
 
 ;; INSTRUMENT-OUT1: error: Option --primary-output cannot be used in instrument mode.
@@ -78,5 +90,11 @@
 ;; MERGE-EMIT-TEXT: error: Option --emit-text cannot be used in merge-profiles mode.
 
 ;; MERGE-DEBUGINFO: error: Option --debuginfo cannot be used in merge-profiles mode.
+
+;; PROFILE-KEEP: error: Cannot use both --profile and --keep-funcs.
+
+;; PROFILE-SPLIT: error: Cannot use both --profile and --split-funcs.
+
+;; KEEP-SPLIT: error: Cannot use both --keep-funcs and --split-funcs.
 
 (module)

--- a/test/lit/wasm-split/verbose.wast
+++ b/test/lit/wasm-split/verbose.wast
@@ -1,6 +1,6 @@
 ;; Test that --verbose mode correctly prints the kept and split funcs
 
-;; RUN: wasm-split %s --keep-funcs=foo,bar --split-funcs=baz --verbose \
+;; RUN: wasm-split %s --keep-funcs=foo,bar --verbose \
 ;; RUN:   -o1 %t1.wasm -o2 %t2.wasm | filecheck %s
 
 ;; CHECK: Keeping functions: bar, foo{{$}}


### PR DESCRIPTION
Previously the set of functions to keep was initially empty, then the profile
added new functions to keep, then the --keep-funcs functions were added, then
the --split-funcs functions were removed. This method of composing these
different options was arbitrary and not necessarily intuitive, and it prevented
reasonable workflows from working. For example, providing only a --split-funcs
list would result in all functions being split out not matter which functions
were listed.

To make the behavior of these options, and --split-funcs in particular, more
intuitive, disallow mixing them and when --split-funcs is used, split out only
the listed functions.