### PR TITLE
[NFC] Use std::variant in GCData

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <iostream>
+#include <variant>
 
 #include "compiler-support.h"
 #include "support/hash.h"
@@ -700,13 +701,17 @@ std::ostream& operator<<(std::ostream& o, wasm::Literals literals);
 // instead we have a static type.
 struct GCData {
   // Either the RTT or the type must be present, but not both.
-  Literal rtt;
-  HeapType type;
+  std::variant<Literal, HeapType> typeInfo;
 
   Literals values;
 
-  GCData(HeapType type, Literals values) : type(type), values(values) {}
-  GCData(Literal rtt, Literals values) : rtt(rtt), values(values) {}
+  GCData(HeapType type, Literals values) : typeInfo(type), values(values) {}
+  GCData(Literal rtt, Literals values) : typeInfo(rtt), values(values) {}
+
+  bool hasRtt() { return std::get_if<Literal>(&typeInfo); }
+  bool hasHeapType() { return std::get_if<HeapType>(&typeInfo); }
+  Literal getRtt() { return std::get<Literal>(typeInfo); }
+  HeapType getHeapType() { return std::get<HeapType>(typeInfo); }
 };
 
 struct RttSuper {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1487,8 +1487,9 @@ public:
       // GC data store an RTT in each instance.
       assert(cast.originalRef.isData());
       auto gcData = cast.originalRef.getGCData();
+      assert(bool(curr->rtt) == gcData->hasRtt());
       if (curr->rtt) {
-        Literal seenRtt = gcData->rtt;
+        auto seenRtt = gcData->getRtt();
         if (!seenRtt.isSubRtt(intendedRtt)) {
           cast.outcome = cast.Failure;
           return cast;
@@ -1496,7 +1497,7 @@ public:
         cast.castRef =
           Literal(gcData, Type(intendedRtt.type.getHeapType(), NonNullable));
       } else {
-        auto seenType = gcData->type;
+        auto seenType = gcData->getHeapType();
         if (!HeapType::isSubType(seenType, curr->intendedType)) {
           cast.outcome = cast.Failure;
           return cast;

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -495,7 +495,9 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
     if (literal.isData()) {
       auto data = literal.getGCData();
       if (data) {
-        o << "[ref " << data->rtt << ' ' << data->values << ']';
+        o << "[ref ";
+        std::visit([&](auto& info) { o << info; }, data->typeInfo);
+        o << ' ' << data->values << ']';
       } else {
         o << "[ref null " << literal.type << ']';
       }


### PR DESCRIPTION
This helps prevent bugs where we assume that the GCData has either a HeapType or
Rtt without checking. Indeed, one such bug is found and fixed.