### PR TITLE
[Wasm GC] Fix CFG traversal of call_ref and add missing validation check

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -392,7 +392,8 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
         break;
       }
       case Expression::Id::CallId:
-      case Expression::Id::CallIndirectId: {
+      case Expression::Id::CallIndirectId:
+      case Expression::Id::CallRefId: {
         self->pushTask(SubType::doEndCall, currp);
         break;
       }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -23,6 +23,7 @@
 #include "ir/features.h"
 #include "ir/global-utils.h"
 #include "ir/intrinsics.h"
+#include "ir/local-graph.h"
 #include "ir/module-utils.h"
 #include "ir/stack-utils.h"
 #include "ir/utils.h"
@@ -2778,6 +2779,36 @@ void FunctionValidator::visitFunction(Function* curr) {
   for (auto& pair : curr->localNames) {
     Name name = pair.second;
     shouldBeTrue(seen.insert(name).second, name, "local names must be unique");
+  }
+
+  if (getModule()->features.hasGCNNLocals()) {
+    // If we have non-nullable locals, verify that no local.get can read a null
+    // default value.
+    // TODO: this can be fairly slow due to the LocalGraph. writing more code to
+    //       do a more specific analysis (we don't need to know all sets, just
+    //       if there is a set of a null default value that is read) could be a
+    //       lot faster.
+    bool hasNNLocals = false;
+    for (const auto& var : curr->vars) {
+      if (var.isNonNullable()) {
+        hasNNLocals = true;
+        break;
+      }
+    }
+    if (hasNNLocals) {
+      LocalGraph graph(curr);
+      for (auto& [get, sets] : graph.getSetses) {
+        if (curr->getLocalType(get->index).isNonNullable()) {
+          for (auto* set : sets) {
+            // If this is a null, then it is the value of a param or the default
+            // value of a var. The latter case is an error.
+            shouldBeTrue(!!set || curr->isParam(get->index),
+                         get->index,
+                         "non-nullable local must not read null");
+          }
+        }
+      }
+    }
   }
 }
 

--- a/test/lit/validation/nn-locals-bad-call_ref.wast
+++ b/test/lit/validation/nn-locals-bad-call_ref.wast
@@ -1,0 +1,31 @@
+;; Test for validation of non-nullable locals
+
+;; RUN: not wasm-opt -all --enable-gc-nn-locals %s 2>&1 | filecheck %s
+
+;; CHECK: non-nullable local must not read null
+
+(module
+  (tag $tag (param i32))
+  (func $func
+    (local $0 (ref any))
+    (try
+      (do
+        (call_ref
+          (ref.func $func)
+        )
+      )
+      (catch $tag
+        (drop
+          (pop (i32))
+        )
+        ;; The path to here is from a possible exception thrown in the call_ref.
+        ;; This is a regression test for call_ref not being seen as possibly
+        ;; throwing. We should see a validation error here, as the local.get is
+        ;; of a null default, and it *is* reachable thanks to the call_ref.
+        (drop
+          (local.get $0)
+        )
+      )
+    )
+  )
+)

--- a/test/lit/validation/nn-locals-bad.wast
+++ b/test/lit/validation/nn-locals-bad.wast
@@ -1,0 +1,15 @@
+;; Test for validation of non-nullable locals
+
+;; RUN: not wasm-opt -all --enable-gc-nn-locals %s 2>&1 | filecheck %s
+
+;; CHECK: non-nullable local must not read null
+
+(module
+  (func $foo
+    (local $nn (ref any))
+    ;; It is not ok to read a non-nullable local.
+    (drop
+      (local.get $nn)
+    )
+  )
+)

--- a/test/lit/validation/nn-locals-ok.wast
+++ b/test/lit/validation/nn-locals-ok.wast
@@ -1,0 +1,14 @@
+;; Test for validation of non-nullable locals
+
+;; RUN: wasm-opt -all --enable-gc-nn-locals %s --print | filecheck %s
+
+;; CHECK: (module
+
+(module
+  (func $foo (param $nn (ref any))
+    ;; It is ok to read a non-nullable param.
+    (drop
+      (local.get $nn)
+    )
+  )
+)


### PR DESCRIPTION
We were missing `CallRef` in the CFG traversal code in a place where we
note possible exceptions. As a result we thought `CallRef` cannot throw, and
were missing some control flow edges.

To actually detect the problem, we need to validate non-nullable locals
properly, which we were not doing. This adds that as well.

This could be split into two PRs if we prefer, one to add validation, and one
to add the CFG fix, but then full testing would only arrive with the second.
Happy to do that if we prefer, but OTOH this PR is fairly small.

Fixes #4689

cc @askeksa-google