### PR TITLE
StackCheck: Add argument stack-check-handler call

### DIFF
--- a/test/lld/basic_safe_stack.wat.out
+++ b/test/lld/basic_safe_stack.wat.out
@@ -3,7 +3,7 @@
  (type $i32_=>_none (func (param i32)))
  (type $i32_=>_i32 (func (param i32) (result i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
- (import "env" "__handle_stack_overflow" (func $__handle_stack_overflow))
+ (import "env" "__handle_stack_overflow" (func $__handle_stack_overflow (param i32)))
  (global $__stack_pointer (mut i32) (i32.const 66112))
  (global $__stack_base (mut i32) (i32.const 0))
  (global $__stack_limit (mut i32) (i32.const 0))
@@ -32,7 +32,9 @@
      (global.get $__stack_limit)
     )
    )
-   (call $__handle_stack_overflow)
+   (call $__handle_stack_overflow
+    (local.get $1)
+   )
   )
   (global.set $__stack_pointer
    (local.get $1)
@@ -64,7 +66,9 @@
       (global.get $__stack_limit)
      )
     )
-    (call $__handle_stack_overflow)
+    (call $__handle_stack_overflow
+     (local.get $3)
+    )
    )
    (global.set $__stack_pointer
     (local.get $3)

--- a/test/lld/recursive_safe_stack.wat.out
+++ b/test/lld/recursive_safe_stack.wat.out
@@ -2,9 +2,10 @@
  (type $0 (func (param i32 i32) (result i32)))
  (type $1 (func))
  (type $2 (func (result i32)))
+ (type $i32_=>_none (func (param i32)))
  (type $i32_i32_=>_none (func (param i32 i32)))
  (import "env" "printf" (func $printf (param i32 i32) (result i32)))
- (import "env" "__handle_stack_overflow" (func $__handle_stack_overflow))
+ (import "env" "__handle_stack_overflow" (func $__handle_stack_overflow (param i32)))
  (global $global$0 (mut i32) (i32.const 66128))
  (global $global$1 i32 (i32.const 66128))
  (global $global$2 i32 (i32.const 587))
@@ -45,7 +46,9 @@
       (global.get $__stack_limit)
      )
     )
-    (call $__handle_stack_overflow)
+    (call $__handle_stack_overflow
+     (local.get $3)
+    )
    )
    (global.set $global$0
     (local.get $3)
@@ -82,7 +85,9 @@
       (global.get $__stack_limit)
      )
     )
-    (call $__handle_stack_overflow)
+    (call $__handle_stack_overflow
+     (local.get $4)
+    )
    )
    (global.set $global$0
     (local.get $4)
@@ -116,7 +121,9 @@
       (global.get $__stack_limit)
      )
     )
-    (call $__handle_stack_overflow)
+    (call $__handle_stack_overflow
+     (local.get $1)
+    )
    )
    (global.set $global$0
     (local.get $1)
@@ -152,7 +159,9 @@
       (global.get $__stack_limit)
      )
     )
-    (call $__handle_stack_overflow)
+    (call $__handle_stack_overflow
+     (local.get $2)
+    )
    )
    (global.set $global$0
     (local.get $2)


### PR DESCRIPTION
This function call now takes the address (which by defintion is outside
of the stack range) that the program was attempting to set SP to.

This allows emscripten to provide a more useful error message on stack
over/under flow.