### PR TITLE
Fix function name `BinaryenTableSizeSetTable`

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1962,7 +1962,7 @@ const char* BinaryenTableSizeGetTable(BinaryenExpressionRef expr) {
   assert(expression->is<TableSize>());
   return static_cast<TableSize*>(expression)->table.c_str();
 }
-void BinaryenTableSetSizeTable(BinaryenExpressionRef expr, const char* table) {
+void BinaryenTableSizeSetTable(BinaryenExpressionRef expr, const char* table) {
   auto* expression = (Expression*)expr;
   assert(expression->is<TableSize>());
   assert(table);

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -1026,7 +1026,11 @@ void test_core() {
 
   BinaryenExpressionPrint(funcrefExpr2);
 
-  BinaryenExpressionPrint(BinaryenTableSize(module, "0"));
+  BinaryenExpressionRef tablesize = BinaryenTableSize(module, "0");
+  BinaryenExpressionPrint(tablesize);
+
+  const char* table = BinaryenTableSizeGetTable(tablesize);
+  BinaryenTableSizeSetTable(tablesize, table);
 
   // Memory. One per module
 


### PR DESCRIPTION
`BinaryenTableSizeSetTable` was being declared in the header correctly, but defined
as `BinaryenTableSetSizeTable`.