### PR TITLE
[NFC] Refactor constant argument finding code

### DIFF
--- a/src/ir/possible-constant.h
+++ b/src/ir/possible-constant.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_possible_constant_h
+#define wasm_ir_possible_constant_h
+
+#include <variant>
+
+#include "wasm-builder.h"
+#include "wasm.h"
+
+namespace wasm {
+
+// Represents data about what constant values are possible in a particular
+// place. There may be no values, or one, or many, or if a non-constant value is
+// possible, then all we can say is that the value is "unknown" - it can be
+// anything. The values can either be literal values (Literal) or the names of
+// immutable globals (Name).
+//
+// Currently this just looks for a single constant value, and even two constant
+// values are treated as unknown. It may be worth optimizing more than that TODO
+struct PossibleConstantValues {
+private:
+  // No possible value.
+  struct None : public std::monostate {};
+
+  // Many possible values, and so this represents unknown data: we cannot infer
+  // anything there.
+  struct Many : public std::monostate {};
+
+  using Variant = std::variant<None, Literal, Name, Many>;
+  Variant value;
+
+public:
+  PossibleConstantValues() : value(None()) {}
+
+  // Note a written value as we see it, and update our internal knowledge based
+  // on it and all previous values noted. This can be called using either a
+  // Literal or a Name, so it uses a template.
+  template<typename T> void note(T curr) {
+    if (std::get_if<None>(&value)) {
+      // This is the first value.
+      value = curr;
+      return;
+    }
+
+    if (std::get_if<Many>(&value)) {
+      // This was already representing multiple values; nothing changes.
+      return;
+    }
+
+    // This is a subsequent value. Check if it is different from all previous
+    // ones.
+    if (Variant(curr) != value) {
+      noteUnknown();
+    }
+  }
+
+  // Notes a value that is unknown - it can be anything. We have failed to
+  // identify a constant value here.
+  void noteUnknown() { value = Many(); }
+
+  // Combine the information in a given PossibleConstantValues to this one. This
+  // is the same as if we have called note*() on us with all the history of
+  // calls to that other object.
+  //
+  // Returns whether we changed anything.
+  bool combine(const PossibleConstantValues& other) {
+    if (std::get_if<None>(&other.value)) {
+      return false;
+    }
+
+    if (std::get_if<None>(&value)) {
+      value = other.value;
+      return true;
+    }
+
+    if (std::get_if<Many>(&value)) {
+      return false;
+    }
+
+    if (other.value != value) {
+      value = Many();
+      return true;
+    }
+
+    return false;
+  }
+
+  // Check if all the values are identical and constant.
+  bool isConstant() const {
+    return !std::get_if<None>(&value) && !std::get_if<Many>(&value);
+  }
+
+  bool isConstantLiteral() const { return std::get_if<Literal>(&value); }
+
+  bool isConstantGlobal() const { return std::get_if<Name>(&value); }
+
+  // Returns the single constant value.
+  Literal getConstantLiteral() const {
+    assert(isConstant());
+    return std::get<Literal>(value);
+  }
+
+  Name getConstantGlobal() const {
+    assert(isConstant());
+    return std::get<Name>(value);
+  }
+
+  // Returns whether we have ever noted a value.
+  bool hasNoted() const { return !std::get_if<None>(&value); }
+
+  void dump(std::ostream& o) {
+    o << '[';
+    if (!hasNoted()) {
+      o << "unwritten";
+    } else if (!isConstant()) {
+      o << "unknown";
+    } else if (isConstantLiteral()) {
+      o << getConstantLiteral();
+    } else if (isConstantGlobal()) {
+      o << '$' << getConstantGlobal();
+    }
+    o << ']';
+  }
+};
+
+} // namespace wasm
+
+#endif // wasm_ir_possible_constant_h

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -27,9 +27,8 @@
 //        wasm GC programs we need to check for type escaping.
 //
 
