### PR TITLE
Setup git submodules so googletest is fetched, unbreaking alpine in releases

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -111,6 +111,8 @@ jobs:
       with:
         python-version: '3.x'
     - uses: actions/checkout@v1
+      with:
+        submodules: true
     - name: start docker
       run: |
         docker run -w /src -dit --name alpine -v $PWD:/src node:lts-alpine
@@ -124,11 +126,6 @@ jobs:
 
     - name: install python dev dependencies
       run: ./alpine.sh pip3 install -r requirements-dev.txt
-
-    - name: git submodules
-      run: |
-        ./alpine.sh git submodule init
-        ./alpine.sh git submodule update
 
     - name: cmake
       run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -125,6 +125,11 @@ jobs:
     - name: install python dev dependencies
       run: ./alpine.sh pip3 install -r requirements-dev.txt
 
+    - name: git submodules
+      run: |
+        ./alpine.sh git submodule init
+        ./alpine.sh git submodule update
+
     - name: cmake
       run: |
         ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON -DCMAKE_INSTALL_PREFIX=install


### PR DESCRIPTION
Without this the CMake step fails on not finding

`googletest/googletest/src/gtest_main.cc`

Fixes #4639 

This won't be tested in this PR. What's the best way to test it? Make a fake release I guess?