### PR TITLE
[WasmGC] OptimizeInstructions: Improve RefIs cast ordering

### DIFF
--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -192,66 +192,79 @@
     )
   )
 
-  ;; TNH:      (func $ref.is_func (type $anyref_=>_none) (param $a anyref)
+  ;; TNH:      (func $ref.is_func_a (type $anyref_=>_i32) (param $a anyref) (result i32)
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block (result i32)
-  ;; TNH-NEXT:    (drop
-  ;; TNH-NEXT:     (ref.as_func
-  ;; TNH-NEXT:      (local.get $a)
-  ;; TNH-NEXT:     )
-  ;; TNH-NEXT:    )
-  ;; TNH-NEXT:    (i32.const 1)
+  ;; TNH-NEXT:   (ref.cast_static $struct
+  ;; TNH-NEXT:    (local.get $a)
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
-  ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block (result i32)
-  ;; TNH-NEXT:    (drop
-  ;; TNH-NEXT:     (ref.as_data
-  ;; TNH-NEXT:      (local.get $a)
-  ;; TNH-NEXT:     )
-  ;; TNH-NEXT:    )
-  ;; TNH-NEXT:    (i32.const 0)
-  ;; TNH-NEXT:   )
-  ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (i32.const 0)
   ;; TNH-NEXT: )
-  ;; NO_TNH:      (func $ref.is_func (type $anyref_=>_none) (param $a anyref)
+  ;; NO_TNH:      (func $ref.is_func_a (type $anyref_=>_i32) (param $a anyref) (result i32)
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (block (result i32)
-  ;; NO_TNH-NEXT:    (drop
-  ;; NO_TNH-NEXT:     (ref.as_func
-  ;; NO_TNH-NEXT:      (local.get $a)
-  ;; NO_TNH-NEXT:     )
-  ;; NO_TNH-NEXT:    )
-  ;; NO_TNH-NEXT:    (i32.const 1)
+  ;; NO_TNH-NEXT:   (ref.cast_static $struct
+  ;; NO_TNH-NEXT:    (local.get $a)
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )
-  ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (block (result i32)
-  ;; NO_TNH-NEXT:    (drop
-  ;; NO_TNH-NEXT:     (ref.as_data
-  ;; NO_TNH-NEXT:      (local.get $a)
-  ;; NO_TNH-NEXT:     )
-  ;; NO_TNH-NEXT:    )
-  ;; NO_TNH-NEXT:    (i32.const 0)
-  ;; NO_TNH-NEXT:   )
-  ;; NO_TNH-NEXT:  )
+  ;; NO_TNH-NEXT:  (i32.const 0)
   ;; NO_TNH-NEXT: )
-  (func $ref.is_func (param $a (ref null any))
-    ;; As above, but a ref.is that is not a null check. We can return 1 here,
-    ;; and drop the rest, with or without TNH.
-    (drop
-      (ref.is_func
-        (ref.as_func
-          (local.get $a)
-        )
+  (func $ref.is_func_a (param $a (ref null any)) (result i32)
+    ;; As above, but ref.is_func instead. Again, we can remove the cast in TNH.
+    (ref.is_func
+      (ref.cast_static $struct
+        (local.get $a)
       )
     )
+  )
+
+  ;; TNH:      (func $ref.is_func_b (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (ref.as_func
+  ;; TNH-NEXT:    (local.get $a)
+  ;; TNH-NEXT:   )
+  ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (i32.const 1)
+  ;; TNH-NEXT: )
+  ;; NO_TNH:      (func $ref.is_func_b (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; NO_TNH-NEXT:  (drop
+  ;; NO_TNH-NEXT:   (ref.as_func
+  ;; NO_TNH-NEXT:    (local.get $a)
+  ;; NO_TNH-NEXT:   )
+  ;; NO_TNH-NEXT:  )
+  ;; NO_TNH-NEXT:  (i32.const 1)
+  ;; NO_TNH-NEXT: )
+  (func $ref.is_func_b (param $a (ref null any)) (result i32)
+    ;; The check must succeed. We can return 1 here, and drop the rest, with or
+    ;; without TNH (in particular, TNH should not just remove the cast but not
+    ;; return a 1).
+    (ref.is_func
+      (ref.as_func
+        (local.get $a)
+      )
+    )
+  )
+
+  ;; TNH:      (func $ref.is_func_c (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (ref.as_data
+  ;; TNH-NEXT:    (local.get $a)
+  ;; TNH-NEXT:   )
+  ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (i32.const 0)
+  ;; TNH-NEXT: )
+  ;; NO_TNH:      (func $ref.is_func_c (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; NO_TNH-NEXT:  (drop
+  ;; NO_TNH-NEXT:   (ref.as_data
+  ;; NO_TNH-NEXT:    (local.get $a)
+  ;; NO_TNH-NEXT:   )
+  ;; NO_TNH-NEXT:  )
+  ;; NO_TNH-NEXT:  (i32.const 0)
+  ;; NO_TNH-NEXT: )
+  (func $ref.is_func_c (param $a (ref null any)) (result i32)
     ;; A case where the type cannot match, and we return 0.
-    (drop
-      (ref.is_func
-        (ref.as_data
-          (local.get $a)
-        )
+    (ref.is_func
+      (ref.as_data
+        (local.get $a)
       )
     )
   )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -136,9 +136,14 @@
   )
 
   ;; TNH:      (func $ref.is (type $eqref_=>_i32) (param $a eqref) (result i32)
-  ;; TNH-NEXT:  (ref.is_null
-  ;; TNH-NEXT:   (local.get $a)
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (ref.cast_static $struct
+  ;; TNH-NEXT:    (ref.as_data
+  ;; TNH-NEXT:     (local.get $a)
+  ;; TNH-NEXT:    )
+  ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (i32.const 0)
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $ref.is (type $eqref_=>_i32) (param $a eqref) (result i32)
   ;; NO_TNH-NEXT:  (drop
@@ -151,12 +156,103 @@
   ;; NO_TNH-NEXT:  (i32.const 0)
   ;; NO_TNH-NEXT: )
   (func $ref.is (param $a (ref null eq)) (result i32)
+    ;; In this case non-nullability is enough to tell that the ref.is will
+    ;; return 0. TNH does not help here.
     (ref.is_null
       (ref.cast_static $struct
         (ref.as_non_null
           (ref.as_data
             (local.get $a)
           )
+        )
+      )
+    )
+  )
+
+  ;; TNH:      (func $ref.is_b (type $eqref_=>_i32) (param $a eqref) (result i32)
+  ;; TNH-NEXT:  (ref.is_null
+  ;; TNH-NEXT:   (ref.cast_static $struct
+  ;; TNH-NEXT:    (local.get $a)
+  ;; TNH-NEXT:   )
+  ;; TNH-NEXT:  )
+  ;; TNH-NEXT: )
+  ;; NO_TNH:      (func $ref.is_b (type $eqref_=>_i32) (param $a eqref) (result i32)
+  ;; NO_TNH-NEXT:  (ref.is_null
+  ;; NO_TNH-NEXT:   (ref.cast_static $struct
+  ;; NO_TNH-NEXT:    (local.get $a)
+  ;; NO_TNH-NEXT:   )
+  ;; NO_TNH-NEXT:  )
+  ;; NO_TNH-NEXT: )
+  (func $ref.is_b(param $a (ref null eq)) (result i32)
+    ;; Here we only have a cast, and no ref.as operations that force the value
+    ;; to be non-nullable. That means we cannot remove the ref.is, but we can
+    ;; remove the cast in TNH.
+    (ref.is_null
+      (ref.cast_static $struct
+        (local.get $a)
+      )
+    )
+  )
+
+  ;; TNH:      (func $ref.is_func (type $anyref_=>_none) (param $a anyref)
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (block (result i32)
+  ;; TNH-NEXT:    (drop
+  ;; TNH-NEXT:     (ref.as_func
+  ;; TNH-NEXT:      (local.get $a)
+  ;; TNH-NEXT:     )
+  ;; TNH-NEXT:    )
+  ;; TNH-NEXT:    (i32.const 1)
+  ;; TNH-NEXT:   )
+  ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (block (result i32)
+  ;; TNH-NEXT:    (drop
+  ;; TNH-NEXT:     (ref.as_data
+  ;; TNH-NEXT:      (local.get $a)
+  ;; TNH-NEXT:     )
+  ;; TNH-NEXT:    )
+  ;; TNH-NEXT:    (i32.const 0)
+  ;; TNH-NEXT:   )
+  ;; TNH-NEXT:  )
+  ;; TNH-NEXT: )
+  ;; NO_TNH:      (func $ref.is_func (type $anyref_=>_none) (param $a anyref)
+  ;; NO_TNH-NEXT:  (drop
+  ;; NO_TNH-NEXT:   (block (result i32)
+  ;; NO_TNH-NEXT:    (drop
+  ;; NO_TNH-NEXT:     (ref.as_func
+  ;; NO_TNH-NEXT:      (local.get $a)
+  ;; NO_TNH-NEXT:     )
+  ;; NO_TNH-NEXT:    )
+  ;; NO_TNH-NEXT:    (i32.const 1)
+  ;; NO_TNH-NEXT:   )
+  ;; NO_TNH-NEXT:  )
+  ;; NO_TNH-NEXT:  (drop
+  ;; NO_TNH-NEXT:   (block (result i32)
+  ;; NO_TNH-NEXT:    (drop
+  ;; NO_TNH-NEXT:     (ref.as_data
+  ;; NO_TNH-NEXT:      (local.get $a)
+  ;; NO_TNH-NEXT:     )
+  ;; NO_TNH-NEXT:    )
+  ;; NO_TNH-NEXT:    (i32.const 0)
+  ;; NO_TNH-NEXT:   )
+  ;; NO_TNH-NEXT:  )
+  ;; NO_TNH-NEXT: )
+  (func $ref.is_func (param $a (ref null any))
+    ;; As above, but a ref.is that is not a null check. We can return 1 here,
+    ;; and drop the rest, with or without TNH.
+    (drop
+      (ref.is_func
+        (ref.as_func
+          (local.get $a)
+        )
+      )
+    )
+    ;; A case where the type cannot match, and we return 0.
+    (drop
+      (ref.is_func
+        (ref.as_data
+          (local.get $a)
         )
       )
     )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -194,38 +194,13 @@
 
   ;; TNH:      (func $ref.is_func_a (type $anyref_=>_i32) (param $a anyref) (result i32)
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (ref.cast_static $struct
-  ;; TNH-NEXT:    (local.get $a)
-  ;; TNH-NEXT:   )
-  ;; TNH-NEXT:  )
-  ;; TNH-NEXT:  (i32.const 0)
-  ;; TNH-NEXT: )
-  ;; NO_TNH:      (func $ref.is_func_a (type $anyref_=>_i32) (param $a anyref) (result i32)
-  ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (ref.cast_static $struct
-  ;; NO_TNH-NEXT:    (local.get $a)
-  ;; NO_TNH-NEXT:   )
-  ;; NO_TNH-NEXT:  )
-  ;; NO_TNH-NEXT:  (i32.const 0)
-  ;; NO_TNH-NEXT: )
-  (func $ref.is_func_a (param $a (ref null any)) (result i32)
-    ;; As above, but ref.is_func instead. Again, we can remove the cast in TNH.
-    (ref.is_func
-      (ref.cast_static $struct
-        (local.get $a)
-      )
-    )
-  )
-
-  ;; TNH:      (func $ref.is_func_b (type $anyref_=>_i32) (param $a anyref) (result i32)
-  ;; TNH-NEXT:  (drop
   ;; TNH-NEXT:   (ref.as_func
   ;; TNH-NEXT:    (local.get $a)
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (i32.const 1)
   ;; TNH-NEXT: )
-  ;; NO_TNH:      (func $ref.is_func_b (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; NO_TNH:      (func $ref.is_func_a (type $anyref_=>_i32) (param $a anyref) (result i32)
   ;; NO_TNH-NEXT:  (drop
   ;; NO_TNH-NEXT:   (ref.as_func
   ;; NO_TNH-NEXT:    (local.get $a)
@@ -233,7 +208,7 @@
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT:  (i32.const 1)
   ;; NO_TNH-NEXT: )
-  (func $ref.is_func_b (param $a (ref null any)) (result i32)
+  (func $ref.is_func_a (param $a (ref null any)) (result i32)
     ;; The check must succeed. We can return 1 here, and drop the rest, with or
     ;; without TNH (in particular, TNH should not just remove the cast but not
     ;; return a 1).
@@ -244,7 +219,7 @@
     )
   )
 
-  ;; TNH:      (func $ref.is_func_c (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; TNH:      (func $ref.is_func_b (type $anyref_=>_i32) (param $a anyref) (result i32)
   ;; TNH-NEXT:  (drop
   ;; TNH-NEXT:   (ref.as_data
   ;; TNH-NEXT:    (local.get $a)
@@ -252,7 +227,7 @@
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (i32.const 0)
   ;; TNH-NEXT: )
-  ;; NO_TNH:      (func $ref.is_func_c (type $anyref_=>_i32) (param $a anyref) (result i32)
+  ;; NO_TNH:      (func $ref.is_func_b (type $anyref_=>_i32) (param $a anyref) (result i32)
   ;; NO_TNH-NEXT:  (drop
   ;; NO_TNH-NEXT:   (ref.as_data
   ;; NO_TNH-NEXT:    (local.get $a)
@@ -260,7 +235,7 @@
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT:  (i32.const 0)
   ;; NO_TNH-NEXT: )
-  (func $ref.is_func_c (param $a (ref null any)) (result i32)
+  (func $ref.is_func_b (param $a (ref null any)) (result i32)
     ;; A case where the type cannot match, and we return 0.
     (ref.is_func
       (ref.as_data

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -171,9 +171,7 @@
 
   ;; TNH:      (func $ref.is_b (type $eqref_=>_i32) (param $a eqref) (result i32)
   ;; TNH-NEXT:  (ref.is_null
-  ;; TNH-NEXT:   (ref.cast_static $struct
-  ;; TNH-NEXT:    (local.get $a)
-  ;; TNH-NEXT:   )
+  ;; TNH-NEXT:   (local.get $a)
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $ref.is_b (type $eqref_=>_i32) (param $a eqref) (result i32)


### PR DESCRIPTION
#4748 regressed us in some cases, because it removed casts first:
```wat
  (ref.is_func
    (ref.as_func
      (local.get $anyref)))
```
If the cast is removed first, and the local has no useful type info, then
we'd have removed the cast but could not remove the `ref.is`. But
the `ref.is` could be optimized to 1, as it must be a func - the type
info proves it thanks to the cast. To avoid this, remove casts after
everything else.