### PR TITLE
[Fuzzer] Ignore relaxed-simd test for initial contents

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -262,6 +262,7 @@ INITIAL_CONTENTS_IGNORE = [
     'relaxed-simd.wast'
 ]
 
+
 def pick_initial_contents():
     # if we use an initial wasm file's contents as the basis for the
     # fuzzing, then that filename, or None if we start entirely from scratch

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -257,6 +257,11 @@ def init_important_initial_contents():
     IMPORTANT_INITIAL_CONTENTS = [os.path.join(shared.get_test_dir('.'), t) for t in initial_contents]
 
 
+INITIAL_CONTENTS_IGNORE = [
+    # not all relaxed SIMD instructions are implemented in the interpreter
+    'relaxed-simd.wast'
+]
+
 def pick_initial_contents():
     # if we use an initial wasm file's contents as the basis for the
     # fuzzing, then that filename, or None if we start entirely from scratch
@@ -279,6 +284,8 @@ def pick_initial_contents():
         # no longer exist, and we should just skip it.
         if not os.path.exists(test_name):
             return
+    if os.path.basename(test_name) in INITIAL_CONTENTS_IGNORE:
+        return
     assert os.path.exists(test_name)
     # tests that check validation errors are not helpful for us
     if '.fail.' in test_name:


### PR DESCRIPTION
If we use it as initial contents, we will try to execute it, and hit the TODOs
in the interpreter for unimplemented parts.