### PR TITLE
[NFC] Templatize/generalize RuntimeExpressionRunner

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3560,16 +3560,18 @@ public:
   };
 
   // Call a function, starting an invocation.
+  template<typename Runner=RuntimeExpressionRunner>
   Literals callFunction(Name name, const Literals& arguments) {
     // if the last call ended in a jump up the stack, it might have left stuff
     // for us to clean up here
     callDepth = 0;
     functionStack.clear();
-    return callFunctionInternal(name, arguments);
+    return callFunctionInternal<Runner>(name, arguments);
   }
 
   // Internal function call. Must be public so that callTable implementations
   // can use it (refactor?)
+  template<typename Runner=RuntimeExpressionRunner>
   Literals callFunctionInternal(Name name, const Literals& arguments) {
     if (callDepth > maxDepth) {
       externalInterface->trap("stack limit");
@@ -3590,8 +3592,7 @@ public:
     }
 #endif
 
-    Flow flow =
-      RuntimeExpressionRunner(*this, scope, maxDepth).visit(function->body);
+    Flow flow = Runner(*this, scope, maxDepth).visit(function->body);
     // cannot still be breaking, it means we missed our stop
     assert(!flow.breaking() || flow.breakTo == RETURN_FLOW);
     auto type = flow.getType();

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2684,8 +2684,9 @@ public:
 
   // Executes expressions with concrete runtime info, the function and module at
   // runtime
-  class RuntimeExpressionRunner
-    : public ExpressionRunner<RuntimeExpressionRunner> {
+  template<typename RERSubType>
+  class RuntimeExpressionRunnerBase
+    : public ExpressionRunner<RERSubType> {
     ModuleInstanceBase& instance;
     FunctionScope& scope;
     // Stack of <caught exception, caught catch's try label>
@@ -2718,10 +2719,10 @@ public:
     }
 
   public:
-    RuntimeExpressionRunner(ModuleInstanceBase& instance,
+    RuntimeExpressionRunnerBase(ModuleInstanceBase& instance,
                             FunctionScope& scope,
                             Index maxDepth)
-      : ExpressionRunner<RuntimeExpressionRunner>(&instance.wasm, maxDepth),
+      : ExpressionRunner<RERSubType>(&instance.wasm, maxDepth),
         instance(instance), scope(scope) {}
 
     Flow visitCall(Call* curr) {
@@ -3548,6 +3549,14 @@ public:
       }
       return value;
     }
+  };
+
+  class RuntimeExpressionRunner : public RuntimeExpressionRunnerBase<RuntimeExpressionRunner> {
+  public:
+    RuntimeExpressionRunner(ModuleInstanceBase& instance,
+                            FunctionScope& scope,
+                            Index maxDepth)
+      : RuntimeExpressionRunnerBase<RuntimeExpressionRunner>(instance, scope, maxDepth) {}
   };
 
   // Call a function, starting an invocation.

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2685,8 +2685,7 @@ public:
   // Executes expressions with concrete runtime info, the function and module at
   // runtime
   template<typename RERSubType>
-  class RuntimeExpressionRunnerBase
-    : public ExpressionRunner<RERSubType> {
+  class RuntimeExpressionRunnerBase : public ExpressionRunner<RERSubType> {
     ModuleInstanceBase& instance;
     FunctionScope& scope;
     // Stack of <caught exception, caught catch's try label>
@@ -2720,8 +2719,8 @@ public:
 
   public:
     RuntimeExpressionRunnerBase(ModuleInstanceBase& instance,
-                            FunctionScope& scope,
-                            Index maxDepth)
+                                FunctionScope& scope,
+                                Index maxDepth)
       : ExpressionRunner<RERSubType>(&instance.wasm, maxDepth),
         instance(instance), scope(scope) {}
 
@@ -3551,16 +3550,18 @@ public:
     }
   };
 
-  class RuntimeExpressionRunner : public RuntimeExpressionRunnerBase<RuntimeExpressionRunner> {
+  class RuntimeExpressionRunner
+    : public RuntimeExpressionRunnerBase<RuntimeExpressionRunner> {
   public:
     RuntimeExpressionRunner(ModuleInstanceBase& instance,
                             FunctionScope& scope,
                             Index maxDepth)
-      : RuntimeExpressionRunnerBase<RuntimeExpressionRunner>(instance, scope, maxDepth) {}
+      : RuntimeExpressionRunnerBase<RuntimeExpressionRunner>(
+          instance, scope, maxDepth) {}
   };
 
   // Call a function, starting an invocation.
-  template<typename Runner=RuntimeExpressionRunner>
+  template<typename Runner = RuntimeExpressionRunner>
   Literals callFunction(Name name, const Literals& arguments) {
     // if the last call ended in a jump up the stack, it might have left stuff
     // for us to clean up here
@@ -3571,7 +3572,7 @@ public:
 
   // Internal function call. Must be public so that callTable implementations
   // can use it (refactor?)
-  template<typename Runner=RuntimeExpressionRunner>
+  template<typename Runner = RuntimeExpressionRunner>
   Literals callFunctionInternal(Name name, const Literals& arguments) {
     if (callDepth > maxDepth) {
       externalInterface->trap("stack limit");


### PR DESCRIPTION
Add a base class for it, that is templated and can be extended in general
ways, and make `callFunction` templated on the runner to use as well.

This allows the interpreter's behavior to be customized in a way that we
couldn't so far. wasm-ctor-eval wants to use a special Runner when it
evals a function, so that it can track certain operations, which this will
enable.