### PR TITLE
Fix RefNull in wasm-delegations-fields.def

### DIFF
--- a/src/wasm-delegations-fields.def
+++ b/src/wasm-delegations-fields.def
@@ -478,7 +478,6 @@ switch (DELEGATE_ID) {
   }
   case Expression::Id::RefNullId: {
     DELEGATE_START(RefNull);
-    DELEGATE_FIELD_TYPE(RefNull, type);
     DELEGATE_END(RefNull);
     break;
   }


### PR DESCRIPTION
The `type` field is present in all Expressions, but RefNull's delegations
marked it as if it were a new field. That meant that we process it twice.
This was just some extra work mostly, but a new pass I will open later
will actually error on such things.