### PR TITLE
[NominalFuzzing] Fix SignaturePruning on types with a super

### DIFF
--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -143,6 +143,15 @@ struct SignaturePruning : public Pass {
         continue;
       }
 
+      // A type with a signature supertype cannot be optimized: we'd need to
+      // remove the field from the super as well, which atm we don't attempt to
+      // do. TODO
+      if (auto super = type.getSuperType()) {
+        if (super->isSignature()) {
+          continue;
+        }
+      }
+
       // Apply constant indexes: find the parameters that are always sent a
       // constant value, and apply that value in the function. That then makes
       // the parameter unused (since the applied value makes us ignore the value

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -656,3 +656,21 @@
     )
   )
 )
+
+(module
+  ;; CHECK:      (type $A (func_subtype (param i32) func))
+  (type $A (func_subtype (param i32) func))
+  ;; CHECK:      (type $B (func_subtype (param i32) $A))
+  (type $B (func_subtype (param i32) $A))
+
+  ;; CHECK:      (func $bar (type $B) (param $x i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $bar (type $B) (param $x i32)
+   ;; The parameter to this function can be pruned. But while doing so we must
+   ;; properly preserve the subtyping of $B from $A, which means we cannot just
+   ;; remove it - we'd need to remove it from $A as well, which we don't
+   ;; attempt to do in the pass atm. So we do not optimize here.
+    (nop)
+  )
+)


### PR DESCRIPTION
Do not prune parameters if there is a supertype that is a signature.

Without this we crash on an assertion in TypeBuilder when we try to
recreate the types (as we try to make a a subtype with fewer fields
than the super).