### PR TITLE
Remove old EffectAnalyzer hacks for asm.js debugInfo

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -32,8 +32,7 @@ public:
                  Expression* ast = nullptr)
     : ignoreImplicitTraps(passOptions.ignoreImplicitTraps),
       trapsNeverHappen(passOptions.trapsNeverHappen),
-      debugInfo(passOptions.debugInfo), module(module),
-      features(module.features) {
+      module(module), features(module.features) {
     if (ast) {
       walk(ast);
     }
@@ -41,7 +40,6 @@ public:
 
   bool ignoreImplicitTraps;
   bool trapsNeverHappen;
-  bool debugInfo;
   Module& module;
   FeatureSet features;
 
@@ -431,12 +429,6 @@ private:
         parent.throws_ = true;
       }
       if (curr->isReturn) {
-        parent.branchesOut = true;
-      }
-      if (parent.debugInfo) {
-        // debugInfo call imports must be preserved very strongly, do not
-        // move code around them
-        // FIXME: we could check if the call is to an import
         parent.branchesOut = true;
       }
     }

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -31,8 +31,8 @@ public:
                  Module& module,
                  Expression* ast = nullptr)
     : ignoreImplicitTraps(passOptions.ignoreImplicitTraps),
-      trapsNeverHappen(passOptions.trapsNeverHappen),
-      module(module), features(module.features) {
+      trapsNeverHappen(passOptions.trapsNeverHappen), module(module),
+      features(module.features) {
     if (ast) {
       walk(ast);
     }


### PR DESCRIPTION
In asm2wasm we modelled debugInfo using special imports. And we tried
 to not move them around much. Current debugInfo is tracked on
instructions and is not affected by removing this.

This may have some tiny effect beneficial effect on code size in debug
builds, perhaps.