### PR TITLE
Escape \t as well as \n when writing JSON output.

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -79,6 +79,11 @@ std::string escape(std::string code) {
     code = code.replace(curr, 2, "\\\\n");
     curr += 3; // skip this one
   }
+  curr = 0;
+  while ((curr = code.find("\\t", curr)) != std::string::npos) {
+    code = code.replace(curr, 2, "\\\\t");
+    curr += 3; // skip this one
+  }
   // replace double quotes with escaped single quotes
   curr = 0;
   while ((curr = code.find('"', curr)) != std::string::npos) {

--- a/test/lld/em_asm.cpp
+++ b/test/lld/em_asm.cpp
@@ -1,7 +1,7 @@
 #include <emscripten/em_asm.h>
 
 int main() {
-  EM_ASM({ Module.print("Hello world"); });
+  EM_ASM({ Module.print("Hello \\ world\t\n"); });
   int x = EM_ASM_INT({ return $0 + $1; }, 13, 27);
   EM_ASM_({ Module.print("Got " + $0); }, x);
   return 0;

--- a/test/lld/em_asm.wat
+++ b/test/lld/em_asm.wat
@@ -6,11 +6,11 @@
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (memory $0 2)
  (data $.rodata (i32.const 568) "\00ii\00i\00")
- (data $em_asm (i32.const 574) "{ Module.print(\"Hello world\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
+ (data $em_asm (i32.const 574) "{ Module.print(\"Hello \\\\ world\\t\\n\"); }\00{ return $0 + $1; }\00{ Module.print(\"Got \" + $0); }\00")
  (table $0 1 1 funcref)
  (global $__stack_pointer (mut i32) (i32.const 66208))
  (global $global$1 i32 (i32.const 574))
- (global $global$2 i32 (i32.const 658))
+ (global $global$2 i32 (i32.const 665))
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
@@ -42,7 +42,7 @@
   (i32.store
    (local.get $0)
    (call $emscripten_asm_const_int
-    (i32.const 607)
+    (i32.const 614)
     (i32.const 569)
     (i32.add
      (local.get $0)
@@ -52,7 +52,7 @@
   )
   (drop
    (call $emscripten_asm_const_int
-    (i32.const 627)
+    (i32.const 634)
     (i32.const 572)
     (local.get $0)
    )

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -6,7 +6,7 @@
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (global $__stack_pointer (mut i32) (i32.const 66208))
  (global $global$1 i32 (i32.const 574))
- (global $global$2 i32 (i32.const 658))
+ (global $global$2 i32 (i32.const 665))
  (memory $0 2)
  (table $0 1 1 funcref)
  (export "memory" (memory $0))
@@ -39,7 +39,7 @@
   (i32.store
    (local.get $0)
    (call $emscripten_asm_const_int
-    (i32.const 607)
+    (i32.const 614)
     (i32.const 569)
     (i32.add
      (local.get $0)
@@ -49,7 +49,7 @@
   )
   (drop
    (call $emscripten_asm_const_int
-    (i32.const 627)
+    (i32.const 634)
     (i32.const 572)
     (local.get $0)
    )
@@ -70,9 +70,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "574": "{ Module.print(\"Hello world\"); }",
-    "607": "{ return $0 + $1; }",
-    "627": "{ Module.print(\"Got \" + $0); }"
+    "574": "{ Module.print(\"Hello \\ world\\t\\n\"); }",
+    "614": "{ return $0 + $1; }",
+    "634": "{ Module.print(\"Got \" + $0); }"
   },
   "declares": [
     "emscripten_asm_const_int"

--- a/test/lld/em_asm.wat.out
+++ b/test/lld/em_asm.wat.out
@@ -6,7 +6,7 @@
  (import "env" "emscripten_asm_const_int" (func $emscripten_asm_const_int (param i32 i32 i32) (result i32)))
  (global $__stack_pointer (mut i32) (i32.const 66208))
  (global $global$1 i32 (i32.const 574))
- (global $global$2 i32 (i32.const 658))
+ (global $global$2 i32 (i32.const 665))
  (memory $0 2)
  (data $.rodata (i32.const 568) "\00ii\00i\00")
  (data $em_asm (i32.const 574) "")
@@ -41,7 +41,7 @@
   (i32.store
    (local.get $0)
    (call $emscripten_asm_const_int
-    (i32.const 607)
+    (i32.const 614)
     (i32.const 569)
     (i32.add
      (local.get $0)
@@ -51,7 +51,7 @@
   )
   (drop
    (call $emscripten_asm_const_int
-    (i32.const 627)
+    (i32.const 634)
     (i32.const 572)
     (local.get $0)
    )
@@ -72,9 +72,9 @@
 --BEGIN METADATA --
 {
   "asmConsts": {
-    "574": "{ Module.print(\"Hello world\"); }",
-    "607": "{ return $0 + $1; }",
-    "627": "{ Module.print(\"Got \" + $0); }"
+    "574": "{ Module.print(\"Hello \\ world\\t\\n\"); }",
+    "614": "{ return $0 + $1; }",
+    "634": "{ Module.print(\"Got \" + $0); }"
   },
   "declares": [
     "emscripten_asm_const_int"


### PR DESCRIPTION
As it happens, this doesn't (normally) break the resulting EM_ASM or
EM_JS strings because (IIUC) JS supports the tab literal inside of
strings as well as "\t".

However, it's better to preserve the original text so that it looks
the same in the JS file as it did in the original source.