### PR TITLE
Avoid a code pattern of vec.resize() followed by std::fill() as suboptimal.

### DIFF
--- a/src/ir/local-utils.h
+++ b/src/ir/local-utils.h
@@ -31,8 +31,8 @@ struct LocalGetCounter : public PostWalker<LocalGetCounter> {
 
   void analyze(Function* func) { analyze(func, func->body); }
   void analyze(Function* func, Expression* ast) {
+    num.clear();
     num.resize(func->getNumLocals());
-    std::fill(num.begin(), num.end(), 0);
     walk(ast);
   }
 

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -41,12 +41,12 @@ struct LocalAnalyzer : public PostWalker<LocalAnalyzer> {
 
   void analyze(Function* func) {
     auto num = func->getNumLocals();
+    numSets.clear();
     numSets.resize(num);
-    std::fill(numSets.begin(), numSets.end(), 0);
+    numGets.clear();
     numGets.resize(num);
-    std::fill(numGets.begin(), numGets.end(), 0);
+    sfa.clear();
     sfa.resize(num);
-    std::fill(sfa.begin(), sfa.begin() + func->getNumParams(), false);
     std::fill(sfa.begin() + func->getNumParams(), sfa.end(), true);
     walk(func->body);
     for (Index i = 0; i < num; i++) {
@@ -245,8 +245,8 @@ struct CodePushing : public WalkerPass<PostWalker<CodePushing>> {
     // pre-scan to find which vars are sfa, and also count their gets&sets
     analyzer.analyze(func);
     // prepare to walk
+    numGetsSoFar.clear();
     numGetsSoFar.resize(func->getNumLocals());
-    std::fill(numGetsSoFar.begin(), numGetsSoFar.end(), 0);
     // walk and optimize
     walk(func->body);
   }

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -75,7 +75,6 @@ struct LoopInvariantCodeMotion
     // FIXME: also the loop tail issue from above.
     auto numLocals = getFunction()->getNumLocals();
     std::vector<Index> numSetsForIndex(numLocals);
-    std::fill(numSetsForIndex.begin(), numSetsForIndex.end(), 0);
     LoopSets loopSets;
     {
       FindAll<LocalSet> finder(loop);

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -50,10 +50,10 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
       return; // nothing to do. All locals are parameters
     }
     Index num = curr->getNumLocals();
+    counts.clear();
     counts.resize(num);
-    std::fill(counts.begin(), counts.end(), 0);
-    firstUses.resize(num);
-    std::fill(firstUses.begin(), firstUses.end(), Unseen);
+    firstUses.clear();
+    firstUses.resize(num, Unseen);
     // Gather information about local usages.
     walk(curr->body);
     // Use the information about local usages.


### PR DESCRIPTION
Avoid a code pattern of vec.resize() followed by std::fill() as suboptimal. Instead do a clear()+resize().

Calling
```cpp
vec.resize(x);
std::fill(vec.begin(), vec.end(), 0);
```
is suboptimal, because .resize() already adds default-initialized (zero-initialized) values onto the vector. std::filling the same elements right after will be redundant.

Also, if the vector will need to reallocate, it will reallocate the vector to a new capacity, then memcpy the old data over, then immediately after fill that copied data to zero.

C++ STL vectors do not support a notion of "resize to new size, discard old data", so the best that one can do is one of:

```cpp
std::fill(vec.begin(), std::min(vec.size(), x), 0);
vec.resize(x);
```
or
```cpp
vec.clear();
vec.resize(x);
```
The first pattern also has the same issue of memcpying junk data over in case of a reallocate. The second pattern avoids that, and is more readable.

This PR switches the code to use the .clear() + .resize() pattern in places where std::fill() is being used. In a [synthetic microbenchmark](https://quick-bench.com/q/TUX7JBB0mhDc0nJ-W00ZFvq3pf0) this does show up, although not sure what the real world impact will be.

![image](https://user-images.githubusercontent.com/225351/161781220-c8ff2dd0-4d39-4713-adb1-3fa5acee0aad.png)
