### PR TITLE
Do not build gtest libs unless BUILD_TESTS is set

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -7,10 +7,7 @@ include_directories(
   googletest/googletest/include
 )
 
-add_library(gtest STATIC
-  googletest/googletest/src/gtest-all.cc
-)
-
-add_library(gtest_main STATIC
-  googletest/googletest/src/gtest_main.cc
-)
+if(BUILD_TESTS)
+  add_library(gtest STATIC googletest/googletest/src/gtest-all.cc)
+  add_library(gtest_main STATIC googletest/googletest/src/gtest_main.cc)
+endif()


### PR DESCRIPTION
This was missed in #4536.