### PR TITLE
Costs: Increase cost of casts

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -31,7 +31,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
 
   CostType cost;
 
-  // A cost that is extremely high, something that is far, far more expensive 
+  // A cost that is extremely high, something that is far, far more expensive
   // than a fast operation like an add. This cost is so high it is unacceptable
   // to add any more of it, say by an If=>Select operation (which would execute
   // both arms; if either arm contains an unacceptable cost, we do not do it).
@@ -614,8 +614,9 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
            maybeVisit(curr->rtt);
   }
   CostType visitBrOn(BrOn* curr) {
-    // BrOnCast has more work to do with the rtt, so add a little there.
-    CostType base = curr->op == BrOnCast ? Unacceptable : 2;
+    // BrOnCast of a null can be fairly fast, but anything else is a cast check
+    // basically, and an unacceptable cost.
+    CostType base = curr->op == BrOnNull || curr->op == BrOnNonNull ? 2 : Unacceptable;
     return base + nullCheckCost(curr->ref) + maybeVisit(curr->ref) +
            maybeVisit(curr->rtt);
   }

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -614,7 +614,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
            maybeVisit(curr->rtt);
   }
   CostType visitBrOn(BrOn* curr) {
-    // BrOnCast of a null can be fairly fast, but anything else is a cast check
+    // BrOn of a null can be fairly fast, but anything else is a cast check
     // basically, and an unacceptable cost.
     CostType base =
       curr->op == BrOnNull || curr->op == BrOnNonNull ? 2 : Unacceptable;

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -616,7 +616,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
   CostType visitBrOn(BrOn* curr) {
     // BrOnCast of a null can be fairly fast, but anything else is a cast check
     // basically, and an unacceptable cost.
-    CostType base = curr->op == BrOnNull || curr->op == BrOnNonNull ? 2 : Unacceptable;
+    CostType base =
+      curr->op == BrOnNull || curr->op == BrOnNonNull ? 2 : Unacceptable;
     return base + nullCheckCost(curr->ref) + maybeVisit(curr->ref) +
            maybeVisit(curr->rtt);
   }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -85,6 +85,9 @@ static bool canTurnIfIntoBrIf(Expression* ifCondition,
 // It can be tuned more later.
 const Index TooCostlyToRunUnconditionally = 9;
 
+static_assert(TooCostlyToRunUnconditionally < CostAnalyzer::Unacceptable,
+              "We never run code unconditionally if it has unacceptable cost");
+
 // Check if it is not worth it to run code unconditionally. This
 // assumes we are trying to run two expressions where previously
 // only one of the two might have executed. We assume here that

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -228,11 +228,25 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (select (result anyref)
+ ;; CHECK-NEXT:    (ref.null any)
  ;; CHECK-NEXT:    (ref.cast_static $struct
  ;; CHECK-NEXT:     (ref.null any)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (ref.null any)
  ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block $block (result (ref $struct))
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (select (result anyref)
+ ;; CHECK-NEXT:      (br_on_cast_static $block $struct
+ ;; CHECK-NEXT:       (ref.null $struct)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (ref.null any)
+ ;; CHECK-NEXT:      (local.get $x)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -236,28 +236,35 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block $block (result (ref $struct))
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (if (result anyref)
- ;; CHECK-NEXT:      (local.get $x)
- ;; CHECK-NEXT:      (br_on_cast_static $block $struct
- ;; CHECK-NEXT:       (ref.null $struct)
+ ;; CHECK-NEXT:   (if (result anyref)
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:    (block $block (result anyref)
+ ;; CHECK-NEXT:     (block $something (result anyref)
+ ;; CHECK-NEXT:      (drop
+ ;; CHECK-NEXT:       (br_on_cast_static $something $struct
+ ;; CHECK-NEXT:        (ref.null $struct)
+ ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (ref.null any)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:    (ref.null any)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block $nothing
- ;; CHECK-NEXT:   (drop
- ;; CHECK-NEXT:    (if (result anyref)
- ;; CHECK-NEXT:     (local.get $x)
- ;; CHECK-NEXT:     (br_on_null $nothing
- ;; CHECK-NEXT:      (ref.null $struct)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (select (result anyref)
+ ;; CHECK-NEXT:    (block $block3 (result anyref)
+ ;; CHECK-NEXT:     (block $nothing
+ ;; CHECK-NEXT:      (drop
+ ;; CHECK-NEXT:       (br_on_null $nothing
+ ;; CHECK-NEXT:        (ref.null $struct)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (ref.null any)
  ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (ref.null any)
+ ;; CHECK-NEXT:    (local.get $x)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -284,29 +291,36 @@
    )
   )
   (drop
-   (block $block (result (ref $struct))
-    (drop
-     (if (result anyref)
-      (local.get $x)
-      (br_on_cast_static $block $struct
-       (ref.null $struct)
+   (if (result anyref)
+    (local.get $x)
+    (block (result anyref)
+     (block $something (result anyref)
+      (drop
+       (br_on_cast_static $something $struct
+        (ref.null $struct)
+       )
       )
       (ref.null any)
      )
     )
-    (unreachable)
+    (ref.null any)
    )
   )
-  ;; However, null checks are fairly fast.
-  (block $nothing
-   (drop
-    (if (result anyref)
-     (local.get $x)
-     (br_on_null $nothing
-      (ref.null $struct)
+  ;; However, null checks are fairly fast, and we will emit a select here.
+  (drop
+   (if (result anyref)
+    (local.get $x)
+    (block (result anyref)
+     (block $nothing
+      (drop
+       (br_on_null $nothing
+        (ref.null $struct)
+       )
+      )
      )
      (ref.null any)
     )
+    (ref.null any)
    )
   )
  )

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -215,4 +215,62 @@
    (unreachable)
   )
  )
+
+ ;; CHECK:      (func $casts-are-costly (param $x i32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (select
+ ;; CHECK-NEXT:    (ref.test_static $struct
+ ;; CHECK-NEXT:     (ref.null any)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (select (result anyref)
+ ;; CHECK-NEXT:    (ref.cast_static $struct
+ ;; CHECK-NEXT:     (ref.null any)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (ref.null any)
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $casts-are-costly (param $x i32)
+  ;; We never turn an if into a select if an arm has a cast of any kind, as
+  ;; those things involve branches internally, so we'd be adding more than we
+  ;; save.
+  (drop
+   (select
+    (ref.test_static $struct
+     (ref.null any)
+    )
+    (i32.const 0)
+    (local.get $x)
+   )
+  )
+  (drop
+   (select (result anyref)
+    (ref.null any)
+    (ref.cast_static $struct
+     (ref.null any)
+    )
+    (local.get $x)
+   )
+  )
+  (drop
+   (block $block (result (ref $struct))
+    (drop
+     (select
+      (br_on_cast_static $block $struct
+       (ref.null $struct)
+      )
+      (ref.null any)
+      (local.get $x)
+     )
+    )
+    (unreachable)
+   )
+  )
+ )
 )

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -218,32 +218,32 @@
 
  ;; CHECK:      (func $casts-are-costly (param $x i32)
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (select
+ ;; CHECK-NEXT:   (if (result i32)
+ ;; CHECK-NEXT:    (local.get $x)
  ;; CHECK-NEXT:    (ref.test_static $struct
  ;; CHECK-NEXT:     (ref.null any)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (i32.const 0)
- ;; CHECK-NEXT:    (local.get $x)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (select (result anyref)
+ ;; CHECK-NEXT:   (if (result anyref)
+ ;; CHECK-NEXT:    (local.get $x)
  ;; CHECK-NEXT:    (ref.null any)
  ;; CHECK-NEXT:    (ref.cast_static $struct
  ;; CHECK-NEXT:     (ref.null any)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.get $x)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block $block (result (ref $struct))
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (select (result anyref)
+ ;; CHECK-NEXT:     (if (result anyref)
+ ;; CHECK-NEXT:      (local.get $x)
  ;; CHECK-NEXT:      (br_on_cast_static $block $struct
  ;; CHECK-NEXT:       (ref.null $struct)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (ref.null any)
- ;; CHECK-NEXT:      (local.get $x)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (unreachable)
@@ -255,32 +255,32 @@
   ;; those things involve branches internally, so we'd be adding more than we
   ;; save.
   (drop
-   (select
+   (if (result i32)
+    (local.get $x)
     (ref.test_static $struct
      (ref.null any)
     )
     (i32.const 0)
-    (local.get $x)
    )
   )
   (drop
-   (select (result anyref)
+   (if (result anyref)
+    (local.get $x)
     (ref.null any)
     (ref.cast_static $struct
      (ref.null any)
     )
-    (local.get $x)
    )
   )
   (drop
    (block $block (result (ref $struct))
     (drop
-     (select
+     (if (result anyref)
+      (local.get $x)
       (br_on_cast_static $block $struct
        (ref.null $struct)
       )
       (ref.null any)
-      (local.get $x)
      )
     )
     (unreachable)

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -249,6 +249,17 @@
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (block $nothing
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (if (result anyref)
+ ;; CHECK-NEXT:     (local.get $x)
+ ;; CHECK-NEXT:     (br_on_null $nothing
+ ;; CHECK-NEXT:      (ref.null $struct)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (ref.null any)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $casts-are-costly (param $x i32)
   ;; We never turn an if into a select if an arm has a cast of any kind, as
@@ -284,6 +295,18 @@
      )
     )
     (unreachable)
+   )
+  )
+  ;; However, null checks are fairly fast.
+  (block $nothing
+   (drop
+    (if (result anyref)
+     (local.get $x)
+     (br_on_null $nothing
+      (ref.null $struct)
+     )
+     (ref.null any)
+    )
    )
   )
  )


### PR DESCRIPTION
Casts involve branches in the VM, so adding a cast in return for removing a branch
(like If=>Select) is not beneficial. We don't want to ever do any more casts than we
already are.