### PR TITLE
[NFC] Add StructUtils namespace, and Scanner => StructScanner

### DIFF
--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -22,6 +22,8 @@
 
 namespace wasm {
 
+namespace StructUtils {
+
 // A vector of a template type's values. One such vector will be used per struct
 // type, where each element in the vector represents a field. We always assume
 // that the vectors are pre-initialized to the right length before accessing any
@@ -128,10 +130,10 @@ struct FunctionStructValuesMap
 // type being written to, and not just that it is of a subtype of the
 // instruction's type, which helps later.
 template<typename T, typename SubType>
-struct Scanner : public WalkerPass<PostWalker<Scanner<T, SubType>>> {
+struct StructScanner : public WalkerPass<PostWalker<StructScanner<T, SubType>>> {
   bool isFunctionParallel() override { return true; }
 
-  Scanner(FunctionStructValuesMap<T>& functionNewInfos,
+  StructScanner(FunctionStructValuesMap<T>& functionNewInfos,
           FunctionStructValuesMap<T>& functionSetGetInfos)
     : functionNewInfos(functionNewInfos),
       functionSetGetInfos(functionSetGetInfos) {}
@@ -266,6 +268,8 @@ private:
     }
   }
 };
+
+} // namespace StructUtils
 
 } // namespace wasm
 

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -130,11 +130,12 @@ struct FunctionStructValuesMap
 // type being written to, and not just that it is of a subtype of the
 // instruction's type, which helps later.
 template<typename T, typename SubType>
-struct StructScanner : public WalkerPass<PostWalker<StructScanner<T, SubType>>> {
+struct StructScanner
+  : public WalkerPass<PostWalker<StructScanner<T, SubType>>> {
   bool isFunctionParallel() override { return true; }
 
   StructScanner(FunctionStructValuesMap<T>& functionNewInfos,
-          FunctionStructValuesMap<T>& functionSetGetInfos)
+                FunctionStructValuesMap<T>& functionSetGetInfos)
     : functionNewInfos(functionNewInfos),
       functionSetGetInfos(functionSetGetInfos) {}
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -243,15 +243,18 @@ private:
   bool changed = false;
 };
 
