### PR TITLE
[GUFA] Ignore trapping children when unreachable

### DIFF
--- a/src/ir/drop.cpp
+++ b/src/ir/drop.cpp
@@ -64,7 +64,12 @@ Expression* getDroppedChildrenAndAppend(Expression* curr,
 
   std::vector<Expression*> contents;
   for (auto* child : ChildIterator(curr)) {
-    if (!EffectAnalyzer(options, wasm, child).hasUnremovableSideEffects()) {
+    EffectAnalyzer effects(options, wasm, child);
+    // Ignore a trap, as the unreachable replacement would trap too.
+    if (last->type == Type::unreachable) {
+      effects.trap = false;
+    }
+    if (!effects.hasUnremovableSideEffects()) {
       continue;
     }
     if (child->type.isConcrete()) {

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -35,10 +35,6 @@
   ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (loop $loop
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -1184,19 +1180,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result (ref null $struct))
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (struct.get $child 0
-  ;; CHECK-NEXT:        (local.get $child)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (ref.null $struct)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $func
@@ -1482,15 +1466,16 @@
 (module
   (type $nothing (array_subtype (mut (ref null any)) data))
 
+  ;; CHECK:      (type $something (array_subtype (mut anyref) data))
+
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
   ;; CHECK:      (type $null (array_subtype (mut anyref) data))
   (type $null (array_subtype (mut (ref null any)) data))
 
-  ;; CHECK:      (type $something (array_subtype (mut anyref) data))
   (type $something (array_subtype (mut (ref null any)) data))
 
   (type $something-child (array_subtype (mut (ref null any)) $something))
-
-  ;; CHECK:      (type $none_=>_none (func_subtype func))
 
   ;; CHECK:      (type $struct (struct_subtype  data))
   (type $struct (struct))
@@ -1507,22 +1492,7 @@
   ;; CHECK-NEXT:   (ref.null any)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (array.get $null
-  ;; CHECK-NEXT:        (array.new_default $null
-  ;; CHECK-NEXT:         (i32.const 10)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (ref.null any)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (array.set $something
   ;; CHECK-NEXT:   (array.new_default $something
@@ -1542,13 +1512,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (unreachable)
-  ;; CHECK-NEXT:     (unreachable)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $func

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -623,7 +623,6 @@
 (module
   ;; CHECK:      (type $struct (struct_subtype (field (mut i32)) data))
   (type $struct (struct (mut i32)))
-  ;; CHECK:      (type $substruct (struct_subtype (field (mut i32)) $struct))
   (type $substruct (struct_subtype (mut i32) $struct))
 
   ;; CHECK:      (type $none_=>_none (func_subtype func))
@@ -641,19 +640,7 @@
   ;; CHECK-NEXT:   (i32.const 10)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result (ref null $substruct))
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (ref.cast_static $substruct
-  ;; CHECK-NEXT:        (local.get $ref)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (ref.null $substruct)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $test


### PR DESCRIPTION
In `getDroppedChildrenAndAppend`, when the type of the given last
expression is unreachable, we [ignore](https://github.com/WebAssembly/binaryen/blob/c40b402aaffa24c641cbb0e8efd0019c5c4a68b6/src/ir/drop.cpp#L46-L49) trapping effects when deciding
whether to drop the current expression because the last expression will
trap anyway.

We can do the same thing when dropping children. This will make GUFA's
generated code a little simpler in some cases. In GUFA's case these are
supposed to be optimized away by DCE anyway, but I think it's good to
handle this in this utility function too.