### PR TITLE
[NominalFuzzing] GTO: trap on null ref in removed struct.set

### DIFF
--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -391,9 +391,10 @@ struct GlobalTypeOptimization : public Pass {
           // Map to the new index.
           curr->index = newIndex;
         } else {
-          // This field was removed, so just emit drops of our children.
+          // This field was removed, so just emit drops of our children (plus a
+          // trap if the input is null).
           Builder builder(*getModule());
-          replaceCurrent(builder.makeSequence(builder.makeDrop(curr->ref),
+          replaceCurrent(builder.makeSequence(builder.makeDrop(builder.makeRefAs(RefAsNonNull, curr->ref)),
                                               builder.makeDrop(curr->value)));
         }
       }

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -394,8 +394,9 @@ struct GlobalTypeOptimization : public Pass {
           // This field was removed, so just emit drops of our children (plus a
           // trap if the input is null).
           Builder builder(*getModule());
-          replaceCurrent(builder.makeSequence(builder.makeDrop(builder.makeRefAs(RefAsNonNull, curr->ref)),
-                                              builder.makeDrop(curr->value)));
+          replaceCurrent(builder.makeSequence(
+            builder.makeDrop(builder.makeRefAs(RefAsNonNull, curr->ref)),
+            builder.makeDrop(curr->value)));
         }
       }
 

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -29,7 +29,9 @@
 
   ;; CHECK:      (func $func (type $ref|$struct|_=>_none) (param $x (ref $struct))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.null func)
@@ -140,7 +142,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (block
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (i32.const 0)
@@ -162,7 +166,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (block
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (i32.const 2)


### PR DESCRIPTION
When a field has no reads, we remove all its writes, but we did this:
```wat
(struct.set $foo A B)
=>
(drop A) (drop B)
```
We also need to trap if `A`, the reference, is null, which this PR
fixes,
```wat
(struct.set $foo A B)
=>
(drop (ref.as_non_null A)) (drop B)
```
