### PR TITLE
Exclude test/ from clang-tidy

### DIFF
--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -24,15 +24,16 @@ function realpath() {
 
 CLANG_DIR=$(dirname $(dirname $(realpath $CLANG_TIDY)))
 CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
+ARG="-quiet -p1 -regex=src/.*"
 if [ ! -e "$CLANG_TIDY_DIFF" ]; then
   echo "Failed to find clang-tidy-diff.py ($CLANG_TIDY_DIFF)"
   exit 1
 fi
-TIDY_MSG=$(git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null)
+TIDY_MSG=$(git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF $ARG 2> /dev/null)
 if [ -n "$TIDY_MSG" -a "$TIDY_MSG" != "No relevant changes found." ]; then
   echo "Please fix clang-tidy errors before committing"
   echo
   # Run clang-tidy once again to show the error
-  git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF -quiet -p1 2> /dev/null
+  git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF $ARG 2> /dev/null
   exit 1
 fi


### PR DESCRIPTION
We don't keep files within test/ clang-tidy compliant, so including this
directory can generate CI errors when test files change.