### PR TITLE
Fix fuzzer's choosing of reference types

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2905,13 +2905,7 @@ Type TranslateToFuzzReader::getSingleConcreteType() {
                      WeightedOption{Type::f32, VeryImportant},
                      WeightedOption{Type::f64, VeryImportant})
                 .add(FeatureSet::SIMD, WeightedOption{Type::v128, Important})
-                // Avoid Type::anyref without GC enabled, as in some contexts
-                // we will not be able to emit any constant for it (with GC, we
-                // can always emit a struct.new etc., even in a global init,
-                // while atm in global inits we don't yet have access to funcs
-                // so ref.func is not an option - FIXME emit at least one
-                // function before global inits).
-                .add(FeatureSet::ReferenceTypes, Type::funcref)
+                .add(FeatureSet::ReferenceTypes, Type::funcref, Type::anyref)
                 .add(FeatureSet::ReferenceTypes | FeatureSet::GC,
                      // Type(HeapType::func, NonNullable),
                      // Type(HeapType::any, NonNullable),

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,43 +1,48 @@
 total
- [exports]      : 3       
- [funcs]        : 3       
+ [exports]      : 4       
+ [funcs]        : 5       
  [globals]      : 6       
  [imports]      : 5       
  [memory-data]  : 22      
  [table-data]   : 0       
  [tables]       : 1       
  [tags]         : 1       
- [total]        : 813     
- [vars]         : 2       
- ArrayInit      : 1       
+ [total]        : 810     
+ [vars]         : 9       
+ ArrayInit      : 6       
+ AtomicCmpxchg  : 2       
  AtomicFence    : 2       
- Binary         : 96      
- Block          : 104     
- Break          : 25      
- Call           : 25      
- CallRef        : 4       
- Const          : 173     
- Drop           : 1       
- GlobalGet      : 54      
- GlobalSet      : 28      
- I31New         : 4       
- If             : 38      
- Load           : 23      
- LocalGet       : 56      
- LocalSet       : 39      
- Loop           : 24      
+ AtomicNotify   : 4       
+ AtomicRMW      : 1       
+ Binary         : 94      
+ Block          : 93      
+ Break          : 29      
+ Call           : 34      
+ CallRef        : 2       
+ Const          : 143     
+ DataDrop       : 1       
+ Drop           : 4       
+ GlobalGet      : 49      
+ GlobalSet      : 25      
+ I31Get         : 1       
+ I31New         : 15      
+ If             : 30      
+ Load           : 24      
+ LocalGet       : 69      
+ LocalSet       : 36      
+ Loop           : 19      
  MemoryFill     : 1       
- MemoryInit     : 1       
- Nop            : 8       
- RefEq          : 1       
- RefFunc        : 6       
- RefIs          : 3       
- RefNull        : 2       
- Return         : 26      
+ Nop            : 10      
+ RefEq          : 2       
+ RefFunc        : 7       
+ RefIs          : 7       
+ RefNull        : 4       
+ Return         : 27      
  SIMDExtract    : 6       
- Select         : 2       
- Store          : 5       
- StructNew      : 2       
- TupleExtract   : 5       
- TupleMake      : 5       
+ SIMDShuffle    : 1       
+ Select         : 3       
+ Store          : 1       
+ StructNew      : 4       
+ TupleExtract   : 4       
+ TupleMake      : 7       
  Unary          : 43      


### PR DESCRIPTION
1. Don't emit "`i31`" or "`data`" if GC is not enabled, as only the GC feature adds those.
2. Don't emit "`any`" without GC either. While it is allowed, fuzzer limitations prevent
  this atm (see details in comment - it's fixable).

Not sure why this wasn't noticed before, I guess we were just lucky...