### PR TITLE
[EH] Improve catch validation

### DIFF
--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -2,6 +2,7 @@ FILE(GLOB ir_HEADERS *.h)
 set(ir_SOURCES
   ExpressionAnalyzer.cpp
   ExpressionManipulator.cpp
+  eh-utils.cpp
   intrinsics.cpp
   names.cpp
   properties.cpp

--- a/src/ir/eh-utils.cpp
+++ b/src/ir/eh-utils.cpp
@@ -16,8 +16,6 @@
 
 #include "ir/eh-utils.h"
 #include "ir/branch-utils.h"
-#include "ir/find_all.h"
-#include "ir/properties.h"
 
 namespace wasm {
 

--- a/src/ir/eh-utils.cpp
+++ b/src/ir/eh-utils.cpp
@@ -66,7 +66,6 @@ bool isPopValid(Expression* catchBody) {
     }
     firstChild = *it.begin();
   }
-  assert(false); // Shouldn't be reached
 }
 
 } // namespace EHUtils

--- a/src/ir/eh-utils.cpp
+++ b/src/ir/eh-utils.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/eh-utils.h"
+#include "ir/branch-utils.h"
+#include "ir/find_all.h"
+#include "ir/properties.h"
+
+namespace wasm {
+
+namespace EHUtils {
+
+bool isPopValid(Expression* catchBody) {
+  Expression* firstChild = nullptr;
+  auto* block = catchBody->dynCast<Block>();
+  if (!block) {
+    firstChild = catchBody;
+  } else {
+    // When there are multiple expressions within a catch body, an implicit
+    // block is created within it for convenience purposes, and if there are no
+    // branches that targets the block, it will be omitted when written back.
+    // But if there is a branch targetting this block, this block cannot be
+    // removed, and 'pop''s location will be like
+    // (catch $e
+    //   (block $l0
+    //     (pop i32) ;; within a block!
+    //     (br $l0)
+    //     ...
+    //   )
+    // )
+    // which is invalid.
+    if (BranchUtils::BranchSeeker::has(block, block->name)) {
+      return false;
+    }
+    // There should be a pop somewhere
+    if (block->list.empty()) {
+      return false;
+    }
+    firstChild = *block->list.begin();
+  }
+
+  // Go down the line for the first child until we reach a leaf. A pop should be
+  // in that first-decendent line.
+  while (true) {
+    if (firstChild->is<Pop>()) {
+      return true;
+    }
+    // We use ValueChildIterator in order not to go into block/loop/try/if
+    // bodies, because a pop cannot be in those control flow expressions.
+    ValueChildIterator it(firstChild);
+    if (it.begin() == it.end()) {
+      return false;
+    }
+    firstChild = *it.begin();
+  }
+  assert(false); // Shouldn't be reached
+}
+
+} // namespace EHUtils
+
+} // namespace wasm

--- a/src/ir/eh-utils.h
+++ b/src/ir/eh-utils.h
@@ -17,9 +17,9 @@
 #ifndef wasm_ir_eh_h
 #define wasm_ir_eh_h
 
