### PR TITLE
Add fast paths for Literals::getType

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -693,6 +693,12 @@ public:
   Literals(size_t initialSize) : SmallVector(initialSize) {}
 
   Type getType() {
+    if (empty()) {
+      return Type::none;
+    }
+    if (size() == 1) {
+      return (*this)[0].type;
+    }
     std::vector<Type> types;
     for (auto& val : *this) {
       types.push_back(val.type);


### PR DESCRIPTION
In the common case, avoid allocating a vector and calling malloc.

This makes us over 3x faster on the benchmark in https://github.com/WebAssembly/binaryen/issues/4452
