### PR TITLE
[EH] Support try-delegate in CFGWalker

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -269,7 +269,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
         // If this delegates to an outer try, we skip catches between this try
         // and the target try.
         bool found = false;
-        for (int j = i; j >= 0; j--) {
+        for (int j = i - 1; j >= 0; j--) {
           if (self->unwindExprStack[j]->template cast<Try>()->name ==
               tryy->delegateTarget) {
             i = j;

--- a/test/lit/passes/rse-eh.wast
+++ b/test/lit/passes/rse-eh.wast
@@ -729,7 +729,7 @@
       )
       (catch_all)
     )
-    ;; The innermost try delegates to $l1, which in turn delgates to $l0,
+    ;; The innermost try delegates to $l1, which in turn delegates to $l0,
     ;; skipping all local.sets in between. So this should NOT be dropped.
     (local.set $x (i32.const 1))
   )


### PR DESCRIPTION
This adds support for `try`-`delegate` to `CFGWalker`. This also adds a
single test for `catch`-less `try`.