### PR TITLE
SmallSet: Mark iterator parent as const

### DIFF
--- a/src/support/small_set.h
+++ b/src/support/small_set.h
@@ -165,7 +165,7 @@ public:
     using pointer = const value_type*;
     using reference = const value_type&;
 
-    Parent* parent;
+    const Parent* parent;
 
     using Iterator = IteratorBase<Parent, FlexibleIterator>;
 
@@ -176,7 +176,7 @@ public:
     size_t fixedIndex;
     FlexibleIterator flexibleIterator;
 
-    IteratorBase(Parent* parent)
+    IteratorBase(const Parent* parent)
       : parent(parent), usingFixed(parent->usingFixed()) {}
 
     void setBegin() {


### PR DESCRIPTION
We already assume the parent does not change,

https://github.com/WebAssembly/binaryen/blob/94d77efa788b46ec3d245fd0e180163877fe2a88/src/support/small_set.h#L202-L208

This also marks the parent as const to reflect that.

This fixed a weird C++ compilation error I had when working on
something unrelated, but seems worth landing independently.