### PR TITLE
[ctor-eval] Add an option to keep some exports

### DIFF
--- a/auto_update_tests.py
+++ b/auto_update_tests.py
@@ -89,6 +89,8 @@ def update_ctor_eval_tests():
         cmd = shared.WASM_CTOR_EVAL + [t, '-all', '-o', 'a.wast', '-S', '--ctors', ctors]
         if 'ignore-external-input' in t:
             cmd += ['--ignore-external-input']
+        if 'results' in t:
+            cmd += ['--kept-exports', 'test1,test3']
         support.run_command(cmd)
         actual = open('a.wast').read()
         out = t + '.out'

--- a/check.py
+++ b/check.py
@@ -118,6 +118,8 @@ def run_ctor_eval_tests():
         cmd = shared.WASM_CTOR_EVAL + [t, '-all', '-o', 'a.wat', '-S', '--ctors', ctors]
         if 'ignore-external-input' in t:
             cmd += ['--ignore-external-input']
+        if 'results' in t:
+            cmd += ['--kept-exports', 'test1,test3']
         support.run_command(cmd)
         actual = open('a.wat').read()
         out = t + '.out'

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -640,8 +640,11 @@ bool evalCtor(EvallingModuleInstance& instance,
 }
 
 // Eval all ctors in a module.
