### PR TITLE
[Parser] Parse function types

### DIFF
--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -337,7 +337,7 @@ struct ParseTypeDefsCtx {
   // Map heap type names to their indices.
   const IndexMap& typeIndices;
 
-  // The index of type definition we are parsing.
+  // The index of the type definition we are parsing.
   Index index = 0;
 
   ParseTypeDefsCtx(TypeBuilder& builder, const IndexMap& typeIndices)

--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -501,7 +501,8 @@ MaybeResult<typename Ctx::TypeT> reftype(Ctx& ctx, ParseInput& in) {
     return {};
   }
 
-  auto nullability = in.takeKeyword("null"sv) ? Nullable : NonNullable;
+  [[maybe_unused]] auto nullability =
+    in.takeKeyword("null"sv) ? Nullable : NonNullable;
 
   auto type = heaptype(ctx, in);
   CHECK_ERR(type);
@@ -675,7 +676,7 @@ Result<typename Ctx::GlobalTypeT> globaltype(Ctx& ctx, ParseInput& in) {
 //           | v:id  => x (if types[x] = v)
 template<typename Ctx>
 Result<typename Ctx::HeapTypeT> typeidx(Ctx& ctx, ParseInput& in) {
-  Index index;
+  [[maybe_unused]] Index index;
   if (auto x = in.takeU32()) {
     index = *x;
   } else if (auto id = in.takeID()) {
@@ -742,7 +743,7 @@ Result<std::vector<Name>> inlineExports(ParseInput& in) {
 
 // type ::= '(' 'type' id? ft:functype ')' => ft
 template<typename Ctx> MaybeResult<> type(Ctx& ctx, ParseInput& in) {
-  auto start = in.getPos();
+  [[maybe_unused]] auto start = in.getPos();
 
   if (!in.takeSExprStart("type"sv)) {
     return {};

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -3,15 +3,24 @@
 ;; RUN: wasm-opt --new-wat-parser -all %s -S -o - | filecheck %s
 
 (module $parse
+ ;; types
+ (type $void (func))
+ (type $many (func (param $x i32) (param i64 f32) (param) (param $y f64)
+                   (result anyref (ref func))))
 
  ;; globals
  (global $g1 (export "g1") (export "g1.1") (import "mod" "g1") i32)
  (global $g2 (import "mod" "g2") (mut i64))
-
+ (global (import "" "g3") (ref 0))
+ (global (import "mod" "") (ref null $many))
 )
 ;; CHECK:      (import "mod" "g1" (global $g1 i32))
 
 ;; CHECK:      (import "mod" "g2" (global $g2 (mut i64)))
+
+;; CHECK:      (import "" "g3" (global $gimport$0 (ref $void)))
+
+;; CHECK:      (import "mod" "" (global $gimport$1 (ref null $many)))
 
 ;; CHECK:      (export "g1" (global $g1))
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -4,7 +4,9 @@
 
 (module $parse
  ;; types
+ ;; CHECK:      (type $void (func))
  (type $void (func))
+ ;; CHECK:      (type $many (func (param i32 i64 f32 f64) (result anyref (ref func))))
  (type $many (func (param $x i32) (param i64 f32) (param) (param $y f64)
                    (result anyref (ref func))))
 


### PR DESCRIPTION
Begin implementing the second phase of parsing, parsing of type definitions.
Extend `valtype` to parse both user-defined and built in ref types, add `type`
as a top-level module field, and implement parsers for params, results, and
functype definitions.