### PR TITLE
[NominalFuzzing] Fix getHeapTypeCounts() on unreachable casts

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -85,15 +85,13 @@ struct CodeScanner
     }
   }
 
-  template<typename T>
-  void handleMake(T* curr) {
+  template<typename T> void handleMake(T* curr) {
     if (!curr->rtt && curr->type != Type::unreachable) {
       counts.note(curr->type.getHeapType());
     }
   }
 
-  template<typename T>
-  void handleCast(T* curr) {
+  template<typename T> void handleCast(T* curr) {
     // Some operations emit a HeapType in the binary format, if they are
     // static and not dynamic (if dynamic, the RTT provides the heap type).
     if (!curr->rtt) {

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -786,3 +786,27 @@
     (call $bar (ref.null func))
   )
 )
+
+(module
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (type $A (struct_subtype  data))
+  (type $A (struct_subtype data))
+  ;; CHECK:      (func $0 (type $none_=>_none)
+  ;; CHECK-NEXT:  (local $0 f32)
+  ;; CHECK-NEXT:  (ref.cast_static $A
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $0 (param $0 f32)
+    ;; $A is only used in an unreachable cast. We should not error when
+    ;; removing the param from this function, during which we collect heap
+    ;; types, and must find this one even though the cast is unreachable, as
+    ;; we do need to handle it in the optimization as well as print it (note how
+    ;; type $A is declared in the output here - it would be a bug if it were
+    ;; not, which this is a regression test for).
+    (ref.cast_static $A
+      (unreachable)
+    )
+  )
+)


### PR DESCRIPTION
The cast instruction may be unreachable but the intended type for the cast
still needs to be collected. Otherwise we end up with problems both during
optimizations that look at heap types and in printing (which will use the heap
type in code but not declare it).

Diff without whitespace is much smaller: this just moves code around so
that we can use a template to avoid code duplication. The actual change
is just to scan `->intendedType` unconditionally, and not ignore it if the
cast is unreachable.

After this nominal fuzzing reaches 93K iterations without an issue, so
things may be getting more stable...