### PR TITLE
Updating wasm-opt example to an available pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,23 +367,22 @@ passes on it, as well as print it (before and/or after the transformations). For
 example, try
 
 ````
-bin/wasm-opt test/passes/lower-if-else.wat --print
+bin/wasm-opt test/lit/passes/name-types.wast -all -S -o -
 ````
 
-That will pretty-print out one of the test cases in the test suite. To run a
+That will output one of the test cases in the test suite. To run a
 transformation pass on it, try
 
 ````
-bin/wasm-opt test/passes/lower-if-else.wat --print --lower-if-else
+bin/wasm-opt test/lit/passes/name-types.wast --name-types -all -S -o -
 ````
 
-The `lower-if-else` pass lowers if-else into a block and a break. You can see
-the change the transformation causes by comparing the output of the two print
-commands.
+The `name-types` pass ensures each type has a name and renames exceptionally long type names. You can see
+the change the transformation causes by comparing the output of the two commands.
 
 It's easy to add your own transformation passes to the shell, just add `.cpp`
 files into `src/passes`, and rebuild the shell. For example code, take a look at
-the [`lower-if-else` pass](https://github.com/WebAssembly/binaryen/blob/main/src/passes/LowerIfElse.cpp).
+the [`name-types` pass](https://github.com/WebAssembly/binaryen/blob/main/src/passes/NameTypes.cpp).
 
 Some more notes:
 


### PR DESCRIPTION
The wasm-opt example was using a test pass that was deleted. Updating to use one of the test passes in test/lit/passes.