### PR TITLE
Allow TypeBuilder::grow to take 0 as an argument

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2810,7 +2810,7 @@ TypeBuilder::TypeBuilder(TypeBuilder&& other) = default;
 TypeBuilder& TypeBuilder::operator=(TypeBuilder&& other) = default;
 
 void TypeBuilder::grow(size_t n) {
-  assert(size() + n > size());
+  assert(size() + n >= size());
   impl->entries.resize(size() + n);
 }
 

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -11,6 +11,8 @@ TEST_F(TypeTest, TypeBuilderGrowth) {
   EXPECT_EQ(builder.size(), 0u);
   builder.grow(3);
   EXPECT_EQ(builder.size(), 3u);
+  builder.grow(0);
+  EXPECT_EQ(builder.size(), 3u);
 }
 
 TEST_F(TypeTest, TypeIterator) {


### PR DESCRIPTION
There's no reason not to allow growing by zero slots, but previously doing so
would trigger an assertion. This caused a crash when roundtripping a trivial
module.

Fixes #4667.