### PR TITLE
Add a `--hybrid` type system option

### DIFF
--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -135,6 +135,15 @@ struct ToolOptions : public Options {
            Options::Arguments::Zero,
            [](Options* o, const std::string& argument) {
              setTypeSystem(TypeSystem::Equirecursive);
+           })
+      .add("--hybrid",
+           "",
+           "Force all GC type definitions to be parsed using the isorecursive "
+           "hybrid type system.",
+           ToolOptionsCategory,
+           Options::Arguments::Zero,
+           [](Options* o, const std::string& argument) {
+             setTypeSystem(TypeSystem::Isorecursive);
            });
   }
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -36,6 +36,7 @@ namespace wasm {
 enum class TypeSystem {
   Equirecursive,
   Nominal,
+  Isorecursive,
 };
 
 // This should only ever be called before any Types or HeapTypes have been

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -3197,6 +3197,9 @@ std::vector<HeapType> TypeBuilder::build() {
     case TypeSystem::Nominal:
       canonicalizeNominal(state);
       break;
+    case TypeSystem::Isorecursive:
+      Fatal() << "Isorecursive types not yet implemented";
+      break;
   }
 
 #if TIME_CANONICALIZATION

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -114,6 +114,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -118,6 +118,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -107,6 +107,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -159,6 +159,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -155,6 +155,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -609,6 +609,10 @@
 ;; CHECK-NEXT:                                                 equirecursive). This is the
 ;; CHECK-NEXT:                                                 default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                                      Force all GC type definitions to
+;; CHECK-NEXT:                                                 be parsed using the isorecursive
+;; CHECK-NEXT:                                                 hybrid type system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -143,6 +143,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -196,6 +196,10 @@
 ;; CHECK-NEXT:                                        parsed as structural (i.e.
 ;; CHECK-NEXT:                                        equirecursive). This is the default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -571,6 +571,10 @@
 ;; CHECK-NEXT:                                                 equirecursive). This is the
 ;; CHECK-NEXT:                                                 default.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                                      Force all GC type definitions to
+;; CHECK-NEXT:                                                 be parsed using the isorecursive
+;; CHECK-NEXT:                                                 hybrid type system.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------


### PR DESCRIPTION
Eventually this will enable the isorecursive hybrid type system described in
https://github.com/WebAssembly/gc/pull/243, but for now it just throws a fatal
error if used.