### PR TITLE
[EH] Fix binary parsing for catchless try + inner delegate

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6345,13 +6345,6 @@ void WasmBinaryBuilder::visitTryOrTryInBlock(Expression*& out) {
   curr->type = getType();
   curr->body = getBlockOrSingleton(curr->type);
 
-  // try without catch or delegate
-  if (lastSeparator == BinaryConsts::End) {
-    curr->finalize();
-    out = curr;
-    return;
-  }
-
   Builder builder(wasm);
   // A nameless label shared by all catch body blocks
   Name catchLabel = getNextLabel();

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -8,7 +8,7 @@
   (func $foo)
   (func $bar)
 
-  (func $eh_test (local $x (i32 i64))
+  (func $eh-test (local $x (i32 i64))
     ;; Simple try-catch
     (try
       (do
@@ -313,7 +313,7 @@
     )
   )
 
-  (func $pop_test
+  (func $pop-test
     (try
       (do)
       (catch $e-i32
@@ -333,6 +333,21 @@
       (catch $e-anyref
         (drop
           (pop funcref) ;; pop can be subtype
+        )
+      )
+    )
+  )
+
+  (func $catchless-try-with-inner-delegate
+    (try $label$0
+      (do
+        (try
+          (do
+            (throw $e-i32
+              (i32.const 0)
+            )
+          )
+          (delegate $label$0)
         )
       )
     )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -15,7 +15,7 @@
  (func $bar
   (nop)
  )
- (func $eh_test
+ (func $eh-test
   (local $x (i32 i64))
   (try $try
    (do
@@ -353,7 +353,7 @@
    )
   )
  )
- (func $pop_test
+ (func $pop-test
   (try $try
    (do
     (nop)
@@ -375,6 +375,20 @@
    (catch $e-anyref
     (drop
      (pop funcref)
+    )
+   )
+  )
+ )
+ (func $catchless-try-with-inner-delegate
+  (try $label$0
+   (do
+    (try $try
+     (do
+      (throw $e-i32
+       (i32.const 0)
+      )
+     )
+     (delegate $label$0)
     )
    )
   )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -15,7 +15,7 @@
  (func $bar
   (nop)
  )
- (func $eh_test
+ (func $eh-test
   (local $x i32)
   (local $1 i64)
   (local $2 (i32 i64))
@@ -197,7 +197,7 @@
     )
    )
   )
-  (try
+  (try $label$37
    (do
     (throw $tag$0
      (i32.const 0)
@@ -382,7 +382,7 @@
    )
   )
  )
- (func $pop_test
+ (func $pop-test
   (try $label$5
    (do
     (nop)
@@ -404,6 +404,22 @@
    (catch $tag$3
     (drop
      (pop anyref)
+    )
+   )
+  )
+ )
+ (func $catchless-try-with-inner-delegate
+  (try $label$6
+   (do
+    (block $label$1
+     (try $label$4
+      (do
+       (throw $tag$0
+        (i32.const 0)
+       )
+      )
+      (delegate $label$6)
+     )
     )
    )
   )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -197,7 +197,7 @@
     )
    )
   )
-  (try
+  (try $label$37
    (do
     (throw $tag$0
      (i32.const 0)
@@ -404,6 +404,22 @@
    (catch $tag$3
     (drop
      (pop anyref)
+    )
+   )
+  )
+ )
+ (func $6
+  (try $label$6
+   (do
+    (block $label$1
+     (try $label$4
+      (do
+       (throw $tag$0
+        (i32.const 0)
+       )
+      )
+      (delegate $label$6)
+     )
     )
    )
   )


### PR DESCRIPTION
We do some postprocessing after parsing `Try` to make sure `delegate`
only targets `try`s and not `block`s:
https://github.com/WebAssembly/binaryen/blob/9659f9b07c1196447edee68fe04c8d7dd2480652/src/wasm/wasm-binary.cpp#L6404-L6426

But in case the outer `try` has neither of `catch` nor `delegate`, the
previous code just return prematurely, skipping the postprocessing part,
resulting in a binary parsing error. This PR removes that early-exiting
code.

Some test outputs have changed because `try`s are assigned labels after
the early exit. But those labels can be removed by other optimization
passes when there is no inner `rethrow` or `delegate` that targets them.

(On a side note, the restriction that `delegate` cannot target a `block`
has been removed a few months ago in the spec, so if a `delegate`
targets a `block`, it means it is just rethrown from that block. But I
still think this is a convenient invariant to hold at least within the
binaryen IR. I'm planning to allow parsing of `delegate` targeting
`block`s later, but I will make them point to `try` when read in the
IR. At the moment the LLVM toolchain does not generate such code.)