### PR TITLE
[NFC] Avoid unnecessary copies of PassOptions

### DIFF
--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -204,12 +204,12 @@ struct RequestInfoMap : public std::unordered_map<Expression*, RequestInfo> {
 
 struct Scanner
   : public LinearExecutionWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
-  PassOptions options;
+  PassOptions& options;
 
   // Request info for all expressions ever seen.
   RequestInfoMap& requestInfos;
 
-  Scanner(PassOptions options, RequestInfoMap& requestInfos)
+  Scanner(PassOptions& options, RequestInfoMap& requestInfos)
     : options(options), requestInfos(requestInfos) {}
 
   // Currently active hashed expressions in the current basic block. If we see
@@ -351,10 +351,10 @@ struct Scanner
 // make Applier ignore them.
 struct Checker
   : public LinearExecutionWalker<Checker, UnifiedExpressionVisitor<Checker>> {
-  PassOptions options;
+  PassOptions& options;
   RequestInfoMap& requestInfos;
 
-  Checker(PassOptions options, RequestInfoMap& requestInfos)
+  Checker(PassOptions& options, RequestInfoMap& requestInfos)
     : options(options), requestInfos(requestInfos) {}
 
   struct ActiveOriginalInfo {
@@ -529,7 +529,7 @@ struct LocalCSE : public WalkerPass<PostWalker<LocalCSE>> {
   Pass* create() override { return new LocalCSE(); }
 
   void doWalkFunction(Function* func) {
-    auto options = getPassOptions();
+    auto& options = getPassOptions();
 
     RequestInfoMap requestInfos;
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1129,7 +1129,7 @@ struct OptimizeInstructions
         // Otherwise, if this is not a tee, then no value falls through. The
         // ref.as_non_null acts as a null check here, basically. If we are
         // ignoring such traps, we can remove it.
-        auto passOptions = getPassOptions();
+        auto& passOptions = getPassOptions();
         if (passOptions.ignoreImplicitTraps || passOptions.trapsNeverHappen) {
           curr->value = as->value;
         }
@@ -1540,7 +1540,7 @@ struct OptimizeInstructions
     }
 
     Builder builder(*getModule());
-    auto passOptions = getPassOptions();
+    auto& passOptions = getPassOptions();
 
     auto fallthrough =
       Properties::getFallthrough(curr->ref, getPassOptions(), *getModule());
@@ -1869,7 +1869,7 @@ private:
     // assume things like local.get's of the same index being identical. (It is
     // also ok to have side effects here, if we can remove them, as we are also
     // checking if we can remove the two inputs anyhow.)
-    auto passOptions = getPassOptions();
+    auto& passOptions = getPassOptions();
     if (EffectAnalyzer(passOptions, *getModule(), left)
           .hasUnremovableSideEffects() ||
         EffectAnalyzer(passOptions, *getModule(), right)
@@ -3292,7 +3292,7 @@ private:
   }
 
   Expression* optimizeMemoryCopy(MemoryCopy* memCopy) {
-    PassOptions options = getPassOptions();
+    auto& options = getPassOptions();
 
     if (options.ignoreImplicitTraps || options.trapsNeverHappen) {
       if (ExpressionAnalyzer::equal(memCopy->dest, memCopy->source)) {
@@ -3371,7 +3371,7 @@ private:
       return nullptr;
     }
 
-    PassOptions options = getPassOptions();
+    auto& options = getPassOptions();
     Builder builder(*getModule());
 
     auto* csize = memFill->size->cast<Const>();


### PR DESCRIPTION
PassOptions is a fairly large structure and even includes a `std::map`. I also
have plans to add further fields there to make it even larger. Before doing that
I noticed that in some places we copy it instead of being consistent and taking
it by reference, which this PR fixes.
