### PR TITLE
[NFC] wasm-reduce: Avoid wasted work on drops

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -590,6 +590,13 @@ struct Reducer
         tryToReplaceCurrent(loop->body);
       }
       return; // nothing more to do
+    } else if (curr->is<Drop>()) {
+      if (curr->type == Type::none) {
+        // We can't improve this: the child has a different type than us. Return
+        // here to avoid reaching the code below that tries to add a drop on
+        // children (which would recreate the current state).
+        return;
+      }
     }
     // Finally, try to replace with a child.
     for (auto* child : ChildIterator(curr)) {


### PR DESCRIPTION
It was wasted work to see a drop and then check if we can replace it with
a drop of its child, which is identical to the original state. This didn't cause
any harm (we'd not reduce code size, and stop eventually) but it did slow us
down.