### PR TITLE
Update filecheck to 0.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+- Updated tests to use filecheck 0.0.22 (#4537). Updating is required to
+  successfully run the lit tests.
+
 v106
 ----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Current Trunk
 
 - Add BUILD_TESTS CMake option to make gtest dependency optional.
 - Updated tests to use filecheck 0.0.22 (#4537). Updating is required to
-  successfully run the lit tests.
+  successfully run the lit tests. This can be done with
+  `pip3 install -r requirements-dev.txt`.
 
 v106
 ----

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@
 # Install with `pip3 install -r requirements-dev.txt`
 
 flake8==3.7.8
-filecheck==0.0.17
+filecheck==0.0.22
 lit==0.11.0.post1

--- a/test/lit/wasm-split/basic.wast
+++ b/test/lit/wasm-split/basic.wast
@@ -148,7 +148,7 @@
 
 ;; KEEP-BOTH: warning: not splitting any functions out to the secondary module
 ;; KEEP-BOTH-NEXT: Keeping functions: bar, foo{{$}}
-;; KEEP-BOTH-NEXT: Splitting out functions:{{$}}
+;; KEEP-BOTH-NEXT: Splitting out functions: {{$}}
 
 ;; KEEP-BOTH-PRIMARY:      (module
 ;; KEEP-BOTH-PRIMARY-NEXT:  (type $i32_=>_i32 (func (param i32) (result i32)))


### PR DESCRIPTION
This update includes a
[fix](https://github.com/mull-project/FileCheck.py/pull/188) to how the
filecheck Python package matches whitespace to more closely match the behavior
of upstream filecheck in LLVM. We have one test affected by this change, so all
users who run the test suite will have to update their installed filecheck. This
can be done via

```
pip3 install -r requirements-dev.txt
```