### PR TITLE
LiteralList => Literals

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -133,7 +133,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
     });
   }
 
-  Literals callImport(Function* import, LiteralList& arguments) override {
+  Literals callImport(Function* import, Literals& arguments) override {
     if (import->module == SPECTEST && import->base.startsWith(PRINT)) {
       for (auto argument : arguments) {
         std::cout << argument << " : " << argument.type << '\n';
@@ -153,7 +153,7 @@ struct ShellExternalInterface : ModuleInstance::ExternalInterface {
   Literals callTable(Name tableName,
                      Index index,
                      HeapType sig,
-                     LiteralList& arguments,
+                     Literals& arguments,
                      Type results,
                      ModuleInstance& instance) override {
 

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -119,6 +119,16 @@ public:
     }
   }
 
+  void reserve(size_t reservedSize) {
+    if (reservedSize > N) {
+      flexible.reserve(reservedSize - N);
+    }
+  }
+
+  void capacity() const {
+    return N + flexible.capacity();
+  }
+
   bool operator==(const SmallVector<T, N>& other) const {
     if (usedFixed != other.usedFixed) {
       return false;

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -125,9 +125,7 @@ public:
     }
   }
 
-  void capacity() const {
-    return N + flexible.capacity();
-  }
+  void capacity() const { return N + flexible.capacity(); }
 
   bool operator==(const SmallVector<T, N>& other) const {
     if (usedFixed != other.usedFixed) {

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -125,7 +125,7 @@ public:
     }
   }
 
-  void capacity() const { return N + flexible.capacity(); }
+  size_t capacity() const { return N + flexible.capacity(); }
 
   bool operator==(const SmallVector<T, N>& other) const {
     if (usedFixed != other.usedFixed) {

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -39,7 +39,7 @@ struct LoggingExternalInterface : public ShellExternalInterface {
 
   LoggingExternalInterface(Loggings& loggings) : loggings(loggings) {}
 
-  Literals callImport(Function* import, LiteralList& arguments) override {
+  Literals callImport(Function* import, Literals& arguments) override {
     if (import->module == "fuzzing-support") {
       std::cout << "[LoggingExternalInterface logging";
       loggings.push_back(Literal()); // buffer with a None between calls
@@ -239,7 +239,7 @@ struct ExecutionResults {
 
   FunctionResult run(Function* func, Module& wasm, ModuleInstance& instance) {
     try {
-      LiteralList arguments;
+      Literals arguments;
       // init hang support, if present
       if (auto* ex = wasm.getExportOrNull("hangLimitInitializer")) {
         instance.callFunction(ex->value, arguments);

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -256,7 +256,7 @@ struct CtorEvalExternalInterface : EvallingModuleInstance::ExternalInterface {
     });
   }
 
-  Literals callImport(Function* import, LiteralList& arguments) override {
+  Literals callImport(Function* import, Literals& arguments) override {
     Name WASI("wasi_snapshot_preview1");
 
     if (ignoreExternalInput) {
@@ -324,7 +324,7 @@ struct CtorEvalExternalInterface : EvallingModuleInstance::ExternalInterface {
   Literals callTable(Name tableName,
                      Index index,
                      HeapType sig,
-                     LiteralList& arguments,
+                     Literals& arguments,
                      Type result,
                      EvallingModuleInstance& instance) override {
 
@@ -524,7 +524,7 @@ EvalCtorOutcome evalCtor(EvallingModuleInstance& instance,
   //        1. Statically or dynamically stop evalling when a param is actually
   //           used, or
   //        2. Split out --ignore-external-input into separate flags.
-  LiteralList params;
+  Literals params;
   for (Index i = 0; i < func->getNumParams(); i++) {
     auto type = func->getLocalType(i);
     if (!LiteralUtils::canMakeZero(type)) {

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -179,7 +179,7 @@ protected:
     Name base = s[i++]->str();
 
     if (s[0]->str() == INVOKE) {
-      LiteralList args;
+      Literals args;
       while (i < s.size()) {
         Expression* argument = builders[moduleName]->parseExpression(*s[i++]);
         args.push_back(getLiteralFromConstExpression(argument));

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -162,8 +162,7 @@ protected:
   // Maximum iterations before giving up on a loop.
   Index maxLoopIterations;
 
-  Flow generateArguments(const ExpressionList& operands,
-                         Literals& arguments) {
+  Flow generateArguments(const ExpressionList& operands, Literals& arguments) {
     NOTE_ENTER_("generateArguments");
     arguments.reserve(operands.size());
     for (auto expression : operands) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -98,9 +98,6 @@ public:
   }
 };
 
-// A list of literals, for function calls
-typedef std::vector<Literal> LiteralList;
-
 // Debugging helpers
 #ifdef WASM_INTERPRETER_DEBUG
 class Indenter {
@@ -166,7 +163,7 @@ protected:
   Index maxLoopIterations;
 
   Flow generateArguments(const ExpressionList& operands,
-                         LiteralList& arguments) {
+                         Literals& arguments) {
     NOTE_ENTER_("generateArguments");
     arguments.reserve(operands.size());
     for (auto expression : operands) {
@@ -1284,7 +1281,7 @@ public:
   }
   Flow visitTupleMake(TupleMake* curr) {
     NOTE_ENTER("tuple.make");
-    LiteralList arguments;
+    Literals arguments;
     Flow flow = generateArguments(curr->operands, arguments);
     if (flow.breaking()) {
       return flow;
@@ -1384,7 +1381,7 @@ public:
   Flow visitTry(Try* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitThrow(Throw* curr) {
     NOTE_ENTER("Throw");
-    LiteralList arguments;
+    Literals arguments;
     Flow flow = generateArguments(curr->operands, arguments);
     if (flow.breaking()) {
       return flow;
@@ -2306,11 +2303,11 @@ public:
     virtual ~ExternalInterface() = default;
     virtual void init(Module& wasm, SubType& instance) {}
     virtual void importGlobals(GlobalManager& globals, Module& wasm) = 0;
-    virtual Literals callImport(Function* import, LiteralList& arguments) = 0;
+    virtual Literals callImport(Function* import, Literals& arguments) = 0;
     virtual Literals callTable(Name tableName,
                                Index index,
                                HeapType sig,
-                               LiteralList& arguments,
+                               Literals& arguments,
                                Type result,
                                SubType& instance) = 0;
     virtual bool growMemory(Address oldSize, Address newSize) = 0;
@@ -2510,13 +2507,13 @@ public:
 
     // run start, if present
     if (wasm.start.is()) {
-      LiteralList arguments;
+      Literals arguments;
       callFunction(wasm.start, arguments);
     }
   }
 
   // call an exported function
-  Literals callExport(Name name, const LiteralList& arguments) {
+  Literals callExport(Name name, const Literals& arguments) {
     Export* export_ = wasm.getExportOrNull(name);
     if (!export_) {
       externalInterface->trap("callExport not found");
@@ -2524,7 +2521,7 @@ public:
     return callFunction(export_->value, arguments);
   }
 
-  Literals callExport(Name name) { return callExport(name, LiteralList()); }
+  Literals callExport(Name name) { return callExport(name, Literals()); }
 
   // get an exported global
   Literals getExport(Name name) {
@@ -2659,7 +2656,7 @@ public:
     std::vector<Literals> locals;
     Function* function;
 
-    FunctionScope(Function* function, const LiteralList& arguments)
+    FunctionScope(Function* function, const Literals& arguments)
       : function(function) {
       if (function->getParams().size() != arguments.size()) {
         std::cerr << "Function `" << function->name << "` expects "
@@ -2731,7 +2728,7 @@ public:
     Flow visitCall(Call* curr) {
       NOTE_ENTER("Call");
       NOTE_NAME(curr->target);
-      LiteralList arguments;
+      Literals arguments;
       Flow flow = this->generateArguments(curr->operands, arguments);
       if (flow.breaking()) {
         return flow;
@@ -2755,7 +2752,7 @@ public:
 
     Flow visitCallIndirect(CallIndirect* curr) {
       NOTE_ENTER("CallIndirect");
-      LiteralList arguments;
+      Literals arguments;
       Flow flow = this->generateArguments(curr->operands, arguments);
       if (flow.breaking()) {
         return flow;
@@ -2780,7 +2777,7 @@ public:
     }
     Flow visitCallRef(CallRef* curr) {
       NOTE_ENTER("CallRef");
-      LiteralList arguments;
+      Literals arguments;
       Flow flow = this->generateArguments(curr->operands, arguments);
       if (flow.breaking()) {
         return flow;
@@ -3555,7 +3552,7 @@ public:
   };
 
   // Call a function, starting an invocation.
-  Literals callFunction(Name name, const LiteralList& arguments) {
+  Literals callFunction(Name name, const Literals& arguments) {
     // if the last call ended in a jump up the stack, it might have left stuff
     // for us to clean up here
     callDepth = 0;
@@ -3565,7 +3562,7 @@ public:
 
   // Internal function call. Must be public so that callTable implementations
   // can use it (refactor?)
-  Literals callFunctionInternal(Name name, const LiteralList& arguments) {
+  Literals callFunctionInternal(Name name, const Literals& arguments) {
     if (callDepth > maxDepth) {
       externalInterface->trap("stack limit");
     }

--- a/test/example/small_vector.cpp
+++ b/test/example/small_vector.cpp
@@ -5,7 +5,7 @@
 
 using namespace wasm;
 
-template<typename T> void test() {
+template<typename T> void test(size_t N) {
   {
     T t;
     // build up
@@ -55,12 +55,23 @@ template<typename T> void test() {
     u.push_back(2);
     assert(t != u);
   }
+  {
+    // Test reserve/capacity.
+    T t;
+
+    // Capacity begins at the size of the fixed storage.
+    assert(t.capacity() == N);
+
+    // Reserving more increases the capacity (but how much is impl-defined).
+    t.reserve(t.capacity() + 100);
+    assert(t.capacity() >= N + 100);
+  }
 }
 
 int main() {
-  test<SmallVector<int, 0>>();
-  test<SmallVector<int, 1>>();
-  test<SmallVector<int, 2>>();
-  test<SmallVector<int, 10>>();
+  test<SmallVector<int, 0>>(0);
+  test<SmallVector<int, 1>>(1);
+  test<SmallVector<int, 2>>(2);
+  test<SmallVector<int, 10>>(10);
   std::cout << "ok.\n";
 }


### PR DESCRIPTION
`LiteralList` overlaps with `Literals`, but is less efficient as it is not a
`SmallVector`.

Add reserve/capacity methods to `SmallVector` which are now
necessary to compile.