### PR TITLE
GlobalStructInference: Handle >2 globals if values coincide

### DIFF
--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -263,10 +263,10 @@ struct GlobalStructInference : public Pass {
         // value. And we have already exited if we have more than 2, so that
         // only leaves 1 and 2. We are looking for the case of 2 here, since
         // other passes (ConstantFieldPropagation) can handle 1.
-        assert(values.size() >= 1 && values.size() <= 2);
-        if (values.size() != 2) {
+        if (values.size() == 1) {
           return;
         }
+        assert(values.size() == 2);
 
         // We have two values. Check that we can pick between them using a
         // single comparison. While doing so, ensure that the index we can check

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -259,7 +259,8 @@ struct GlobalStructInference : public Pass {
           }
         }
 
-        // We have at globals (at least 2), and so must have at least one value.
+        // We have some globals (at least 2), and so must have at least one
+        // value.
         assert(values.size() >= 1);
         if (values.size() != 2) {
           // More than two values to pick from, so we'd need more than one

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -260,11 +260,11 @@ struct GlobalStructInference : public Pass {
         }
 
         // We have some globals (at least 2), and so must have at least one
-        // value.
-        assert(values.size() >= 1);
+        // value. And we have already exited if we have more than 2, so that
+        // only leaves 1 and 2. We are looking for the case of 2 here, since
+        // other passes (ConstantFieldPropagation) can handle 1.
+        assert(values.size() >= 1 && values.size() <= 2);
         if (values.size() != 2) {
-          // More than two values to pick from, so we'd need more than one
-          // comparison. Give up.
           return;
         }
 

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -288,10 +288,9 @@ struct GlobalStructInference : public Pass {
         auto otherIndex = 1 - checkIndex;
         Builder builder(wasm);
         replaceCurrent(builder.makeSelect(
-          builder.makeRefEq(
-            builder.makeRefAs(RefAsNonNull, curr->ref),
-            builder.makeGlobalGet(checkGlobal,
-                                  wasm.getGlobal(checkGlobal)->type)),
+          builder.makeRefEq(builder.makeRefAs(RefAsNonNull, curr->ref),
+                            builder.makeGlobalGet(
+                              checkGlobal, wasm.getGlobal(checkGlobal)->type)),
           builder.makeConstantExpression(values[checkIndex]),
           builder.makeConstantExpression(values[otherIndex])));
       }

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -284,13 +284,14 @@ struct GlobalStructInference : public Pass {
         // Excellent, we can optimize here! Emit a select.
         //
         // Note that we must trap on null, so add a ref.as_non_null here.
+        auto checkGlobal = globalsForValue[checkIndex][0];
         auto otherIndex = 1 - checkIndex;
         Builder builder(wasm);
         replaceCurrent(builder.makeSelect(
           builder.makeRefEq(
             builder.makeRefAs(RefAsNonNull, curr->ref),
-            builder.makeGlobalGet(globals[checkIndex],
-                                  wasm.getGlobal(globals[checkIndex])->type)),
+            builder.makeGlobalGet(checkGlobal,
+                                  wasm.getGlobal(checkGlobal)->type)),
           builder.makeConstantExpression(values[checkIndex]),
           builder.makeConstantExpression(values[otherIndex])));
       }

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -269,8 +269,8 @@ struct GlobalStructInference : public Pass {
         }
 
         // We have two values. Check that we can pick between them using a
-        // single comparison. While doing so, ensure that the index can can
-        // check on is 0, that is, the first value has a single global.
+        // single comparison. While doing so, ensure that the index we can check
+        // on is 0, that is, the first value has a single global.
         if (globalsForValue[0].size() == 1) {
           // The checked global is already in index 0.
         } else if (globalsForValue[1].size() == 1) {

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -287,9 +287,10 @@ struct GlobalStructInference : public Pass {
         auto otherIndex = 1 - checkIndex;
         Builder builder(wasm);
         replaceCurrent(builder.makeSelect(
-          builder.makeRefEq(builder.makeRefAs(RefAsNonNull, curr->ref),
-                            builder.makeGlobalGet(
-                              globals[checkIndex], wasm.getGlobal(globals[checkIndex])->type)),
+          builder.makeRefEq(
+            builder.makeRefAs(RefAsNonNull, curr->ref),
+            builder.makeGlobalGet(globals[checkIndex],
+                                  wasm.getGlobal(globals[checkIndex])->type)),
           builder.makeConstantExpression(values[checkIndex]),
           builder.makeConstantExpression(values[otherIndex])));
       }

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -302,7 +302,7 @@
   ;; CHECK-NEXT:     (ref.as_non_null
   ;; CHECK-NEXT:      (ref.null $struct)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (global.get $global2) ;; XXX bad!
+  ;; CHECK-NEXT:     (global.get $global3)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -412,7 +412,7 @@
   ;; CHECK-NEXT:     (ref.as_non_null
   ;; CHECK-NEXT:      (ref.null $struct)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (global.get $global2) ;; XXX bad
+  ;; CHECK-NEXT:     (global.get $global3)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -162,6 +162,270 @@
   )
 )
 
+;; Three globals, as above, but now two agree on their values. We can optimize
+;; by comparing to the one that has a single value.
+(module
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (i32.const 42)
+  ;; CHECK-NEXT:    (i32.const 1337)
+  ;; CHECK-NEXT:    (ref.eq
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (ref.null $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (global.get $global1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (drop
+      (struct.get $struct 0
+        (ref.null $struct)
+      )
+    )
+  )
+)
+
+;; As above, but move the different value of the three to the middle.
+(module
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (i32.const 42)
+  ;; CHECK-NEXT:    (i32.const 1337)
+  ;; CHECK-NEXT:    (ref.eq
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (ref.null $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (global.get $global2)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (drop
+      (struct.get $struct 0
+        (ref.null $struct)
+      )
+    )
+  )
+)
+
+;; As above, but move the different value of the three to the end.
+(module
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (i32.const 42)
+  ;; CHECK-NEXT:    (i32.const 1337)
+  ;; CHECK-NEXT:    (ref.eq
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (ref.null $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (global.get $global2) ;; XXX bad!
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (drop
+      (struct.get $struct 0
+        (ref.null $struct)
+      )
+    )
+  )
+)
+
+;; Four values, two pairs of equal ones. We do not optimize this.
+(module
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global4 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global4 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $struct 0
+  ;; CHECK-NEXT:    (ref.null $struct)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (drop
+      (struct.get $struct 0
+        (ref.null $struct)
+      )
+    )
+  )
+)
+
+;; Four values, three equal and one unique. We can optimize this with a single
+;; comparison on the unique one.
+(module
+  ;; CHECK:      (type $struct (struct_subtype (field i32) data))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global4 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 42)
+  ;; CHECK-NEXT: ))
+  (global $global4 (ref $struct) (struct.new $struct
+    (i32.const 42)
+  ))
+
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (i32.const 1337)
+  ;; CHECK-NEXT:    (i32.const 42)
+  ;; CHECK-NEXT:    (ref.eq
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (ref.null $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (global.get $global2) ;; XXX bad
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (drop
+      (struct.get $struct 0
+        (ref.null $struct)
+      )
+    )
+  )
+)
+
 ;; A struct.new inside a function stops us from optimizing.
 (module
   ;; CHECK:      (type $struct (struct_subtype (field i32) data))


### PR DESCRIPTION
In GSI we look for a read of a global in a situation like this:

```wat
$global1: value1
$global2: value2

(struct.get $Type (ref))
```
If global inference shows this get must be of either `$global1` or `$global2`, then we
can optimize to this:
```
(ref) == $global1 ? value1 : value2
```

We focus on the case of two values because 1 is handled by other passes, and >2
makes the tradeoffs less clear.

However, a simple extension is the case where there are more than 2 globals, but
there are only two values, and one value is unique to one global:

```wat
$global1: valueA
$global2: valueB
$global3: valueA

=>

(ref) == $global2 ? valueB : valueA
```
We can still use a single comparison here, on the global that has the
unique value. Then the else will handle all the other globals.

This increases the cases that GSI can optimize J2Wasm output by over 50%.