### PR TITLE
Validator: Check features for ref.null's type

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3045,12 +3045,9 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
                  HeapType::data));
       case HeapType::eq:
         // TODO: nontrivial types as well.
-        return pick(
-          FeatureOptions<HeapType>()
-            .add(FeatureSet::ReferenceTypes, HeapType::eq)
-            .add(FeatureSet::ReferenceTypes | FeatureSet::GC,
-                 HeapType::i31,
-                 HeapType::data));
+        assert(wasm.features.hasReferenceTypes());
+        assert(wasm.features.hasGC());
+        return pick(HeapType::eq, HeapType::i31, HeapType::data);
       case HeapType::i31:
         return HeapType::i31;
       case HeapType::data:

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3045,7 +3045,12 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
                  HeapType::data));
       case HeapType::eq:
         // TODO: nontrivial types as well.
-        return pick(HeapType::eq, HeapType::i31, HeapType::data);
+        return pick(
+          FeatureOptions<HeapType>()
+            .add(FeatureSet::ReferenceTypes, HeapType::eq)
+            .add(FeatureSet::ReferenceTypes | FeatureSet::GC,
+                 HeapType::i31,
+                 HeapType::data));
       case HeapType::i31:
         return HeapType::i31;
       case HeapType::data:

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1999,6 +1999,11 @@ void FunctionValidator::visitRefNull(RefNull* curr) {
                "ref.null requires reference-types to be enabled");
   shouldBeTrue(
     curr->type.isNullable(), curr, "ref.null types must be nullable");
+
+  // The type of the null must also be valid for the features.
+  shouldBeTrue(curr->type.getFeatures() <= getModule()->features,
+               curr->type,
+               "ref.null type should be allowed");
 }
 
 void FunctionValidator::visitRefIs(RefIs* curr) {

--- a/test/lit/validation/eqref.wast
+++ b/test/lit/validation/eqref.wast
@@ -1,0 +1,19 @@
+;; Test for eqref validating only with GC, and not just reference types, even
+;; when only declared in a null.
+
+;; RUN: not wasm-opt --enable-reference-types %s 2>&1 | filecheck %s --check-prefix NO-GC
+;; RUN:     wasm-opt --enable-reference-types --enable-gc %s -o - -S | filecheck %s --check-prefix GC
+
+;; NO-GC: ref.null type should be allowed
+
+;; GC:   (drop
+;; GC:    (ref.null eq)
+;; GC:   )
+
+(module
+  (func $foo
+    (drop
+      (ref.null eq)
+    )
+  )
+)


### PR DESCRIPTION
Yet another case of this. `eq` only requires reference types, so we can't
unconditionally pick `i31` or `data` as subtypes of it, we need GC to be
enabled.