### PR TITLE
Detect erroneous use of "FileCheck" in update script

### DIFF
--- a/scripts/update_lit_checks.py
+++ b/scripts/update_lit_checks.py
@@ -146,7 +146,7 @@ def get_command_output(args, test, lines, tmp):
         if len(commands) > 1 and commands[1].startswith('filecheck '):
             filecheck_cmd = commands[1]
             commands = commands[:1]
-        if len(commands) > 1 and commands[1].startswith('FileCheck '):
+        elif len(commands) > 1 and commands[1].startswith('FileCheck '):
             warn('`FileCheck` is not a known command. '
                  'Did you mean to use `filecheck` instead?')
 

--- a/scripts/update_lit_checks.py
+++ b/scripts/update_lit_checks.py
@@ -44,7 +44,7 @@ ITEM_RE = re.compile(r'(^\s*)\((' + '|'.join(items) + r')\s+(\$?[^\s()]*).*$',
 
 
 def warn(msg):
-    print(f'WARNING: {msg}', file=sys.stderr)
+    print(f'warning: {msg}', file=sys.stderr)
 
 
 def itertests(args):
@@ -146,6 +146,9 @@ def get_command_output(args, test, lines, tmp):
         if len(commands) > 1 and commands[1].startswith('filecheck '):
             filecheck_cmd = commands[1]
             commands = commands[:1]
+        if len(commands) > 1 and commands[1].startswith('FileCheck '):
+            warn('`FileCheck` is not a known command. '
+                 'Did you mean to use `filecheck` instead?')
 
         prefix = ''
         if filecheck_cmd.startswith('filecheck '):

--- a/scripts/update_lit_checks.py
+++ b/scripts/update_lit_checks.py
@@ -142,13 +142,13 @@ def get_command_output(args, test, lines, tmp):
     command_output = []
     for line in find_run_lines(test, lines):
         commands = [cmd.strip() for cmd in line.rsplit('|', 1)]
+        if (len(commands) > 2 or
+           (len(commands) == 2 and not commands[1].startswith('filecheck '))):
+            warn('pipes only supported for one command piped to `filecheck`')
         filecheck_cmd = ''
         if len(commands) > 1 and commands[1].startswith('filecheck '):
             filecheck_cmd = commands[1]
             commands = commands[:1]
-        elif len(commands) > 1 and commands[1].startswith('FileCheck '):
-            warn('`FileCheck` is not a known command. '
-                 'Did you mean to use `filecheck` instead?')
 
         prefix = ''
         if filecheck_cmd.startswith('filecheck '):


### PR DESCRIPTION
The upstream name of the command in LLVM is FileCheck, but we use a Python
package called filecheck instead and using `FileCheck` in lit tests will not
work. To make catching this common error easier, add a warning about it in
scripts/update_lit_checks.py.