### PR TITLE
Fix Emscripten build by changing `|` to `||`

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -299,7 +299,7 @@ void CoalesceLocals::pickIndicesFromOrder(std::vector<Index>& order,
       // go in the order, we only need to update for those we will see later
       auto j = order[k];
       newInterferences[found * numLocals + j] =
-        newInterferences[found * numLocals + j] | interferes(actual, j);
+        newInterferences[found * numLocals + j] || interferes(actual, j);
       newCopies[found * numLocals + j] += getCopies(actual, j);
     }
   }


### PR DESCRIPTION
Emscripten must have rolled in a new warning about using `|` on booleans.