### PR TITLE
Isorecursive binary format

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -386,6 +386,8 @@ enum EncodedType {
   FuncExtending = -0x23,   // 0x5d
   StructExtending = -0x24, // 0x5c
   ArrayExtending = -0x25,  // 0x5b
+  // isorecursive recursion groups
+  Rec = -0x31, // 0x4f
   // block_type
   Empty = -0x40 // 0x40
 };

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -232,7 +232,7 @@ void WasmBinaryWriter::writeTypes() {
   BYN_TRACE("== writeTypes\n");
   auto start = startSection(BinaryConsts::Section::Type);
   o << U32LEB(numGroups);
-  lastGroup = {};
+  lastGroup = std::nullopt;
   for (Index i = 0; i < indexedTypes.types.size(); ++i) {
     auto type = indexedTypes.types[i];
     // Check whether we need to start a new recursion group. Recursion groups of

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -219,7 +219,9 @@ void WasmBinaryWriter::writeTypes() {
   if (indexedTypes.types.size() == 0) {
     return;
   }
-  // Count the number of recursion groups
+  // Count the number of recursion groups, which is always the number of
+  // elements in the type section. In non-isorecursive type systems, it is also
+  // equivalent to the number of types.
   std::optional<RecGroup> lastGroup;
   size_t numGroups = 0;
   for (auto type : indexedTypes.types) {
@@ -233,7 +235,10 @@ void WasmBinaryWriter::writeTypes() {
   lastGroup = {};
   for (Index i = 0; i < indexedTypes.types.size(); ++i) {
     auto type = indexedTypes.types[i];
-    // Check whether we need to start a new recursion group.
+    // Check whether we need to start a new recursion group. Recursion groups of
+    // size 1 are implicit, so only emit a group header for larger groups. This
+    // gracefully handles non-isorecursive type systems, which only have groups
+    // of size 1.
     auto currGroup = type.getRecGroup();
     if (lastGroup != currGroup && currGroup.size() > 1) {
       o << S32LEB(BinaryConsts::EncodedType::Rec) << U32LEB(currGroup.size());

--- a/test/lit/isorecursive-good.wast
+++ b/test/lit/isorecursive-good.wast
@@ -1,9 +1,8 @@
 ;; TODO: Autogenerate these checks! The current script cannot handle `rec`.
 
 ;; RUN: wasm-opt %s -all --hybrid -S -o - | filecheck %s --check-prefix HYBRID
+;; RUN: wasm-opt %s -all --hybrid --roundtrip -S -o - | filecheck %s --check-prefix HYBRID
 ;; RUN: wasm-opt %s -all --nominal -S -o - | filecheck %s --check-prefix NOMINAL
-
-;; TDOO: test with --roundtrip as well
 
 (module
 

--- a/test/lit/isorecursive-output-ordering.wast
+++ b/test/lit/isorecursive-output-ordering.wast
@@ -1,6 +1,7 @@
 ;; TODO: Autogenerate these checks! The current script cannot handle `rec`.
 
 ;; RUN: foreach %s %t wasm-opt -all --hybrid -S -o - | filecheck %s
+;; RUN: foreach %s %t wasm-opt -all --hybrid --roundtrip -S -o - | filecheck %s
 
 (module
  ;; Test that we order groups by average uses.

--- a/test/lit/isorecursive-singleton-group.wast
+++ b/test/lit/isorecursive-singleton-group.wast
@@ -1,6 +1,7 @@
 ;; TODO: Autogenerate these checks! The current script cannot handle `rec`.
 
 ;; RUN: wasm-opt %s -all --hybrid -S -o - | filecheck %s
+;; RUN: wasm-opt %s -all --hybrid --roundtrip -S -o - | filecheck %s
 
 ;; Check that everything works correctly when a recursion group has only a
 ;; single member. The rec group is implicit, so does not need to be printed.

--- a/test/lit/isorecursive-whole-group.wast
+++ b/test/lit/isorecursive-whole-group.wast
@@ -1,6 +1,7 @@
 ;; TODO: Autogenerate these checks! The current script cannot handle `rec`.
 
 ;; RUN: wasm-opt %s -all --hybrid -S -o - | filecheck %s
+;; RUN: wasm-opt %s -all --hybrid --roundtrip -S -o - | filecheck %s
 
 ;; Check that unused types are still included in the output when they are part
 ;; of a recursion group with used types.


### PR DESCRIPTION
Write and parse recursion groups in binary type sections. Unlike in the text
format, where we ignore recursion groups when not using isorecursive types, do
not allow parsing binary recursion group when using other type systems. Doing so
would produce incorrect results because recursions groups only count as single
entries in the type system vector so we dynamically grow the TypeBuilder when we
encounter them. That would change the mapping of later indices to types, and
would change the meaning of previous type definitions that use those later
indices. This is not a problem in the isorecursive system because in that system
type definitions are not allowed to use later indices.