### PR TITLE
[Strings] string.eq

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -622,6 +622,7 @@ instructions = [
     ("string.encode_wtf8",   "makeStringEncode(s, StringEncodeWTF8)"),
     ("string.encode_wtf16",  "makeStringEncode(s, StringEncodeWTF16)"),
     ("string.concat",        "makeStringConcat(s)"),
+    ("string.eq",        "makeStringEq(s)"),
 ]
 
 

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3141,12 +3141,20 @@ switch (op[0]) {
                 }
               }
               case 'e': {
-                switch (op[17]) {
-                  case '1':
-                    if (strcmp(op, "string.encode_wtf16") == 0) { return makeStringEncode(s, StringEncodeWTF16); }
-                    goto parse_error;
-                  case '8':
-                    if (strcmp(op, "string.encode_wtf8") == 0) { return makeStringEncode(s, StringEncodeWTF8); }
+                switch (op[8]) {
+                  case 'n': {
+                    switch (op[17]) {
+                      case '1':
+                        if (strcmp(op, "string.encode_wtf16") == 0) { return makeStringEncode(s, StringEncodeWTF16); }
+                        goto parse_error;
+                      case '8':
+                        if (strcmp(op, "string.encode_wtf8") == 0) { return makeStringEncode(s, StringEncodeWTF8); }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
+                  case 'q':
+                    if (strcmp(op, "string.eq") == 0) { return makeStringEq(s); }
                     goto parse_error;
                   default: goto parse_error;
                 }

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -177,6 +177,7 @@ void ReFinalize::visitStringConst(StringConst* curr) { curr->finalize(); }
 void ReFinalize::visitStringMeasure(StringMeasure* curr) { curr->finalize(); }
 void ReFinalize::visitStringEncode(StringEncode* curr) { curr->finalize(); }
 void ReFinalize::visitStringConcat(StringConcat* curr) { curr->finalize(); }
+void ReFinalize::visitStringEq(StringEq* curr) { curr->finalize(); }
 
 void ReFinalize::visitFunction(Function* curr) {
   // we may have changed the body from unreachable to none, which might be bad

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -684,6 +684,10 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
   CostType visitStringConcat(StringConcat* curr) {
     return 10 + visit(curr->left) + visit(curr->right);
   }
+  CostType visitStringEq(StringEq* curr) {
+    // This assumes strings are interned in the engine.
+    return 1 + visit(curr->left) + visit(curr->right);
+  }
 
 private:
   CostType nullCheckCost(Expression* ref) {

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -685,8 +685,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return 10 + visit(curr->left) + visit(curr->right);
   }
   CostType visitStringEq(StringEq* curr) {
-    // This assumes strings are interned in the engine.
-    return 1 + visit(curr->left) + visit(curr->right);
+    // "3" is chosen since strings might or might not be interned in the engine.
+    return 3 + visit(curr->left) + visit(curr->right);
   }
 
 private:

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -746,6 +746,7 @@ private:
       // traps when an input is null.
       parent.implicitTrap = true;
     }
+    void visitStringEq(StringEq* curr) {}
   };
 
 public:

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -693,6 +693,10 @@ struct InfoCollector
     // TODO: optimize when possible
     addRoot(curr);
   }
+  void visitStringEq(StringEq* curr) {
+    // TODO: optimize when possible
+    addRoot(curr);
+  }
 
   // TODO: Model which throws can go to which catches. For now, anything thrown
   //       is sent to the location of that tag, and any catch of that tag can

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2275,6 +2275,9 @@ struct PrintExpressionContents
   void visitStringConcat(StringConcat* curr) {
     printMedium(o, "string.concat");
   }
+  void visitStringEq(StringEq* curr) {
+    printMedium(o, "string.eq");
+  }
 };
 
 // Prints an expression in s-expr format, including both the

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2275,9 +2275,7 @@ struct PrintExpressionContents
   void visitStringConcat(StringConcat* curr) {
     printMedium(o, "string.concat");
   }
-  void visitStringEq(StringEq* curr) {
-    printMedium(o, "string.eq");
-  }
+  void visitStringEq(StringEq* curr) { printMedium(o, "string.eq"); }
 };
 
 // Prints an expression in s-expr format, including both the

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1145,6 +1145,7 @@ enum ASTNodes {
   StringEncodeWTF8 = 0x86,
   StringEncodeWTF16 = 0x87,
   StringConcat = 0x88,
+  StringEq = 0x89,
 };
 
 enum MemoryAccess {
@@ -1730,6 +1731,7 @@ public:
   bool maybeVisitStringMeasure(Expression*& out, uint32_t code);
   bool maybeVisitStringEncode(Expression*& out, uint32_t code);
   bool maybeVisitStringConcat(Expression*& out, uint32_t code);
+  bool maybeVisitStringEq(Expression*& out, uint32_t code);
   void visitSelect(Select* curr, uint8_t code);
   void visitReturn(Return* curr);
   void visitMemorySize(MemorySize* curr);

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1027,6 +1027,13 @@ public:
     ret->finalize();
     return ret;
   }
