### PR TITLE
Make RefCast safe by default

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1460,7 +1460,7 @@ public:
   // Support the unsafe `ref.cast_nop_static` to enable precise cast overhead
   // measurements.
   enum Safety { Safe, Unsafe };
-  Safety safety;
+  Safety safety = Safe;
 
   void finalize();
 


### PR DESCRIPTION
This prevents new `RefCast` expressions that don't explicitly have their safety
set from getting an unitialized safety value.