### PR TITLE
Fix MemoryPacking bug

### DIFF
--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -473,7 +473,6 @@ void MemoryPacking::dropUnusedSegments(std::vector<Memory::Segment>& segments,
   ReferrersMap usedReferrers;
   // Remove segments that are never used
   // TODO: remove unused portions of partially used segments as well
-  size_t newSegIndex = 0;
   for (size_t i = 0; i < segments.size(); ++i) {
     bool used = false;
     auto referrersIt = referrers.find(i);
@@ -494,7 +493,7 @@ void MemoryPacking::dropUnusedSegments(std::vector<Memory::Segment>& segments,
     if (used) {
       usedSegments.push_back(std::move(segments[i]));
       if (hasReferrers) {
-        usedReferrers[newSegIndex++] = std::move(referrersIt->second);
+        usedReferrers[usedSegments.size() - 1] = std::move(referrersIt->second);
       }
     } else if (hasReferrers) {
       // All referrers are data.drops. Make them nops.

--- a/test/lit/passes/memory-packing_all-features.wast
+++ b/test/lit/passes/memory-packing_all-features.wast
@@ -2270,4 +2270,30 @@
  (data (i32.const 1024) "x")
  (data (i32.const 2048) "\00")
 )
+
 ;; CHECK:      (data (i32.const 1024) "x")
+(module
+ ;; Regression test for a bug where referrers were accidentally associated with
+ ;; the wrong segments in the presence of unreferenced segments.
+ ;; CHECK:      (type $none_=>_none (func))
+
+ ;; CHECK:      (memory $0 (shared 1 1))
+ (memory $0 (shared 1 1))
+ (data (i32.const 0) "")
+ ;; CHECK:      (data "foo")
+ (data "foo")
+ ;; CHECK:      (func $0
+ ;; CHECK-NEXT:  (memory.init 0
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $0
+  (memory.init 1
+   (i32.const 0)
+   (i32.const 1)
+   (i32.const 1)
+  )
+ )
+)


### PR DESCRIPTION
247f4c20a1 introduced a bug that caused expressions that refer to data segments
to be associated with the wrong segments in the presence of other segments that
have no referring expressions at all.

Fixes #4569.
Fixes #4571.