### PR TITLE
Fix dynamic linking for non-Debian Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ function(binaryen_setup_rpath name)
     set(_install_name_dir INSTALL_NAME_DIR "@rpath")
     set(_install_rpath "@loader_path/../lib")
   elseif(UNIX)
-    set(_install_rpath "\$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+    set(_install_rpath "\$ORIGIN/../lib")
     if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
       set_property(TARGET ${name} APPEND_STRING PROPERTY
                    LINK_FLAGS " -Wl,-z,origin ")


### PR DESCRIPTION
Line 167 in CMakeLists.txt causes libraries to be put into `/lib`.
Line 110, before this patch, causes binaries to look for libraries in `/${CMAKE_INSTALL_LIBDIR}`. This works out if CMAKE_INSTALL_LIBDIR equals `/lib`, which is the case on non-Linux and on Debian, see https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/GNUInstallDirs.cmake#L221. On non-Debian Linux systems, however, it causes dynamic linking to fail unless `export LD_LIBRARY_PATH=/path/to/binaryen/lib` is manually set in the shell (or a `lib64 ->lib` symlink is created inside the Binaryen checkout). This patch fixes the inconsistency by putting `/lib` as the library search path into the created binaries.
(I suppose an alternative fix would be to update lines 167/168 to use `${CMAKE_INSTALL_LIBDIR}` instead, not sure if that would be preferable.)