### PR TITLE
[Costs] More precise costs for int div & rem

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -274,7 +274,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
       case DivUInt64:
       case RemSInt64:
       case RemUInt64:
-        ret = curr->right->is<Const>() ? 2 : 4;
+        ret = curr->right->is<Const>() ? 3 : 4;
         break;
       case AndInt64:
       case OrInt64:


### PR DESCRIPTION
If left expression is constant VM usually uses pretty cheap mul + shift by magic constant. So has approx same cost as multiply. 64-bit div/rem usually more costly than 32-bit ones so this cost was increased.