### PR TITLE
Fuzzer: Add support for creating structs and arrays in makeConst

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2017,14 +2017,14 @@ Expression* TranslateToFuzzReader::makeConstCompoundRef(Type type) {
   assert(wasm.features.hasReferenceTypes());
   if (heapType.isSignature()) {
     return makeRefFuncConst(type);
-  } else {
-    // TODO: Handle nontrivial array and struct types.
   }
+
   // We weren't able to directly materialize a non-null constant. Try again to
   // create a null.
   if (type.isNullable()) {
     return builder.makeRefNull(type);
   }
+
   // We have to produce a non-null value. Possibly create a null and cast it
   // to non-null even though that will trap at runtime. We must have a
   // function context for this because the cast is not allowed in globals.

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2008,8 +2008,7 @@ Expression* TranslateToFuzzReader::makeConst(Type type) {
       return builder.makeStructNew(type.getHeapType(),
                                    std::vector<Expression*>{});
     } else if (type.isArray()) {
-      return builder.makeArrayNew(type.getHeapType(),
-                                  makeConst(Type::i32));
+      return builder.makeArrayNew(type.getHeapType(), makeConst(Type::i32));
     } else {
       WASM_UNREACHABLE("bad user-defined ref type");
     }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1993,13 +1993,26 @@ Expression* TranslateToFuzzReader::makeConst(Type type) {
     }
     // We have to produce a non-null value. Possibly create a null and cast it
     // to non-null even though that will trap at runtime. We must have a
-    // function context because the cast is not allowed in globals.
-    if (!funcContext) {
-      std::cerr << type << "\n";
+    // function context for this because the cast is not allowed in globals.
+    if (funcContext) {
+      return builder.makeRefAs(RefAsNonNull,
+                               builder.makeRefNull(Type(heapType, Nullable)));
     }
-    assert(funcContext);
-    return builder.makeRefAs(RefAsNonNull,
-                             builder.makeRefNull(Type(heapType, Nullable)));
+
+    // Otherwise, we are not in a function context. This can happen if we need
+    // to make a constant for the initializer of a global, for example. We've
+    // already handled simple cases of this above, for basic heap types, so what
+    // we have left here are user-defined heap types like structs.
+    // TODO: support non-defaultable fields. for now, just use default values.
+    if (type.isStruct()) {
+      return builder.makeStructNew(type.getHeapType(),
+                                   std::vector<Expression*>{});
+    } else if (type.isArray()) {
+      return builder.makeArrayNew(type.getHeapType(),
+                                  makeConst(Type::i32));
+    } else {
+      WASM_UNREACHABLE("bad user-defined ref type");
+    }
   } else if (type.isRtt()) {
     return builder.makeRtt(type);
   } else if (type.isTuple()) {


### PR DESCRIPTION
#4659 adds a testcase with an import of `(ref $struct)`. This could cause an error in
the fuzzer, since it wants to remove imports (because the various fuzzers cannot pass
in custom imports - they want to just run the wasm). When it tries to remove that
import it tries to create a constant for a struct reference, and fails. To fix that, add
enough support to create structs and arrays at least in the simple case where all their
fields are defaultable.