### PR TITLE
changes to print profile data to readable format 

### DIFF
--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -101,24 +101,23 @@ WasmSplitOptions::WasmSplitOptions()
       Options::Arguments::Zero,
       [&](Options* o, const std::string& argument) { mode = Mode::Instrument; })
     .add("--merge-profiles",
-      "",
-      "Merge multiple profiles for the same module into a single profile.",
-      WasmSplitOption,
-      Options::Arguments::Zero,
-      [&](Options* o, const std::string& argument) {
-      mode = Mode::MergeProfiles;
-      })
-    .add(
-      "--print-profile",
-      "",
-      "The profile to use to guide splitting.",
-      WasmSplitOption,
-      {Mode::PrintProfile},
-      Options::Arguments::One,
-      [&](Options* o, const std::string& argument) { 
-        mode = Mode::PrintProfile;
-        profileFile = argument; 
-      })
+         "",
+         "Merge multiple profiles for the same module into a single profile.",
+         WasmSplitOption,
+         Options::Arguments::Zero,
+         [&](Options* o, const std::string& argument) {
+           mode = Mode::MergeProfiles;
+         })
+    .add("--print-profile",
+         "",
+         "Print profile contents in a human-readable format.",
+         WasmSplitOption,
+         {Mode::PrintProfile},
+         Options::Arguments::One,
+         [&](Options* o, const std::string& argument) {
+           mode = Mode::PrintProfile;
+           profileFile = argument;
+         })
     .add(
       "--profile",
       "",
@@ -378,7 +377,7 @@ bool WasmSplitOptions::validate() {
       break;
     case Mode::PrintProfile:
       if (inputFiles.size() != 1) {
-        fail("Input one and only one profile path");
+        fail("Must have exactly one profile path.");
       }
       break;
   }

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -296,9 +296,7 @@ WasmSplitOptions::WasmSplitOptions()
          "Un-escape function names (in print-profile output)",
          WasmSplitOption,
          Options::Arguments::Zero,
-        [&](Options* o, const std::string& argument) {
-            unescape = true;
-        })
+         [&](Options* o, const std::string& argument) { unescape = true; })
     .add("--verbose",
          "-v",
          "Verbose output mode. Prints the functions that will be kept "

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -67,6 +67,9 @@ std::ostream& operator<<(std::ostream& o, WasmSplitOptions::Mode& mode) {
     case WasmSplitOptions::Mode::MergeProfiles:
       o << "merge-profiles";
       break;
+    case WasmSplitOptions::Mode::PrintProfile:
+      o << "print-profile";
+      break;
   }
   return o;
 }
@@ -98,13 +101,24 @@ WasmSplitOptions::WasmSplitOptions()
       Options::Arguments::Zero,
       [&](Options* o, const std::string& argument) { mode = Mode::Instrument; })
     .add("--merge-profiles",
-         "",
-         "Merge multiple profiles for the same module into a single profile.",
-         WasmSplitOption,
-         Options::Arguments::Zero,
-         [&](Options* o, const std::string& argument) {
-           mode = Mode::MergeProfiles;
-         })
+      "",
+      "Merge multiple profiles for the same module into a single profile.",
+      WasmSplitOption,
+      Options::Arguments::Zero,
+      [&](Options* o, const std::string& argument) {
+      mode = Mode::MergeProfiles;
+      })
+    .add(
+      "--print-profile",
+      "",
+      "The profile to use to guide splitting.",
+      WasmSplitOption,
+      {Mode::PrintProfile},
+      Options::Arguments::One,
+      [&](Options* o, const std::string& argument) { 
+        mode = Mode::PrintProfile;
+        profileFile = argument; 
+      })
     .add(
       "--profile",
       "",
@@ -361,6 +375,11 @@ bool WasmSplitOptions::validate() {
       break;
     case Mode::MergeProfiles:
       // Any number >= 1 allowed.
+      break;
+    case Mode::PrintProfile:
+      if (inputFiles.size() != 1) {
+        fail("Input one and only one profile path");
+      }
       break;
   }
 

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -291,6 +291,14 @@ WasmSplitOptions::WasmSplitOptions()
          {Mode::Instrument, Mode::MergeProfiles},
          Options::Arguments::One,
          [&](Options* o, const std::string& argument) { output = argument; })
