### PR TITLE
Refactor ModuleUtils::collectHeapTypes

### DIFF
--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -6,6 +6,7 @@ set(ir_SOURCES
   intrinsics.cpp
   lubs.cpp
   memory-utils.cpp
+  module-utils.cpp
   names.cpp
   properties.cpp
   LocalGraph.cpp

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2022 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "module-utils.h"
+#include "support/insert_ordered.h"
+
+namespace wasm::ModuleUtils {
+
+namespace {
+
+// Helper for collecting HeapTypes and their frequencies.
+struct Counts : public InsertOrderedMap<HeapType, size_t> {
+  void note(HeapType type) {
+    if (!type.isBasic()) {
+      (*this)[type]++;
+    }
+  }
+  void note(Type type) {
+    for (HeapType ht : type.getHeapTypeChildren()) {
+      note(ht);
+    }
+  }
+};
+
+Counts getHeapTypeCounts(Module& wasm) {
+  struct CodeScanner
+    : PostWalker<CodeScanner, UnifiedExpressionVisitor<CodeScanner>> {
+    Counts& counts;
+
+    CodeScanner(Module& wasm, Counts& counts) : counts(counts) {
+      setModule(&wasm);
+    }
+
+    void visitExpression(Expression* curr) {
+      if (auto* call = curr->dynCast<CallIndirect>()) {
+        counts.note(call->heapType);
+      } else if (curr->is<RefNull>()) {
+        counts.note(curr->type);
+      } else if (curr->is<RttCanon>() || curr->is<RttSub>()) {
+        counts.note(curr->type.getRtt().heapType);
+      } else if (auto* make = curr->dynCast<StructNew>()) {
+        // Some operations emit a HeapType in the binary format, if they are
+        // static and not dynamic (if dynamic, the RTT provides the heap type).
+        if (!make->rtt && make->type != Type::unreachable) {
+          counts.note(make->type.getHeapType());
+        }
+      } else if (auto* make = curr->dynCast<ArrayNew>()) {
+        if (!make->rtt && make->type != Type::unreachable) {
+          counts.note(make->type.getHeapType());
+        }
+      } else if (auto* make = curr->dynCast<ArrayInit>()) {
+        if (!make->rtt && make->type != Type::unreachable) {
+          counts.note(make->type.getHeapType());
+        }
+      } else if (auto* cast = curr->dynCast<RefCast>()) {
+        if (!cast->rtt && cast->type != Type::unreachable) {
+          counts.note(cast->getIntendedType());
+        }
+      } else if (auto* cast = curr->dynCast<RefTest>()) {
+        if (!cast->rtt && cast->type != Type::unreachable) {
+          counts.note(cast->getIntendedType());
+        }
+      } else if (auto* cast = curr->dynCast<BrOn>()) {
+        if (cast->op == BrOnCast || cast->op == BrOnCastFail) {
+          if (!cast->rtt && cast->type != Type::unreachable) {
+            counts.note(cast->getIntendedType());
+          }
+        }
+      } else if (auto* get = curr->dynCast<StructGet>()) {
+        counts.note(get->ref->type);
+      } else if (auto* set = curr->dynCast<StructSet>()) {
+        counts.note(set->ref->type);
+      } else if (Properties::isControlFlowStructure(curr)) {
+        if (curr->type.isTuple()) {
+          // TODO: Allow control flow to have input types as well
+          counts.note(Signature(Type::none, curr->type));
+        } else {
+          counts.note(curr->type);
+        }
+      }
+    }
+  };
+
+  // Collect module-level info.
+  Counts counts;
+  CodeScanner(wasm, counts).walkModuleCode(&wasm);
+  for (auto& curr : wasm.tags) {
+    counts.note(curr->sig);
+  }
+  for (auto& curr : wasm.tables) {
+    counts.note(curr->type);
+  }
+  for (auto& curr : wasm.elementSegments) {
+    counts.note(curr->type);
+  }
+
+  // Collect info from functions in parallel.
+  ModuleUtils::ParallelFunctionAnalysis<Counts, InsertOrderedMap> analysis(
+    wasm, [&](Function* func, Counts& counts) {
+      counts.note(func->type);
+      for (auto type : func->vars) {
+        counts.note(type);
+      }
+      if (!func->imported()) {
+        CodeScanner(wasm, counts).walk(func->body);
+      }
+    });
+
+  // Combine the function info with the module info.
+  for (auto& [_, functionCounts] : analysis.map) {
+    for (auto& [sig, count] : functionCounts) {
+      counts[sig] += count;
+    }
+  }
+
+  // Recursively traverse each reference type, which may have a child type that
+  // is itself a reference type. This reflects an appearance in the binary
+  // format that is in the type section itself.
+  // As we do this we may find more and more types, as nested children of
+  // previous ones. Each such type will appear in the type section once, so
+  // we just need to visit it once.
+  InsertOrderedSet<HeapType> newTypes;
+  for (auto& [type, _] : counts) {
+    newTypes.insert(type);
+  }
+  while (!newTypes.empty()) {
+    auto iter = newTypes.begin();
+    auto ht = *iter;
+    newTypes.erase(iter);
+    for (HeapType child : ht.getHeapTypeChildren()) {
+      if (!child.isBasic()) {
+        if (!counts.count(child)) {
+          newTypes.insert(child);
+        }
+        counts.note(child);
+      }
+    }
+
+    if (auto super = ht.getSuperType()) {
+      if (!counts.count(*super)) {
+        newTypes.insert(*super);
+        // We should unconditionally count supertypes, but while the type system
+        // is in flux, skip counting them to keep the type orderings in nominal
+        // test outputs more similar to the orderings in the equirecursive
+        // outputs. FIXME
+        counts.note(*super);
+      }
+    }
+  }
+
+  return counts;
+}
+
+} // anonymous namespace
+
+std::vector<HeapType> collectHeapTypes(Module& wasm) {
+  Counts counts = getHeapTypeCounts(wasm);
+  std::vector<HeapType> types;
+  types.reserve(counts.size());
+  for (auto& [type, _] : counts) {
+    types.push_back(type);
+  }
+  return types;
+}
+
+IndexedHeapTypes getIndexedHeapTypes(Module& wasm) {
+  Counts counts = getHeapTypeCounts(wasm);
+  IndexedHeapTypes indexedTypes;
+  Index i = 0;
+  for (auto& [type, _] : counts) {
+    indexedTypes.types.push_back(type);
+    indexedTypes.indices[type] = i++;
+  }
+  return indexedTypes;
+}
+
+IndexedHeapTypes getOptimizedIndexedHeapTypes(Module& wasm) {
+  Counts counts = getHeapTypeCounts(wasm);
+
+  // Sort by frequency and then original insertion order.
+  std::vector<std::pair<HeapType, size_t>> sorted(counts.begin(), counts.end());
+  std::stable_sort(sorted.begin(), sorted.end(), [&](auto a, auto b) {
+    return a.second > b.second;
+  });
+
+  // Collect the results.
+  IndexedHeapTypes indexedTypes;
+  for (Index i = 0; i < sorted.size(); ++i) {
+    HeapType type = sorted[i].first;
+    indexedTypes.types.push_back(type);
+    indexedTypes.indices[type] = i;
+  }
+  return indexedTypes;
+}
+
+} // namespace wasm::ModuleUtils

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -22,7 +22,6 @@
 #include "ir/manipulation.h"
 #include "ir/properties.h"
 #include "pass.h"
-#include "support/insert_ordered.h"
 #include "support/unique_deferring_queue.h"
 #include "wasm.h"
 
@@ -456,165 +455,22 @@ template<typename T> struct CallGraphPropertyAnalysis {
   }
 };
 
