### PR TITLE
Refactor doIndent

### DIFF
--- a/src/dataflow/utils.h
+++ b/src/dataflow/utils.h
@@ -32,11 +32,7 @@
 namespace wasm::DataFlow {
 
 inline std::ostream& dump(Node* node, std::ostream& o, size_t indent = 0) {
-  auto doIndent = [&]() {
-    for (size_t i = 0; i < indent; i++) {
-      o << ' ';
-    }
-  };
+  auto doIndent = [&]() { o << std::string(indent, ' '); };
   doIndent();
   o << '[' << node << ' ';
   switch (node->type) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3538,11 +3538,7 @@ printStackInst(StackInst* inst, std::ostream& o, Function* func) {
 static std::ostream&
 printStackIR(StackIR* ir, std::ostream& o, Function* func) {
   size_t indent = func ? 2 : 0;
-  auto doIndent = [&indent, &o]() {
-    for (size_t j = 0; j < indent; j++) {
-      o << ' ';
-    }
-  };
+  auto doIndent = [&]() { o << std::string(indent, ' '); };
 
   int controlFlowDepth = 0;
   // Stack to track indices of catches within a try

--- a/src/pretty_printing.h
+++ b/src/pretty_printing.h
@@ -26,10 +26,7 @@
 #include "support/colors.h"
 
 inline std::ostream& doIndent(std::ostream& o, unsigned indent) {
-  for (unsigned i = 0; i < indent; i++) {
-    o << " ";
-  }
-  return o;
+  return o << std::string(indent, ' ');
 }
 
 inline std::ostream& prepareMajorColor(std::ostream& o) {


### PR DESCRIPTION
Refactor everywhere from:
```c++
for (size_t i = 0; i < indent; i++) {
   o << ' ';
}
```
to:
```c++
o << std::string(indent, ' ');
```
### Motivation

It is much simpler and should produce smaller code.See godbolt:
https://godbolt.org/z/KMYMdn7z5