### PR TITLE
Update nominal type ordering

### DIFF
--- a/test/lit/lub-bug-3843.wast
+++ b/test/lit/lub-bug-3843.wast
@@ -16,11 +16,12 @@
  (type $B (struct_subtype (field (ref null $D)) $A))
 
  ;; CHECK:      (type $D (struct (field (mut (ref $A))) (field (mut (ref $A)))))
+ ;; NOMNL:      (type $C (struct_subtype (field (mut (ref $A))) data))
+
  ;; NOMNL:      (type $D (struct_subtype (field (mut (ref $A))) (field (mut (ref $A))) $C))
  (type $D (struct_subtype (field (mut (ref $A))) (field (mut (ref $A))) $C))
 
  ;; CHECK:      (type $C (struct (field (mut (ref $A)))))
- ;; NOMNL:      (type $C (struct_subtype (field (mut (ref $A))) data))
  (type $C (struct (field (mut (ref $A)))))
 
 

--- a/test/lit/nominal-chain.wast
+++ b/test/lit/nominal-chain.wast
@@ -7,18 +7,21 @@
 ;; types.
 
 (module
+  ;; CHECK:      (type $root (struct_subtype  data))
+
+  ;; CHECK:      (type $trunk (struct_subtype (field i32) $root))
+
+  ;; CHECK:      (type $branch (struct_subtype (field i32) (field i64) $trunk))
+
+  ;; CHECK:      (type $twig (struct_subtype (field i32) (field i64) (field f32) $branch))
+
   ;; CHECK:      (type $leaf (struct_subtype (field i32) (field i64) (field f32) (field f64) $twig))
   (type $leaf (struct_subtype i32 i64 f32 f64 $twig))
 
-  ;; CHECK:      (type $root (struct_subtype  data))
-
-  ;; CHECK:      (type $twig (struct_subtype (field i32) (field i64) (field f32) $branch))
   (type $twig (struct_subtype i32 i64 f32 $branch))
 
-  ;; CHECK:      (type $branch (struct_subtype (field i32) (field i64) $trunk))
   (type $branch (struct_subtype i32 i64 $trunk))
 
-  ;; CHECK:      (type $trunk (struct_subtype (field i32) $root))
   (type $trunk (struct_subtype i32 $root))
 
   (type $root (struct))

--- a/test/lit/parse-nominal-types-extends.wast
+++ b/test/lit/parse-nominal-types-extends.wast
@@ -8,10 +8,11 @@
 
 ;; void function type
 (module
+  ;; CHECK:      (type $super (func_subtype func))
+
   ;; CHECK:      (type $sub (func_subtype $super))
   (type $sub (func) (extends $super))
 
-  ;; CHECK:      (type $super (func_subtype func))
   (type $super (func))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -20,10 +21,11 @@
 
 ;; function type with params and results
 (module
+  ;; CHECK:      (type $super (func_subtype (param i32) (result i32) func))
+
   ;; CHECK:      (type $sub (func_subtype (param i32) (result i32) $super))
   (type $sub (func (param i32) (result i32)) (extends $super))
 
-  ;; CHECK:      (type $super (func_subtype (param i32) (result i32) func))
   (type $super (func (param i32) (result i32)))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -32,10 +34,11 @@
 
 ;; empty struct type
 (module
+  ;; CHECK:      (type $super (struct_subtype  data))
+
   ;; CHECK:      (type $sub (struct_subtype  $super))
   (type $sub (struct) (extends $super))
 
-  ;; CHECK:      (type $super (struct_subtype  data))
   (type $super (struct))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -44,10 +47,11 @@
 
 ;; struct type with fields
 (module
+  ;; CHECK:      (type $super (struct_subtype (field i32) (field i64) data))
+
   ;; CHECK:      (type $sub (struct_subtype (field i32) (field i64) $super))
   (type $sub (struct i32 (field i64)) (extends $super))
 
-  ;; CHECK:      (type $super (struct_subtype (field i32) (field i64) data))
   (type $super (struct (field i32) i64))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -56,10 +60,11 @@
 
 ;; array type
 (module
+  ;; CHECK:      (type $super (array_subtype i8 data))
+
   ;; CHECK:      (type $sub (array_subtype i8 $super))
   (type $sub (array i8) (extends $super))
 
-  ;; CHECK:      (type $super (array_subtype i8 data))
   (type $super (array i8))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))

--- a/test/lit/parse-nominal-types.wast
+++ b/test/lit/parse-nominal-types.wast
@@ -8,10 +8,11 @@
 
 ;; void function type
 (module
+  ;; CHECK:      (type $super (func_subtype func))
+
   ;; CHECK:      (type $sub (func_subtype $super))
   (type $sub (func_subtype $super))
 
-  ;; CHECK:      (type $super (func_subtype func))
   (type $super (func_subtype func))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -20,10 +21,11 @@
 
 ;; function type with params and results
 (module
+  ;; CHECK:      (type $super (func_subtype (param i32) (result i32) func))
+
   ;; CHECK:      (type $sub (func_subtype (param i32) (result i32) $super))
   (type $sub (func_subtype (param i32) (result i32) $super))
 
-  ;; CHECK:      (type $super (func_subtype (param i32) (result i32) func))
   (type $super (func_subtype (param i32) (result i32) func))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -32,10 +34,11 @@
 
 ;; empty struct type
 (module
+  ;; CHECK:      (type $super (struct_subtype  data))
+
   ;; CHECK:      (type $sub (struct_subtype  $super))
   (type $sub (struct_subtype $super))
 
-  ;; CHECK:      (type $super (struct_subtype  data))
   (type $super (struct_subtype data))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -44,10 +47,11 @@
 
 ;; struct type with fields
 (module
+  ;; CHECK:      (type $super (struct_subtype (field i32) (field i64) data))
+
   ;; CHECK:      (type $sub (struct_subtype (field i32) (field i64) $super))
   (type $sub (struct_subtype i32 (field i64) $super))
 
-  ;; CHECK:      (type $super (struct_subtype (field i32) (field i64) data))
   (type $super (struct_subtype (field i32) i64 data))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))
@@ -56,10 +60,11 @@
 
 ;; array type
 (module
+  ;; CHECK:      (type $super (array_subtype i8 data))
+
   ;; CHECK:      (type $sub (array_subtype i8 $super))
   (type $sub (array_subtype i8 $super))
 
-  ;; CHECK:      (type $super (array_subtype i8 data))
   (type $super (array_subtype i8 data))
 
   ;; CHECK:      (global $g (ref null $super) (ref.null $sub))

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -664,10 +664,11 @@
 (module
   ;; CHECK:      (type $none_=>_none (func_subtype func))
 
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+
   ;; CHECK:      (type $substruct (struct_subtype (field i32) (field f64) $struct))
   (type $substruct (struct_subtype i32 f64 $struct))
 
-  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
   (type $struct (struct i32))
 
   ;; CHECK:      (func $create (type $none_=>_none)
@@ -834,10 +835,11 @@
 (module
   ;; CHECK:      (type $none_=>_none (func_subtype func))
 
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+
   ;; CHECK:      (type $substruct (struct_subtype (field i32) (field f64) $struct))
   (type $substruct (struct_subtype i32 f64 $struct))
 
-  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
   (type $struct (struct i32))
 
   ;; CHECK:      (func $create (type $none_=>_none)
@@ -958,16 +960,18 @@
 ;; Multi-level subtyping, check that we propagate not just to the immediate
 ;; supertype but all the way as needed.
 (module
+  ;; CHECK:      (type $struct1 (struct_subtype (field i32) data))
+
+  ;; CHECK:      (type $struct2 (struct_subtype (field i32) (field f64) $struct1))
+
   ;; CHECK:      (type $struct3 (struct_subtype (field i32) (field f64) (field anyref) $struct2))
   (type $struct3 (struct_subtype i32 f64 anyref $struct2))
 
-  ;; CHECK:      (type $none_=>_none (func_subtype func))
-
-  ;; CHECK:      (type $struct2 (struct_subtype (field i32) (field f64) $struct1))
   (type $struct2 (struct_subtype i32 f64 $struct1))
 
-  ;; CHECK:      (type $struct1 (struct_subtype (field i32) data))
   (type $struct1 (struct i32))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
 
   ;; CHECK:      (func $create (type $none_=>_none)
   ;; CHECK-NEXT:  (drop
@@ -1093,13 +1097,15 @@
 ;; different values in the sub-most type. Create the top and bottom types, but
 ;; not the middle one.
 (module
+  ;; CHECK:      (type $struct1 (struct_subtype (field i32) (field i32) data))
+
+  ;; CHECK:      (type $struct2 (struct_subtype (field i32) (field i32) (field f64) (field f64) $struct1))
+
   ;; CHECK:      (type $struct3 (struct_subtype (field i32) (field i32) (field f64) (field f64) (field anyref) (field anyref) $struct2))
   (type $struct3 (struct_subtype i32 i32 f64 f64 anyref anyref $struct2))
 
-  ;; CHECK:      (type $struct1 (struct_subtype (field i32) (field i32) data))
   (type $struct1 (struct i32 i32))
 
-  ;; CHECK:      (type $struct2 (struct_subtype (field i32) (field i32) (field f64) (field f64) $struct1))
   (type $struct2 (struct_subtype i32 i32 f64 f64 $struct1))
 
   ;; CHECK:      (type $anyref_=>_none (func_subtype (param anyref) func))
@@ -1427,10 +1433,11 @@
 ;; As above, but add not just a new of the middle class with a different value
 ;; but also a set. That prevents all optimizations.
 (module
+  ;; CHECK:      (type $struct1 (struct_subtype (field (mut i32)) data))
+
   ;; CHECK:      (type $struct2 (struct_subtype (field (mut i32)) (field f64) $struct1))
   (type $struct2 (struct_subtype (mut i32) f64 $struct1))
 
-  ;; CHECK:      (type $struct1 (struct_subtype (field (mut i32)) data))
   (type $struct1 (struct (mut i32)))
 
   ;; CHECK:      (type $struct3 (struct_subtype (field (mut i32)) (field f64) (field anyref) $struct2))
@@ -1657,20 +1664,22 @@
 ;; sets, and the final subtype C has a create and a get. The set to A should
 ;; apply to it, preventing optimization.
 (module
+  ;; CHECK:      (type $A (struct_subtype (field (mut i32)) data))
+
+  ;; CHECK:      (type $B (struct_subtype (field (mut i32)) $A))
+
   ;; CHECK:      (type $C (struct_subtype (field (mut i32)) $B))
   (type $C (struct_subtype (mut i32) $B))
 
-  ;; CHECK:      (type $A (struct_subtype (field (mut i32)) data))
   (type $A (struct (mut i32)))
+
+  (type $B (struct_subtype (mut i32) $A))
 
   ;; CHECK:      (type $none_=>_none (func_subtype func))
 
   ;; CHECK:      (type $ref|$A|_=>_none (func_subtype (param (ref $A)) func))
 
   ;; CHECK:      (type $ref|$C|_=>_none (func_subtype (param (ref $C)) func))
-
-  ;; CHECK:      (type $B (struct_subtype (field (mut i32)) $A))
-  (type $B (struct_subtype (mut i32) $A))
 
   ;; CHECK:      (func $create (type $none_=>_none)
   ;; CHECK-NEXT:  (drop

--- a/test/lit/passes/dae-gc-refine-params.wast
+++ b/test/lit/passes/dae-gc-refine-params.wast
@@ -4,11 +4,12 @@
 
 (module
  ;; CHECK:      (type ${i32} (struct (field i32)))
+ ;; NOMNL:      (type ${} (struct_subtype  data))
+
  ;; NOMNL:      (type ${i32} (struct_subtype (field i32) ${}))
  (type ${i32} (struct_subtype (field i32) ${}))
 
  ;; CHECK:      (type ${} (struct ))
- ;; NOMNL:      (type ${} (struct_subtype  data))
  (type ${} (struct))
 
  ;; CHECK:      (type ${i32_i64} (struct (field i32) (field i64)))

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -12,6 +12,8 @@
  ;; CHECK:      (type ${i32_i64} (struct (field i32) (field i64)))
 
  ;; CHECK:      (type ${i32_f32} (struct (field i32) (field f32)))
+ ;; NOMNL:      (type ${} (struct_subtype  data))
+
  ;; NOMNL:      (type ${i32} (struct_subtype (field i32) ${}))
 
  ;; NOMNL:      (type ${i32_i64} (struct_subtype (field i32) (field i64) ${i32}))
@@ -24,7 +26,6 @@
  (type ${i32} (struct_subtype (field i32) ${}))
 
  ;; CHECK:      (type ${} (struct ))
- ;; NOMNL:      (type ${} (struct_subtype  data))
  (type ${} (struct))
 
  (table 1 1 funcref)

--- a/test/lit/passes/gto-mutability.wast
+++ b/test/lit/passes/gto-mutability.wast
@@ -531,10 +531,9 @@
   ;; As above, but add a write in the sub, which prevents optimization.
 
 
-  ;; CHECK:      (type $sub (struct_subtype (field (mut i32)) $super))
-
   ;; CHECK:      (type $super (struct_subtype (field (mut i32)) data))
   (type $super (struct (field (mut i32))))
+  ;; CHECK:      (type $sub (struct_subtype (field (mut i32)) $super))
   (type $sub (struct_subtype (field (mut i32)) $super))
 
   ;; CHECK:      (type $ref|$sub|_=>_none (func_subtype (param (ref $sub)) func))

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -645,10 +645,11 @@
 ;; We can remove fields from the end if they are only used in subtypes, because
 ;; the subtypes can always add fields at the end (and only at the end).
 (module
+  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) data))
+
   ;; CHECK:      (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
   (type $child (struct_subtype (field i32) (field i64) (field f32) (field f64) (field anyref) $parent))
 
-  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) data))
   (type $parent (struct_subtype (field i32) (field i64) (field f32) (field f64) data))
 
   ;; CHECK:      (type $ref|$parent|_ref|$child|_=>_none (func_subtype (param (ref $parent) (ref $child)) func))
@@ -694,10 +695,11 @@
 )
 
 (module
+  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) (field (mut f32)) data))
+
   ;; CHECK:      (type $child (struct_subtype (field i32) (field i64) (field (mut f32)) (field f64) (field anyref) $parent))
   (type $child (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) (field (mut anyref)) $parent))
 
-  ;; CHECK:      (type $parent (struct_subtype (field i32) (field i64) (field (mut f32)) data))
   (type $parent (struct_subtype (field (mut i32)) (field (mut i64)) (field (mut f32)) (field (mut f64)) data))
 
   ;; CHECK:      (type $ref|$parent|_ref|$child|_=>_none (func_subtype (param (ref $parent) (ref $child)) func))
@@ -774,13 +776,14 @@
 ;; As above, but now the read is just of one child. We can remove the field
 ;; from the parent and the other child.
 (module
+  ;; CHECK:      (type $parent (struct_subtype  data))
+
   ;; CHECK:      (type $child1 (struct_subtype (field i32) $parent))
   (type $child1 (struct_subtype (field i32) $parent))
 
+  (type $parent (struct_subtype (field i32) data))
   ;; CHECK:      (type $ref|$parent|_ref|$child1|_ref|$child2|_=>_none (func_subtype (param (ref $parent) (ref $child1) (ref $child2)) func))
 
-  ;; CHECK:      (type $parent (struct_subtype  data))
-  (type $parent (struct_subtype (field i32) data))
   ;; CHECK:      (type $child2 (struct_subtype  $parent))
   (type $child2 (struct_subtype (field i32) $parent))
 

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -372,21 +372,17 @@
   ;; CHECK:      (type $B (struct (field (ref null $A))))
 
   ;; CHECK:      (type $A (struct ))
-  ;; NOMNL:      (type $C (struct_subtype (field (ref null $D)) $B))
-
-  ;; NOMNL:      (type $D (struct_subtype  $A))
-
   ;; NOMNL:      (type $A (struct_subtype  data))
-  ;; NOMNL-TNH:      (type $C (struct_subtype (field (ref null $D)) $B))
-
-  ;; NOMNL-TNH:      (type $D (struct_subtype  $A))
-
   ;; NOMNL-TNH:      (type $A (struct_subtype  data))
   (type $A (struct_subtype  data))
   ;; NOMNL:      (type $B (struct_subtype (field (ref null $A)) $A))
   ;; NOMNL-TNH:      (type $B (struct_subtype (field (ref null $A)) $A))
   (type $B (struct_subtype (field (ref null $A)) $A))
+  ;; NOMNL:      (type $C (struct_subtype (field (ref null $D)) $B))
+  ;; NOMNL-TNH:      (type $C (struct_subtype (field (ref null $D)) $B))
   (type $C (struct_subtype (field (ref null $D)) $B))
+  ;; NOMNL:      (type $D (struct_subtype  $A))
+  ;; NOMNL-TNH:      (type $D (struct_subtype  $A))
   (type $D (struct_subtype  $A))
 
   ;; CHECK:      (func $test (param $C (ref $B)) (result anyref)

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -123,13 +123,14 @@
 
   ;; CHECK:      (type $none_=>_none (func_subtype func))
 
+  ;; CHECK:      (type $struct (struct_subtype  data))
+
   ;; CHECK:      (type $struct-sub1 (struct_subtype  $struct))
   (type $struct-sub1 (struct_subtype $struct))
 
   ;; CHECK:      (type $struct-sub2 (struct_subtype  $struct))
   (type $struct-sub2 (struct_subtype $struct))
 
-  ;; CHECK:      (type $struct (struct_subtype  data))
   (type $struct (struct_subtype data))
 
   ;; CHECK:      (func $func-1 (type $sig) (param $x (ref $struct))

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -121,10 +121,11 @@
   ;; As above, but all writes are of $child-A, which allows more optimization
   ;; up to that type.
 
+  ;; CHECK:      (type $struct (struct_subtype (field (mut (ref $child-A))) data))
+
   ;; CHECK:      (type $child-A (struct_subtype (field (mut (ref $child-A))) $struct))
   (type $child-A (struct_subtype (field (mut dataref)) $struct))
 
-  ;; CHECK:      (type $struct (struct_subtype (field (mut (ref $child-A))) data))
   (type $struct (struct_subtype (field (mut dataref)) data))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child-A|_=>_none (func_subtype (param (ref $struct) (ref $child-A)) func))
@@ -205,10 +206,11 @@
 (module
   ;; As above, but both writes are of $child, so we can optimize.
 
+  ;; CHECK:      (type $struct (struct_subtype (field (mut (ref $child))) data))
+
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref $child))) $struct))
   (type $child (struct_subtype (field (mut dataref)) $struct))
 
-  ;; CHECK:      (type $struct (struct_subtype (field (mut (ref $child))) data))
   (type $struct (struct_subtype (field (mut dataref)) data))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func_subtype (param (ref $struct) (ref $child)) func))
@@ -435,10 +437,14 @@
 )
 
 (module
+  ;; CHECK:      (type $X (struct_subtype  data))
+
   ;; CHECK:      (type $Y (struct_subtype  $X))
   (type $Y (struct_subtype $X))
 
   ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (type $A (struct_subtype (field (ref $Y)) data))
 
   ;; CHECK:      (type $C (struct_subtype (field (ref $Y)) $A))
   (type $C (struct_subtype (field (ref $X)) $A))
@@ -446,10 +452,8 @@
   ;; CHECK:      (type $B (struct_subtype (field (ref $Y)) $A))
   (type $B (struct_subtype (field (ref $X)) $A))
 
-  ;; CHECK:      (type $A (struct_subtype (field (ref $Y)) data))
   (type $A (struct_subtype (field (ref $X)) data))
 
-  ;; CHECK:      (type $X (struct_subtype  data))
   (type $X (struct_subtype data))
 
   ;; CHECK:      (func $foo (type $none_=>_none)
@@ -489,6 +493,8 @@
 
   ;; CHECK:      (type $none_=>_none (func_subtype func))
 
+  ;; CHECK:      (type $A (struct_subtype (field (ref $X)) data))
+
   ;; CHECK:      (type $C (struct_subtype (field (ref $X)) $A))
   (type $C (struct_subtype (field (ref $X)) $A))
 
@@ -498,7 +504,6 @@
   ;; CHECK:      (type $Y (struct_subtype  $X))
   (type $Y (struct_subtype $X))
 
-  ;; CHECK:      (type $A (struct_subtype (field (ref $X)) data))
   (type $A (struct_subtype (field (ref $X)) data))
 
   ;; CHECK:      (func $foo (type $none_=>_none)
@@ -520,10 +525,11 @@
   (type $X (struct_subtype data))
   ;; CHECK:      (type $none_=>_none (func_subtype func))
 
+  ;; CHECK:      (type $A (struct_subtype (field (ref $X)) data))
+
   ;; CHECK:      (type $B (struct_subtype (field (ref $Y)) $A))
   (type $B (struct_subtype (field (ref $Y)) $A))
 
-  ;; CHECK:      (type $A (struct_subtype (field (ref $X)) data))
   (type $A (struct_subtype (field (ref $X)) data))
 
   ;; CHECK:      (type $Y (struct_subtype  $X))
@@ -784,10 +790,14 @@
   ;; Root-Outer[Root-Inner] -> Leaf1-Outer[Leaf1-Inner]
   ;;                        -> Leaf2-Outer[Leaf2-Inner]
 
+  ;; CHECK:      (type $Root-Inner (struct_subtype  data))
+
   ;; CHECK:      (type $Leaf2-Inner (struct_subtype  $Root-Inner))
   (type $Leaf2-Inner (struct_subtype  $Root-Inner))
 
   ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (type $Root-Outer (struct_subtype (field (ref $Leaf2-Inner)) data))
 
   ;; CHECK:      (type $Leaf1-Outer (struct_subtype (field (ref $Leaf2-Inner)) $Root-Outer))
   (type $Leaf1-Outer (struct_subtype (field (ref $Leaf1-Inner)) $Root-Outer))
@@ -795,10 +805,8 @@
  ;; CHECK:      (type $Leaf2-Outer (struct_subtype (field (ref $Leaf2-Inner)) $Root-Outer))
  (type $Leaf2-Outer (struct_subtype (field (ref $Leaf2-Inner)) $Root-Outer))
 
-  ;; CHECK:      (type $Root-Outer (struct_subtype (field (ref $Leaf2-Inner)) data))
   (type $Root-Outer (struct_subtype (field (ref $Root-Inner)) data))
 
-  ;; CHECK:      (type $Root-Inner (struct_subtype  data))
   (type $Root-Inner (struct_subtype  data))
 
   (type $Leaf1-Inner (struct_subtype (field i32) $Root-Inner))


### PR DESCRIPTION
V8 requires that supertypes come before subtypes when it parses
isorecursive (i.e. standards-track) type definitions. Since 2268f2a we are
emitting nominal types using the standard isorecursive format, so respect the
ordering requirement.