### PR TITLE
Set CMAKE_OSX_DEPLOYMENT_TARGET to 10.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Version set according the the cmake versions available in Ubuntu/Bionic:
 # https://packages.ubuntu.com/bionic/cmake
 cmake_minimum_required(VERSION 3.10.2)
+# Needed for C++17 (std::variant)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
 project(binaryen LANGUAGES C CXX VERSION 102)
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Apparently this is needed for std::variant.  Without this
the emsdk build fails with:

```
/Users/distiller/project/binaryen/main/src/literal.h:713:34: error: 'get<wasm::Literal, wasm::Literal, wasm::HeapType>' is unavailable: introduced in macOS 10.14
  Literal getRtt() { return std::get<Literal>(typeInfo); }
                                 ^
/Applications/Xcode-12.2.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/variant:1429:16: note: 'get<wasm::Literal, wasm::Literal, wasm::HeapType>' has been explicitly marked unavailable here
constexpr _Tp& get(variant<_Types...>& __v) {
```
