### PR TITLE
--enable-shared-memory pass

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -32,6 +32,7 @@ set(passes_SOURCES
   DuplicateImportElimination.cpp
   DuplicateFunctionElimination.cpp
   DWARF.cpp
+  EnableSharedMemory.cpp
   ExtractFunction.cpp
   Flatten.cpp
   FuncCastEmulation.cpp

--- a/src/passes/EnableSharedMemory.cpp
+++ b/src/passes/EnableSharedMemory.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pass.h"
+#include "wasm-features.h"
+
+namespace wasm {
+
+struct EnableSharedMemory : public Pass {
+  void run(PassRunner* runner, Module* module) override {
+    if (module->memory.shared) {
+      return;
+    }
+
+    module->memory.shared = true;
+    module->features.set(FeatureSet::Atomics, true);
+  };
+};
+
+Pass* createEnableSharedMemoryPass() { return new EnableSharedMemory(); }
+
+} // namespace wasm

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -138,6 +138,9 @@ void PassRegistry::registerPasses() {
   registerPass("duplicate-function-elimination",
                "removes duplicate functions",
                createDuplicateFunctionEliminationPass);
+  registerPass("enable-shared-memory",
+               "enable shared memory",
+               createEnableSharedMemoryPass);
   registerPass("emit-target-features",
                "emit the target features section in the output",
                createEmitTargetFeaturesPass);

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -41,6 +41,7 @@ Pass* createDirectizePass();
 Pass* createDWARFDumpPass();
 Pass* createDuplicateImportEliminationPass();
 Pass* createDuplicateFunctionEliminationPass();
+Pass* createEnableSharedMemoryPass();
 Pass* createEmitTargetFeaturesPass();
 Pass* createExtractFunctionPass();
 Pass* createExtractFunctionIndexPass();


### PR DESCRIPTION
Hi, I want to use shared memory for my WebAssembly module. It's needed for js-dos. Currently emulation works in worker and frame updates are send using postMessage. I want to use SharedArrayBuffer to avoid copying/sending big rgba data. I dont' need to use pthread or threading, I just want to share memory between worker and main process. 

I found similar question here: https://github.com/emscripten-core/emscripten/issues/12098
As suggested I tried to use wasm2wat and then wat2wasm, but it not working for me. Looks like it affects  -s INVOKE_RUN=0, because after wasm2wat my module immediately starts and I can't provide own memory.

Without wasm2wat I have this error:

```LinkError: WebAssembly.instantiate(): mismatch in shared state of memory, declared = 0, imported = 1```

After wasm2wat this:

```LinkError: WebAssembly.instantiate(): mismatch in shared state of memory, declared = 1, imported = 0```

So, I decided to add this pass to binaryen.

--
[google groups source](https://groups.google.com/g/emscripten-discuss/c/IsRC-MRGQjw)