-#include <variant>
-
 #include "ir/module-utils.h"
+#include "ir/possible-constant.h"
 #include "ir/properties.h"
 #include "ir/struct-utils.h"
 #include "ir/utils.h"
@@ -42,120 +41,6 @@
 namespace wasm {
 
 namespace {
-
-// No possible value.
-struct None : public std::monostate {};
-
-// Many possible values, and so this represents unknown data: we cannot infer
-// anything there.
-struct Many : public std::monostate {};
-
-// Represents data about what constant values are possible in a particular
-// place. There may be no values, or one, or many, or if a non-constant value is
-// possible, then all we can say is that the value is "unknown" - it can be
-// anything. The values can either be literal values (Literal) or the names of
-// immutable globals (Name).
-//
-// Currently this just looks for a single constant value, and even two constant
-// values are treated as unknown. It may be worth optimizing more than that TODO
-struct PossibleConstantValues {
-private:
-  using Variant = std::variant<None, Literal, Name, Many>;
-  Variant value;
-
-public:
-  PossibleConstantValues() : value(None()) {}
-
-  // Note a written value as we see it, and update our internal knowledge based
-  // on it and all previous values noted. This can be called using either a
-  // Literal or a Name, so it uses a template.
-  template<typename T> void note(T curr) {
-    if (std::get_if<None>(&value)) {
-      // This is the first value.
-      value = curr;
-      return;
-    }
-
-    if (std::get_if<Many>(&value)) {
-      // This was already representing multiple values; nothing changes.
-      return;
-    }
-
-    // This is a subsequent value. Check if it is different from all previous
-    // ones.
-    if (Variant(curr) != value) {
-      noteUnknown();
-    }
-  }
-
-  // Notes a value that is unknown - it can be anything. We have failed to
-  // identify a constant value here.
-  void noteUnknown() { value = Many(); }
-
-  // Combine the information in a given PossibleConstantValues to this one. This
-  // is the same as if we have called note*() on us with all the history of
-  // calls to that other object.
-  //
-  // Returns whether we changed anything.
-  bool combine(const PossibleConstantValues& other) {
-    if (std::get_if<None>(&other.value)) {
-      return false;
-    }
-
-    if (std::get_if<None>(&value)) {
-      value = other.value;
-      return true;
-    }
-
-    if (std::get_if<Many>(&value)) {
-      return false;
-    }
-
-    if (other.value != value) {
-      value = Many();
-      return true;
-    }
-
-    return false;
-  }
-
-  // Check if all the values are identical and constant.
-  bool isConstant() const {
-    return !std::get_if<None>(&value) && !std::get_if<Many>(&value);
-  }
-
-  bool isConstantLiteral() const { return std::get_if<Literal>(&value); }
-
-  bool isConstantGlobal() const { return std::get_if<Name>(&value); }
-
-  // Returns the single constant value.
-  Literal getConstantLiteral() const {
-    assert(isConstant());
-    return std::get<Literal>(value);
-  }
-
-  Name getConstantGlobal() const {
-    assert(isConstant());
-    return std::get<Name>(value);
-  }
-
-  // Returns whether we have ever noted a value.
-  bool hasNoted() const { return !std::get_if<None>(&value); }
-
-  void dump(std::ostream& o) {
-    o << '[';
-    if (!hasNoted()) {
-      o << "unwritten";
-    } else if (!isConstant()) {
-      o << "unknown";
-    } else if (isConstantLiteral()) {
-      o << getConstantLiteral();
-    } else if (isConstantGlobal()) {
-      o << '$' << getConstantGlobal();
-    }
-    o << ']';
-  }
-};
 
 using PCVStructValuesMap = StructUtils::StructValuesMap<PossibleConstantValues>;
 using PCVFunctionStructValuesMap =


### PR DESCRIPTION
This just moves `PossibleConstantValues` to a new separate file
(as a preparation for other passes using it too).