### PR TITLE
[Wasm GC] LUBFinder helper. NFC

### DIFF
--- a/src/ir/lubs.h
+++ b/src/ir/lubs.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_lubs_h
+#define wasm_ir_lubs_h
+
+#include "ir/module-utils.h"
+#include "wasm.h"
+
+namespace wasm {
+
+// Helper to find a LUB of a series of expressions. This works incrementally so
+// that if we see we are not improving on an existing type then we can stop
+// early.
+struct LUBFinder {
+  // The least upper bound we found so far.
+  Type lub = Type::unreachable;
+
+  // Note another type to take into account in the lub. Returns the new lub.
+  Type note(Type type) {
+    return lub = Type::getLeastUpperBound(lub, type);
+  }
+
+  Type note(Expression* curr) {
+    return note(curr->type);
+  }
+
+  // Returns whether we noted any (reachable) value.
+  bool noted() {
+    return lub == Type::unreachable;
+  }
+
+  // Returns the lub that we found.
+  Type get() {
+    return lub;
+  }
+};
+
+} // namespace wasm
+
+#endif // wasm_ir_lubs_h

--- a/src/ir/lubs.h
+++ b/src/ir/lubs.h
@@ -35,7 +35,7 @@ struct LUBFinder {
   Type note(Expression* curr) { return note(curr->type); }
 
   // Returns whether we noted any (reachable) value.
-  bool noted() { return lub == Type::unreachable; }
+  bool noted() { return lub != Type::unreachable; }
 
   // Returns the lub that we found.
   Type get() { return lub; }

--- a/src/ir/lubs.h
+++ b/src/ir/lubs.h
@@ -30,23 +30,15 @@ struct LUBFinder {
   Type lub = Type::unreachable;
 
   // Note another type to take into account in the lub. Returns the new lub.
-  Type note(Type type) {
-    return lub = Type::getLeastUpperBound(lub, type);
-  }
+  Type note(Type type) { return lub = Type::getLeastUpperBound(lub, type); }
 
-  Type note(Expression* curr) {
-    return note(curr->type);
-  }
+  Type note(Expression* curr) { return note(curr->type); }
 
   // Returns whether we noted any (reachable) value.
-  bool noted() {
-    return lub == Type::unreachable;
-  }
+  bool noted() { return lub == Type::unreachable; }
 
   // Returns the lub that we found.
-  Type get() {
-    return lub;
-  }
+  Type get() { return lub; }
 };
 
 } // namespace wasm

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -41,6 +41,7 @@
 #include "ir/effects.h"
 #include "ir/element-utils.h"
 #include "ir/find_all.h"
+#include "ir/lubs.h"
 #include "ir/module-utils.h"
 #include "ir/type-updating.h"
 #include "ir/utils.h"
@@ -556,21 +557,20 @@ private:
         newParamTypes.push_back(originalType);
         continue;
       }
-      Type refinedType = Type::unreachable;
+      LUBFinder lub;
       for (auto* call : calls) {
         auto* operand = call->operands[i];
-        refinedType = Type::getLeastUpperBound(refinedType, operand->type);
-        if (refinedType == originalType) {
+        if (lub.note(operand) == originalType) {
           // We failed to refine this parameter to anything more specific.
           break;
         }
       }
 
       // Nothing is sent here at all; leave such optimizations to DCE.
-      if (refinedType == Type::unreachable) {
+      if (!lub.noted()) {
         return;
       }
-      newParamTypes.push_back(refinedType);
+      newParamTypes.push_back(lub.get());
     }
 
     // Check if we are able to optimize here before we do the work to scan the
@@ -654,17 +654,16 @@ private:
     //  )
     ReFinalize().walkFunctionInModule(func, module);
 
-    Type refinedType = func->body->type;
-    if (refinedType == originalType) {
+    LUBFinder lub;
+    if (lub.note(func->body) == originalType) {
       return false;
     }
 
     // Scan the body and look at the returns.
     auto processReturnType = [&](Type type) {
-      refinedType = Type::getLeastUpperBound(refinedType, type);
       // Return whether we still look ok to do the optimization. If this is
       // false then we can stop here.
-      return refinedType != originalType;
+      return lub.note(type) != originalType;
     };
     for (auto* ret : FindAll<Return>(func->body).list) {
       if (!processReturnType(ret->value->type)) {
@@ -694,20 +693,20 @@ private:
         }
       }
     }
-    assert(refinedType != originalType);
+    assert(lub.get() != originalType);
 
     // If the refined type is unreachable then nothing actually returns from
     // this function.
     // TODO: We can propagate that to the outside, and not just for GC.
-    if (refinedType == Type::unreachable) {
+    if (!lub.noted()) {
       return false;
     }
 
     // Success. Update the type, and the calls.
-    func->setResults(refinedType);
+    func->setResults(lub.get());
     for (auto* call : calls) {
       if (call->type != Type::unreachable) {
-        call->type = refinedType;
+        call->type = lub.get();
       }
     }
     return true;


### PR DESCRIPTION
This is a minor refactoring in DAE to have a helper class that does the
incremental LUB calculation. The class is also used in LocalSubtyping,
where it has the effect of making the work incremental which it was not
before (that would have no observable consequence, but it should make
us faster in the common case where we fail to find a new LUB).

This refactoring by itself does little, but it provides a central place to
further optimize this LUB calculation, which will be in a later PR.