### PR TITLE
wasm-emscripten-finalize: Improve detection of mainReadsParams

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -477,12 +477,16 @@ std::string EmscriptenGlueGenerator::generateEmscriptenMetadata() {
     if (exp) {
       if (exp->kind == ExternalKind::Function) {
         auto* main = wasm.getFunction(exp->value);
-        mainReadsParams = true;
-        // If main does not read its parameters, it will just be a stub that
-        // calls __original_main (which has no parameters).
-        if (auto* call = main->body->dynCast<Call>()) {
-          if (call->operands.empty()) {
-            mainReadsParams = false;
+        mainReadsParams = main->getNumParams() > 0;
+        if (mainReadsParams) {
+          // Main could also be stub that just calls __original_main with
+          // no parameters.
+          // TODO(sbc): Remove this once https://reviews.llvm.org/D75277
+          // lands.
+          if (auto* call = main->body->dynCast<Call>()) {
+            if (call->operands.empty()) {
+              mainReadsParams = false;
+            }
           }
         }
       }

--- a/test/lld/basic_safe_stack.wat.out
+++ b/test/lld/basic_safe_stack.wat.out
@@ -107,7 +107,7 @@
   },
   "invokeFuncs": [
   ],
-  "mainReadsParams": 1,
+  "mainReadsParams": 0,
   "features": [
   ]
 }

--- a/test/lld/duplicate_imports.wat.out
+++ b/test/lld/duplicate_imports.wat.out
@@ -85,7 +85,7 @@
   "invokeFuncs": [
     "invoke_ffd"
   ],
-  "mainReadsParams": 1,
+  "mainReadsParams": 0,
   "features": [
   ]
 }


### PR DESCRIPTION
The first way to should detect this is if the main function actually
doesn't take any params.   They we fallback to looking deeper.

In preparation for https://reviews.llvm.org/D75277