### PR TITLE
[fuzz-opt] Pretty print of feature opts

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -119,7 +119,7 @@ def randomize_feature_opts():
                 FEATURE_OPTS.append(possible)
                 if possible in IMPLIED_FEATURE_OPTS:
                     FEATURE_OPTS.extend(IMPLIED_FEATURE_OPTS[possible])
-    print('randomized feature opts:', ' '.join(FEATURE_OPTS))
+    print('randomized feature opts:', '\n  ' + '\n  '.join(FEATURE_OPTS))
 
 
 ALL_FEATURE_OPTS = ['--all-features', '-all', '--mvp-features', '-mvp']
@@ -1048,7 +1048,7 @@ def test_one(random_input, given_wasm):
     pick_initial_contents()
 
     opts = randomize_opt_flags()
-    print('randomized opts:', ' '.join(opts))
+    print('randomized opts:', '\n  ' + '\n  '.join(opts))
     print()
 
     if given_wasm:


### PR DESCRIPTION
Instead, to print opts as row-based, I propose switch to column-based output for better readability:
```
...
randomized feature opts: 
  --all-features
  --nominal
  --disable-mutable-globals
  --disable-nontrapping-float-to-int
  --disable-simd
  --disable-bulk-memory
  --disable-multivalue
  --disable-memory64
  --disable-typed-function-references
  --disable-extended-const
randomized settings (NaNs, OOB, legalize): False True True
randomized opts: 
  --duplicate-function-elimination
  --rse
  --shrink-level=3
  -fimfs=99999999
  
 ...
```