### PR TITLE
[NominalFuzzing] Fix replaceWithIdenticalType() on nondefaultable tuples

### DIFF
--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1148,7 +1148,7 @@ public:
   // Returns a replacement with the precise same type, and with minimal contents
   // as best we can. As a replacement, this may reuse the input node.
   template<typename T> Expression* replaceWithIdenticalType(T* curr) {
-    if (curr->type.isTuple()) {
+    if (curr->type.isTuple() && curr->type.isDefaultable()) {
       return makeConstantExpression(Literal::makeZeros(curr->type));
     }
     if (curr->type.isNullable()) {


### PR DESCRIPTION
I noticed this bug when running the reducer (it crashed the reducer internally).