### PR TITLE
[Fuzzer] Allow empty data in --translate-to-fuzz

### DIFF
--- a/src/tools/fuzzing/random.cpp
+++ b/src/tools/fuzzing/random.cpp
@@ -20,8 +20,8 @@
 
 namespace wasm {
 
-Random::Random(std::vector<char>&& bytes, FeatureSet features)
-  : bytes(std::move(bytes)), features(features) {
+Random::Random(std::vector<char>&& bytes_, FeatureSet features)
+  : bytes(std::move(bytes_)), features(features) {
   // Ensure there is *some* input to be read.
   if (bytes.empty()) {
     bytes.push_back(0);

--- a/test/unit/test_fuzz_empty_data.py
+++ b/test/unit/test_fuzz_empty_data.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import tempfile
 from scripts.test import shared
 from . import utils
@@ -7,6 +6,9 @@ from . import utils
 
 class EmptyDataFuzzTest(utils.BinaryenTestCase):
     def test_empty_data(self):
-        with tempfile.NamedTemporaryFile() as f:
-            shared.run_process(shared.WASM_OPT + ['-ttf', f.name],
+        try:
+            temp = tempfile.NamedTemporaryFile(delete=False).name
+            shared.run_process(shared.WASM_OPT + ['-ttf', temp],
                                capture_output=True)
+        finally:
+            os.unlink(temp)

--- a/test/unit/test_fuzz_empty_data.py
+++ b/test/unit/test_fuzz_empty_data.py
@@ -1,0 +1,12 @@
+import os
+import subprocess
+import tempfile
+from scripts.test import shared
+from . import utils
+
+
+class EmptyDataFuzzTest(utils.BinaryenTestCase):
+    def test_empty_data(self):
+        with tempfile.NamedTemporaryFile() as f:
+            shared.run_process(shared.WASM_OPT + ['-ttf', f.name],
+                               capture_output=True)


### PR DESCRIPTION
When a parameter and a member variable have the same name within a
constructor, to access (and change) the member variable, we need to
either use `this->` or change the name of the parameter. The current
code ended up changing the parameter and didn't affect the status of the
member variable, which remained empty.