### PR TITLE
Revert "Re-enable a previously flaky type test"

### DIFF
--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -364,7 +364,7 @@ TEST_F(IsorecursiveTest, CanonicalizeUses) {
   EXPECT_NE(built[4], built[6]);
 }
 
-TEST_F(IsorecursiveTest, CanonicalizeSelfReferences) {
+TEST_F(IsorecursiveTest, DISABLED_CanonicalizeSelfReferences) {
   TypeBuilder builder(5);
   // Single self-reference
   builder[0] = makeStruct(builder, {0});


### PR DESCRIPTION
Reverts WebAssembly/binaryen#4582.

This test is still sporadically failing on at least the mac builder.