### PR TITLE
#4285: Clarify that `-O` is equivalent to `-Os` in tools help message.

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -166,10 +166,13 @@ struct PassOptions {
   // passes.
   std::map<std::string, std::string> arguments;
 
+  // -Os is our default
+  static constexpr const int DEFAULT_OPTIMIZE_LEVEL = 2;
+  static constexpr const int DEFAULT_SHRINK_LEVEL = 1;
+
   void setDefaultOptimizationOptions() {
-    // -Os is our default
-    optimizeLevel = 2;
-    shrinkLevel = 1;
+    optimizeLevel = DEFAULT_OPTIMIZE_LEVEL;
+    shrinkLevel = DEFAULT_SHRINK_LEVEL;
   }
 
   static PassOptions getWithDefaultOptimizationOptions() {

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -27,6 +27,8 @@ namespace wasm {
 
 struct OptimizationOptions : public ToolOptions {
   static constexpr const char* DEFAULT_OPT_PASSES = "O";
+  static constexpr const int OS_OPTIMIZE_LEVEL = 2;
+  static constexpr const int OS_SHRINK_LEVEL = 1;
 
   std::vector<std::string> passes;
 
@@ -37,15 +39,20 @@ struct OptimizationOptions : public ToolOptions {
                       const std::string& description)
     : ToolOptions(command, description) {
     (*this)
-      .add("",
-           "-O",
-           "execute default optimization passes",
-           OptimizationOptionsCategory,
-           Options::Arguments::Zero,
-           [this](Options*, const std::string&) {
-             passOptions.setDefaultOptimizationOptions();
-             passes.push_back(DEFAULT_OPT_PASSES);
-           })
+      .add(
+        "",
+        "-O",
+        "execute default optimization passes (equivalent to -Os)",
+        OptimizationOptionsCategory,
+        Options::Arguments::Zero,
+        [this](Options*, const std::string&) {
+          passOptions.setDefaultOptimizationOptions();
+          static_assert(
+            PassOptions::DEFAULT_OPTIMIZE_LEVEL == OS_OPTIMIZE_LEVEL &&
+              PassOptions::DEFAULT_SHRINK_LEVEL == OS_SHRINK_LEVEL,
+            "Help text states that -O is equivalent to -Os but now it isn't.");
+          passes.push_back(DEFAULT_OPT_PASSES);
+        })
       .add("",
            "-O0",
            "execute no optimization passes",
@@ -106,8 +113,8 @@ struct OptimizationOptions : public ToolOptions {
            OptimizationOptionsCategory,
            Options::Arguments::Zero,
            [this](Options*, const std::string&) {
-             passOptions.optimizeLevel = 2;
-             passOptions.shrinkLevel = 1;
+             passOptions.optimizeLevel = OS_OPTIMIZE_LEVEL;
+             passOptions.shrinkLevel = OS_SHRINK_LEVEL;
              passes.push_back(DEFAULT_OPT_PASSES);
            })
       .add("",

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -422,7 +422,7 @@
 ;; CHECK-NEXT: ---------------------
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:    -O                                           execute default optimization
-;; CHECK-NEXT:                                                 passes
+;; CHECK-NEXT:                                                 passes (equivalent to -Os)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:    -O0                                          execute no optimization passes
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -384,7 +384,7 @@
 ;; CHECK-NEXT: ---------------------
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:    -O                                           execute default optimization
-;; CHECK-NEXT:                                                 passes
+;; CHECK-NEXT:                                                 passes (equivalent to -Os)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:    -O0                                          execute no optimization passes
 ;; CHECK-NEXT:


### PR DESCRIPTION
Also update two relevant tests.

#4285 