+    .add("--unescape",
+         "-u",
+         "Un-escape function names (in print-profile output)",
+         WasmSplitOption,
+         Options::Arguments::Zero,
+        [&](Options* o, const std::string& argument) {
+            unescape = true;
+        })
     .add("--verbose",
          "-v",
          "Verbose output mode. Prints the functions that will be kept "

--- a/src/tools/wasm-split/split-options.h
+++ b/src/tools/wasm-split/split-options.h
@@ -40,6 +40,7 @@ struct WasmSplitOptions : ToolOptions {
   };
   StorageKind storageKind = StorageKind::InGlobals;
 
+  bool unescape = false;
   bool verbose = false;
   bool emitBinary = true;
   bool symbolMap = false;

--- a/src/tools/wasm-split/split-options.h
+++ b/src/tools/wasm-split/split-options.h
@@ -28,10 +28,11 @@ struct WasmSplitOptions : ToolOptions {
     Split,
     Instrument,
     MergeProfiles,
+    PrintProfile,
   };
   Mode mode = Mode::Split;
   constexpr static size_t NumModes =
-    static_cast<unsigned>(Mode::MergeProfiles) + 1;
+    static_cast<unsigned>(Mode::PrintProfile) + 1;
 
   enum class StorageKind : unsigned {
     InGlobals, // Store profile data in WebAssembly Globals

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -385,8 +385,8 @@ void mergeProfiles(const WasmSplitOptions& options) {
   buffer.writeTo(out.getStream());
 }
 
-void removeHexNumbersFrom(std::string input, std::string &output) {
-  output.clear();
+std::string replaceHexNumbersWithChar(std::string input) {
+  std::string output;
   for (size_t i = 0; i < input.length(); i++) {
     if (input[i] == '\\') {
       std::string byte = input.substr(i + 1, 2);
@@ -398,6 +398,7 @@ void removeHexNumbersFrom(std::string input, std::string &output) {
       output.push_back(chr);
     }
   }
+  return output;
 }
 
 void printReadableProfile(const WasmSplitOptions& options) {
@@ -433,11 +434,10 @@ void printReadableProfile(const WasmSplitOptions& options) {
     }
   }
 
-  std::string fnName;
   auto printFnSet = [&](auto funcs, std::string prefix) {
     for (auto it = funcs.begin(); it != funcs.end(); ++it) {
-      removeHexNumbersFrom(it->c_str(), fnName);
-      std::cout << prefix << " " << fnName << std::endl;
+      std::cout << prefix << " " << replaceHexNumbersWithChar(it->c_str())
+                << std::endl;
     }
   };
 

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -17,7 +17,7 @@
 // wasm-split: Split a module in two or instrument a module to inform future
 // splitting.
 
-#include <filesystem>
+#include <fstream>
 
 #include "ir/module-splitting.h"
 #include "ir/names.h"
@@ -417,7 +417,8 @@ std::string unescape(std::string input) {
 }
 
 void checkExists(const std::string& path) {
-  if (!std::filesystem::exists(path)) {
+  std::ifstream infile(path);
+  if (!infile.is_open()) {
     Fatal() << "File not found: " << path;
   }
 }

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -409,7 +409,14 @@ void printReadableProfile(const WasmSplitOptions& options) {
 
   if (options.profileFile.size()) {
     // Use the profile to set `keepFuncs`.
+    uint64_t hash = hashFile(options.inputFiles[0]);
     ProfileData profile = readProfile(options.profileFile);
+    if (profile.hash != hash) {
+      Fatal() << "error: checksum in profile does not match module checksum. "
+              << "The split module must be the original module that was "
+              << "instrumented to generate the profile.";
+    }
+
     size_t i = 0;
     ModuleUtils::iterDefinedFunctions(wasm, [&](Function* func) {
       if (i >= profile.timestamps.size()) {

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -427,19 +427,19 @@ void printReadableProfile(const WasmSplitOptions& options) {
   }
 
   std::string fnName;
-  auto printFnSet = [&](auto funcs) {
+  auto printFnSet = [&](auto funcs, std::string prefix) {
     for (auto it = funcs.begin(); it != funcs.end(); ++it) {
       removeHexNumbersFrom(it->c_str(), fnName);
-      std::cout << fnName << std::endl;
+      std::cout << prefix << " " << fnName << std::endl;
     }
   };
 
   std::cout << "Keeping functions: " << std::endl;
-  printFnSet(keepFuncs);
+  printFnSet(keepFuncs, "+");
   std::cout << std::endl;
 
   std::cout << "Splitting out functions: " << std::endl;
-  printFnSet(splitFuncs);
+  printFnSet(splitFuncs, "-");
   std::cout << std::endl;
 }
 

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -385,6 +385,21 @@ void mergeProfiles(const WasmSplitOptions& options) {
   buffer.writeTo(out.getStream());
 }
 
+void removeHexNumbersFrom(std::string input, std::string &output) {
+  output.clear();
+  for (size_t i = 0; i < input.length(); i++) {
+    if (input[i] == '\\') {
+      std::string byte = input.substr(i + 1, 2);
+      i += 2;
+      char chr = (char)(int)strtol(byte.c_str(), nullptr, 16);
+      output.push_back(chr);
+    } else {
+      char chr = input[i];
+      output.push_back(chr);
+    }
+  }
+}
+
 void printReadableProfile(const WasmSplitOptions& options) {
   Module wasm;
   parseInput(wasm, options);
@@ -411,9 +426,11 @@ void printReadableProfile(const WasmSplitOptions& options) {
     }
   }
 
+  std::string fnName;
   auto printFnSet = [&](auto funcs) {
     for (auto it = funcs.begin(); it != funcs.end(); ++it) {
-      std::cout << *it << std::endl;
+      removeHexNumbersFrom(it->c_str(), fnName);
+      std::cout << fnName << std::endl;
     }
   };
 

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -22,6 +22,9 @@
 ;; CHECK-NEXT:   --merge-profiles                     Merge multiple profiles for the same
 ;; CHECK-NEXT:                                        module into a single profile.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --print-profile                      [print-profile] Print profile contents in
+;; CHECK-NEXT:                                        a human-readable format.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --profile                            [split] The profile to use to guide
 ;; CHECK-NEXT:                                        splitting.
 ;; CHECK-NEXT:
@@ -104,6 +107,9 @@
 ;; CHECK-NEXT:                                        wasm binary (or full debuginfo in wast)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --output,-o                          [instrument, merge-profiles] Output file.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --unescape,-u                        Un-escape function names (in
+;; CHECK-NEXT:                                        print-profile output)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --verbose,-v                         Verbose output mode. Prints the functions
 ;; CHECK-NEXT:                                        that will be kept and split out when


### PR DESCRIPTION
There are several reasons why a function may not be trained in deterministically. 
So to perform quick validation we need to inspect profile.data (another ways requires split to be performed). However as profile.data is a binary file and is not self sufficient, so we cannot currently use it to perform such validation.

Therefore to allow quick check on whether a particular function has been trained in, we need to dump profile.data in a more readable format. 

This PR, allows us to output, the list of functions to be kept (in main wasm) and those split functions (to be moved to deferred.wasm) in a readable format, to console. 

Added a new option `--print-profile` 
- input path to orig.wasm (its the original wasm file that will be used later during split)
- input path to profile.data that we need to output
optionally pass `--unescape`
to unescape the function names

Usage:
```
binaryen\build>bin\wasm-split.exe test\profile_data\MY.orig.wasm --print-profile=test\profile_data\profile.data > test\profile_data\out.log
```

note: meaning of prefixes
`+` => fn to be kept in main wasm
`-` => fn to be split and moved to deferred wasm