-void evalCtors(Module& wasm, std::vector<std::string>& ctors, std::vector<std::string>& keptExports) {
-  std::unordered_set<std::string> keptExportsSet(keptExports.begin(), keptExports.end());
+void evalCtors(Module& wasm,
+               std::vector<std::string>& ctors,
+               std::vector<std::string>& keptExports) {
+  std::unordered_set<std::string> keptExportsSet(keptExports.begin(),
+                                                 keptExports.end());
 
   std::map<Name, std::shared_ptr<EvallingModuleInstance>> linkedInstances;
 
@@ -743,13 +746,14 @@ int main(int argc, const char* argv[]) {
          WasmCtorEvalOption,
          Options::Arguments::Zero,
          [&](Options* o, const std::string& arguments) { debugInfo = true; })
-    .add(
-      "--ctors",
-      "-c",
-      "Comma-separated list of global constructor functions to evaluate",
-      WasmCtorEvalOption,
-      Options::Arguments::One,
-      [&](Options* o, const std::string& argument) { ctors =  String::Split(argument, ","); })
+    .add("--ctors",
+         "-c",
+         "Comma-separated list of global constructor functions to evaluate",
+         WasmCtorEvalOption,
+         Options::Arguments::One,
+         [&](Options* o, const std::string& argument) {
+           ctors = String::Split(argument, ",");
+         })
     .add(
       "--kept-exports",
       "-ke",
@@ -757,7 +761,9 @@ int main(int argc, const char* argv[]) {
       "eval those ctors",
       WasmCtorEvalOption,
       Options::Arguments::One,
-      [&](Options* o, const std::string& argument) { keptExports = String::Split(argument, ","); })
+      [&](Options* o, const std::string& argument) {
+        keptExports = String::Split(argument, ",");
+      })
     .add("--ignore-external-input",
          "-ipi",
          "Assumes no env vars are to be read, stdin is empty, etc.",

--- a/test/ctor-eval/results.wast
+++ b/test/ctor-eval/results.wast
@@ -1,6 +1,7 @@
 (module
-  (global $global1 (mut i32) (i32.const 0))
-  (global $global2 (mut i32) (i32.const 1))
+  (global $global1 (mut i32) (i32.const 1))
+  (global $global2 (mut i32) (i32.const 2))
+  (global $global3 (mut i32) (i32.const 3))
 
   (func $test1 (export "test1")
     ;; This function can be evalled. But in this test we keep this export,
@@ -11,20 +12,23 @@
     ;; (constant) result in the remaining export once we can handle results.
 
     (global.set $global1
-      (i32.const 2)
+      (i32.const 11)
     )
   )
 
   (func $test2 (export "test2")
     ;; As the above function, but the export is *not* kept.
     (global.set $global2
-      (i32.const 3)
+      (i32.const 12)
     )
   )
 
   (func $test3 (export "test3") (result i32)
     ;; The presence of a result stops us from evalling this function (at least
-    ;; for now).
+    ;; for now). Not even the global set will be evalled.
+    (global.set $global3
+      (i32.const 13)
+    )
     (i32.const 42)
   )
 
@@ -41,7 +45,7 @@
     )
 
     ;; Keeping these alive should show the changes to the globals (that should
-    ;; contain 2 and 3).
+    ;; contain 11, 12, and 3).
     (i32.add
       (global.get $global1)
       (global.get $global2)

--- a/test/ctor-eval/results.wast
+++ b/test/ctor-eval/results.wast
@@ -2,7 +2,7 @@
   (global $global1 (mut i32) (i32.const 0))
   (global $global2 (mut i32) (i32.const 1))
 
-  (func "test1"
+  (func $test1 (export "test1")
     ;; This function can be evalled. But in this test we keep this export,
     ;; so we should still see an export, but the export should do nothing since
     ;; the code has already run.
@@ -15,20 +15,33 @@
     )
   )
 
-  (func "test2"
+  (func $test2 (export "test2")
     ;; As the above function, but the export is *not* kept.
     (global.set $global2
       (i32.const 3)
     )
   )
 
-  (func "test3" (result i32)
+  (func $test3 (export "test3") (result i32)
     ;; The presence of a result stops us from evalling this function (at least
     ;; for now).
     (i32.const 42)
   )
 
   (func "keepalive" (result i32)
+    ;; Keep everything alive to see the changes.
+
+    ;; These should call the original $test1, not the one that is nopped out
+    ;; after evalling.
+    (call $test1)
+    (call $test2)
+
+    (drop
+      (call $test3)
+    )
+
+    ;; Keeping these alive should show the changes to the globals (that should
+    ;; contain 2 and 3).
     (i32.add
       (global.get $global1)
       (global.get $global2)

--- a/test/ctor-eval/results.wast
+++ b/test/ctor-eval/results.wast
@@ -1,7 +1,37 @@
 (module
-  (func "test1" (result i32)
+  (global $global1 (mut i32) (i32.const 0))
+  (global $global2 (mut i32) (i32.const 1))
+
+  (func "test1"
+    ;; This function can be evalled. But in this test we keep this export,
+    ;; so we should still see an export, but the export should do nothing since
+    ;; the code has already run.
+    ;;
+    ;; In comparison, test3 below, with a result, will still contain a
+    ;; (constant) result in the remaining export once we can handle results.
+
+    (global.set $global1
+      (i32.const 2)
+    )
+  )
+
+  (func "test2"
+    ;; As the above function, but the export is *not* kept.
+    (global.set $global2
+      (i32.const 3)
+    )
+  )
+
+  (func "test3" (result i32)
     ;; The presence of a result stops us from evalling this function (at least
     ;; for now).
     (i32.const 42)
+  )
+
+  (func "keepalive" (result i32)
+    (i32.add
+      (global.get $global1)
+      (global.get $global2)
+    )
   )
 )

--- a/test/ctor-eval/results.wast.ctors
+++ b/test/ctor-eval/results.wast.ctors
@@ -1,1 +1,1 @@
-test1
+test1,test2,test3

--- a/test/ctor-eval/results.wast.out
+++ b/test/ctor-eval/results.wast.out
@@ -1,21 +1,36 @@
 (module
- (type $none_=>_i32 (func (result i32)))
  (type $none_=>_none (func))
+ (type $none_=>_i32 (func (result i32)))
  (global $global1 (mut i32) (i32.const 2))
  (global $global2 (mut i32) (i32.const 3))
- (export "test1" (func $0_0))
- (export "test3" (func $2))
+ (export "test1" (func $test1_0))
+ (export "test3" (func $test3))
  (export "keepalive" (func $3))
- (func $2 (result i32)
+ (func $test1
+  (global.set $global1
+   (i32.const 2)
+  )
+ )
+ (func $test2
+  (global.set $global2
+   (i32.const 3)
+  )
+ )
+ (func $test3 (result i32)
   (i32.const 42)
  )
  (func $3 (result i32)
+  (call $test1)
+  (call $test2)
+  (drop
+   (call $test3)
+  )
   (i32.add
    (global.get $global1)
    (global.get $global2)
   )
  )
- (func $0_0
+ (func $test1_0
   (nop)
  )
 )

--- a/test/ctor-eval/results.wast.out
+++ b/test/ctor-eval/results.wast.out
@@ -1,22 +1,26 @@
 (module
  (type $none_=>_none (func))
  (type $none_=>_i32 (func (result i32)))
- (global $global1 (mut i32) (i32.const 2))
- (global $global2 (mut i32) (i32.const 3))
+ (global $global1 (mut i32) (i32.const 11))
+ (global $global2 (mut i32) (i32.const 12))
+ (global $global3 (mut i32) (i32.const 3))
  (export "test1" (func $test1_0))
  (export "test3" (func $test3))
  (export "keepalive" (func $3))
  (func $test1
   (global.set $global1
-   (i32.const 2)
+   (i32.const 11)
   )
  )
  (func $test2
   (global.set $global2
-   (i32.const 3)
+   (i32.const 12)
   )
  )
  (func $test3 (result i32)
+  (global.set $global3
+   (i32.const 13)
+  )
   (i32.const 42)
  )
  (func $3 (result i32)

--- a/test/ctor-eval/results.wast.out
+++ b/test/ctor-eval/results.wast.out
@@ -1,7 +1,21 @@
 (module
  (type $none_=>_i32 (func (result i32)))
- (export "test1" (func $0))
- (func $0 (result i32)
+ (type $none_=>_none (func))
+ (global $global1 (mut i32) (i32.const 2))
+ (global $global2 (mut i32) (i32.const 3))
+ (export "test1" (func $0_0))
+ (export "test3" (func $2))
+ (export "keepalive" (func $3))
+ (func $2 (result i32)
   (i32.const 42)
+ )
+ (func $3 (result i32)
+  (i32.add
+   (global.get $global1)
+   (global.get $global2)
+  )
+ )
+ (func $0_0
+  (nop)
  )
 )

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -19,6 +19,10 @@
 ;; CHECK-NEXT:   --ctors,-c                           Comma-separated list of global
 ;; CHECK-NEXT:                                        constructor functions to evaluate
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --kept-exports,-ke                   Comma-separated list of ctors whose
+;; CHECK-NEXT:                                        exports we keep around even if we eval
+;; CHECK-NEXT:                                        those ctors
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --ignore-external-input,-ipi         Assumes no env vars are to be read, stdin
 ;; CHECK-NEXT:                                        is empty, etc.
 ;; CHECK-NEXT:


### PR DESCRIPTION
By default wasm-ctor-eval removes exports that it manages to completely
eval (if it just partially evals then the export remains, but points to a function
with partially-evalled contents). However, in some cases we do want to keep
the export around even so, for example during fuzzing (as the fuzzer wants
to call the same exports before and after wasm-ctor-eval runs) and also
if there is an ABI we need to preserve (like if we manage to eval all of
`main()`), or if the function returns a value (which we don't support yet, but
this is a PR to prepare for that).

Specifically, there is now a new option:

```
--kept-exports foo,bar
```

That is a list of exports to keep around.

Note that when we keep around an export after evalling the ctor we
make the export point to a new function. That new function just
contains a nop, so that nothing happens when it is called. But the
original function is kept around as it may have other callers, who we
do not want to modify.