-#include "wasm.h"
-
 namespace wasm {
+
+class Expression;
 
 namespace EHUtils {
 

--- a/src/ir/eh-utils.h
+++ b/src/ir/eh-utils.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_eh_h
+#define wasm_ir_eh_h
+
+#include "wasm.h"
+
+namespace wasm {
+
+namespace EHUtils {
+
+// Returns true if a 'pop' instruction exists in a valid location, which means
+// right after a 'catch' instruction in binary writing order.
+// - This assumes there should be at least a single pop. So given a catch body
+//   whose tag type is void or a catch_all's body, this returns false.
+// - This returns true even if there are more pops after the first one within a
+//   catch body, which is invalid. That will be taken care of in validation.
+bool isPopValid(Expression* catchBody);
+
+} // namespace EHUtils
+
+} // namespace wasm
+
+#endif // wasm_ir_eh_h

--- a/src/ir/iteration.h
+++ b/src/ir/iteration.h
@@ -53,6 +53,8 @@ template<class Specific> class AbstractChildIterator {
       return index != other.index || &parent != &(other.parent);
     }
 
+    bool operator==(const Iterator& other) const { return !(*this != other); }
+
     void operator++() { index++; }
 
     Expression*& operator*() {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2170,9 +2170,9 @@ void FunctionValidator::visitTry(Try* curr) {
   for (Index i = 0; i < curr->catchTags.size(); i++) {
     Name tagName = curr->catchTags[i];
     auto* tag = getModule()->getTagOrNull(tagName);
-    std::string msg =
-      std::string("catch's tag name is invalid: ") + tagName.c_str();
-    shouldBeTrue(tag != nullptr, curr, msg.c_str());
+    if (!shouldBeTrue(tag != nullptr, curr)) {
+      getStream() << "tag name is invalid: " << tagName << "\n";
+    }
 
     auto* catchBody = curr->catchBodies[i];
     std::vector<Pop*> pops = findPops(catchBody);
@@ -2184,8 +2184,7 @@ void FunctionValidator::visitTry(Try* curr) {
       std::string msg =
         std::string("catch's tag (") + tagName.c_str() +
         ") has params, so there should be a single pop within the catch body";
-      shouldBeTrue(pops.size() == 1, curr, msg.c_str());
-      if (pops.size() == 1) {
+      if (shouldBeTrue(pops.size() == 1, curr, msg.c_str())) {
         auto* pop = *pops.begin();
         msg = std::string("catch's tag (") + tagName.c_str() +
               ")'s pop doesn't have the same type as the tag's params";

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2146,8 +2146,8 @@ void FunctionValidator::visitTry(Try* curr) {
 
   // Given a catch body, find pops corresponding to the catch
   auto findPops = [](Expression* expr) {
-    std::vector<Pop*> pops;
-    std::vector<Expression*> work;
+    SmallVector<Pop*, 1> pops;
+    SmallVector<Expression*, 8> work;
     work.push_back(expr);
     while (!work.empty()) {
       auto* curr = work.back();
@@ -2170,12 +2170,12 @@ void FunctionValidator::visitTry(Try* curr) {
   for (Index i = 0; i < curr->catchTags.size(); i++) {
     Name tagName = curr->catchTags[i];
     auto* tag = getModule()->getTagOrNull(tagName);
-    if (!shouldBeTrue(tag != nullptr, curr)) {
+    if (!shouldBeTrue(tag != nullptr, curr, "")) {
       getStream() << "tag name is invalid: " << tagName << "\n";
     }
 
     auto* catchBody = curr->catchBodies[i];
-    std::vector<Pop*> pops = findPops(catchBody);
+    SmallVector<Pop*, 1> pops = findPops(catchBody);
     if (tag->sig.params == Type::none) {
       std::string msg = std::string("catch's tag (") + tagName.c_str() +
                         ") doesn't have any params, but there are pops";

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2177,21 +2177,26 @@ void FunctionValidator::visitTry(Try* curr) {
     auto* catchBody = curr->catchBodies[i];
     SmallVector<Pop*, 1> pops = findPops(catchBody);
     if (tag->sig.params == Type::none) {
-      std::string msg = std::string("catch's tag (") + tagName.c_str() +
-                        ") doesn't have any params, but there are pops";
-      shouldBeTrue(pops.empty(), curr, msg.c_str());
+      if (!shouldBeTrue(pops.empty(), curr, "")) {
+        getStream() << "catch's tag (" << tagName
+                    << ") doesn't have any params, but there are pops";
+      }
     } else {
-      std::string msg =
-        std::string("catch's tag (") + tagName.c_str() +
-        ") has params, so there should be a single pop within the catch body";
-      if (shouldBeTrue(pops.size() == 1, curr, msg.c_str())) {
+      if (shouldBeTrue(pops.size() == 1, curr, "")) {
         auto* pop = *pops.begin();
-        msg = std::string("catch's tag (") + tagName.c_str() +
-              ")'s pop doesn't have the same type as the tag's params";
-        shouldBeSubType(pop->type, tag->sig.params, curr, msg.c_str());
-        msg = std::string("catch's body (") + tagName.c_str() +
-              ")'s pop's location is not valid";
-        shouldBeTrue(EHUtils::isPopValid(catchBody), curr, msg.c_str());
+        if (!shouldBeSubType(pop->type, tag->sig.params, curr, "")) {
+          getStream()
+            << "catch's tag (" << tagName
+            << ")'s pop doesn't have the same type as the tag's params";
+        }
+        if (!shouldBeTrue(EHUtils::isPopValid(catchBody), curr, "")) {
+          getStream() << "catch's body (" << tagName
+                      << ")'s pop's location is not valid";
+        }
+      } else {
+        getStream() << "catch's tag (" << tagName
+                    << ") has params, so there should be a single pop within "
+                       "the catch body";
       }
     }
   }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2188,7 +2188,7 @@ void FunctionValidator::visitTry(Try* curr) {
         auto* pop = *pops.begin();
         msg = std::string("catch's tag (") + tagName.c_str() +
               ")'s pop doesn't have the same type as the tag's params";
-        shouldBeTrue(pop->type == tag->sig.params, curr, msg.c_str());
+        shouldBeSubType(pop->type, tag->sig.params, curr, msg.c_str());
         msg = std::string("catch's body (") + tagName.c_str() +
               ")'s pop's location is not valid";
         shouldBeTrue(EHUtils::isPopValid(catchBody), curr, msg.c_str());

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -2,6 +2,7 @@
   (tag $e-i32 (param i32))
   (tag $e-i64 (param i64))
   (tag $e-i32-i64 (param i32 i64))
+  (tag $e-anyref (param anyref))
   (tag $e-empty)
 
   (func $foo)
@@ -307,6 +308,31 @@
             (rethrow 1) ;; by depth
           )
           (catch_all)
+        )
+      )
+    )
+  )
+
+  (func $pop_test
+    (try
+      (do)
+      (catch $e-i32
+        (throw $e-i32
+          (if (result i32)
+            ;; pop is within an if condition, so this is OK.
+            (pop i32)
+            (i32.const 0)
+            (i32.const 3)
+          )
+        )
+      )
+    )
+
+    (try
+      (do)
+      (catch $e-anyref
+        (drop
+          (pop funcref) ;; pop can be subtype
         )
       )
     )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -3,9 +3,11 @@
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
+ (type $anyref_=>_none (func (param anyref)))
  (tag $e-i32 (param i32))
  (tag $e-i64 (param i64))
  (tag $e-i32-i64 (param i32 i64))
+ (tag $e-anyref (param anyref))
  (tag $e-empty (param))
  (func $foo
   (nop)
@@ -347,6 +349,32 @@
      (catch_all
       (nop)
      )
+    )
+   )
+  )
+ )
+ (func $pop_test
+  (try $try
+   (do
+    (nop)
+   )
+   (catch $e-i32
+    (throw $e-i32
+     (if (result i32)
+      (pop i32)
+      (i32.const 0)
+      (i32.const 3)
+     )
+    )
+   )
+  )
+  (try $try28
+   (do
+    (nop)
+   )
+   (catch $e-anyref
+    (drop
+     (pop funcref)
     )
    )
   )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -3,10 +3,12 @@
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
+ (type $anyref_=>_none (func (param anyref)))
  (tag $tag$0 (param i32))
  (tag $tag$1 (param i64))
  (tag $tag$2 (param i32 i64))
- (tag $tag$3 (param))
+ (tag $tag$3 (param anyref))
+ (tag $tag$4 (param))
  (func $foo
   (nop)
  )
@@ -269,7 +271,7 @@
    (do
     (nop)
    )
-   (catch $tag$3
+   (catch $tag$4
     (nop)
    )
   )
@@ -376,6 +378,32 @@
      (catch_all
       (nop)
      )
+    )
+   )
+  )
+ )
+ (func $pop_test
+  (try $label$5
+   (do
+    (nop)
+   )
+   (catch $tag$0
+    (throw $tag$0
+     (if (result i32)
+      (pop i32)
+      (i32.const 0)
+      (i32.const 3)
+     )
+    )
+   )
+  )
+  (try $label$8
+   (do
+    (nop)
+   )
+   (catch $tag$3
+    (drop
+     (pop anyref)
     )
    )
   )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -3,10 +3,12 @@
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
+ (type $anyref_=>_none (func (param anyref)))
  (tag $tag$0 (param i32))
  (tag $tag$1 (param i64))
  (tag $tag$2 (param i32 i64))
- (tag $tag$3 (param))
+ (tag $tag$3 (param anyref))
+ (tag $tag$4 (param))
  (func $0
   (nop)
  )
@@ -269,7 +271,7 @@
    (do
     (nop)
    )
-   (catch $tag$3
+   (catch $tag$4
     (nop)
    )
   )
@@ -376,6 +378,32 @@
      (catch_all
       (nop)
      )
+    )
+   )
+  )
+ )
+ (func $5
+  (try $label$5
+   (do
+    (nop)
+   )
+   (catch $tag$0
+    (throw $tag$0
+     (if (result i32)
+      (pop i32)
+      (i32.const 0)
+      (i32.const 3)
+     )
+    )
+   )
+  )
+  (try $label$8
+   (do
+    (nop)
+   )
+   (catch $tag$3
+    (drop
+     (pop anyref)
     )
    )
   )

--- a/test/lit/passes/inlining-eh.wast
+++ b/test/lit/passes/inlining-eh.wast
@@ -11,7 +11,9 @@
     (try $label
       (do)
       (catch $tag$0
-        (nop)
+        (drop
+          (pop i32)
+        )
       )
     )
   )
@@ -27,7 +29,9 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (catch $tag$0
-  ;; CHECK-NEXT:       (nop)
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (pop i32)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/remove-unused-names-eh.wast
+++ b/test/lit/passes/remove-unused-names-eh.wast
@@ -10,7 +10,7 @@
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (catch $tag$0
+  ;; CHECK-NEXT:   (catch_all
   ;; CHECK-NEXT:    (try $label$8
   ;; CHECK-NEXT:     (do
   ;; CHECK-NEXT:      (try
@@ -32,7 +32,7 @@
   (func $func0
     (try $label$9 ;; needed due to a rethrow
       (do)
-      (catch $tag$0
+      (catch_all
         (try $label$8 ;; needed due to a delegate
           (do
             (try $label$6 ;; this one is not needed

--- a/test/spec/exception-handling.wast
+++ b/test/spec/exception-handling.wast
@@ -201,22 +201,6 @@
       )
     )
   )
-
-  (func (export "pop_validation_test")
-    (try
-      (do)
-      (catch $e-i32
-        (throw $e-i32
-          (if (result i32)
-            ;; pop is within an if condition, so this is OK.
-            (pop i32)
-            (i32.const 0)
-            (i32.const 3)
-          )
-        )
-      )
-    )
-  )
 )
 
 (assert_trap (invoke "throw_single_value"))
@@ -232,7 +216,6 @@
 (assert_return (invoke "rethrow_target_test1") (i32.const 2))
 (assert_return (invoke "rethrow_target_test2") (i32.const 1))
 (assert_return (invoke "rethrow_target_test3") (i32.const 1))
-(assert_return (invoke  "pop_validation_test"))
 
 (assert_invalid
   (module


### PR DESCRIPTION
This improves validation of `catch` bodies mostly by checking the
validity of `pop`s.

For every `catch` body:
- Checks if its tag exists
- If the tag's type is none:
  - Ensures there shouldn't be any `pop`s
- If the tag's type is not none:
  - Checks if there's a single `pop` within the catch body
  - Checks if the tag type matches the `pop`'s type
  - Checks if the `pop`'s location is valid

For every `catch_all` body:
- Ensures there shuldn't be any `pop`s

This uncovers several bugs related to `pop`s in existing tests, which
this PR also fixes.