### PR TITLE
Disable a flaky isorecursion test

### DIFF
--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -350,7 +350,7 @@ TEST_F(IsorecursiveTest, CanonicalizeUses) {
   EXPECT_NE(built[4], built[6]);
 }
 
-TEST_F(IsorecursiveTest, CanonicalizeSelfReferences) {
+TEST_F(IsorecursiveTest, DISABLED_CanonicalizeSelfReferences) {
   TypeBuilder builder(5);
   // Single self-reference
   builder[0] = makeStruct(builder, {0});


### PR DESCRIPTION
The IsorecursiveTest.CanonicalizeSelfReferences has been frequently failing on
Windows and MacOS CI. Disable it for now until I can investigate thoroughly.