### PR TITLE
SAFE_HEAP: Avoid annotating any function reachable from start function

### DIFF
--- a/test/passes/safe-heap_start-function.txt
+++ b/test/passes/safe-heap_start-function.txt
@@ -2,8 +2,8 @@
  (type $i32_i32_=>_i64 (func (param i32 i32) (result i64)))
  (type $i32_i32_i64_=>_none (func (param i32 i32 i64)))
  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
- (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $none_=>_none (func))
+ (type $i32_i32_i32_=>_none (func (param i32 i32 i32)))
  (type $i32_i32_=>_f64 (func (param i32 i32) (result f64)))
  (type $i32_i32_f64_=>_none (func (param i32 i32 f64)))
  (type $i32_i32_=>_f32 (func (param i32 i32) (result f32)))
@@ -29,6 +29,15 @@
     (i32.const 1234)
    )
    (i32.const 5678)
+  )
+  (call $foo2)
+ )
+ (func $foo2
+  (i32.store
+   (i32.load
+    (i32.const 98)
+   )
+   (i32.const 99)
   )
  )
  (func $bar

--- a/test/passes/safe-heap_start-function.wast
+++ b/test/passes/safe-heap_start-function.wast
@@ -6,8 +6,13 @@
    (call $foo)
   )
   (func $foo
-   ;; should not be modified because its called from the start function
+   ;; should not be modified because its reachable from start function
    (i32.store (i32.load (i32.const 1234)) (i32.const 5678))
+   (call $foo2)
+  )
+  (func $foo2
+   ;; should not be modified because its reachable from start function
+   (i32.store (i32.load (i32.const 98)) (i32.const 99))
   )
   (func $bar
    (i32.store (i32.load (i32.const 1234)) (i32.const 5678))


### PR DESCRIPTION
Since https://reviews.llvm.org/D117412 landed it has causes a bunch of
SAFE_HEAP tests in emscripten to start failing, because
`__wasm_apply_data_relocs` can now sometimes be called from with
`__wasm_init_memory` as opposed to directly from the start function.