### PR TITLE
[Parser][NFC] Refactor to use context callbacks

### DIFF
--- a/src/wat-parser.h
+++ b/src/wat-parser.h
@@ -62,6 +62,8 @@ template<typename T = Ok> struct MaybeResult {
   Err* getErr() { return std::get_if<Err>(&val); }
   T& operator*() { return *std::get_if<T>(&val); }
   T* operator->() { return std::get_if<T>(&val); }
+
+  T* getPtr() { return std::get_if<T>(&val); }
 };
 
 // Parse a single WAT module.


### PR DESCRIPTION
The parser functions previously both parsed the input and controlled what was
done with the results using `constexpr` if-else chains. As the number of parsing
contexts grew, these if-else chains became increasingly complex and distracting
from the core parsing logic of the parsing functions.

To simplify the code, refactor the parsing functions to replace the `constexpr`
if-else chains with unconditional calls to methods on the context. To avoid
duplicating most method definitions for multiple parsing contexts, introduce new
utility contexts that implement common methods and (ab)use inheritance and
multiple inheritance to reuse their methods from the main parsing contexts.

This change will also make it easier to reuse the parser code for entirely
different purposes in the future by providing new context implementations. For
example, V8 could reuse the code and provide different parser contexts that
construct V8-internal data structures rather than Binaryen data structures.