### PR TITLE
[GUFA] Handle GUFA + Intrinsics

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -554,8 +554,11 @@ struct InfoCollector
       handleDirectCall(curr, refFunc->func);
     } else {
       // We can't see where this goes. We must be pessimistic and assume it
-      // can call anything of the proper type, the same as a CallRef. Do that
-      // by reusing the CallRef code.
+      // can call anything of the proper type, the same as a CallRef. (We could
+      // look at the possible contents of |target| during the flow, but that
+      // would require special logic like we have for RefCast etc., and the
+      // intrinsics will be lowered away anyhow, so just running after that is
+      // a workaround.)
       handleIndirectCall(curr, target->type);
     }
   }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -544,7 +544,9 @@ struct InfoCollector
     // handle this automatically by the reference flowing out to an import,
     // which is what binaryen intrinsics look like. For now, to support use
     // cases of a closed world but that also use this intrinsic, handle the
-    // intrinsic specifically here.
+    // intrinsic specifically here. (Without that, the closed world assumption
+    // makes us ignore the function ref that flows to an import, so we are not
+    // aware that it is actually called.)
     auto* target = curr->operands.back();
     if (auto* refFunc = target->dynCast<RefFunc>()) {
       // We can see exactly where this goes.

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -503,8 +503,7 @@ struct InfoCollector
   // Calls send values to params in their possible targets, and receive
   // results.
 
-  template<typename T>
-  void handleDirectCall(T* curr, Name targetName) {
+  template<typename T> void handleDirectCall(T* curr, Name targetName) {
     auto* target = getModule()->getFunction(targetName);
     handleCall(
       curr,
@@ -515,8 +514,7 @@ struct InfoCollector
         return ResultLocation{target, i};
       });
   }
-  template<typename T>
-  void handleIndirectCall(T* curr, HeapType targetType) {
+  template<typename T> void handleIndirectCall(T* curr, HeapType targetType) {
     handleCall(
       curr,
       [&](Index i) {
@@ -526,8 +524,7 @@ struct InfoCollector
         return SignatureResultLocation{targetType, i};
       });
   }
-  template<typename T>
-  void handleIndirectCall(T* curr, Type targetType) {
+  template<typename T> void handleIndirectCall(T* curr, Type targetType) {
     // If the type is unreachable, nothing can be called (and there is no heap
     // type to get).
     if (targetType != Type::unreachable) {

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -515,6 +515,7 @@ struct InfoCollector
   }
   void visitCallIndirect(CallIndirect* curr) {
     // TODO: the table identity could also be used here
+    // TODO: optimize the call target like CallRef
     auto targetType = curr->heapType;
     handleCall(
       curr,
@@ -526,6 +527,9 @@ struct InfoCollector
       });
   }
   void visitCallRef(CallRef* curr) {
+    // TODO: Optimize like RefCast etc.: the values reaching us depend on the
+    //       possible values of |target| (which might be nothing, or might be a
+    //       constant function).
     auto targetType = curr->target->type;
     if (targetType != Type::unreachable) {
       auto heapType = targetType.getHeapType();

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -132,7 +132,9 @@ struct ReachabilityAnalyzer : public PostWalker<ReachabilityAnalyzer> {
       // handle this automatically by the reference flowing out to an import,
       // which is what binaryen intrinsics look like. For now, to support use
       // cases of a closed world but that also use this intrinsic, handle the
-      // intrinsic specifically here.
+      // intrinsic specifically here. (Without that, the closed world assumption
+      // makes us ignore the function ref that flows to an import, so we are not
+      // aware that it is actually called.)
       auto* target = curr->operands.back();
       if (auto* refFunc = target->dynCast<RefFunc>()) {
         // We can see exactly where this goes.

--- a/test/lit/passes/gufa.wast
+++ b/test/lit/passes/gufa.wast
@@ -956,7 +956,8 @@
   ;; CHECK-NEXT: )
   (func $foo (export "foo")
     ;; Calling the intrinsic with a reference is considered a call of the
-    ;; reference, so $target-keep's code is reachable.
+    ;; reference, so $target-keep's code is reachable. We should leave it alone,
+    ;; but we can put an unreachable in $target-drop.
     (call $call-without-effects
      (i32.const 1)
      (ref.func $target-keep)
@@ -969,7 +970,7 @@
 
   ;; CHECK:      (func $target-keep (param $x i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $target-keep (type $A) (param $x i32)
@@ -1029,7 +1030,8 @@
   (func $foo (export "foo")
     ;; Call the intrinsic without a RefFunc. All we infer here is the type,
     ;; which means we must assume anything with type $A (and a reference) can be
-    ;; called, which will keep alive both $target-keep and $target-keep-2
+    ;; called, which will keep alive the bodies of both $target-keep and
+    ;; $target-keep-2 - no unreachables will be placed in either one.
     (call $call-without-effects
       (i32.const 1)
       (ref.null $A)
@@ -1044,7 +1046,7 @@
 
   ;; CHECK:      (func $target-keep (param $x i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $target-keep (type $A) (param $x i32)
@@ -1055,7 +1057,7 @@
 
   ;; CHECK:      (func $target-keep-2 (param $x i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $target-keep-2 (type $A) (param $x i32)


### PR DESCRIPTION
Like RemoveUnusedModuleElements, places that build graphs of function
reachability must special-case the call-without-effects intrinsic. Without that,
it looks like a call to an import. Normally a call to an import is fine - it makes us
be super-pessimistic, as we think things escape all the way out - but in GC
for now we are assuming a closed world, and so we end up broken. To fix that,
properly handle the intrinsic case.