### PR TITLE
[NFC] Move type system test fixture to its own header

### DIFF
--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -1,39 +1,9 @@
+#include "type-test.h"
 #include "wasm-type-printing.h"
 #include "wasm-type.h"
 #include "gtest/gtest.h"
 
 using namespace wasm;
-
-// Helper test fixture for managing the global type system state.
-template<TypeSystem system> class TypeSystemTest : public ::testing::Test {
-  TypeSystem originalSystem;
-
-protected:
-  void SetUp() override {
-    originalSystem = getTypeSystem();
-    setTypeSystem(system);
-  }
-  void TearDown() override {
-    destroyAllTypesForTestingPurposesOnly();
-    setTypeSystem(originalSystem);
-  }
-
-  // Utilities
-  Struct makeStruct(TypeBuilder& builder,
-                    std::initializer_list<size_t> indices) {
-    FieldList fields;
-    for (auto index : indices) {
-      Type ref = builder.getTempRefType(builder[index], Nullable);
-      fields.emplace_back(ref, Mutable);
-    }
-    return Struct(std::move(fields));
-  }
-};
-
-using TypeTest = TypeSystemTest<TypeSystem::Equirecursive>;
-using EquirecursiveTest = TypeSystemTest<TypeSystem::Equirecursive>;
-using NominalTest = TypeSystemTest<TypeSystem::Nominal>;
-using IsorecursiveTest = TypeSystemTest<TypeSystem::Isorecursive>;
 
 TEST_F(TypeTest, TypeBuilderGrowth) {
   TypeBuilder builder;

--- a/test/gtest/type-test.h
+++ b/test/gtest/type-test.h
@@ -1,0 +1,40 @@
+#include "wasm-type.h"
+#include "gtest/gtest.h"
+
+#ifndef wasm_test_gtest_type_test_h
+#define wasm_test_gtest_type_test_h
+
+// Helper test fixture for managing the global type system state.
+template<wasm::TypeSystem system>
+class TypeSystemTest : public ::testing::Test {
+  wasm::TypeSystem originalSystem;
+
+protected:
+  void SetUp() override {
+    originalSystem = wasm::getTypeSystem();
+    wasm::setTypeSystem(system);
+  }
+  void TearDown() override {
+    wasm::destroyAllTypesForTestingPurposesOnly();
+    wasm::setTypeSystem(originalSystem);
+  }
+
+  // Utilities
+  wasm::Struct makeStruct(wasm::TypeBuilder& builder,
+                          std::initializer_list<size_t> indices) {
+    using namespace wasm;
+    FieldList fields;
+    for (auto index : indices) {
+      Type ref = builder.getTempRefType(builder[index], Nullable);
+      fields.emplace_back(ref, Mutable);
+    }
+    return Struct(std::move(fields));
+  }
+};
+
+using TypeTest = TypeSystemTest<wasm::TypeSystem::Equirecursive>;
+using EquirecursiveTest = TypeSystemTest<wasm::TypeSystem::Equirecursive>;
+using NominalTest = TypeSystemTest<wasm::TypeSystem::Nominal>;
+using IsorecursiveTest = TypeSystemTest<wasm::TypeSystem::Isorecursive>;
+
+#endif // wasm_test_gtest_type_test_h


### PR DESCRIPTION
Allow the fixture to be shared with other test .cpp files we might add in the
future.