### PR TITLE
Missing include

### DIFF
--- a/src/passes/ExtractFunction.cpp
+++ b/src/passes/ExtractFunction.cpp
@@ -20,6 +20,8 @@
 // This pass will run --remove-unused-module-elements automatically for you, in
 // order to remove as many things as possible.
 
+#include <cctype>
+
 #include "pass.h"
 #include "wasm-builder.h"
 #include "wasm.h"


### PR DESCRIPTION
This makes a build on Windows fail with `Errors : 'isdigit': is not a member of 'std'` 