### PR TITLE
Finalize some classes

### DIFF
--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -533,7 +533,7 @@ struct RelooperRecursor {
   RelooperRecursor(Relooper* ParentInit) : Parent(ParentInit) {}
 };
 
-struct Liveness : public RelooperRecursor {
+struct Liveness final : public RelooperRecursor {
   Liveness(Relooper* Parent) : RelooperRecursor(Parent) {}
   BlockSet Live;
 
@@ -556,7 +556,7 @@ struct Liveness : public RelooperRecursor {
 
 typedef std::pair<Branch*, Block*> BranchBlock;
 
-struct Optimizer : public RelooperRecursor {
+struct Optimizer final : public RelooperRecursor {
   Block* Entry;
 
   Optimizer(Relooper* Parent, Block* EntryInit)
@@ -1072,7 +1072,7 @@ void Relooper::Calculate(Block* Entry) {
 
   // Recursively process the graph
 
-  struct Analyzer : public RelooperRecursor {
+  struct Analyzer final : public RelooperRecursor {
     Analyzer(Relooper* Parent) : RelooperRecursor(Parent) {}
 
     // Create a list of entries from a block. If LimitTo is provided, only

--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -234,7 +234,7 @@ struct Shape {
   }
 };
 
-struct SimpleShape : public Shape {
+struct SimpleShape final : public Shape {
   Block* Inner = nullptr;
 
   SimpleShape() : Shape(Simple) {}
@@ -243,7 +243,7 @@ struct SimpleShape : public Shape {
 
 typedef std::map<int, Shape*> IdShapeMap;
 
-struct MultipleShape : public Shape {
+struct MultipleShape final : public Shape {
   IdShapeMap InnerMap; // entry block ID -> shape
 
   MultipleShape() : Shape(Multiple) {}
@@ -251,7 +251,7 @@ struct MultipleShape : public Shape {
   wasm::Expression* Render(RelooperBuilder& Builder, bool InLoop) override;
 };
 
-struct LoopShape : public Shape {
+struct LoopShape final : public Shape {
   Shape* Inner = nullptr;
 
   BlockSet Entries; // we must visit at least one of these

--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -39,7 +39,7 @@ namespace wasm::DataFlow {
 // Bad node if not supported, or nullptr if not relevant (we only
 // use the return value for internal expressions, that is, the
 // value of a local.set or the condition of an if etc).
-struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
+struct Graph final : public UnifiedExpressionVisitor<Graph, Node*> {
   // We only need one canonical bad node. It is never modified.
   Node bad = Node(Node::Type::Bad);
 

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -35,7 +35,7 @@ struct Info {
 
 // flow helper class. flows the gets to their sets
 
-struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
+struct Flower final : public CFGWalker<Flower, Visitor<Flower>, Info> {
   LocalGraph::GetSetses& getSetses;
   LocalGraph::Locations& locations;
 

--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -154,7 +154,7 @@ inline bool replacePossibleTarget(Expression* branch, Name from, Name to) {
 
 // Replace all delegate/rethrow targets within the given AST.
 inline void replaceExceptionTargets(Expression* ast, Name from, Name to) {
-  struct Replacer
+  struct Replacer final
     : public PostWalker<Replacer, UnifiedExpressionVisitor<Replacer>> {
     Name from, to;
     Replacer(Name from, Name to) : from(from), to(to) {}
@@ -174,7 +174,7 @@ inline void replaceExceptionTargets(Expression* ast, Name from, Name to) {
 
 // Replace all branch targets within the given AST.
 inline void replaceBranchTargets(Expression* ast, Name from, Name to) {
-  struct Replacer
+  struct Replacer final
     : public PostWalker<Replacer, UnifiedExpressionVisitor<Replacer>> {
     Name from, to;
     Replacer(Name from, Name to) : from(from), to(to) {}
@@ -195,7 +195,7 @@ inline void replaceBranchTargets(Expression* ast, Name from, Name to) {
 // Returns the set of targets to which we branch that are
 // outside of an expression.
 inline NameSet getExitingBranches(Expression* ast) {
-  struct Scanner
+  struct Scanner final
     : public PostWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
     NameSet targets;
 
@@ -217,7 +217,7 @@ inline NameSet getExitingBranches(Expression* ast) {
 // returns the list of all branch targets in a node
 
 inline NameSet getBranchTargets(Expression* ast) {
-  struct Scanner
+  struct Scanner final
     : public PostWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
     NameSet targets;
 
@@ -241,7 +241,7 @@ inline bool hasBranchTarget(Expression* ast, Name target) {
     return false;
   }
 
-  struct Scanner
+  struct Scanner final
     : public PostWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
     Name target;
     bool has = false;
@@ -279,7 +279,7 @@ inline Expression* getSentValue(Expression* curr) {
 // Finds if there are branches targeting a name. Note that since names are
 // unique in our IR, we just need to look for the name, and do not need
 // to analyze scoping.
-struct BranchSeeker
+struct BranchSeeker final
   : public PostWalker<BranchSeeker, UnifiedExpressionVisitor<BranchSeeker>> {
   Name target;
 
@@ -322,7 +322,7 @@ struct BranchSeeker
 };
 
 // Accumulates all the branches in an entire tree.
-struct BranchAccumulator
+struct BranchAccumulator final
   : public PostWalker<BranchAccumulator,
                       UnifiedExpressionVisitor<BranchAccumulator>> {
   NameSet branches;
@@ -411,7 +411,8 @@ struct BranchTargets {
   }
 
 private:
-  struct Inner : public PostWalker<Inner, UnifiedExpressionVisitor<Inner>> {
+  struct Inner final
+    : public PostWalker<Inner, UnifiedExpressionVisitor<Inner>> {
     void visitExpression(Expression* curr) {
       operateOnScopeNameDefs(curr, [&](Name name) {
         if (name.is()) {

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -26,7 +26,7 @@ namespace wasm {
 
 using CostType = uint32_t;
 
-struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
+struct CostAnalyzer final : public OverriddenVisitor<CostAnalyzer, CostType> {
   CostAnalyzer(Expression* ast) { cost = visit(ast); }
 
   CostType cost;

--- a/src/ir/debug.h
+++ b/src/ir/debug.h
@@ -27,7 +27,8 @@ inline void copyDebugInfo(Expression* origin,
                           Expression* copy,
                           Function* originFunc,
                           Function* copyFunc) {
-  struct Lister : public PostWalker<Lister, UnifiedExpressionVisitor<Lister>> {
+  struct Lister final
+    : public PostWalker<Lister, UnifiedExpressionVisitor<Lister>> {
     std::vector<Expression*> list;
     void visitExpression(Expression* curr) { list.push_back(curr); }
   };

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -322,7 +322,7 @@ public:
   std::set<Name> delegateTargets;
 
 private:
-  struct InternalAnalyzer
+  struct InternalAnalyzer final
     : public PostWalker<InternalAnalyzer, OverriddenVisitor<InternalAnalyzer>> {
 
     EffectAnalyzer& parent;

--- a/src/ir/find_all.h
+++ b/src/ir/find_all.h
@@ -27,7 +27,7 @@ template<typename T> struct FindAll {
   std::vector<T*> list;
 
   FindAll(Expression* ast) {
-    struct Finder
+    struct Finder final
       : public PostWalker<Finder, UnifiedExpressionVisitor<Finder>> {
       std::vector<T*>* list;
       void visitExpression(Expression* curr) {
@@ -46,7 +46,7 @@ template<typename T> struct FindAll {
 
 // Find all pointers to instances of a certain node type
 
-struct PointerFinder
+struct PointerFinder final
   : public PostWalker<PointerFinder, UnifiedExpressionVisitor<PointerFinder>> {
   Expression::Id id;
   std::vector<Expression**>* list;

--- a/src/ir/flat.h
+++ b/src/ir/flat.h
@@ -70,7 +70,7 @@
 namespace wasm::Flat {
 
 inline void verifyFlatness(Function* func) {
-  struct VerifyFlatness
+  struct VerifyFlatness final
     : public PostWalker<VerifyFlatness,
                         UnifiedExpressionVisitor<VerifyFlatness>> {
     void visitExpression(Expression* curr) {
@@ -111,7 +111,7 @@ inline void verifyFlatness(Function* func) {
 }
 
 inline void verifyFlatness(Module* module) {
-  struct VerifyFlatness
+  struct VerifyFlatness final
     : public WalkerPass<
         PostWalker<VerifyFlatness, UnifiedExpressionVisitor<VerifyFlatness>>> {
     bool isFunctionParallel() override { return true; }

--- a/src/ir/hashed.h
+++ b/src/ir/hashed.h
@@ -26,7 +26,7 @@ namespace wasm {
 
 // A pass that hashes all functions
 
-struct FunctionHasher : public WalkerPass<PostWalker<FunctionHasher>> {
+struct FunctionHasher final : public WalkerPass<PostWalker<FunctionHasher>> {
   bool isFunctionParallel() override { return true; }
 
   struct Map : public std::map<Function*, size_t> {};

--- a/src/ir/label-utils.h
+++ b/src/ir/label-utils.h
@@ -24,7 +24,7 @@ namespace wasm::LabelUtils {
 
 // Handles branch/loop labels in a function; makes it easy to add new
 // ones without duplicates
-class LabelManager : public PostWalker<LabelManager> {
+class LabelManager final : public PostWalker<LabelManager> {
 public:
   LabelManager(Function* func) { walkFunction(func); }
 

--- a/src/ir/local-utils.h
+++ b/src/ir/local-utils.h
@@ -22,7 +22,7 @@
 
 namespace wasm {
 
-struct LocalGetCounter : public PostWalker<LocalGetCounter> {
+struct LocalGetCounter final : public PostWalker<LocalGetCounter> {
   std::vector<Index> num;
 
   LocalGetCounter() = default;
@@ -41,7 +41,7 @@ struct LocalGetCounter : public PostWalker<LocalGetCounter> {
 
 // Removes trivially unneeded sets: sets for whom there is no possible get, and
 // sets of the same value immediately.
-struct UnneededSetRemover : public PostWalker<UnneededSetRemover> {
+struct UnneededSetRemover final : public PostWalker<UnneededSetRemover> {
   PassOptions& passOptions;
 
   LocalGetCounter* localGetCounter = nullptr;

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -412,7 +412,7 @@ void ModuleSplitter::thunkExportedSecondaryFunctions() {
 void ModuleSplitter::indirectCallsToSecondaryFunctions() {
   // Update direct calls of secondary functions to be indirect calls of their
   // corresponding table indices instead.
-  struct CallIndirector : public WalkerPass<PostWalker<CallIndirector>> {
+  struct CallIndirector final : public WalkerPass<PostWalker<CallIndirector>> {
     ModuleSplitter& parent;
     Builder builder;
     CallIndirector(ModuleSplitter& parent)
@@ -444,7 +444,7 @@ void ModuleSplitter::exportImportCalledPrimaryFunctions() {
   // Find primary functions called in the secondary module.
   ModuleUtils::ParallelFunctionAnalysis<std::vector<Name>> callCollector(
     secondary, [&](Function* func, std::vector<Name>& calledPrimaryFuncs) {
-      struct CallCollector : PostWalker<CallCollector> {
+      struct CallCollector final : PostWalker<CallCollector> {
         const std::set<Name>& primaryFuncs;
         std::vector<Name>& calledPrimaryFuncs;
         CallCollector(const std::set<Name>& primaryFuncs,

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -42,7 +42,7 @@ struct Counts : public InsertOrderedMap<HeapType, size_t> {
   }
 };
 
-struct CodeScanner
+struct CodeScanner final
   : PostWalker<CodeScanner, UnifiedExpressionVisitor<CodeScanner>> {
   Counts& counts;
 

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -333,7 +333,7 @@ struct ParallelFunctionAnalysis {
       }
     }
 
-    struct Mapper : public WalkerPass<PostWalker<Mapper>> {
+    struct Mapper final : public WalkerPass<PostWalker<Mapper>> {
       bool isFunctionParallel() override { return true; }
       bool modifiesBinaryenIR() override { return Mut; }
 
@@ -393,7 +393,7 @@ template<typename T> struct CallGraphPropertyAnalysis {
       if (func->imported()) {
         return;
       }
-      struct Mapper : public PostWalker<Mapper> {
+      struct Mapper final : public PostWalker<Mapper> {
         Mapper(Module* module, T& info, Func work)
           : module(module), info(info), work(work) {}
 

--- a/src/ir/parents.h
+++ b/src/ir/parents.h
@@ -27,7 +27,7 @@ struct Parents {
   Expression* getParent(Expression* curr) { return inner.parentMap[curr]; }
 
 private:
-  struct Inner
+  struct Inner final
     : public ExpressionStackWalker<Inner, UnifiedExpressionVisitor<Inner>> {
     void visitExpression(Expression* curr) { parentMap[curr] = getParent(); }
 

--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -26,7 +26,7 @@ bool isGenerative(Expression* curr, FeatureSet features) {
     return false;
   }
 
-  struct Scanner : public PostWalker<Scanner> {
+  struct Scanner final : public PostWalker<Scanner> {
     bool generative = false;
     void visitStructNew(StructNew* curr) { generative = true; }
     void visitArrayNew(ArrayNew* curr) { generative = true; }

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -93,7 +93,7 @@ void GlobalTypeRewriter::update() {
   }
 
   // Replace all the old types in the module with the new ones.
-  struct CodeUpdater
+  struct CodeUpdater final
     : public WalkerPass<
         PostWalker<CodeUpdater, UnifiedExpressionVisitor<CodeUpdater>>> {
     bool isFunctionParallel() override { return true; }

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -115,7 +115,7 @@ struct ExpressionAnalyzer {
 // exist, but the breaks don't declare the type, rather everything
 // depends on the block. To avoid looking at the parent or something
 // else, just remove such un-taken branches.
-struct ReFinalize
+struct ReFinalize final
   : public WalkerPass<PostWalker<ReFinalize, OverriddenVisitor<ReFinalize>>> {
   bool isFunctionParallel() override { return true; }
 
@@ -152,7 +152,7 @@ private:
 
 // Re-finalize a single node. This is slow, if you want to refinalize
 // an entire ast, use ReFinalize
-struct ReFinalizeNode : public OverriddenVisitor<ReFinalizeNode> {
+struct ReFinalizeNode final : public OverriddenVisitor<ReFinalizeNode> {
 #define DELEGATE(CLASS_TO_VISIT)                                               \
   void visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) { curr->finalize(); }
 
@@ -180,7 +180,7 @@ struct ReFinalizeNode : public OverriddenVisitor<ReFinalizeNode> {
 // dropping can change types, and depends on types being cleaned up - no
 // unnecessary block/if/loop types (see refinalize)
 // TODO: optimize that, interleave them
-struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
+struct AutoDrop final : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new AutoDrop; }

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -27,7 +27,7 @@ namespace wasm {
 
 // Measure the size of an AST
 
-struct Measurer
+struct Measurer final
   : public PostWalker<Measurer, UnifiedExpressionVisitor<Measurer>> {
   Index size = 0;
 

--- a/src/literal.h
+++ b/src/literal.h
@@ -680,7 +680,7 @@ private:
   Literal avgrUInt(const Literal& other) const;
 };
 
-class Literals : public SmallVector<Literal, 1> {
+class Literals final : public SmallVector<Literal, 1> {
 public:
   Literals() = default;
   Literals(std::initializer_list<Literal> init)

--- a/src/passes/AlignmentLowering.cpp
+++ b/src/passes/AlignmentLowering.cpp
@@ -26,7 +26,8 @@
 
 namespace wasm {
 
-struct AlignmentLowering : public WalkerPass<PostWalker<AlignmentLowering>> {
+struct AlignmentLowering final
+  : public WalkerPass<PostWalker<AlignmentLowering>> {
   // Core lowering of a 32-bit load: ensures it is done using aligned
   // operations, which means we can leave it alone if it's already aligned, or
   // else we break it up into smaller loads that are.

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -394,7 +394,7 @@ private:
         if (!func->body) {
           return;
         }
-        struct TypeCollector : PostWalker<TypeCollector> {
+        struct TypeCollector final : PostWalker<TypeCollector> {
           Types& types;
           TypeCollector(Types& types) : types(types) {}
           void visitCall(Call* curr) {
@@ -491,7 +491,7 @@ class ModuleAnalyzer {
   Module& module;
   bool canIndirectChangeState;
 
-  struct Info
+  struct Info final
     : public ModuleUtils::CallGraphPropertyAnalysis<Info>::FunctionInfo {
     // The function name.
     Name name;
@@ -574,7 +574,7 @@ public:
           }
           return;
         }
-        struct Walker : PostWalker<Walker> {
+        struct Walker final : PostWalker<Walker> {
           Info& info;
           Module& module;
           bool canIndirectChangeState;
@@ -727,7 +727,7 @@ public:
     // Look inside to see if we call any of the things we know can change the
     // state.
     // TODO: caching, this is O(N^2)
-    struct Walker : PostWalker<Walker> {
+    struct Walker final : PostWalker<Walker> {
       void visitCall(Call* curr) {
         // We only implement these at the very end, but we know that they
         // definitely change the state.
@@ -830,7 +830,7 @@ public:
 };
 
 // Instrument control flow, around calls and adding skips for rewinding.
-struct AsyncifyFlow : public Pass {
+struct AsyncifyFlow final : public Pass {
   bool isFunctionParallel() override { return true; }
 
   ModuleAnalyzer* analyzer;
@@ -1159,7 +1159,7 @@ private:
                             builder->makeGlobalGet(ASYNCIFY_STATE, Type::i32)),
       func->body);
     // Add a check around every call.
-    struct Walker : PostWalker<Walker> {
+    struct Walker final : PostWalker<Walker> {
       void visitCall(Call* curr) {
         // Tail calls will need another type of check, as they wouldn't reach
         // this assertion.
@@ -1204,7 +1204,7 @@ private:
 };
 
 // Instrument local saving/restoring.
-struct AsyncifyLocals : public WalkerPass<PostWalker<AsyncifyLocals>> {
+struct AsyncifyLocals final : public WalkerPass<PostWalker<AsyncifyLocals>> {
   bool isFunctionParallel() override { return true; }
 
   ModuleAnalyzer* analyzer;
@@ -1316,7 +1316,7 @@ private:
   std::set<Index> relevantLiveLocals;
 
   void findRelevantLiveLocals(Function* func) {
-    struct RelevantLiveLocalsWalker
+    struct RelevantLiveLocalsWalker final
       : public LivenessWalker<RelevantLiveLocalsWalker,
                               Visitor<RelevantLiveLocalsWalker>> {
       // Basic blocks that have a possible unwind/rewind in them.
@@ -1478,7 +1478,7 @@ static std::string getFullImportName(Name module, Name base) {
   return std::string(module.str) + '.' + base.str;
 }
 
-struct Asyncify : public Pass {
+struct Asyncify final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     bool optimize = runner->options.optimizeLevel > 0;
 
@@ -1697,7 +1697,7 @@ Pass* createAsyncifyPass() { return new Asyncify(); }
 // Helper passes that can be run after Asyncify.
 
 template<bool neverRewind, bool neverUnwind, bool importsAlwaysUnwind>
-struct ModAsyncify
+struct ModAsyncify final
   : public WalkerPass<LinearExecutionWalker<
       ModAsyncify<neverRewind, neverUnwind, importsAlwaysUnwind>>> {
   bool isFunctionParallel() override { return true; }
@@ -1825,7 +1825,7 @@ Pass* createModAsyncifyAlwaysOnlyUnwindPass() {
 //
 // Assume that we never unwind, but may still rewind.
 //
-struct ModAsyncifyNeverUnwind : public Pass {
+struct ModAsyncifyNeverUnwind final : public Pass {
   void run(PassRunner* runner, Module* module) override {}
 };
 

--- a/src/passes/AvoidReinterprets.cpp
+++ b/src/passes/AvoidReinterprets.cpp
@@ -73,7 +73,8 @@ static bool isReinterpret(Unary* curr) {
          curr->op == ReinterpretFloat32 || curr->op == ReinterpretFloat64;
 }
 
-struct AvoidReinterprets : public WalkerPass<PostWalker<AvoidReinterprets>> {
+struct AvoidReinterprets final
+  : public WalkerPass<PostWalker<AvoidReinterprets>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new AvoidReinterprets; }
@@ -130,7 +131,7 @@ struct AvoidReinterprets : public WalkerPass<PostWalker<AvoidReinterprets>> {
       infos.erase(load);
     }
     // We now know which we can optimize, and how.
-    struct FinalOptimizer : public PostWalker<FinalOptimizer> {
+    struct FinalOptimizer final : public PostWalker<FinalOptimizer> {
       std::map<Load*, Info>& infos;
       LocalGraph* localGraph;
       Module* module;

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -561,7 +561,7 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices,
   getFunction()->localIndices.clear();
 }
 
-struct CoalesceLocalsWithLearning : public CoalesceLocals {
+struct CoalesceLocalsWithLearning final : public CoalesceLocals {
   virtual Pass* create() override { return new CoalesceLocalsWithLearning; }
 
   virtual void pickIndices(std::vector<Index>& indices) override;

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -70,7 +70,7 @@ namespace wasm {
 
 static const Index WORTH_ADDING_BLOCK_TO_REMOVE_THIS_MUCH = 3;
 
-struct ExpressionMarker
+struct ExpressionMarker final
   : public PostWalker<ExpressionMarker,
                       UnifiedExpressionVisitor<ExpressionMarker>> {
   std::set<Expression*>& marked;
@@ -83,7 +83,7 @@ struct ExpressionMarker
   void visitExpression(Expression* expr) { marked.insert(expr); }
 };
 
-struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
+struct CodeFolding final : public WalkerPass<ControlFlowWalker<CodeFolding>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new CodeFolding; }

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -34,7 +34,7 @@ namespace wasm {
 // This is a much weaker property than SSA, obviously, but together with
 // our implicit dominance properties in the structured AST is quite useful.
 //
-struct LocalAnalyzer : public PostWalker<LocalAnalyzer> {
+struct LocalAnalyzer final : public PostWalker<LocalAnalyzer> {
   std::vector<bool> sfa;
   std::vector<Index> numSets;
   std::vector<Index> numGets;
@@ -231,7 +231,7 @@ private:
   std::unordered_map<LocalSet*, EffectAnalyzer> pushableEffects;
 };
 
-struct CodePushing : public WalkerPass<PostWalker<CodePushing>> {
+struct CodePushing final : public WalkerPass<PostWalker<CodePushing>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new CodePushing; }

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -41,7 +41,7 @@ namespace wasm {
 // with fewer uses than this, it is never beneficial to hoist
 static const Index MIN_USES = 2;
 
-struct ConstHoisting : public WalkerPass<PostWalker<ConstHoisting>> {
+struct ConstHoisting final : public WalkerPass<PostWalker<ConstHoisting>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new ConstHoisting; }

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -49,7 +49,8 @@ using PCVFunctionStructValuesMap =
 // TODO Aside from writes, we could use information like whether any struct of
 //      this type has even been created (to handle the case of struct.sets but
 //      no struct.news).
-struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
+struct FunctionOptimizer final
+  : public WalkerPass<PostWalker<FunctionOptimizer>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new FunctionOptimizer(infos); }
@@ -121,7 +122,7 @@ private:
   bool changed = false;
 };
 
-struct PCVScanner
+struct PCVScanner final
   : public StructUtils::StructScanner<PossibleConstantValues, PCVScanner> {
   Pass* create() override {
     return new PCVScanner(functionNewInfos, functionSetGetInfos);
@@ -174,7 +175,7 @@ struct PCVScanner
   }
 };
 
-struct ConstantFieldPropagation : public Pass {
+struct ConstantFieldPropagation final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     if (getTypeSystem() != TypeSystem::Nominal) {
       Fatal() << "ConstantFieldPropagation requires nominal typing";

--- a/src/passes/DWARF.cpp
+++ b/src/passes/DWARF.cpp
@@ -29,7 +29,7 @@
 
 namespace wasm {
 
-struct DWARFDump : public Pass {
+struct DWARFDump final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     Debug::dumpDWARF(*module);
   }

--- a/src/passes/DataFlowOpts.cpp
+++ b/src/passes/DataFlowOpts.cpp
@@ -36,7 +36,7 @@
 
 namespace wasm {
 
-struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
+struct DataFlowOpts final : public WalkerPass<PostWalker<DataFlowOpts>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new DataFlowOpts; }

--- a/src/passes/DeAlign.cpp
+++ b/src/passes/DeAlign.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct DeAlign : public WalkerPass<PostWalker<DeAlign>> {
+struct DeAlign final : public WalkerPass<PostWalker<DeAlign>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new DeAlign(); }

--- a/src/passes/DeNaN.cpp
+++ b/src/passes/DeNaN.cpp
@@ -30,8 +30,9 @@
 
 namespace wasm {
 
-struct DeNaN : public WalkerPass<
-                 ControlFlowWalker<DeNaN, UnifiedExpressionVisitor<DeNaN>>> {
+struct DeNaN final
+  : public WalkerPass<
+      ControlFlowWalker<DeNaN, UnifiedExpressionVisitor<DeNaN>>> {
 
   Name deNan32, deNan64;
 

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -86,7 +86,7 @@ struct DAEFunctionInfo {
 
 typedef std::unordered_map<Name, DAEFunctionInfo> DAEFunctionInfoMap;
 
-struct DAEScanner
+struct DAEScanner final
   : public WalkerPass<PostWalker<DAEScanner, Visitor<DAEScanner>>> {
   bool isFunctionParallel() override { return true; }
 
@@ -165,7 +165,7 @@ struct DAEScanner
   }
 };
 
-struct DAE : public Pass {
+struct DAE final : public Pass {
   // This pass changes locals and parameters.
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
@@ -317,7 +317,7 @@ private:
     func->setResults(Type::none);
     Builder builder(*module);
     // Remove any return values.
-    struct ReturnUpdater : public PostWalker<ReturnUpdater> {
+    struct ReturnUpdater final : public PostWalker<ReturnUpdater> {
       Module* module;
       ReturnUpdater(Function* func, Module* module) : module(module) {
         walk(func->body);

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -38,7 +38,7 @@
 
 namespace wasm {
 
-struct DeadCodeElimination
+struct DeadCodeElimination final
   : public WalkerPass<
       PostWalker<DeadCodeElimination,
                  UnifiedExpressionVisitor<DeadCodeElimination>>> {

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -35,7 +35,8 @@ namespace wasm {
 
 namespace {
 
-struct FunctionDirectizer : public WalkerPass<PostWalker<FunctionDirectizer>> {
+struct FunctionDirectizer final
+  : public WalkerPass<PostWalker<FunctionDirectizer>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new FunctionDirectizer(tables); }
@@ -157,7 +158,7 @@ private:
   }
 };
 
-struct Directize : public Pass {
+struct Directize final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     // Find which tables are valid to optimize on. They must not be imported nor
     // exported (so the outside cannot modify them), and must have no sets in

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -30,7 +30,7 @@
 
 namespace wasm {
 
-struct DuplicateFunctionElimination : public Pass {
+struct DuplicateFunctionElimination final : public Pass {
   // FIXME Merge DWARF info
   bool invalidatesDWARF() override { return true; }
 

--- a/src/passes/DuplicateImportElimination.cpp
+++ b/src/passes/DuplicateImportElimination.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct DuplicateImportElimination : public Pass {
+struct DuplicateImportElimination final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     ImportInfo imports(*module);
     std::map<Name, Name> replacements;

--- a/src/passes/ExtractFunction.cpp
+++ b/src/passes/ExtractFunction.cpp
@@ -58,7 +58,7 @@ static void extract(PassRunner* runner, Module* module, Name name) {
   postRunner.run();
 }
 
-struct ExtractFunction : public Pass {
+struct ExtractFunction final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     Name name = runner->options.getArgument(
       "extract-function",
@@ -67,7 +67,7 @@ struct ExtractFunction : public Pass {
   }
 };
 
-struct ExtractFunctionIndex : public Pass {
+struct ExtractFunctionIndex final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     std::string index =
       runner->options.getArgument("extract-function-index",

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -67,7 +67,7 @@ namespace wasm {
 // Once exception is that we allow an (unreachable) node, which is used
 // when we move something unreachable to another place, and need a
 // placeholder. We will never reach that (unreachable) anyhow
-struct Flatten
+struct Flatten final
   : public WalkerPass<
       ExpressionStackWalker<Flatten, UnifiedExpressionVisitor<Flatten>>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -126,7 +126,7 @@ static Expression* fromABI(Expression* value, Type type, Module* module) {
   return value;
 }
 
-struct ParallelFuncCastEmulation
+struct ParallelFuncCastEmulation final
   : public WalkerPass<PostWalker<ParallelFuncCastEmulation>> {
   bool isFunctionParallel() override { return true; }
 
@@ -164,7 +164,7 @@ private:
   Index numParams;
 };
 
-struct FuncCastEmulation : public Pass {
+struct FuncCastEmulation final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     Index numParams =
       std::stoul(runner->options.getArgumentOrDefault("max-func-params", "16"));

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -35,7 +35,8 @@
 
 namespace wasm {
 
-struct GenerateDynCalls : public WalkerPass<PostWalker<GenerateDynCalls>> {
+struct GenerateDynCalls final
+  : public WalkerPass<PostWalker<GenerateDynCalls>> {
   GenerateDynCalls(bool onlyI64) : onlyI64(onlyI64) {}
 
   void doWalkModule(Module* wasm) {

--- a/src/passes/GlobalRefining.cpp
+++ b/src/passes/GlobalRefining.cpp
@@ -30,7 +30,7 @@ namespace wasm {
 
 namespace {
 
-struct GlobalRefining : public Pass {
+struct GlobalRefining final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     if (getTypeSystem() != TypeSystem::Nominal) {
       Fatal() << "GlobalRefining requires nominal typing";
@@ -96,7 +96,7 @@ struct GlobalRefining : public Pass {
 
     // Update function contents for their new parameter types: global.gets must
     // now return the new type for any globals that we modified.
-    struct GetUpdater : public WalkerPass<PostWalker<GetUpdater>> {
+    struct GetUpdater final : public WalkerPass<PostWalker<GetUpdater>> {
       bool isFunctionParallel() override { return true; }
 
       GlobalRefining& parent;

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -56,7 +56,7 @@ namespace wasm {
 
 namespace {
 
-struct GlobalStructInference : public Pass {
+struct GlobalStructInference final : public Pass {
   // Maps optimizable struct types to the globals whose init is a struct.new of
   // them. If a global is not present here, it cannot be optimized.
   std::unordered_map<HeapType, std::vector<Name>> typeGlobals;
@@ -168,7 +168,7 @@ struct GlobalStructInference : public Pass {
     }
 
     // Optimize based on the above.
-    struct FunctionOptimizer
+    struct FunctionOptimizer final
       : public WalkerPass<PostWalker<FunctionOptimizer>> {
       bool isFunctionParallel() override { return true; }
 

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -59,7 +59,7 @@ struct FieldInfo {
   }
 };
 
-struct FieldInfoScanner
+struct FieldInfoScanner final
   : public StructUtils::StructScanner<FieldInfo, FieldInfoScanner> {
   Pass* create() override {
     return new FieldInfoScanner(functionNewInfos, functionSetGetInfos);
@@ -92,7 +92,7 @@ struct FieldInfoScanner
   }
 };
 
-struct GlobalTypeOptimization : public Pass {
+struct GlobalTypeOptimization final : public Pass {
   StructUtils::StructValuesMap<FieldInfo> combinedSetGetInfos;
 
   // Maps types to a vector of booleans that indicate whether a field can
@@ -311,7 +311,7 @@ struct GlobalTypeOptimization : public Pass {
   // After updating the types to remove certain fields, we must also remove
   // them from struct instructions.
   void removeFieldsInInstructions(PassRunner* runner, Module& wasm) {
-    struct FieldRemover : public WalkerPass<PostWalker<FieldRemover>> {
+    struct FieldRemover final : public WalkerPass<PostWalker<FieldRemover>> {
       bool isFunctionParallel() override { return true; }
 
       GlobalTypeOptimization& parent;

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -245,7 +245,7 @@ struct GlobalTypeOptimization final : public Pass {
   }
 
   void updateTypes(Module& wasm) {
-    class TypeRewriter : public GlobalTypeRewriter {
+    class TypeRewriter final : public GlobalTypeRewriter {
       GlobalTypeOptimization& parent;
 
     public:

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -233,7 +233,7 @@ struct Heap2LocalOptimizer {
   //
   // TODO: Doing a single rewrite walk at the end would be more efficient, but
   //       it would need to be more complex.
-  struct Rewriter : PostWalker<Rewriter> {
+  struct Rewriter final : PostWalker<Rewriter> {
     StructNew* allocation;
     Function* func;
     Builder builder;
@@ -580,7 +580,7 @@ struct Heap2LocalOptimizer {
       return ParentChildInteraction::Escapes;
     }
 
-    struct Checker : public Visitor<Checker> {
+    struct Checker final : public Visitor<Checker> {
       Expression* child;
 
       // Assume escaping (or some other problem we cannot analyze) unless we are
@@ -740,7 +740,7 @@ struct Heap2LocalOptimizer {
   }
 };
 
-struct Heap2Local : public WalkerPass<PostWalker<Heap2Local>> {
+struct Heap2Local final : public WalkerPass<PostWalker<Heap2Local>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new Heap2Local(); }

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -38,7 +38,8 @@ namespace wasm {
 
 static Name makeHighName(Name n) { return std::string(n.c_str()) + "$hi"; }
 
-struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
+struct I64ToI32Lowering final
+  : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   struct TempVar {
     TempVar(Index idx, Type ty, I64ToI32Lowering& pass)
       : idx(idx), pass(pass), moved(false), ty(ty) {}

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -134,7 +134,7 @@ static bool canHandleParams(Function* func) {
 
 typedef std::unordered_map<Name, FunctionInfo> NameInfoMap;
 
-struct FunctionInfoScanner
+struct FunctionInfoScanner final
   : public WalkerPass<PostWalker<FunctionInfoScanner>> {
   bool isFunctionParallel() override { return true; }
 
@@ -204,7 +204,7 @@ struct InliningState {
   std::unordered_map<Name, std::vector<InliningAction>> actionsForFunction;
 };
 
-struct Planner : public WalkerPass<PostWalker<Planner>> {
+struct Planner final : public WalkerPass<PostWalker<Planner>> {
   bool isFunctionParallel() override { return true; }
 
   Planner(InliningState* state) : state(state) {}
@@ -243,7 +243,7 @@ private:
   InliningState* state;
 };
 
-struct Updater : public PostWalker<Updater> {
+struct Updater final : public PostWalker<Updater> {
   Module* module;
   std::map<Index, Index> localMapping;
   Name returnName;
@@ -819,7 +819,7 @@ private:
   }
 };
 
-struct Inlining : public Pass {
+struct Inlining final : public Pass {
   // This pass changes locals and parameters.
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
@@ -1094,7 +1094,7 @@ struct Inlining : public Pass {
 static const char* MAIN = "main";
 static const char* ORIGINAL_MAIN = "__original_main";
 
-struct InlineMainPass : public Pass {
+struct InlineMainPass final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     auto* main = module->getFunctionOrNull(MAIN);
     auto* originalMain = module->getFunctionOrNull(ORIGINAL_MAIN);

--- a/src/passes/InstrumentLocals.cpp
+++ b/src/passes/InstrumentLocals.cpp
@@ -73,7 +73,8 @@ Name set_eqref("set_eqref");
 Name set_i31ref("set_i31ref");
 Name set_dataref("set_dataref");
 
-struct InstrumentLocals : public WalkerPass<PostWalker<InstrumentLocals>> {
+struct InstrumentLocals final
+  : public WalkerPass<PostWalker<InstrumentLocals>> {
   void visitLocalGet(LocalGet* curr) {
     Builder builder(*getModule());
     Name import;

--- a/src/passes/InstrumentMemory.cpp
+++ b/src/passes/InstrumentMemory.cpp
@@ -96,7 +96,8 @@ static Name array_set_index("array_set_index");
 
 // TODO: Add support for atomicRMW/cmpxchg
 
-struct InstrumentMemory : public WalkerPass<PostWalker<InstrumentMemory>> {
+struct InstrumentMemory final
+  : public WalkerPass<PostWalker<InstrumentMemory>> {
   void visitLoad(Load* curr) {
     id++;
     Builder builder(*getModule());

--- a/src/passes/Intrinsics.cpp
+++ b/src/passes/Intrinsics.cpp
@@ -21,7 +21,8 @@
 
 namespace wasm {
 
-struct IntrinsicLowering : public WalkerPass<PostWalker<IntrinsicLowering>> {
+struct IntrinsicLowering final
+  : public WalkerPass<PostWalker<IntrinsicLowering>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new IntrinsicLowering; }

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -43,7 +43,7 @@
 
 namespace wasm {
 
-struct LegalizeJSInterface : public Pass {
+struct LegalizeJSInterface final : public Pass {
   bool full;
 
   LegalizeJSInterface(bool full) : full(full) {}
@@ -109,7 +109,7 @@ struct LegalizeJSInterface : public Pass {
     if (!illegalImportsToLegal.empty()) {
       // fix up imports: call_import of an illegal must be turned to a call of a
       // legal. the same must be done with ref.funcs.
-      struct Fixer : public WalkerPass<PostWalker<Fixer>> {
+      struct Fixer final : public WalkerPass<PostWalker<Fixer>> {
         bool isFunctionParallel() override { return true; }
 
         Pass* create() override { return new Fixer(illegalImportsToLegal); }

--- a/src/passes/LimitSegments.cpp
+++ b/src/passes/LimitSegments.cpp
@@ -20,7 +20,7 @@
 
 namespace wasm {
 
-struct LimitSegments : public Pass {
+struct LimitSegments final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     if (!MemoryUtils::ensureLimitedSegments(*module)) {
       std::cerr << "Unable to merge segments. "

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -202,7 +202,7 @@ struct RequestInfoMap : public std::unordered_map<Expression*, RequestInfo> {
   }
 };
 
-struct Scanner
+struct Scanner final
   : public LinearExecutionWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
   PassOptions& options;
 
@@ -349,7 +349,7 @@ struct Scanner
 //
 // This updates the RequestInfos of things it sees are invalidated, which will
 // make Applier ignore them.
-struct Checker
+struct Checker final
   : public LinearExecutionWalker<Checker, UnifiedExpressionVisitor<Checker>> {
   PassOptions& options;
   RequestInfoMap& requestInfos;
@@ -472,7 +472,7 @@ struct Checker
 };
 
 // Applies the optimization now that we know which requests are valid.
-struct Applier
+struct Applier final
   : public LinearExecutionWalker<Applier, UnifiedExpressionVisitor<Applier>> {
   RequestInfoMap requestInfos;
 
@@ -520,7 +520,7 @@ struct Applier
 
 } // anonymous namespace
 
-struct LocalCSE : public WalkerPass<PostWalker<LocalCSE>> {
+struct LocalCSE final : public WalkerPass<PostWalker<LocalCSE>> {
   bool isFunctionParallel() override { return true; }
 
   // FIXME DWARF updating does not handle local changes yet.

--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -33,7 +33,7 @@
 
 namespace wasm {
 
-struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
+struct LocalSubtyping final : public WalkerPass<PostWalker<LocalSubtyping>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new LocalSubtyping(); }

--- a/src/passes/LogExecution.cpp
+++ b/src/passes/LogExecution.cpp
@@ -38,7 +38,7 @@ namespace wasm {
 
 Name LOGGER("log_execution");
 
-struct LogExecution : public WalkerPass<PostWalker<LogExecution>> {
+struct LogExecution final : public WalkerPass<PostWalker<LogExecution>> {
   void visitLoop(Loop* curr) { curr->body = makeLogCall(curr->body); }
 
   void visitReturn(Return* curr) { replaceCurrent(makeLogCall(curr)); }

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -33,7 +33,7 @@
 
 namespace wasm {
 
-struct LoopInvariantCodeMotion
+struct LoopInvariantCodeMotion final
   : public WalkerPass<ExpressionStackWalker<LoopInvariantCodeMotion>> {
   bool isFunctionParallel() override { return true; }
 

--- a/src/passes/Memory64Lowering.cpp
+++ b/src/passes/Memory64Lowering.cpp
@@ -27,7 +27,8 @@
 
 namespace wasm {
 
-struct Memory64Lowering : public WalkerPass<PostWalker<Memory64Lowering>> {
+struct Memory64Lowering final
+  : public WalkerPass<PostWalker<Memory64Lowering>> {
 
   void run(PassRunner* runner, Module* module) override {
     if (module->memory.is64()) {

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -93,7 +93,7 @@ makeGtShiftedMemorySize(Builder& builder, Module& module, MemoryInit* curr) {
 
 } // anonymous namespace
 
-struct MemoryPacking : public Pass {
+struct MemoryPacking final : public Pass {
   void run(PassRunner* runner, Module* module) override;
   bool canOptimize(const Memory& memory, const PassOptions& passOptions);
   void optimizeBulkMemoryOps(PassRunner* runner, Module* module);
@@ -367,7 +367,7 @@ void MemoryPacking::calculateRanges(const Memory::Segment& segment,
 }
 
 void MemoryPacking::optimizeBulkMemoryOps(PassRunner* runner, Module* module) {
-  struct Optimizer : WalkerPass<PostWalker<Optimizer>> {
+  struct Optimizer final : WalkerPass<PostWalker<Optimizer>> {
     bool isFunctionParallel() override { return true; }
     Pass* create() override { return new Optimizer; }
 
@@ -441,7 +441,7 @@ void MemoryPacking::getSegmentReferrers(Module* module,
     if (func->imported()) {
       return;
     }
-    struct Collector : WalkerPass<PostWalker<Collector>> {
+    struct Collector final : WalkerPass<PostWalker<Collector>> {
       ReferrersMap& referrers;
       Collector(ReferrersMap& referrers) : referrers(referrers) {}
 
@@ -756,7 +756,7 @@ void MemoryPacking::createReplacements(Module* module,
 void MemoryPacking::replaceBulkMemoryOps(PassRunner* runner,
                                          Module* module,
                                          Replacements& replacements) {
-  struct Replacer : WalkerPass<PostWalker<Replacer>> {
+  struct Replacer final : WalkerPass<PostWalker<Replacer>> {
     bool isFunctionParallel() override { return true; }
 
     Replacements& replacements;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -85,7 +85,7 @@ namespace wasm {
 // Looks for reasons we can't remove the values from breaks to an origin
 // For example, if there is a switch targeting us, we can't do it - we can't
 // remove the value from other targets
-struct ProblemFinder
+struct ProblemFinder final
   : public ControlFlowWalker<ProblemFinder,
                              UnifiedExpressionVisitor<ProblemFinder>> {
   Name origin;
@@ -138,7 +138,7 @@ struct ProblemFinder
 
 // Drops values from breaks to an origin.
 // While doing so it can create new blocks, so optimize blocks as well.
-struct BreakValueDropper : public ControlFlowWalker<BreakValueDropper> {
+struct BreakValueDropper final : public ControlFlowWalker<BreakValueDropper> {
   Name origin;
   PassOptions& passOptions;
   BranchUtils::BranchSeekerCache& branchInfo;
@@ -398,7 +398,7 @@ void BreakValueDropper::visitBlock(Block* curr) {
   optimizeBlock(curr, getModule(), passOptions, branchInfo);
 }
 
-struct MergeBlocks
+struct MergeBlocks final
   : public WalkerPass<
       PostWalker<MergeBlocks, UnifiedExpressionVisitor<MergeBlocks>>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -53,7 +53,7 @@
 
 namespace wasm {
 
-struct MergeLocals
+struct MergeLocals final
   : public WalkerPass<
       PostWalker<MergeLocals, UnifiedExpressionVisitor<MergeLocals>>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/MergeSimilarFunctions.cpp
+++ b/src/passes/MergeSimilarFunctions.cpp
@@ -171,7 +171,7 @@ struct EquivalentClass {
                     bool isIndirectionEnabled);
 };
 
-struct MergeSimilarFunctions : public Pass {
+struct MergeSimilarFunctions final : public Pass {
   bool invalidatesDWARF() override { return true; }
 
   void run(PassRunner* runner, Module* module) override {

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -29,7 +29,7 @@ typedef std::map<const char*, int> Counts;
 static Counts lastCounts;
 
 // Prints metrics between optimization passes.
-struct Metrics
+struct Metrics final
   : public WalkerPass<PostWalker<Metrics, UnifiedExpressionVisitor<Metrics>>> {
   bool modifiesBinaryenIR() override { return false; }
 

--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -45,7 +45,7 @@
 
 namespace wasm {
 
-struct MinifyImportsAndExports : public Pass {
+struct MinifyImportsAndExports final : public Pass {
   bool minifyExports, minifyModules;
 
 public:

--- a/src/passes/NameList.cpp
+++ b/src/passes/NameList.cpp
@@ -25,7 +25,7 @@
 
 namespace wasm {
 
-struct NameList : public Pass {
+struct NameList final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     ModuleUtils::iterDefinedFunctions(*module, [&](Function* func) {
       std::cout << "    " << func->name << " : "

--- a/src/passes/NameTypes.cpp
+++ b/src/passes/NameTypes.cpp
@@ -27,7 +27,7 @@ namespace wasm {
 // An arbitrary limit, above which we rename types.
 static const size_t NameLenLimit = 20;
 
-struct NameTypes : public Pass {
+struct NameTypes final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     // Find all the types.
     std::vector<HeapType> types = ModuleUtils::collectHeapTypes(*module);

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -81,7 +81,7 @@ struct OptInfo {
     newOnceGlobalsSetInFuncs;
 };
 
-struct Scanner : public WalkerPass<PostWalker<Scanner>> {
+struct Scanner final : public WalkerPass<PostWalker<Scanner>> {
   bool isFunctionParallel() override { return true; }
 
   Scanner(OptInfo& optInfo) : optInfo(optInfo) {}
@@ -211,7 +211,7 @@ struct BlockInfo {
 // also do a full propagation to a fixed point in between running local
 // optimization, but that would require more code - it might be more efficient,
 // though).
-struct Optimizer
+struct Optimizer final
   : public WalkerPass<CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>> {
   bool isFunctionParallel() override { return true; }
 
@@ -341,7 +341,7 @@ private:
 
 } // anonymous namespace
 
-struct OnceReduction : public Pass {
+struct OnceReduction final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     OptInfo optInfo;
 

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -236,7 +236,7 @@ private:
   }
 };
 
-struct OptimizeAddedConstants
+struct OptimizeAddedConstants final
   : public WalkerPass<
       PostWalker<OptimizeAddedConstants,
                  UnifiedExpressionVisitor<OptimizeAddedConstants>>> {
@@ -365,7 +365,7 @@ private:
   std::map<LocalSet*, Index> helperIndexes;
 
   void createHelperIndexes() {
-    struct Creator : public PostWalker<Creator> {
+    struct Creator final : public PostWalker<Creator> {
       std::map<LocalSet*, Index>& helperIndexes;
       Module* module;
 

--- a/src/passes/OptimizeForJS.cpp
+++ b/src/passes/OptimizeForJS.cpp
@@ -25,7 +25,8 @@
 
 namespace wasm {
 
-struct OptimizeForJSPass : public WalkerPass<PostWalker<OptimizeForJSPass>> {
+struct OptimizeForJSPass final
+  : public WalkerPass<PostWalker<OptimizeForJSPass>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new OptimizeForJSPass; }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -57,7 +57,7 @@ struct LocalInfo {
   Index signExtedBits;
 };
 
-struct LocalScanner : PostWalker<LocalScanner> {
+struct LocalScanner final : PostWalker<LocalScanner> {
   std::vector<LocalInfo>& localInfo;
   const PassOptions& passOptions;
 
@@ -139,7 +139,7 @@ struct LocalScanner : PostWalker<LocalScanner> {
 
 namespace {
 // perform some final optimizations
-struct FinalOptimizer : public PostWalker<FinalOptimizer> {
+struct FinalOptimizer final : public PostWalker<FinalOptimizer> {
   const PassOptions& passOptions;
 
   FinalOptimizer(const PassOptions& passOptions) : passOptions(passOptions) {}
@@ -202,7 +202,7 @@ template<class Opt> struct Match::Internal::MatchSelf<PureMatcherKind<Opt>> {
 };
 
 // Main pass class
-struct OptimizeInstructions
+struct OptimizeInstructions final
   : public WalkerPass<PostWalker<OptimizeInstructions>> {
   bool isFunctionParallel() override { return true; }
 
@@ -2414,7 +2414,7 @@ private:
       c->value = Literal::makeZero(c->type);
     }
     // remove added/subbed zeros
-    struct ZeroRemover : public PostWalker<ZeroRemover> {
+    struct ZeroRemover final : public PostWalker<ZeroRemover> {
       // TODO: we could save the binarys and costs we drop, and reuse them later
 
       PassOptions& passOptions;

--- a/src/passes/PickLoadSigns.cpp
+++ b/src/passes/PickLoadSigns.cpp
@@ -25,7 +25,8 @@ namespace wasm {
 // help remove the most sign/unsign operations
 // unsigned, then it could be either
 
-struct PickLoadSigns : public WalkerPass<ExpressionStackWalker<PickLoadSigns>> {
+struct PickLoadSigns final
+  : public WalkerPass<ExpressionStackWalker<PickLoadSigns>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new PickLoadSigns; }

--- a/src/passes/Poppify.cpp
+++ b/src/passes/Poppify.cpp
@@ -91,7 +91,7 @@ Name getGlobalElem(Module* module, Name global, Index i) {
     *module, std::string(global.c_str()) + '$' + std::to_string(i));
 }
 
-struct Poppifier : BinaryenIRWriter<Poppifier> {
+struct Poppifier final : BinaryenIRWriter<Poppifier> {
   // Collects instructions to be inserted into a block at a certain scope, as
   // well as what kind of scope it is, which determines how the instructions are
   // inserted.
@@ -428,7 +428,7 @@ void Poppifier::emitGlobalSet(GlobalSet* curr) {
 }
 
 void Poppifier::poppify(Expression* expr) {
-  struct Poppifier : PostWalker<Poppifier> {
+  struct Poppifier final : PostWalker<Poppifier> {
     bool scanned = false;
     Builder builder;
     Poppifier(Builder& builder) : builder(builder) {}

--- a/src/passes/Poppify.cpp
+++ b/src/passes/Poppify.cpp
@@ -459,7 +459,7 @@ class PoppifyFunctionsPass : public Pass {
 
 } // anonymous namespace
 
-class PoppifyPass : public Pass {
+class PoppifyPass final : public Pass {
   void run(PassRunner* runner, Module* module) {
     PassRunner subRunner(runner);
     subRunner.add(std::make_unique<PoppifyFunctionsPass>());

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -43,7 +43,7 @@ static bool isInvoke(Function* F) {
 
 } // namespace
 
-struct PostEmscripten : public Pass {
+struct PostEmscripten final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     // Optimize exceptions
     optimizeExceptions(runner, module);
@@ -73,7 +73,7 @@ struct PostEmscripten : public Pass {
     }
     // This code has exceptions. Find functions that definitely cannot throw,
     // and remove invokes to them.
-    struct Info
+    struct Info final
       : public ModuleUtils::CallGraphPropertyAnalysis<Info>::FunctionInfo {
       bool canThrow = false;
     };
@@ -94,7 +94,8 @@ struct PostEmscripten : public Pass {
       analyzer.NonDirectCallsHaveProperty);
 
     // Apply the information.
-    struct OptimizeInvokes : public WalkerPass<PostWalker<OptimizeInvokes>> {
+    struct OptimizeInvokes final
+      : public WalkerPass<PostWalker<OptimizeInvokes>> {
       bool isFunctionParallel() override { return true; }
 
       Pass* create() override { return new OptimizeInvokes(map, flatTable); }

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -72,7 +72,7 @@ using HeapValues = std::unordered_map<Expression*, std::shared_ptr<GCData>>;
 // precomputed. Inherits most of its functionality from
 // ConstantExpressionRunner, which it shares with the C-API, but adds handling
 // of GetValues computed during the precompute pass.
-class PrecomputingExpressionRunner
+class PrecomputingExpressionRunner final
   : public ConstantExpressionRunner<PrecomputingExpressionRunner> {
 
   using Super = ConstantExpressionRunner<PrecomputingExpressionRunner>;

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -194,7 +194,7 @@ public:
   }
 };
 
-struct Precompute
+struct Precompute final
   : public WalkerPass<
       PostWalker<Precompute, UnifiedExpressionVisitor<Precompute>>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3225,7 +3225,7 @@ Pass* createPrinterPass() { return new Printer(); }
 
 // Prints out a minified module
 
-class MinifiedPrinter : public Printer {
+class MinifiedPrinter final : public Printer {
 public:
   MinifiedPrinter() = default;
   MinifiedPrinter(std::ostream* o) : Printer(o) {}
@@ -3242,7 +3242,7 @@ Pass* createMinifiedPrinterPass() { return new MinifiedPrinter(); }
 
 // Prints out a module withough elision, i.e., the full ast
 
-class FullPrinter : public Printer {
+class FullPrinter final : public Printer {
 public:
   FullPrinter() = default;
   FullPrinter(std::ostream* o) : Printer(o) {}
@@ -3259,7 +3259,7 @@ Pass* createFullPrinterPass() { return new FullPrinter(); }
 
 // Print Stack IR (if present)
 
-class PrintStackIR : public Printer {
+class PrintStackIR final : public Printer {
 public:
   PrintStackIR() = default;
   PrintStackIR(std::ostream* o) : Printer(o) {}

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -354,7 +354,7 @@ static Type forceConcrete(Type type) {
 
 // Prints the internal contents of an expression: everything but
 // the children.
-struct PrintExpressionContents
+struct PrintExpressionContents final
   : public OverriddenVisitor<PrintExpressionContents> {
   Module* wasm = nullptr;
   Function* currFunction = nullptr;
@@ -2207,7 +2207,8 @@ struct PrintExpressionContents
 
 // Prints an expression in s-expr format, including both the
 // internal contents and the nested children.
-struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
+struct PrintSExpression final
+  : public UnifiedExpressionVisitor<PrintSExpression> {
   std::ostream& o;
   unsigned indent = 0;
 

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -71,7 +71,7 @@ struct PrintCallGraph final : public Pass {
       }
     }
 
-    struct CallPrinter : public PostWalker<CallPrinter> {
+    struct CallPrinter final : public PostWalker<CallPrinter> {
       Module* module;
       Function* currFunction;
       std::set<Name> visitedTargets; // Used to avoid printing duplicate edges.

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -30,7 +30,7 @@
 
 namespace wasm {
 
-struct PrintCallGraph : public Pass {
+struct PrintCallGraph final : public Pass {
   bool modifiesBinaryenIR() override { return false; }
 
   void run(PassRunner* runner, Module* module) override {

--- a/src/passes/PrintFeatures.cpp
+++ b/src/passes/PrintFeatures.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct PrintFeatures : public Pass {
+struct PrintFeatures final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     module->features.iterFeatures([](FeatureSet::Feature f) {
       std::cout << "--enable-" << FeatureSet::toString(f) << std::endl;

--- a/src/passes/PrintFunctionMap.cpp
+++ b/src/passes/PrintFunctionMap.cpp
@@ -31,7 +31,7 @@
 
 namespace wasm {
 
-struct PrintFunctionMap : public Pass {
+struct PrintFunctionMap final : public Pass {
   bool modifiesBinaryenIR() override { return false; }
 
   void run(PassRunner* runner, Module* module) override {

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -200,7 +200,7 @@ struct ReReloop final : public Pass {
     }
   };
 
-  struct BreakTask : public Task {
+  struct BreakTask final : public Task {
     static void handle(ReReloop& parent, Break* curr) {
       // add the branch. note how if the condition is false, it is the right
       // value there as well
@@ -216,7 +216,7 @@ struct ReReloop final : public Pass {
     }
   };
 
-  struct SwitchTask : public Task {
+  struct SwitchTask final : public Task {
     static void handle(ReReloop& parent, Switch* curr) {
       // set the switch condition for the block ending now
       auto* before = parent.getCurrCFGBlock();
@@ -245,7 +245,7 @@ struct ReReloop final : public Pass {
     }
   };
 
-  struct ReturnTask : public Task {
+  struct ReturnTask final : public Task {
     static void handle(ReReloop& parent, Return* curr) {
       // reuse the return
       parent.getCurrBlock()->list.push_back(curr);
@@ -253,7 +253,7 @@ struct ReReloop final : public Pass {
     }
   };
 
-  struct UnreachableTask : public Task {
+  struct UnreachableTask final : public Task {
     static void handle(ReReloop& parent, Unreachable* curr) {
       // reuse the unreachable
       parent.getCurrBlock()->list.push_back(curr);

--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -57,7 +57,7 @@ struct Info {
   std::vector<Expression**> setps;
 };
 
-struct RedundantSetElimination
+struct RedundantSetElimination final
   : public WalkerPass<CFGWalker<RedundantSetElimination,
                                 Visitor<RedundantSetElimination>,
                                 Info>> {

--- a/src/passes/RemoveImports.cpp
+++ b/src/passes/RemoveImports.cpp
@@ -29,7 +29,7 @@
 
 namespace wasm {
 
-struct RemoveImports : public WalkerPass<PostWalker<RemoveImports>> {
+struct RemoveImports final : public WalkerPass<PostWalker<RemoveImports>> {
   void visitCall(Call* curr) {
     auto* func = getModule()->getFunction(curr->target);
     if (!func->imported()) {

--- a/src/passes/RemoveMemory.cpp
+++ b/src/passes/RemoveMemory.cpp
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-struct RemoveMemory : public Pass {
+struct RemoveMemory final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     module->memory.segments.clear();
   }

--- a/src/passes/RemoveNonJSOps.cpp
+++ b/src/passes/RemoveNonJSOps.cpp
@@ -49,7 +49,8 @@
 
 namespace wasm {
 
-struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
+struct RemoveNonJSOpsPass final
+  : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
   std::unique_ptr<Builder> builder;
   std::unordered_set<Name> neededIntrinsics;
   InsertOrderedSet<std::pair<Name, Type>> neededImportedGlobals;
@@ -335,7 +336,7 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
   }
 };
 
-struct StubUnsupportedJSOpsPass
+struct StubUnsupportedJSOpsPass final
   : public WalkerPass<PostWalker<StubUnsupportedJSOpsPass>> {
   bool isFunctionParallel() override { return true; }
 

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -114,7 +114,7 @@ static bool tooCostlyToRunUnconditionally(const PassOptions& passOptions,
   return CostAnalyzer(curr).cost >= TooCostlyToRunUnconditionally;
 }
 
-struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
+struct RemoveUnusedBrs final : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new RemoveUnusedBrs; }
@@ -611,7 +611,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
   }
 
   bool sinkBlocks(Function* func) {
-    struct Sinker : public PostWalker<Sinker> {
+    struct Sinker final : public PostWalker<Sinker> {
       bool worked = false;
 
       void visitBlock(Block* curr) {
@@ -693,7 +693,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       return false;
     }
 
-    struct Optimizer : public PostWalker<Optimizer> {
+    struct Optimizer final : public PostWalker<Optimizer> {
       bool worked = false;
 
       void visitBrOn(BrOn* curr) {
@@ -803,7 +803,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
     } while (anotherCycle);
 
     // thread trivial jumps
-    struct JumpThreader : public ControlFlowWalker<JumpThreader> {
+    struct JumpThreader final : public ControlFlowWalker<JumpThreader> {
       // map of all value-less breaks and switches going to a block (and not a
       // loop)
       std::map<Block*, std::vector<Expression*>> branchesToBlock;
@@ -883,7 +883,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
     jumpThreader.finish(func);
 
     // perform some final optimizations
-    struct FinalOptimizer : public PostWalker<FinalOptimizer> {
+    struct FinalOptimizer final : public PostWalker<FinalOptimizer> {
       bool shrink;
       PassOptions& passOptions;
 

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -39,7 +39,7 @@ typedef std::pair<ModuleElementKind, Name> ModuleElement;
 // Finds reachabilities
 // TODO: use Effects to determine if a memory is used
 
-struct ReachabilityAnalyzer : public PostWalker<ReachabilityAnalyzer> {
+struct ReachabilityAnalyzer final : public PostWalker<ReachabilityAnalyzer> {
   Module* module;
   std::vector<ModuleElement> queue;
   std::set<ModuleElement> reachable;
@@ -226,7 +226,7 @@ struct ReachabilityAnalyzer : public PostWalker<ReachabilityAnalyzer> {
   }
 };
 
-struct RemoveUnusedModuleElements : public Pass {
+struct RemoveUnusedModuleElements final : public Pass {
   bool rootAllFunctions;
 
   RemoveUnusedModuleElements(bool rootAllFunctions)

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -26,7 +26,7 @@
 
 namespace wasm {
 
-struct RemoveUnusedNames
+struct RemoveUnusedNames final
   : public WalkerPass<PostWalker<RemoveUnusedNames,
                                  UnifiedExpressionVisitor<RemoveUnusedNames>>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -37,7 +37,8 @@ namespace wasm {
 
 typedef std::unordered_map<Name, std::atomic<Index>> NameCountMap;
 
-struct CallCountScanner : public WalkerPass<PostWalker<CallCountScanner>> {
+struct CallCountScanner final
+  : public WalkerPass<PostWalker<CallCountScanner>> {
   bool isFunctionParallel() override { return true; }
 
   CallCountScanner(NameCountMap* counts) : counts(counts) {}
@@ -54,7 +55,7 @@ private:
   NameCountMap* counts;
 };
 
-struct ReorderFunctions : public Pass {
+struct ReorderFunctions final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     NameCountMap counts;
     // fill in info, as we operate on it in parallel (each function to its own

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -29,7 +29,7 @@
 
 namespace wasm {
 
-struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
+struct ReorderLocals final : public WalkerPass<PostWalker<ReorderLocals>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new ReorderLocals; }
@@ -110,7 +110,7 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
       }
     }
     // apply the renaming to AST nodes
-    struct ReIndexer : public PostWalker<ReIndexer> {
+    struct ReIndexer final : public PostWalker<ReIndexer> {
       Function* func;
       std::vector<Index>& oldToNew;
 

--- a/src/passes/RoundTrip.cpp
+++ b/src/passes/RoundTrip.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct RoundTrip : public Pass {
+struct RoundTrip final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     BufferWithRandomAccess buffer;
     // Save features, which would not otherwise make it through a round trip if

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -67,7 +67,7 @@ static LocalSet IMPOSSIBLE_SET;
 // Tracks assignments to locals, assuming single-assignment form, i.e.,
 // each assignment creates a new variable.
 
-struct SSAify : public Pass {
+struct SSAify final : public Pass {
   bool isFunctionParallel() override { return true; }
 
   // SSAify maps each original local to a number of new ones.

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -63,7 +63,8 @@ static Name getStoreName(Store* curr) {
   return ret;
 }
 
-struct AccessInstrumenter : public WalkerPass<PostWalker<AccessInstrumenter>> {
+struct AccessInstrumenter final
+  : public WalkerPass<PostWalker<AccessInstrumenter>> {
   // A set of function that we should ignore (not instrument).
   std::set<Name> ignoreFunctions;
 
@@ -126,7 +127,7 @@ static std::set<Name> findCalledFunctions(Module* module, Name startFunc) {
   return called;
 }
 
-struct SafeHeap : public Pass {
+struct SafeHeap final : public Pass {
   PassOptions options;
 
   void run(PassRunner* runner, Module* module) override {

--- a/src/passes/SetGlobals.cpp
+++ b/src/passes/SetGlobals.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-struct SetGlobals : public Pass {
+struct SetGlobals final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     Name input = runner->options.getArgument(
       "set-globals",

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -41,7 +41,7 @@ namespace wasm {
 
 namespace {
 
-struct SignaturePruning : public Pass {
+struct SignaturePruning final : public Pass {
   // Maps each heap type to the possible pruned heap type. We will fill this
   // during analysis and then use it while doing an update of the types. If a
   // type has no improvement that we can find, it will not appear in this map.

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -40,7 +40,7 @@ namespace wasm {
 
 namespace {
 
-struct SignatureRefining : public Pass {
+struct SignatureRefining final : public Pass {
   // Maps each heap type to the possible refinement of the types in their
   // signatures. We will fill this during analysis and then use it while doing
   // an update of the types. If a type has no improvement that we can find, it
@@ -234,7 +234,7 @@ struct SignatureRefining : public Pass {
     }
 
     // Update function contents for their new parameter types.
-    struct CodeUpdater : public WalkerPass<PostWalker<CodeUpdater>> {
+    struct CodeUpdater final : public WalkerPass<PostWalker<CodeUpdater>> {
       bool isFunctionParallel() override { return true; }
 
       SignatureRefining& parent;

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -92,7 +92,8 @@ struct GlobalInfo {
 
 using GlobalInfoMap = std::map<Name, GlobalInfo>;
 
-struct GlobalUseScanner : public WalkerPass<PostWalker<GlobalUseScanner>> {
+struct GlobalUseScanner final
+  : public WalkerPass<PostWalker<GlobalUseScanner>> {
   bool isFunctionParallel() override { return true; }
 
   GlobalUseScanner(GlobalInfoMap* infos) : infos(infos) {}
@@ -190,7 +191,7 @@ struct GlobalUseScanner : public WalkerPass<PostWalker<GlobalUseScanner>> {
     //
     // To check this, find the get of the global in the condition, and look up
     // through its parents to see how the global's value is used.
-    struct FlowScanner
+    struct FlowScanner final
       : public ExpressionStackWalker<FlowScanner,
                                      UnifiedExpressionVisitor<FlowScanner>> {
       GlobalUseScanner& globalUseScanner;
@@ -301,7 +302,8 @@ private:
 using NameNameMap = std::map<Name, Name>;
 using NameSet = std::set<Name>;
 
-struct GlobalUseModifier : public WalkerPass<PostWalker<GlobalUseModifier>> {
+struct GlobalUseModifier final
+  : public WalkerPass<PostWalker<GlobalUseModifier>> {
   bool isFunctionParallel() override { return true; }
 
   GlobalUseModifier(NameNameMap* copiedParentMap)
@@ -322,7 +324,7 @@ private:
   NameNameMap* copiedParentMap;
 };
 
-struct ConstantGlobalApplier
+struct ConstantGlobalApplier final
   : public WalkerPass<
       LinearExecutionWalker<ConstantGlobalApplier,
                             UnifiedExpressionVisitor<ConstantGlobalApplier>>> {
@@ -393,7 +395,8 @@ private:
   std::map<Name, Literals> currConstantGlobals;
 };
 
-struct GlobalSetRemover : public WalkerPass<PostWalker<GlobalSetRemover>> {
+struct GlobalSetRemover final
+  : public WalkerPass<PostWalker<GlobalSetRemover>> {
   GlobalSetRemover(const NameSet* toRemove, bool optimize)
     : toRemove(toRemove), optimize(optimize) {}
 
@@ -427,7 +430,7 @@ private:
 
 } // anonymous namespace
 
-struct SimplifyGlobals : public Pass {
+struct SimplifyGlobals final : public Pass {
   PassRunner* runner;
   Module* module;
 

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -65,7 +65,7 @@ namespace wasm {
 template<bool allowTee = true,
          bool allowStructure = true,
          bool allowNesting = true>
-struct SimplifyLocals
+struct SimplifyLocals final
   : public WalkerPass<LinearExecutionWalker<
       SimplifyLocals<allowTee, allowStructure, allowNesting>>> {
   bool isFunctionParallel() override { return true; }
@@ -970,7 +970,7 @@ struct SimplifyLocals
     //    )
     //   )
     // will inhibit us creating an if return value.
-    struct EquivalentOptimizer
+    struct EquivalentOptimizer final
       : public LinearExecutionWalker<EquivalentOptimizer> {
       std::vector<Index>* numLocalGets;
       bool removeEquivalentSets;

--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -699,7 +699,7 @@ struct Printer {
 
 } // namespace DataFlow
 
-struct Souperify : public WalkerPass<PostWalker<Souperify>> {
+struct Souperify final : public WalkerPass<PostWalker<Souperify>> {
   // Not parallel, for now - could parallelize and combine outputs at the end.
   // If Souper is thread-safe, we could also run it in parallel.
 

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -33,7 +33,7 @@
 
 namespace wasm {
 
-struct SpillPointers
+struct SpillPointers final
   : public WalkerPass<LivenessWalker<SpillPointers, Visitor<SpillPointers>>> {
   bool isFunctionParallel() override { return true; }
 

--- a/src/passes/StackCheck.cpp
+++ b/src/passes/StackCheck.cpp
@@ -56,7 +56,8 @@ static void addExportedFunction(Module& module,
   module.addExport(std::move(export_));
 }
 
-struct EnforceStackLimits : public WalkerPass<PostWalker<EnforceStackLimits>> {
+struct EnforceStackLimits final
+  : public WalkerPass<PostWalker<EnforceStackLimits>> {
   EnforceStackLimits(const Global* stackPointer,
                      const Global* stackBase,
                      const Global* stackLimit,
@@ -122,7 +123,7 @@ private:
   Name handler;
 };
 
-struct StackCheck : public Pass {
+struct StackCheck final : public Pass {
   void run(PassRunner* runner, Module* module) override {
     Global* stackPointer = getStackPointerGlobal(*module);
     if (!stackPointer) {

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -28,7 +28,7 @@ namespace wasm {
 
 // Generate Stack IR from Binaryen IR
 
-struct GenerateStackIR : public WalkerPass<PostWalker<GenerateStackIR>> {
+struct GenerateStackIR final : public WalkerPass<PostWalker<GenerateStackIR>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new GenerateStackIR; }
@@ -365,7 +365,7 @@ private:
   }
 };
 
-struct OptimizeStackIR : public WalkerPass<PostWalker<OptimizeStackIR>> {
+struct OptimizeStackIR final : public WalkerPass<PostWalker<OptimizeStackIR>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new OptimizeStackIR; }

--- a/src/passes/Strip.cpp
+++ b/src/passes/Strip.cpp
@@ -27,7 +27,7 @@
 
 namespace wasm {
 
-struct Strip : public Pass {
+struct Strip final : public Pass {
   // A function that returns true if the method should be removed.
   typedef std::function<bool(UserSection&)> Decider;
   Decider decider;

--- a/src/passes/StripTargetFeatures.cpp
+++ b/src/passes/StripTargetFeatures.cpp
@@ -18,7 +18,7 @@
 
 namespace wasm {
 
-struct StripTargetFeatures : public Pass {
+struct StripTargetFeatures final : public Pass {
   bool isStripped = false;
   StripTargetFeatures(bool isStripped) : isStripped(isStripped) {}
   void run(PassRunner* runner, Module* module) override {

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -298,7 +298,7 @@ Expression* makeTrappingUnary(Unary* curr,
   return builder.makeCall(name, {curr->value}, curr->type);
 }
 
-struct TrapModePass : public WalkerPass<PostWalker<TrapModePass>> {
+struct TrapModePass final : public WalkerPass<PostWalker<TrapModePass>> {
 public:
   // Needs to be non-parallel so that visitModule gets called after visiting
   // each node in the module, so we can add the functions that we created.

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -36,7 +36,7 @@ namespace {
 // as well as relevant nulls (nulls force us to keep the type nullable).
 using FieldInfo = LUBFinder;
 
-struct FieldInfoScanner
+struct FieldInfoScanner final
   : public StructUtils::StructScanner<FieldInfo, FieldInfoScanner> {
   Pass* create() override {
     return new FieldInfoScanner(functionNewInfos, functionSetGetInfos);
@@ -74,7 +74,7 @@ struct FieldInfoScanner
   }
 };
 
-struct TypeRefining : public Pass {
+struct TypeRefining final : public Pass {
   StructUtils::StructValuesMap<FieldInfo> finalInfos;
 
   void run(PassRunner* runner, Module* module) override {
@@ -210,7 +210,7 @@ struct TypeRefining : public Pass {
   // something that is invalid for that read. To ensure the code still
   // validates, simply remove such reads.
   void updateInstructions(Module& wasm, PassRunner* runner) {
-    struct ReadUpdater : public WalkerPass<PostWalker<ReadUpdater>> {
+    struct ReadUpdater final : public WalkerPass<PostWalker<ReadUpdater>> {
       bool isFunctionParallel() override { return true; }
 
       TypeRefining& parent;

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -251,7 +251,7 @@ struct TypeRefining final : public Pass {
   }
 
   void updateTypes(Module& wasm, PassRunner* runner) {
-    class TypeRewriter : public GlobalTypeRewriter {
+    class TypeRewriter final : public GlobalTypeRewriter {
       TypeRefining& parent;
 
     public:

--- a/src/passes/Untee.cpp
+++ b/src/passes/Untee.cpp
@@ -28,7 +28,7 @@
 
 namespace wasm {
 
-struct Untee : public WalkerPass<PostWalker<Untee>> {
+struct Untee final : public WalkerPass<PostWalker<Untee>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new Untee; }

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -30,7 +30,7 @@
 
 namespace wasm {
 
-struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
+struct Vacuum final : public WalkerPass<ExpressionStackWalker<Vacuum>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new Vacuum; }

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -56,7 +56,7 @@ inline void optimizeAfterInlining(const std::unordered_set<Function*>& funcs,
   module->updateMaps();
 }
 
-struct FunctionRefReplacer
+struct FunctionRefReplacer final
   : public WalkerPass<PostWalker<FunctionRefReplacer>> {
   bool isFunctionParallel() override { return true; }
 

--- a/src/passes/param-utils.cpp
+++ b/src/passes/param-utils.cpp
@@ -111,7 +111,7 @@ bool removeParameter(const std::vector<Function*>& funcs,
     newIndexes.push_back(Builder::addVar(func, type));
   }
   // Update local operations.
-  struct LocalUpdater : public PostWalker<LocalUpdater> {
+  struct LocalUpdater final : public PostWalker<LocalUpdater> {
     Index removedIndex;
     Index newIndex;
     LocalUpdater(Function* func, Index removedIndex, Index newIndex)

--- a/src/passes/test_passes.cpp
+++ b/src/passes/test_passes.cpp
@@ -29,7 +29,7 @@ namespace wasm {
 namespace {
 
 // Pass to test EHUtil::handleBlockNestedPops function
-struct CatchPopFixup : public WalkerPass<PostWalker<CatchPopFixup>> {
+struct CatchPopFixup final : public WalkerPass<PostWalker<CatchPopFixup>> {
   bool isFunctionParallel() override { return true; }
   Pass* create() override { return new CatchPopFixup; }
 

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -171,13 +171,14 @@ public:
     }
   };
 
-  struct Iterator : IteratorBase<SmallVector<T, N>, Iterator> {
+  struct Iterator final : IteratorBase<SmallVector<T, N>, Iterator> {
     Iterator(SmallVector<T, N>* parent, size_t index)
       : IteratorBase<SmallVector<T, N>, Iterator>(parent, index) {}
     value_type& operator*() { return (*this->parent)[this->index]; }
   };
 
-  struct ConstIterator : IteratorBase<const SmallVector<T, N>, ConstIterator> {
+  struct ConstIterator final
+    : IteratorBase<const SmallVector<T, N>, ConstIterator> {
     ConstIterator(const SmallVector<T, N>* parent, size_t index)
       : IteratorBase<const SmallVector<T, N>, ConstIterator>(parent, index) {}
     const value_type& operator*() const { return (*this->parent)[this->index]; }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -579,7 +579,7 @@ void TranslateToFuzzReader::recombine(Function* func) {
     return;
   }
   // First, scan and group all expressions by type.
-  struct Scanner
+  struct Scanner final
     : public PostWalker<Scanner, UnifiedExpressionVisitor<Scanner>> {
     TranslateToFuzzReader& parent;
     // A map of all expressions, categorized by type.
@@ -620,7 +620,8 @@ void TranslateToFuzzReader::recombine(Function* func) {
   // Second, with some probability replace an item with another item having
   // the same type. (This is not always valid due to nesting of labels, but
   // we'll fix that up later.)
-  struct Modder : public PostWalker<Modder, UnifiedExpressionVisitor<Modder>> {
+  struct Modder final
+    : public PostWalker<Modder, UnifiedExpressionVisitor<Modder>> {
     Module& wasm;
     Scanner& scanner;
     TranslateToFuzzReader& parent;
@@ -647,7 +648,8 @@ void TranslateToFuzzReader::mutate(Function* func) {
   if (oneIn(2)) {
     return;
   }
-  struct Modder : public PostWalker<Modder, UnifiedExpressionVisitor<Modder>> {
+  struct Modder final
+    : public PostWalker<Modder, UnifiedExpressionVisitor<Modder>> {
     Module& wasm;
     TranslateToFuzzReader& parent;
 
@@ -676,7 +678,7 @@ void TranslateToFuzzReader::mutate(Function* func) {
 }
 
 void TranslateToFuzzReader::fixLabels(Function* func) {
-  struct Fixer
+  struct Fixer final
     : public ControlFlowWalker<Fixer, UnifiedExpressionVisitor<Fixer>> {
     Module& wasm;
     TranslateToFuzzReader& parent;
@@ -794,7 +796,7 @@ void TranslateToFuzzReader::dropToLog(Function* func) {
   if (oneIn(2)) {
     return;
   }
-  struct Modder : public PostWalker<Modder> {
+  struct Modder final : public PostWalker<Modder> {
     Module& wasm;
     TranslateToFuzzReader& parent;
 

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -189,7 +189,7 @@ struct MetaDCEGraph {
     // Add initializer dependencies
     // if we provide a parent DCE name, that is who can reach what we see
     // if none is provided, then it is something we must root
-    struct InitScanner : public PostWalker<InitScanner> {
+    struct InitScanner final : public PostWalker<InitScanner> {
       InitScanner(MetaDCEGraph* parent, Name parentDceName)
         : parent(parent), parentDceName(parentDceName) {}
 
@@ -242,7 +242,7 @@ struct MetaDCEGraph {
     }
 
     // A parallel scanner for function bodies
-    struct Scanner : public WalkerPass<PostWalker<Scanner>> {
+    struct Scanner final : public WalkerPass<PostWalker<Scanner>> {
       bool isFunctionParallel() override { return true; }
 
       Scanner(MetaDCEGraph* parent) : parent(parent) {}

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -228,7 +228,7 @@ ProgramResult expected;
 // case we may try again but much later.
 static std::unordered_set<Name> functionsWeTriedToRemove;
 
-struct Reducer
+struct Reducer final
   : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<Reducer>>> {
   std::string command, test, working;
   bool binary, deNan, verbose, debugInfo;
@@ -1068,7 +1068,7 @@ struct Reducer
     }
 
     // remove all references to them
-    struct FunctionReferenceRemover
+    struct FunctionReferenceRemover final
       : public PostWalker<FunctionReferenceRemover> {
       std::unordered_set<Name> names;
       std::vector<Name> exportsToRemove;

--- a/src/tools/wasm-split/instrumenter.h
+++ b/src/tools/wasm-split/instrumenter.h
@@ -26,7 +26,7 @@ namespace wasm {
 // Add a global monotonic counter and a timestamp global for each function, code
 // at the beginning of each function to set its timestamp, and a new exported
 // function for dumping the profile data.
-struct Instrumenter : public Pass {
+struct Instrumenter final : public Pass {
   PassRunner* runner = nullptr;
   Module* wasm = nullptr;
 

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -36,7 +36,7 @@ namespace {
 static void optimizeWasm(Module& wasm, PassOptions options) {
   // Perform various optimizations that will be good for JS, but would not be
   // great for wasm in general
-  struct OptimizeForJS : public WalkerPass<PostWalker<OptimizeForJS>> {
+  struct OptimizeForJS final : public WalkerPass<PostWalker<OptimizeForJS>> {
     bool isFunctionParallel() override { return true; }
 
     Pass* create() override { return new OptimizeForJS; }

--- a/src/wasm/parsing.cpp
+++ b/src/wasm/parsing.cpp
@@ -105,7 +105,7 @@ void UniqueNameMapper::clear() {
 }
 
 void UniqueNameMapper::uniquify(Expression* curr) {
-  struct Walker
+  struct Walker final
     : public ControlFlowWalker<Walker, UnifiedExpressionVisitor<Walker>> {
     UniqueNameMapper mapper;
 

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -130,7 +130,7 @@ private:
     std::unordered_map<Index, Address> passiveOffsets;
     if (wasm.features.hasBulkMemory()) {
       // Fetch passive segment offsets out of memory.init instructions
-      struct OffsetSearcher : PostWalker<OffsetSearcher> {
+      struct OffsetSearcher final : PostWalker<OffsetSearcher> {
         std::unordered_map<Index, Address>& offsets;
         OffsetSearcher(std::unordered_map<unsigned, Address>& offsets)
           : offsets(offsets) {}
@@ -188,7 +188,7 @@ struct AsmConst {
   std::string code;
 };
 
-struct SegmentRemover : WalkerPass<PostWalker<SegmentRemover>> {
+struct SegmentRemover final : WalkerPass<PostWalker<SegmentRemover>> {
   SegmentRemover(Index segment) : segment(segment) {}
 
   bool isFunctionParallel() override { return true; }
@@ -282,7 +282,7 @@ static std::vector<AsmConst> findEmAsmConsts(Module& wasm,
   return asmConsts;
 }
 
-struct EmJsWalker : public PostWalker<EmJsWalker> {
+struct EmJsWalker final : public PostWalker<EmJsWalker> {
   Module& wasm;
   StringConstantTracker stringTracker;
   std::vector<Export> toRemove;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -3068,7 +3068,7 @@ void CanonicalizationState::updateUses(ReplacementMap& replacements,
     return;
   }
   // Replace all old types reachable from `info`.
-  struct ChildUpdater : HeapTypeChildWalker<ChildUpdater> {
+  struct ChildUpdater final : HeapTypeChildWalker<ChildUpdater> {
     ReplacementMap& replacements;
     ChildUpdater(ReplacementMap& replacements) : replacements(replacements) {}
     void noteChild(HeapType* child) {
@@ -3394,7 +3394,7 @@ ShapeCanonicalizer::ShapeCanonicalizer(std::vector<HeapType>& roots) {
 }
 
 void ShapeCanonicalizer::initialize(std::vector<HeapType>& roots) {
-  struct Initializer : HeapTypeGraphWalker<Initializer> {
+  struct Initializer final : HeapTypeGraphWalker<Initializer> {
     ShapeCanonicalizer& canonicalizer;
 
     // Maps shallow HeapType shapes to corresponding HeapType indices.
@@ -3426,7 +3426,7 @@ void ShapeCanonicalizer::initialize(std::vector<HeapType>& roots) {
 
       // Traverse the non-basic children to collect graph edges, i.e.
       // transitions in the DFA.
-      struct TransitionInitializer
+      struct TransitionInitializer final
         : HeapTypeChildWalker<TransitionInitializer> {
         Initializer& initializer;
         size_t parent;
@@ -3569,7 +3569,7 @@ void ShapeCanonicalizer::createReplacements() {
 void globallyCanonicalize(CanonicalizationState& state) {
   // Map each temporary Type and HeapType to the locations where they will
   // have to be replaced with canonical Types and HeapTypes.
-  struct Locations : TypeGraphWalker<Locations> {
+  struct Locations final : TypeGraphWalker<Locations> {
     std::unordered_map<Type, std::unordered_set<Type*>> types;
     std::unordered_map<HeapType, std::unordered_set<HeapType*>> heapTypes;
 
@@ -3871,7 +3871,7 @@ void canonicalizeBasicTypes(CanonicalizationState& state) {
     // Canonicalizing basic heap types may cause their parent types to become
     // canonicalizable as well, for example after creating `(ref null any)` we
     // can futher canonicalize to `anyref`.
-    struct TypeCanonicalizer : TypeGraphWalkerBase<TypeCanonicalizer> {
+    struct TypeCanonicalizer final : TypeGraphWalkerBase<TypeCanonicalizer> {
       void scanType(Type* type) {
         if (type->isTuple()) {
           TypeGraphWalkerBase<TypeCanonicalizer>::scanType(type);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -204,7 +204,8 @@ struct ValidationInfo {
   }
 };
 
-struct FunctionValidator : public WalkerPass<PostWalker<FunctionValidator>> {
+struct FunctionValidator final
+  : public WalkerPass<PostWalker<FunctionValidator>> {
   bool isFunctionParallel() override { return true; }
 
   Pass* create() override { return new FunctionValidator(*getModule(), &info); }
@@ -2864,7 +2865,7 @@ void FunctionValidator::validateAlignment(
 }
 
 static void validateBinaryenIR(Module& wasm, ValidationInfo& info) {
-  struct BinaryenIRValidator
+  struct BinaryenIRValidator final
     : public PostWalker<BinaryenIRValidator,
                         UnifiedExpressionVisitor<BinaryenIRValidator>> {
     ValidationInfo& info;

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1039,7 +1039,7 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
     }
   };
 
-  struct ExpressionProcessor
+  struct ExpressionProcessor final
     : public OverriddenVisitor<ExpressionProcessor, Ref> {
     Wasm2JSBuilder* parent;
     IString result; // TODO: remove

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -950,7 +950,7 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
   // be optimized into the switch, since they must be reached normally,
   // unless they happen to be right after us, in which case it's just
   // a fallthrough anyhow.
-  struct SwitchProcessor : public ExpressionStackWalker<SwitchProcessor> {
+  struct SwitchProcessor final : public ExpressionStackWalker<SwitchProcessor> {
     // A list of expressions we don't need to emit, as we are handling them
     // in another way.
     std::set<Expression*> unneededExpressions;


### PR DESCRIPTION
This PR introduces minor optimization for classes. Adding "final" for derived classes with virtual members may reduce dynamic dispatching