### PR TITLE
[NFC] Refactor Feature::All to match FeatureSet.setAll()

### DIFF
--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -134,7 +134,7 @@ protected:
     lastModule = module->name;
     builders[moduleName] = builder;
     modules[moduleName].swap(module);
-    modules[moduleName]->features.setAll();
+    modules[moduleName]->features = FeatureSet::All;
     bool valid = WasmValidator().validate(*modules[moduleName]);
     if (!valid) {
       std::cout << *modules[moduleName] << '\n';
@@ -237,7 +237,7 @@ protected:
 
   void parseModuleAssertion(Element& s) {
     Module wasm;
-    wasm.features.setAll();
+    wasm.features = FeatureSet::All;
     std::unique_ptr<SExpressionWasmBuilder> builder;
     auto id = s[0]->str();
 
@@ -358,7 +358,7 @@ protected:
       "memory", spectest->memory.name, ExternalKind::Memory));
 
     modules["spectest"].swap(spectest);
-    modules["spectest"]->features.setAll();
+    modules["spectest"]->features = FeatureSet::All;
     instantiate(modules["spectest"].get());
     linkedInstances["spectest"] = instances["spectest"];
     // print_* functions are handled separately, no need to define here.

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -44,8 +44,8 @@ struct FeatureSet {
     RelaxedSIMD = 1 << 14,
     ExtendedConst = 1 << 15,
     // GCNNLocals are opt-in: merely asking for "All" does not apply them. To
-    // get all possible values use AllPossible.
-    // setAll() below for more details.
+    // get all possible values use AllPossible. See setAll() below for more
+    // details.
     All = ((1 << 16) - 1) & ~GCNNLocals,
     AllPossible = (1 << 16) - 1,
   };

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -44,7 +44,7 @@ Features.Memory64: 2048
 Features.TypedFunctionReferences: 4096
 Features.RelaxedSIMD: 16384
 Features.ExtendedConst: 32768
-Features.All: 65535
+Features.All: 57343
 InvalidId: 0
 BlockId: 1
 IfId: 2

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -28,7 +28,7 @@ BinaryenFeatureMemory64: 2048
 BinaryenFeatureTypedFunctionReferences: 4096
 BinaryenFeatureRelaxedSIMD: 16384
 BinaryenFeatureExtendedConst: 32768
-BinaryenFeatureAll: 65535
+BinaryenFeatureAll: 57343
 (f32.neg
  (f32.const -33.61199951171875)
 )


### PR DESCRIPTION
As we recently noted in #4555, that `Feature::All` and `FeatureSet.setAll()`
are different is potentially confusing...

I think the best thing is to make them identical. This does that, and adds a
new `Feature::AllPossible` which is everything possible and not just the
set of all features that are enabled by `-all`.

This undoes part of #4555 as now the old/simpler code works properly.