### PR TITLE
CoalesceLocals: Remove a redundant tee of the same local as a parent set

### DIFF
--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -515,7 +515,12 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices,
             continue;
           }
         }
-        // TODO: do the same for a tee
+        if (auto* subSet = set->value->dynCast<LocalSet>()) {
+          if (subSet->index == set->index) {
+            set->value = subSet->value;
+            continue;
+          }
+        }
         // remove ineffective actions
         if (!action.effective) {
           // value may have no side effects, further optimizations can eliminate

--- a/test/lit/passes/Oz.wast
+++ b/test/lit/passes/Oz.wast
@@ -58,11 +58,9 @@
   ;; CHECK:      (func $8 (; has Stack IR ;) (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
   ;; CHECK-NEXT:  (i32.store
   ;; CHECK-NEXT:   (local.tee $0
-  ;; CHECK-NEXT:    (local.tee $0
-  ;; CHECK-NEXT:     (i32.add
-  ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:      (i32.const 4)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    (i32.add
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:     (i32.const 4)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.and

--- a/test/lit/passes/coalesce-locals.wast
+++ b/test/lit/passes/coalesce-locals.wast
@@ -2572,9 +2572,7 @@
   ;; CHECK:      (func $tee-copies-do-not-interfere (result i32)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (local.tee $0
-  ;; CHECK-NEXT:    (i32.const 100)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 100)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $0)
@@ -2599,11 +2597,7 @@
   ;; CHECK:      (func $multiple-tee-copies-do-not-interfere (result i32)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (local.tee $0
-  ;; CHECK-NEXT:    (local.tee $0
-  ;; CHECK-NEXT:     (i32.const 100)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 100)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $0)

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2428,7 +2428,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining (param $x eqref)
+  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining (type $eqref_=>_none) (param $x eqref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result (ref null $B))
   ;; NOMNL-NEXT:    (call $ref-cast-static-fallthrough-remaining
@@ -2477,7 +2477,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-child (param $x eqref)
+  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-child (type $eqref_=>_none) (param $x eqref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.cast_static $B
   ;; NOMNL-NEXT:    (block (result eqref)
@@ -2526,7 +2526,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-impossible (param $x (ref eq))
+  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-impossible (type $ref|eq|_=>_none) (param $x (ref eq))
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result (ref $array))
   ;; NOMNL-NEXT:    (drop
@@ -2575,7 +2575,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-nonnull (param $x (ref eq))
+  ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-nonnull (type $ref|eq|_=>_none) (param $x (ref eq))
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.cast_static $A
   ;; NOMNL-NEXT:    (block (result (ref eq))


### PR DESCRIPTION
Tiny followup to #4314

Existing tests happen to already cover this pretty well.

Also updates some function types in test output - I suspect that is from a
race in landing of PRs.