### PR TITLE
Remove forgotten call_ref logic in Directize. NFC

### DIFF
--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -226,12 +226,10 @@ struct Directize : public Pass {
       }
     }
 
-    // Without typed function references, all we can do is optimize table
-    // accesses, so if we can't do that, stop.
-    if (validTables.empty() && !module->features.hasTypedFunctionReferences()) {
+    if (validTables.empty()) {
       return;
     }
-    // The table exists and is constant, so this is possible.
+
     FunctionDirectizer(validTables).run(runner, module);
   }
 };


### PR DESCRIPTION
We moved `call_ref` out of there, but it was still checking for the possible
presence of `call_refs` (using the feature), which means that even if we had
no valid tables to optimize on, we'd scan the whole module.