### PR TITLE
Add BUILD_TESTS CMake option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- Add BUILD_TESTS CMake option to make gtest dependency optional.
+
 v106
 ----
 
@@ -63,7 +65,7 @@ v102
 
 - Replace `BinaryenExpressionGetSideEffects`'s features parameter with a module
   parameter.
-  
+
 - OptimizeInstructions now lifts identical code in `select`/`if` arms (#3828). This may cause direct `BinaryenTupleExtract(BinaryenTupleMake(...))` to [use multivalue types](https://github.com/grain-lang/grain/pull/1158).
 
 v101

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ endif()
 # more useful error reports from users.
 option(BYN_ENABLE_ASSERTIONS "Enable assertions" ON)
 
+# Turn this off to avoid the dependency on gtest.
+option(BUILD_TESTS "Build GTest-based tests" ON)
+
 # For git users, attempt to generate a more useful version string
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git QUIET REQUIRED)
@@ -320,8 +323,10 @@ add_subdirectory(third_party)
 # Configure lit tests
 add_subdirectory(test/lit)
 
-# Configure GTest unit tests
-add_subdirectory(test/gtest)
+if(BUILD_TESTS)
+  # Configure GTest unit tests
+  add_subdirectory(test/gtest)
+endif()
 
 # Object files
 set(binaryen_objs

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ cmake . && make
 
 A C++17 compiler is required. Note that you can also use `ninja` as your generator: `cmake -G Ninja . && ninja`.
 
-To avoid the gtest dependency, you can pass `-DBUILD_TESTS=NO` to cmake.
+To avoid the gtest dependency, you can pass `-DBUILD_TESTS=OFF` to cmake.
 
 Binaryen.js can be built using Emscripten, which can be installed via [the SDK](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html)).
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ After that you can build with CMake:
 cmake . && make
 ```
 
-A C++14 compiler is required. Note that you can also use `ninja` as your generator: `cmake -G Ninja . && ninja`.
+A C++17 compiler is required. Note that you can also use `ninja` as your generator: `cmake -G Ninja . && ninja`.
+
+To avoid the gtest dependency, you can pass `-DBUILD_TESTS=NO` to cmake.
 
 Binaryen.js can be built using Emscripten, which can be installed via [the SDK](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html)).
 

--- a/check.py
+++ b/check.py
@@ -343,11 +343,14 @@ def run_lit():
 def run_gtest():
     def run():
         gtest = os.path.join(shared.options.binaryen_bin, 'binaryen-unittests')
-        result = subprocess.run(gtest)
-        if result.returncode != 0:
-            shared.num_failures += 1
-        if shared.options.abort_on_first_failure and shared.num_failures:
-            raise Exception("gtest test failed")
+        if not os.path.isfile(gtest):
+            shared.warn('gtest binary not found - skipping tests')
+        else:
+            result = subprocess.run(gtest)
+            if result.returncode != 0:
+                shared.num_failures += 1
+            if shared.options.abort_on_first_failure and shared.num_failures:
+                raise Exception("gtest test failed")
 
     shared.with_pass_debug(run)
 


### PR DESCRIPTION
Turning it off removes the build dependency on the third-party googletest
library.