### PR TITLE
[WasmGC] Fix try-catch and non-nullable local sets in values in SimplifyLocals

### DIFF
--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -346,10 +346,12 @@ struct SimplifyLocals
         // The problem described can also occur on the *value* and not the set
         // itself. For example, |X| above could be a local.set of a non-nullable
         // local. For that reason we must scan it all.
-        for (auto* set : FindAll<LocalSet>(*info.item).list) {
-          if (self->getFunction()->getLocalType(set->index).isNonNullable()) {
-            invalidated.push_back(index);
-            break;
+        if (self->getModule()->features.hasGCNNLocals()) {
+          for (auto* set : FindAll<LocalSet>(*info.item).list) {
+            if (self->getFunction()->getLocalType(set->index).isNonNullable()) {
+              invalidated.push_back(index);
+              break;
+            }
           }
         }
       }

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -92,20 +92,22 @@
   ;; CHECK:      (func $test-nested-nn
   ;; CHECK-NEXT:  (local $nullable anyref)
   ;; CHECK-NEXT:  (local $nn (ref any))
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (local.set $nullable
+  ;; CHECK-NEXT:   (block $block (result (ref any))
+  ;; CHECK-NEXT:    (local.set $nn
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (ref.null any)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (ref.null any)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (try $try
   ;; CHECK-NEXT:   (do
-  ;; CHECK-NEXT:    (local.set $nullable
-  ;; CHECK-NEXT:     (block $block (result (ref any))
-  ;; CHECK-NEXT:      (local.set $nn
-  ;; CHECK-NEXT:       (ref.as_non_null
-  ;; CHECK-NEXT:        (ref.null any)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (ref.as_non_null
-  ;; CHECK-NEXT:       (ref.null any)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $nullable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch_all

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -87,4 +87,69 @@
         )
       )
     )
-  ))
+  )
+
+  ;; CHECK:      (func $test-nested-nn
+  ;; CHECK-NEXT:  (local $nullable anyref)
+  ;; CHECK-NEXT:  (local $nn (ref any))
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (try $try
+  ;; CHECK-NEXT:   (do
+  ;; CHECK-NEXT:    (local.set $nullable
+  ;; CHECK-NEXT:     (block $block (result (ref any))
+  ;; CHECK-NEXT:      (local.set $nn
+  ;; CHECK-NEXT:       (ref.as_non_null
+  ;; CHECK-NEXT:        (ref.null any)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (ref.as_non_null
+  ;; CHECK-NEXT:       (ref.null any)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (catch_all
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $nullable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $nn)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test-nested-nn
+    ;; As above, the set we want to move is nullable, but now it has a nested
+    ;; value that is a non-nullable set. That should also prevent us from
+    ;; moving it.
+    (local $nullable (ref null any))
+    (local $nn (ref any))
+    (local.set $nullable
+      (block (result (ref any))
+        (local.set $nn
+          (ref.as_non_null
+            (ref.null any)
+          )
+        )
+        (ref.as_non_null
+          (ref.null any)
+        )
+      )
+    )
+    (try
+      (do
+        (drop
+          (local.get $nullable)
+        )
+      )
+      (catch_all
+        (drop
+          (local.get $nullable)
+        )
+        (drop
+          (local.get $nn)
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Followup to #4703, this also handles the case where there is a non-
nullable local.set in the value of a nullable one, which we also cannot
optimize.

Fixes #4702 

cc @askeksa-google