### PR TITLE
SafeHeap: Avoid instrumenting functions directly called from the "start"

### DIFF
--- a/test/passes/safe-heap_start-function.txt
+++ b/test/passes/safe-heap_start-function.txt
@@ -13,7 +13,16 @@
  (import "env" "segfault" (func $segfault))
  (import "env" "alignfault" (func $alignfault))
  (memory $0 1 1)
- (start $foo)
+ (start $mystart)
+ (func $mystart
+  (i32.store
+   (i32.load
+    (i32.const 42)
+   )
+   (i32.const 43)
+  )
+  (call $foo)
+ )
  (func $foo
   (i32.store
    (i32.load

--- a/test/passes/safe-heap_start-function.wast
+++ b/test/passes/safe-heap_start-function.wast
@@ -1,11 +1,16 @@
 (module
   (memory 1 1)
-  (func $foo
+  (func $mystart
    ;; should not be modified because its the start function
+   (i32.store (i32.load (i32.const 42)) (i32.const 43))
+   (call $foo)
+  )
+  (func $foo
+   ;; should not be modified because its called from the start function
    (i32.store (i32.load (i32.const 1234)) (i32.const 5678))
   )
   (func $bar
    (i32.store (i32.load (i32.const 1234)) (i32.const 5678))
   )
-  (start $foo)
+  (start $mystart)
 )


### PR DESCRIPTION
The `__wasm_memory_init` function is not always used as the start
function.  Sometimes it is just one of a sequence of functions that are
called from the start function.  In order to handle this case we can
instead avoid instrumenting the start function as well as any functions
call from it.

This fixes the SAFE_HEAP + USE_PTHREADS + MAIN_MODULE configuration
which is currently broken in emscripten.