### PR TITLE
[OptimizeInstructions] Combine some relational ops joined Or/And (Part 1)

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -773,11 +773,6 @@ struct OptimizeInstructions
       }
     }
     if (curr->op == AndInt32 || curr->op == OrInt32) {
-      // bitwise operations
-      // for and and or, we can potentially conditionalize
-      if (auto* ret = conditionalizeExpensiveOnBitwise(curr)) {
-        return replaceCurrent(ret);
-      }
       if (curr->op == AndInt32) {
         if (auto* ret = combineAnd(curr)) {
           return replaceCurrent(ret);
@@ -788,6 +783,11 @@ struct OptimizeInstructions
         if (auto* ret = combineOr(curr)) {
           return replaceCurrent(ret);
         }
+      }
+      // bitwise operations
+      // for and and or, we can potentially conditionalize
+      if (auto* ret = conditionalizeExpensiveOnBitwise(curr)) {
+        return replaceCurrent(ret);
       }
     }
     // relation/comparisons allow for math optimizations

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2493,7 +2493,6 @@ private:
 
   // We can combine `and` operations, e.g.
   //   (x == 0) & (y == 0)   ==>    (x | y) == 0
-  //   (x < 0) & (y < 0)     ==>    (x & y) < 0
   Expression* combineAnd(Binary* curr) {
     using namespace Abstract;
     using namespace Match;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -772,17 +772,22 @@ struct OptimizeInstructions
         return replaceCurrent(ret);
       }
     }
-    // bitwise operations
-    // for and and or, we can potentially conditionalize
     if (curr->op == AndInt32 || curr->op == OrInt32) {
+      // bitwise operations
+      // for and and or, we can potentially conditionalize
       if (auto* ret = conditionalizeExpensiveOnBitwise(curr)) {
         return replaceCurrent(ret);
       }
-    }
-    // for or, we can potentially combine
-    if (curr->op == OrInt32) {
-      if (auto* ret = combineOr(curr)) {
-        return replaceCurrent(ret);
+      if (curr->op == AndInt32) {
+        if (auto* ret = combineAnd(curr)) {
+          return replaceCurrent(ret);
+        }
+      }
+      // for or, we can potentially combine
+      if (curr->op == OrInt32) {
+        if (auto* ret = combineOr(curr)) {
+          return replaceCurrent(ret);
+        }
       }
     }
     // relation/comparisons allow for math optimizations
@@ -2484,6 +2489,28 @@ private:
       return builder.makeIf(
         left, right, builder.makeConst(Literal(int32_t(0))));
     }
+  }
+
+  // We can combine `and` operations, e.g.
+  //   (x == 0) & (y == 0)   ==>    (x | y) == 0
+  //   (x < 0) & (y < 0)     ==>    (x & y) < 0
+  Expression* combineAnd(Binary* curr) {
+    using namespace Abstract;
+    using namespace Match;
+    {
+      // (i32(x) == 0) & (i32(y) == 0)   ==>   i32(x | y) == 0
+      // (i64(x) == 0) & (i64(y) == 0)   ==>   i64(x | y) == 0
+      Expression *x, *y;
+      if (matches(curr,
+                  binary(AndInt32, unary(EqZ, any(&x)), unary(EqZ, any(&y)))) &&
+          x->type == y->type) {
+        auto* inner = curr->left->cast<Unary>();
+        inner->value = Builder(*getModule())
+                         .makeBinary(Abstract::getBinary(x->type, Or), x, y);
+        return inner;
+      }
+    }
+    return nullptr;
   }
 
   // We can combine `or` operations, e.g.

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -10971,6 +10971,37 @@
       )
     ))
   )
+
+  ;; CHECK:      (func $optimize-combined-by-and-equals-to-zero (param $x i32) (param $y i32) (param $a i64) (param $b i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (i32.or
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.eqz
+  ;; CHECK-NEXT:    (i64.or
+  ;; CHECK-NEXT:     (local.get $a)
+  ;; CHECK-NEXT:     (local.get $b)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $optimize-combined-by-and-equals-to-zero (param $x i32) (param $y i32) (param $a i64) (param $b i64)
+    ;; (i32(x) == 0) & (i32(y) == 0)   ==>   i32(x | y) == 0
+    (drop (i32.and
+      (i32.eq (local.get $x) (i32.const 0))
+      (i32.eq (local.get $y) (i32.const 0))
+    ))
+    ;; (i64(x) == 0) & (i64(y) == 0)   ==>   i64(x | y) == 0
+    (drop (i32.and
+      (i64.eq (local.get $a) (i64.const 0))
+      (i64.eq (local.get $b) (i64.const 0))
+    ))
+  )
   ;; CHECK:      (func $optimize-relationals (param $x i32) (param $y i32) (param $X i64) (param $Y i64)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eq


### PR DESCRIPTION
It's first part of #4265

```rust
(i32(x) == 0) & (i32(y) == 0)   ==>   i32(x | y) == 0
(i64(x) == 0) & (i64(y) == 0)   ==>   i64(x | y) == 0
```