### PR TITLE
[SIMD] Make swizzle's opcode name consistent (NFC)

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -503,7 +503,7 @@ instructions = [
     ("i64x2.extend_high_i32x4_s", "makeUnary(s, UnaryOp::ExtendHighSVecI32x4ToVecI64x2)"),
     ("i64x2.extend_low_i32x4_u",  "makeUnary(s, UnaryOp::ExtendLowUVecI32x4ToVecI64x2)"),
     ("i64x2.extend_high_i32x4_u", "makeUnary(s, UnaryOp::ExtendHighUVecI32x4ToVecI64x2)"),
-    ("i8x16.swizzle",             "makeBinary(s, BinaryOp::SwizzleVec8x16)"),
+    ("i8x16.swizzle",             "makeBinary(s, BinaryOp::SwizzleVecI8x16)"),
     ("i16x8.extadd_pairwise_i8x16_s", "makeUnary(s, UnaryOp::ExtAddPairwiseSVecI8x16ToI16x8)"),
     ("i16x8.extadd_pairwise_i8x16_u", "makeUnary(s, UnaryOp::ExtAddPairwiseUVecI8x16ToI16x8)"),
     ("i32x4.extadd_pairwise_i16x8_s", "makeUnary(s, UnaryOp::ExtAddPairwiseSVecI16x8ToI32x4)"),
@@ -516,7 +516,7 @@ instructions = [
     ("f64x2.promote_low_f32x4",       "makeUnary(s, UnaryOp::PromoteLowVecF32x4ToVecF64x2)"),
 
     # relaxed SIMD ops
-    ("i8x16.relaxed_swizzle", "makeBinary(s, BinaryOp::RelaxedSwizzleVec8x16)"),
+    ("i8x16.relaxed_swizzle", "makeBinary(s, BinaryOp::RelaxedSwizzleVecI8x16)"),
     ("i32x4.relaxed_trunc_f32x4_s", "makeUnary(s, UnaryOp::RelaxedTruncSVecF32x4ToVecI32x4)"),
     ("i32x4.relaxed_trunc_f32x4_u", "makeUnary(s, UnaryOp::RelaxedTruncUVecF32x4ToVecI32x4)"),
     ("i32x4.relaxed_trunc_f64x2_s_zero", "makeUnary(s, UnaryOp::RelaxedTruncZeroSVecF64x2ToVecI32x4)"),

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -757,7 +757,7 @@ BinaryenOp BinaryenDemoteZeroVecF64x2ToVecF32x4(void) {
 BinaryenOp BinaryenPromoteLowVecF32x4ToVecF64x2(void) {
   return PromoteLowVecF32x4ToVecF64x2;
 }
-BinaryenOp BinaryenSwizzleVec8x16(void) { return SwizzleVec8x16; }
+BinaryenOp BinaryenSwizzleVec8x16(void) { return SwizzleVecI8x16; }
 BinaryenOp BinaryenRefIsNull(void) { return RefIsNull; }
 BinaryenOp BinaryenRefIsFunc(void) { return RefIsFunc; }
 BinaryenOp BinaryenRefIsData(void) { return RefIsData; }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -757,7 +757,7 @@ BinaryenOp BinaryenDemoteZeroVecF64x2ToVecF32x4(void) {
 BinaryenOp BinaryenPromoteLowVecF32x4ToVecF64x2(void) {
   return PromoteLowVecF32x4ToVecF64x2;
 }
-BinaryenOp BinaryenSwizzleVec8x16(void) { return SwizzleVecI8x16; }
+BinaryenOp BinaryenSwizzleVecI8x16(void) { return SwizzleVecI8x16; }
 BinaryenOp BinaryenRefIsNull(void) { return RefIsNull; }
 BinaryenOp BinaryenRefIsFunc(void) { return RefIsFunc; }
 BinaryenOp BinaryenRefIsData(void) { return RefIsData; }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -592,7 +592,7 @@ BINARYEN_API BinaryenOp BinaryenTruncSatZeroSVecF64x2ToVecI32x4(void);
 BINARYEN_API BinaryenOp BinaryenTruncSatZeroUVecF64x2ToVecI32x4(void);
 BINARYEN_API BinaryenOp BinaryenDemoteZeroVecF64x2ToVecF32x4(void);
 BINARYEN_API BinaryenOp BinaryenPromoteLowVecF32x4ToVecF64x2(void);
-BINARYEN_API BinaryenOp BinaryenSwizzleVec8x16(void);
+BINARYEN_API BinaryenOp BinaryenSwizzleVecI8x16(void);
 BINARYEN_API BinaryenOp BinaryenRefIsNull(void);
 BINARYEN_API BinaryenOp BinaryenRefIsFunc(void);
 BINARYEN_API BinaryenOp BinaryenRefIsData(void);

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -2828,7 +2828,7 @@ switch (op[0]) {
           case 'r': {
             switch (op[8]) {
               case 'l':
-                if (strcmp(op, "i8x16.relaxed_swizzle") == 0) { return makeBinary(s, BinaryOp::RelaxedSwizzleVec8x16); }
+                if (strcmp(op, "i8x16.relaxed_swizzle") == 0) { return makeBinary(s, BinaryOp::RelaxedSwizzleVecI8x16); }
                 goto parse_error;
               case 'p':
                 if (strcmp(op, "i8x16.replace_lane") == 0) { return makeSIMDReplace(s, SIMDReplaceOp::ReplaceLaneVecI8x16, 16); }
@@ -2883,7 +2883,7 @@ switch (op[0]) {
                 }
               }
               case 'w':
-                if (strcmp(op, "i8x16.swizzle") == 0) { return makeBinary(s, BinaryOp::SwizzleVec8x16); }
+                if (strcmp(op, "i8x16.swizzle") == 0) { return makeBinary(s, BinaryOp::SwizzleVecI8x16); }
                 goto parse_error;
               default: goto parse_error;
             }

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -491,8 +491,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
       case NarrowUVecI16x8ToVecI8x16:
       case NarrowSVecI32x4ToVecI16x8:
       case NarrowUVecI32x4ToVecI16x8:
-      case SwizzleVec8x16:
-      case RelaxedSwizzleVec8x16:
+      case SwizzleVecI8x16:
+      case RelaxedSwizzleVecI8x16:
         ret = 1;
         break;
       case InvalidBinary:

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -530,7 +530,7 @@ function initializeConstants() {
     'TruncSatZeroUVecF64x2ToVecI32x4',
     'DemoteZeroVecF64x2ToVecF32x4',
     'PromoteLowVecF32x4ToVecF64x2',
-    'SwizzleVec8x16',
+    'SwizzleVecI8x16',
     'RefIsNull',
     'RefIsFunc',
     'RefIsData',
@@ -1597,7 +1597,7 @@ function wrapModule(module, self = {}) {
       return preserveStack(() => Module['_BinaryenSIMDShuffle'](module, left, right, i8sToStack(mask)));
     },
     'swizzle'(left, right) {
-      return Module['_BinaryenBinary'](module, Module['SwizzleVec8x16'], left, right);
+      return Module['_BinaryenBinary'](module, Module['SwizzleVecI8x16'], left, right);
     },
     'splat'(value) {
       return Module['_BinaryenUnary'](module, Module['SplatVecI8x16'], value);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1832,7 +1832,7 @@ struct PrintExpressionContents
         o << "i16x8.narrow_i32x4_u";
         break;
 
-      case SwizzleVec8x16:
+      case SwizzleVecI8x16:
         o << "i8x16.swizzle";
         break;
 
@@ -1848,7 +1848,7 @@ struct PrintExpressionContents
       case RelaxedMaxVecF64x2:
         o << "f64x2.relaxed_max";
         break;
-      case RelaxedSwizzleVec8x16:
+      case RelaxedSwizzleVecI8x16:
         o << "i8x16.relaxed_swizzle";
         break;
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2442,7 +2442,7 @@ Expression* TranslateToFuzzReader::makeBinary(Type type) {
                                NarrowUVecI16x8ToVecI8x16,
                                NarrowSVecI32x4ToVecI16x8,
                                NarrowUVecI32x4ToVecI16x8,
-                               SwizzleVec8x16),
+                               SwizzleVecI8x16),
                           make(Type::v128),
                           make(Type::v128)});
     }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1011,8 +1011,8 @@ public:
       case NarrowUVecI32x4ToVecI16x8:
         return left.narrowUToI16x8(right);
 
-      case SwizzleVec8x16:
-      case RelaxedSwizzleVec8x16:
+      case SwizzleVecI8x16:
+      case RelaxedSwizzleVecI8x16:
         return left.swizzleI8x16(right);
 
       case InvalidBinary:

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -464,10 +464,10 @@ enum BinaryOp {
   NarrowUVecI32x4ToVecI16x8,
 
   // SIMD Swizzle
-  SwizzleVec8x16,
+  SwizzleVecI8x16,
 
   // Relaxed SIMD
-  RelaxedSwizzleVec8x16,
+  RelaxedSwizzleVecI8x16,
   RelaxedMinVecF32x4,
   RelaxedMaxVecF32x4,
   RelaxedMinVecF64x2,

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -5575,11 +5575,11 @@ bool WasmBinaryBuilder::maybeVisitSIMDBinary(Expression*& out, uint32_t code) {
       break;
     case BinaryConsts::I8x16Swizzle:
       curr = allocator.alloc<Binary>();
-      curr->op = SwizzleVec8x16;
+      curr->op = SwizzleVecI8x16;
       break;
     case BinaryConsts::I8x16RelaxedSwizzle:
       curr = allocator.alloc<Binary>();
-      curr->op = RelaxedSwizzleVec8x16;
+      curr->op = RelaxedSwizzleVecI8x16;
       break;
     case BinaryConsts::F32x4RelaxedMin:
       curr = allocator.alloc<Binary>();

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -1817,12 +1817,12 @@ void BinaryInstWriter::visitBinary(Binary* curr) {
         << U32LEB(BinaryConsts::I16x8NarrowI32x4U);
       break;
 
-    case SwizzleVec8x16:
+    case SwizzleVecI8x16:
       o << int8_t(BinaryConsts::SIMDPrefix)
         << U32LEB(BinaryConsts::I8x16Swizzle);
       break;
 
-    case RelaxedSwizzleVec8x16:
+    case RelaxedSwizzleVecI8x16:
       o << int8_t(BinaryConsts::SIMDPrefix)
         << U32LEB(BinaryConsts::I8x16RelaxedSwizzle);
       break;

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1633,8 +1633,8 @@ void FunctionValidator::visitBinary(Binary* curr) {
     case NarrowUVecI16x8ToVecI8x16:
     case NarrowSVecI32x4ToVecI16x8:
     case NarrowUVecI32x4ToVecI16x8:
-    case SwizzleVec8x16:
-    case RelaxedSwizzleVec8x16: {
+    case SwizzleVecI8x16:
+    case RelaxedSwizzleVecI8x16: {
       shouldBeEqualOrFirstIsUnreachable(
         curr->left->type, Type(Type::v128), curr, "v128 op");
       shouldBeEqualOrFirstIsUnreachable(

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -675,7 +675,7 @@ void test_core() {
     makeBinary(module, BinaryenNarrowUVecI16x8ToVecI8x16(), v128),
     makeBinary(module, BinaryenNarrowSVecI32x4ToVecI16x8(), v128),
     makeBinary(module, BinaryenNarrowUVecI32x4ToVecI16x8(), v128),
-    makeBinary(module, BinaryenSwizzleVec8x16(), v128),
+    makeBinary(module, BinaryenSwizzleVecI8x16(), v128),
     // SIMD lane manipulation
     makeSIMDExtract(module, BinaryenExtractLaneSVecI8x16()),
     makeSIMDExtract(module, BinaryenExtractLaneUVecI8x16()),


### PR DESCRIPTION
Other opcode ends with `Inxm` or `Fnxm` (where n and m are integers),
while `i8x16.swizzle`'s opcode name doesn't have an `I` in there.