### PR TITLE
[NFC] Make InsertOrderedMap::insert's param const

### DIFF
--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -96,7 +96,7 @@ template<typename Key, typename T> struct InsertOrderedMap {
   const_iterator begin() const { return List.begin(); }
   const_iterator end() const { return List.end(); }
 
-  std::pair<iterator, bool> insert(std::pair<const Key, T>& kv) {
+  std::pair<iterator, bool> insert(const std::pair<const Key, T>& kv) {
     // Try inserting with a placeholder list iterator.
     auto inserted = Map.insert({kv.first, List.end()});
     if (inserted.second) {


### PR DESCRIPTION
Being a const reference allows writing `insert({a, b})`, which will be
useful in a future PR, and there is no reason to actually update the
reference.