### PR TITLE
CRTP topological sort utility

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -196,10 +196,7 @@ void setIndices(IndexedHeapTypes& indexedTypes) {
 // means the predecessors have all been finished so the current element is
 // finished as well and should be popped.
 template<typename T> struct TopologicalSortStack {
-  std::list<T> workStack;
-  // Map items to their locations in the work stack so that we can make sure
-  // each appears and is finished only once.
-  std::unordered_map<T, typename std::list<T>::iterator> locations;
+  std::vector<T> workStack;
   // Remember which items we have finished so we don't visit them again.
   std::unordered_set<T> finished;
 
@@ -210,22 +207,17 @@ template<typename T> struct TopologicalSortStack {
       return;
     }
     workStack.push_back(item);
-    auto newLocation = std::prev(workStack.end());
-    auto [it, inserted] = locations.insert({item, newLocation});
-    if (!inserted) {
-      // Remove the previous iteration of the pushed item and update its
-      // location.
-      workStack.erase(it->second);
-      it->second = newLocation;
-    }
   }
 
   T& peek() { return workStack.back(); }
 
   void pop() {
+    // Pop until the stack is empty or it has an unfinished item on top.
     finished.insert(workStack.back());
-    locations.erase(workStack.back());
     workStack.pop_back();
+    while (!workStack.empty() && finished.count(workStack.back())) {
+      workStack.pop_back();
+    }
   }
 };
 

--- a/src/support/topological_sort.h
+++ b/src/support/topological_sort.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_support_topological_sort_h
+#define wasm_support_topological_sort_h
+
+namespace wasm {
+
+template<typename T, typename Subtype> struct TopologicalSort {
+private:
+  // The DFS work list.
+  std::vector<T> workStack;
+
+  // Remember which items we have finished so we don't visit them again.
+  std::unordered_set<T> finished;
+
+  // Should be overridden by `Subtype`.
+  void pushPredecessors(T item) {
+    static_assert(&TopologicalSort<T, Subtype>::pushPredecessors !=
+                    &Subtype::pushPredecessors,
+                  "TopologicalSort subclass must implement `pushPredecessors`");
+    WASM_UNREACHABLE("Derived class must implement pushPredecessors");
+  }
+
+  // Pop until the stack is empty or it has an unfinished item on top.
+  void pop() {
+    finished.insert(workStack.back());
+    workStack.pop_back();
+    while (!workStack.empty() && finished.count(workStack.back())) {
+      workStack.pop_back();
+    }
+  }
+
+  // Advance until the next item to be finished is on top of the stack or the
+  // stack is empty.
+  void step() {
+    while (!workStack.empty()) {
+      T item = workStack.back();
+      static_cast<Subtype*>(this)->pushPredecessors(item);
+      if (workStack.back() == item) {
+        // No unfinished predecessors, so this is the next item in the sort.
+        break;
+      }
+    }
+  }
+
+protected:
+  // Call this from the `Subtype` constructor to add the root items and from
+  // `Subtype::pushPredecessors` to add predecessors.
+  void push(T item) {
+    if (finished.count(item)) {
+      return;
+    }
+    workStack.push_back(item);
+  }
+
+public:
+  struct iterator {
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using reference = T&;
+    using pointer = T*;
+    using iterator_category = std::input_iterator_tag;
+
+    TopologicalSort<T, Subtype>* parent;
+
+    bool isEnd() const { return !parent || parent->workStack.empty(); }
+    bool operator==(iterator& other) const { return isEnd() == other.isEnd(); }
+    bool operator!=(iterator& other) const { return !(*this == other); }
+    T operator*() { return parent->workStack.back(); }
+    void operator++(int) {
+      parent->pop();
+      parent->step();
+    }
+    iterator& operator++() {
+      (*this)++;
+      return *this;
+    }
+  };
+
+  iterator begin() {
+    step();
+    return {this};
+  }
+  iterator end() { return {nullptr}; }
+};
+
+} // namespace wasm
+
+#endif // wasm_support_topological_sort_h

--- a/src/support/topological_sort.h
+++ b/src/support/topological_sort.h
@@ -17,6 +17,11 @@
 #ifndef wasm_support_topological_sort_h
 #define wasm_support_topological_sort_h
 
+#include <cstddef>
+#include <iterator>
+#include <unordered_set>
+#include <vector>
+
 namespace wasm {
 
 // CRTP utility that provides an iterator through arbitrary directed acyclic


### PR DESCRIPTION
Refactor the `TopologicalSortStack` into a `TopologicalSort` CRTP utility that
manipulates the DFS stack internally instead of exposing it to the user. The
only method users have to implement to use the utility is `pushPredecessors`,
which should call the provided `push` method on all the predecessors of a given
item. The public interface to `TopologicalSort` is an input iterator, so it can
easily be used in range-based for loops.