### PR TITLE
Eagerly canonicalize basic types

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -3814,7 +3814,13 @@ void canonicalizeBasicTypes(CanonicalizationState& state) {
     // canonicalizable as well, for example after creating `(ref null extern)`
     // we can futher canonicalize to `externref`.
     struct TypeCanonicalizer : TypeGraphWalkerBase<TypeCanonicalizer> {
-      void scanType(Type* type) { *type = asCanonical(*type); }
+      void scanType(Type* type) {
+        if (type->isTuple()) {
+          TypeGraphWalkerBase<TypeCanonicalizer>::scanType(type);
+        } else {
+          *type = asCanonical(*type);
+        }
+      }
     };
     for (auto& info : state.newInfos) {
       auto root = asHeapType(info);

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -459,19 +459,23 @@ TEST_F(IsorecursiveTest, CanonicalizeTypesBeforeSubtyping) {
 }
 
 static void testCanonicalizeBasicTypes() {
-  TypeBuilder builder(3);
+  TypeBuilder builder(5);
 
   Type externref = builder.getTempRefType(builder[0], Nullable);
+  Type externrefs = builder.getTempTupleType({externref, externref});
 
   builder[0] = HeapType::ext;
   builder[1] = Struct({Field(externref, Immutable)});
   builder[2] = Struct({Field(Type::externref, Immutable)});
+  builder[3] = Signature(externrefs, Type::none);
+  builder[4] = Signature(Type({Type::externref, Type::externref}), Type::none);
 
   auto result = builder.build();
   ASSERT_TRUE(result);
   auto built = *result;
 
   EXPECT_EQ(built[1], built[2]);
+  EXPECT_EQ(built[3], built[4]);
 }
 
 TEST_F(EquirecursiveTest, CanonicalizeBasicTypes) {

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -468,7 +468,7 @@ static void testCanonicalizeBasicTypes() {
   builder[1] = Struct({Field(externref, Immutable)});
   builder[2] = Struct({Field(Type::externref, Immutable)});
   builder[3] = Signature(externrefs, Type::none);
-  builder[4] = Signature(Type({Type::externref, Type::externref}), Type::none);
+  builder[4] = Signature({Type::externref, Type::externref}, Type::none);
 
   auto result = builder.build();
   ASSERT_TRUE(result);

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -457,3 +457,26 @@ TEST_F(IsorecursiveTest, CanonicalizeTypesBeforeSubtyping) {
   auto result = builder.build();
   EXPECT_TRUE(result);
 }
+
+static void testCanonicalizeBasicTypes() {
+  TypeBuilder builder(3);
+
+  Type externref = builder.getTempRefType(builder[0], Nullable);
+
+  builder[0] = HeapType::ext;
+  builder[1] = Struct({Field(externref, Immutable)});
+  builder[2] = Struct({Field(Type::externref, Immutable)});
+
+  auto result = builder.build();
+  ASSERT_TRUE(result);
+  auto built = *result;
+
+  EXPECT_EQ(built[1], built[2]);
+}
+
+TEST_F(EquirecursiveTest, CanonicalizeBasicTypes) {
+  testCanonicalizeBasicTypes();
+}
+TEST_F(IsorecursiveTest, CanonicalizeBasicTypes) {
+  testCanonicalizeBasicTypes();
+}


### PR DESCRIPTION
We were already eagerly canonicalizing basic HeapTypes when building types so
the more complicated canonicalization algorithms would not have to handle
noncanonical heap types, but we were not doing the same for Types. Equirecursive
canonicalization was properly handling noncanonical Types everywhere, but
isorecursive canonicalization was not. Rather than update isorecursive
canonicalization in multiple places, remove the special handling from
equirecursive canonicalization and canonicalize types in a single location.