### PR TITLE
[Wasm GC] GlobalTypeOptimization: Remove fields from end based on subtypes

### DIFF
--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -221,15 +221,19 @@ public:
   SubTypes subTypes;
 
   void propagateToSuperTypes(StructValuesMap<T>& infos) {
-    propagate(infos, false);
+    propagate(infos, false, true);
+  }
+
+  void propagateToSubTypes(StructValuesMap<T>& infos) {
+    propagate(infos, true, false);
   }
 
   void propagateToSuperAndSubTypes(StructValuesMap<T>& infos) {
-    propagate(infos, true);
+    propagate(infos, true, true);
   }
 
 private:
-  void propagate(StructValuesMap<T>& combinedInfos, bool toSubTypes) {
+  void propagate(StructValuesMap<T>& combinedInfos, bool toSubTypes, bool toSuperTypes) {
     UniqueDeferredQueue<HeapType> work;
     for (auto& [type, _] : combinedInfos) {
       work.push(type);
@@ -238,13 +242,15 @@ private:
       auto type = work.pop();
       auto& infos = combinedInfos[type];
 
-      // Propagate shared fields to the supertype.
-      if (auto superType = type.getSuperType()) {
-        auto& superInfos = combinedInfos[*superType];
-        auto& superFields = superType->getStruct().fields;
-        for (Index i = 0; i < superFields.size(); i++) {
-          if (superInfos[i].combine(infos[i])) {
-            work.push(*superType);
+      if (toSuperTypes) {
+        // Propagate shared fields to the supertype.
+        if (auto superType = type.getSuperType()) {
+          auto& superInfos = combinedInfos[*superType];
+          auto& superFields = superType->getStruct().fields;
+          for (Index i = 0; i < superFields.size(); i++) {
+            if (superInfos[i].combine(infos[i])) {
+              work.push(*superType);
+            }
           }
         }
       }

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -233,7 +233,9 @@ public:
   }
 
 private:
-  void propagate(StructValuesMap<T>& combinedInfos, bool toSubTypes, bool toSuperTypes) {
+  void propagate(StructValuesMap<T>& combinedInfos,
+                 bool toSubTypes,
+                 bool toSuperTypes) {
     UniqueDeferredQueue<HeapType> work;
     for (auto& [type, _] : combinedInfos) {
       work.push(type);

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -75,6 +75,12 @@ void GlobalTypeRewriter::update() {
   }
 
   auto buildResults = typeBuilder.build();
+#ifndef NDEBUG
+  if (auto* err = buildResults.getError()) {
+    Fatal() << "Internal GlobalTypeRewriter build error: " << err->reason
+            << " at index " << err->index;
+  }
+#endif
   auto& newTypes = *buildResults;
 
   // Map the old types to the new ones. This uses the fact that type indices

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -158,7 +158,7 @@ struct GlobalTypeOptimization : public Pass {
     auto subSupers = combinedSetGetInfos;
     propagator.propagateToSuperAndSubTypes(subSupers);
     auto subs = std::move(combinedSetGetInfos);
-    propagator.propagateToSuperAndSubTypes(subs);
+    propagator.propagateToSubTypes(subs);
 
     // Process the propagated info.
     for (auto type : propagator.subTypes.types) {

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -207,7 +207,10 @@ struct GlobalTypeOptimization : public Pass {
         // possible read of the data at all. But here we just propagated to
         // subtypes, and so we need to care about the case where the parent
         // writes to a field but does not read from it - we still need those
-        // writes to happen as children may read them.
+        // writes to happen as children may read them. (Note that if no child
+        // reads this field, and since we check for reads in parents here, that
+        // means the field is not read anywhere at all, and we would have
+        // handled that case in the previous loop anyhow.)
         if (!sub[i].hasRead && !sub[i].hasWrite) {
           removableIndexes.insert(i);
         } else {

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -136,6 +136,15 @@ struct GlobalTypeOptimization : public Pass {
     //  * For removing unread fields, we can only remove a field if it is never
     //    read in any sub or supertype, as such a read may alias any of those
     //    types (where the field is present).
+    //    (Note that we could propagate reads only to supertypes, but we would
+    //    be limited in what we optimize. If type A has fields {a, b}, and its
+    //    subtype B has the same fields, and if field a is only used in reads of
+    //    type B, then we still cannot remove it. If we removed it then A would
+    //    have fields {b}, that is, field b would be at index 0, while type B
+    //    would still be {a, b} which has field b at index 1, which is not
+    //    compatible. The only case in which we can optimize is to remove a
+    //    field from the end, that is, we could remove field b from A. TODO:
+    //    optimize that case.)
     //
     //  * For immutability, this is necessary because we cannot have a
     //    supertype's field be immutable while a subtype's is not - they must

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -200,7 +200,13 @@ struct GlobalTypeOptimization : public Pass {
         }
       }
       for (int i = int(fields.size()) - 1; i >= 0; i--) {
-        if (!sub[i].hasRead) {
+        // Unlike above, a write would stop us here: above we propagated to both
+        // sub- and super-types, which means if we see no reads then there is no
+        // possible read of the data at all. But here we just propagated to
+        // subtypes, and so we need to care about the case where the parent
+        // writes to a field but does not read from it - we still need those
+        // writes to happen.
+        if (!sub[i].hasRead && !sub[i].hasWrite) {
           removableIndexes.insert(i);
         } else {
           // Once we see something we can't remove, we must stop, as we can only

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -137,13 +137,15 @@ struct GlobalTypeOptimization : public Pass {
     //    types (where the field is present).
     //
     //    Note that we *can* propagate reads only to supertypes, but we are
-    //    be limited in what we optimize. If type A has fields {a, b}, and its
+    //    limited in what we optimize. If type A has fields {a, b}, and its
     //    subtype B has the same fields, and if field a is only used in reads of
     //    type B, then we still cannot remove it. If we removed it then A would
     //    have fields {b}, that is, field b would be at index 0, while type B
     //    would still be {a, b} which has field b at index 1, which is not
     //    compatible. The only case in which we can optimize is to remove a
     //    field from the end, that is, we could remove field b from A.
+    //    Otherwise, as mentioned before we can only remove a field if we also
+    //    remove it from all sub- and super-types.
     //
     //  * For immutability, this is necessary because we cannot have a
     //    supertype's field be immutable while a subtype's is not - they must
@@ -205,7 +207,7 @@ struct GlobalTypeOptimization : public Pass {
         // possible read of the data at all. But here we just propagated to
         // subtypes, and so we need to care about the case where the parent
         // writes to a field but does not read from it - we still need those
-        // writes to happen.
+        // writes to happen as children may read them.
         if (!sub[i].hasRead && !sub[i].hasWrite) {
           removableIndexes.insert(i);
         } else {

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -764,3 +764,28 @@
     (drop (struct.get $parent 0 (local.get $parent)))
   )
 )
+
+;; As above, but now the read is just of one child. We can remove the field
+;; from the parent and the other child.
+(module
+  ;; CHECK:      (type $child1 (struct_subtype (field i32) $parent))
+  (type $child1 (struct_subtype (field i32) $parent))
+
+  ;; CHECK:      (type $ref|$parent|_ref|$child1|_ref|$child2|_=>_none (func_subtype (param (ref $parent) (ref $child1) (ref $child2)) func))
+
+  ;; CHECK:      (type $parent (struct_subtype  data))
+  (type $parent (struct_subtype (field i32) data))
+  ;; CHECK:      (type $child2 (struct_subtype  $parent))
+  (type $child2 (struct_subtype (field i32) $parent))
+
+  ;; CHECK:      (func $func (type $ref|$parent|_ref|$child1|_ref|$child2|_=>_none) (param $parent (ref $parent)) (param $child1 (ref $child1)) (param $child2 (ref $child2))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $child1 0
+  ;; CHECK-NEXT:    (local.get $child1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $func (param $parent (ref $parent)) (param $child1 (ref $child1)) (param $child2 (ref $child2))
+    (drop (struct.get $child1 0 (local.get $child1)))
+  )
+)

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -686,3 +686,56 @@
     (drop (struct.get $child  4 (local.get $y)))
   )
 )
+
+(module
+  ;; CHECK:      (type $child (struct_subtype (field i32) (field i64) (field (mut f32)) (field f64) (field anyref) $parent))
+
+  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) (field (mut f32)) data))
+  (type $parent (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) data))
+  (type $child (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) (field (mut anyref)) $parent))
+
+  ;; CHECK:      (type $ref|$parent|_ref|$child|_=>_none (func_subtype (param (ref $parent) (ref $child)) func))
+
+  ;; CHECK:      (func $func (type $ref|$parent|_ref|$child|_=>_none) (param $x (ref $parent)) (param $y (ref $child))
+  ;; CHECK-NEXT:  (struct.set $parent 2
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (f32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $parent 1
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $child 0
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $child 2
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $child 3
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $child 4
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $func (param $x (ref $parent)) (param $y (ref $child))
+    ;; As above, but add a write in the parent of field 2. That prevents us from
+    ;; removing it from the parent.
+    (struct.set $parent 2 (local.get $x) (f32.const 0))
+
+    (drop (struct.get $parent 1 (local.get $x)))
+    (drop (struct.get $child  0 (local.get $y)))
+    (drop (struct.get $child  2 (local.get $y)))
+    (drop (struct.get $child  3 (local.get $y)))
+    (drop (struct.get $child  4 (local.get $y)))
+  )
+)

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -641,7 +641,7 @@
 (module
   ;; CHECK:      (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
 
-  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) (field f32) (field f64) data))
+  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) data))
   (type $parent (struct_subtype (field i32) (field i64) (field f32) (field f64) data))
   (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
 

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -640,10 +640,10 @@
 ;; the subtypes can always add fields at the end (and only at the end).
 (module
   ;; CHECK:      (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
+  (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
 
   ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) data))
   (type $parent (struct_subtype (field i32) (field i64) (field f32) (field f64) data))
-  (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
 
   ;; CHECK:      (type $ref|$parent|_ref|$child|_=>_none (func_subtype (param (ref $parent) (ref $child)) func))
 
@@ -689,10 +689,10 @@
 
 (module
   ;; CHECK:      (type $child (struct_subtype (field i32) (field i64) (field (mut f32)) (field f64) (field anyref) $parent))
+  (type $child (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) (field (mut anyref)) $parent))
 
   ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) (field (mut f32)) data))
   (type $parent (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) data))
-  (type $child (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) (field (mut anyref)) $parent))
 
   ;; CHECK:      (type $ref|$parent|_ref|$child|_=>_none (func_subtype (param (ref $parent) (ref $child)) func))
 


### PR DESCRIPTION
Previously we'd remove a field from a type if that field has no uses in any
sub- or super-type. In that case we'd remove it from all the types at once.
However, there is a case where we can remove a field only from a parent
but not from its children, if the field is at the end: if `A` has fields `{x, y, z}`
and its subtype `B` has fields `{x, y, z, w}`, and `A` pointers only access
field `y` while `B` pointers access all the fields, then we can remove `z`
from `A`. Removing it from the end is safe, and then `B` will not only add
`w` as it did before but also add `z`. Note that we cannot remove `x`,
because it is not at the end: removing it from just `A` but not `B` would
shift the indexes, making them incompatible.
