### PR TITLE
[NFC] Avoid scanning code in hasBranchTarget if the target is null

### DIFF
--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -237,6 +237,10 @@ inline NameSet getBranchTargets(Expression* ast) {
 // Check if an expression defines a particular name as a branch target anywhere
 // inside it.
 inline bool hasBranchTarget(Expression* ast, Name target) {
+  if (!target.is()) {
+    return false;
+  }
+
   struct Scanner
     : public PostWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
     Name target;


### PR DESCRIPTION
A null target is not a valid name so nothing can branch to there. This just
saves the wasted work.

No existing code in the codebase benefits from this atm, but a later PR
will. In particular this lets callers call this without checking if the name
is non-null, which is more concise.