### PR TITLE
Fix an assertion in the validator on call_ref heaptypes

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2326,7 +2326,7 @@ void FunctionValidator::visitCallRef(CallRef* curr) {
   if (curr->target->type != Type::unreachable) {
     if (shouldBeTrue(curr->target->type.isFunction(),
                      curr,
-                     "call_ref target must be a function reference");
+                     "call_ref target must be a function reference")) {
       validateCallParamsAndResult(curr, curr->target->type.getHeapType());
     }
   }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2324,10 +2324,11 @@ void FunctionValidator::visitCallRef(CallRef* curr) {
                curr,
                "call_ref requires typed-function-references to be enabled");
   if (curr->target->type != Type::unreachable) {
-    shouldBeTrue(curr->target->type.isFunction(),
-                 curr,
-                 "call_ref target must be a function reference");
-    validateCallParamsAndResult(curr, curr->target->type.getHeapType());
+    if (shouldBeTrue(curr->target->type.isFunction(),
+                     curr,
+                     "call_ref target must be a function reference");
+      validateCallParamsAndResult(curr, curr->target->type.getHeapType());
+    }
   }
 }
 


### PR DESCRIPTION
We can only call getHeapType if it is indeed a function type. Otherwise we should
show the error and move on.