### PR TITLE
[Optimize Instructions] Refactor squared rules

### DIFF
--- a/src/ir/abstract.h
+++ b/src/ir/abstract.h
@@ -59,11 +59,15 @@ enum Op {
   GeU
 };
 
-inline bool hasAnyShift(BinaryOp op) {
-  return op == ShlInt32 || op == ShrSInt32 || op == ShrUInt32 ||
-         op == RotLInt32 || op == RotRInt32 || op == ShlInt64 ||
-         op == ShrSInt64 || op == ShrUInt64 || op == RotLInt64 ||
+inline bool hasAnyRotateShift(BinaryOp op) {
+  return op == RotLInt32 || op == RotRInt32 || op == RotLInt64 ||
          op == RotRInt64;
+}
+
+inline bool hasAnyShift(BinaryOp op) {
+  return hasAnyRotateShift(op) || op == ShlInt32 || op == ShrSInt32 ||
+         op == ShrUInt32 || op == ShlInt64 || op == ShrSInt64 ||
+         op == ShrUInt64;
 }
 
 inline bool hasAnyReinterpret(UnaryOp op) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3441,7 +3441,7 @@ private:
             c1->value = Literal::makeFromInt32(total, c1->type);
             return inner;
           } else {
-            // owerflow. Handle different scenarious
+            // overflow. Handle different scenarious
             if (hasAnyRotateShift(op)) {
               // overflow always accepted in rotation shifts
               c1->value = Literal::makeFromInt32(effectiveTotal, c1->type);
@@ -3450,14 +3450,16 @@ private:
             // handle overflows for general shifts
             //   x << C1 << C2    =>   0
             //   x >>> C1 >>> C2  =>   0
-            // iff C1 + C2 -> overflows
-            if (op == getBinary(type, Shl) || op == getBinary(type, ShrU)) {
+            // iff `C1 + C2` -> overflows
+            // and `x` has no side effects
+            if ((op == getBinary(type, Shl) || op == getBinary(type, ShrU)) &&
+                !effects(inner->left).hasSideEffects()) {
               c1->value = Literal::makeZero(c1->type);
               return c1;
             }
             //   i32(x) >> C1 >> C2   =>   x >> 31
             //   i64(x) >> C1 >> C2   =>   x >> 63
-            // iff C1 + C2 -> overflows
+            // iff `C1 + C2` -> overflows
             if (op == getBinary(type, ShrS)) {
               c1->value = Literal::makeFromInt32(c1->type.getByteSize() * 8 - 1,
                                                  c1->type);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3425,10 +3425,10 @@ private:
         if (op == getBinary(type, Mul)) {
           c1->value = c1->value.mul(c2->value);
           return x;
-
-          // TODO:
-          // handle signed / unsigned divisions. They are more complex
         }
+        // TODO:
+        // handle signed / unsigned divisions. They are more complex
+
         // (x <<>> C1) <<>> C2   =>   x <<>> (C1 + C2)
         // iff C1 + C2 doesn't overflow
         if (hasAnyShift(op)) {
@@ -3451,8 +3451,8 @@ private:
       }
     }
     {
-      Const *c1, *c2;
       Binary* x;
+      Const *c1, *c2;
       // (x << C1) * C2   =>   x * (C2 << C1)
       if (matches(curr,
                   binary(Mul, binary(&x, Shl, any(), ival(&c1)), ival(&c2)))) {
@@ -3462,8 +3462,8 @@ private:
       }
     }
     {
-      Const *c1, *c2;
       Binary* x;
+      Const *c1, *c2;
       // (x * C1) << C2   =>   x * (C1 << C2)
       if (matches(curr,
                   binary(Shl, binary(&x, Mul, any(), ival(&c1)), ival(&c2)))) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -682,57 +682,8 @@ struct OptimizeInstructions
       if (auto* ret = optimizeWithConstantOnRight(curr)) {
         return replaceCurrent(ret);
       }
-      // the square of some operations can be merged
-      if (auto* left = curr->left->dynCast<Binary>()) {
-        if (left->op == curr->op) {
-          if (auto* leftRight = left->right->dynCast<Const>()) {
-            if (left->op == AndInt32 || left->op == AndInt64) {
-              leftRight->value = leftRight->value.and_(right->value);
-              return replaceCurrent(left);
-            } else if (left->op == OrInt32 || left->op == OrInt64) {
-              leftRight->value = leftRight->value.or_(right->value);
-              return replaceCurrent(left);
-            } else if (left->op == XorInt32 || left->op == XorInt64) {
-              leftRight->value = leftRight->value.xor_(right->value);
-              return replaceCurrent(left);
-            } else if (left->op == MulInt32 || left->op == MulInt64) {
-              leftRight->value = leftRight->value.mul(right->value);
-              return replaceCurrent(left);
-
-              // TODO:
-              // handle signed / unsigned divisions. They are more complex
-            } else if (left->op == ShlInt32 || left->op == ShrUInt32 ||
-                       left->op == ShrSInt32 || left->op == ShlInt64 ||
-                       left->op == ShrUInt64 || left->op == ShrSInt64) {
-              // shifts only use an effective amount from the constant, so
-              // adding must be done carefully
-              auto total = Bits::getEffectiveShifts(leftRight) +
-                           Bits::getEffectiveShifts(right);
-              if (total == Bits::getEffectiveShifts(total, right->type)) {
-                // no overflow, we can do this
-                leftRight->value = Literal::makeFromInt32(total, right->type);
-                return replaceCurrent(left);
-              } // TODO: handle overflows
-            }
-          }
-        }
-        if (left->op == Abstract::getBinary(left->type, Abstract::Shl) &&
-            curr->op == Abstract::getBinary(curr->type, Abstract::Mul)) {
-          if (auto* leftRight = left->right->dynCast<Const>()) {
-            left->op = Abstract::getBinary(left->type, Abstract::Mul);
-            // (x << C1) * C2   ->   x * (C2 << C1)
-            leftRight->value = right->value.shl(leftRight->value);
-            return replaceCurrent(left);
-          }
-        }
-        if (left->op == Abstract::getBinary(left->type, Abstract::Mul) &&
-            curr->op == Abstract::getBinary(curr->type, Abstract::Shl)) {
-          if (auto* leftRight = left->right->dynCast<Const>()) {
-            // (x * C1) << C2   ->   x * (C1 << C2)
-            leftRight->value = leftRight->value.shl(right->value);
-            return replaceCurrent(left);
-          }
-        }
+      if (auto* ret = foldRepeatedWithConstantsOnRight(curr)) {
+        return replaceCurrent(ret);
       }
       if (right->type == Type::i32) {
         BinaryOp op;
@@ -3438,6 +3389,84 @@ private:
         matches(curr, binary(DivU, any(&left), constant(1)))) {
       if (curr->type.isInteger() || fastMath) {
         return left;
+      }
+    }
+    return nullptr;
+  }
+
+  Expression* foldRepeatedWithConstantsOnRight(Binary* curr) {
+    using namespace Match;
+    using namespace Abstract;
+    {
+      Binary* x;
+      Const *c1, *c2 = curr->right->cast<Const>();
+      if (matches(curr->left, binary(&x, any(), ival(&c1))) &&
+          x->op == curr->op) {
+        Type type = x->type;
+        BinaryOp op = x->op;
+        // (x & C1) & C2   =>   x & (C1 & C2)
+        if (op == getBinary(type, And)) {
+          c1->value = c1->value.and_(c2->value);
+          return x;
+        }
+        // (x | C1) | C2   =>   x | (C1 | C2)
+        if (op == getBinary(type, Or)) {
+          c1->value = c1->value.or_(c2->value);
+          return x;
+        }
+        // (x ^ C1) ^ C2   =>   x ^ (C1 ^ C2)
+        if (op == getBinary(type, Xor)) {
+          c1->value = c1->value.xor_(c2->value);
+          return x;
+        }
+        // (x * C1) * C2   =>   x * (C1 * C2)
+        if (op == MulInt32 || op == MulInt64) {
+          c1->value = c1->value.mul(c2->value);
+          return x;
+
+          // TODO:
+          // handle signed / unsigned divisions. They are more complex
+        }
+        // (x <<>> C1) <<>> C2   =>   x <<>> (C1 + C2)
+        // iff C1 + C2 doesn't overflow
+        if (Abstract::hasAnyShift(op)) {
+          // shifts only use an effective amount from the constant, so
+          // adding must be done carefully
+          auto total =
+            Bits::getEffectiveShifts(c1) + Bits::getEffectiveShifts(c2);
+          auto effectiveTotal = Bits::getEffectiveShifts(total, c2->type);
+          if (total == effectiveTotal) {
+            // no overflow, we can do this
+            c1->value = Literal::makeFromInt32(total, c2->type);
+            return x;
+          } else if (hasAnyRotateShift(op)) {
+            // overflow accepted in rotation shifts
+            c1->value = Literal::makeFromInt32(effectiveTotal, c2->type);
+            return x;
+          }
+          // TODO: handle overflows
+        }
+      }
+    }
+    {
+      Const *c1, *c2;
+      Binary* x;
+      // (x << C1) * C2   =>   x * (C2 << C1)
+      if (matches(curr,
+                  binary(Mul, binary(&x, Shl, any(), ival(&c1)), ival(&c2)))) {
+        x->op = getBinary(x->type, Mul);
+        c1->value = c2->value.shl(c1->value);
+        return x;
+      }
+    }
+    {
+      Const *c1, *c2;
+      Binary* x;
+      // (x * C1) << C2   =>   x * (C1 << C2)
+      if (matches(curr,
+                  binary(Shl, binary(&x, Mul, any(), ival(&c1)), ival(&c2)))) {
+        c1->value = c1->value.shl(c2->value);
+        return x;
       }
     }
     return nullptr;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3440,11 +3440,13 @@ private:
             // no overflow, we can do this
             c1->value = Literal::makeFromInt32(total, c1->type);
             return inner;
-          } else if (hasAnyRotateShift(op)) {
-            // overflow always accepted in rotation shifts
-            c1->value = Literal::makeFromInt32(effectiveTotal, c1->type);
-            return inner;
           } else {
+            // owerflow. Handle different scenarious
+            if (hasAnyRotateShift(op)) {
+              // overflow always accepted in rotation shifts
+              c1->value = Literal::makeFromInt32(effectiveTotal, c1->type);
+              return inner;
+            }
             // handle overflows for general shifts
             //   x << C1 << C2    =>   0
             //   x >>> C1 >>> C2  =>   0

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3493,6 +3493,7 @@ private:
       }
     }
     {
+      // TODO: Add canonicalization rotr to rotl and remove these rules.
       // rotl(rotr(x, C1), C2)   =>   rotr(x, C1 - C2)
       // rotr(rotl(x, C1), C2)   =>   rotl(x, C1 - C2)
       Binary* inner;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -682,7 +682,7 @@ struct OptimizeInstructions
       if (auto* ret = optimizeWithConstantOnRight(curr)) {
         return replaceCurrent(ret);
       }
-      if (auto* ret = foldSimilarWithConstantsOnRight(curr)) {
+      if (auto* ret = optimizeDoubletonWithConstantOnRight(curr)) {
         return replaceCurrent(ret);
       }
       if (right->type == Type::i32) {
@@ -3396,7 +3396,7 @@ private:
 
   // Folding two expressions into one with similar operations and
   // constants on RHSs
-  Expression* foldSimilarWithConstantsOnRight(Binary* curr) {
+  Expression* optimizeDoubletonWithConstantOnRight(Binary* curr) {
     using namespace Match;
     using namespace Abstract;
     {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -682,7 +682,7 @@ struct OptimizeInstructions
       if (auto* ret = optimizeWithConstantOnRight(curr)) {
         return replaceCurrent(ret);
       }
-      if (auto* ret = foldRepeatedWithConstantsOnRight(curr)) {
+      if (auto* ret = foldSimilarWithConstantsOnRight(curr)) {
         return replaceCurrent(ret);
       }
       if (right->type == Type::i32) {
@@ -3394,7 +3394,9 @@ private:
     return nullptr;
   }
 
-  Expression* foldRepeatedWithConstantsOnRight(Binary* curr) {
+  // Folding two expressions into one with similar operations and
+  // constants on RHSs
+  Expression* foldSimilarWithConstantsOnRight(Binary* curr) {
     using namespace Match;
     using namespace Abstract;
     {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3422,7 +3422,7 @@ private:
           return x;
         }
         // (x * C1) * C2   =>   x * (C1 * C2)
-        if (op == MulInt32 || op == MulInt64) {
+        if (op == getBinary(type, Mul)) {
           c1->value = c1->value.mul(c2->value);
           return x;
 
@@ -3431,7 +3431,7 @@ private:
         }
         // (x <<>> C1) <<>> C2   =>   x <<>> (C1 + C2)
         // iff C1 + C2 doesn't overflow
-        if (Abstract::hasAnyShift(op)) {
+        if (hasAnyShift(op)) {
           // shifts only use an effective amount from the constant, so
           // adding must be done carefully
           auto total =

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5941,29 +5941,29 @@
   ;; CHECK:      (func $rotate-right-left-pos (param $x i32) (result i32)
   ;; CHECK-NEXT:  (i32.rotl
   ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:   (i32.const 5)
+  ;; CHECK-NEXT:   (i32.const 23)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $rotate-right-left-pos (param $x i32) (result i32)
     (i32.rotr
       (i32.rotl
         (local.get $x)
-        (i32.const 10)
+        (i32.const 27)
       )
-      (i32.const 5)
+      (i32.const 4)
     )
   )
   ;; CHECK:      (func $rotate-left-right-pos (param $x i32) (result i32)
   ;; CHECK-NEXT:  (i32.rotr
   ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:   (i32.const 5)
+  ;; CHECK-NEXT:   (i32.const 7)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $rotate-left-right-pos (param $x i32) (result i32)
     (i32.rotl
       (i32.rotr
         (local.get $x)
-        (i32.const 10)
+        (i32.const 12)
       )
       (i32.const 5)
     )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5725,6 +5725,21 @@
     (i32.const 1)
    )
   )
+  ;; CHECK:      (func $left-shifts-square-overflow-with-side-effect (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (call $ne0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (i32.const 0)
+  ;; CHECK-NEXT: )
+  (func $left-shifts-square-overflow-with-side-effect (param $x i32) (result i32)
+   (i32.shl
+    (i32.shl
+     (call $ne0) ;; side effect
+     (i32.const 31)
+    )
+    (i32.const 5)
+   )
+  )
   ;; CHECK:      (func $right-shifts-square-overflow-unsigned (param $x i32) (result i32)
   ;; CHECK-NEXT:  (i32.const 0)
   ;; CHECK-NEXT: )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5842,6 +5842,60 @@
       )
     )
   )
+  ;; CHECK:      (func $rotate-left-square-no-overflow-small (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotl
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 7)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-left-square-no-overflow-small (param $x i32) (result i32)
+    (i32.rotl
+      (i32.rotl
+        (local.get $x)
+        (i32.const 3)
+      )
+      (i32.const 4)
+    )
+  )
+  ;; CHECK:      (func $rotate-right-square-no-overflow-small (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotr
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 7)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-right-square-no-overflow-small (param $x i32) (result i32)
+    (i32.rotr
+      (i32.rotr
+        (local.get $x)
+        (i32.const 3)
+      )
+      (i32.const 4)
+    )
+  )
+  ;; CHECK:      (func $rotate-left-square-no-shifts (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $rotate-left-square-no-shifts (param $x i32) (result i32)
+    (i32.rotl
+      (i32.rotl
+        (local.get $x)
+        (i32.const 12)
+      )
+      (i32.const 20)
+    )
+  )
+  ;; CHECK:      (func $rotate-right-square-no-shifts (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $rotate-right-square-no-shifts (param $x i32) (result i32)
+    (i32.rotr
+      (i32.rotr
+        (local.get $x)
+        (i32.const 30)
+      )
+      (i32.const 2)
+    )
+  )
   ;; CHECK:      (func $and-popcount32 (result i32)
   ;; CHECK-NEXT:  (i32.and
   ;; CHECK-NEXT:   (i32.popcnt

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5713,18 +5713,39 @@
     (i32.const 255)
    )
   )
-  ;; CHECK:      (func $shifts-square-overflow (param $x i32) (result i32)
-  ;; CHECK-NEXT:  (i32.shr_u
-  ;; CHECK-NEXT:   (i32.shr_u
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i32.const 31)
-  ;; CHECK-NEXT:   )
+  ;; CHECK:      (func $left-shifts-square-overflow (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.const 0)
+  ;; CHECK-NEXT: )
+  (func $left-shifts-square-overflow (param $x i32) (result i32)
+   (i32.shl
+    (i32.shl
+     (local.get $x)
+     (i32.const 31)
+    )
+    (i32.const 1)
+   )
+  )
+  ;; CHECK:      (func $right-shifts-square-overflow-unsigned (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.const 0)
+  ;; CHECK-NEXT: )
+  (func $right-shifts-square-overflow-unsigned (param $x i32) (result i32)
+   (i32.shr_u
+    (i32.shr_u
+     (local.get $x)
+     (i32.const 65535) ;; 31 bits effectively
+    )
+    (i32.const 32767) ;; also 31 bits, so two shifts that force the value into nothing for sure
+   )
+  )
+  ;; CHECK:      (func $shifts-square-overflow-signed (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.shr_s
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (i32.const 31)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $shifts-square-overflow (param $x i32) (result i32)
-   (i32.shr_u
-    (i32.shr_u
+  (func $shifts-square-overflow-signed (param $x i32) (result i32)
+   (i32.shr_s
+    (i32.shr_s
      (local.get $x)
      (i32.const 65535) ;; 31 bits effectively
     )
@@ -5746,18 +5767,39 @@
     (i32.const 4098) ;; 2 bits effectively
    )
   )
-  ;; CHECK:      (func $shifts-square-overflow-64 (param $x i64) (result i64)
-  ;; CHECK-NEXT:  (i64.shr_u
-  ;; CHECK-NEXT:   (i64.shr_u
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i64.const 63)
-  ;; CHECK-NEXT:   )
+  ;; CHECK:      (func $left-shifts-square-overflow-unsigned-64 (param $x i64) (result i64)
+  ;; CHECK-NEXT:  (i64.const 0)
+  ;; CHECK-NEXT: )
+  (func $left-shifts-square-overflow-unsigned-64 (param $x i64) (result i64)
+   (i64.shl
+    (i64.shl
+     (local.get $x)
+     (i64.const 2)
+    )
+    (i64.const 63)
+   )
+  )
+  ;; CHECK:      (func $right-shifts-square-overflow-unsigned-64 (param $x i64) (result i64)
+  ;; CHECK-NEXT:  (i64.const 0)
+  ;; CHECK-NEXT: )
+  (func $right-shifts-square-overflow-unsigned-64 (param $x i64) (result i64)
+   (i64.shr_u
+    (i64.shr_u
+     (local.get $x)
+     (i64.const 65535) ;; 63 bits effectively
+    )
+    (i64.const 64767) ;; also 63 bits, so two shifts that force the value into nothing for sure
+   )
+  )
+  ;; CHECK:      (func $right-shifts-square-overflow-signed-64 (param $x i64) (result i64)
+  ;; CHECK-NEXT:  (i64.shr_s
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (i64.const 63)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $shifts-square-overflow-64 (param $x i64) (result i64)
-   (i64.shr_u
-    (i64.shr_u
+  (func $right-shifts-square-overflow-signed-64 (param $x i64) (result i64)
+   (i64.shr_s
+    (i64.shr_s
      (local.get $x)
      (i64.const 65535) ;; 63 bits effectively
     )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5725,6 +5725,18 @@
     (i32.const 1)
    )
   )
+  ;; CHECK:      (func $left-shifts-square-overflow-2 (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.const 0)
+  ;; CHECK-NEXT: )
+  (func $left-shifts-square-overflow-2 (param $x i32) (result i32)
+   (i32.shl
+    (i32.shl
+     (local.get $x)
+     (i32.const 5)
+    )
+    (i32.const -5)
+   )
+  )
   ;; CHECK:      (func $right-shifts-square-overflow-unsigned (param $x i32) (result i32)
   ;; CHECK-NEXT:  (i32.const 0)
   ;; CHECK-NEXT: )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5725,18 +5725,6 @@
     (i32.const 1)
    )
   )
-  ;; CHECK:      (func $left-shifts-square-overflow-2 (param $x i32) (result i32)
-  ;; CHECK-NEXT:  (i32.const 0)
-  ;; CHECK-NEXT: )
-  (func $left-shifts-square-overflow-2 (param $x i32) (result i32)
-   (i32.shl
-    (i32.shl
-     (local.get $x)
-     (i32.const 5)
-    )
-    (i32.const -5)
-   )
-  )
   ;; CHECK:      (func $right-shifts-square-overflow-unsigned (param $x i32) (result i32)
   ;; CHECK-NEXT:  (i32.const 0)
   ;; CHECK-NEXT: )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -5896,6 +5896,120 @@
       (i32.const 2)
     )
   )
+  ;; CHECK:      (func $rotate-right-left-pos (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotl
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 5)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-right-left-pos (param $x i32) (result i32)
+    (i32.rotr
+      (i32.rotl
+        (local.get $x)
+        (i32.const 10)
+      )
+      (i32.const 5)
+    )
+  )
+  ;; CHECK:      (func $rotate-left-right-pos (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotr
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 5)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-left-right-pos (param $x i32) (result i32)
+    (i32.rotl
+      (i32.rotr
+        (local.get $x)
+        (i32.const 10)
+      )
+      (i32.const 5)
+    )
+  )
+  ;; CHECK:      (func $rotate-right-left-neg (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotl
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 27)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-right-left-neg (param $x i32) (result i32)
+    (i32.rotr
+      (i32.rotl
+        (local.get $x)
+        (i32.const 5)
+      )
+      (i32.const 10)
+    )
+  )
+  ;; CHECK:      (func $rotate-left-right-neg (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotr
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 27)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-left-right-neg (param $x i32) (result i32)
+    (i32.rotl
+      (i32.rotr
+        (local.get $x)
+        (i32.const 5)
+      )
+      (i32.const 10)
+    )
+  )
+  ;; CHECK:      (func $rotate-right-left-none (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $rotate-right-left-none (param $x i32) (result i32)
+    (i32.rotr
+      (i32.rotl
+        (local.get $x)
+        (i32.const 16)
+      )
+      (i32.const 16)
+    )
+  )
+  ;; CHECK:      (func $rotate-left-right-none (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
+  (func $rotate-left-right-none (param $x i32) (result i32)
+    (i32.rotl
+      (i32.rotr
+        (local.get $x)
+        (i32.const 16)
+      )
+      (i32.const 16)
+    )
+  )
+  ;; CHECK:      (func $rotate-right-left-overflow (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotl
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 27)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-right-left-overflow (param $x i32) (result i32)
+    (i32.rotr
+      (i32.rotl
+        (local.get $x)
+        (i32.const 18)
+      )
+      (i32.const 23)
+    )
+  )
+  ;; CHECK:      (func $rotate-left-right-overflow (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.rotr
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 27)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $rotate-left-right-overflow (param $x i32) (result i32)
+    (i32.rotl
+      (i32.rotr
+        (local.get $x)
+        (i32.const 18)
+      )
+      (i32.const 23)
+    )
+  )
   ;; CHECK:      (func $and-popcount32 (result i32)
   ;; CHECK-NEXT:  (i32.and
   ;; CHECK-NEXT:   (i32.popcnt


### PR DESCRIPTION
As I promised [in this comment](https://github.com/WebAssembly/binaryen/pull/4808#issuecomment-1194982890)

+ Move this rules to separate function;
+ Refactor it with matches;
+ Add comments;
+ Handle rotational shifts as well;
+ Handle overflows for `<<`, `>>`, `>>>` shifts;
+ Add mixed rotate rules:
```rust
   rotl(rotr(x, C1), C2)   =>   rotr(x, C1 - C2)
   rotr(rotl(x, C1), C2)   =>   rotl(x, C1 - C2)
```