### PR TITLE
fix: Avoid trying to read offset if segment is passive

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2519,8 +2519,13 @@ function wrapModule(module, self = {}) {
     return Module['_BinaryenGetNumMemorySegments'](module);
   };
   self['getMemorySegmentInfoByIndex'] = function(id) {
+    const passive = Boolean(Module['_BinaryenGetMemorySegmentPassive'](module, id));
+    let offset = null;
+    if (!passive) {
+      offset = Module['_BinaryenGetMemorySegmentByteOffset'](module, id);
+    }
     return {
-      'offset': Module['_BinaryenGetMemorySegmentByteOffset'](module, id),
+      'offset': offset,
       'data': (function(){
         const size = Module['_BinaryenGetMemorySegmentByteLength'](module, id);
         const ptr = _malloc(size);
@@ -2530,7 +2535,7 @@ function wrapModule(module, self = {}) {
         _free(ptr);
         return res.buffer;
       })(),
-      'passive': Boolean(Module['_BinaryenGetMemorySegmentPassive'](module, id))
+      'passive': passive
     };
   };
   self['setStart'] = function(start) {

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -1091,9 +1091,9 @@ function test_for_each() {
     assert(module.getExportByIndex(i) === exps[i]);
   }
 
-  var expected_offsets = [10, 125];
-  var expected_data = ["hello, world", "segment data 2"];
-  var expected_passive = [false, false];
+  var expected_offsets = [10, 125, null];
+  var expected_data = ["hello, world", "segment data 2", "hello, passive"];
+  var expected_passive = [false, false, true];
 
   var glos = [
     module.addGlobal("a-global", binaryen.i32, false, module.i32.const(expected_offsets[1])),
@@ -1115,6 +1115,11 @@ function test_for_each() {
       passive: expected_passive[1],
       offset: module.global.get("a-global"),
       data: expected_data[1].split('').map(function(x) { return x.charCodeAt(0) })
+    },
+    {
+      passive: expected_passive[2],
+      offset: expected_offsets[2],
+      data: expected_data[2].split('').map(function(x) { return x.charCodeAt(0) })
     }
   ], false);
   for (i = 0; i < module.getNumMemorySegments(); i++) {

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -4860,6 +4860,7 @@ sizeof Literal: 24
  (memory $0 1 256)
  (data (i32.const 10) "hello, world")
  (data (global.get $a-global) "segment data 2")
+ (data "hello, passive")
  (table $t0 1 funcref)
  (elem $e0 (i32.const 0) $fn0 $fn1 $fn2)
  (export "export0" (func $fn0))


### PR DESCRIPTION
When trying to implement some tests in Binaryen.ml, @ospencer encountered an issue where `getMemorySegmentInfoByIndex` throws if the segment is passive. This happens because the helper function was trying to *always* read the offset, even if it isn't a valid operation.

This just re-orders the calls and defaults `offset` to null for passive segments.

I want to make a follow-up PR that allows Binaryen.ml to use these utilities individually, but this is the quickest fix.