### PR TITLE
[OptimizeInstructions] Optimize zero sized bulk memory ops even without "ignoreImplicitTraps"

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3216,6 +3216,16 @@ private:
             // memory.copy(dst, src, 0)  ==>  {drop(dst), drop(src)}
             return builder.makeBlock({builder.makeDrop(memCopy->dest),
                                       builder.makeDrop(memCopy->source)});
+          } else {
+            // memory.copy(dst, src, 0)  ==>  {
+            //   drop(i32.load8_u(dst)),
+            //   drop(i32.load8_u(src))
+            // }
+            return builder.makeBlock(
+              {builder.makeDrop(
+                builder.makeLoad(1, false, 0, 1, memCopy->dest, Type::i32)),
+              builder.makeDrop(builder.makeLoad(
+                1, false, 0, 1, memCopy->source, Type::i32))});
           }
           break;
         }
@@ -3278,11 +3288,17 @@ private:
     auto* csize = memFill->size->cast<Const>();
     auto bytes = csize->value.getInteger();
 
-    if (bytes == 0LL &&
-        (options.ignoreImplicitTraps || options.trapsNeverHappen)) {
-      // memory.fill(d, v, 0)  ==>  { drop(d), drop(v) }
-      return builder.makeBlock(
-        {builder.makeDrop(memFill->dest), builder.makeDrop(memFill->value)});
+    if (bytes == 0LL) {
+      if (options.ignoreImplicitTraps || options.trapsNeverHappen) {
+        // memory.fill(d, v, 0)  ==>  { drop(d), drop(v) }
+        return builder.makeBlock(
+          {builder.makeDrop(memFill->dest), builder.makeDrop(memFill->value)});
+      } else {
+        // memory.fill(d, v, 0)  ==>  { drop(i32.load8_u(d)), drop(v) }
+        return builder.makeBlock({builder.makeDrop(builder.makeLoad(
+                                    1, false, 0, 1, memFill->dest, Type::i32)),
+                                  builder.makeDrop(memFill->value)});
+      }
     }
 
     const uint32_t offset = 0, align = 1;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3223,9 +3223,9 @@ private:
             // }
             return builder.makeBlock(
               {builder.makeDrop(
-                builder.makeLoad(1, false, 0, 1, memCopy->dest, Type::i32)),
-              builder.makeDrop(builder.makeLoad(
-                1, false, 0, 1, memCopy->source, Type::i32))});
+                 builder.makeLoad(1, false, 0, 1, memCopy->dest, Type::i32)),
+               builder.makeDrop(builder.makeLoad(
+                 1, false, 0, 1, memCopy->source, Type::i32))});
           }
           break;
         }

--- a/test/lit/passes/optimize-instructions-bulk-memory.wast
+++ b/test/lit/passes/optimize-instructions-bulk-memory.wast
@@ -10,10 +10,17 @@
   ;; CHECK-NEXT:   (local.get $dst)
   ;; CHECK-NEXT:   (local.get $sz)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (memory.copy
-  ;; CHECK-NEXT:   (local.get $dst)
-  ;; CHECK-NEXT:   (local.get $src)
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.load8_u
+  ;; CHECK-NEXT:     (local.get $dst)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.load8_u
+  ;; CHECK-NEXT:     (local.get $src)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.store8
   ;; CHECK-NEXT:   (local.get $dst)
@@ -84,10 +91,17 @@
   ;; NOSIMD-NEXT:   (local.get $dst)
   ;; NOSIMD-NEXT:   (local.get $sz)
   ;; NOSIMD-NEXT:  )
