### PR TITLE
Fix errors when building in C++20 mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,11 @@ include(GNUInstallDirs)
 # The C++ standard whose features are required to build Binaryen.
 # Keep in sync with scripts/test/shared.py cxx_standard
 # The if condition allows embedding in a project with a higher default C++ standard set
-if((NOT CMAKE_CXX_STANDARD) OR (CMAKE_CXX_STANDARD LESS 17))
-  set(CMAKE_CXX_STANDARD 17)
+set(REQUIRED_CXX_STANDARD 17)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD ${REQUIRED_CXX_STANDARD})
+elseif(CMAKE_CXX_STANDARD LESS ${REQUIRED_CXX_STANDARD})
+  message(SEND_ERROR "Building with C++ standards older than C++${REQUIRED_CXX_STANDARD} is not supported, change CMAKE_CXX_STANDARD to ${REQUIRED_CXX_STANDARD} or later")
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,12 @@ include(GNUInstallDirs)
 
 # The C++ standard whose features are required to build Binaryen.
 # Keep in sync with scripts/test/shared.py cxx_standard
-set(CXX_STANDARD 17)
+# The if condition allows embedding in a project with a higher default C++ standard set
+if((NOT CMAKE_CXX_STANDARD) OR (CMAKE_CXX_STANDARD LESS 17))
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to Release")
@@ -109,8 +114,6 @@ function(binaryen_add_executable name sources)
   add_executable(${name} ${sources})
   target_link_libraries(${name} ${CMAKE_THREAD_LIBS_INIT})
   target_link_libraries(${name} binaryen)
-  set_property(TARGET ${name} PROPERTY CXX_STANDARD ${CXX_STANDARD})
-  set_property(TARGET ${name} PROPERTY CXX_STANDARD_REQUIRED ON)
   binaryen_setup_rpath(${name})
   install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endfunction()
@@ -175,12 +178,11 @@ if(MSVC)
       add_compile_flag("/arch:sse2")
     endif()
   endif()
-  add_compile_flag("/std:c++${CXX_STANDARD}")
   add_compile_flag("/wd4146") # Ignore warning "warning C4146: unary minus operator applied to unsigned type, result still unsigned", this pattern is used somewhat commonly in the code.
   # 4267 and 4244 are conversion/truncation warnings. We might want to fix these but they are currently pervasive.
   add_compile_flag("/wd4267")
   add_compile_flag("/wd4244")
-  # 4722 warns that destructors never return, even with WASM_NORETURN.
+  # 4722 warns that destructors never return, even with [[noreturn]].
   add_compile_flag("/wd4722")
   # "destructor was implicitly defined as deleted" caused by LLVM headers.
   add_compile_flag("/wd4624")
@@ -233,7 +235,6 @@ else()
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   set(CMAKE_THREAD_PREFER_PTHREAD ON)
   find_package(Threads REQUIRED)
-  add_cxx_flag("-std=c++${CXX_STANDARD}")
   if(NOT EMSCRIPTEN)
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
       # wasm doesn't allow for x87 floating point math
@@ -384,8 +385,6 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_wasm optimized "--closure-args \"--language_in=ECMASCRIPT6 --language_out=ECMASCRIPT6\"")
   target_link_libraries(binaryen_wasm optimized "-flto")
   target_link_libraries(binaryen_wasm debug "--profiling")
-  set_property(TARGET binaryen_wasm PROPERTY CXX_STANDARD ${CXX_STANDARD})
-  set_property(TARGET binaryen_wasm PROPERTY CXX_STANDARD_REQUIRED ON)
   install(TARGETS binaryen_wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   # binaryen.js JavaScript variant
@@ -409,8 +408,6 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_js optimized "-flto")
   target_link_libraries(binaryen_js debug "--profiling")
   target_link_libraries(binaryen_js debug "-s ASSERTIONS")
