### PR TITLE
Reset global type state between tests

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -48,7 +48,7 @@ TypeSystem getTypeSystem();
 // Dangerous! Frees all types and heap types that have ever been created and
 // resets the type system's internal state. This is only really meant to be used
 // for tests.
-void destroyAllTypes();
+void destroyAllTypesForTestingPurposesOnly();
 
 // The types defined in this file. All of them are small and typically passed by
 // value except for `Tuple` and `Struct`, which may own an unbounded amount of

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -45,6 +45,11 @@ void setTypeSystem(TypeSystem system);
 
 TypeSystem getTypeSystem();
 
+// Dangerous! Frees all types and heap types that have ever been created and
+// resets the type system's internal state. This is only really meant to be used
+// for tests.
+void destroyAllTypes();
+
 // The types defined in this file. All of them are small and typically passed by
 // value except for `Tuple` and `Struct`, which may own an unbounded amount of
 // data.

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -768,7 +768,7 @@ static SignatureTypeCache nominalSignatureCache;
 
 } // anonymous namespace
 
-void destroyAllTypes() {
+void destroyAllTypesForTestingPurposesOnly() {
   globalTypeStore.clear();
   globalHeapTypeStore.clear();
   nominalSignatureCache.clear();

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -654,6 +654,11 @@ template<typename Info> struct Store {
   }
   bool hasCanonical(const Info& info, typename Info::type_t& canonical);
 
+  void clear() {
+    typeIDs.clear();
+    constructedTypes.clear();
+  }
+
 private:
   template<typename Ref> typename Info::type_t doInsert(Ref& infoRef) {
     const Info& info = [&]() {
@@ -755,11 +760,19 @@ struct SignatureTypeCache {
     std::lock_guard<std::mutex> lock(mutex);
     cache.insert({type.getSignature(), type});
   }
+
+  void clear() { cache.clear(); }
 };
 
 static SignatureTypeCache nominalSignatureCache;
 
 } // anonymous namespace
+
+void destroyAllTypes() {
+  globalTypeStore.clear();
+  globalHeapTypeStore.clear();
+  nominalSignatureCache.clear();
+}
 
 Type::Type(std::initializer_list<Type> types) : Type(Tuple(types)) {}
 

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -9,12 +9,11 @@ template<TypeSystem system> class TypeSystemTest : public ::testing::Test {
 
 protected:
   void SetUp() override {
-    destroyAllTypes();
     originalSystem = getTypeSystem();
     setTypeSystem(system);
   }
   void TearDown() override {
-    destroyAllTypes();
+    destroyAllTypesForTestingPurposesOnly();
     setTypeSystem(originalSystem);
   }
 };

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -3,6 +3,25 @@
 
 using namespace wasm;
 
+// Helper test fixture for managing the global type system state.
+template<TypeSystem system> class TypeSystemTest : public ::testing::Test {
+  TypeSystem originalSystem;
+
+protected:
+  void SetUp() override {
+    destroyAllTypes();
+    originalSystem = getTypeSystem();
+    setTypeSystem(system);
+  }
+  void TearDown() override {
+    destroyAllTypes();
+    setTypeSystem(originalSystem);
+  }
+};
+using EquirecursiveTest = TypeSystemTest<TypeSystem::Equirecursive>;
+using NominalTest = TypeSystemTest<TypeSystem::Nominal>;
+using IsorecursiveTest = TypeSystemTest<TypeSystem::Isorecursive>;
+
 TEST(TypeBuilder, Growth) {
   TypeBuilder builder;
   EXPECT_EQ(builder.size(), size_t{0});
@@ -10,11 +29,10 @@ TEST(TypeBuilder, Growth) {
   EXPECT_EQ(builder.size(), size_t{3});
 }
 
-TEST(TypeBuilder, Basics) {
+TEST_F(EquirecursiveTest, Basics) {
   // (type $sig (func (param (ref $struct)) (result (ref $array) i32)))
   // (type $struct (struct (field (ref null $array) (mut rtt 0 $array))))
   // (type $array (array (mut externref)))
-
   TypeBuilder builder(3);
   ASSERT_EQ(builder.size(), size_t{3});
 


### PR DESCRIPTION
Add a `destroyAllTypes` function to clear the global state of the type system
and use it in a custom gtest test fixture to ensure that each test starts and
ends with a fresh state.