### PR TITLE
Optimize call_ref+table.get => call_indirect

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1190,6 +1190,16 @@ struct OptimizeInstructions
       return;
     }
 
+    if (auto* get = curr->target->dynCast<TableGet>()) {
+      // (call_ref ..args.. (table.get $table (index))
+      //   =>
+      // (call_indirect $table ..args.. (index))
+      replaceCurrent(
+        Builder(*getModule())
+          .makeCallIndirect(get->table, get->index, curr->operands, get->type.getHeapType().getSignature(), curr->isReturn));
+      return;
+    }
+
     auto features = getModule()->features;
 
     // It is possible the target is not a function reference, but we can infer

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1194,9 +1194,12 @@ struct OptimizeInstructions
       // (call_ref ..args.. (table.get $table (index))
       //   =>
       // (call_indirect $table ..args.. (index))
-      replaceCurrent(
-        Builder(*getModule())
-          .makeCallIndirect(get->table, get->index, curr->operands, get->type.getHeapType().getSignature(), curr->isReturn));
+      replaceCurrent(Builder(*getModule())
+                       .makeCallIndirect(get->table,
+                                         get->index,
+                                         curr->operands,
+                                         get->type.getHeapType().getSignature(),
+                                         curr->isReturn));
       return;
     }
 

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -5,21 +5,27 @@
 ;; remove-unused-names is to allow fallthrough computations to work on blocks
 
 (module
- ;; CHECK:      (type $none_=>_i32 (func (result i32)))
- (type $none_=>_i32 (func (result i32)))
-
  ;; CHECK:      (type $i32_i32_=>_none (func (param i32 i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
+
+ ;; CHECK:      (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_i32 (func (result i32)))
 
  ;; CHECK:      (type $none_=>_none (func))
  (type $none_=>_none (func))
 
+ ;; CHECK:      (type $i32_=>_none (func (param i32)))
+
  ;; CHECK:      (type $data_=>_none (func (param dataref)))
  (type $data_=>_none (func (param (ref data))))
 
- ;; CHECK:      (type $i32_=>_none (func (param i32)))
+ ;; CHECK:      (table $table-1 10 (ref null $i32_i32_=>_none))
+ (table $table-1 10 (ref null $i32_i32_=>_none))
+ ;; CHECK:      (elem $elem-1 (table $table-1) (i32.const 0) (ref null $i32_i32_=>_none) (ref.func $foo))
+ (elem $elem-1 (table $table-1) (i32.const 0) (ref null $i32_i32_=>_none)
+  (ref.func $foo))
 
- ;; CHECK:      (elem declare func $fallthrough-no-params $fallthrough-non-nullable $foo $return-nothing)
+ ;; CHECK:      (elem declare func $fallthrough-no-params $fallthrough-non-nullable $return-nothing)
 
  ;; CHECK:      (func $foo (param $0 i32) (param $1 i32)
  ;; CHECK-NEXT:  (unreachable)
@@ -204,6 +210,23 @@
   ;; Ignore an unreachable call_ref target entirely.
   (call_ref
    (unreachable)
+  )
+ )
+
+ ;; CHECK:      (func $call-table-get (param $x i32)
+ ;; CHECK-NEXT:  (call_indirect $table-1 (type $i32_i32_=>_none)
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:   (i32.const 2)
+ ;; CHECK-NEXT:   (local.get $x)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $call-table-get (param $x i32)
+  (call_ref
+   (i32.const 1)
+   (i32.const 2)
+   (table.get $table-1
+    (local.get $x)
+   )
   )
  )
 )


### PR DESCRIPTION
Rather than load from the table and call that reference, call using the table.

Am I missing some corner case that prevents doing this? (Would be sad if so, as I
hope to build on this to do more devirtualization.)