-// Helper function for collecting all the types that are declared in a module,
-// which means the HeapTypes (that are non-basic, that is, not eqref etc., which
-// do not need to be defined).
-//
-// Used when emitting or printing a module to give HeapTypes canonical
-// indices. HeapTypes are sorted in order of decreasing frequency to minize the
-// size of their collective encoding. Both a vector mapping indices to
-// HeapTypes and a map mapping HeapTypes to indices are produced.
-inline void collectHeapTypes(Module& wasm,
-                             std::vector<HeapType>& types,
-                             std::unordered_map<HeapType, Index>& typeIndices) {
-  struct Counts : public InsertOrderedMap<HeapType, size_t> {
-    void note(HeapType type) {
-      if (!type.isBasic()) {
-        (*this)[type]++;
-      }
-    }
-    void note(Type type) {
-      for (HeapType ht : type.getHeapTypeChildren()) {
-        note(ht);
-      }
-    }
-  };
+// Helper function for collecting all the non-basic heap types used in the
+// module, i.e. the types that would appear in the type section.
+std::vector<HeapType> collectHeapTypes(Module& wasm);
 
-  struct CodeScanner
-    : PostWalker<CodeScanner, UnifiedExpressionVisitor<CodeScanner>> {
-    Counts& counts;
+struct IndexedHeapTypes {
+  std::vector<HeapType> types;
+  std::unordered_map<HeapType, Index> indices;
+};
 
-    CodeScanner(Module& wasm, Counts& counts) : counts(counts) {
-      setModule(&wasm);
-    }
+// Similar to `collectHeapTypes`, but provides fast lookup of the index for each
+// type as well.
+IndexedHeapTypes getIndexedHeapTypes(Module& wasm);
 
-    void visitExpression(Expression* curr) {
-      if (auto* call = curr->dynCast<CallIndirect>()) {
-        counts.note(call->heapType);
-      } else if (curr->is<RefNull>()) {
-        counts.note(curr->type);
-      } else if (curr->is<RttCanon>() || curr->is<RttSub>()) {
-        counts.note(curr->type.getRtt().heapType);
-      } else if (auto* make = curr->dynCast<StructNew>()) {
-        // Some operations emit a HeapType in the binary format, if they are
-        // static and not dynamic (if dynamic, the RTT provides the heap type).
-        if (!make->rtt && make->type != Type::unreachable) {
-          counts.note(make->type.getHeapType());
-        }
-      } else if (auto* make = curr->dynCast<ArrayNew>()) {
-        if (!make->rtt && make->type != Type::unreachable) {
-          counts.note(make->type.getHeapType());
-        }
-      } else if (auto* make = curr->dynCast<ArrayInit>()) {
-        if (!make->rtt && make->type != Type::unreachable) {
-          counts.note(make->type.getHeapType());
-        }
-      } else if (auto* cast = curr->dynCast<RefCast>()) {
-        if (!cast->rtt && cast->type != Type::unreachable) {
-          counts.note(cast->getIntendedType());
-        }
-      } else if (auto* cast = curr->dynCast<RefTest>()) {
-        if (!cast->rtt && cast->type != Type::unreachable) {
-          counts.note(cast->getIntendedType());
-        }
-      } else if (auto* cast = curr->dynCast<BrOn>()) {
-        if (cast->op == BrOnCast || cast->op == BrOnCastFail) {
-          if (!cast->rtt && cast->type != Type::unreachable) {
-            counts.note(cast->getIntendedType());
-          }
-        }
-      } else if (auto* get = curr->dynCast<StructGet>()) {
-        counts.note(get->ref->type);
-      } else if (auto* set = curr->dynCast<StructSet>()) {
-        counts.note(set->ref->type);
-      } else if (Properties::isControlFlowStructure(curr)) {
-        if (curr->type.isTuple()) {
-          // TODO: Allow control flow to have input types as well
-          counts.note(Signature(Type::none, curr->type));
-        } else {
-          counts.note(curr->type);
-        }
-      }
-    }
-  };
-
-  // Collect module-level info.
-  Counts counts;
-  CodeScanner(wasm, counts).walkModuleCode(&wasm);
-  for (auto& curr : wasm.tags) {
-    counts.note(curr->sig);
-  }
-  for (auto& curr : wasm.tables) {
-    counts.note(curr->type);
-  }
-  for (auto& curr : wasm.elementSegments) {
-    counts.note(curr->type);
-  }
-
-  // Collect info from functions in parallel.
-  ModuleUtils::ParallelFunctionAnalysis<Counts, InsertOrderedMap> analysis(
-    wasm, [&](Function* func, Counts& counts) {
-      counts.note(func->type);
-      for (auto type : func->vars) {
-        counts.note(type);
-      }
-      if (!func->imported()) {
-        CodeScanner(wasm, counts).walk(func->body);
-      }
-    });
-
-  // Combine the function info with the module info.
-  for (auto& [_, functionCounts] : analysis.map) {
-    for (auto& [sig, count] : functionCounts) {
-      counts[sig] += count;
-    }
-  }
-
-  // Recursively traverse each reference type, which may have a child type that
-  // is itself a reference type. This reflects an appearance in the binary
-  // format that is in the type section itself.
-  // As we do this we may find more and more types, as nested children of
-  // previous ones. Each such type will appear in the type section once, so
-  // we just need to visit it once.
-  InsertOrderedSet<HeapType> newTypes;
-  for (auto& [type, _] : counts) {
-    newTypes.insert(type);
-  }
-  while (!newTypes.empty()) {
-    auto iter = newTypes.begin();
-    auto ht = *iter;
-    newTypes.erase(iter);
-    for (HeapType child : ht.getHeapTypeChildren()) {
-      if (!child.isBasic()) {
-        if (!counts.count(child)) {
-          newTypes.insert(child);
-        }
-        counts.note(child);
-      }
-    }
-
-    if (auto super = ht.getSuperType()) {
-      if (!counts.count(*super)) {
-        newTypes.insert(*super);
-        // We should unconditionally count supertypes, but while the type system
-        // is in flux, skip counting them to keep the type orderings in nominal
-        // test outputs more similar to the orderings in the equirecursive
-        // outputs. FIXME
-        counts.note(*super);
-      }
-    }
-  }
-
-  // Sort by frequency and then original insertion order.
-  std::vector<std::pair<HeapType, size_t>> sorted(counts.begin(), counts.end());
-  std::stable_sort(sorted.begin(), sorted.end(), [&](auto a, auto b) {
-    return a.second > b.second;
-  });
-  for (Index i = 0; i < sorted.size(); ++i) {
-    typeIndices[sorted[i].first] = i;
-    types.push_back(sorted[i].first);
-  }
-}
+// The same as `getIndexedHeapTypes`, but also sorts the types by frequency of
+// use to minimize code size.
+IndexedHeapTypes getOptimizedIndexedHeapTypes(Module& wasm);
 
 } // namespace wasm::ModuleUtils
 

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -26,8 +26,7 @@ namespace wasm {
 // them.
 struct SubTypes {
   SubTypes(Module& wasm) {
-    std::unordered_map<HeapType, Index> typeIndices;
-    ModuleUtils::collectHeapTypes(wasm, types, typeIndices);
+    types = ModuleUtils::collectHeapTypes(wasm);
     for (auto type : types) {
       note(type);
     }

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -18,6 +18,7 @@
 #define wasm_ir_type_updating_h
 
 #include "ir/branch-utils.h"
+#include "ir/module-utils.h"
 #include "wasm-traversal.h"
 
 namespace wasm {
@@ -336,11 +337,8 @@ public:
 private:
   TypeBuilder typeBuilder;
 
-  // The list of old types.
-  std::vector<HeapType> types;
-
-  // Type indices of the old types.
-  std::unordered_map<HeapType, Index> typeIndices;
+  // The old types and their indices.
+  ModuleUtils::IndexedHeapTypes indexedTypes;
 };
 
 namespace TypeUpdating {

--- a/src/passes/NameTypes.cpp
+++ b/src/passes/NameTypes.cpp
@@ -30,9 +30,7 @@ static const size_t NameLenLimit = 20;
 struct NameTypes : public Pass {
   void run(PassRunner* runner, Module* module) override {
     // Find all the types.
-    std::vector<HeapType> types;
-    std::unordered_map<HeapType, Index> typeIndices;
-    ModuleUtils::collectHeapTypes(*module, types, typeIndices);
+    std::vector<HeapType> types = ModuleUtils::collectHeapTypes(*module);
 
     // Ensure simple names. If a name already exists, and is short enough, keep
     // it.

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3064,10 +3064,10 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
       printName(curr->name, o);
     }
     incIndent();
-    std::vector<HeapType> types;
-    std::unordered_map<HeapType, Index> indices;
-    ModuleUtils::collectHeapTypes(*curr, types, indices);
-    for (auto type : types) {
+    // Use the same type order as the binary output would even though there is
+    // no code size benefit in the text format.
+    auto indexedTypes = ModuleUtils::getOptimizedIndexedHeapTypes(*curr);
+    for (auto type : indexedTypes.types) {
       doIndent(o, indent);
       o << '(';
       printMedium(o, "type") << ' ';

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1310,8 +1310,7 @@ private:
   Module* wasm;
   BufferWithRandomAccess& o;
   BinaryIndexes indexes;
-  std::unordered_map<HeapType, Index> typeIndices;
-  std::vector<HeapType> types;
+  ModuleUtils::IndexedHeapTypes indexedTypes;
 
   bool debugInfo = true;
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -34,7 +34,7 @@ namespace wasm {
 void WasmBinaryWriter::prepare() {
   // Collect function types and their frequencies. Collect information in each
   // function in parallel, then merge.
-  ModuleUtils::collectHeapTypes(*wasm, types, typeIndices);
+  indexedTypes = ModuleUtils::getOptimizedIndexedHeapTypes(*wasm);
   importInfo = wasm::make_unique<ImportInfo>(*wasm);
 }
 
@@ -216,14 +216,14 @@ void WasmBinaryWriter::writeMemory() {
 }
 
 void WasmBinaryWriter::writeTypes() {
-  if (types.size() == 0) {
+  if (indexedTypes.types.size() == 0) {
     return;
   }
   BYN_TRACE("== writeTypes\n");
   auto start = startSection(BinaryConsts::Section::Type);
-  o << U32LEB(types.size());
-  for (Index i = 0; i < types.size(); ++i) {
-    auto type = types[i];
+  o << U32LEB(indexedTypes.types.size());
+  for (Index i = 0; i < indexedTypes.types.size(); ++i) {
+    auto type = indexedTypes.types[i];
     bool nominal = type.isNominal() || getTypeSystem() == TypeSystem::Nominal;
     BYN_TRACE("write " << type << std::endl);
     if (type.isSignature()) {
@@ -539,9 +539,9 @@ uint32_t WasmBinaryWriter::getTagIndex(Name name) const {
 }
 
 uint32_t WasmBinaryWriter::getTypeIndex(HeapType type) const {
-  auto it = typeIndices.find(type);
+  auto it = indexedTypes.indices.find(type);
 #ifndef NDEBUG
-  if (it == typeIndices.end()) {
+  if (it == indexedTypes.indices.end()) {
     std::cout << "Missing type: " << type << '\n';
     assert(0);
   }
@@ -774,7 +774,7 @@ void WasmBinaryWriter::writeNames() {
   // type names
   {
     std::vector<HeapType> namedTypes;
-    for (auto& [type, _] : typeIndices) {
+    for (auto& [type, _] : indexedTypes.indices) {
       if (wasm->typeNames.count(type) && wasm->typeNames[type].name.is()) {
         namedTypes.push_back(type);
       }
@@ -784,7 +784,7 @@ void WasmBinaryWriter::writeNames() {
         startSubsection(BinaryConsts::UserSections::Subsection::NameType);
       o << U32LEB(namedTypes.size());
       for (auto type : namedTypes) {
-        o << U32LEB(typeIndices[type]);
+        o << U32LEB(indexedTypes.indices[type]);
         writeEscapedName(wasm->typeNames[type].name.str);
       }
       finishSubsection(substart);
@@ -909,7 +909,7 @@ void WasmBinaryWriter::writeNames() {
   // GC field names
   if (wasm->features.hasGC()) {
     std::vector<HeapType> relevantTypes;
-    for (auto& type : types) {
+    for (auto& type : indexedTypes.types) {
       if (type.isStruct() && wasm->typeNames.count(type) &&
           !wasm->typeNames[type].fieldNames.empty()) {
         relevantTypes.push_back(type);
@@ -921,7 +921,7 @@ void WasmBinaryWriter::writeNames() {
       o << U32LEB(relevantTypes.size());
       for (Index i = 0; i < relevantTypes.size(); i++) {
         auto type = relevantTypes[i];
-        o << U32LEB(typeIndices[type]);
+        o << U32LEB(indexedTypes.indices[type]);
         std::unordered_map<Index, Name>& fieldNames =
           wasm->typeNames.at(type).fieldNames;
         o << U32LEB(fieldNames.size());


### PR DESCRIPTION
Move the code into a new .cpp file because it is too complicated for a header
and update the API to make both the type indices and optimized sorting optional.
It will become more important to avoid unnecessary sorting once isorecursive
types have been implemented because they will make the sorting more complicated.