### PR TITLE
Add '-vv' verbosity to binaryen-lit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         path: out/install
 
     - name: test binaryen-lit
-      run: python out/bin/binaryen-lit test/lit/parse-error.wast
+      run: python out/bin/binaryen-lit -vv test/lit/parse-error.wast
 
     - name: test
       run: python check.py --binaryen-bin=out/bin
@@ -128,7 +128,7 @@ jobs:
     - name: build
       run: cmake --build out -v
     - name: test binaryen-lit
-      run: python out/bin/binaryen-lit test/lit/parse-error.wast
+      run: python out/bin/binaryen-lit -vv test/lit/parse-error.wast
     - name: test
       run: python check.py --binaryen-bin=out/bin
 


### PR DESCRIPTION
To help debug them when they go wrong, as seems to be happening on #4574.