### PR TITLE
Reducer: Apply --debug to all commands

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -289,9 +289,6 @@ struct Reducer
       for (auto pass : passes) {
         std::string currCommand = Path::getBinaryenBinaryTool("wasm-opt") + " ";
         currCommand += working + " -o " + test + " " + pass + " " + extraFlags;
-        if (debugInfo) {
-          currCommand += " -g ";
-        }
         if (!binary) {
           currCommand += " -S ";
         }
@@ -1260,6 +1257,9 @@ int main(int argc, const char* argv[]) {
       [&](Options* o, const std::string& argument) { input = argument; });
   options.parse(argc, argv);
 
+  if (debugInfo) {
+    extraFlags += " -g ";
+  }
   if (getTypeSystem() == TypeSystem::Nominal) {
     extraFlags += " --nominal";
   }
@@ -1282,6 +1282,7 @@ int main(int argc, const char* argv[]) {
   std::cerr << "|test: " << test << '\n';
   std::cerr << "|working: " << working << '\n';
   std::cerr << "|bin dir: " << binDir << '\n';
+  std::cerr << "|extra flags: " << extraFlags << '\n';
 
   // get the expected output
   copy_file(input, test);


### PR DESCRIPTION
Do so by applying `--debug` to `extraFlags` right at the start. That global
is used everywhere already. In particular, this PR removes manually adding
`-g` in the first diff chunk here, and you can see `extraFlags` appears there
already on the previous line.
