### PR TITLE
Document submodule initialization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,15 @@ etc.
 
 ## Building
 
+Binaryen uses git submodules (at time of writing just for gtest), so before you build you will have to initialize the submodules:
+
+```
+git submodule init
+git submodule update
+```
+
+After that you can build with CMake:
+
 ```
 cmake . && make
 ```


### PR DESCRIPTION
Add the missing initialization instructions to the `Building` section.

Fixes #4488.