### PR TITLE
[Fuzzer] Fix another reference types vs gc types issue

### DIFF
--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,48 +1,36 @@
 total
- [exports]      : 4       
- [funcs]        : 5       
+ [exports]      : 5       
+ [funcs]        : 4       
  [globals]      : 6       
  [imports]      : 5       
  [memory-data]  : 22      
  [table-data]   : 0       
  [tables]       : 1       
  [tags]         : 1       
- [total]        : 810     
+ [total]        : 363     
  [vars]         : 9       
- ArrayInit      : 6       
- AtomicCmpxchg  : 2       
- AtomicFence    : 2       
- AtomicNotify   : 4       
+ AtomicFence    : 1       
  AtomicRMW      : 1       
- Binary         : 94      
- Block          : 93      
- Break          : 29      
- Call           : 34      
- CallRef        : 2       
- Const          : 143     
- DataDrop       : 1       
- Drop           : 4       
- GlobalGet      : 49      
- GlobalSet      : 25      
- I31Get         : 1       
- I31New         : 15      
- If             : 30      
- Load           : 24      
- LocalGet       : 69      
- LocalSet       : 36      
- Loop           : 19      
- MemoryFill     : 1       
- Nop            : 10      
- RefEq          : 2       
- RefFunc        : 7       
- RefIs          : 7       
- RefNull        : 4       
- Return         : 27      
- SIMDExtract    : 6       
- SIMDShuffle    : 1       
- Select         : 3       
- Store          : 1       
- StructNew      : 4       
- TupleExtract   : 4       
- TupleMake      : 7       
- Unary          : 43      
+ Binary         : 65      
+ Block          : 36      
+ Break          : 7       
+ Call           : 2       
+ CallRef        : 1       
+ Const          : 75      
+ Drop           : 1       
+ GlobalGet      : 19      
+ GlobalSet      : 10      
+ I31New         : 1       
+ If             : 13      
+ Load           : 19      
+ LocalGet       : 47      
+ LocalSet       : 24      
+ Loop           : 6       
+ MemoryCopy     : 1       
+ Nop            : 6       
+ RefFunc        : 2       
+ Return         : 10      
+ Select         : 2       
+ Store          : 2       
+ TupleMake      : 1       
+ Unary          : 11      


### PR DESCRIPTION
Diff without whitespace is smaller.

We can't emit `HeapType::data` without GC. Fixing that by switching to `func`,
another problem was uncovered: `makeRefFuncConst` had a TODO to handle
the case where we need a function to refer to but have created none yet. In
fact that TODO was done at the end of the function. Fix up the logic in
between to actually get there.