### PR TITLE
Allow fractional timeouts in wasm2js Atomics.wait. Followup to #4385

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -2860,7 +2860,7 @@ void Wasm2JSGlue::emitSpecialSupport() {
     if (timeoutHigh >= 0) {
       // Convert from nanoseconds to milliseconds
       // Taken from convertI32PairToI53 in emscripten's library_int53.js
-      timeout = ((timeoutLow / 1e6) >>> 0) + timeoutHigh * (4294967296 / 1e6);
+      timeout = ((timeoutLow >>> 0) / 1e6) + timeoutHigh * (4294967296 / 1e6);
     }
     var view = new Int32Array(bufferView.buffer); // TODO cache
     var result = Atomics.wait(view, ptr >> 2, expected, timeout);

--- a/test/wasm2js/atomics_32.2asm.js
+++ b/test/wasm2js/atomics_32.2asm.js
@@ -34,7 +34,7 @@ memorySegments[1] = base64DecodeToExistingUint8Array(new Uint8Array(6), 0, "d29y
     if (timeoutHigh >= 0) {
       // Convert from nanoseconds to milliseconds
       // Taken from convertI32PairToI53 in emscripten's library_int53.js
-      timeout = ((timeoutLow / 1e6) >>> 0) + timeoutHigh * (4294967296 / 1e6);
+      timeout = ((timeoutLow >>> 0) / 1e6) + timeoutHigh * (4294967296 / 1e6);
     }
     var view = new Int32Array(bufferView.buffer); // TODO cache
     var result = Atomics.wait(view, ptr >> 2, expected, timeout);

--- a/test/wasm2js/atomics_32.2asm.js.opt
+++ b/test/wasm2js/atomics_32.2asm.js.opt
@@ -34,7 +34,7 @@ memorySegments[1] = base64DecodeToExistingUint8Array(new Uint8Array(6), 0, "d29y
     if (timeoutHigh >= 0) {
       // Convert from nanoseconds to milliseconds
       // Taken from convertI32PairToI53 in emscripten's library_int53.js
-      timeout = ((timeoutLow / 1e6) >>> 0) + timeoutHigh * (4294967296 / 1e6);
+      timeout = ((timeoutLow >>> 0) / 1e6) + timeoutHigh * (4294967296 / 1e6);
     }
     var view = new Int32Array(bufferView.buffer); // TODO cache
     var result = Atomics.wait(view, ptr >> 2, expected, timeout);


### PR DESCRIPTION
Opening a quick PR for this so we don't forget - this is the kind of issue that
can be easily missed later as noticing the lack of fractional timeouts is very, very
hard...