### PR TITLE
OptimizeInstructions: Optimize i64(x) != 0 to !!x

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -826,6 +826,14 @@ struct OptimizeInstructions
       }
       {
         // eqz(eqz(x - y))  =>  x != y
+        //
+        // Note that this rule is not strictly needed, since inner eqz here fits
+        // the above pattern, and then we get the outer eqz on x == y which can
+        // then turn into x != y. However, the rule "i64(x) != 0  ==>  !!x"
+        // introduces two eqzs, and as we run in postorder (to keep the pass in
+        // linear time) we do not process the inner one again. We could leave
+        // optimizing that for another run of the pass, in theory, but instead
+        // we just handle it here to avoid regressions.
         Binary* inner;
         if (matches(curr, unary(EqZ, unary(EqZ, binary(&inner, Sub, any(), any()))))) {
           inner->op = Abstract::getBinary(inner->left->type, Ne);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -835,7 +835,9 @@ struct OptimizeInstructions
         // optimizing that for another run of the pass, in theory, but instead
         // we just handle it here to avoid regressions.
         Binary* inner;
-        if (matches(curr, unary(EqZ, unary(EqZ, binary(&inner, Sub, any(), any()))))) {
+        if (matches(
+              curr,
+              unary(EqZ, unary(EqZ, binary(&inner, Sub, any(), any()))))) {
           inner->op = Abstract::getBinary(inner->left->type, Ne);
           inner->type = Type::i32;
           return replaceCurrent(inner);

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -515,6 +515,51 @@
       (i64.const 0)
     )
   )
+  ;; CHECK:      (func $neq-zero-i64 (param $x i64) (result i32)
+  ;; CHECK-NEXT:  (i32.eqz
+  ;; CHECK-NEXT:   (i64.eqz
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $neq-zero-i64 (param $x i64) (result i32)
+    (i64.ne
+      (local.get $x)
+      (i64.const 0)
+    )
+  )
+  ;; CHECK:      (func $neq-neq-sub-i32 (param $x i32) (param $y i32) (result i32)
+  ;; CHECK-NEXT:  (i32.ne
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (local.get $y)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $neq-neq-sub-i32 (param $x i32) (param $y i32) (result i32)
+    (i32.eqz
+      (i32.eqz
+        (i32.sub
+          (local.get $x)
+          (local.get $y)
+        )
+      )
+    )
+  )
+  ;; CHECK:      (func $neq-neq-sub-i64 (param $x i64) (param $y i64) (result i32)
+  ;; CHECK-NEXT:  (i64.ne
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (local.get $y)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $neq-neq-sub-i64 (param $x i64) (param $y i64) (result i32)
+    (i32.eqz
+      (i64.eqz
+        (i64.sub
+          (local.get $x)
+          (local.get $y)
+        )
+      )
+    )
+  )
   ;; CHECK:      (func $if-eqz-eqz
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (i32.const 123)
@@ -7212,12 +7257,13 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.ne
-  ;; CHECK-NEXT:    (i64.and
-  ;; CHECK-NEXT:     (local.get $y)
-  ;; CHECK-NEXT:     (i64.const 9223372036854775807)
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (i64.eqz
+  ;; CHECK-NEXT:     (i64.and
+  ;; CHECK-NEXT:      (local.get $y)
+  ;; CHECK-NEXT:      (i64.const 9223372036854775807)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -9018,9 +9064,10 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.ne
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (i64.eqz
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -9873,9 +9920,10 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.ne
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (i64.eqz
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop


### PR DESCRIPTION
That saves one byte, since a const of 0 takes two bytes.

Also add a rule for `!!(x - y)`, see details in the comment. This is debatable,
feedback welcome.

Helps #4181