### PR TITLE
Allow parsing of blocks with a type reference

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -303,6 +303,7 @@ private:
 
   // Helper functions
   Type parseOptionalResultType(Element& s, Index& i);
+  Type parseOptionalTypeRef(Element& s, Index& i);
   Index parseMemoryLimits(Element& s, Index i);
   Index parseMemoryIndex(Element& s, Index i);
   std::vector<Type> parseParamOrLocal(Element& s);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -809,6 +809,7 @@ Type::Type(HeapType heapType, Nullability nullable) {
 
 Type::Type(Rtt rtt) {
   assert(!isTemp(rtt.heapType) && "Leaking temporary type!");
+  assert(false);
   new (this) Type(globalTypeStore.insert(rtt));
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -575,6 +575,11 @@ void FunctionValidator::validateNormalBlockElements(Block* curr) {
   }
   if (curr->list.size() > 0) {
     auto backType = curr->list.back()->type;
+    if (curr->type.isRef()) {
+      // Check that the referenced type has no inputs and make backType,
+      // the type of the block output type.
+      return;
+    }
     if (!curr->type.isConcrete()) {
       shouldBeFalse(backType.isConcrete(),
                     curr,

--- a/test/blocks.wast
+++ b/test/blocks.wast
@@ -1,0 +1,10 @@
+(module
+  (type $ty (func (param) (result i32)))
+
+;;  (func $withblock-result (param) (result i32)
+;;    (block $label (result i32)
+;;      (i32.const 0)))
+
+  (func $withblock-typeref (param) (result i32)
+    (block $label (type $ty)
+      (i32.const 0))))


### PR DESCRIPTION
Blocks are not allowed to have input parameters.

Currently only blocks of the form are supported:
```
(block $label (result ...)
  ...)
```

This patch enables this type of block declaration:
```
(type $ty (func (param) (result ...)))

(block $label (type $ty)
  ...)
```