### PR TITLE
Fuzz more basic GC types

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -249,6 +249,7 @@ private:
   // Makes a small change to a constant value.
   Literal tweak(Literal value);
   Literal makeLiteral(Type type);
+  Expression* makeRefFuncConst(Type type);
   Expression* makeConst(Type type);
   Expression* buildUnary(const UnaryArgs& args);
   Expression* makeUnary(Type type);
@@ -291,6 +292,9 @@ private:
   Type getStorableType();
   Type getLoggableType();
   bool isLoggableType(Type type);
+  Nullability getSubType(Nullability nullability);
+  HeapType getSubType(HeapType type);
+  Rtt getSubType(Rtt rtt);
   Type getSubType(Type type);
 
   // Utilities

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3074,8 +3074,7 @@ bool TranslateToFuzzReader::isLoggableType(Type type) {
 
 Nullability TranslateToFuzzReader::getSubType(Nullability nullability) {
   return nullability == NonNullable ? NonNullable
-         : oneIn(2)                 ? Nullable
-                                    : NonNullable;
+                                    : oneIn(2) ? Nullable : NonNullable;
 }
 
 HeapType TranslateToFuzzReader::getSubType(HeapType type) {
@@ -3109,9 +3108,9 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
 }
 
 Rtt TranslateToFuzzReader::getSubType(Rtt rtt) {
-  uint32_t depth = rtt.depth != Rtt::NoDepth ? rtt.depth
-                   : oneIn(2)                ? Rtt::NoDepth
-                                             : upTo(MAX_RTT_DEPTH + 1);
+  uint32_t depth = rtt.depth != Rtt::NoDepth
+                     ? rtt.depth
+                     : oneIn(2) ? Rtt::NoDepth : upTo(MAX_RTT_DEPTH + 1);
   return Rtt(depth, rtt.heapType);
 }
 

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,31 +1,31 @@
 total
- [exports]      : 57      
- [funcs]        : 82      
+ [exports]      : 38      
+ [funcs]        : 62      
  [globals]      : 7       
  [imports]      : 4       
  [memory-data]  : 4       
- [table-data]   : 17      
+ [table-data]   : 22      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3244    
- [vars]         : 178     
- Binary         : 261     
- Block          : 470     
- Break          : 79      
- Call           : 223     
- CallIndirect   : 9       
- Const          : 622     
- Drop           : 58      
- GlobalGet      : 278     
- GlobalSet      : 126     
- If             : 189     
- Load           : 63      
- LocalGet       : 191     
- LocalSet       : 108     
- Loop           : 56      
- Nop            : 76      
- RefFunc        : 17      
- Return         : 152     
- Select         : 23      
- Store          : 20      
- Unary          : 223     
+ [total]        : 7561    
+ [vars]         : 214     
+ Binary         : 542     
+ Block          : 1140    
+ Break          : 287     
+ Call           : 236     
+ CallIndirect   : 94      
+ Const          : 1510    
+ Drop           : 66      
+ GlobalGet      : 625     
+ GlobalSet      : 266     
+ If             : 487     
+ Load           : 128     
+ LocalGet       : 477     
+ LocalSet       : 264     
+ Loop           : 182     
+ Nop            : 223     
+ RefFunc        : 22      
+ Return         : 301     
+ Select         : 58      
+ Store          : 91      
+ Unary          : 562     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,42 +1,42 @@
 total
- [exports]      : 7       
- [funcs]        : 6       
+ [exports]      : 8       
+ [funcs]        : 9       
  [globals]      : 6       
  [imports]      : 5       
  [memory-data]  : 22      
- [table-data]   : 0       
+ [table-data]   : 4       
  [tables]       : 1       
- [tags]         : 2       
- [total]        : 764     
- [vars]         : 29      
- AtomicFence    : 2       
- Binary         : 88      
- Block          : 79      
- Break          : 19      
- Call           : 39      
- CallRef        : 4       
- Const          : 166     
+ [tags]         : 1       
+ [total]        : 465     
+ [vars]         : 10      
+ ArrayInit      : 1       
+ AtomicCmpxchg  : 1       
+ AtomicNotify   : 1       
+ Binary         : 64      
+ Block          : 51      
+ Break          : 6       
+ Call           : 19      
+ Const          : 121     
  DataDrop       : 1       
- Drop           : 5       
- GlobalGet      : 31      
- GlobalSet      : 19      
- If             : 33      
- Load           : 24      
- LocalGet       : 55      
- LocalSet       : 32      
- Loop           : 11      
- MemoryCopy     : 1       
- MemoryInit     : 2       
- Nop            : 6       
- RefEq          : 2       
- RefFunc        : 4       
- RefIs          : 2       
- RefNull        : 54      
+ Drop           : 6       
+ GlobalGet      : 22      
+ GlobalSet      : 12      
+ If             : 20      
+ Load           : 13      
+ LocalGet       : 22      
+ LocalSet       : 18      
+ Loop           : 3       
+ MemoryFill     : 1       
+ Nop            : 20      
+ RefAs          : 1       
+ RefFunc        : 5       
+ RefIs          : 3       
+ RefNull        : 3       
  Return         : 18      
- SIMDExtract    : 1       
- SIMDShuffle    : 1       
- Select         : 3       
- Store          : 6       
- TupleExtract   : 5       
- TupleMake      : 16      
- Unary          : 35      
+ SIMDExtract    : 3       
+ Select         : 1       
+ Store          : 3       
+ StructNew      : 3       
+ TupleExtract   : 2       
+ TupleMake      : 4       
+ Unary          : 17      


### PR DESCRIPTION
Generate both nullable and non-nullable references to basic HeapTypes and
introduce `i31` and `data` HeapTypes. Generate subtypes rather than exact types
for all concrete-typed children.