### PR TITLE
[NFC] Refactor DeadArgumentElimination code to use LocalGraph

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -87,8 +87,7 @@ struct DAEFunctionInfo {
 typedef std::unordered_map<Name, DAEFunctionInfo> DAEFunctionInfoMap;
 
 struct DAEScanner
-  : public WalkerPass<
-      PostWalker<DAEScanner, Visitor<DAEScanner>>> {
+  : public WalkerPass<PostWalker<DAEScanner, Visitor<DAEScanner>>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new DAEScanner(infoMap); }
@@ -144,8 +143,7 @@ struct DAEScanner
   void doWalkFunction(Function* func) {
     numParams = func->getNumParams();
     info = &((*infoMap)[func->name]);
-    PostWalker<DAEScanner, Visitor<DAEScanner>>::doWalkFunction(
-      func);
+    PostWalker<DAEScanner, Visitor<DAEScanner>>::doWalkFunction(func);
     // If there are relevant params, check if they are used. If we can't
     // optimize the function anyhow, there's no point (note that our check here
     // is technically racy - another thread could update hasUnseenCalls to true


### PR DESCRIPTION
I believe this old code was written before we had LocalGraph. It does a flow
analysis to see if the values arriving in parameters are actually used, but
there is no reason to do it manually since we have LocalGraph now which
makes that trivial, as it matches the values for each get, so we can just check
if any get can read the param's incoming value.