### PR TITLE
[Strings] Print shorthand types where possible

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -274,6 +274,22 @@ static std::ostream& printType(std::ostream& o, Type type, Module* wasm) {
     TypeNamePrinter(o, wasm).print(rtt.heapType);
     o << ')';
   } else if (type.isRef() && !type.isBasic()) {
+    auto heapType = type.getHeapType();
+    if (type.isNullable() && heapType.isBasic()) {
+      // Print shorthands for certain nullable basic heap types.
+      switch (heapType.getBasic()) {
+        case HeapType::string:
+          return o << "stringref";
+        case HeapType::stringview_wtf8:
+          return o << "stringview_wtf8";
+        case HeapType::stringview_wtf16:
+          return o << "stringview_wtf16";
+        case HeapType::stringview_iter:
+          return o << "stringview_iter";
+        default:
+          break;
+      }
+    }
     o << "(ref ";
     if (type.isNullable()) {
       o << "null ";

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2103,11 +2103,27 @@ std::ostream& TypePrinter::print(Type type) {
   if (type.isTuple()) {
     print(type.getTuple());
   } else if (type.isRef()) {
+    auto heapType = type.getHeapType();
+    if (type.isNullable() && heapType.isBasic()) {
+      // Print shorthands for certain nullable basic heap types.
+      switch (heapType.getBasic()) {
+        case HeapType::string:
+          return os << "stringref";
+        case HeapType::stringview_wtf8:
+          return os << "stringview_wtf8";
+        case HeapType::stringview_wtf16:
+          return os << "stringview_wtf16";
+        case HeapType::stringview_iter:
+          return os << "stringview_iter";
+        default:
+          break;
+      }
+    }
     os << "(ref ";
     if (type.isNullable()) {
       os << "null ";
     }
-    printHeapTypeName(type.getHeapType());
+    printHeapTypeName(heapType);
     os << ')';
   } else if (type.isRtt()) {
     print(type.getRtt());

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -5,7 +5,7 @@
 ;; RUN: foreach %s %t wasm-opt -all --roundtrip -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (func $foo (param $a (ref null string)) (param $b (ref null stringview_wtf8)) (param $c (ref null stringview_wtf16)) (param $d (ref null stringview_iter)) (param $e (ref null string)) (param $f (ref null stringview_wtf8)) (param $g (ref null stringview_wtf16)) (param $h (ref null stringview_iter)) (param $i (ref string)) (param $j (ref stringview_wtf8)) (param $k (ref stringview_wtf16)) (param $l (ref stringview_iter))
+  ;; CHECK:      (func $foo (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter) (param $e stringref) (param $f stringview_wtf8) (param $g stringview_wtf16) (param $h stringview_iter) (param $i (ref string)) (param $j (ref stringview_wtf8)) (param $k (ref stringview_wtf16)) (param $l (ref stringview_iter))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.new_wtf8 utf8
   ;; CHECK-NEXT:    (i32.const 1)


### PR DESCRIPTION
As suggested in #4755

It doesn't look like there's an obvious way to share this code. Perhaps `TypePrinter`
could be in a header and used from `Print`?