### PR TITLE
Include type names in error messages from building

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -936,7 +936,16 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
 
   auto result = builder.build();
   if (auto* err = result.getError()) {
-    Fatal() << "Invalid type: " << err->reason << " at index " << err->index;
+    // Find the name to provide a better error message.
+    std::stringstream msg;
+    msg << "Invalid type: " << err->reason;
+    for (auto& [name, index] : typeIndices) {
+      if (index == err->index) {
+        Fatal() << msg.str() << " at type $" << name;
+      }
+    }
+    // No name, just report the index.
+    Fatal() << msg.str() << " at index " << err->index;
   }
   types = *result;
 

--- a/test/lit/parse-bad-supertype.wast
+++ b/test/lit/parse-bad-supertype.wast
@@ -1,0 +1,9 @@
+;; Test that an invalid supertype results in a useful error message
+
+;; RUN: not wasm-opt %s -all --nominal 2>&1 | filecheck %s
+
+;; CHECK: Fatal: Invalid type: Heap type has an invalid supertype at type $sub
+(module
+  (type $super (struct_subtype i32 data))
+  (type $sub (struct_subtype i64 $super))
+)


### PR DESCRIPTION
Instead of just reporting the type index that causes an error when building
types, report the name of the responsible type when parsing the text format.