### PR TITLE
[CI] Fix alpine builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,14 +164,14 @@ jobs:
     - uses: actions/checkout@v1
     - name: start docker
       run: |
-        docker run -w /src -dit --name alpine -v $PWD:/src --entrypoint /usr/bin/python3 node:lts-alpine
+        docker run -w /src -dit --name alpine -v $PWD:/src node:lts-alpine
         echo 'docker exec alpine "$@";' > ./alpine.sh
         chmod +x ./alpine.sh
 
     - name: install packages
       run: |
         ./alpine.sh apk update
-        ./alpine.sh apk add build-base cmake git python3 clang ninja
+        ./alpine.sh apk add build-base cmake git python3 py3-pip clang ninja
 
     - name: install python dev dependencies
       run: ./alpine.sh pip3 install -r requirements-dev.txt


### PR DESCRIPTION
It seems since some LTS version alpine required explicitly installed pip3