### PR TITLE
Isorecursive type output ordering

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -33,6 +33,7 @@ struct Counts : public InsertOrderedMap<HeapType, size_t> {
       note(ht);
     }
   }
+  // Ensure a type is included without increasing its count.
   void include(HeapType type) {
     if (!type.isBasic()) {
       (*this)[type];
@@ -260,7 +261,9 @@ IndexedHeapTypes getOptimizedIndexedHeapTypes(Module& wasm) {
     }
   }
 
-  // Fix up the cumulative counts to be an average instead.
+  // Fix up the cumulative counts to be an average instead. Use the average to
+  // prioritize groups that have large reference counts and also do not take up
+  // too much of the address space.
   for (auto& [group, info] : groupInfos) {
     info.count /= group.size();
   }

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -250,6 +250,9 @@ IndexedHeapTypes getOptimizedIndexedHeapTypes(Module& wasm) {
     info.count += counts.at(type);
     // Collect predecessor groups.
     for (auto child : type.getReferencedHeapTypes()) {
+      if (child.isBasic()) {
+        continue;
+      }
       RecGroup otherGroup = child.getRecGroup();
       if (otherGroup != group) {
         info.predecessors.insert(otherGroup);

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -465,11 +465,8 @@ struct IndexedHeapTypes {
 };
 
 // Similar to `collectHeapTypes`, but provides fast lookup of the index for each
-// type as well.
-IndexedHeapTypes getIndexedHeapTypes(Module& wasm);
-
-// The same as `getIndexedHeapTypes`, but also sorts the types by frequency of
-// use to minimize code size.
+// type as well. Also orders the types to be valid and sorts the types by
+// frequency of use to minimize code size.
 IndexedHeapTypes getOptimizedIndexedHeapTypes(Module& wasm);
 
 } // namespace wasm::ModuleUtils

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -26,7 +26,7 @@ namespace wasm {
 GlobalTypeRewriter::GlobalTypeRewriter(Module& wasm) : wasm(wasm) {}
 
 void GlobalTypeRewriter::update() {
-  indexedTypes = ModuleUtils::getIndexedHeapTypes(wasm);
+  indexedTypes = ModuleUtils::getOptimizedIndexedHeapTypes(wasm);
   if (indexedTypes.types.empty()) {
     return;
   }

--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -112,6 +112,8 @@ template<typename Key, typename T> struct InsertOrderedMap {
     return insert(kv).first->second;
   }
 
+  T& at(const Key& k) { return Map.at(k)->second; }
+
   iterator find(const Key& k) {
     auto it = Map.find(k);
     if (it == Map.end()) {

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -376,7 +376,11 @@ public:
   static bool isSubType(HeapType left, HeapType right);
 
   // Return the ordered HeapType children, looking through child Types.
-  std::vector<HeapType> getHeapTypeChildren();
+  std::vector<HeapType> getHeapTypeChildren() const;
+
+  // Similar to `getHeapTypeChildren`, but also includes the supertype if it
+  // exists.
+  std::vector<HeapType> getReferencedHeapTypes() const;
 
   // Return the LUB of two HeapTypes. The LUB always exists.
   static HeapType getLeastUpperBound(HeapType a, HeapType b);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2411,7 +2411,12 @@ size_t RecGroupHasher::hash(HeapType type) const {
   // an index into a rec group. Only take the rec group identity into account if
   // the child is not a member of the top-level group because in that case the
   // group may not be canonicalized yet.
-  size_t digest = wasm::hash(type.getRecGroupIndex());
+  size_t digest = wasm::hash(type.isBasic());
+  if (type.isBasic()) {
+    wasm::rehash(digest, type.getID());
+    return digest;
+  }
+  wasm::rehash(digest, type.getRecGroupIndex());
   auto currGroup = type.getRecGroup();
   if (currGroup != group) {
     wasm::rehash(digest, currGroup.getID());
@@ -2534,6 +2539,9 @@ bool RecGroupEquator::eq(HeapType a, HeapType b) const {
   // be canonicalized, explicitly check whether `a` and `b` are in the
   // respective recursion groups of the respective top-level groups we are
   // comparing, in which case the structure is still equivalent.
+  if (a.isBasic() || b.isBasic()) {
+    return a == b;
+  }
   if (a.getRecGroupIndex() != b.getRecGroupIndex()) {
     return false;
   }

--- a/test/lit/isorecursive-output-ordering.wast
+++ b/test/lit/isorecursive-output-ordering.wast
@@ -95,3 +95,15 @@
   (unreachable)
  )
 )
+
+(module
+ ;; Test that basic heap type children do not trigger assertions.
+
+ (rec
+  (type $contains-basic (struct_subtype (ref any) data))
+ )
+
+ (func $use (param (ref $contains-basic))
+   (unreachable)
+ )
+)

--- a/test/lit/isorecursive-output-ordering.wast
+++ b/test/lit/isorecursive-output-ordering.wast
@@ -47,6 +47,11 @@
  ;; CHECK-NEXT: )
 
  ;; CHECK-NEXT: (rec
+ ;; CHECK-NEXT:  (type $used-a-ton (struct_subtype  data))
+ ;; CHECK-NEXT:  (type $shrub (struct_subtype  $leaf))
+ ;; CHECK-NEXT: )
+
+ ;; CHECK-NEXT: (rec
  ;; CHECK-NEXT:  (type $used-a-bit (struct_subtype (field (ref $leaf)) data))
  ;; CHECK-NEXT:  (type $twig (struct_subtype  data))
  ;; CHECK-NEXT: )
@@ -67,11 +72,17 @@
  )
 
  (rec
+  (type $shrub (struct_subtype $leaf))
+  (type $used-a-ton (struct_subtype data))
+ )
+
+ (rec
   (type $root (struct_subtype data))
   (type $used-a-lot (struct_subtype $twig))
  )
 
  (func $use (param (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot)) (result (ref $used-a-bit) (ref $used-a-bit) (ref $used-a-bit))
+  (local (ref null $used-a-ton) (ref null $used-a-ton) (ref null $used-a-ton) (ref null $used-a-ton) (ref null $used-a-ton) (ref null $used-a-ton) (ref null $used-a-ton))
   (unreachable)
  )
 )

--- a/test/lit/isorecursive-output-ordering.wast
+++ b/test/lit/isorecursive-output-ordering.wast
@@ -1,0 +1,97 @@
+;; TODO: Autogenerate these checks! The current script cannot handle `rec`.
+
+;; RUN: foreach %s %t wasm-opt -all --hybrid -S -o - | filecheck %s
+
+(module
+ ;; Test that we order groups by average uses and types within each group by uses.
+
+ ;; CHECK:      (rec
+ ;; CHECK-NEXT:  (type $used-a-bit (struct_subtype data))
+ ;; CHECK-NEXT:  (type $unused-6 (struct_subtype data))
+ ;; CHECK-NEXT: )
+
+ ;; CHECK-NEXT: (rec
+ ;; CHECK-NEXT:  (type $used-a-lot (struct_subtype data))
+ ;; CHECK-NEXT:  (type $unused-1 (struct_subtype data))
+ ;; CHECK-NEXT:  (type $unused-2 (struct_subtype data))
+ ;; CHECK-NEXT:  (type $unused-3 (struct_subtype data))
+ ;; CHECK-NEXT:  (type $unused-4 (struct_subtype data))
+ ;; CHECK-NEXT:  (type $unused-5 (struct_subtype data))
+ ;; CHECK-NEXT: )
+
+ (rec
+  (type $unused-1 (struct_subtype data))
+  (type $unused-2 (struct_subtype data))
+  (type $unused-3 (struct_subtype data))
+  (type $unused-4 (struct_subtype data))
+  (type $used-a-lot (struct_subtype data))
+  (type $unused-5 (struct_subtype data))
+ )
+
+ (rec
+  (type $unused-6 (struct_subtype data))
+  (type $used-a-bit (struct_subtype data))
+ )
+
+ (func $use (param (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot)) (result (ref $used-a-bit) (ref $used-a-bit) (ref $used-a-bit) (ref $used-a-bit))
+  (unreachable)
+ )
+)
+
+(module
+ ;; Test that we respect dependencies between groups before considering counts.
+
+ ;; CHECK:      (rec
+ ;; CHECK-NEXT:  (type $leaf (struct_subtype  data))
+ ;; CHECK-NEXT:  (type $unused (struct_subtype  data))
+ ;; CHECK-NEXT: )
+
+ ;; CHECK-NEXT: (rec
+ ;; CHECK-NEXT:  (type $used-a-bit (struct_subtype (field (ref $leaf)) data))
+ ;; CHECK-NEXT:  (type $twig (struct_subtype  data))
+ ;; CHECK-NEXT: )
+
+ ;; CHECK-NEXT: (rec
+ ;; CHECK-NEXT:  (type $used-a-lot (struct_subtype  $twig))
+ ;; CHECK-NEXT:  (type $root (struct_subtype  data))
+ ;; CHECK-NEXT: )
+
+ (rec
+  (type $leaf (struct_subtype data))
+  (type $unused (struct_subtype data))
+ )
+
+ (rec
+  (type $twig (struct_subtype data))
+  (type $used-a-bit (struct_subtype (ref $leaf) data))
+ )
+
+ (rec
+  (type $root (struct_subtype data))
+  (type $used-a-lot (struct_subtype $twig))
+ )
+
+ (func $use (param (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot)) (result (ref $used-a-bit) (ref $used-a-bit) (ref $used-a-bit))
+  (unreachable)
+ )
+)
+
+(module
+ ;; Test that we order types inside a group by supertype but not by inclusion.
+
+ ;; CHECK:      (rec
+ ;; CHECK-NEXT:  (type $used-some-more (struct_subtype (field (ref $used-a-bit)) data))
+ ;; CHECK-NEXT:  (type $used-a-lot (struct_subtype (field (ref $used-a-bit)) $used-some-more))
+ ;; CHECK-NEXT:  (type $used-a-bit (struct_subtype data))
+ ;; CHECK-NEXT: )
+
+ (rec
+  (type $used-a-bit (struct_subtype data))
+  (type $used-some-more (struct_subtype (ref $used-a-bit) data))
+  (type $used-a-lot (struct_subtype (ref $used-a-bit) $used-some-more))
+ )
+
+ (func $use (param (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot) (ref $used-a-lot)) (result (ref $used-some-more) (ref $used-some-more) (ref $used-some-more))
+  (unreachable)
+ )
+)


### PR DESCRIPTION
Generally we try to order types by decreasing use count so that frequently used
types get smaller indices. For the equirecursive and nominal systems, there are
no contraints on the ordering of types, so we just have to sort them according
to their use counts. For the isorecursive type system, however, there are a
number of ordering constraints that have to be met for the type section to be
valid.

First, types in the same recursion group must be adjacent so they can be grouped
together. Next, groups must be ordered topologically. Finally, supertypes must
appear before their subtypes, even within a single group. Only after satisfying
these constraints can we additionally order by use count.

Update type ordering to produce a valid and optimal ordering. In principle it
would be possible to do less work for use cases that don't require the optimal
ordering, such as in type updating passes, but skipping unnecessary work
wouldn't improve the algorithmic complexity of the sorting, so don't bother for
now.