### PR TITLE
Ensure symmetric results in PossibleConstantValues

### DIFF
--- a/src/ir/possible-constant.h
+++ b/src/ir/possible-constant.h
@@ -112,7 +112,7 @@ public:
       auto otherType = other.getConstantLiteral().type.getHeapType();
       auto lub = HeapType::getLeastUpperBound(type, otherType);
       if (lub != type) {
-        value = Literal::makeNull(Type(type, Nullable));
+        value = Literal::makeNull(Type(lub, Nullable));
         return true;
       }
       return false;

--- a/src/ir/possible-constant.h
+++ b/src/ir/possible-constant.h
@@ -105,8 +105,11 @@ public:
       return true;
     }
 
-    // Nulls compare equal, but we must combine them into a null of the LUB,
-    // both for determinism (the order should not matter) and to validate.
+    // Nulls compare equal, and we could consider any of the input nulls as the
+    // combination of the two (as any of them would be valid to place in the
+    // location we are working to optimize). In order to have simple symmetric
+    // behavior here, which does not depend on the order of the inputs, use the
+    // LUB.
     if (isNull() && other.isNull()) {
       auto type = getConstantLiteral().type.getHeapType();
       auto otherType = other.getConstantLiteral().type.getHeapType();

--- a/src/ir/possible-constant.h
+++ b/src/ir/possible-constant.h
@@ -115,7 +115,7 @@ public:
       auto otherType = other.getConstantLiteral().type.getHeapType();
       auto lub = HeapType::getLeastUpperBound(type, otherType);
       if (lub != type) {
-        value = Literal::makeNull(Type(lub, Nullable));
+        value = Literal::makeNull(lub);
         return true;
       }
       return false;

--- a/src/ir/possible-constant.h
+++ b/src/ir/possible-constant.h
@@ -118,7 +118,20 @@ public:
       return true;
     }
 
+    if (isNull() && other.isNull()) {
+      return combineNull(other.getConstantValue());
+    }
+
     return false;
+  }
+
+  // Nulls compare equal, but we must combine them into a null of the LUB, both
+  // for determinism (the order should not matter) and to validate in all cases.
+  //
+  // Returns whether we changed anything.
+  bool combineNull(Literal otherNull) {
+    assert(isNull());
+    
   }
 
   // Check if all the values are identical and constant.
@@ -129,6 +142,10 @@ public:
   bool isConstantLiteral() const { return std::get_if<Literal>(&value); }
 
   bool isConstantGlobal() const { return std::get_if<Name>(&value); }
+
+  bool isNull() const {
+    return isConstantLiteral() && getConstantLiteral().isNull();
+  }
 
   // Returns the single constant value.
   Literal getConstantLiteral() const {

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -218,8 +218,8 @@
  ;; NOMNL-NEXT: )
  (func $call-bar
   ;; Call with nulls. Mixing nulls is fine as they all have the same value, and
-  ;; we can optimize. However, mixing a null with a reference stops us in the
-  ;; second param.
+  ;; we can optimize (to the LUB of the nulls). However, mixing a null with a
+  ;; reference stops us in the second param.
   (call $bar
    (ref.null func)
    (ref.null func)

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -169,7 +169,7 @@
  ;; CHECK:      (func $bar (param $0 (ref null $none_=>_none))
  ;; CHECK-NEXT:  (local $1 anyref)
  ;; CHECK-NEXT:  (local.set $1
- ;; CHECK-NEXT:   (ref.null func)
+ ;; CHECK-NEXT:   (ref.null any)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (block
  ;; CHECK-NEXT:   (drop
@@ -183,7 +183,7 @@
  ;; NOMNL:      (func $bar (type $ref?|none_->_none|_=>_none) (param $0 (ref null $none_=>_none))
  ;; NOMNL-NEXT:  (local $1 anyref)
  ;; NOMNL-NEXT:  (local.set $1
- ;; NOMNL-NEXT:   (ref.null func)
+ ;; NOMNL-NEXT:   (ref.null any)
  ;; NOMNL-NEXT:  )
  ;; NOMNL-NEXT:  (block
  ;; NOMNL-NEXT:   (drop


### PR DESCRIPTION
Previously we could return different results depending on the order we
noted things:
```js
note(anyref.null);
note(funcref.null);
get() => anyref.null

note(funcref.null);
note(anyref.null);
get() => funcref.null
```
This is correct, as nulls are equal anyhow, and any could be used in
the location we are optimizing. However, it can lead to nondeterminism
if the caller's order of notes is nondeterministic. That is the case in
DeadArgumentElimination, where we scan functions in parallel, then
merge them without special ordering.

To fix this, make the note operation symmetric. That seems simplest and
least likely to be confusing. We can use the LUB to do that.

To avoid duplicating the null logic, refactor `note()` to use `combine()`.
