### PR TITLE
[NominalFuzzing] Use feature flags in a missing place

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -858,7 +858,7 @@ class Wasm2JS(TestCaseHandler):
         # the trap, which lets us compare at least some results in some cases.
         # (this is why wasm2js is not in CompareVMs, which does full
         # comparisons - we need to limit the comparison in a special way here)
-        interpreter = run([in_bin('wasm-opt'), before_wasm_temp, '--fuzz-exec-before'])
+        interpreter = run_bynterp(before_wasm_temp, ['--fuzz-exec-before'])
         if TRAP_PREFIX in interpreter:
             trap_index = interpreter.index(TRAP_PREFIX)
             # we can't test this function, which the trap is in the middle of.


### PR DESCRIPTION
Instead of a raw run command, use the helper function, which adds the
feature flags. That adds `--nominal` which is needed more now after #4625 

This fixes the fuzz failures mentioned in https://github.com/WebAssembly/binaryen/pull/4625#issuecomment-1115033311