+  StringEq* makeStringEq(Expression* left, Expression* right) {
+    auto* ret = wasm.allocator.alloc<StringEq>();
+    ret->left = left;
+    ret->right = right;
+    ret->finalize();
+    return ret;
+  }
 
   // Additional helpers
 

--- a/src/wasm-delegations-fields.def
+++ b/src/wasm-delegations-fields.def
@@ -749,6 +749,13 @@ switch (DELEGATE_ID) {
     DELEGATE_END(StringConcat);
     break;
   }
+  case Expression::Id::StringEqId: {
+    DELEGATE_START(StringEq);
+    DELEGATE_FIELD_CHILD(StringEq, right);
+    DELEGATE_FIELD_CHILD(StringEq, left);
+    DELEGATE_END(StringEq);
+    break;
+  }
 }
 
 #undef DELEGATE_ID

--- a/src/wasm-delegations.def
+++ b/src/wasm-delegations.def
@@ -90,5 +90,6 @@ DELEGATE(StringConst);
 DELEGATE(StringMeasure);
 DELEGATE(StringEncode);
 DELEGATE(StringConcat);
+DELEGATE(StringEq);
 
 #undef DELEGATE

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1970,6 +1970,9 @@ public:
   Flow visitStringConcat(StringConcat* curr) {
     WASM_UNREACHABLE("unimplemented string.concat");
   }
+  Flow visitStringEq(StringEq* curr) {
+    WASM_UNREACHABLE("unimplemented string.eq");
+  }
 
   virtual void trap(const char* why) { WASM_UNREACHABLE("unimp"); }
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -308,6 +308,7 @@ private:
   Expression* makeStringMeasure(Element& s, StringMeasureOp op);
   Expression* makeStringEncode(Element& s, StringEncodeOp op);
   Expression* makeStringConcat(Element& s);
+  Expression* makeStringEq(Element& s);
 
   // Helper functions
   Type parseOptionalResultType(Element& s, Index& i);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -702,6 +702,7 @@ public:
     StringMeasureId,
     StringEncodeId,
     StringConcatId,
+    StringEqId,
     NumExpressionIds
   };
   Id _id;