-  set_property(TARGET binaryen_js PROPERTY CXX_STANDARD ${CXX_STANDARD})
-  set_property(TARGET binaryen_js PROPERTY CXX_STANDARD_REQUIRED ON)
   install(TARGETS binaryen_js DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 

--- a/src/compiler-support.h
+++ b/src/compiler-support.h
@@ -31,14 +31,6 @@
 #define WASM_BUILTIN_UNREACHABLE __assume(false)
 #endif
 
-#ifdef __GNUC__
-#define WASM_NORETURN __attribute__((noreturn))
-#elif defined(_MSC_VER)
-#define WASM_NORETURN __declspec(noreturn)
-#else
-#define WASM_NORETURN
-#endif
-
 // The code might contain TODOs or stubs that read some values but do nothing
 // with them. The compiler might fail with [-Werror,-Wunused-variable].
 // The WASM_UNUSED(varible) is a wrapper that helps to suppress the error.

--- a/src/support/utilities.cpp
+++ b/src/support/utilities.cpp
@@ -24,9 +24,8 @@
 #include "sanitizer/common_interface_defs.h"
 #endif
 
-void wasm::handle_unreachable(const char* msg,
-                              const char* file,
-                              unsigned line) {
+[[noreturn]] void
+wasm::handle_unreachable(const char* msg, const char* file, unsigned line) {
 #ifndef NDEBUG
   if (msg) {
     std::cerr << msg << "\n";

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -155,7 +155,7 @@ struct ToolOptions : public Options {
            std::string("Enable ") + description,
            ToolOptionsCategory,
            Arguments::Zero,
-           [=](Options*, const std::string&) {
+           [=, this](Options*, const std::string&) {
              enabledFeatures.set(feature, true);
              disabledFeatures.set(feature, false);
            })
@@ -165,7 +165,7 @@ struct ToolOptions : public Options {
            std::string("Disable ") + description,
            ToolOptionsCategory,
            Arguments::Zero,
-           [=](Options*, const std::string&) {
+           [=, this](Options*, const std::string&) {
              enabledFeatures.set(feature, false);
              disabledFeatures.set(feature, true);
            });

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -155,7 +155,7 @@ struct ToolOptions : public Options {
            std::string("Enable ") + description,
            ToolOptionsCategory,
            Arguments::Zero,
-           [=, this](Options*, const std::string&) {
+           [this, feature](Options*, const std::string&) {
              enabledFeatures.set(feature, true);
              disabledFeatures.set(feature, false);
            })
@@ -165,7 +165,7 @@ struct ToolOptions : public Options {
            std::string("Disable ") + description,
            ToolOptionsCategory,
            Arguments::Zero,
-           [=, this](Options*, const std::string&) {
+           [this, feature](Options*, const std::string&) {
              enabledFeatures.set(feature, false);
              disabledFeatures.set(feature, true);
            });

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -82,7 +82,7 @@ struct FeatureSet {
     }
   }
 
-  std::string toString() {
+  std::string toString() const {
     std::string ret;
     uint32_t x = 1;
     while (x & Feature::All) {
@@ -102,7 +102,7 @@ struct FeatureSet {
   operator uint32_t() const { return features; }
 
   bool isMVP() const { return features == MVP; }
-  bool has(FeatureSet f) { return (features & f) == f; }
+  bool has(FeatureSet f) const { return (features & f) == f.features; }
   bool hasAtomics() const { return (features & Atomics) != 0; }
   bool hasMutableGlobals() const { return (features & MutableGlobals) != 0; }
   bool hasTruncSat() const { return (features & TruncSat) != 0; }
@@ -165,7 +165,7 @@ struct FeatureSet {
     features = features & ~other.features & All;
   }
 
-  template<typename F> void iterFeatures(F f) {
+  template<typename F> void iterFeatures(F f) const {
     for (uint32_t feature = MVP + 1; feature < All; feature <<= 1) {
       if (has(feature)) {
         f(static_cast<Feature>(feature));


### PR DESCRIPTION
C++:
 * use [[noreturn]] available since C++11 instead of compiler-specific attributes
 * replace deprecated std::is_pod with is_trivial&&is_standard_layout (also available since C++11/14)
 * explicitly capture this in [=] lambdas
 * extra const functions in FeatureSet, fix ambiguous operator& call error

CMake:
 * Use CMAKE_CXX_STANDARD set in the directory scope to set the default CXX_STANDARD for all targets
 * The above made it unnecessary for the -std=c++17 flag to be passed directly in compiler options
 * Explicitly disable vendor c++ standard extensions (GNU/MSVC) in directory scope as they are on by default in CMake