### PR TITLE
Fix binary parsing of the prototype nominal format

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1866,9 +1866,6 @@ void WasmBinaryBuilder::readMemory() {
 void WasmBinaryBuilder::readTypes() {
   BYN_TRACE("== readTypes\n");
   TypeBuilder builder(getU32LEB());
-  if (getTypeSystem() == TypeSystem::Nominal && builder.size() > 1) {
-    throwError("Nominal type sections must have a single element");
-  }
   BYN_TRACE("num: " << builder.size() << std::endl);
 
   auto makeType = [&](int32_t typeCode) {

--- a/test/lit/binary/prototype-nominal-format.test
+++ b/test/lit/binary/prototype-nominal-format.test
@@ -1,27 +1,27 @@
 ;; Test the we can properly parse the prototype nominal binary format that we no
 ;; longer emit.
 
-;; RUN: wasm-dis %s.wasm -all | filecheck %s
+;; RUN: wasm-dis %s.wasm -all --nominal | filecheck %s
 
 ;; CHECK:      (module
-;; CHECK-NEXT:  (type $super-struct (struct (field i32)))
-;; CHECK-NEXT:  (type $sub-struct (struct (field i32) (field i64)))
-;; CHECK-NEXT:  (type $none_=>_ref|$super-struct| (func (result (ref $super-struct))))
-;; CHECK-NEXT:  (type $none_=>_ref|$sub-struct| (func (result (ref $sub-struct))))
-;; CHECK-NEXT:  (type $none_=>_ref|$super-array| (func (result (ref $super-array))))
-;; CHECK-NEXT:  (type $none_=>_ref|$sub-array| (func (result (ref $sub-array))))
-;; CHECK-NEXT:  (type $super-array (array (ref $super-struct)))
-;; CHECK-NEXT:  (type $sub-array (array (ref $sub-struct)))
-;; CHECK-NEXT:  (func $make-super-struct (result (ref $super-struct))
+;; CHECK-NEXT:  (type $super-struct (struct_subtype (field i32) data))
+;; CHECK-NEXT:  (type $sub-struct (struct_subtype (field i32) (field i64) data))
+;; CHECK-NEXT:  (type $none_=>_ref|$super-struct| (func_subtype (result (ref $super-struct)) func))
+;; CHECK-NEXT:  (type $none_=>_ref|$sub-struct| (func_subtype (result (ref $sub-struct)) func))
+;; CHECK-NEXT:  (type $none_=>_ref|$super-array| (func_subtype (result (ref $super-array)) func))
+;; CHECK-NEXT:  (type $none_=>_ref|$sub-array| (func_subtype (result (ref $sub-array)) func))
+;; CHECK-NEXT:  (type $super-array (array_subtype (ref $super-struct) data))
+;; CHECK-NEXT:  (type $sub-array (array_subtype (ref $sub-struct) data))
+;; CHECK-NEXT:  (func $make-super-struct (type $none_=>_ref|$super-struct|) (result (ref $super-struct))
 ;; CHECK-NEXT:   (call $make-sub-struct)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (func $make-sub-struct (result (ref $sub-struct))
+;; CHECK-NEXT:  (func $make-sub-struct (type $none_=>_ref|$sub-struct|) (result (ref $sub-struct))
 ;; CHECK-NEXT:   (unreachable)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (func $make-super-array (result (ref $super-array))
+;; CHECK-NEXT:  (func $make-super-array (type $none_=>_ref|$super-array|) (result (ref $super-array))
 ;; CHECK-NEXT:   (call $make-sub-array)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (func $make-sub-array (result (ref $sub-array))
+;; CHECK-NEXT:  (func $make-sub-array (type $none_=>_ref|$sub-array|) (result (ref $sub-array))
 ;; CHECK-NEXT:   (unreachable)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )


### PR DESCRIPTION
We were checking that nominal modules only had a single element in their type
sections, but that's not correct for the prototype nominal binary format we
still want to support. The test for this missed catching the bug because it
wasn't actually parsing in nominal mode.