### PR TITLE
Remove renameMainArgcArgv from wasm-emscripten-finalize

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -266,12 +266,6 @@ int main(int argc, const char* argv[]) {
   generator.onlyI64DynCalls = onlyI64DynCalls;
   generator.noDynCalls = noDynCalls;
 
-  if (!standaloneWasm) {
-    // This is also not needed in standalone mode since standalone mode uses
-    // crt1.c to invoke the main and is aware of __main_argc_argv mangling.
-    generator.renameMainArgcArgv();
-  }
-
   PassRunner passRunner(&wasm, options.passOptions);
   passRunner.setDebug(options.debug);
   passRunner.setDebugInfo(debugInfo);

--- a/src/wasm-emscripten.h
+++ b/src/wasm-emscripten.h
@@ -37,12 +37,6 @@ public:
 
   void fixInvokeFunctionNames();
 
-  // clang uses name mangling to rename the argc/argv form of main to
-  // __main_argc_argv.  Emscripten in non-standalone mode expects that function
-  // to be exported as main.  This function renames __main_argc_argv to main
-  // as expected by emscripten.
-  void renameMainArgcArgv();
-
   // Emits the data segments to a file. The file contains data from address base
   // onwards (we must pass in base, as we can't tell it from the wasm - the
   // first segment may start after a run of zeros, but we need those zeros in

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -525,16 +525,4 @@ void EmscriptenGlueGenerator::separateDataSegments(Output* outfile,
   wasm.memory.segments.clear();
 }
 
-void EmscriptenGlueGenerator::renameMainArgcArgv() {
-  // If an export call ed __main_argc_argv exists rename it to main
-  Export* ex = wasm.getExportOrNull("__main_argc_argv");
-  if (!ex) {
-    BYN_TRACE("renameMain: __main_argc_argv not found\n");
-    return;
-  }
-  ex->name = "main";
-  wasm.updateMaps();
-  ModuleUtils::renameFunction(wasm, "__main_argc_argv", "main");
-}
-
 } // namespace wasm


### PR DESCRIPTION
This part to finalize is currently not used and was added in preparation
for https://reviews.llvm.org/D75277.

However, the better solution to dealing with this alternative name for
main is on the emscripten side.  The main reason for this is that
doing the rename here in binaryen would require finalize to always
re-write the binary, which is expensive.