### PR TITLE
[NominalFuzzing] Fix TranslateToFuzzReader::getSubType(Rtt)

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3041,10 +3041,10 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
 }
 
 Rtt TranslateToFuzzReader::getSubType(Rtt rtt) {
-  if (getTypeSystem() == TypeSystem::Nominal) {
-    // With nominal typing the depth in rtts must match the nominal hierarchy,
-    // so we cannot create a random depth like we do below.
-    // TODO: fuzz more stuff?
+  if (getTypeSystem() == TypeSystem::Nominal ||
+      getTypeSystem() == TypeSystem::Isorecursive) {
+    // With nominal or isorecursive typing the depth in rtts must match the
+    // nominal hierarchy, so we cannot create a random depth like we do below.
     return rtt;
   }
   uint32_t depth = rtt.depth != Rtt::NoDepth

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3041,6 +3041,12 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
 }
 
 Rtt TranslateToFuzzReader::getSubType(Rtt rtt) {
+  if (getTypeSystem() == TypeSystem::Nominal) {
+    // With nominal typing the depth in rtts must match the nominal hierarchy,
+    // so we cannot create a random depth like we do below.
+    // TODO: fuzz more stuff?
+    return rtt;
+  }
   uint32_t depth = rtt.depth != Rtt::NoDepth
                      ? rtt.depth
                      : oneIn(2) ? Rtt::NoDepth : upTo(MAX_RTT_DEPTH + 1);


### PR DESCRIPTION
Randomly selecting a depth is ok for structural typing, but in nominal it
must match the actual hierarchy of types.