### PR TITLE
[NFC] Refactor type canonicalization

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2807,6 +2807,9 @@ ShapeCanonicalizer::translatePartitionsToTypes(std::vector<HeapType>& roots) {
   // globally canonical type, no temporary types will end up being patched into
   // the globally canonical types and we can skip patching the children of those
   // types.
+  //
+  // Reserve enough room in these vectors so that no reallocations will be
+  // necessary. It's ok if `newCanonInfos` doesn't fill the reserved space.
   std::vector<HeapType> canonPartitionTypes;
   std::vector<HeapTypeInfo*> newCanonInfos;
   canonPartitionTypes.reserve(partitions.sets);
@@ -2849,7 +2852,7 @@ ShapeCanonicalizer::translatePartitionsToTypes(std::vector<HeapType>& roots) {
 #endif
 
   // Walk each of the new globally canonical HeapTypes and update all the
-  // HeapTypes it reaches.
+  // HeapTypes it reaches to also be globally canonical.
   for (auto& info : newCanonInfos) {
     struct ChildUpdater : HeapTypeChildWalker<ChildUpdater> {
       ShapeCanonicalizer& canonicalizer;
@@ -2865,7 +2868,7 @@ ShapeCanonicalizer::translatePartitionsToTypes(std::vector<HeapType>& roots) {
         }
         auto it = canonicalizer.states.find(*child);
         if (it != canonicalizer.states.end()) {
-          // heapType hasn't already been replaced; replace it.
+          // `child` hasn't already been replaced; replace it.
           auto set = canonicalizer.partitions.getSetForElem(it->second);
           *child = canonPartitionTypes.at(set.index);
         }


### PR DESCRIPTION
We previously split equirecursive canonicalization into two stages: first, shape
canonicalization, which minimized the type definition graph, and next type
canonicalization that traversed the minimized type graph and replaced temporary
HeapTypes and Types with globally canonical equivalents. Nominal
canonicalization went through an entirely different code path that never
introduced temporary types at all because all the built HeapTypes would
eventually be moved directly to the global store, meaning it was safe to build
the "temporary" types that referred to them directly in the global store as well.

For the new milestone 4 GC spec, however, we want to have nominal and
equirecursive types coexist. That means that the TypeBuilder API does not know
whether a built HeapType will be nominal or equirecursive up front, so it has to
conservatively use real temporary Types even if they only refer to built
HeapTypes that end up being nominal. That means that both the nominal and
equirecursive code paths will need to canonicalize temporary Types.

Refactor equirecursive shape canonicalization so that it takes care of making
all the resulting HeapTypes globally canonical, leaving the second type
canonicalization step to handle canonicalizing only temporary Types. That second
step is now shared between both nominal and equirecursive canonicalization. As
part of the refactoring, the public interface to ShapeCanonicalizer is also
significantly simplified.