### PR TITLE
[EH] Make doEndThrowingInst simpler (NFC)

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -259,7 +259,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     // end
     assert(self->unwindExprStack.size() == self->throwingInstsStack.size());
     for (int i = self->throwingInstsStack.size() - 1; i >= 0; i--) {
-      Try* tryy = self->unwindExprStack[i]->template cast<Try>();
+      auto* tryy = self->unwindExprStack[i]->template cast<Try>();
       // Exception thrown. Note outselves so that we will create a link to each
       // catch within the try when we get there.
       self->throwingInstsStack[i].push_back(self->currBasicBlock);


### PR DESCRIPTION
The current code the innermost (`i`th) case specially first and handles
`i-1`th `try` in each loop iteration. This puts the `i`th case in the
loop and each iteration handles `i`th `try`, which is simpler. Then we
don't need to check `throwingInstsStack.empty()` in the beginning
because the `for` loop wouldn't be entered if it's empty anyway.