### PR TITLE
Update heuristic for finding `__stack_pointer` to allow exports. NFC

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -55,7 +55,7 @@ bool isExported(Module& wasm, Name name) {
 
 Global* getStackPointerGlobal(Module& wasm) {
   // Assumption: The stack pointer is either imported as __stack_pointer or
-  // we just assume its the first non-imported global.
+  // we just assume it's the first non-imported global.
   // TODO(sbc): Find a better way to discover the stack pointer.  Perhaps the
   // linker could export it by name?
   for (auto& g : wasm.globals) {

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -55,15 +55,16 @@ bool isExported(Module& wasm, Name name) {
 
 Global* getStackPointerGlobal(Module& wasm) {
   // Assumption: The stack pointer is either imported as __stack_pointer or
-  // its the first non-imported and non-exported global.
+  // we just assume its the first non-imported global.
   // TODO(sbc): Find a better way to discover the stack pointer.  Perhaps the
   // linker could export it by name?
   for (auto& g : wasm.globals) {
-    if (g->imported()) {
-      if (g->base == STACK_POINTER) {
-        return g.get();
-      }
-    } else if (!isExported(wasm, g->name)) {
+    if (g->imported() && g->base == STACK_POINTER) {
+      return g.get();
+    }
+  }
+  for (auto& g : wasm.globals) {
+    if (!g->imported()) {
       return g.get();
     }
   }


### PR DESCRIPTION
There is no reason the `__stack_pointer` global can't be exported from
the module, and in fact I'm experimenting with a non-relocatable main
module that requires this.

See https://github.com/emscripten-core/emscripten/issues/12682

This heuristic still kind of sucks but should always be good enough
for llvm output that always puts the stack pointer first.