### PR TITLE
Enable GlobalStructInference by default

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -567,6 +567,7 @@ void PassRunner::addDefaultGlobalOptimizationPrePasses() {
     addIfNoDWARFIssues("gto");
     addIfNoDWARFIssues("remove-unused-module-elements");
     addIfNoDWARFIssues("cfp");
+    addIfNoDWARFIssues("gsi");
   }
 }
 


### PR DESCRIPTION
This pass helps on at least one Java microbenchmark in a clear way. Real-world data
is mixed, with no obvious benefit. But it does optimize 819 callsites on the real-world
14 MB J2Wasm binary, so we may find it helps if/when we run into those code paths.

On that binary (the biggest we have for GC) this pass runs in 0.12 seconds, so there
is very little downside to enabling it. It is a fast linear-time operation.