### PR TITLE
Validate supertypes after isorecursive canonicalization

### DIFF
--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -431,3 +431,29 @@ TEST_F(IsorecursiveTest, HeapTypeConstructors) {
   EXPECT_EQ(struct_, struct2);
   EXPECT_EQ(array, array2);
 }
+
+TEST_F(IsorecursiveTest, CanonicalizeTypesBeforeSubtyping) {
+  TypeBuilder builder(6);
+  // A rec group
+  builder.createRecGroup(0, 2);
+  builder[0] = Struct{};
+  builder[1] = Struct{};
+  builder[1].subTypeOf(builder[0]);
+
+  // The same rec group again
+  builder.createRecGroup(2, 2);
+  builder[2] = Struct{};
+  builder[3] = Struct{};
+  builder[3].subTypeOf(builder[2]);
+
+  // This subtyping only validates if the previous two groups are deduplicated
+  // before checking subtype validity.
+  builder[4] =
+    Struct({Field(builder.getTempRefType(builder[0], Nullable), Immutable)});
+  builder[5] =
+    Struct({Field(builder.getTempRefType(builder[3], Nullable), Immutable)});
+  builder[5].subTypeOf(builder[4]);
+
+  auto result = builder.build();
+  EXPECT_TRUE(result);
+}


### PR DESCRIPTION
Validating nominally declared supertypes depends on being able to test type
equality, which in turn depends on the compared types having already been
canonicalized. Previously we validated supertypes before canonicalization, so
validation would fail in cases where it should have succeeded. Fix the bug by
canonicalizing first. This means that the global type store can now end up
holding invalid types, but those types will never be exposed to the user, so
that's not a huge problem.

Also fix an unrelated bug that was preventing the test from passing, which is
that supertypes were being hashed and compared without the special logic for
detecting self-references. This bug preventing the equivalent recursion groups
in the test from being deduplicated.