### PR TITLE
Fix vacuum on rtts with depth

### DIFF
--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -35,6 +35,14 @@ inline bool canMakeZero(Type type) {
   if (type.isNonNullable()) {
     return false;
   }
+  if (type.isRtt() && type.getRtt().hasDepth()) {
+    // An rtt with depth cannot be constructed as a simple zero: we'd need to
+    // create not just a zero (an rtt.canon) but also some rtt.subs that add to
+    // the depth, so disallow that. Also, there is no practical way to create a
+    // zero Literal for such a type, as we'd need to supply the list of super
+    // types somehow, and creating a zero Literal is how makeZero works.
+    return false;
+  }
   if (type.isTuple()) {
     for (auto t : type) {
       if (!canMakeZero(t)) {
@@ -46,6 +54,7 @@ inline bool canMakeZero(Type type) {
 }
 
 inline Expression* makeZero(Type type, Module& wasm) {
+  assert(canMakeZero(type));
   // TODO: Remove this function once V8 supports v128.const
   // (https://bugs.chromium.org/p/v8/issues/detail?id=8460)
   Builder builder(wasm);

--- a/test/lit/passes/vacuum-gc.wast
+++ b/test/lit/passes/vacuum-gc.wast
@@ -2,6 +2,8 @@
 ;; RUN: wasm-opt %s --vacuum -all -S -o - | filecheck %s
 
 (module
+  (type ${} (struct))
+
   ;; CHECK:      (func $drop-ref-as (param $x anyref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
@@ -45,6 +47,31 @@
     (drop
       (ref.as_i31
         (local.get $x)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $vacuum-rtt-with-depth
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $vacuum-rtt-with-depth
+    (drop
+      (if (result (rtt 1 ${}))
+        (i32.const 1)
+        ;; This block's result is not used. As a consequence vacuum will try to
+        ;; generate a replacement zero for the block's fallthrough value. An rtt
+        ;; with depth is a problem for that, since we can't just create an
+        ;; rtt.canon - we'd need to add some rtt.subs, and it's not clear that we'd
+        ;; be improving code size while doing so, hence we do not allow making a
+        ;; zero of that type. Vacuum should not error on trying to do so. And
+        ;; the end result of this function should simply be empty, as everything
+        ;; here can be vacuumed away.
+        (block (result (rtt 1 ${}))
+          (rtt.sub ${}
+            (rtt.canon ${})
+          )
+        )
+        (unreachable)
       )
     )
   )


### PR DESCRIPTION
Found by the fuzzer. Calling makeZero on an rtt with depth will
error because we try to create a zero Literal from it, and we can't
do that - we don't know a list of super types to give it. We could
work around it, but we don't want to: if the rtt has depth then we
can't make a nice zero for it, we'd need some rtt.subs anyhow,
so simply mark it as a type we can't make a zero for.