### PR TITLE
Check for correct subtyping in the type fuzzer

### DIFF
--- a/src/tools/fuzzing/heap-types.h
+++ b/src/tools/fuzzing/heap-types.h
@@ -19,14 +19,27 @@
 
 #include "tools/fuzzing/random.h"
 #include "wasm-type.h"
+#include "wasm.h"
+#include <optional>
 #include <vector>
 
-namespace wasm::HeapTypeFuzzer {
+namespace wasm {
 
-// Generate a vector of `n` random HeapTypes with interesting subtyping.
-std::vector<HeapType>
-generateHeapTypes(Random& rand, FeatureSet features, size_t n);
+struct HeapTypeGenerator {
+  // The builder containing the randomly generated types.
+  TypeBuilder builder;
 
-} // namespace wasm::HeapTypeFuzzer
+  // The intended subtypes of each built type.
+  std::vector<std::vector<Index>> subtypeIndices;
+
+  // The intended supertype of each built type, if any.
+  std::vector<std::optional<Index>> supertypeIndices;
+
+  // Create a populated `HeapTypeGenerator` with `n` random HeapTypes with
+  // interesting subtyping.
+  static HeapTypeGenerator create(Random& rand, FeatureSet features, size_t n);
+};
+
+} // namespace wasm
 
 #endif // wasm_tools_fuzzing_heap_types_h

--- a/src/tools/wasm-fuzz-types.cpp
+++ b/src/tools/wasm-fuzz-types.cpp
@@ -70,8 +70,7 @@ struct Fuzzer {
   void checkSubtypes(const std::vector<HeapType>& types,
                      const std::vector<std::vector<Index>>& subtypeIndices) {
     for (size_t super = 0; super < types.size(); ++super) {
-      for (size_t j = 0; j < subtypeIndices[super].size(); ++j) {
-        size_t sub = subtypeIndices[super][j];
+      for (auto sub : subtypeIndices[super]) {
         if (!HeapType::isSubType(types[sub], types[super])) {
           Fatal() << "HeapType " << sub << " should be a subtype of HeapType "
                   << super << " but is not!\n"

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -559,8 +559,10 @@ struct TypeBuilder {
   ~TypeBuilder();
 
   TypeBuilder(TypeBuilder& other) = delete;
-  TypeBuilder(TypeBuilder&& other) = delete;
   TypeBuilder& operator=(TypeBuilder&) = delete;
+
+  TypeBuilder(TypeBuilder&& other);
+  TypeBuilder& operator=(TypeBuilder&& other);
 
   // Append `n` new uninitialized HeapType slots to the end of the TypeBuilder.
   void grow(size_t n);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2270,6 +2270,9 @@ TypeBuilder::TypeBuilder(size_t n) {
 
 TypeBuilder::~TypeBuilder() = default;
 
+TypeBuilder::TypeBuilder(TypeBuilder&& other) = default;
+TypeBuilder& TypeBuilder::operator=(TypeBuilder&& other) = default;
+
 void TypeBuilder::grow(size_t n) {
   assert(size() + n > size());
   impl->entries.resize(size() + n);


### PR DESCRIPTION
Check that types that were meant to have a subtype relationship actually do. To
expose the intended subtyping to the fuzzer, expose `subtypeIndices` in the
return value of the type generation function.