### PR TITLE
[wasm-metadce] Don't add null names to roots

### DIFF
--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -209,9 +209,7 @@ struct MetaDCEGraph {
           // it's an import.
           dceName = parent->importIdToDCENode[parent->getGlobalImportId(name)];
         }
-        if (parentDceName.isNull()) {
-          parent->roots.insert(parentDceName);
-        } else {
+        if (!parentDceName.isNull()) {
           parent->nodes[parentDceName].reaches.push_back(dceName);
         }
       }
@@ -368,7 +366,7 @@ public:
   void dump() {
     std::cout << "=== graph ===\n";
     for (auto root : roots) {
-      std::cout << "root: " << root.str << '\n';
+      std::cout << "root: " << root << '\n';
     }
     std::map<Name, ImportId> importMap;
     for (auto& pair : importIdToDCENode) {
@@ -379,12 +377,12 @@ public:
     for (auto& pair : nodes) {
       auto name = pair.first;
       auto& node = pair.second;
-      std::cout << "node: " << name.str << '\n';
+      std::cout << "node: " << name << '\n';
       if (importMap.find(name) != importMap.end()) {
         std::cout << "  is import " << importMap[name] << '\n';
       }
       if (DCENodeToExport.find(name) != DCENodeToExport.end()) {
-        std::cout << "  is export " << DCENodeToExport[name].str << ", "
+        std::cout << "  is export " << DCENodeToExport[name] << ", "
                   << wasm.getExport(DCENodeToExport[name])->value << '\n';
       }
       if (DCENodeToFunction.find(name) != DCENodeToFunction.end()) {
@@ -397,7 +395,7 @@ public:
         std::cout << "  is tag " << DCENodeToTag[name] << '\n';
       }
       for (auto target : node.reaches) {
-        std::cout << "  reaches: " << target.str << '\n';
+        std::cout << "  reaches: " << target << '\n';
       }
     }
     std::cout << "=============\n";


### PR DESCRIPTION
Not sure why the current code tries to add the name even when it is
null, but it causes `dump()` to behave strangely and pollute stdout when
it tries to [print `root.str`](https://github.com/WebAssembly/binaryen/blob/805534eee318012ce0c26d323335e5a9cb132267/src/tools/wasm-metadce.cpp#L371).

Also this changes code printing `Name.str` to printing just `Name`; when
`Name.str` is null, it prints `(null Name)` instead of polluting stdout,
and it is the recommended way of printing `Name` anyway.