### PR TITLE
[Wasm GC] Fix casts of rtt.canon with nominal typing

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -2562,7 +2562,17 @@ bool Literal::isSubRtt(const Literal& other) const {
   if (otherSupers.size() < supers.size()) {
     return other.type == supers[otherSupers.size()].type;
   } else {
-    return other.type == type;
+    if (getTypeSystem() == TypeSystem::Nominal) {
+      // If the type system is nominal, then allow not just type equality here
+      // but also subtyping. This allows, for example, (rtt.canon $B) to be a
+      // sub-rtt of (rtt.canon $A), if $B is a subtype of $A. But it is unclear
+      // how sub-RTT semantics should actually work with nominal subtyping
+      // (really, nominal subtyping makes the most sense in the *non*-rtt case).
+      // XXX Remove this hack once the typesystem spec stabilizes.
+      return HeapType::isSubType(type.getHeapType(), other.type.getHeapType());
+    } else {
+      return other.type == type;
+    }
   }
 }
 

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -1496,7 +1496,7 @@
  ;; CHECK-NEXT:  (i32.const 0)
  ;; CHECK-NEXT: )
  ;; NOMNL:      (func $ref-test-rtt-canons (result i32)
- ;; NOMNL-NEXT:  (i32.const 0)
+ ;; NOMNL-NEXT:  (i32.const 1)
  ;; NOMNL-NEXT: )
  (func $ref-test-rtt-canons (result i32)
   ;; Create a struct of a subtype, test against the supertype. Both use


### PR DESCRIPTION
I am not sure this PR is right or not. We seem to have a few notions of casts atm, one for the original structural typing, one for nominal typing, and also for rtt-free instructions that might involve either or both of structural and nominal subtyping. The specific problem this PR tries to address is that j2wasm used to do
```wat
(ref.test
  (struct.new $subclass ;; declared as struct_subtype of $class
    (rtt.sub $subclass (rtt.canon $class))
  )
  (rtt.canon $class)
)
```
That worked (i.e. it returns `1`). They are now switching to
```wat
(ref.test
  (struct.new $subclass
    (rtt.canon $subclass)) ;; this line changed to a canon of the subclass
  )
  (rtt.canon $class)
)
```
This apparently works in V8, though I am not entirely sure which spec to read to understand why. This PR adds a possible hack to get things to work, that when we use nominal typing, then use the nominal info at the base of rtt chains..? :shrug: 
