### PR TITLE
Fix a DeadArgumentElimination determinism bug

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -291,7 +291,7 @@ struct DAE : public Pass {
     // Scan all the functions.
     scanner.run(runner, module);
     // Combine all the info.
-    std::unordered_map<Name, std::vector<Call*>> allCalls;
+    std::map<Name, std::vector<Call*>> allCalls;
     std::unordered_set<Name> tailCallees;
     for (auto& [_, info] : infoMap) {
       for (auto& [name, calls] : info.calls) {


### PR DESCRIPTION
We iterate on that data structure in two loops, and the fuzzer found a case
where the difference in ordering actually ended up mattering in the output.

Doing it this way is actually faster when I tested it now, so this seems like a
win-win...