### PR TITLE
[Parser] Token classification

### DIFF
--- a/src/wasm/wat-lexer.cpp
+++ b/src/wasm/wat-lexer.cpp
@@ -841,7 +841,7 @@ std::optional<uint32_t> Token::getI32() const {
 
 std::optional<double> Token::getF64() const {
   constexpr int signif = 52;
-  constexpr uint64_t nanMask = (1ull << signif) - 1;
+  constexpr uint64_t payloadMask = (1ull << signif) - 1;
   constexpr uint64_t nanDefault = 1ull << (signif - 1);
   if (auto* tok = std::get_if<FloatTok>(&data)) {
     double d = tok->d;
@@ -851,7 +851,7 @@ std::optional<double> Token::getF64() const {
       uint64_t bits;
       static_assert(sizeof(bits) == sizeof(d));
       memcpy(&bits, &d, sizeof(bits));
-      bits = (bits & ~nanMask) | payload;
+      bits = (bits & ~payloadMask) | payload;
       memcpy(&d, &bits, sizeof(bits));
     }
     return d;
@@ -870,7 +870,7 @@ std::optional<double> Token::getF64() const {
 
 std::optional<float> Token::getF32() const {
   constexpr int signif = 23;
-  constexpr uint32_t nanMask = (1u << signif) - 1;
+  constexpr uint32_t payloadMask = (1u << signif) - 1;
   constexpr uint64_t nanDefault = 1ull << (signif - 1);
   if (auto* tok = std::get_if<FloatTok>(&data)) {
     float f = tok->d;
@@ -884,7 +884,7 @@ std::optional<float> Token::getF32() const {
       uint32_t bits;
       static_assert(sizeof(bits) == sizeof(f));
       memcpy(&bits, &f, sizeof(bits));
-      bits = (bits & ~nanMask) | payload;
+      bits = (bits & ~payloadMask) | payload;
       memcpy(&f, &bits, sizeof(bits));
     }
     return f;

--- a/src/wat-lexer.h
+++ b/src/wat-lexer.h
@@ -15,6 +15,7 @@
  */
 
 #include <cstddef>
+#include <cstring>
 #include <iterator>
 #include <optional>
 #include <ostream>
@@ -100,6 +101,37 @@ struct Token {
                             KeywordTok>;
   std::string_view span;
   Data data;
+
+  // ====================
+  // Token classification
+  // ====================
+
+  bool isLParen() const { return std::get_if<LParenTok>(&data); }
+
+  bool isRParen() const { return std::get_if<RParenTok>(&data); }
+
+  std::optional<std::string_view> getID() const {
+    if (std::get_if<IdTok>(&data)) {
+      return span;
+    }
+    return {};
+  }
+
+  std::optional<std::string_view> getKeyword() const {
+    if (std::get_if<KeywordTok>(&data)) {
+      return span;
+    }
+    return {};
+  }
+  std::optional<uint64_t> getU64() const;
+  std::optional<int64_t> getS64() const;
+  std::optional<uint64_t> getI64() const;
+  std::optional<uint32_t> getU32() const;
+  std::optional<int32_t> getS32() const;
+  std::optional<uint32_t> getI32() const;
+  std::optional<double> getF64() const;
+  std::optional<float> getF32() const;
+  std::optional<std::string_view> getString() const;
 
   bool operator==(const Token&) const;
   friend std::ostream& operator<<(std::ostream& os, const Token&);


### PR DESCRIPTION
Add methods to `Token` for determining whether the token can be interpreted as a
particular token type, returning the interpreted value as appropriate. These
methods perform additional bounds checks for integers and NaN payloads that
could not be done during the initial lexing because the lexer did not know what
the intended token type was. The float methods also reinterpret integer tokens
as floating point tokens since the float grammar is a superset of the integer
grammar and inject the NaN payloads into parsed NaN values.