### PR TITLE
Revert "[OptimizeInstructions] Optimize zero sized bulk memory ops even without "ignoreImplicitTraps""

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3406,16 +3406,6 @@ private:
             // memory.copy(dst, src, 0)  ==>  {drop(dst), drop(src)}
             return builder.makeBlock({builder.makeDrop(memCopy->dest),
                                       builder.makeDrop(memCopy->source)});
-          } else {
-            // memory.copy(dst, src, 0)  ==>  {
-            //   drop(i32.load8_u(dst)),
-            //   drop(i32.load8_u(src))
-            // }
-            return builder.makeBlock(
-              {builder.makeDrop(
-                 builder.makeLoad(1, false, 0, 1, memCopy->dest, Type::i32)),
-               builder.makeDrop(builder.makeLoad(
-                 1, false, 0, 1, memCopy->source, Type::i32))});
           }
           break;
         }
@@ -3478,17 +3468,11 @@ private:
     auto* csize = memFill->size->cast<Const>();
     auto bytes = csize->value.getInteger();
 
-    if (bytes == 0LL) {
-      if (options.ignoreImplicitTraps || options.trapsNeverHappen) {
-        // memory.fill(d, v, 0)  ==>  { drop(d), drop(v) }
-        return builder.makeBlock(
-          {builder.makeDrop(memFill->dest), builder.makeDrop(memFill->value)});
-      } else {
-        // memory.fill(d, v, 0)  ==>  { drop(i32.load8_u(d)), drop(v) }
-        return builder.makeBlock({builder.makeDrop(builder.makeLoad(
-                                    1, false, 0, 1, memFill->dest, Type::i32)),
-                                  builder.makeDrop(memFill->value)});
-      }
+    if (bytes == 0LL &&
+        (options.ignoreImplicitTraps || options.trapsNeverHappen)) {
+      // memory.fill(d, v, 0)  ==>  { drop(d), drop(v) }
+      return builder.makeBlock(
+        {builder.makeDrop(memFill->dest), builder.makeDrop(memFill->value)});
     }
 
     const uint32_t offset = 0, align = 1;

--- a/test/lit/passes/optimize-instructions-bulk-memory.wast
+++ b/test/lit/passes/optimize-instructions-bulk-memory.wast
@@ -10,17 +10,10 @@
   ;; CHECK-NEXT:   (local.get $dst)
   ;; CHECK-NEXT:   (local.get $sz)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.load8_u
-  ;; CHECK-NEXT:     (local.get $dst)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.load8_u
-  ;; CHECK-NEXT:     (local.get $src)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (memory.copy
+  ;; CHECK-NEXT:   (local.get $dst)
+  ;; CHECK-NEXT:   (local.get $src)
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.store8
   ;; CHECK-NEXT:   (local.get $dst)
@@ -91,17 +84,10 @@
   ;; NOSIMD-NEXT:   (local.get $dst)
   ;; NOSIMD-NEXT:   (local.get $sz)
   ;; NOSIMD-NEXT:  )
-  ;; NOSIMD-NEXT:  (block
-  ;; NOSIMD-NEXT:   (drop
-  ;; NOSIMD-NEXT:    (i32.load8_u
-  ;; NOSIMD-NEXT:     (local.get $dst)
-  ;; NOSIMD-NEXT:    )
-  ;; NOSIMD-NEXT:   )
-  ;; NOSIMD-NEXT:   (drop
-  ;; NOSIMD-NEXT:    (i32.load8_u
-  ;; NOSIMD-NEXT:     (local.get $src)
-  ;; NOSIMD-NEXT:    )
-  ;; NOSIMD-NEXT:   )
+  ;; NOSIMD-NEXT:  (memory.copy
+  ;; NOSIMD-NEXT:   (local.get $dst)
+  ;; NOSIMD-NEXT:   (local.get $src)
+  ;; NOSIMD-NEXT:   (i32.const 0)
   ;; NOSIMD-NEXT:  )
   ;; NOSIMD-NEXT:  (i32.store8
   ;; NOSIMD-NEXT:   (local.get $dst)
@@ -248,15 +234,10 @@
   )
 
   ;; CHECK:      (func $optimize-bulk-memory-fill (param $dst i32) (param $val i32) (param $sz i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.load8_u
-  ;; CHECK-NEXT:     (local.get $dst)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.const 0)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (memory.fill
+  ;; CHECK-NEXT:   (local.get $dst)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.store8
   ;; CHECK-NEXT:   (local.get $dst)
@@ -314,15 +295,10 @@
   ;; CHECK-NEXT:   (local.get $dst)
   ;; CHECK-NEXT:   (v128.const i32x4 0xffffffff 0xffffffff 0xffffffff 0xffffffff)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.load8_u
-  ;; CHECK-NEXT:     (local.get $dst)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (local.get $val)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (memory.fill
+  ;; CHECK-NEXT:   (local.get $dst)
+  ;; CHECK-NEXT:   (local.get $val)
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (memory.fill
   ;; CHECK-NEXT:   (local.get $dst)
@@ -359,15 +335,10 @@
   ;; NOSIMD-NEXT:  (local $3 i32)
   ;; NOSIMD-NEXT:  (local $4 i32)
   ;; NOSIMD-NEXT:  (local $5 i32)
-  ;; NOSIMD-NEXT:  (block
-  ;; NOSIMD-NEXT:   (drop
-  ;; NOSIMD-NEXT:    (i32.load8_u
-  ;; NOSIMD-NEXT:     (local.get $dst)
-  ;; NOSIMD-NEXT:    )
-  ;; NOSIMD-NEXT:   )
-  ;; NOSIMD-NEXT:   (drop
-  ;; NOSIMD-NEXT:    (i32.const 0)
-  ;; NOSIMD-NEXT:   )
+  ;; NOSIMD-NEXT:  (memory.fill
+  ;; NOSIMD-NEXT:   (local.get $dst)
+  ;; NOSIMD-NEXT:   (i32.const 0)
+  ;; NOSIMD-NEXT:   (i32.const 0)
   ;; NOSIMD-NEXT:  )
   ;; NOSIMD-NEXT:  (i32.store8
   ;; NOSIMD-NEXT:   (local.get $dst)
@@ -449,15 +420,10 @@
   ;; NOSIMD-NEXT:    (i64.const -1)
   ;; NOSIMD-NEXT:   )
   ;; NOSIMD-NEXT:  )
-  ;; NOSIMD-NEXT:  (block
-  ;; NOSIMD-NEXT:   (drop
-  ;; NOSIMD-NEXT:    (i32.load8_u
-  ;; NOSIMD-NEXT:     (local.get $dst)
-  ;; NOSIMD-NEXT:    )
-  ;; NOSIMD-NEXT:   )
-  ;; NOSIMD-NEXT:   (drop
-  ;; NOSIMD-NEXT:    (local.get $val)
-  ;; NOSIMD-NEXT:   )
+  ;; NOSIMD-NEXT:  (memory.fill
+  ;; NOSIMD-NEXT:   (local.get $dst)
+  ;; NOSIMD-NEXT:   (local.get $val)
+  ;; NOSIMD-NEXT:   (i32.const 0)
   ;; NOSIMD-NEXT:  )
   ;; NOSIMD-NEXT:  (memory.fill
   ;; NOSIMD-NEXT:   (local.get $dst)


### PR DESCRIPTION
Reverts WebAssembly/binaryen#4295

This optimization could introduce a new trap in cases where the destination address is out of bounds and the second operand to memory.fill could branch. In that case, the memory.fill in the original code would never have been executed but the first out-of-bounds load in the optimized code would be executed.