### PR TITLE
[NominalFuzzing] Add a validation error on ref.cast's intended type

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2375,6 +2375,8 @@ void FunctionValidator::visitRefTest(RefTest* curr) {
                     HeapType(),
                     curr,
                     "static ref.test must set intendedType field");
+    shouldBeTrue(
+      !curr->intendedType.isBasic(), curr, "ref.test must test a non-basic");
   }
 }
 
@@ -2429,6 +2431,8 @@ void FunctionValidator::visitBrOn(BrOn* curr) {
                       HeapType(),
                       curr,
                       "static br_on_cast* must set intendedType field");
+      shouldBeTrue(
+        !curr->intendedType.isBasic(), curr, "br_on_cast* must cast to a non-basic");
     }
   } else {
     shouldBeTrue(curr->rtt == nullptr, curr, "non-cast BrOn must not have rtt");

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2399,6 +2399,8 @@ void FunctionValidator::visitRefCast(RefCast* curr) {
                     HeapType(),
                     curr,
                     "static ref.cast must set intendedType field");
+    shouldBeTrue(
+      !curr->intendedType.isBasic(), curr, "ref.cast must cast to a non-basic");
   }
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2431,8 +2431,9 @@ void FunctionValidator::visitBrOn(BrOn* curr) {
                       HeapType(),
                       curr,
                       "static br_on_cast* must set intendedType field");
-      shouldBeTrue(
-        !curr->intendedType.isBasic(), curr, "br_on_cast* must cast to a non-basic");
+      shouldBeTrue(!curr->intendedType.isBasic(),
+                   curr,
+                   "br_on_cast* must cast to a non-basic");
     }
   } else {
     shouldBeTrue(curr->rtt == nullptr, curr, "non-cast BrOn must not have rtt");


### PR DESCRIPTION
`(ref.cast func (..))` for example is not allowed (and the binary format emitter will
crash when it looks for the heap type index).