### PR TITLE
Lit tests: print failing modules

### DIFF
--- a/scripts/foreach.py
+++ b/scripts/foreach.py
@@ -39,6 +39,12 @@ def main():
         result = subprocess.run(new_cmd)
         if result.returncode != 0:
             returncode = result.returncode
+            # For ease of debugging, print out the module that failed (otherwise
+            # the user would need to sift through all the modules in the wat to
+            # find the failing one).
+            print("[Failing module]")
+            print(module)
+            break
     sys.exit(returncode)
 
 

--- a/scripts/foreach.py
+++ b/scripts/foreach.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import subprocess
 
@@ -31,6 +32,7 @@ def main():
     tempfile = sys.argv[2]
     cmd = sys.argv[3:]
     returncode = 0
+    all_modules = open(infile).read()
     for i, (module, asserts) in enumerate(support.split_wast(infile)):
         tempname = tempfile + '.' + str(i)
         with open(tempname, 'w') as temp:
@@ -39,12 +41,9 @@ def main():
         result = subprocess.run(new_cmd)
         if result.returncode != 0:
             returncode = result.returncode
-            # For ease of debugging, print out the module that failed (otherwise
-            # the user would need to sift through all the modules in the wat to
-            # find the failing one).
-            print("[Failing module]")
-            print(module)
-            break
+            module_char_start = all_modules.find(module)
+            module_line_start = all_modules[:module_char_start].count(os.linesep)
+            print(f'[Failing module at line {module_line_start}]', file=sys.stderr)
     sys.exit(returncode)
 
 


### PR DESCRIPTION
This is probably not the right fix, but it's been extremely useful for me locally. With this change, the auto-update script will print out a failing module, which is nice if the failing module was one out of dozens in a single file - without this change, there is no hint as to which of the modules failed, just the filename.

I suspect this is wrong as it stops at the first failing module, but we don't want that for the check script, I assume. If this is the right direction I could look into fixing that part.