### PR TITLE
[EH] Handle nested pops after inlining

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,3 +535,5 @@ Windows and OS X as most of the core devs are on Linux.
 [minification]: https://kripken.github.io/talks/binaryen.html#/2
 [unreachable]: https://github.com/WebAssembly/binaryen/issues/903
 [binaryen_ir]: https://github.com/WebAssembly/binaryen/issues/663
+
+

--- a/README.md
+++ b/README.md
@@ -535,5 +535,3 @@ Windows and OS X as most of the core devs are on Linux.
 [minification]: https://kripken.github.io/talks/binaryen.html#/2
 [unreachable]: https://github.com/WebAssembly/binaryen/issues/903
 [binaryen_ir]: https://github.com/WebAssembly/binaryen/issues/663
-
-

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -32,6 +32,7 @@
 
 #include "ir/branch-utils.h"
 #include "ir/debug.h"
+#include "ir/eh-utils.h"
 #include "ir/element-utils.h"
 #include "ir/literal-utils.h"
 #include "ir/module-utils.h"
@@ -878,6 +879,10 @@ struct Inlining : public Pass {
 #ifdef INLINING_DEBUG
       std::cout << "  inlined into " << inlinedInto.size() << " funcs.\n";
 #endif
+
+      for (auto* func : inlinedInto) {
+        EHUtils::handleBlockNestedPops(func, *module);
+      }
 
       for (auto* func : inlinedInto) {
         if (++iterationCounts[func->name] >= MaxIterationsForFunc) {

--- a/test/lit/passes/inlining-eh.wast
+++ b/test/lit/passes/inlining-eh.wast
@@ -76,7 +76,7 @@
   )
 
   ;; ---------------------------------------------------------------------------
-  (func $callee (result i32)
+  (func $callee-a (result i32)
     (i32.const 42)
   )
 
@@ -90,7 +90,7 @@
   ;; CHECK-NEXT:   (delegate 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (block (result i32)
-  ;; CHECK-NEXT:   (block $__inlined_func$callee (result i32)
+  ;; CHECK-NEXT:   (block $__inlined_func$callee-a (result i32)
   ;; CHECK-NEXT:    (i32.const 42)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -100,6 +100,47 @@
       (do)
       (delegate 0)
     )
-    (call $callee)
+    (call $callee-a)
+  )
+
+
+  ;; ---------------------------------------------------------------------------
+  (func $callee-b (param i32))
+
+  ;; CHECK:      (func $caller-with-pop
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (try $try
+  ;; CHECK-NEXT:   (do
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (catch $tag$0
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (pop i32)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block
+  ;; CHECK-NEXT:     (block $__inlined_func$callee-b
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (nop)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $caller-with-pop
+    (try
+      (do)
+      (catch $tag$0
+        ;; After this $callee-b is inlined, there will be additional 'block's
+        ;; surrouding this 'pop', which makes its location invalid. We fix it by
+        ;; creating a new local to set the result of 'pop' and later use
+        ;; local.get to get the value within the inlined function body.
+        (call $callee-b
+          (pop i32)
+        )
+      )
+    )
   )
 )


### PR DESCRIPTION
Inlining creates additional `block`s at inlined call sites, which can be
inside a `catch`. For example:
```wast
(try
  (do)
  (catch $tag
    (call $callee
      (pop i32)
    )
  )
)
```

After inlining, this becomes
```wast
(try
  (do)
  (catch $tag
    (block $__inlined_func$callee
      (local.set $0
        (pop i32) ;; Invalid!!
      )
    (nop)
    )
  )
)
```

Now the `pop` is nested in a `block`, which makes this invalid. This PR
runs `EHUtils::handleBlockNestedPops` at the end to assign the `pop` to
a local right after the `catch`, making the code valid again:
```wast
(try
  (do)
  (catch $tag
    (local.set $new ;; New local to store `pop` result
      (pop i32)
    )
    (block $__inlined_func$callee
      (local.set $0
        (local.get $new)
      )
    (nop)
    )
  )
)
```