### PR TITLE
[NFC] Fix some outdated comments

### DIFF
--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -21,8 +21,6 @@
 //  * Immutability: If a field has no struct.set, it can become immutable.
 //  * Fields that are never read from can be removed entirely.
 //
-// TODO: Specialize field types.
-//
 
 #include "ir/effects.h"
 #include "ir/localize.h"

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -32,10 +32,8 @@ namespace wasm {
 
 namespace {
 
-// We use a LUBFinder to track field info. A LUBFinder keeps track of the best
-// possible LUB so far. The only extra functionality we need here is whether
-// there is a default null value (which would force us to keep the type
-// nullable).
+// We use a LUBFinder to track field info, which includes the best LUB possible
+// as well as relevant nulls (nulls force us to keep the type nullable).
 using FieldInfo = LUBFinder;
 
 struct FieldInfoScanner


### PR DESCRIPTION
* We implemented specialization of field types (the TypeRefining pass).
* LUBFinder now handles nulls, so we need nothing extra for it in TypeRefining.