### PR TITLE
[NFC] Make Literal::makeNull take a HeapType

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -101,7 +101,7 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
       return Literal::makeFunc(x.func);
     case Type::anyref:
     case Type::eqref:
-      return Literal::makeNull(Type(x.type));
+      return Literal::makeNull(Type(x.type).getHeapType());
     case Type::i31ref:
       WASM_UNREACHABLE("TODO: i31ref");
     case Type::dataref:

--- a/src/literal.h
+++ b/src/literal.h
@@ -248,9 +248,8 @@ public:
         WASM_UNREACHABLE("unexpected type");
     }
   }
-  static Literal makeNull(Type type) {
-    assert(type.isNullable());
-    return Literal(type);
+  static Literal makeNull(HeapType type) {
+    return Literal(Type(type, Nullable));
   }
   static Literal makeFunc(Name func, Type type = Type::funcref) {
     return Literal(func, type);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1337,7 +1337,7 @@ public:
   Flow visitCallRef(CallRef* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitRefNull(RefNull* curr) {
     NOTE_ENTER("RefNull");
-    return Literal::makeNull(curr->type);
+    return Literal::makeNull(curr->type.getHeapType());
   }
   Flow visitRefIs(RefIs* curr) {
     NOTE_ENTER("RefIs");
@@ -1531,7 +1531,7 @@ public:
     if (auto* breaking = cast.getBreaking()) {
       return *breaking;
     } else if (cast.getNull()) {
-      return Literal::makeNull(Type(curr->type.getHeapType(), Nullable));
+      return Literal::makeNull(curr->type.getHeapType());
     } else if (auto* result = cast.getSuccess()) {
       return *result;
     }
@@ -2573,7 +2573,7 @@ private:
       if (table->type.isNullable()) {
         // Initial with nulls in a nullable table.
         auto info = getTableInterfaceInfo(table->name);
-        auto null = Literal::makeNull(table->type);
+        auto null = Literal::makeNull(table->type.getHeapType());
         for (Address i = 0; i < table->initial; i++) {
           info.interface->tableStore(info.name, i, null);
         }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -238,7 +238,7 @@ Literal Literal::makeZero(Type type) {
     if (type == Type::i31ref) {
       return makeI31(0);
     } else {
-      return makeNull(type);
+      return makeNull(type.getHeapType());
     }
   } else if (type.isRtt()) {
     return Literal(type);


### PR DESCRIPTION
Taking a Type is redundant as we only care about the heap type -
the nullability must be Nullable.

This avoids needing an assertion in the function, that is, it makes
the API more type-safe.