### PR TITLE
[Wasm GC] GTO should not reorder trapping of removed sets

### DIFF
--- a/src/ir/ordering.h
+++ b/src/ir/ordering.h
@@ -34,7 +34,7 @@ namespace wasm {
 //
 //   (temp = first, second, temp)
 //
-Expression* getResultOfFirst(Expression* first,
+inline Expression* getResultOfFirst(Expression* first,
                              Expression* second,
                              Function* func,
                              Module* wasm,

--- a/src/ir/ordering.h
+++ b/src/ir/ordering.h
@@ -35,10 +35,10 @@ namespace wasm {
 //   (temp = first, second, temp)
 //
 inline Expression* getResultOfFirst(Expression* first,
-                             Expression* second,
-                             Function* func,
-                             Module* wasm,
-                             const PassOptions& passOptions) {
+                                    Expression* second,
+                                    Function* func,
+                                    Module* wasm,
+                                    const PassOptions& passOptions) {
   assert(first->type.isConcrete());
 
   Builder builder(*wasm);

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -399,10 +399,12 @@ struct GlobalTypeOptimization : public Pass {
           Builder builder(*getModule());
           auto* block = builder.makeBlock();
           auto sets =
-            ChildLocalizer(curr, getFunction(), getModule(), getPassOptions()).sets;
+            ChildLocalizer(curr, getFunction(), getModule(), getPassOptions())
+              .sets;
           block->list.set(sets);
           block->list.push_back(builder.makeDrop(curr->value));
-          block->list.push_back(builder.makeDrop(builder.makeRefAs(RefAsNonNull, curr->ref)));
+          block->list.push_back(
+            builder.makeDrop(builder.makeRefAs(RefAsNonNull, curr->ref)));
           block->finalize();
           replaceCurrent(block);
           addedLocals = true;

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -399,13 +399,12 @@ struct GlobalTypeOptimization : public Pass {
           // which might have side effects.
           Builder builder(*getModule());
           auto flipped = getResultOfFirst(curr->ref,
-                                               builder.makeDrop(curr->value),
-                                               getFunction(),
-                                               getModule(),
-                                               getPassOptions());
-          replaceCurrent(builder.makeDrop(
-            builder.makeRefAs(RefAsNonNull, flipped
-                              )));
+                                          builder.makeDrop(curr->value),
+                                          getFunction(),
+                                          getModule(),
+                                          getPassOptions());
+          replaceCurrent(
+            builder.makeDrop(builder.makeRefAs(RefAsNonNull, flipped)));
           addedLocals = true;
         }
       }

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -398,9 +398,13 @@ struct GlobalTypeOptimization : public Pass {
           // operations here: the trap on a null ref happens after the value,
           // which might have side effects.
           Builder builder(*getModule());
-          replaceCurrent(builder.makeDrop(builder.makeRefAs(RefAsNonNull, getResultOfFirst(curr->ref,
-                             builder.makeDrop(curr->value),
-                             getFunction(), getModule(), getPassOptions()))));
+          replaceCurrent(builder.makeDrop(
+            builder.makeRefAs(RefAsNonNull,
+                              getResultOfFirst(curr->ref,
+                                               builder.makeDrop(curr->value),
+                                               getFunction(),
+                                               getModule(),
+                                               getPassOptions()))));
           addedLocals = true;
         }
       }

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -398,13 +398,14 @@ struct GlobalTypeOptimization : public Pass {
           // operations here: the trap on a null ref happens after the value,
           // which might have side effects.
           Builder builder(*getModule());
-          replaceCurrent(builder.makeDrop(
-            builder.makeRefAs(RefAsNonNull,
-                              getResultOfFirst(curr->ref,
+          auto flipped = getResultOfFirst(curr->ref,
                                                builder.makeDrop(curr->value),
                                                getFunction(),
                                                getModule(),
-                                               getPassOptions()))));
+                                               getPassOptions());
+          replaceCurrent(builder.makeDrop(
+            builder.makeRefAs(RefAsNonNull, flipped
+                              )));
           addedLocals = true;
         }
       }

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -22,18 +22,20 @@
 (module
   ;; A write does not keep a field from being removed.
 
-  ;; CHECK:      (type $ref|$struct|_=>_none (func_subtype (param (ref $struct)) func))
-
   ;; CHECK:      (type $struct (struct_subtype  data))
   (type $struct (struct_subtype (field (mut funcref)) data))
 
+  ;; CHECK:      (type $ref|$struct|_=>_none (func_subtype (param (ref $struct)) func))
+
   ;; CHECK:      (func $func (type $ref|$struct|_=>_none) (param $x (ref $struct))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.null func)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (block (result (ref $struct))
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (ref.null func)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -140,12 +142,12 @@
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.const 0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (block (result (ref $mut-struct))
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -164,12 +166,12 @@
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (block (result (ref $mut-struct))
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (i32.const 2)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -800,24 +802,24 @@
 )
 
 (module
-  ;; CHECK:      (type $none_=>_none (func_subtype func))
-
   ;; CHECK:      (type ${mut:i8} (struct_subtype  data))
   (type ${mut:i8} (struct_subtype (field (mut i8)) data))
 
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
   ;; CHECK:      (type $none_=>_i32 (func_subtype (result i32) func))
 
+  ;; CHECK:      (type $none_=>_ref|${mut:i8}| (func_subtype (result (ref ${mut:i8})) func))
+
   ;; CHECK:      (func $unreachable-set (type $none_=>_none)
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (call $helper-i32)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (ref.null ${mut:i8})
+  ;; CHECK-NEXT:    (block (result (ref null ${mut:i8}))
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (call $helper-i32)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (ref.null ${mut:i8})
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -840,12 +842,12 @@
 
   ;; CHECK:      (func $unreachable-set-2 (type $none_=>_none)
   ;; CHECK-NEXT:  (block $block
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (br $block)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (block (result (ref null ${mut:i8}))
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br $block)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (ref.null ${mut:i8})
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -858,8 +860,38 @@
     ;; (in fact, the br will skip the trap here).
     (block
       (struct.set ${mut:i8} 0
-      (ref.null ${mut:i8})
+        (ref.null ${mut:i8})
         (br $block)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $unreachable-set-3 (type $none_=>_none)
+  ;; CHECK-NEXT:  (local $0 (ref null ${mut:i8}))
+  ;; CHECK-NEXT:  (block $block
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (block (result (ref ${mut:i8}))
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (call $helper-ref)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (call $helper-i32)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (ref.as_non_null
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $unreachable-set-3
+    ;; As above, but now we have side effects in both children.
+    (block
+      (struct.set ${mut:i8} 0
+        (call $helper-ref)
+        (call $helper-i32)
       )
     )
   )
@@ -869,5 +901,12 @@
   ;; CHECK-NEXT: )
   (func $helper-i32 (result i32)
     (i32.const 1)
+  )
+
+  ;; CHECK:      (func $helper-ref (type $none_=>_ref|${mut:i8}|) (result (ref ${mut:i8}))
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $helper-ref (result (ref ${mut:i8}))
+    (unreachable)
   )
 )

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -827,6 +827,11 @@
     ;; optimize here we should be careful to not emit something with different
     ;; ordering (naively emitting ref.as_non_null on the reference would trap
     ;; before the call, so we must reorder).
+    ;;
+    ;; Note that the output here will use a local unnecessarily. That is a
+    ;; limitation of ChildLocalizer atm (we just need to reorder, but that
+    ;; class also ensures we can remove any of the children, so it replaces them
+    ;; all with local.gets).
     (struct.set ${mut:i8} 0
       (ref.null ${mut:i8})
       (call $helper-i32)

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -850,9 +850,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $unreachable-set-2
-    ;; As above, but the side effects now are a br. Here we can avoid a local,
-    ;; but must still reorder: the br must happen before the ref.as_non_null
-    ;; (in fact, the br will skip the trap here).
+    ;; As above, but the side effects now are a br. Again, the br must happen
+    ;; before the trap (in fact, the br will skip the trap here).
     (block
       (struct.set ${mut:i8} 0
         (ref.null ${mut:i8})

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -829,11 +829,6 @@
     ;; optimize here we should be careful to not emit something with different
     ;; ordering (naively emitting ref.as_non_null on the reference would trap
     ;; before the call, so we must reorder).
-    ;;
-    ;; Note that the output here will use a local unnecessarily. That is a
-    ;; limitation of ChildLocalizer atm (we just need to reorder, but that
-    ;; class also ensures we can remove any of the children, so it replaces them
-    ;; all with local.gets).
     (struct.set ${mut:i8} 0
       (ref.null ${mut:i8})
       (call $helper-i32)


### PR DESCRIPTION
Minor fuzz bug. When we replace a `struct.set` with its children we also
add a `ref.as_non_null` on the reference, but that must not occur before
effects in the other child.