### PR TITLE
Fix unreachable handling in getDroppedChildrenAndAppend

### DIFF
--- a/src/ir/drop.cpp
+++ b/src/ir/drop.cpp
@@ -44,7 +44,7 @@ Expression* getDroppedChildrenAndAppend(Expression* curr,
   // effects would never help us (and would be slower to run).
   ShallowEffectAnalyzer effects(options, wasm, curr);
   // Ignore a trap, as the unreachable replacement would trap too.
-  if (last->type == Type::unreachable) {
+  if (last->is<Unreachable>()) {
     effects.trap = false;
   }
 


### PR DESCRIPTION
The previous code assumes if `last`'s type is unreachable it traps. But
it's not always the case because it can be other instructions like `br`
whose type is unreachable but doesn't necessarily trap.
Context:
https://github.com/WebAssembly/binaryen/pull/4827#discussion_r929395477

Not sure how I can add a test for this, because the `last` argument of
this function is currently only used in GUFA, and we only add
`unreachable` for it, so to add a test case, I think we need a separate
test pass or something to test this. I'm not sure if it's worth it, but
please let me know if you think it does.