### PR TITLE
performance improvements to dae

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -60,7 +60,7 @@ struct DAEFunctionInfo {
   Function* func = nullptr;
   // The unused parameters, if any.
   SortedVector unusedParams;
-  // Maps a function name to the calls going to it.
+  // calls going to this function.
   std::vector<Call*> calls;
   // Whether this function contains any tail calls (including indirect tail
   // calls) and the set of functions this function tail calls. Tail-callers and

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -36,6 +36,7 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <mutex>
 
 #include "ir/effects.h"
 #include "ir/element-utils.h"
@@ -55,13 +56,12 @@ namespace wasm {
 
 // Information for a function
 struct DAEFunctionInfo {
+  std::mutex mutex;
+  Function* func = nullptr;
   // The unused parameters, if any.
   SortedVector unusedParams;
   // Maps a function name to the calls going to it.
-  std::unordered_map<Name, std::vector<Call*>> calls;
-  // Map of all calls that are dropped, to their drops' locations (so that
-  // if we can optimize out the drop, we can replace the drop there).
-  std::unordered_map<Call*, Expression**> droppedCalls;
+  std::vector<Call*> calls;
   // Whether this function contains any tail calls (including indirect tail
   // calls) and the set of functions this function tail calls. Tail-callers and
   // tail-callees cannot have their dropped returns removed because of the
@@ -71,7 +71,6 @@ struct DAEFunctionInfo {
   // returns from tail-callers if their tail-callees can have their returns
   // removed as well.
   bool hasTailCalls = false;
-  std::unordered_set<Name> tailCallees;
   // Whether the function can be called from places that
   // affect what we can do. For now, any call we don't
   // see inhibits our optimizations, but TODO: an export
@@ -85,27 +84,39 @@ struct DAEFunctionInfo {
 };
 
 typedef std::unordered_map<Name, DAEFunctionInfo> DAEFunctionInfoMap;
+struct DAEFunctionState {
+  std::mutex mutex;
+  DAEFunctionInfoMap functions;
+  // Map of all calls that are dropped, to their drops' locations (so that
+  // if we can optimize out the drop, we can replace the drop there).
+  std::unordered_map<Call*, Expression**> droppedCalls;
+};
 
 struct DAEScanner
   : public WalkerPass<PostWalker<DAEScanner, Visitor<DAEScanner>>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new DAEScanner(infoMap); }
+  Pass* create() override { return new DAEScanner(state); }
 
-  DAEScanner(DAEFunctionInfoMap* infoMap) : infoMap(infoMap) {}
+  DAEScanner(DAEFunctionState* state) : state(state) {}
 
-  DAEFunctionInfoMap* infoMap;
+  DAEFunctionState* state;
   DAEFunctionInfo* info;
 
   Index numParams;
 
   void visitCall(Call* curr) {
     if (!getModule()->getFunction(curr->target)->imported()) {
-      info->calls[curr->target].push_back(curr);
+      auto& info = state->functions[curr->target];
+      if (info.hasUnseenCalls) {
+        return;
+      }
+      std::lock_guard<std::mutex> lock(info.mutex);
+      info.calls.push_back(curr);
     }
     if (curr->isReturn) {
       info->hasTailCalls = true;
-      info->tailCallees.insert(curr->target);
+      state->functions[curr->target].hasTailCalls = true;
     }
   }
 
@@ -123,26 +134,27 @@ struct DAEScanner
 
   void visitDrop(Drop* curr) {
     if (auto* call = curr->value->dynCast<Call>()) {
-      info->droppedCalls[call] = getCurrentPointer();
+       std::lock_guard<std::mutex> lock(state->mutex);
+       state->droppedCalls[call] = getCurrentPointer();
     }
   }
 
   void visitRefFunc(RefFunc* curr) {
     // We can't modify another function in parallel.
-    assert((*infoMap).count(curr->func));
+    assert(state->functions.count(curr->func));
     // Treat a ref.func as an unseen call, preventing us from changing the
     // function's type. If we did change it, it could be an observable
     // difference from the outside, if the reference escapes, for example.
     // TODO: look for actual escaping?
     // TODO: create a thunk for external uses that allow internal optimizations
-    (*infoMap)[curr->func].hasUnseenCalls = true;
+    state->functions[curr->func].hasUnseenCalls = true;
   }
 
   // main entry point
 
   void doWalkFunction(Function* func) {
     numParams = func->getNumParams();
-    info = &((*infoMap)[func->name]);
+    info = &state->functions[func->name];
     PostWalker<DAEScanner, Visitor<DAEScanner>>::doWalkFunction(func);
     // If there are relevant params, check if they are used. If we can't
     // optimize the function anyhow, there's no point (note that our check here
@@ -182,63 +194,44 @@ struct DAE : public Pass {
   }
 
   bool iteration(PassRunner* runner, Module* module) {
-    allDroppedCalls.clear();
-
-    DAEFunctionInfoMap infoMap;
+    DAEFunctionState state;
     // Ensure they all exist so the parallel threads don't modify the data
     // structure.
     for (auto& func : module->functions) {
-      infoMap[func->name];
+      state.functions[func->name].func = func.get();
     }
-    DAEScanner scanner(&infoMap);
-    scanner.walkModuleCode(module);
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        infoMap[curr->value].hasUnseenCalls = true;
+        state.functions[curr->value].hasUnseenCalls = true;
       }
     }
+    DAEScanner scanner(&state);
+    scanner.walkModuleCode(module);
     // Scan all the functions.
     scanner.run(runner, module);
-    // Combine all the info.
-    std::map<Name, std::vector<Call*>> allCalls;
-    std::unordered_set<Name> tailCallees;
-    for (auto& [_, info] : infoMap) {
-      for (auto& [name, calls] : info.calls) {
-        auto& allCallsToName = allCalls[name];
-        allCallsToName.insert(allCallsToName.end(), calls.begin(), calls.end());
-      }
-      for (auto& callee : info.tailCallees) {
-        tailCallees.insert(callee);
-      }
-      for (auto& [name, calls] : info.droppedCalls) {
-        allDroppedCalls[name] = calls;
-      }
-    }
     // If we refine return types then we will need to do more type updating
     // at the end.
     bool refinedReturnTypes = false;
     // We now have a mapping of all call sites for each function, and can look
     // for optimization opportunities.
-    for (auto& [name, calls] : allCalls) {
-      // We can only optimize if we see all the calls and can modify them.
-      if (infoMap[name].hasUnseenCalls) {
+    for (auto& [name, info] : state.functions) {
+      if (info.hasUnseenCalls || info.calls.empty()) {
         continue;
       }
-      auto* func = module->getFunction(name);
       // Refine argument types before doing anything else. This does not
       // affect whether an argument is used or not, it just refines the type
       // where possible.
-      refineArgumentTypes(func, calls, module, infoMap[name]);
+      refineArgumentTypes(info.func, info.calls, module, info.unusedParams);
       // Refine return types as well.
-      if (refineReturnTypes(func, calls, module)) {
+      if (refineReturnTypes(info.func, info.calls, module)) {
         refinedReturnTypes = true;
       }
       auto optimizedIndexes =
-        ParamUtils::applyConstantValues({func}, calls, {}, module);
+        ParamUtils::applyConstantValues({info.func}, info.calls, {}, module);
       for (auto i : optimizedIndexes) {
         // Mark it as unused, which we know it now is (no point to re-scan just
         // for that).
-        infoMap[name].unusedParams.insert(i);
+        info.unusedParams.insert(i);
       }
     }
     if (refinedReturnTypes) {
@@ -250,57 +243,26 @@ struct DAE : public Pass {
     // Track which functions we changed, and optimize them later if necessary.
     std::unordered_set<Function*> changed;
     // We now know which parameters are unused, and can potentially remove them.
-    for (auto& [name, calls] : allCalls) {
-      if (infoMap[name].hasUnseenCalls) {
+    for (auto& [name, info] :  state.functions) {
+      if (info.hasUnseenCalls || info.calls.empty()) {
         continue;
       }
-      auto* func = module->getFunction(name);
-      auto numParams = func->getNumParams();
-      if (numParams == 0) {
-        continue;
-      }
-      auto removedIndexes = ParamUtils::removeParameters(
-        {func}, infoMap[name].unusedParams, calls, {}, module, runner);
-      if (!removedIndexes.empty()) {
+      if (info.func->getNumParams() > 0 && !ParamUtils::removeParameters(
+        {info.func}, info.unusedParams, info.calls, {}, module, runner).empty()) {
         // Success!
-        changed.insert(func);
-      }
-    }
-    // We can also tell which calls have all their return values dropped. Note
-    // that we can't do this if we changed anything so far, as we may have
-    // modified allCalls (we can't modify a call site twice in one iteration,
-    // once to remove a param, once to drop the return value).
-    if (changed.empty()) {
-      for (auto& func : module->functions) {
-        if (func->getResults() == Type::none) {
-          continue;
-        }
-        auto name = func->name;
-        if (infoMap[name].hasUnseenCalls) {
-          continue;
-        }
-        if (infoMap[name].hasTailCalls) {
-          continue;
-        }
-        if (tailCallees.count(name)) {
-          continue;
-        }
-        auto iter = allCalls.find(name);
-        if (iter == allCalls.end()) {
-          continue;
-        }
-        auto& calls = iter->second;
-        bool allDropped =
-          std::all_of(calls.begin(), calls.end(), [&](Call* call) {
-            return allDroppedCalls.count(call);
-          });
+        changed.insert(info.func);
+      } else if (!info.hasTailCalls && info.func->getResults() != Type::none) {
+        // We can also tell which calls have all their return values dropped.
+        bool allDropped = std::all_of(info.calls.begin(), info.calls.end(), [&](Call* call) {
+          return state.droppedCalls.count(call);
+        });
         if (!allDropped) {
           continue;
         }
-        removeReturnValue(func.get(), calls, module);
+        removeReturnValue(info.func, info.calls, module, state.droppedCalls);
         // TODO Removing a drop may also open optimization opportunities in the
         // callers.
-        changed.insert(func.get());
+        changed.insert(info.func);
       }
     }
     if (optimize && !changed.empty()) {
@@ -310,10 +272,10 @@ struct DAE : public Pass {
   }
 
 private:
-  std::unordered_map<Call*, Expression**> allDroppedCalls;
-
-  void
-  removeReturnValue(Function* func, std::vector<Call*>& calls, Module* module) {
+  void removeReturnValue(Function* func, 
+                    const std::vector<Call*>& calls,
+                    Module* module, 
+                    const std::unordered_map<Call*, Expression**>& droppedCalls) {
     func->setResults(Type::none);
     Builder builder(*module);
     // Remove any return values.
@@ -336,8 +298,8 @@ private:
     }
     // Remove the drops on the calls.
     for (auto* call : calls) {
-      auto iter = allDroppedCalls.find(call);
-      assert(iter != allDroppedCalls.end());
+      auto iter = droppedCalls.find(call);
+      assert(iter != droppedCalls.end());
       Expression** location = iter->second;
       *location = call;
       // Update the call's type.
@@ -356,7 +318,7 @@ private:
   void refineArgumentTypes(Function* func,
                            const std::vector<Call*>& calls,
                            Module* module,
-                           const DAEFunctionInfo& info) {
+                           const SortedVector& unusedParams) {
     if (!module->features.hasGC()) {
       return;
     }
@@ -372,7 +334,7 @@ private:
       // think about corner cases involving refining the type of an unused
       // param (in particular, unused params are turned into locals, which means
       // we'd need to think about defaultability etc.).
-      if (!originalType.isRef() || info.unusedParams.has(i)) {
+      if (!originalType.isRef() || unusedParams.has(i)) {
         newParamTypes.push_back(originalType);
         continue;
       }


### PR DESCRIPTION
#4619

Two main changes here. 

* Reduce the number of iterations required to convergence
  * Allow return value removal if the call's parameters were not changed
* Improve individual iteration time 
  * Take more advantage of DAEScanner threading by combing aggregating call to function as they are scanned opposed to tracking the calls a function makes and then combine in another pass.  This does introduce a mutex, but with larger binaries that merging after the scan is a large portion of the time

Crude measurements 
Before:
```
[PassRunner]   running pass: dae-optimizing...                     53.1484 seconds.
```
After:
```
[PassRunner]   running pass: dae-optimizing...                     20.1887 seconds.
```

<details>
<summary>More details</summary>
<details>
<summary>Before</summary>

```
[PassRunner] running passes
[PassRunner]   running pass: duplicate-function-elimination...     14.3721 seconds.
[PassRunner]   running pass: memory-packing...                     0.375367 seconds.
[PassRunner]   running pass: once-reduction...                     0.284163 seconds.
[PassRunner]   running pass: ssa-nomerge...                        8.43984 seconds.
[PassRunner]   running pass: dce...                                2.62311 seconds.
[PassRunner]   running pass: remove-unused-names...                0.436566 seconds.
[PassRunner]   running pass: remove-unused-brs...                  2.46523 seconds.
[PassRunner]   running pass: remove-unused-names...                0.421022 seconds.
[PassRunner]   running pass: optimize-instructions...              2.00798 seconds.
[PassRunner]   running pass: pick-load-signs...                    0.591743 seconds.
[PassRunner]   running pass: precompute...                         1.29118 seconds.
[PassRunner]   running pass: optimize-added-constants-propagate... 18.0451 seconds.
[PassRunner]   running pass: code-pushing...                       0.877306 seconds.
[PassRunner]   running pass: simplify-locals-nostructure...        4.57143 seconds.
[PassRunner]   running pass: vacuum...                             3.66881 seconds.
[PassRunner]   running pass: reorder-locals...                     0.735429 seconds.
[PassRunner]   running pass: remove-unused-brs...                  1.81832 seconds.
[PassRunner]   running pass: coalesce-locals...                    4.37666 seconds.
[PassRunner]   running pass: local-cse...                          2.48903 seconds.
[PassRunner]   running pass: simplify-locals...                    6.08436 seconds.
[PassRunner]   running pass: vacuum...                             3.85254 seconds.
[PassRunner]   running pass: reorder-locals...                     0.612518 seconds.
[PassRunner]   running pass: coalesce-locals...                    3.73631 seconds.
[PassRunner]   running pass: reorder-locals...                     0.594931 seconds.
[PassRunner]   running pass: vacuum...                             4.17217 seconds.
[PassRunner]   running pass: code-folding...                       2.27605 seconds.
[PassRunner]   running pass: merge-blocks...                       1.1134 seconds.
[PassRunner]   running pass: remove-unused-brs...                  1.94706 seconds.
[PassRunner]   running pass: remove-unused-names...                0.411736 seconds.
[PassRunner]   running pass: merge-blocks...                       0.896258 seconds.
[PassRunner]   running pass: precompute...                         1.24529 seconds.
[PassRunner]   running pass: optimize-instructions...              1.73888 seconds.
[PassRunner]   running pass: rse...                                3.88464 seconds.
[PassRunner]   running pass: vacuum...                             3.32334 seconds.
[PassRunner]   running pass: dae-optimizing...                     
Function Count: 132035

Iteration: 1
  removedParams: 12961
  returnValuesRemoved: 0
Iteration: 2
  removedParams: 2343
  returnValuesRemoved: 0
Iteration: 3
  removedParams: 903
  returnValuesRemoved: 0
Iteration: 4
  removedParams: 553
  returnValuesRemoved: 0
Iteration: 5
  removedParams: 409
  returnValuesRemoved: 0
Iteration: 6
  removedParams: 303
  returnValuesRemoved: 0
Iteration: 7
  removedParams: 124
  returnValuesRemoved: 0
Iteration: 8
  removedParams: 100
  returnValuesRemoved: 0
Iteration: 9
  removedParams: 88
  returnValuesRemoved: 0
Iteration: 10
  removedParams: 69
  returnValuesRemoved: 0
Iteration: 11
  removedParams: 53
  returnValuesRemoved: 0
Iteration: 12
  removedParams: 41
  returnValuesRemoved: 0
Iteration: 13
  removedParams: 21
  returnValuesRemoved: 0
Iteration: 14
  removedParams: 17
  returnValuesRemoved: 0
Iteration: 15
  removedParams: 12
  returnValuesRemoved: 0
Iteration: 16
  removedParams: 10
  returnValuesRemoved: 0
Iteration: 17
  removedParams: 7
  returnValuesRemoved: 0
Iteration: 18
  removedParams: 4
  returnValuesRemoved: 0
Iteration: 19
  removedParams: 4
  returnValuesRemoved: 0
Iteration: 20
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 21
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 22
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 23
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 24
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 25
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 26
  removedParams: 0
  returnValuesRemoved: 16824
Iteration: 27
  removedParams: 11
  returnValuesRemoved: 0
Iteration: 28
  removedParams: 1
  returnValuesRemoved: 0
Iteration: 29
  removedParams: 0
  returnValuesRemoved: 1523
Iteration: 30
  removedParams: 1
  returnValuesRemoved: 0
Iteration: 31
  removedParams: 0
  returnValuesRemoved: 101
Iteration: 32
  removedParams: 0
  returnValuesRemoved: 73
Iteration: 33
  removedParams: 0
  returnValuesRemoved: 24
Iteration: 34
  removedParams: 0
  returnValuesRemoved: 2
Iteration: 35
  removedParams: 0
  returnValuesRemoved: 1

Total Iterations: 35

Total removedParams: 18047

Total returnValuesRemoved : 18548
62.534 seconds.
[PassRunner]   running pass: inlining-optimizing...                19.0418 seconds.
[PassRunner]   running pass: duplicate-function-elimination...     1.20115 seconds.
[PassRunner]   running pass: duplicate-import-elimination...       0.0219464 seconds.
[PassRunner]   running pass: simplify-globals-optimizing...        0.238322 seconds.
[PassRunner]   running pass: remove-unused-module-elements...      0.744704 seconds.
[PassRunner]   running pass: directize...                          0.099373 seconds.
[PassRunner]   running pass: generate-stack-ir...                  3.8177 seconds.
[PassRunner]   running pass: optimize-stack-ir...                  11.7025 seconds.
[PassRunner]   running pass: strip-dwarf...                        0.381858 seconds.
[PassRunner]   running pass: post-emscripten...                    0.596744 seconds.
[PassRunner]   running pass: strip-debug...                        0.0331753 seconds.
[PassRunner]   running pass: strip-producers...                    0.0101664 seconds.
[PassRunner] passes took 206.203 seconds.

real	3m37.656s
user	8m52.359s
sys	0m1.559s

```

</details>
<details>
<summary>After</summary>

```
[PassRunner] running passes
[PassRunner]   running pass: duplicate-function-elimination...     15.0078 seconds.
[PassRunner]   running pass: memory-packing...                     0.390619 seconds.
[PassRunner]   running pass: once-reduction...                     0.32075 seconds.
[PassRunner]   running pass: ssa-nomerge...                        8.3342 seconds.
[PassRunner]   running pass: dce...                                2.6724 seconds.
[PassRunner]   running pass: remove-unused-names...                0.439206 seconds.
[PassRunner]   running pass: remove-unused-brs...                  2.43178 seconds.
[PassRunner]   running pass: remove-unused-names...                0.42836 seconds.
[PassRunner]   running pass: optimize-instructions...              2.01661 seconds.
[PassRunner]   running pass: pick-load-signs...                    0.60229 seconds.
[PassRunner]   running pass: precompute...                         1.29365 seconds.
[PassRunner]   running pass: optimize-added-constants-propagate... 15.0877 seconds.
[PassRunner]   running pass: code-pushing...                       0.825163 seconds.
[PassRunner]   running pass: simplify-locals-nostructure...        4.57273 seconds.
[PassRunner]   running pass: vacuum...                             3.6144 seconds.
[PassRunner]   running pass: reorder-locals...                     0.668802 seconds.
[PassRunner]   running pass: remove-unused-brs...                  1.7005 seconds.
[PassRunner]   running pass: coalesce-locals...                    3.7669 seconds.
[PassRunner]   running pass: local-cse...                          2.2485 seconds.
[PassRunner]   running pass: simplify-locals...                    5.48495 seconds.
[PassRunner]   running pass: vacuum...                             3.33565 seconds.
[PassRunner]   running pass: reorder-locals...                     0.575778 seconds.
[PassRunner]   running pass: coalesce-locals...                    3.47178 seconds.
[PassRunner]   running pass: reorder-locals...                     0.559923 seconds.
[PassRunner]   running pass: vacuum...                             3.30451 seconds.
[PassRunner]   running pass: code-folding...                       1.32623 seconds.
[PassRunner]   running pass: merge-blocks...                       0.969594 seconds.
[PassRunner]   running pass: remove-unused-brs...                  1.90931 seconds.
[PassRunner]   running pass: remove-unused-names...                0.401803 seconds.
[PassRunner]   running pass: merge-blocks...                       0.899873 seconds.
[PassRunner]   running pass: precompute...                         1.19759 seconds.
[PassRunner]   running pass: optimize-instructions...              1.73715 seconds.
[PassRunner]   running pass: rse...                                3.73981 seconds.
[PassRunner]   running pass: vacuum...                             3.36944 seconds.
[PassRunner]   running pass: dae-optimizing...                     
Function Count: 132035

Iteration: 1
  removedParams: 12961
  returnValuesRemoved: 15818
Iteration: 2
  removedParams: 2352
  returnValuesRemoved: 2472
Iteration: 3
  removedParams: 906
  returnValuesRemoved: 154
Iteration: 4
  removedParams: 553
  returnValuesRemoved: 78
Iteration: 5
  removedParams: 409
  returnValuesRemoved: 27
Iteration: 6
  removedParams: 303
  returnValuesRemoved: 2
Iteration: 7
  removedParams: 124
  returnValuesRemoved: 1
Iteration: 8
  removedParams: 100
  returnValuesRemoved: 0
Iteration: 9
  removedParams: 88
  returnValuesRemoved: 0
Iteration: 10
  removedParams: 69
  returnValuesRemoved: 0
Iteration: 11
  removedParams: 53
  returnValuesRemoved: 0
Iteration: 12
  removedParams: 41
  returnValuesRemoved: 0
Iteration: 13
  removedParams: 21
  returnValuesRemoved: 0
Iteration: 14
  removedParams: 17
  returnValuesRemoved: 0
Iteration: 15
  removedParams: 12
  returnValuesRemoved: 0
Iteration: 16
  removedParams: 10
  returnValuesRemoved: 0
Iteration: 17
  removedParams: 7
  returnValuesRemoved: 0
Iteration: 18
  removedParams: 4
  returnValuesRemoved: 0
Iteration: 19
  removedParams: 4
  returnValuesRemoved: 0
Iteration: 20
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 21
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 22
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 23
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 24
  removedParams: 2
  returnValuesRemoved: 0
Iteration: 25
  removedParams: 2
  returnValuesRemoved: 0

Total Iterations: 25

Total removedParams: 18046

Total returnValuesRemoved : 18552
22.6605 seconds.
[PassRunner]   running pass: inlining-optimizing...                20.0691 seconds.
[PassRunner]   running pass: duplicate-function-elimination...     1.26333 seconds.
[PassRunner]   running pass: duplicate-import-elimination...       0.0230375 seconds.
[PassRunner]   running pass: simplify-globals-optimizing...        0.259489 seconds.
[PassRunner]   running pass: remove-unused-module-elements...      0.763686 seconds.
[PassRunner]   running pass: directize...                          0.0925571 seconds.
[PassRunner]   running pass: generate-stack-ir...                  0.653405 seconds.
[PassRunner]   running pass: optimize-stack-ir...                  12.3452 seconds.
[PassRunner]   running pass: strip-dwarf...                        0.419868 seconds.
[PassRunner]   running pass: post-emscripten...                    0.603769 seconds.
[PassRunner]   running pass: strip-debug...                        0.0351469 seconds.
[PassRunner]   running pass: strip-producers...                    0.0250297 seconds.
[PassRunner] passes took 157.92 seconds.

real	2m49.617s
user	7m59.884s
sys	0m22.072s
```

</details>

</details>