@@ -1718,6 +1719,16 @@ public:
 class StringConcat : public SpecificExpression<Expression::StringConcatId> {
 public:
   StringConcat(MixedArena& allocator) {}
+
+  Expression* left;
+  Expression* right;
+
+  void finalize();
+};
+
+class StringEq : public SpecificExpression<Expression::StringEqId> {
+public:
+  StringEq(MixedArena& allocator) {}
 
   Expression* left;
   Expression* right;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3933,6 +3933,9 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       if (maybeVisitStringConcat(curr, opcode)) {
         break;
       }
+      if (maybeVisitStringEq(curr, opcode)) {
+        break;
+      }
       if (opcode == BinaryConsts::RefIsFunc ||
           opcode == BinaryConsts::RefIsData ||
           opcode == BinaryConsts::RefIsI31) {
@@ -7231,6 +7234,17 @@ bool WasmBinaryBuilder::maybeVisitStringConcat(Expression*& out,
   auto* right = popNonVoidExpression();
   auto* left = popNonVoidExpression();
   out = Builder(wasm).makeStringConcat(left, right);
+  return true;
+}
+
+bool WasmBinaryBuilder::maybeVisitStringEq(Expression*& out,
+                                           uint32_t code) {
+  if (code != BinaryConsts::StringEq) {
+    return false;
+  }
+  auto* right = popNonVoidExpression();
+  auto* left = popNonVoidExpression();
+  out = Builder(wasm).makeStringEq(left, right);
   return true;
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7237,8 +7237,7 @@ bool WasmBinaryBuilder::maybeVisitStringConcat(Expression*& out,
   return true;
 }
 
-bool WasmBinaryBuilder::maybeVisitStringEq(Expression*& out,
-                                           uint32_t code) {
+bool WasmBinaryBuilder::maybeVisitStringEq(Expression*& out, uint32_t code) {
   if (code != BinaryConsts::StringEq) {
     return false;
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2995,6 +2995,11 @@ Expression* SExpressionWasmBuilder::makeStringConcat(Element& s) {
                                         parseExpression(s[2]));
 }
 
+Expression* SExpressionWasmBuilder::makeStringEq(Element& s) {
+  return Builder(wasm).makeStringEq(parseExpression(s[1]),
+                                    parseExpression(s[2]));
+}
+
 // converts an s-expression string representing binary data into an output
 // sequence of raw bytes this appends to data, which may already contain
 // content.

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2304,6 +2304,10 @@ void BinaryInstWriter::visitStringConcat(StringConcat* curr) {
   o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringConcat);
 }
 
+void BinaryInstWriter::visitStringEq(StringEq* curr) {
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringEq);
+}
+
 void BinaryInstWriter::emitScopeEnd(Expression* curr) {
   assert(!breakStack.empty());
   breakStack.pop_back();

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1208,6 +1208,14 @@ void StringConcat::finalize() {
   }
 }
 
+void StringEq::finalize() {
+  if (left->type == Type::unreachable || right->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = Type::i32;
+  }
+}
+
 size_t Function::getNumParams() { return getParams().size(); }
 
 size_t Function::getNumVars() { return vars.size(); }

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -2323,6 +2323,10 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");
     }
+    Ref visitStringEq(StringEq* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
     Ref visitRefAs(RefAs* curr) {
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -7,11 +7,11 @@
 (module
   ;; CHECK:      (type $ref?|string|_=>_none (func (param stringref)))
 
+  ;; CHECK:      (type $ref?|string|_ref?|string|_=>_none (func (param stringref stringref)))
+
   ;; CHECK:      (type $ref?|string|_ref?|stringview_wtf8|_ref?|stringview_wtf16|_ref?|stringview_iter|_ref?|string|_ref?|stringview_wtf8|_ref?|stringview_wtf16|_ref?|stringview_iter|_ref|string|_ref|stringview_wtf8|_ref|stringview_wtf16|_ref|stringview_iter|_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter stringref stringview_wtf8 stringview_wtf16 stringview_iter (ref string) (ref stringview_wtf8) (ref stringview_wtf16) (ref stringview_iter))))
 
   ;; CHECK:      (type $none_=>_none (func))
-
-  ;; CHECK:      (type $ref?|string|_ref?|string|_=>_none (func (param stringref stringref)))
 
   ;; CHECK:      (global $string-const stringref (string.const "string in a global"))
   (global $string-const stringref (string.const "string in a global"))
@@ -201,6 +201,27 @@
       (string.concat
         (local.get $a)
         (local.get $b)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $string.eq (param $a stringref) (param $b stringref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (string.eq
+  ;; CHECK-NEXT:     (local.get $a)
+  ;; CHECK-NEXT:     (local.get $b)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $string.eq (param $a stringref) (param $b stringref)
+    (drop
+      (i32.eqz ;; validate the output is an i32
+        (string.eq
+          (local.get $a)
+          (local.get $b)
+        )
       )
     )
   )


### PR DESCRIPTION
I considered maybe making this a shared class with `RefEq`. They are quite similar. But the internal opcode would need to be something like "compare references" versus "compare data", which seems slightly awkward. Overall the amount of boilerplate per new class is fairly small now, so I lean towards that.