### PR TITLE
Add option to disable building tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ option(BUILD_TESTS "Build GTest-based tests" ON)
 # Turn this on to build binaryen.js as ES5, with additional compatibility configuration for js_of_ocaml.
 option(JS_OF_OCAML "Build binaryen.js for js_of_ocaml" OFF)
 
+# Turn this off to build only the library
+option(BUILD_TOOLS "Build tools" ON)
+
 # For git users, attempt to generate a more useful version string
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   find_package(Git QUIET REQUIRED)
@@ -318,7 +321,12 @@ add_subdirectory(src/emscripten-optimizer)
 add_subdirectory(src/passes)
 add_subdirectory(src/support)
 add_subdirectory(src/wasm)
-add_subdirectory(src/tools)
+
+if(BUILD_TOOLS)
+  # Build binaryen tools
+  add_subdirectory(src/tools)
+endif()
+
 add_subdirectory(third_party)
 
 # Configure lit tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,11 @@ option(BYN_ENABLE_ASSERTIONS "Enable assertions" ON)
 # Turn this off to avoid the dependency on gtest.
 option(BUILD_TESTS "Build GTest-based tests" ON)
 
+# Turn this off to build only the library.
+option(BUILD_TOOLS "Build tools" ON)
+
 # Turn this on to build binaryen.js as ES5, with additional compatibility configuration for js_of_ocaml.
 option(JS_OF_OCAML "Build binaryen.js for js_of_ocaml" OFF)
-
-# Turn this off to build only the library
-option(BUILD_TOOLS "Build tools" ON)
 
 # For git users, attempt to generate a more useful version string
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)


### PR DESCRIPTION
Adds `BUILD_TOOLS` flag that can be disabled to build just the library. Saves time and storage space for developers who need only the library. Is set to `ON` by default