### PR TITLE
[NominalFuzzing] SignatureRefining can modify the IR while running a parallel analysis

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -115,17 +115,16 @@ Counts getHeapTypeCounts(Module& wasm) {
   }
 
   // Collect info from functions in parallel.
-  ModuleUtils::
-    ParallelFunctionAnalysis<Counts, Immutable, InsertOrderedMap>
-      analysis(wasm, [&](Function* func, Counts& counts) {
-        counts.note(func->type);
-        for (auto type : func->vars) {
-          counts.note(type);
-        }
-        if (!func->imported()) {
-          CodeScanner(wasm, counts).walk(func->body);
-        }
-      });
+  ModuleUtils::ParallelFunctionAnalysis<Counts, Immutable, InsertOrderedMap>
+    analysis(wasm, [&](Function* func, Counts& counts) {
+      counts.note(func->type);
+      for (auto type : func->vars) {
+        counts.note(type);
+      }
+      if (!func->imported()) {
+        CodeScanner(wasm, counts).walk(func->body);
+      }
+    });
 
   // Combine the function info with the module info.
   for (auto& [_, functionCounts] : analysis.map) {

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -115,7 +115,7 @@ Counts getHeapTypeCounts(Module& wasm) {
   }
 
   // Collect info from functions in parallel.
-  ModuleUtils::ParallelFunctionAnalysis<Counts, InsertOrderedMap> analysis(
+  ModuleUtils::ParallelFunctionAnalysis<Counts, Modifies(false), InsertOrderedMap> analysis(
     wasm, [&](Function* func, Counts& counts) {
       counts.note(func->type);
       for (auto type : func->vars) {

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -116,7 +116,7 @@ Counts getHeapTypeCounts(Module& wasm) {
 
   // Collect info from functions in parallel.
   ModuleUtils::
-    ParallelFunctionAnalysis<Counts, Modifies(false), InsertOrderedMap>
+    ParallelFunctionAnalysis<Counts, Immutable, InsertOrderedMap>
       analysis(wasm, [&](Function* func, Counts& counts) {
         counts.note(func->type);
         for (auto type : func->vars) {

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -115,16 +115,17 @@ Counts getHeapTypeCounts(Module& wasm) {
   }
 
   // Collect info from functions in parallel.
-  ModuleUtils::ParallelFunctionAnalysis<Counts, Modifies(false), InsertOrderedMap> analysis(
-    wasm, [&](Function* func, Counts& counts) {
-      counts.note(func->type);
-      for (auto type : func->vars) {
-        counts.note(type);
-      }
-      if (!func->imported()) {
-        CodeScanner(wasm, counts).walk(func->body);
-      }
-    });
+  ModuleUtils::
+    ParallelFunctionAnalysis<Counts, Modifies(false), InsertOrderedMap>
+      analysis(wasm, [&](Function* func, Counts& counts) {
+        counts.note(func->type);
+        for (auto type : func->vars) {
+          counts.note(type);
+        }
+        if (!func->imported()) {
+          CodeScanner(wasm, counts).walk(func->body);
+        }
+      });
 
   // Combine the function info with the module info.
   for (auto& [_, functionCounts] : analysis.map) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -303,7 +303,7 @@ template<typename T> inline void iterImports(Module& wasm, T visitor) {
 // Helper class for performing an operation on all the functions in the module,
 // in parallel, with an Info object for each one that can contain results of
 // some computation that the operation performs.
-// The operation performend should not modify the wasm module in any way, by
+// The operation performed should not modify the wasm module in any way, by
 // default - otherwise, set the Mutability to Mutable. (This is not enforced at
 // compile time - TODO find a way - but at runtime in pass-debug mode it is
 // checked.)

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -303,10 +303,13 @@ template<typename T> inline void iterImports(Module& wasm, T visitor) {
 // Helper class for performing an operation on all the functions in the module,
 // in parallel, with an Info object for each one that can contain results of
 // some computation that the operation performs.
-// The operation performend should not modify the wasm module in any way.
-// TODO: enforce this
+// The operation performend should not modify the wasm module in any way, by
+// default - otherwise, ModifiesIR should be set to true. (This is not enforced
+// at compile time - TODO find a way - but at runtime in pass-debug mode it is
+// checked.)
+using Modifies = bool;
 template<typename K, typename V> using DefaultMap = std::map<K, V>;
-template<typename T, template<typename, typename> class MapT = DefaultMap>
+template<typename T, Modifies Mod=false, template<typename, typename> class MapT = DefaultMap>
 struct ParallelFunctionAnalysis {
   Module& wasm;
 
@@ -331,7 +334,7 @@ struct ParallelFunctionAnalysis {
 
     struct Mapper : public WalkerPass<PostWalker<Mapper>> {
       bool isFunctionParallel() override { return true; }
-      bool modifiesBinaryenIR() override { return false; }
+      bool modifiesBinaryenIR() override { return Mod; }
 
       Mapper(Module& module, Map& map, Func work)
         : module(module), map(map), work(work) {}

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -304,13 +304,12 @@ template<typename T> inline void iterImports(Module& wasm, T visitor) {
 // in parallel, with an Info object for each one that can contain results of
 // some computation that the operation performs.
 // The operation performend should not modify the wasm module in any way, by
-// default - otherwise, ModifiesIR should be set to true. (This is not enforced
-// at compile time - TODO find a way - but at runtime in pass-debug mode it is
+// default - otherwise, set the Mutability to Mutable. (This is not enforced at
+// compile time - TODO find a way - but at runtime in pass-debug mode it is
 // checked.)
-using Modifies = bool;
 template<typename K, typename V> using DefaultMap = std::map<K, V>;
 template<typename T,
-         Modifies Mod = false,
+         Mutability Mut = Immutable,
          template<typename, typename> class MapT = DefaultMap>
 struct ParallelFunctionAnalysis {
   Module& wasm;
@@ -336,7 +335,7 @@ struct ParallelFunctionAnalysis {
 
     struct Mapper : public WalkerPass<PostWalker<Mapper>> {
       bool isFunctionParallel() override { return true; }
-      bool modifiesBinaryenIR() override { return Mod; }
+      bool modifiesBinaryenIR() override { return Mut; }
 
       Mapper(Module& module, Map& map, Func work)
         : module(module), map(map), work(work) {}

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -309,7 +309,9 @@ template<typename T> inline void iterImports(Module& wasm, T visitor) {
 // checked.)
 using Modifies = bool;
 template<typename K, typename V> using DefaultMap = std::map<K, V>;
-template<typename T, Modifies Mod=false, template<typename, typename> class MapT = DefaultMap>
+template<typename T,
+         Modifies Mod = false,
+         template<typename, typename> class MapT = DefaultMap>
 struct ParallelFunctionAnalysis {
   Module& wasm;
 

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -78,8 +78,8 @@ struct SignatureRefining : public Pass {
 
     // This analysis also modifies the wasm as it goes, as the getResultsLUB()
     // operation has side effects (see comment on header declaration).
-    ModuleUtils::ParallelFunctionAnalysis<Info, Mutable>
-      analysis(*module, [&](Function* func, Info& info) {
+    ModuleUtils::ParallelFunctionAnalysis<Info, Mutable> analysis(
+      *module, [&](Function* func, Info& info) {
         if (func->imported()) {
           return;
         }

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -78,7 +78,7 @@ struct SignatureRefining : public Pass {
 
     // This analysis also modifies the wasm as it goes, as the getResultsLUB()
     // operation has side effects (see comment on header declaration).
-    ModuleUtils::ParallelFunctionAnalysis<Info, ModuleUtils::Modifies(true)>
+    ModuleUtils::ParallelFunctionAnalysis<Info, Mutable>
       analysis(*module, [&](Function* func, Info& info) {
         if (func->imported()) {
           return;

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -78,8 +78,8 @@ struct SignatureRefining : public Pass {
 
     // This analysis also modifies the wasm as it goes, as the getResultsLUB()
     // operation has side effects (see comment on header declaration).
-    ModuleUtils::ParallelFunctionAnalysis<Info, ModuleUtils::Modifies(true)> analysis(
-      *module, [&](Function* func, Info& info) {
+    ModuleUtils::ParallelFunctionAnalysis<Info, ModuleUtils::Modifies(true)>
+      analysis(*module, [&](Function* func, Info& info) {
         if (func->imported()) {
           return;
         }

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -76,7 +76,9 @@ struct SignatureRefining : public Pass {
       bool canModify = true;
     };
 
-    ModuleUtils::ParallelFunctionAnalysis<Info> analysis(
+    // This analysis also modifies the wasm as it goes, as the getResultsLUB()
+    // operation has side effects (see comment on header declaration).
+    ModuleUtils::ParallelFunctionAnalysis<Info, ModuleUtils::Modifies(true)> analysis(
       *module, [&](Function* func, Info& info) {
         if (func->imported()) {
           return;


### PR DESCRIPTION
Normally ParallelFunctionAnalysis is just an analysis, and has no effects. However, in
SignatureRefining we actually do have side effects, due to an internal limitation of the
helper code it runs. This adds a template parameter to the class so users can note that
they do modify the IR. The parameter is added in the middle as it is easier to add this
param than to add the last one (the map).