### PR TITLE
Validate LUBs in the type fuzzer

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -420,6 +420,9 @@ public:
   // Return the ordered HeapType children, looking through child Types.
   std::vector<HeapType> getHeapTypeChildren();
 
+  // Return the LUB of two HeapTypes. The LUB always exists.
+  static HeapType getLeastUpperBound(HeapType a, HeapType b);
+
   std::string toString() const;
 };
 


### PR DESCRIPTION
Update the LUB calculation code to use std::optional rather than out params and
validate LUBs in the fuzzer to ensure that the change is NFC as intended. Also
add HeapType::getLeastUpperBound to the public API as a convenience.