### PR TITLE
Fix emscripten build by removing dummy atexit function

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4617,10 +4617,6 @@ void BinaryenSetColorsEnabled(bool enabled) { Colors::setEnabled(enabled); }
 bool BinaryenAreColorsEnabled() { return Colors::isEnabled(); }
 
 #ifdef __EMSCRIPTEN__
-// Override atexit - we don't need any global ctors to actually run, and
-// otherwise we get clutter in the output in debug builds
-int atexit(void (*function)(void)) { return 0; }
-
 // Internal binaryen.js APIs
 
 // Returns the size of a Literal object.


### PR DESCRIPTION
Since https://github.com/emscripten-core/emscripten/pull/15905 landed
emscripten now includes its own dummy atexit function when building with
EXIT_RUNTIME=0.

This dummy function conflicts with the emscripten-provided one:

```
wasm-ld: error: duplicate symbol: atexit
>>> defined in CMakeFiles/binaryen_wasm.dir/src/binaryen-c.cpp.o
>>> defined in ...wasm32-emscripten/lto/libnoexit.a(atexit_dummy.o)
```

Normally overriding symbols from libc does not causes issues but one
needs to be sure to override all the symbols in a given object file so
that the object in question (atexit_dummy.o) does not get linked in.  In
this case some other symbol being defined in in atexit_dummy.o (e.g.
__cxa_atexit) is likely the cause of the conflict.

Overriding symbols from libc is likely to break in this way as the libc
evolves, and since emscripten is now providing a dummy, just as we want,
its better/safer to simply remove our dummy.