### PR TITLE
[EH] Fix printing bug in nested blocks + delegate

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2390,7 +2390,6 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
       }
     }
 
-    int startControlFlowDepth = controlFlowDepth;
     controlFlowDepth += stack.size();
     auto* top = stack.back();
     while (stack.size() > 0) {
@@ -2413,6 +2412,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
         }
         printFullLine(list[i]);
       }
+      controlFlowDepth--;
     }
     decIndent();
     if (full) {
@@ -2421,7 +2421,6 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
         o << ' ' << curr->name;
       }
     }
-    controlFlowDepth = startControlFlowDepth;
   }
   void visitIf(If* curr) {
     controlFlowDepth++;

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -352,4 +352,17 @@
       )
     )
   )
+
+  ;; When 'delegate' is next to a nested block, make sure its delegate argument
+  ;; is parsed correctly.
+  (func $nested-block-and-try
+    (block $l0
+      (block $l1)
+      (try
+        (do)
+        (delegate 1) ;; to caller
+      )
+    )
+    (nop)
+  )
 )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -393,4 +393,17 @@
    )
   )
  )
+ (func $nested-block-and-try
+  (block $l0
+   (block $l1
+   )
+   (try $try
+    (do
+     (nop)
+    )
+    (delegate 1)
+   )
+  )
+  (nop)
+ )
 )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -424,5 +424,18 @@
    )
   )
  )
+ (func $nested-block-and-try
+  (block $label$1
+   (block $label$2
+   )
+   (try $label$5
+    (do
+     (nop)
+    )
+    (delegate 1)
+   )
+  )
+  (nop)
+ )
 )
 

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -424,5 +424,18 @@
    )
   )
  )
+ (func $7
+  (block $label$1
+   (block $label$2
+   )
+   (try $label$5
+    (do
+     (nop)
+    )
+    (delegate 1)
+   )
+  )
+  (nop)
+ )
 )
 


### PR DESCRIPTION
`controlFlowDepth` is a variable used to print `delegate`'s target. When
printing nested blocks, we increase `controlFlowDepth` by the number of
nested blocks at once. But we should decrement it as we finish each
block, rather than decrease by the number of nested blocks at once,
because we need correct `controlFlowDepth` within nested blocks.