### PR TITLE
Re-enable a previously flaky type test

### DIFF
--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -364,7 +364,7 @@ TEST_F(IsorecursiveTest, CanonicalizeUses) {
   EXPECT_NE(built[4], built[6]);
 }
 
-TEST_F(IsorecursiveTest, DISABLED_CanonicalizeSelfReferences) {
+TEST_F(IsorecursiveTest, CanonicalizeSelfReferences) {
   TypeBuilder builder(5);
   // Single self-reference
   builder[0] = makeStruct(builder, {0});


### PR DESCRIPTION
I don't know what exactly was causing this test to flake, but since it was
disabled we added the type fuzzer and fixed a lot of bugs, so I hope it is no
longer flaky. If that turns out to be wrong, I can dig deeper.