### PR TITLE
Make IndexedTypeNameGenerator more powerful

### DIFF
--- a/src/tools/wasm-fuzz-types.cpp
+++ b/src/tools/wasm-fuzz-types.cpp
@@ -85,8 +85,8 @@ void Fuzzer::printTypes(const std::vector<HeapType>& types) {
     TypeNames getNames(HeapType type) {
       Fatal() << "trying to print unknown heap type";
     }
-  };
-  IndexedTypeNameGenerator<FatalTypeNameGenerator> print(types);
+  } fatalGenerator;
+  IndexedTypeNameGenerator<FatalTypeNameGenerator> print(types, fatalGenerator);
   std::unordered_map<HeapType, size_t> seen;
   for (size_t i = 0; i < types.size(); ++i) {
     auto type = types[i];

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -67,17 +67,23 @@ struct DefaultTypeNameGenerator
 template<typename FallbackGenerator = DefaultTypeNameGenerator>
 struct IndexedTypeNameGenerator
   : TypeNameGeneratorBase<IndexedTypeNameGenerator<FallbackGenerator>> {
-  FallbackGenerator fallback;
+  DefaultTypeNameGenerator defaultGenerator;
+  FallbackGenerator& fallback;
   std::unordered_map<HeapType, TypeNames> names;
-  template<typename T, typename... Args>
+
+  template<typename T>
   IndexedTypeNameGenerator(T& types,
-                           const std::string& prefix = "",
-                           Args&&... args)
-    : fallback(std::forward<Args>(args)...) {
+                           FallbackGenerator& fallback,
+                           const std::string& prefix = "")
+    : fallback(fallback) {
     for (size_t i = 0; i < types.size(); ++i) {
       names.insert({types[i], {prefix + std::to_string(i), {}}});
     }
   }
+  template<typename T>
+  IndexedTypeNameGenerator(T& types, const std::string& prefix = "")
+    : IndexedTypeNameGenerator(types, defaultGenerator, prefix) {}
+
   TypeNames getNames(HeapType type) {
     if (auto it = names.find(type); it != names.end()) {
       return it->second;

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -69,9 +69,13 @@ struct IndexedTypeNameGenerator
   : TypeNameGeneratorBase<IndexedTypeNameGenerator<FallbackGenerator>> {
   FallbackGenerator fallback;
   std::unordered_map<HeapType, TypeNames> names;
-  template<typename T> IndexedTypeNameGenerator(T& types) {
+  template<typename T, typename... Args>
+  IndexedTypeNameGenerator(T& types,
+                           const std::string& prefix = "",
+                           Args&&... args)
+    : fallback(std::forward<Args>(args)...) {
     for (size_t i = 0; i < types.size(); ++i) {
-      names.insert({types[i], {std::to_string(i), {}}});
+      names.insert({types[i], {prefix + std::to_string(i), {}}});
     }
   }
   TypeNames getNames(HeapType type) {

--- a/test/example/type-builder-nominal.cpp
+++ b/test/example/type-builder-nominal.cpp
@@ -30,31 +30,35 @@ void test_builder() {
   Struct struct_({Field(refNullArray, Immutable), Field(rttArray, Mutable)});
   Array array(Field(refNullExt, Mutable));
 
-  IndexedTypeNameGenerator print(builder);
-
-  std::cout << "Before setting heap types:\n";
-  std::cout << "$sig => " << print(builder[0]) << "\n";
-  std::cout << "$struct => " << print(builder[1]) << "\n";
-  std::cout << "$array => " << print(builder[2]) << "\n";
-  std::cout << "(ref $sig) => " << print(refSig) << "\n";
-  std::cout << "(ref $struct) => " << print(refStruct) << "\n";
-  std::cout << "(ref $array) => " << print(refArray) << "\n";
-  std::cout << "(ref null $array) => " << print(refNullArray) << "\n";
-  std::cout << "(rtt 0 $array) => " << print(rttArray) << "\n\n";
+  {
+    IndexedTypeNameGenerator print(builder);
+    std::cout << "Before setting heap types:\n";
+    std::cout << "$sig => " << print(builder[0]) << "\n";
+    std::cout << "$struct => " << print(builder[1]) << "\n";
+    std::cout << "$array => " << print(builder[2]) << "\n";
+    std::cout << "(ref $sig) => " << print(refSig) << "\n";
+    std::cout << "(ref $struct) => " << print(refStruct) << "\n";
+    std::cout << "(ref $array) => " << print(refArray) << "\n";
+    std::cout << "(ref null $array) => " << print(refNullArray) << "\n";
+    std::cout << "(rtt 0 $array) => " << print(rttArray) << "\n\n";
+  }
 
   builder[0] = sig;
   builder[1] = struct_;
   builder[2] = array;
 
-  std::cout << "After setting heap types:\n";
-  std::cout << "$sig => " << print(builder[0]) << "\n";
-  std::cout << "$struct => " << print(builder[1]) << "\n";
-  std::cout << "$array => " << print(builder[2]) << "\n";
-  std::cout << "(ref $sig) => " << print(refSig) << "\n";
-  std::cout << "(ref $struct) => " << print(refStruct) << "\n";
-  std::cout << "(ref $array) => " << print(refArray) << "\n";
-  std::cout << "(ref null $array) => " << print(refNullArray) << "\n";
-  std::cout << "(rtt 0 $array) => " << print(rttArray) << "\n\n";
+  {
+    IndexedTypeNameGenerator print(builder);
+    std::cout << "After setting heap types:\n";
+    std::cout << "$sig => " << print(builder[0]) << "\n";
+    std::cout << "$struct => " << print(builder[1]) << "\n";
+    std::cout << "$array => " << print(builder[2]) << "\n";
+    std::cout << "(ref $sig) => " << print(refSig) << "\n";
+    std::cout << "(ref $struct) => " << print(refStruct) << "\n";
+    std::cout << "(ref $array) => " << print(refArray) << "\n";
+    std::cout << "(ref null $array) => " << print(refNullArray) << "\n";
+    std::cout << "(rtt 0 $array) => " << print(rttArray) << "\n\n";
+  }
 
   std::vector<HeapType> built = *builder.build();
 
@@ -64,17 +68,18 @@ void test_builder() {
   Type newRefNullArray = Type(built[2], Nullable);
   Type newRttArray = Type(Rtt(0, built[2]));
 
-  print = IndexedTypeNameGenerator(built);
-
-  std::cout << "After building types:\n";
-  std::cout << "$sig => " << print(built[0]) << "\n";
-  std::cout << "$struct => " << print(built[1]) << "\n";
-  std::cout << "$array => " << print(built[2]) << "\n";
-  std::cout << "(ref $sig) => " << print(newRefSig) << "\n";
-  std::cout << "(ref $struct) => " << print(newRefStruct) << "\n";
-  std::cout << "(ref $array) => " << print(newRefArray) << "\n";
-  std::cout << "(ref null $array) => " << print(newRefNullArray) << "\n";
-  std::cout << "(rtt 0 $array) => " << print(newRttArray) << "\n\n";
+  {
+    IndexedTypeNameGenerator print(built);
+    std::cout << "After building types:\n";
+    std::cout << "$sig => " << print(built[0]) << "\n";
+    std::cout << "$struct => " << print(built[1]) << "\n";
+    std::cout << "$array => " << print(built[2]) << "\n";
+    std::cout << "(ref $sig) => " << print(newRefSig) << "\n";
+    std::cout << "(ref $struct) => " << print(newRefStruct) << "\n";
+    std::cout << "(ref $array) => " << print(newRefArray) << "\n";
+    std::cout << "(ref null $array) => " << print(newRefNullArray) << "\n";
+    std::cout << "(rtt 0 $array) => " << print(newRttArray) << "\n\n";
+  }
 }
 
 // Check that the builder works when there are duplicate definitions

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -102,7 +102,7 @@ TEST_F(TypeTest, TypeIterator) {
   EXPECT_EQ(reverse, tuple.rend());
 }
 
-TEST_F(TypeTest, PrintTypes) {
+TEST_F(TypeTest, IndexedTypePrinter) {
   TypeBuilder builder(4);
 
   Type refStructA = builder.getTempRefType(builder[0], Nullable);
@@ -121,6 +121,7 @@ TEST_F(TypeTest, PrintTypes) {
   std::vector<HeapType> structs{built[0], built[1]};
   std::vector<HeapType> arrays{built[2], built[3]};
 
+  // Check that IndexedTypePrinters configured with fallbacks work correctly.
   using ArrayPrinter = IndexedTypeNameGenerator<DefaultTypeNameGenerator>;
   ArrayPrinter printArrays(arrays, "array");
   using StructPrinter = IndexedTypeNameGenerator<ArrayPrinter>;

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -122,8 +122,9 @@ TEST_F(TypeTest, PrintTypes) {
   std::vector<HeapType> arrays{built[2], built[3]};
 
   using ArrayPrinter = IndexedTypeNameGenerator<DefaultTypeNameGenerator>;
+  ArrayPrinter printArrays(arrays, "array");
   using StructPrinter = IndexedTypeNameGenerator<ArrayPrinter>;
-  StructPrinter print(structs, "struct", arrays, "array");
+  StructPrinter print(structs, printArrays, "struct");
 
   std::stringstream stream;
   stream << print(built[0]);


### PR DESCRIPTION
Allow IndexedTypeNameGenerator to be configured with a custom prefix and also
allow it to forward additional arguments to initializing its fallback generator.
This allows multiple IndexedTypeNameGenerators to be composed together, for
example.