-struct PCVScanner : public StructUtils::StructScanner<PossibleConstantValues, PCVScanner> {
+struct PCVScanner
+  : public StructUtils::StructScanner<PossibleConstantValues, PCVScanner> {
   Pass* create() override {
     return new PCVScanner(functionNewInfos, functionSetGetInfos);
   }
 
-  PCVScanner(StructUtils::FunctionStructValuesMap<PossibleConstantValues>& functionNewInfos,
-             StructUtils::FunctionStructValuesMap<PossibleConstantValues>& functionSetInfos)
-    : StructUtils::StructScanner<PossibleConstantValues, PCVScanner>(functionNewInfos,
-                                                  functionSetInfos) {}
+  PCVScanner(StructUtils::FunctionStructValuesMap<PossibleConstantValues>&
+               functionNewInfos,
+             StructUtils::FunctionStructValuesMap<PossibleConstantValues>&
+               functionSetInfos)
+    : StructUtils::StructScanner<PossibleConstantValues, PCVScanner>(
+        functionNewInfos, functionSetInfos) {}
 
   void noteExpression(Expression* expr,
                       HeapType type,
@@ -359,7 +362,8 @@ struct ConstantFieldPropagation : public Pass {
     // iff $A is a subtype of $B, so we only need to propagate in one direction
     // there, to supertypes.
 
-    StructUtils::TypeHierarchyPropagator<PossibleConstantValues> propagator(*module);
+    StructUtils::TypeHierarchyPropagator<PossibleConstantValues> propagator(
+      *module);
     propagator.propagateToSuperTypes(combinedNewInfos);
     propagator.propagateToSuperAndSubTypes(combinedSetInfos);
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -157,9 +157,9 @@ public:
   }
 };
 
-using PCVStructValuesMap = StructValuesMap<PossibleConstantValues>;
+using PCVStructValuesMap = StructUtils::StructValuesMap<PossibleConstantValues>;
 using PCVFunctionStructValuesMap =
-  FunctionStructValuesMap<PossibleConstantValues>;
+  StructUtils::FunctionStructValuesMap<PossibleConstantValues>;
 
 // Optimize struct gets based on what we've learned about writes.
 //
@@ -243,14 +243,14 @@ private:
   bool changed = false;
 };
 
-struct PCVScanner : public Scanner<PossibleConstantValues, PCVScanner> {
+struct PCVScanner : public StructUtils::StructScanner<PossibleConstantValues, PCVScanner> {
   Pass* create() override {
     return new PCVScanner(functionNewInfos, functionSetGetInfos);
   }
 
-  PCVScanner(FunctionStructValuesMap<PossibleConstantValues>& functionNewInfos,
-             FunctionStructValuesMap<PossibleConstantValues>& functionSetInfos)
-    : Scanner<PossibleConstantValues, PCVScanner>(functionNewInfos,
+  PCVScanner(StructUtils::FunctionStructValuesMap<PossibleConstantValues>& functionNewInfos,
+             StructUtils::FunctionStructValuesMap<PossibleConstantValues>& functionSetInfos)
+    : StructUtils::StructScanner<PossibleConstantValues, PCVScanner>(functionNewInfos,
                                                   functionSetInfos) {}
 
   void noteExpression(Expression* expr,
@@ -359,7 +359,7 @@ struct ConstantFieldPropagation : public Pass {
     // iff $A is a subtype of $B, so we only need to propagate in one direction
     // there, to supertypes.
 
-    TypeHierarchyPropagator<PossibleConstantValues> propagator(*module);
+    StructUtils::TypeHierarchyPropagator<PossibleConstantValues> propagator(*module);
     propagator.propagateToSuperTypes(combinedNewInfos);
     propagator.propagateToSuperAndSubTypes(combinedSetInfos);
 

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -64,14 +64,14 @@ struct FieldInfo {
   }
 };
 
-struct FieldInfoScanner : public Scanner<FieldInfo, FieldInfoScanner> {
+struct FieldInfoScanner : public StructUtils::StructScanner<FieldInfo, FieldInfoScanner> {
   Pass* create() override {
     return new FieldInfoScanner(functionNewInfos, functionSetGetInfos);
   }
 
-  FieldInfoScanner(FunctionStructValuesMap<FieldInfo>& functionNewInfos,
-                   FunctionStructValuesMap<FieldInfo>& functionSetGetInfos)
-    : Scanner<FieldInfo, FieldInfoScanner>(functionNewInfos,
+  FieldInfoScanner(StructUtils::FunctionStructValuesMap<FieldInfo>& functionNewInfos,
+                   StructUtils::FunctionStructValuesMap<FieldInfo>& functionSetGetInfos)
+    : StructUtils::StructScanner<FieldInfo, FieldInfoScanner>(functionNewInfos,
                                            functionSetGetInfos) {}
 
   void noteExpression(Expression* expr,
@@ -96,7 +96,7 @@ struct FieldInfoScanner : public Scanner<FieldInfo, FieldInfoScanner> {
 };
 
 struct GlobalTypeOptimization : public Pass {
-  StructValuesMap<FieldInfo> combinedSetGetInfos;
+  StructUtils::StructValuesMap<FieldInfo> combinedSetGetInfos;
 
   // Maps types to a vector of booleans that indicate whether a field can
   // become immutable. To avoid eager allocation of memory, the vectors are
@@ -120,7 +120,7 @@ struct GlobalTypeOptimization : public Pass {
     }
 
     // Find and analyze struct operations inside each function.
-    FunctionStructValuesMap<FieldInfo> functionNewInfos(*module),
+    StructUtils::FunctionStructValuesMap<FieldInfo> functionNewInfos(*module),
       functionSetGetInfos(*module);
     FieldInfoScanner scanner(functionNewInfos, functionSetGetInfos);
     scanner.run(runner, module);
@@ -146,7 +146,7 @@ struct GlobalTypeOptimization : public Pass {
     //    subtypes (as wasm only allows the type to differ if the fields are
     //    immutable). Note that by making more things immutable we therefore
     //    make it possible to apply more specific subtypes in subtype fields.
-    TypeHierarchyPropagator<FieldInfo> propagator(*module);
+    StructUtils::TypeHierarchyPropagator<FieldInfo> propagator(*module);
     propagator.propagateToSuperAndSubTypes(combinedSetGetInfos);
 
     // Process the propagated info.

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -64,15 +64,17 @@ struct FieldInfo {
   }
 };
 
-struct FieldInfoScanner : public StructUtils::StructScanner<FieldInfo, FieldInfoScanner> {
+struct FieldInfoScanner
+  : public StructUtils::StructScanner<FieldInfo, FieldInfoScanner> {
   Pass* create() override {
     return new FieldInfoScanner(functionNewInfos, functionSetGetInfos);
   }
 
-  FieldInfoScanner(StructUtils::FunctionStructValuesMap<FieldInfo>& functionNewInfos,
-                   StructUtils::FunctionStructValuesMap<FieldInfo>& functionSetGetInfos)
-    : StructUtils::StructScanner<FieldInfo, FieldInfoScanner>(functionNewInfos,
-                                           functionSetGetInfos) {}
+  FieldInfoScanner(
+    StructUtils::FunctionStructValuesMap<FieldInfo>& functionNewInfos,
+    StructUtils::FunctionStructValuesMap<FieldInfo>& functionSetGetInfos)
+    : StructUtils::StructScanner<FieldInfo, FieldInfoScanner>(
+        functionNewInfos, functionSetGetInfos) {}
 
   void noteExpression(Expression* expr,
                       HeapType type,


### PR DESCRIPTION
This avoids cluttering the main `wasm` namespace, and clarifies what the
scanner does.