### PR TITLE
Do not track effects of immutable things

### DIFF
--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -612,7 +612,6 @@ void test_effects() {
     assert_equal(effects.readsArray, true);
     assert_equal(effects.writesArray, true);
     assert_equal(effects.readsMutableStruct, false);
-    assert_equal(effects.readsImmutableStruct, false);
     assert_equal(effects.writesStruct, false);
   }
 }


### PR DESCRIPTION
As suggested by @aheejin , we don't use those effects now in any way, and
if we need them some day we can add them back. For now they just add
overhead and complexity.