### PR TITLE
Fix clang-tidy regex

### DIFF
--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -24,7 +24,7 @@ function realpath() {
 
 CLANG_DIR=$(dirname $(dirname $(realpath $CLANG_TIDY)))
 CLANG_TIDY_DIFF=$CLANG_DIR/share/clang/clang-tidy-diff.py
-ARG="-quiet -p1 -regex=src/.*"
+ARG="-quiet -p1 -iregex=src/.*\.(cpp|cc|c\+\+|cxx|c|cl|h|hpp|m|mm|inc)"
 if [ ! -e "$CLANG_TIDY_DIFF" ]; then
   echo "Failed to find clang-tidy-diff.py ($CLANG_TIDY_DIFF)"
   exit 1


### PR DESCRIPTION
While making clang-tidy CI only check for src/, #4193 accidentally
overrided the existing default regex that checks only c/cpp/h... files:
https://github.com/llvm/llvm-project/blob/8971b99c8387f3daf2e802956f2688b3b77335a4/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py#L131-L132

This fixes the problem by appending all those extensions after `src/`.