### PR TITLE
[Effects] call_ref traps only when the target is null

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -662,12 +662,14 @@ private:
       if (curr->isReturn) {
         parent.branchesOut = true;
       }
-      // traps when the arg is null
-      parent.implicitTrap = true;
+      // traps when the call target is null
+      if (curr->target->type.isNullable()) {
+        parent.implicitTrap = true;
+      }
     }
     void visitRefTest(RefTest* curr) {}
     void visitRefCast(RefCast* curr) {
-      // Traps if the ref is not null and it has an invalid rtt.
+      // Traps if the ref is not null and the cast fails.
       parent.implicitTrap = true;
     }
     void visitBrOn(BrOn* curr) { parent.breakTargets.insert(curr->name); }


### PR DESCRIPTION
This is not observable in practice atm since `call_ref` also does a call,
which has even more effects. However, future optimizations might benefit
from this, and it is more consistent to avoid marking the instruction as
trapping if it can't.