### PR TITLE
[NominalFuzzing] Don't compare nominal types in the fuzzer

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -151,9 +151,14 @@ struct ExecutionResults {
   bool areEqual(Literal a, Literal b) {
     // We allow nulls to have different types (as they compare equal regardless)
     // but anything else must have an identical type.
-    if (a.type != b.type && !(a.isNull() && b.isNull())) {
-      std::cout << "types not identical! " << a << " != " << b << '\n';
-      return false;
+    // We cannot do this in nominal typing, however, as different modules will
+    // have different types in general. We could perhaps compare them
+    // structurally, but that would not be right either.
+    if (getTypeSystem() != TypeSystem::Nominal) {
+      if (a.type != b.type && !(a.isNull() && b.isNull())) {
+        std::cout << "types not identical! " << a << " != " << b << '\n';
+        return false;
+      }
     }
     if (a.type.isRef()) {
       // Don't compare references - only their types. There are several issues

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -152,8 +152,8 @@ struct ExecutionResults {
     // We allow nulls to have different types (as they compare equal regardless)
     // but anything else must have an identical type.
     // We cannot do this in nominal typing, however, as different modules will
-    // have different types in general. We could perhaps compare them
-    // structurally, but that would not be right either.
+    // have different types in general. We could perhaps compare the entire
+    // graph structurally TODO
     if (getTypeSystem() != TypeSystem::Nominal) {
       if (a.type != b.type && !(a.isNull() && b.isNull())) {
         std::cout << "types not identical! " << a << " != " << b << '\n';


### PR DESCRIPTION
The same module will have a different type after some transformations, even
though that is not observable, like `--roundtrip`. Basically, we should not be
comparing types between separate modules, which is what the fuzzer does.
