### PR TITLE
[Strings] stringview access operations

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -627,11 +627,11 @@ instructions = [
     ("string.as_wtf8",       "makeStringAs(s, StringAsWTF8)"),
     ("string.as_wtf16",      "makeStringAs(s, StringAsWTF16)"),
     ("string.as_iter",       "makeStringAs(s, StringAsIter)"),
-    ("stringview_wtf8.advance", "makeStringViewAccess(s, StringViewAccessWTF8Advance)"),
-    ("stringview_wtf16.get",    "makeStringViewAccess(s, StringViewAccessWTF16Get)"),
-    ("stringview_iter.next",    "makeStringViewAccess(s, StringViewAccessIterNext)"),
-    ("stringview_iter.advance", "makeStringViewAccess(s, StringViewAccessIterAdvance)"),
-    ("stringview_iter.rewind",  "makeStringViewAccess(s, StringViewAccessIterRewind)"),
+    ("stringview_wtf8.advance",       "makeStringViewAccess(s, StringViewAccessWTF8Advance)"),
+    ("stringview_wtf16.get_codeunit", "makeStringViewAccess(s, StringViewAccessWTF16Get)"),
+    ("stringview_iter.next",          "makeStringViewAccess(s, StringViewAccessIterNext)"),
+    ("stringview_iter.advance",       "makeStringViewAccess(s, StringViewAccessIterAdvance)"),
+    ("stringview_iter.rewind",        "makeStringViewAccess(s, StringViewAccessIterRewind)"),
 ]
 
 

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -628,7 +628,7 @@ instructions = [
     ("string.as_wtf16",      "makeStringAs(s, StringAsWTF16)"),
     ("string.as_iter",       "makeStringAs(s, StringAsIter)"),
     ("stringview_wtf8.advance",       "makeStringViewAccess(s, StringViewAccessWTF8Advance)"),
-    ("stringview_wtf16.get_codeunit", "makeStringViewAccess(s, StringViewAccessWTF16Get)"),
+    ("stringview_wtf16.get_codeunit", "makeStringViewAccess(s, StringViewAccessWTF16GetCodeUnit)"),
     ("stringview_iter.next",          "makeStringViewAccess(s, StringViewAccessIterNext)"),
     ("stringview_iter.advance",       "makeStringViewAccess(s, StringViewAccessIterAdvance)"),
     ("stringview_iter.rewind",        "makeStringViewAccess(s, StringViewAccessIterRewind)"),

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -627,6 +627,11 @@ instructions = [
     ("string.as_wtf8",       "makeStringAs(s, StringAsWTF8)"),
     ("string.as_wtf16",      "makeStringAs(s, StringAsWTF16)"),
     ("string.as_iter",       "makeStringAs(s, StringAsIter)"),
+    ("stringview_wtf8.advance", "makeStringViewAccess(s, StringViewWTF8Advance)"),
+    ("stringview_wtf16.get",    "makeStringViewAccess(s, StringViewWTF16Get)"),
+    ("stringview_iter.next",    "makeStringViewAccess(s, StringViewIterNext)"),
+    ("stringview_iter.advance", "makeStringViewAccess(s, StringViewIterAdvance)"),
+    ("stringview_iter.rewind",  "makeStringViewAccess(s, StringViewIterRewind)"),
 ]
 
 

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -627,11 +627,11 @@ instructions = [
     ("string.as_wtf8",       "makeStringAs(s, StringAsWTF8)"),
     ("string.as_wtf16",      "makeStringAs(s, StringAsWTF16)"),
     ("string.as_iter",       "makeStringAs(s, StringAsIter)"),
-    ("stringview_wtf8.advance", "makeStringViewAccess(s, StringViewWTF8Advance)"),
-    ("stringview_wtf16.get",    "makeStringViewAccess(s, StringViewWTF16Get)"),
-    ("stringview_iter.next",    "makeStringViewAccess(s, StringViewIterNext)"),
-    ("stringview_iter.advance", "makeStringViewAccess(s, StringViewIterAdvance)"),
-    ("stringview_iter.rewind",  "makeStringViewAccess(s, StringViewIterRewind)"),
+    ("stringview_wtf8.advance", "makeStringViewAccess(s, StringViewAccessWTF8Advance)"),
+    ("stringview_wtf16.get",    "makeStringViewAccess(s, StringViewAccessWTF16Get)"),
+    ("stringview_iter.next",    "makeStringViewAccess(s, StringViewAccessIterNext)"),
+    ("stringview_iter.advance", "makeStringViewAccess(s, StringViewAccessIterAdvance)"),
+    ("stringview_iter.rewind",  "makeStringViewAccess(s, StringViewAccessIterRewind)"),
 ]
 
 

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -627,11 +627,11 @@ instructions = [
     ("string.as_wtf8",       "makeStringAs(s, StringAsWTF8)"),
     ("string.as_wtf16",      "makeStringAs(s, StringAsWTF16)"),
     ("string.as_iter",       "makeStringAs(s, StringAsIter)"),
-    ("stringview_wtf8.advance",       "makeStringViewAccess(s, StringViewAccessWTF8Advance)"),
-    ("stringview_wtf16.get_codeunit", "makeStringViewAccess(s, StringViewAccessWTF16GetCodeUnit)"),
-    ("stringview_iter.next",          "makeStringViewAccess(s, StringViewAccessIterNext)"),
-    ("stringview_iter.advance",       "makeStringViewAccess(s, StringViewAccessIterAdvance)"),
-    ("stringview_iter.rewind",        "makeStringViewAccess(s, StringViewAccessIterRewind)"),
+    ("stringview_wtf8.advance",       "makeStringWTF8Advance(s)"),
+    ("stringview_wtf16.get_codeunit", "makeStringWTF16Get(s)"),
+    ("stringview_iter.next",          "makeStringIterNext(s)"),
+    ("stringview_iter.advance",       "makeStringIterMove(s, StringIterMoveAdvance)"),
+    ("stringview_iter.rewind",        "makeStringIterMove(s, StringIterMoveRewind)"),
 ]
 
 

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3227,7 +3227,7 @@ switch (op[0]) {
                   case 'w': {
                     switch (op[14]) {
                       case '1':
-                        if (strcmp(op, "stringview_wtf16.get") == 0) { return makeStringViewAccess(s, StringViewAccessWTF16Get); }
+                        if (strcmp(op, "stringview_wtf16.get_codeunit") == 0) { return makeStringViewAccess(s, StringViewAccessWTF16Get); }
                         goto parse_error;
                       case '8':
                         if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringViewAccess(s, StringViewAccessWTF8Advance); }
@@ -8947,7 +8947,7 @@ switch (op[0]) {
                   case 'w': {
                     switch (op[14]) {
                       case '1':
-                        if (op == "stringview_wtf16.get"sv) {
+                        if (op == "stringview_wtf16.get_codeunit"sv) {
                           auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF16Get);
                           CHECK_ERR(ret);
                           return *ret;

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3128,78 +3128,113 @@ switch (op[0]) {
       case 't': {
         switch (op[3]) {
           case 'i': {
-            switch (op[7]) {
-              case 'a': {
-                switch (op[10]) {
+            switch (op[6]) {
+              case '.': {
+                switch (op[7]) {
+                  case 'a': {
+                    switch (op[10]) {
+                      case 'i':
+                        if (strcmp(op, "string.as_iter") == 0) { return makeStringAs(s, StringAsIter); }
+                        goto parse_error;
+                      case 'w': {
+                        switch (op[13]) {
+                          case '1':
+                            if (strcmp(op, "string.as_wtf16") == 0) { return makeStringAs(s, StringAsWTF16); }
+                            goto parse_error;
+                          case '8':
+                            if (strcmp(op, "string.as_wtf8") == 0) { return makeStringAs(s, StringAsWTF8); }
+                            goto parse_error;
+                          default: goto parse_error;
+                        }
+                      }
+                      default: goto parse_error;
+                    }
+                  }
+                  case 'c': {
+                    switch (op[10]) {
+                      case 'c':
+                        if (strcmp(op, "string.concat") == 0) { return makeStringConcat(s); }
+                        goto parse_error;
+                      case 's':
+                        if (strcmp(op, "string.const") == 0) { return makeStringConst(s); }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
+                  case 'e': {
+                    switch (op[8]) {
+                      case 'n': {
+                        switch (op[17]) {
+                          case '1':
+                            if (strcmp(op, "string.encode_wtf16") == 0) { return makeStringEncode(s, StringEncodeWTF16); }
+                            goto parse_error;
+                          case '8':
+                            if (strcmp(op, "string.encode_wtf8") == 0) { return makeStringEncode(s, StringEncodeWTF8); }
+                            goto parse_error;
+                          default: goto parse_error;
+                        }
+                      }
+                      case 'q':
+                        if (strcmp(op, "string.eq") == 0) { return makeStringEq(s); }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
                   case 'i':
-                    if (strcmp(op, "string.as_iter") == 0) { return makeStringAs(s, StringAsIter); }
+                    if (strcmp(op, "string.is_usv_sequence") == 0) { return makeStringMeasure(s, StringMeasureIsUSV); }
                     goto parse_error;
-                  case 'w': {
-                    switch (op[13]) {
+                  case 'm': {
+                    switch (op[18]) {
                       case '1':
-                        if (strcmp(op, "string.as_wtf16") == 0) { return makeStringAs(s, StringAsWTF16); }
+                        if (strcmp(op, "string.measure_wtf16") == 0) { return makeStringMeasure(s, StringMeasureWTF16); }
                         goto parse_error;
                       case '8':
-                        if (strcmp(op, "string.as_wtf8") == 0) { return makeStringAs(s, StringAsWTF8); }
+                        if (strcmp(op, "string.measure_wtf8") == 0) { return makeStringMeasure(s, StringMeasureWTF8); }
                         goto parse_error;
                       default: goto parse_error;
                     }
                   }
-                  default: goto parse_error;
-                }
-              }
-              case 'c': {
-                switch (op[10]) {
-                  case 'c':
-                    if (strcmp(op, "string.concat") == 0) { return makeStringConcat(s); }
-                    goto parse_error;
-                  case 's':
-                    if (strcmp(op, "string.const") == 0) { return makeStringConst(s); }
-                    goto parse_error;
-                  default: goto parse_error;
-                }
-              }
-              case 'e': {
-                switch (op[8]) {
                   case 'n': {
-                    switch (op[17]) {
+                    switch (op[14]) {
                       case '1':
-                        if (strcmp(op, "string.encode_wtf16") == 0) { return makeStringEncode(s, StringEncodeWTF16); }
+                        if (strcmp(op, "string.new_wtf16") == 0) { return makeStringNew(s, StringNewWTF16); }
                         goto parse_error;
                       case '8':
-                        if (strcmp(op, "string.encode_wtf8") == 0) { return makeStringEncode(s, StringEncodeWTF8); }
+                        if (strcmp(op, "string.new_wtf8") == 0) { return makeStringNew(s, StringNewWTF8); }
                         goto parse_error;
                       default: goto parse_error;
                     }
                   }
-                  case 'q':
-                    if (strcmp(op, "string.eq") == 0) { return makeStringEq(s); }
-                    goto parse_error;
                   default: goto parse_error;
                 }
               }
-              case 'i':
-                if (strcmp(op, "string.is_usv_sequence") == 0) { return makeStringMeasure(s, StringMeasureIsUSV); }
-                goto parse_error;
-              case 'm': {
-                switch (op[18]) {
-                  case '1':
-                    if (strcmp(op, "string.measure_wtf16") == 0) { return makeStringMeasure(s, StringMeasureWTF16); }
-                    goto parse_error;
-                  case '8':
-                    if (strcmp(op, "string.measure_wtf8") == 0) { return makeStringMeasure(s, StringMeasureWTF8); }
-                    goto parse_error;
-                  default: goto parse_error;
-                }
-              }
-              case 'n': {
-                switch (op[14]) {
-                  case '1':
-                    if (strcmp(op, "string.new_wtf16") == 0) { return makeStringNew(s, StringNewWTF16); }
-                    goto parse_error;
-                  case '8':
-                    if (strcmp(op, "string.new_wtf8") == 0) { return makeStringNew(s, StringNewWTF8); }
-                    goto parse_error;
+              case 'v': {
+                switch (op[11]) {
+                  case 'i': {
+                    switch (op[16]) {
+                      case 'a':
+                        if (strcmp(op, "stringview_iter.advance") == 0) { return makeStringViewAccess(s, StringViewIterAdvance); }
+                        goto parse_error;
+                      case 'n':
+                        if (strcmp(op, "stringview_iter.next") == 0) { return makeStringViewAccess(s, StringViewIterNext); }
+                        goto parse_error;
+                      case 'r':
+                        if (strcmp(op, "stringview_iter.rewind") == 0) { return makeStringViewAccess(s, StringViewIterRewind); }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
+                  case 'w': {
+                    switch (op[14]) {
+                      case '1':
+                        if (strcmp(op, "stringview_wtf16.get") == 0) { return makeStringViewAccess(s, StringViewWTF16Get); }
+                        goto parse_error;
+                      case '8':
+                        if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringViewAccess(s, StringViewWTF8Advance); }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
                   default: goto parse_error;
                 }
               }
@@ -8749,28 +8784,109 @@ switch (op[0]) {
       case 't': {
         switch (op[3]) {
           case 'i': {
-            switch (op[7]) {
-              case 'a': {
-                switch (op[10]) {
+            switch (op[6]) {
+              case '.': {
+                switch (op[7]) {
+                  case 'a': {
+                    switch (op[10]) {
+                      case 'i':
+                        if (op == "string.as_iter"sv) {
+                          auto ret = makeStringAs(ctx, in, StringAsIter);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      case 'w': {
+                        switch (op[13]) {
+                          case '1':
+                            if (op == "string.as_wtf16"sv) {
+                              auto ret = makeStringAs(ctx, in, StringAsWTF16);
+                              CHECK_ERR(ret);
+                              return *ret;
+                            }
+                            goto parse_error;
+                          case '8':
+                            if (op == "string.as_wtf8"sv) {
+                              auto ret = makeStringAs(ctx, in, StringAsWTF8);
+                              CHECK_ERR(ret);
+                              return *ret;
+                            }
+                            goto parse_error;
+                          default: goto parse_error;
+                        }
+                      }
+                      default: goto parse_error;
+                    }
+                  }
+                  case 'c': {
+                    switch (op[10]) {
+                      case 'c':
+                        if (op == "string.concat"sv) {
+                          auto ret = makeStringConcat(ctx, in);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      case 's':
+                        if (op == "string.const"sv) {
+                          auto ret = makeStringConst(ctx, in);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
+                  case 'e': {
+                    switch (op[8]) {
+                      case 'n': {
+                        switch (op[17]) {
+                          case '1':
+                            if (op == "string.encode_wtf16"sv) {
+                              auto ret = makeStringEncode(ctx, in, StringEncodeWTF16);
+                              CHECK_ERR(ret);
+                              return *ret;
+                            }
+                            goto parse_error;
+                          case '8':
+                            if (op == "string.encode_wtf8"sv) {
+                              auto ret = makeStringEncode(ctx, in, StringEncodeWTF8);
+                              CHECK_ERR(ret);
+                              return *ret;
+                            }
+                            goto parse_error;
+                          default: goto parse_error;
+                        }
+                      }
+                      case 'q':
+                        if (op == "string.eq"sv) {
+                          auto ret = makeStringEq(ctx, in);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      default: goto parse_error;
+                    }
+                  }
                   case 'i':
-                    if (op == "string.as_iter"sv) {
-                      auto ret = makeStringAs(ctx, in, StringAsIter);
+                    if (op == "string.is_usv_sequence"sv) {
+                      auto ret = makeStringMeasure(ctx, in, StringMeasureIsUSV);
                       CHECK_ERR(ret);
                       return *ret;
                     }
                     goto parse_error;
-                  case 'w': {
-                    switch (op[13]) {
+                  case 'm': {
+                    switch (op[18]) {
                       case '1':
-                        if (op == "string.as_wtf16"sv) {
-                          auto ret = makeStringAs(ctx, in, StringAsWTF16);
+                        if (op == "string.measure_wtf16"sv) {
+                          auto ret = makeStringMeasure(ctx, in, StringMeasureWTF16);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case '8':
-                        if (op == "string.as_wtf8"sv) {
-                          auto ret = makeStringAs(ctx, in, StringAsWTF8);
+                        if (op == "string.measure_wtf8"sv) {
+                          auto ret = makeStringMeasure(ctx, in, StringMeasureWTF8);
                           CHECK_ERR(ret);
                           return *ret;
                         }
@@ -8778,42 +8894,18 @@ switch (op[0]) {
                       default: goto parse_error;
                     }
                   }
-                  default: goto parse_error;
-                }
-              }
-              case 'c': {
-                switch (op[10]) {
-                  case 'c':
-                    if (op == "string.concat"sv) {
-                      auto ret = makeStringConcat(ctx, in);
-                      CHECK_ERR(ret);
-                      return *ret;
-                    }
-                    goto parse_error;
-                  case 's':
-                    if (op == "string.const"sv) {
-                      auto ret = makeStringConst(ctx, in);
-                      CHECK_ERR(ret);
-                      return *ret;
-                    }
-                    goto parse_error;
-                  default: goto parse_error;
-                }
-              }
-              case 'e': {
-                switch (op[8]) {
                   case 'n': {
-                    switch (op[17]) {
+                    switch (op[14]) {
                       case '1':
-                        if (op == "string.encode_wtf16"sv) {
-                          auto ret = makeStringEncode(ctx, in, StringEncodeWTF16);
+                        if (op == "string.new_wtf16"sv) {
+                          auto ret = makeStringNew(ctx, in, StringNewWTF16);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case '8':
-                        if (op == "string.encode_wtf8"sv) {
-                          auto ret = makeStringEncode(ctx, in, StringEncodeWTF8);
+                        if (op == "string.new_wtf8"sv) {
+                          auto ret = makeStringNew(ctx, in, StringNewWTF8);
                           CHECK_ERR(ret);
                           return *ret;
                         }
@@ -8821,58 +8913,56 @@ switch (op[0]) {
                       default: goto parse_error;
                     }
                   }
-                  case 'q':
-                    if (op == "string.eq"sv) {
-                      auto ret = makeStringEq(ctx, in);
-                      CHECK_ERR(ret);
-                      return *ret;
-                    }
-                    goto parse_error;
                   default: goto parse_error;
                 }
               }
-              case 'i':
-                if (op == "string.is_usv_sequence"sv) {
-                  auto ret = makeStringMeasure(ctx, in, StringMeasureIsUSV);
-                  CHECK_ERR(ret);
-                  return *ret;
-                }
-                goto parse_error;
-              case 'm': {
-                switch (op[18]) {
-                  case '1':
-                    if (op == "string.measure_wtf16"sv) {
-                      auto ret = makeStringMeasure(ctx, in, StringMeasureWTF16);
-                      CHECK_ERR(ret);
-                      return *ret;
+              case 'v': {
+                switch (op[11]) {
+                  case 'i': {
+                    switch (op[16]) {
+                      case 'a':
+                        if (op == "stringview_iter.advance"sv) {
+                          auto ret = makeStringViewAccess(ctx, in, StringViewIterAdvance);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      case 'n':
+                        if (op == "stringview_iter.next"sv) {
+                          auto ret = makeStringViewAccess(ctx, in, StringViewIterNext);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      case 'r':
+                        if (op == "stringview_iter.rewind"sv) {
+                          auto ret = makeStringViewAccess(ctx, in, StringViewIterRewind);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      default: goto parse_error;
                     }
-                    goto parse_error;
-                  case '8':
-                    if (op == "string.measure_wtf8"sv) {
-                      auto ret = makeStringMeasure(ctx, in, StringMeasureWTF8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                  }
+                  case 'w': {
+                    switch (op[14]) {
+                      case '1':
+                        if (op == "stringview_wtf16.get"sv) {
+                          auto ret = makeStringViewAccess(ctx, in, StringViewWTF16Get);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      case '8':
+                        if (op == "stringview_wtf8.advance"sv) {
+                          auto ret = makeStringViewAccess(ctx, in, StringViewWTF8Advance);
+                          CHECK_ERR(ret);
+                          return *ret;
+                        }
+                        goto parse_error;
+                      default: goto parse_error;
                     }
-                    goto parse_error;
-                  default: goto parse_error;
-                }
-              }
-              case 'n': {
-                switch (op[14]) {
-                  case '1':
-                    if (op == "string.new_wtf16"sv) {
-                      auto ret = makeStringNew(ctx, in, StringNewWTF16);
-                      CHECK_ERR(ret);
-                      return *ret;
-                    }
-                    goto parse_error;
-                  case '8':
-                    if (op == "string.new_wtf8"sv) {
-                      auto ret = makeStringNew(ctx, in, StringNewWTF8);
-                      CHECK_ERR(ret);
-                      return *ret;
-                    }
-                    goto parse_error;
+                  }
                   default: goto parse_error;
                 }
               }

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3213,13 +3213,13 @@ switch (op[0]) {
                   case 'i': {
                     switch (op[16]) {
                       case 'a':
-                        if (strcmp(op, "stringview_iter.advance") == 0) { return makeStringViewAccess(s, StringViewIterAdvance); }
+                        if (strcmp(op, "stringview_iter.advance") == 0) { return makeStringViewAccess(s, StringViewAccessIterAdvance); }
                         goto parse_error;
                       case 'n':
-                        if (strcmp(op, "stringview_iter.next") == 0) { return makeStringViewAccess(s, StringViewIterNext); }
+                        if (strcmp(op, "stringview_iter.next") == 0) { return makeStringViewAccess(s, StringViewAccessIterNext); }
                         goto parse_error;
                       case 'r':
-                        if (strcmp(op, "stringview_iter.rewind") == 0) { return makeStringViewAccess(s, StringViewIterRewind); }
+                        if (strcmp(op, "stringview_iter.rewind") == 0) { return makeStringViewAccess(s, StringViewAccessIterRewind); }
                         goto parse_error;
                       default: goto parse_error;
                     }
@@ -3227,10 +3227,10 @@ switch (op[0]) {
                   case 'w': {
                     switch (op[14]) {
                       case '1':
-                        if (strcmp(op, "stringview_wtf16.get") == 0) { return makeStringViewAccess(s, StringViewWTF16Get); }
+                        if (strcmp(op, "stringview_wtf16.get") == 0) { return makeStringViewAccess(s, StringViewAccessWTF16Get); }
                         goto parse_error;
                       case '8':
-                        if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringViewAccess(s, StringViewWTF8Advance); }
+                        if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringViewAccess(s, StringViewAccessWTF8Advance); }
                         goto parse_error;
                       default: goto parse_error;
                     }
@@ -8922,21 +8922,21 @@ switch (op[0]) {
                     switch (op[16]) {
                       case 'a':
                         if (op == "stringview_iter.advance"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewIterAdvance);
+                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessIterAdvance);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case 'n':
                         if (op == "stringview_iter.next"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewIterNext);
+                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessIterNext);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "stringview_iter.rewind"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewIterRewind);
+                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessIterRewind);
                           CHECK_ERR(ret);
                           return *ret;
                         }
@@ -8948,14 +8948,14 @@ switch (op[0]) {
                     switch (op[14]) {
                       case '1':
                         if (op == "stringview_wtf16.get"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewWTF16Get);
+                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF16Get);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case '8':
                         if (op == "stringview_wtf8.advance"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewWTF8Advance);
+                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF8Advance);
                           CHECK_ERR(ret);
                           return *ret;
                         }

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3213,13 +3213,13 @@ switch (op[0]) {
                   case 'i': {
                     switch (op[16]) {
                       case 'a':
-                        if (strcmp(op, "stringview_iter.advance") == 0) { return makeStringViewAccess(s, StringViewAccessIterAdvance); }
+                        if (strcmp(op, "stringview_iter.advance") == 0) { return makeStringIterMove(s, StringIterMoveAdvance); }
                         goto parse_error;
                       case 'n':
-                        if (strcmp(op, "stringview_iter.next") == 0) { return makeStringViewAccess(s, StringViewAccessIterNext); }
+                        if (strcmp(op, "stringview_iter.next") == 0) { return makeStringIterNext(s); }
                         goto parse_error;
                       case 'r':
-                        if (strcmp(op, "stringview_iter.rewind") == 0) { return makeStringViewAccess(s, StringViewAccessIterRewind); }
+                        if (strcmp(op, "stringview_iter.rewind") == 0) { return makeStringIterMove(s, StringIterMoveRewind); }
                         goto parse_error;
                       default: goto parse_error;
                     }
@@ -3227,10 +3227,10 @@ switch (op[0]) {
                   case 'w': {
                     switch (op[14]) {
                       case '1':
-                        if (strcmp(op, "stringview_wtf16.get_codeunit") == 0) { return makeStringViewAccess(s, StringViewAccessWTF16GetCodeUnit); }
+                        if (strcmp(op, "stringview_wtf16.get_codeunit") == 0) { return makeStringWTF16Get(s); }
                         goto parse_error;
                       case '8':
-                        if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringViewAccess(s, StringViewAccessWTF8Advance); }
+                        if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringWTF8Advance(s); }
                         goto parse_error;
                       default: goto parse_error;
                     }
@@ -8922,21 +8922,21 @@ switch (op[0]) {
                     switch (op[16]) {
                       case 'a':
                         if (op == "stringview_iter.advance"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessIterAdvance);
+                          auto ret = makeStringIterMove(ctx, in, StringIterMoveAdvance);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case 'n':
                         if (op == "stringview_iter.next"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessIterNext);
+                          auto ret = makeStringIterNext(ctx, in);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "stringview_iter.rewind"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessIterRewind);
+                          auto ret = makeStringIterMove(ctx, in, StringIterMoveRewind);
                           CHECK_ERR(ret);
                           return *ret;
                         }
@@ -8948,14 +8948,14 @@ switch (op[0]) {
                     switch (op[14]) {
                       case '1':
                         if (op == "stringview_wtf16.get_codeunit"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF16GetCodeUnit);
+                          auto ret = makeStringWTF16Get(ctx, in);
                           CHECK_ERR(ret);
                           return *ret;
                         }
                         goto parse_error;
                       case '8':
                         if (op == "stringview_wtf8.advance"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF8Advance);
+                          auto ret = makeStringWTF8Advance(ctx, in);
                           CHECK_ERR(ret);
                           return *ret;
                         }

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3227,7 +3227,7 @@ switch (op[0]) {
                   case 'w': {
                     switch (op[14]) {
                       case '1':
-                        if (strcmp(op, "stringview_wtf16.get_codeunit") == 0) { return makeStringViewAccess(s, StringViewAccessWTF16Get); }
+                        if (strcmp(op, "stringview_wtf16.get_codeunit") == 0) { return makeStringViewAccess(s, StringViewAccessWTF16GetCodeUnit); }
                         goto parse_error;
                       case '8':
                         if (strcmp(op, "stringview_wtf8.advance") == 0) { return makeStringViewAccess(s, StringViewAccessWTF8Advance); }
@@ -8948,7 +8948,7 @@ switch (op[0]) {
                     switch (op[14]) {
                       case '1':
                         if (op == "stringview_wtf16.get_codeunit"sv) {
-                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF16Get);
+                          auto ret = makeStringViewAccess(ctx, in, StringViewAccessWTF16GetCodeUnit);
                           CHECK_ERR(ret);
                           return *ret;
                         }

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -179,7 +179,9 @@ void ReFinalize::visitStringEncode(StringEncode* curr) { curr->finalize(); }
 void ReFinalize::visitStringConcat(StringConcat* curr) { curr->finalize(); }
 void ReFinalize::visitStringEq(StringEq* curr) { curr->finalize(); }
 void ReFinalize::visitStringAs(StringAs* curr) { curr->finalize(); }
-void ReFinalize::visitStringViewAccess(StringViewAccess* curr) { curr->finalize(); }
+void ReFinalize::visitStringViewAccess(StringViewAccess* curr) {
+  curr->finalize();
+}
 
 void ReFinalize::visitFunction(Function* curr) {
   // we may have changed the body from unreachable to none, which might be bad

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -179,6 +179,7 @@ void ReFinalize::visitStringEncode(StringEncode* curr) { curr->finalize(); }
 void ReFinalize::visitStringConcat(StringConcat* curr) { curr->finalize(); }
 void ReFinalize::visitStringEq(StringEq* curr) { curr->finalize(); }
 void ReFinalize::visitStringAs(StringAs* curr) { curr->finalize(); }
+void ReFinalize::visitStringViewAccess(StringViewAccess* curr) { curr->finalize(); }
 
 void ReFinalize::visitFunction(Function* curr) {
   // we may have changed the body from unreachable to none, which might be bad

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -182,15 +182,9 @@ void ReFinalize::visitStringAs(StringAs* curr) { curr->finalize(); }
 void ReFinalize::visitStringWTF8Advance(StringWTF8Advance* curr) {
   curr->finalize();
 }
-void ReFinalize::visitStringWTF16Get(StringWTF16Get* curr) {
-  curr->finalize();
-}
-void ReFinalize::visitStringIterNext(StringIterNext* curr) {
-  curr->finalize();
-}
-void ReFinalize::visitStringIterMove(StringIterMove* curr) {
-  curr->finalize();
-}
+void ReFinalize::visitStringWTF16Get(StringWTF16Get* curr) { curr->finalize(); }
+void ReFinalize::visitStringIterNext(StringIterNext* curr) { curr->finalize(); }
+void ReFinalize::visitStringIterMove(StringIterMove* curr) { curr->finalize(); }
 
 void ReFinalize::visitFunction(Function* curr) {
   // we may have changed the body from unreachable to none, which might be bad

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -179,7 +179,16 @@ void ReFinalize::visitStringEncode(StringEncode* curr) { curr->finalize(); }
 void ReFinalize::visitStringConcat(StringConcat* curr) { curr->finalize(); }
 void ReFinalize::visitStringEq(StringEq* curr) { curr->finalize(); }
 void ReFinalize::visitStringAs(StringAs* curr) { curr->finalize(); }
-void ReFinalize::visitStringViewAccess(StringViewAccess* curr) {
+void ReFinalize::visitStringWTF8Advance(StringWTF8Advance* curr) {
+  curr->finalize();
+}
+void ReFinalize::visitStringWTF16Get(StringWTF16Get* curr) {
+  curr->finalize();
+}
+void ReFinalize::visitStringIterNext(StringIterNext* curr) {
+  curr->finalize();
+}
+void ReFinalize::visitStringIterMove(StringIterMove* curr) {
   curr->finalize();
 }
 

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -689,6 +689,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return 3 + visit(curr->left) + visit(curr->right);
   }
   CostType visitStringAs(StringAs* curr) { return 4 + visit(curr->ref); }
+  CostType visitStringViewAccess(StringViewAccess* curr) { return 2 + visit(curr->ref); }
 
 private:
   CostType nullCheckCost(Expression* ref) {

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -689,8 +689,17 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return 3 + visit(curr->left) + visit(curr->right);
   }
   CostType visitStringAs(StringAs* curr) { return 4 + visit(curr->ref); }
-  CostType visitStringViewAccess(StringViewAccess* curr) {
+  CostType visitStringWTF8Advance(StringWTF8Advance* curr) {
+    return 4 + visit(curr->ref) + visit(curr->pos) + visit(curr->bytes);
+  }
+  CostType visitStringWTF16Get(StringWTF16Get* curr) {
+    return 1 + visit(curr->ref) + visit(curr->pos);
+  }
+  CostType visitStringIterNext(StringIterNext* curr) {
     return 2 + visit(curr->ref);
+  }
+  CostType visitStringIterMove(StringIterMove* curr) {
+    return 2 + visit(curr->ref) + visit(curr->num);
   }
 
 private:

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -699,7 +699,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return 2 + visit(curr->ref);
   }
   CostType visitStringIterMove(StringIterMove* curr) {
-    return 2 + visit(curr->ref) + visit(curr->num);
+    return 4 + visit(curr->ref) + visit(curr->num);
   }
 
 private:

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -689,7 +689,9 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return 3 + visit(curr->left) + visit(curr->right);
   }
   CostType visitStringAs(StringAs* curr) { return 4 + visit(curr->ref); }
-  CostType visitStringViewAccess(StringViewAccess* curr) { return 2 + visit(curr->ref); }
+  CostType visitStringViewAccess(StringViewAccess* curr) {
+    return 2 + visit(curr->ref);
+  }
 
 private:
   CostType nullCheckCost(Expression* ref) {

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -762,11 +762,11 @@ private:
     void visitStringIterNext(StringIterNext* curr) {
       // traps when ref is null.
       parent.implicitTrap = true;
-      // modifies state in the iterator. we model that as modifying heap memory
+      // modifies state in the iterator. we model that as accessing heap memory
       // in an array atm TODO consider adding a new effect type for this (we
-      // added one for arrays because struct/array operations often interleave
-      // like with vtable accesses, but it's not clear adding overhead to this
-      // class is worth it for string iters.
+      // added one for arrays because struct/array operations often interleave,
+      // say with vtable accesses, but it's not clear adding overhead to this
+      // class is worth it for string iters)
       parent.readsArray = true;
       parent.writesArray = true;
     }

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -751,9 +751,31 @@ private:
       // traps when ref is null.
       parent.implicitTrap = true;
     }
-    void visitStringViewAccess(StringViewAccess* curr) {
+    void visitStringWTF8Advance(StringWTF8Advance* curr) {
       // traps when ref is null.
       parent.implicitTrap = true;
+    }
+    void visitStringWTF16Get(StringWTF16Get* curr) {
+      // traps when ref is null.
+      parent.implicitTrap = true;
+    }
+    void visitStringIterNext(StringIterNext* curr) {
+      // traps when ref is null.
+      parent.implicitTrap = true;
+      // modifies state in the iterator. we model that as modifying heap memory
+      // in an array atm TODO consider adding a new effect type for this (we
+      // added one for arrays because struct/array operations often interleave
+      // like with vtable accesses, but it's not clear adding overhead to this
+      // class is worth it for string iters.
+      parent.readsArray = true;
+      parent.writesArray = true;
+    }
+    void visitStringIterMove(StringIterMove* curr) {
+      // traps when ref is null.
+      parent.implicitTrap = true;
+      // see StringIterNext.
+      parent.readsArray = true;
+      parent.writesArray = true;
     }
   };
 

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -751,6 +751,10 @@ private:
       // traps when ref is null.
       parent.implicitTrap = true;
     }
+    void visitStringViewAccess(StringViewAccess* curr) {
+      // traps when ref is null.
+      parent.implicitTrap = true;
+    }
   };
 
 public:

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -701,7 +701,19 @@ struct InfoCollector
     // TODO: optimize when possible
     addRoot(curr);
   }
-  void visitStringViewAccess(StringViewAccess* curr) {
+  void visitStringWTF8Advance(StringWTF8Advance* curr) {
+    // TODO: optimize when possible
+    addRoot(curr);
+  }
+  void visitStringWTF16Get(StringWTF16Get* curr) {
+    // TODO: optimize when possible
+    addRoot(curr);
+  }
+  void visitStringIterNext(StringIterNext* curr) {
+    // TODO: optimize when possible
+    addRoot(curr);
+  }
+  void visitStringIterMove(StringIterMove* curr) {
     // TODO: optimize when possible
     addRoot(curr);
   }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -701,6 +701,10 @@ struct InfoCollector
     // TODO: optimize when possible
     addRoot(curr);
   }
+  void visitStringViewAccess(StringViewAccess* curr) {
+    // TODO: optimize when possible
+    addRoot(curr);
+  }
 
   // TODO: Model which throws can go to which catches. For now, anything thrown
   //       is sent to the location of that tag, and any catch of that tag can

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2300,7 +2300,7 @@ struct PrintExpressionContents
         printMedium(o, "stringview_wtf8.advance");
         break;
       case StringViewAccessWTF16Get:
-        printMedium(o, "stringview_wtf16.get");
+        printMedium(o, "stringview_wtf16.get_codeunit");
         break;
       case StringViewAccessIterNext:
         printMedium(o, "stringview_iter.next");

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2294,9 +2294,15 @@ struct PrintExpressionContents
         WASM_UNREACHABLE("invalid string.as*");
     }
   }
-  void visitStringWTF8Advance(StringWTF8Advance* curr) { printMedium(o, "stringview_wtf8.advance"); }
-  void visitStringWTF16Get(StringWTF16Get* curr) { printMedium(o, "stringview_wtf16.get"); }
-  void visitStringIterNext(StringIterNext* curr) { printMedium(o, "stringview_iter.next"); }
+  void visitStringWTF8Advance(StringWTF8Advance* curr) {
+    printMedium(o, "stringview_wtf8.advance");
+  }
+  void visitStringWTF16Get(StringWTF16Get* curr) {
+    printMedium(o, "stringview_wtf16.get");
+  }
+  void visitStringIterNext(StringIterNext* curr) {
+    printMedium(o, "stringview_iter.next");
+  }
   void visitStringIterMove(StringIterMove* curr) {
     switch (curr->op) {
       case StringIterMoveAdvance:

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2294,25 +2294,19 @@ struct PrintExpressionContents
         WASM_UNREACHABLE("invalid string.as*");
     }
   }
-  void visitStringViewAccess(StringViewAccess* curr) {
+  void visitStringWTF8Advance(StringWTF8Advance* curr) { printMedium(o, "stringview_wtf8.advance"); }
+  void visitStringWTF16Get(StringWTF16Get* curr) { printMedium(o, "stringview_wtf16.get"); }
+  void visitStringIterNext(StringIterNext* curr) { printMedium(o, "stringview_iter.next"); }
+  void visitStringIterMove(StringIterMove* curr) {
     switch (curr->op) {
-      case StringViewAccessWTF8Advance:
-        printMedium(o, "stringview_wtf8.advance");
-        break;
-      case StringViewAccessWTF16Get:
-        printMedium(o, "stringview_wtf16.get_codeunit");
-        break;
-      case StringViewAccessIterNext:
-        printMedium(o, "stringview_iter.next");
-        break;
-      case StringViewAccessIterAdvance:
+      case StringIterMoveAdvance:
         printMedium(o, "stringview_iter.advance");
         break;
-      case StringViewAccessIterRewind:
+      case StringIterMoveRewind:
         printMedium(o, "stringview_iter.rewind");
         break;
       default:
-        WASM_UNREACHABLE("invalid string.as*");
+        WASM_UNREACHABLE("invalid string.move*");
     }
   }
 };

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2294,6 +2294,27 @@ struct PrintExpressionContents
         WASM_UNREACHABLE("invalid string.as*");
     }
   }
+  void visitStringViewAccess(StringViewAccess* curr) {
+    switch (curr->op) {
+      case StringViewAccessWTF8Advance:
+        printMedium(o, "stringview_wtf8.advance");
+        break;
+      case StringViewAccessWTF16Get:
+        printMedium(o, "stringview_wtf16.get");
+        break;
+      case StringViewAccessIterNext:
+        printMedium(o, "stringview_iter.next");
+        break;
+      case StringViewAccessIterAdvance:
+        printMedium(o, "stringview_iter.advance");
+        break;
+      case StringViewAccessIterRewind:
+        printMedium(o, "stringview_iter.rewind");
+        break;
+      default:
+        WASM_UNREACHABLE("invalid string.as*");
+    }
+  }
 };
 
 // Prints an expression in s-expr format, including both the

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2298,7 +2298,7 @@ struct PrintExpressionContents
     printMedium(o, "stringview_wtf8.advance");
   }
   void visitStringWTF16Get(StringWTF16Get* curr) {
-    printMedium(o, "stringview_wtf16.get");
+    printMedium(o, "stringview_wtf16.get_codeunit");
   }
   void visitStringIterNext(StringIterNext* curr) {
     printMedium(o, "stringview_iter.next");

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1150,7 +1150,7 @@ enum ASTNodes {
   StringAsWTF8 = 0x90,
   StringViewWTF8Advance = 0x91,
   StringAsWTF16 = 0x98,
-  StringViewWTF16Get = 0x9a,
+  StringViewWTF16GetCodePoint = 0x9a,
   StringAsIter = 0xa0,
   StringViewIterNext = 0xa1,
   StringViewIterAdvance = 0xa2,
@@ -1742,7 +1742,10 @@ public:
   bool maybeVisitStringConcat(Expression*& out, uint32_t code);
   bool maybeVisitStringEq(Expression*& out, uint32_t code);
   bool maybeVisitStringAs(Expression*& out, uint32_t code);
-  bool maybeVisitStringViewAccess(Expression*& out, uint32_t code);
+  bool maybeVisitStringWTF8Advance(Expression*& out, uint32_t code);
+  bool maybeVisitStringWTF16Get(Expression*& out, uint32_t code);
+  bool maybeVisitStringIterNext(Expression*& out, uint32_t code);
+  bool maybeVisitStringIterMove(Expression*& out, uint32_t code);
   void visitSelect(Select* curr, uint8_t code);
   void visitReturn(Return* curr);
   void visitMemorySize(MemorySize* curr);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1148,8 +1148,13 @@ enum ASTNodes {
   StringEq = 0x89,
   StringIsUSV = 0x8a,
   StringAsWTF8 = 0x90,
+  StringViewWTF8Advance = 0x91,
   StringAsWTF16 = 0x98,
+  StringViewWTF16Get = 0x9a,
   StringAsIter = 0xa0,
+  StringViewIterNext = 0xa1,
+  StringViewIterAdvance = 0xa2,
+  StringViewIterRewind = 0xa3,
 };
 
 enum MemoryAccess {
@@ -1737,6 +1742,7 @@ public:
   bool maybeVisitStringConcat(Expression*& out, uint32_t code);
   bool maybeVisitStringEq(Expression*& out, uint32_t code);
   bool maybeVisitStringAs(Expression*& out, uint32_t code);
+  bool maybeVisitStringViewAccess(Expression*& out, uint32_t code);
   void visitSelect(Select* curr, uint8_t code);
   void visitReturn(Return* curr);
   void visitMemorySize(MemorySize* curr);

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1041,9 +1041,8 @@ public:
     ret->finalize();
     return ret;
   }
-  StringWTF8Advance* makeStringWTF8Advance(Expression* ref,
-                                         Expression* pos,
-                                         Expression* bytes) {
+  StringWTF8Advance*
+  makeStringWTF8Advance(Expression* ref, Expression* pos, Expression* bytes) {
     auto* ret = wasm.allocator.alloc<StringWTF8Advance>();
     ret->ref = ref;
     ret->pos = pos;
@@ -1051,8 +1050,7 @@ public:
     ret->finalize();
     return ret;
   }
-  StringWTF16Get* makeStringWTF16Get(Expression* ref,
-                                         Expression* pos) {
+  StringWTF16Get* makeStringWTF16Get(Expression* ref, Expression* pos) {
     auto* ret = wasm.allocator.alloc<StringWTF16Get>();
     ret->ref = ref;
     ret->pos = pos;
@@ -1066,8 +1064,8 @@ public:
     return ret;
   }
   StringIterMove* makeStringIterMove(StringIterMoveOp op,
-                                         Expression* ref,
-                                         Expression* num = nullptr) {
+                                     Expression* ref,
+                                     Expression* num = nullptr) {
     auto* ret = wasm.allocator.alloc<StringIterMove>();
     ret->op = op;
     ret->ref = ref;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1041,6 +1041,14 @@ public:
     ret->finalize();
     return ret;
   }
+  StringViewAccess* makeStringViewAccess(StringViewAccessOp op, Expression* ref, Expression* num = nullptr) {
+    auto* ret = wasm.allocator.alloc<StringViewAccess>();
+    ret->op = op;
+    ret->ref = ref;
+    ref->num = num;
+    ret->finalize();
+    return ret;
+  }
 
   // Additional helpers
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1047,7 +1047,7 @@ public:
     auto* ret = wasm.allocator.alloc<StringViewAccess>();
     ret->op = op;
     ret->ref = ref;
-    ref->num = num;
+    ret->num = num;
     ret->finalize();
     return ret;
   }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1041,7 +1041,9 @@ public:
     ret->finalize();
     return ret;
   }
-  StringViewAccess* makeStringViewAccess(StringViewAccessOp op, Expression* ref, Expression* num = nullptr) {
+  StringViewAccess* makeStringViewAccess(StringViewAccessOp op,
+                                         Expression* ref,
+                                         Expression* num = nullptr) {
     auto* ret = wasm.allocator.alloc<StringViewAccess>();
     ret->op = op;
     ret->ref = ref;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1041,10 +1041,34 @@ public:
     ret->finalize();
     return ret;
   }
-  StringViewAccess* makeStringViewAccess(StringViewAccessOp op,
+  StringWTF8Advance* makeStringWTF8Advance(Expression* ref,
+                                         Expression* pos,
+                                         Expression* bytes) {
+    auto* ret = wasm.allocator.alloc<StringWTF8Advance>();
+    ret->ref = ref;
+    ret->pos = pos;
+    ret->bytes = bytes;
+    ret->finalize();
+    return ret;
+  }
+  StringWTF16Get* makeStringWTF16Get(Expression* ref,
+                                         Expression* pos) {
+    auto* ret = wasm.allocator.alloc<StringWTF16Get>();
+    ret->ref = ref;
+    ret->pos = pos;
+    ret->finalize();
+    return ret;
+  }
+  StringIterNext* makeStringIterNext(Expression* ref) {
+    auto* ret = wasm.allocator.alloc<StringIterNext>();
+    ret->ref = ref;
+    ret->finalize();
+    return ret;
+  }
+  StringIterMove* makeStringIterMove(StringIterMoveOp op,
                                          Expression* ref,
                                          Expression* num = nullptr) {
-    auto* ret = wasm.allocator.alloc<StringViewAccess>();
+    auto* ret = wasm.allocator.alloc<StringIterMove>();
     ret->op = op;
     ret->ref = ref;
     ret->num = num;

--- a/src/wasm-delegations-fields.def
+++ b/src/wasm-delegations-fields.def
@@ -763,6 +763,14 @@ switch (DELEGATE_ID) {
     DELEGATE_END(StringAs);
     break;
   }
+  case Expression::Id::StringViewAccessId: {
+    DELEGATE_START(StringViewAccess);
+    DELEGATE_FIELD_INT(StringViewAccess, op);
+    DELEGATE_FIELD_OPTIONAL_CHILD(StringViewAccess, num);
+    DELEGATE_FIELD_CHILD(StringViewAccess, ref);
+    DELEGATE_END(StringViewAccess);
+    break;
+  }
 }
 
 #undef DELEGATE_ID

--- a/src/wasm-delegations-fields.def
+++ b/src/wasm-delegations-fields.def
@@ -763,12 +763,33 @@ switch (DELEGATE_ID) {
     DELEGATE_END(StringAs);
     break;
   }
-  case Expression::Id::StringViewAccessId: {
-    DELEGATE_START(StringViewAccess);
-    DELEGATE_FIELD_INT(StringViewAccess, op);
-    DELEGATE_FIELD_OPTIONAL_CHILD(StringViewAccess, num);
-    DELEGATE_FIELD_CHILD(StringViewAccess, ref);
-    DELEGATE_END(StringViewAccess);
+  case Expression::Id::StringWTF8AdvanceId: {
+    DELEGATE_START(StringWTF8Advance);
+    DELEGATE_FIELD_CHILD(StringWTF8Advance, bytes);
+    DELEGATE_FIELD_CHILD(StringWTF8Advance, pos);
+    DELEGATE_FIELD_CHILD(StringWTF8Advance, ref);
+    DELEGATE_END(StringWTF8Advance);
+    break;
+  }
+  case Expression::Id::StringWTF16GetId: {
+    DELEGATE_START(StringWTF16Get);
+    DELEGATE_FIELD_CHILD(StringWTF16Get, pos);
+    DELEGATE_FIELD_CHILD(StringWTF16Get, ref);
+    DELEGATE_END(StringWTF16Get);
+    break;
+  }
+  case Expression::Id::StringIterNextId: {
+    DELEGATE_START(StringIterNext);
+    DELEGATE_FIELD_CHILD(StringIterNext, ref);
+    DELEGATE_END(StringIterNext);
+    break;
+  }
+  case Expression::Id::StringIterMoveId: {
+    DELEGATE_START(StringIterMove);
+    DELEGATE_FIELD_INT(StringIterMove, op);
+    DELEGATE_FIELD_CHILD(StringIterMove, num);
+    DELEGATE_FIELD_CHILD(StringIterMove, ref);
+    DELEGATE_END(StringIterMove);
     break;
   }
 }

--- a/src/wasm-delegations.def
+++ b/src/wasm-delegations.def
@@ -92,7 +92,7 @@ DELEGATE(StringEncode);
 DELEGATE(StringConcat);
 DELEGATE(StringEq);
 DELEGATE(StringAs);
-DELEGATE(StringWTF8Advance;
+DELEGATE(StringWTF8Advance);
 DELEGATE(StringWTF16Get);
 DELEGATE(StringIterNext);
 DELEGATE(StringIterMove);

--- a/src/wasm-delegations.def
+++ b/src/wasm-delegations.def
@@ -92,6 +92,9 @@ DELEGATE(StringEncode);
 DELEGATE(StringConcat);
 DELEGATE(StringEq);
 DELEGATE(StringAs);
-DELEGATE(StringViewAccess);
+DELEGATE(StringWTF8Advance;
+DELEGATE(StringWTF16Get);
+DELEGATE(StringIterNext);
+DELEGATE(StringIterMove);
 
 #undef DELEGATE

--- a/src/wasm-delegations.def
+++ b/src/wasm-delegations.def
@@ -92,5 +92,6 @@ DELEGATE(StringEncode);
 DELEGATE(StringConcat);
 DELEGATE(StringEq);
 DELEGATE(StringAs);
+DELEGATE(StringViewAccess);
 
 #undef DELEGATE

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1976,7 +1976,16 @@ public:
   Flow visitStringAs(StringAs* curr) {
     WASM_UNREACHABLE("unimplemented string.as");
   }
-  Flow visitStringViewAccess(StringViewAccess* curr) {
+  Flow visitStringWTF8Advance(StringWTF8Advance* curr) {
+    WASM_UNREACHABLE("unimplemented stringview_adjust*");
+  }
+  Flow visitStringWTF16Get(StringWTF16Get* curr) {
+    WASM_UNREACHABLE("unimplemented stringview_adjust*");
+  }
+  Flow visitStringIterNext(StringIterNext* curr) {
+    WASM_UNREACHABLE("unimplemented stringview_adjust*");
+  }
+  Flow visitStringIterMove(StringIterMove* curr) {
     WASM_UNREACHABLE("unimplemented stringview_adjust*");
   }
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1976,6 +1976,9 @@ public:
   Flow visitStringAs(StringAs* curr) {
     WASM_UNREACHABLE("unimplemented string.as");
   }
+  Flow visitStringViewAccess(StringViewAccess* curr) {
+    WASM_UNREACHABLE("unimplemented stringview_adjust*");
+  }
 
   virtual void trap(const char* why) { WASM_UNREACHABLE("unimp"); }
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -310,7 +310,10 @@ private:
   Expression* makeStringConcat(Element& s);
   Expression* makeStringEq(Element& s);
   Expression* makeStringAs(Element& s, StringAsOp op);
-  Expression* makeStringViewAccess(Element& s, StringViewAccessOp op);
+  Expression* makeStringWTF8Advance(Element& s);
+  Expression* makeStringWTF16Get(Element& s);
+  Expression* makeStringIterNext(Element& s);
+  Expression* makeStringIterMove(Element& s, StringIterMoveOp op);
 
   // Helper functions
   Type parseOptionalResultType(Element& s, Index& i);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -310,6 +310,7 @@ private:
   Expression* makeStringConcat(Element& s);
   Expression* makeStringEq(Element& s);
   Expression* makeStringAs(Element& s, StringAsOp op);
+  Expression* makeStringViewAccess(Element& s, StringViewAccess op);
 
   // Helper functions
   Type parseOptionalResultType(Element& s, Index& i);

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -310,7 +310,7 @@ private:
   Expression* makeStringConcat(Element& s);
   Expression* makeStringEq(Element& s);
   Expression* makeStringAs(Element& s, StringAsOp op);
-  Expression* makeStringViewAccess(Element& s, StringViewAccess op);
+  Expression* makeStringViewAccess(Element& s, StringViewAccessOp op);
 
   // Helper functions
   Type parseOptionalResultType(Element& s, Index& i);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1769,9 +1769,6 @@ class StringWTF8Advance
 public:
   StringWTF8Advance(MixedArena& allocator) {}
 
-  // Whether the movement is to advance or reverse.
-  StringWTF8AdvanceOp op;
-
   Expression* ref;
   Expression* pos;
   Expression* bytes;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1766,7 +1766,8 @@ public:
   void finalize();
 };
 
-class StringViewAccess : public SpecificExpression<Expression::StringViewAccessId> {
+class StringViewAccess
+  : public SpecificExpression<Expression::StringViewAccessId> {
 public:
   StringViewAccess(MixedArena& allocator) {}
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1779,8 +1779,7 @@ public:
   void finalize();
 };
 
-class StringWTF16Get
-  : public SpecificExpression<Expression::StringWTF16GetId> {
+class StringWTF16Get : public SpecificExpression<Expression::StringWTF16GetId> {
 public:
   StringWTF16Get(MixedArena& allocator) {}
 
@@ -1790,8 +1789,7 @@ public:
   void finalize();
 };
 
-class StringIterNext
-  : public SpecificExpression<Expression::StringIterNextId> {
+class StringIterNext : public SpecificExpression<Expression::StringIterNextId> {
 public:
   StringIterNext(MixedArena& allocator) {}
 
@@ -1800,8 +1798,7 @@ public:
   void finalize();
 };
 
-class StringIterMove
-  : public SpecificExpression<Expression::StringIterMoveId> {
+class StringIterMove : public SpecificExpression<Expression::StringIterMoveId> {
 public:
   StringIterMove(MixedArena& allocator) {}
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -613,7 +613,7 @@ enum StringAsOp {
 // cursor while doing so.
 enum StringViewAccessOp {
   StringViewAccessWTF8Advance,
-  StringViewAccessWTF16Get,
+  StringViewAccessWTF16GetCodeUnit,
   StringViewAccessIterNext,
   StringViewAccessIterAdvance,
   StringViewAccessIterRewind,

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1775,7 +1775,8 @@ public:
 
   Expression* ref;
 
-  // Advance and Rewind take the number of code points to advance/rewind.
+  // Next has no numeric index (it always advances by one). All other ops have a
+  // second parameter.
   Expression* num = nullptr;
 
   void finalize();

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -609,14 +609,9 @@ enum StringAsOp {
   StringAsIter,
 };
 
-// Operations that access the code points in the view, and possibly move the
-// cursor while doing so.
-enum StringViewAccessOp {
-  StringViewAccessWTF8Advance,
-  StringViewAccessWTF16GetCodeUnit,
-  StringViewAccessIterNext,
-  StringViewAccessIterAdvance,
-  StringViewAccessIterRewind,
+enum StringIterMoveOp {
+  StringIterMoveAdvance,
+  StringIterMoveRewind,
 };
 
 //
@@ -721,7 +716,10 @@ public:
     StringConcatId,
     StringEqId,
     StringAsId,
-    StringViewAccessId,
+    StringWTF8AdvanceId,
+    StringWTF16GetId,
+    StringIterNextId,
+    StringIterMoveId,
     NumExpressionIds
   };
   Id _id;
@@ -1766,18 +1764,54 @@ public:
   void finalize();
 };
 
-class StringViewAccess
-  : public SpecificExpression<Expression::StringViewAccessId> {
+class StringWTF8Advance
+  : public SpecificExpression<Expression::StringWTF8AdvanceId> {
 public:
-  StringViewAccess(MixedArena& allocator) {}
+  StringWTF8Advance(MixedArena& allocator) {}
 
-  StringViewAccessOp op;
+  // Whether the movement is to advance or reverse.
+  StringWTF8AdvanceOp op;
+
+  Expression* ref;
+  Expression* pos;
+  Expression* bytes;
+
+  void finalize();
+};
+
+class StringWTF16Get
+  : public SpecificExpression<Expression::StringWTF16GetId> {
+public:
+  StringWTF16Get(MixedArena& allocator) {}
+
+  Expression* ref;
+  Expression* pos;
+
+  void finalize();
+};
+
+class StringIterNext
+  : public SpecificExpression<Expression::StringIterNextId> {
+public:
+  StringIterNext(MixedArena& allocator) {}
 
   Expression* ref;
 
-  // Next has no numeric index (it always advances by one). All other ops have a
-  // second parameter.
-  Expression* num = nullptr;
+  void finalize();
+};
+
+class StringIterMove
+  : public SpecificExpression<Expression::StringIterMoveId> {
+public:
+  StringIterMove(MixedArena& allocator) {}
+
+  // Whether the movement is to advance or reverse.
+  StringIterMoveOp op;
+
+  Expression* ref;
+
+  // How many codepoints to advance or reverse.
+  Expression* num;
 
   void finalize();
 };

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -609,6 +609,16 @@ enum StringAsOp {
   StringAsIter,
 };
 
+// Operations that access the code points in the view, and possibly move the
+// cursor while doing so.
+enum StringViewAccessOp {
+  StringViewAccessWTF8Advance,
+  StringViewAccessWTF16Get,
+  StringViewAccessIterNext,
+  StringViewAccessIterAdvance,
+  StringViewAccessIterRewind,
+};
+
 //
 // Expressions
 //
@@ -711,6 +721,7 @@ public:
     StringConcatId,
     StringEqId,
     StringAsId,
+    StringViewAccessId,
     NumExpressionIds
   };
   Id _id;
@@ -1751,6 +1762,20 @@ public:
   StringAsOp op;
 
   Expression* ref;
+
+  void finalize();
+};
+
+class StringViewAccess : public SpecificExpression<Expression::StringViewAccessId> {
+public:
+  StringViewAccess(MixedArena& allocator) {}
+
+  StringViewAccessOp op;
+
+  Expression* ref;
+
+  // Advance and Rewind take the number of code points to advance/rewind.
+  Expression* num = nullptr;
 
   void finalize();
 };

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7305,7 +7305,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
 
 bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
                                                    uint32_t code) {
-  if (code != BinaryConsts::StringIterNext) {
+  if (code != BinaryConsts::StringViewIterNext) {
     return false;
   }
   auto* ref = popNonVoidExpression();
@@ -7316,9 +7316,9 @@ bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
 bool WasmBinaryBuilder::maybeVisitStringIterMove(Expression*& out,
                                                  uint32_t code) {
   StringIterMoveOp op;
-  if (code == BinaryConsts::StringIterAdvance) {
+  if (code == BinaryConsts::StringViewIterAdvance) {
     op = StringIterAdvance;
-  } else if (code == BinaryConsts::StringIterRewind) {
+  } else if (code == BinaryConsts::StringViewIterRewind) {
     op = StringIterRewind;
   } else {
     return false;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7294,7 +7294,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF8Advance(Expression*& out,
 
 bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
                                                  uint32_t code) {
-  if (code != BinaryConsts::StringViewIterWTF16Get) {
+  if (code != BinaryConsts::StringViewWTF16Get) {
     return false;
   }
   auto* pos = popNonVoidExpression();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7275,17 +7275,17 @@ bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
                                                    uint32_t code) {
   StringViewAccessOp op;
   Expression* num = nullptr;
-  if (code == BinaryConsts::StringViewAccessWTF8Advance) {
+  if (code == BinaryConsts::StringViewWTF8Advance) {
     op = StringViewAccessWTF8Advance;
     num = popNonVoidExpression();
-  } else if (code == BinaryConsts::StringViewAccessWTF16Get) {
+  } else if (code == BinaryConsts::StringViewWTF16Get) {
     op = StringViewAccessWTF16Get;
-  } else if (code == BinaryConsts::StringViewAccessIterNext) {
+  } else if (code == BinaryConsts::StringViewIterNext) {
     op = StringViewAccessIterNext;
-  } else if (code == BinaryConsts::StringViewAccessIterAdvance) {
+  } else if (code == BinaryConsts::StringViewIterAdvance) {
     op = StringViewAccessIterAdvance;
     num = popNonVoidExpression();
-  } else if (code == BinaryConsts::StringViewAccessIterRewind) {
+  } else if (code == BinaryConsts::StringViewIterRewind) {
     op = StringViewAccessIterRewind;
     num = popNonVoidExpression();
   } else {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7294,7 +7294,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF8Advance(Expression*& out,
 
 bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
                                                  uint32_t code) {
-  if (code != BinaryConsts::StringViewWTF16Get) {
+  if (code != BinaryConsts::StringViewWTF16GetCodePoint) {
     return false;
   }
   auto* pos = popNonVoidExpression();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7281,7 +7281,7 @@ bool WasmBinaryBuilder::maybeVisitStringAs(Expression*& out, uint32_t code) {
 }
 
 bool WasmBinaryBuilder::maybeVisitStringWTF8Advance(Expression*& out,
-                                                   uint32_t code) {
+                                                    uint32_t code) {
   if (code != BinaryConsts::StringViewWTF8Advance) {
     return false;
   }
@@ -7293,7 +7293,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF8Advance(Expression*& out,
 }
 
 bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
-                                                   uint32_t code) {
+                                                 uint32_t code) {
   if (code != BinaryConsts::StringViewWTF16Get) {
     return false;
   }
@@ -7314,7 +7314,7 @@ bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
 }
 
 bool WasmBinaryBuilder::maybeVisitStringIterMove(Expression*& out,
-                                                   uint32_t code) {
+                                                 uint32_t code) {
   StringIterMoveOp op;
   if (code == BinaryConsts::StringIterAdvance) {
     op = StringIterAdvance;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7280,6 +7280,7 @@ bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
     num = popNonVoidExpression();
   } else if (code == BinaryConsts::StringViewWTF16Get) {
     op = StringViewAccessWTF16Get;
+    num = popNonVoidExpression();
   } else if (code == BinaryConsts::StringViewIterNext) {
     op = StringViewAccessIterNext;
   } else if (code == BinaryConsts::StringViewIterAdvance) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7304,7 +7304,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
 }
 
 bool WasmBinaryBuilder::maybeVisitStringIterNext(Expression*& out,
-                                                   uint32_t code) {
+                                                 uint32_t code) {
   if (code != BinaryConsts::StringViewIterNext) {
     return false;
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7279,7 +7279,7 @@ bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
     op = StringViewAccessWTF8Advance;
     num = popNonVoidExpression();
   } else if (code == BinaryConsts::StringViewWTF16Get) {
-    op = StringViewAccessWTF16Get;
+    op = StringViewAccessWTF16GetCodeUnit;
     num = popNonVoidExpression();
   } else if (code == BinaryConsts::StringViewIterNext) {
     op = StringViewAccessIterNext;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3939,6 +3939,9 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       if (maybeVisitStringAs(curr, opcode)) {
         break;
       }
+      if (maybeVisitStringViewAccess(curr, opcode)) {
+        break;
+      }
       if (opcode == BinaryConsts::RefIsFunc ||
           opcode == BinaryConsts::RefIsData ||
           opcode == BinaryConsts::RefIsI31) {
@@ -7265,6 +7268,30 @@ bool WasmBinaryBuilder::maybeVisitStringAs(Expression*& out, uint32_t code) {
   }
   auto* ref = popNonVoidExpression();
   out = Builder(wasm).makeStringAs(op, ref);
+  return true;
+}
+
+bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out, uint32_t code) {
+  StringViewAccessOp op;
+  Expression* num = nullptr;
+  if (code == BinaryConsts::StringViewAccessWTF8Advance) {
+    op = StringViewAccessWTF8Advance;
+    num = popNonVoidExpression();
+  } else if (code == BinaryConsts::StringViewAccessWTF16Get) {
+    op = StringViewAccessWTF16Get;
+  } else if (code == BinaryConsts::StringViewAccessIterNext) {
+    op = StringViewAccessIterNext;
+  } else if (code == BinaryConsts::StringViewAccessIterAdvance) {
+    op = StringViewAccessIterAdvance;
+    num = popNonVoidExpression();
+  } else if (code == BinaryConsts::StringViewAccessIterRewind) {
+    op = StringViewAccessIterRewind;
+    num = popNonVoidExpression();
+  } else {
+    return false;
+  }
+  auto* ref = popNonVoidExpression();
+  out = Builder(wasm).makeStringViewAccess(op, ref, num);
   return true;
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7271,7 +7271,8 @@ bool WasmBinaryBuilder::maybeVisitStringAs(Expression*& out, uint32_t code) {
   return true;
 }
 
-bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out, uint32_t code) {
+bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
+                                                   uint32_t code) {
   StringViewAccessOp op;
   Expression* num = nullptr;
   if (code == BinaryConsts::StringViewAccessWTF8Advance) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7294,7 +7294,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF8Advance(Expression*& out,
 
 bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
                                                  uint32_t code) {
-  if (code != BinaryConsts::StringViewWTF16Get) {
+  if (code != BinaryConsts::StringViewIterWTF16Get) {
     return false;
   }
   auto* pos = popNonVoidExpression();
@@ -7303,7 +7303,7 @@ bool WasmBinaryBuilder::maybeVisitStringWTF16Get(Expression*& out,
   return true;
 }
 
-bool WasmBinaryBuilder::maybeVisitStringViewAccess(Expression*& out,
+bool WasmBinaryBuilder::maybeVisitStringIterNext(Expression*& out,
                                                    uint32_t code) {
   if (code != BinaryConsts::StringViewIterNext) {
     return false;
@@ -7317,9 +7317,9 @@ bool WasmBinaryBuilder::maybeVisitStringIterMove(Expression*& out,
                                                  uint32_t code) {
   StringIterMoveOp op;
   if (code == BinaryConsts::StringViewIterAdvance) {
-    op = StringIterAdvance;
+    op = StringIterMoveAdvance;
   } else if (code == BinaryConsts::StringViewIterRewind) {
-    op = StringIterRewind;
+    op = StringIterMoveRewind;
   } else {
     return false;
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3004,27 +3004,22 @@ Expression* SExpressionWasmBuilder::makeStringAs(Element& s, StringAsOp op) {
   return Builder(wasm).makeStringAs(op, parseExpression(s[1]));
 }
 
-Expression*
-SExpressionWasmBuilder::makeStringWTF8Advance(Element& s) {
+Expression* SExpressionWasmBuilder::makeStringWTF8Advance(Element& s) {
   return Builder(wasm).makeStringWTF8Advance(
     parseExpression(s[1]), parseExpression(s[2]), parseExpression(s[3]));
 }
 
-Expression*
-SExpressionWasmBuilder::makeStringWTF16Get(Element& s) {
-  return Builder(wasm).makeStringWTF16Get(
-    parseExpression(s[1]), parseExpression(s[2]));
+Expression* SExpressionWasmBuilder::makeStringWTF16Get(Element& s) {
+  return Builder(wasm).makeStringWTF16Get(parseExpression(s[1]),
+                                          parseExpression(s[2]));
 }
 
-Expression*
-SExpressionWasmBuilder::makeStringIterNext(Element& s) {
-  return Builder(wasm).makeStringIterNext(
-    parseExpression(s[1]));
+Expression* SExpressionWasmBuilder::makeStringIterNext(Element& s) {
+  return Builder(wasm).makeStringIterNext(parseExpression(s[1]));
 }
 
-Expression*
-SExpressionWasmBuilder::makeStringIterMove(Element& s,
-                                             StringIterMoveOp op) {
+Expression* SExpressionWasmBuilder::makeStringIterMove(Element& s,
+                                                       StringIterMoveOp op) {
   return Builder(wasm).makeStringIterMove(
     op, parseExpression(s[1]), parseExpression(s[2]));
 }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3004,6 +3004,10 @@ Expression* SExpressionWasmBuilder::makeStringAs(Element& s, StringAsOp op) {
   return Builder(wasm).makeStringAs(op, parseExpression(s[1]));
 }
 
+Expression* SExpressionWasmBuilder::makeStringViewAccess(Element& s, StringViewAccessOp op) {
+  return Builder(wasm).makeStringViewAccess(op, parseExpression(s[1]), s.size() == 3 ? parseExpression(s[2]) : nullptr);
+}
+
 // converts an s-expression string representing binary data into an output
 // sequence of raw bytes this appends to data, which may already contain
 // content.

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3004,8 +3004,11 @@ Expression* SExpressionWasmBuilder::makeStringAs(Element& s, StringAsOp op) {
   return Builder(wasm).makeStringAs(op, parseExpression(s[1]));
 }
 
-Expression* SExpressionWasmBuilder::makeStringViewAccess(Element& s, StringViewAccessOp op) {
-  return Builder(wasm).makeStringViewAccess(op, parseExpression(s[1]), s.size() == 3 ? parseExpression(s[2]) : nullptr);
+Expression*
+SExpressionWasmBuilder::makeStringViewAccess(Element& s,
+                                             StringViewAccessOp op) {
+  return Builder(wasm).makeStringViewAccess(
+    op, parseExpression(s[1]), s.size() == 3 ? parseExpression(s[2]) : nullptr);
 }
 
 // converts an s-expression string representing binary data into an output

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3005,10 +3005,28 @@ Expression* SExpressionWasmBuilder::makeStringAs(Element& s, StringAsOp op) {
 }
 
 Expression*
-SExpressionWasmBuilder::makeStringViewAccess(Element& s,
-                                             StringViewAccessOp op) {
-  return Builder(wasm).makeStringViewAccess(
-    op, parseExpression(s[1]), s.size() == 3 ? parseExpression(s[2]) : nullptr);
+SExpressionWasmBuilder::makeStringWTF8Advance(Element& s) {
+  return Builder(wasm).makeStringWTF8Advance(
+    parseExpression(s[1]), parseExpression(s[2]), parseExpression(s[3]));
+}
+
+Expression*
+SExpressionWasmBuilder::makeStringWTF16Get(Element& s) {
+  return Builder(wasm).makeStringWTF16Get(
+    parseExpression(s[1]), parseExpression(s[2]));
+}
+
+Expression*
+SExpressionWasmBuilder::makeStringIterNext(Element& s) {
+  return Builder(wasm).makeStringIterNext(
+    parseExpression(s[1]));
+}
+
+Expression*
+SExpressionWasmBuilder::makeStringIterMove(Element& s,
+                                             StringIterMoveOp op) {
+  return Builder(wasm).makeStringIterMove(
+    op, parseExpression(s[1]), parseExpression(s[2]));
 }
 
 // converts an s-expression string representing binary data into an output

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2339,7 +2339,8 @@ void BinaryInstWriter::visitStringWTF16Get(StringWTF16Get* curr) {
 }
 
 void BinaryInstWriter::visitStringIterNext(StringIterNext* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringViewIterNext);
+  o << int8_t(BinaryConsts::GCPrefix)
+    << U32LEB(BinaryConsts::StringViewIterNext);
 }
 
 void BinaryInstWriter::visitStringIterMove(StringIterMove* curr) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2328,6 +2328,29 @@ void BinaryInstWriter::visitStringAs(StringAs* curr) {
   }
 }
 
+void BinaryInstWriter::visitStringViewAccess(StringViewAccess* curr) {
+  o << int8_t(BinaryConsts::GCPrefix);
+  switch (curr->op) {
+    case StringViewAccessWTF8Advance:
+      o << U32LEB(BinaryConsts::StringViewAccessWTF8Advance);
+      break;
+    case StringViewAccessWTF16Get:
+      o << U32LEB(BinaryConsts::StringViewAccessWTF16Get);
+      break;
+    case StringViewAccessIterNext:
+      o << U32LEB(BinaryConsts::StringViewAccessIterNext);
+      break;
+    case StringViewAccessIterAdvance:
+      o << U32LEB(BinaryConsts::StringViewAccessIterAdvance);
+      break;
+    case StringViewAccessIterRewind:
+      o << U32LEB(BinaryConsts::StringViewAccessIterRewind);
+      break;
+    default:
+      WASM_UNREACHABLE("invalid string.as*");
+  }
+}
+
 void BinaryInstWriter::emitScopeEnd(Expression* curr) {
   assert(!breakStack.empty());
   breakStack.pop_back();

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2329,11 +2329,13 @@ void BinaryInstWriter::visitStringAs(StringAs* curr) {
 }
 
 void BinaryInstWriter::visitStringWTF8Advance(StringWTF8Advance* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringWTF8Advance);
+  o << int8_t(BinaryConsts::GCPrefix)
+    << U32LEB(BinaryConsts::StringWTF8Advance);
 }
 
 void BinaryInstWriter::visitStringWTF16Get(StringWTF16Get* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringWTF16GetCodeUnit);
+  o << int8_t(BinaryConsts::GCPrefix)
+    << U32LEB(BinaryConsts::StringWTF16GetCodeUnit);
 }
 
 void BinaryInstWriter::visitStringIterNext(StringIterNext* curr) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2342,13 +2342,13 @@ void BinaryInstWriter::visitStringIterNext(StringIterNext* curr) {
   o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringViewIterNext);
 }
 
-void BinaryInstWriter::visitStringMove(StringMove* curr) {
+void BinaryInstWriter::visitStringIterMove(StringIterMove* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   switch (curr->op) {
-    case StringMoveWTF8Advance:
+    case StringIterMoveAdvance:
       o << U32LEB(BinaryConsts::StringViewIterAdvance);
       break;
-    case StringMoveIterRewind:
+    case StringIterMoveRewind:
       o << U32LEB(BinaryConsts::StringViewIterRewind);
       break;
     default:

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2332,19 +2332,19 @@ void BinaryInstWriter::visitStringViewAccess(StringViewAccess* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   switch (curr->op) {
     case StringViewAccessWTF8Advance:
-      o << U32LEB(BinaryConsts::StringViewAccessWTF8Advance);
+      o << U32LEB(BinaryConsts::StringViewWTF8Advance);
       break;
     case StringViewAccessWTF16Get:
-      o << U32LEB(BinaryConsts::StringViewAccessWTF16Get);
+      o << U32LEB(BinaryConsts::StringViewWTF16Get);
       break;
     case StringViewAccessIterNext:
-      o << U32LEB(BinaryConsts::StringViewAccessIterNext);
+      o << U32LEB(BinaryConsts::StringViewIterNext);
       break;
     case StringViewAccessIterAdvance:
-      o << U32LEB(BinaryConsts::StringViewAccessIterAdvance);
+      o << U32LEB(BinaryConsts::StringViewIterAdvance);
       break;
     case StringViewAccessIterRewind:
-      o << U32LEB(BinaryConsts::StringViewAccessIterRewind);
+      o << U32LEB(BinaryConsts::StringViewIterRewind);
       break;
     default:
       WASM_UNREACHABLE("invalid string.as*");

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2328,26 +2328,29 @@ void BinaryInstWriter::visitStringAs(StringAs* curr) {
   }
 }
 
-void BinaryInstWriter::visitStringViewAccess(StringViewAccess* curr) {
+void BinaryInstWriter::visitStringWTF8Advance(StringWTF8Advance* curr) {
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringWTF8Advance);
+}
+
+void BinaryInstWriter::visitStringWTF16Get(StringWTF16Get* curr) {
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringWTF16GetCodeUnit);
+}
+
+void BinaryInstWriter::visitStringIterNext(StringIterNext* curr) {
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringIterNext);
+}
+
+void BinaryInstWriter::visitStringMove(StringMove* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   switch (curr->op) {
-    case StringViewAccessWTF8Advance:
-      o << U32LEB(BinaryConsts::StringViewWTF8Advance);
+    case StringMoveWTF8Advance:
+      o << U32LEB(BinaryConsts::StringIterAdvance);
       break;
-    case StringViewAccessWTF16GetCodeUnit:
-      o << U32LEB(BinaryConsts::StringViewWTF16Get);
-      break;
-    case StringViewAccessIterNext:
-      o << U32LEB(BinaryConsts::StringViewIterNext);
-      break;
-    case StringViewAccessIterAdvance:
-      o << U32LEB(BinaryConsts::StringViewIterAdvance);
-      break;
-    case StringViewAccessIterRewind:
-      o << U32LEB(BinaryConsts::StringViewIterRewind);
+    case StringMoveIterRewind:
+      o << U32LEB(BinaryConsts::StringIterRewind);
       break;
     default:
-      WASM_UNREACHABLE("invalid string.as*");
+      WASM_UNREACHABLE("invalid string.move*");
   }
 }
 

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2330,26 +2330,26 @@ void BinaryInstWriter::visitStringAs(StringAs* curr) {
 
 void BinaryInstWriter::visitStringWTF8Advance(StringWTF8Advance* curr) {
   o << int8_t(BinaryConsts::GCPrefix)
-    << U32LEB(BinaryConsts::StringWTF8Advance);
+    << U32LEB(BinaryConsts::StringViewWTF8Advance);
 }
 
 void BinaryInstWriter::visitStringWTF16Get(StringWTF16Get* curr) {
   o << int8_t(BinaryConsts::GCPrefix)
-    << U32LEB(BinaryConsts::StringWTF16GetCodeUnit);
+    << U32LEB(BinaryConsts::StringViewWTF16GetCodePoint);
 }
 
 void BinaryInstWriter::visitStringIterNext(StringIterNext* curr) {
-  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringIterNext);
+  o << int8_t(BinaryConsts::GCPrefix) << U32LEB(BinaryConsts::StringViewIterNext);
 }
 
 void BinaryInstWriter::visitStringMove(StringMove* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   switch (curr->op) {
     case StringMoveWTF8Advance:
-      o << U32LEB(BinaryConsts::StringIterAdvance);
+      o << U32LEB(BinaryConsts::StringViewIterAdvance);
       break;
     case StringMoveIterRewind:
-      o << U32LEB(BinaryConsts::StringIterRewind);
+      o << U32LEB(BinaryConsts::StringViewIterRewind);
       break;
     default:
       WASM_UNREACHABLE("invalid string.move*");

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2334,7 +2334,7 @@ void BinaryInstWriter::visitStringViewAccess(StringViewAccess* curr) {
     case StringViewAccessWTF8Advance:
       o << U32LEB(BinaryConsts::StringViewWTF8Advance);
       break;
-    case StringViewAccessWTF16Get:
+    case StringViewAccessWTF16GetCodeUnit:
       o << U32LEB(BinaryConsts::StringViewWTF16Get);
       break;
     case StringViewAccessIterNext:

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1237,7 +1237,8 @@ void StringAs::finalize() {
 }
 
 void StringViewAccess::finalize() {
-  if (ref->type == Type::unreachable || (num && num->type == Type::unreachable)) {
+  if (ref->type == Type::unreachable ||
+      (num && num->type == Type::unreachable)) {
     type = Type::unreachable;
   } else {
     type = Type::i32;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1237,7 +1237,8 @@ void StringAs::finalize() {
 }
 
 void StringWTF8Advance::finalize() {
-  if (ref->type == Type::unreachable || pos->type == Type::unreachable == bytes->type == Type::unreachable) {
+  if (ref->type == Type::unreachable ||
+      pos->type == Type::unreachable == bytes->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
     type = Type::i32;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1237,8 +1237,8 @@ void StringAs::finalize() {
 }
 
 void StringWTF8Advance::finalize() {
-  if (ref->type == Type::unreachable ||
-      pos->type == Type::unreachable || bytes->type == Type::unreachable) {
+  if (ref->type == Type::unreachable || pos->type == Type::unreachable ||
+      bytes->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
     type = Type::i32;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1238,7 +1238,7 @@ void StringAs::finalize() {
 
 void StringWTF8Advance::finalize() {
   if (ref->type == Type::unreachable ||
-      pos->type == Type::unreachable == bytes->type == Type::unreachable) {
+      pos->type == Type::unreachable || bytes->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
     type = Type::i32;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1236,6 +1236,14 @@ void StringAs::finalize() {
   }
 }
 
+void StringViewAccess::finalize() {
+  if (ref->type == Type::unreachable || (num && num->type == Type::unreachable)) {
+    type = Type::unreachable;
+  } else {
+    type = Type::i32;
+  }
+}
+
 size_t Function::getNumParams() { return getParams().size(); }
 
 size_t Function::getNumVars() { return vars.size(); }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1253,7 +1253,7 @@ void StringWTF16Get::finalize() {
   }
 }
 
-void StringViewAccess::finalize() {
+void StringIterNext::finalize() {
   if (ref->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
@@ -1261,7 +1261,7 @@ void StringViewAccess::finalize() {
   }
 }
 
-void StringViewAccess::finalize() {
+void StringIterMove::finalize() {
   if (ref->type == Type::unreachable || num->type == Type::unreachable) {
     type = Type::unreachable;
   } else {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1236,9 +1236,32 @@ void StringAs::finalize() {
   }
 }
 
+void StringWTF8Advance::finalize() {
+  if (ref->type == Type::unreachable || pos->type == Type::unreachable == bytes->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = Type::i32;
+  }
+}
+
+void StringWTF16Get::finalize() {
+  if (ref->type == Type::unreachable || pos->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = Type::i32;
+  }
+}
+
 void StringViewAccess::finalize() {
-  if (ref->type == Type::unreachable ||
-      (num && num->type == Type::unreachable)) {
+  if (ref->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = Type::i32;
+  }
+}
+
+void StringViewAccess::finalize() {
+  if (ref->type == Type::unreachable || num->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
     type = Type::i32;

--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -676,7 +676,8 @@ Result<typename Ctx::InstrT> makeStringEq(Ctx&, ParseInput&);
 template<typename Ctx>
 Result<typename Ctx::InstrT> makeStringAs(Ctx&, ParseInput&, StringAsOp op);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringViewAccess(Ctx&, ParseInput&, StringViewAccessOp op);
+Result<typename Ctx::InstrT>
+makeStringViewAccess(Ctx&, ParseInput&, StringViewAccessOp op);
 
 // Modules
 template<typename Ctx>

--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -676,8 +676,14 @@ Result<typename Ctx::InstrT> makeStringEq(Ctx&, ParseInput&);
 template<typename Ctx>
 Result<typename Ctx::InstrT> makeStringAs(Ctx&, ParseInput&, StringAsOp op);
 template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringWTF8Advance(Ctx&, ParseInput&);
+template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringWTF16Get(Ctx&, ParseInput&);
+template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringIterNext(Ctx&, ParseInput&);
+template<typename Ctx>
 Result<typename Ctx::InstrT>
-makeStringViewAccess(Ctx&, ParseInput&, StringViewAccessOp op);
+makeStringIterMove(Ctx&, ParseInput&, StringIterMoveOp op);
 
 // Modules
 template<typename Ctx>
@@ -1673,8 +1679,23 @@ makeStringAs(Ctx& ctx, ParseInput& in, StringAsOp op) {
 }
 
 template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringWTF8Advance(Ctx& ctx, ParseInput& in) {
+  return in.err("unimplemented instruction");
+}
+
+template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringWTF16Get(Ctx& ctx, ParseInput& in) {
+  return in.err("unimplemented instruction");
+}
+
+template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringIterNext(Ctx& ctx, ParseInput& in) {
+  return in.err("unimplemented instruction");
+}
+
+template<typename Ctx>
 Result<typename Ctx::InstrT>
-makeStringViewAccess(Ctx& ctx, ParseInput& in, StringViewAccessOp op) {
+makeStringIterMove(Ctx& ctx, ParseInput& in, StringIterMoveOp op) {
   return in.err("unimplemented instruction");
 }
 

--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -675,6 +675,8 @@ template<typename Ctx>
 Result<typename Ctx::InstrT> makeStringEq(Ctx&, ParseInput&);
 template<typename Ctx>
 Result<typename Ctx::InstrT> makeStringAs(Ctx&, ParseInput&, StringAsOp op);
+template<typename Ctx>
+Result<typename Ctx::InstrT> makeStringViewAccess(Ctx&, ParseInput&, StringViewAccessOp op);
 
 // Modules
 template<typename Ctx>
@@ -1666,6 +1668,12 @@ Result<typename Ctx::InstrT> makeStringEq(Ctx& ctx, ParseInput& in) {
 template<typename Ctx>
 Result<typename Ctx::InstrT>
 makeStringAs(Ctx& ctx, ParseInput& in, StringAsOp op) {
+  return in.err("unimplemented instruction");
+}
+
+template<typename Ctx>
+Result<typename Ctx::InstrT>
+makeStringViewAccess(Ctx& ctx, ParseInput& in, StringViewAccessOp op) {
   return in.err("unimplemented instruction");
 }
 

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -2331,6 +2331,10 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");
     }
+    Ref visitStringViewAccess(StringViewAccess* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
     Ref visitRefAs(RefAs* curr) {
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -2331,7 +2331,19 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");
     }
-    Ref visitStringViewAccess(StringViewAccess* curr) {
+    Ref visitStringWTF8Advance(StringWTF8Advance* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
+    Ref visitStringWTF16Get(StringWTF16Get* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
+    Ref visitStringIterNext(StringIterNext* curr) {
+      unimplemented(curr);
+      WASM_UNREACHABLE("unimp");
+    }
+    Ref visitStringIterMove(StringIterMove* curr) {
       unimplemented(curr);
       WASM_UNREACHABLE("unimp");
     }

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -294,11 +294,9 @@
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $b)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $i32
-  ;; CHECK-NEXT:   (stringview_wtf16.get
+  ;; CHECK-NEXT:   (stringview_wtf16.get_codeunit
+  ;; CHECK-NEXT:    (local.get $b)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -296,7 +296,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $i32
   ;; CHECK-NEXT:   (stringview_wtf16.get_codeunit
-  ;; CHECK-NEXT:    (local.get $b)
+  ;; CHECK-NEXT:    (local.get $c)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -332,7 +332,7 @@
     )
     (local.set $i32
       (stringview_wtf16.get_codeunit
-        (local.get $b)
+        (local.get $c)
         (i32.const 2)
       )
     )

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -286,11 +286,12 @@
     )
   )
 
-  ;; CHECK:      (func $stringview.adjust (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter)
+  ;; CHECK:      (func $stringview-access (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter)
   ;; CHECK-NEXT:  (local $i32 i32)
   ;; CHECK-NEXT:  (local.set $i32
   ;; CHECK-NEXT:   (stringview_wtf8.advance
   ;; CHECK-NEXT:    (local.get $b)
+  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -318,7 +318,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $stringview.adjust
+  (func $stringview-access
     (param $a stringref)
     (param $b stringview_wtf8)
     (param $c stringview_wtf16)
@@ -327,6 +327,7 @@
     (local.set $i32 ;; validate the output type
       (stringview_wtf8.advance
         (local.get $b)
+        (i32.const 0)
         (i32.const 1)
       )
     )

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -9,11 +9,11 @@
 
   ;; CHECK:      (type $ref?|string|_ref?|string|_=>_none (func (param stringref stringref)))
 
+  ;; CHECK:      (type $ref?|string|_ref?|stringview_wtf8|_ref?|stringview_wtf16|_ref?|stringview_iter|_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter)))
+
   ;; CHECK:      (type $ref?|string|_ref?|stringview_wtf8|_ref?|stringview_wtf16|_ref?|stringview_iter|_ref?|string|_ref?|stringview_wtf8|_ref?|stringview_wtf16|_ref?|stringview_iter|_ref|string|_ref|stringview_wtf8|_ref|stringview_wtf16|_ref|stringview_iter|_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter stringref stringview_wtf8 stringview_wtf16 stringview_iter (ref string) (ref stringview_wtf8) (ref stringview_wtf16) (ref stringview_iter))))
 
   ;; CHECK:      (type $none_=>_none (func))
-
-  ;; CHECK:      (type $ref?|string|_ref?|stringview_wtf8|_ref?|stringview_wtf16|_ref?|stringview_iter|_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter)))
 
   ;; CHECK:      (global $string-const stringref (string.const "string in a global"))
   (global $string-const stringref (string.const "string in a global"))
@@ -286,6 +286,40 @@
     )
   )
 
+  ;; CHECK:      (func $stringview.adjust (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter)
+  ;; CHECK-NEXT:  (local $i32 i32)
+  ;; CHECK-NEXT:  (local.set $i32
+  ;; CHECK-NEXT:   (stringview_wtf8.advance
+  ;; CHECK-NEXT:    (local.get $b)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $b)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $i32
+  ;; CHECK-NEXT:   (stringview_wtf16.get
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $i32
+  ;; CHECK-NEXT:   (stringview_iter.next
+  ;; CHECK-NEXT:    (local.get $d)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $i32
+  ;; CHECK-NEXT:   (stringview_iter.advance
+  ;; CHECK-NEXT:    (local.get $d)
+  ;; CHECK-NEXT:    (i32.const 3)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $i32
+  ;; CHECK-NEXT:   (stringview_iter.rewind
+  ;; CHECK-NEXT:    (local.get $d)
+  ;; CHECK-NEXT:    (i32.const 4)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $stringview.adjust
     (param $a stringref)
     (param $b stringview_wtf8)
@@ -299,8 +333,8 @@
       )
     )
     (local.set $i32
-      (stringview_iter.advance
-        (local.get $d)
+      (stringview_wtf16.get_codeunit
+        (local.get $b)
         (i32.const 2)
       )
     )
@@ -310,8 +344,15 @@
       )
     )
     (local.set $i32
-      (stringview_iter.get_codeunit
-        (local.get $c)
+      (stringview_iter.advance
+        (local.get $d)
+        (i32.const 3)
+      )
+    )
+    (local.set $i32
+      (stringview_iter.rewind
+        (local.get $d)
+        (i32.const 4)
       )
     )
   )

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -285,4 +285,34 @@
       )
     )
   )
+
+  (func $stringview.adjust
+    (param $a stringref)
+    (param $b stringview_wtf8)
+    (param $c stringview_wtf16)
+    (param $d stringview_iter)
+    (local $i32 i32)
+    (local.set $i32 ;; validate the output type
+      (stringview_wtf8.advance
+        (local.get $b)
+        (i32.const 1)
+      )
+    )
+    (local.set $i32
+      (stringview_iter.advance
+        (local.get $d)
+        (i32.const 2)
+      )
+    )
+    (local.set $i32
+      (stringview_iter.next
+        (local.get $d)
+      )
+    )
+    (local.set $i32
+      (stringview_iter.get_codeunit
+        (local.get $c)
+      )
+    )
+  )
 )


### PR DESCRIPTION
`stringview`s have a variety of access types based on what they are: wtf8 can
only advance forward as it reads, wtf16 only random access, and `iter` can iterate in any
direction. I think it's best to merge all these into a single class for simplicity.