### PR TITLE
[GC Fuzzing] Avoid non-nullable eqref without GC

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3011,15 +3011,15 @@ bool TranslateToFuzzReader::isLoggableType(Type type) {
 }
 
 Nullability TranslateToFuzzReader::getSubType(Nullability nullability) {
+  if (nullability == NonNullable) {
+    return NonNullable;
+  }
   // Without wasm GC, avoid non-nullable types as we cannot create any values
   // of such types. For example, reference types adds eqref, but there is no
   // way to create such a value, only to receive it from the outside, while GC
   // adds i31/struct/array creation. Without GC, we will likely need to create a
   // null of this type (unless we are lucky enough to have a non-null value
   // arriving from an import), so avoid a non-null type if possible.
-  if (nullability == NonNullable) {
-    return NonNullable;
-  }
   if (wasm.features.hasGC() && oneIn(2)) {
     return NonNullable;
   }


### PR DESCRIPTION
With only reference types but not GC, we cannot easily create a constant
for `eqref` for example. Only GC adds `i31.new` etc. To avoid assertions in
the fuzzer, avoid randomly picking `(ref eq)` etc., that is, keep it nullable
so that we can emit a `(ref.null eq)` if we need a constant value of that type.