-  ;; NOSIMD-NEXT:  (memory.copy
-  ;; NOSIMD-NEXT:   (local.get $dst)
-  ;; NOSIMD-NEXT:   (local.get $src)
-  ;; NOSIMD-NEXT:   (i32.const 0)
+  ;; NOSIMD-NEXT:  (block
+  ;; NOSIMD-NEXT:   (drop
+  ;; NOSIMD-NEXT:    (i32.load8_u
+  ;; NOSIMD-NEXT:     (local.get $dst)
+  ;; NOSIMD-NEXT:    )
+  ;; NOSIMD-NEXT:   )
+  ;; NOSIMD-NEXT:   (drop
+  ;; NOSIMD-NEXT:    (i32.load8_u
+  ;; NOSIMD-NEXT:     (local.get $src)
+  ;; NOSIMD-NEXT:    )
+  ;; NOSIMD-NEXT:   )
   ;; NOSIMD-NEXT:  )
   ;; NOSIMD-NEXT:  (i32.store8
   ;; NOSIMD-NEXT:   (local.get $dst)
@@ -234,10 +248,15 @@
   )
 
   ;; CHECK:      (func $optimize-bulk-memory-fill (param $dst i32) (param $val i32) (param $sz i32)
-  ;; CHECK-NEXT:  (memory.fill
-  ;; CHECK-NEXT:   (local.get $dst)
-  ;; CHECK-NEXT:   (i32.const 0)
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.load8_u
+  ;; CHECK-NEXT:     (local.get $dst)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.store8
   ;; CHECK-NEXT:   (local.get $dst)
@@ -295,10 +314,15 @@
   ;; CHECK-NEXT:   (local.get $dst)
   ;; CHECK-NEXT:   (v128.const i32x4 0xffffffff 0xffffffff 0xffffffff 0xffffffff)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (memory.fill
-  ;; CHECK-NEXT:   (local.get $dst)
-  ;; CHECK-NEXT:   (local.get $val)
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.load8_u
+  ;; CHECK-NEXT:     (local.get $dst)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $val)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (memory.fill
   ;; CHECK-NEXT:   (local.get $dst)
@@ -335,10 +359,15 @@
   ;; NOSIMD-NEXT:  (local $3 i32)
   ;; NOSIMD-NEXT:  (local $4 i32)
   ;; NOSIMD-NEXT:  (local $5 i32)
-  ;; NOSIMD-NEXT:  (memory.fill
-  ;; NOSIMD-NEXT:   (local.get $dst)
-  ;; NOSIMD-NEXT:   (i32.const 0)
-  ;; NOSIMD-NEXT:   (i32.const 0)
+  ;; NOSIMD-NEXT:  (block
+  ;; NOSIMD-NEXT:   (drop
+  ;; NOSIMD-NEXT:    (i32.load8_u
+  ;; NOSIMD-NEXT:     (local.get $dst)
+  ;; NOSIMD-NEXT:    )
+  ;; NOSIMD-NEXT:   )
+  ;; NOSIMD-NEXT:   (drop
+  ;; NOSIMD-NEXT:    (i32.const 0)
+  ;; NOSIMD-NEXT:   )
   ;; NOSIMD-NEXT:  )
   ;; NOSIMD-NEXT:  (i32.store8
   ;; NOSIMD-NEXT:   (local.get $dst)
@@ -420,10 +449,15 @@
   ;; NOSIMD-NEXT:    (i64.const -1)
   ;; NOSIMD-NEXT:   )
   ;; NOSIMD-NEXT:  )
-  ;; NOSIMD-NEXT:  (memory.fill
-  ;; NOSIMD-NEXT:   (local.get $dst)
-  ;; NOSIMD-NEXT:   (local.get $val)
-  ;; NOSIMD-NEXT:   (i32.const 0)
+  ;; NOSIMD-NEXT:  (block
+  ;; NOSIMD-NEXT:   (drop
+  ;; NOSIMD-NEXT:    (i32.load8_u
+  ;; NOSIMD-NEXT:     (local.get $dst)
+  ;; NOSIMD-NEXT:    )
+  ;; NOSIMD-NEXT:   )
+  ;; NOSIMD-NEXT:   (drop
+  ;; NOSIMD-NEXT:    (local.get $val)
+  ;; NOSIMD-NEXT:   )
   ;; NOSIMD-NEXT:  )
   ;; NOSIMD-NEXT:  (memory.fill
   ;; NOSIMD-NEXT:   (local.get $dst)


### PR DESCRIPTION
I guess we could optimize even this cases like:
```rust
memory.copy(dst, src, 0)  ==>  { drop(i32.load8_u(dst)), drop(i32.load8_u(src)) }
``` 
i.e. adding one read each for source and destination pointers.
Same for `memory.fill`:
```rust
memory.fill(d, v, 0)  ==>  { drop(i32.load8_u(d)), drop(v) }
```

@kripken wdyt?