### PR TITLE
Add CHANGELOG entry for v102 OptimizeInstructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ v102
 
 - Replace `BinaryenExpressionGetSideEffects`'s features parameter with a module
   parameter.
+  
+- OptimizeInstructions now lifts identical code in `select`/`if` arms (#3828). This may cause direct `BinaryenTupleExtract(BinaryenTupleMake(...))` to [use multivalue types](https://github.com/grain-lang/grain/pull/1158).
 
 v101
 ----


### PR DESCRIPTION
We (the Grain team) ran into a funny thing when upgrading to Binaryen 102—we occasionally use tuples to use the wasm stack via a direct `BinaryenTupleExtract` on a `BinaryenTupleMake` to avoid managing an extra local. We support some runtimes that still don't have multivalue, but by never returning a tuple from an `if` or `block` we've avoided any actual use of multivalue in the generated binaries. The update to OptimizeInstructions allows the `BinaryenTupleExtract` to be pulled outside of an `if`, which makes the `if` actually return multiple values. We shouldn't have been abusing tuples in this way, but we figured we'd call it out in the changelog for anyone else who might have done the same 😅 