### PR TITLE
[OptimizeInstructions] Early return for functions with single childless body

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -208,6 +208,13 @@ struct OptimizeInstructions
   bool fastMath;
 
   void doWalkFunction(Function* func) {
+    // Early skip single childless expressions in function's body like:
+    // (nop), (i32.const 3), (local.get $0), (global.get $g0)
+    if (func->body->is<Nop>() || func->body->is<Const>() ||
+        func->body->is<LocalGet>() || func->body->is<GlobalGet>()) {
+      return;
+    }
+
     fastMath = getPassOptions().fastMath;
 
     // First, scan locals.

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -209,9 +209,10 @@ struct OptimizeInstructions
 
   void doWalkFunction(Function* func) {
     // Early skip single childless expressions in function's body like:
-    // (nop), (i32.const 3), (local.get $0), (global.get $g0)
+    // (nop), (unreachable), (i32.const 3), (local.get $0), (global.get $g0)
     if (func->body->is<Nop>() || func->body->is<Const>() ||
-        func->body->is<LocalGet>() || func->body->is<GlobalGet>()) {
+        func->body->is<Unreachable>() || func->body->is<LocalGet>() ||
+        func->body->is<GlobalGet>()) {
       return;
     }
 


### PR DESCRIPTION
It skips of optimize processing for some most frequent simple expressions like:
```wat
(func $0 (param $0) ... (nop))
(func $1 (param $0) ... (unreachable))
(func $2 (param $0) ... (return i32) (local.get $0))
(func $3 (param $0) ... (return i32) (i32.const 0))
```
Only in lit tests it may skip up to 8 functions and 2 in average per test. For real world examples it could be even more meaningful.