### PR TITLE
[Optimize Instructions] Fold eqz(eqz(x)) to relational binary

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -931,6 +931,7 @@ struct OptimizeInstructions
         // i32.eqz(i32.eqz(x))  =>  i32(x) != 0
         // i32.eqz(i64.eqz(x))  =>  i64(x) != 0
         //   iff shinkLevel == 0
+        // (1 instruction instead of 2, but 1 more byte)
         if (getPassRunner()->options.shrinkLevel == 0) {
           Expression* x;
           if (matches(curr, unary(EqZInt32, unary(EqZ, any(&x))))) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -924,7 +924,6 @@ struct OptimizeInstructions
         if (matches(curr, unary(EqZInt32, unary(&inner, WrapInt64, any(&x)))) &&
             Bits::getMaxBits(x, this) <= 32) {
           inner->op = EqZInt64;
-          inner->value = x;
           return replaceCurrent(inner);
         }
       }
@@ -964,12 +963,10 @@ struct OptimizeInstructions
       if (getModule()->features.hasSignExt()) {
         // i64.extend_i32_s(i32.wrap_i64(x))  =>  i64.extend32_s(x)
         Unary* inner;
-        Expression* x;
         if (matches(curr,
-                    unary(ExtendSInt32, unary(&inner, WrapInt64, any(&x))))) {
+                    unary(ExtendSInt32, unary(&inner, WrapInt64, any())))) {
           inner->op = ExtendS32Int64;
           inner->type = Type::i64;
-          inner->value = x;
           return replaceCurrent(inner);
         }
       }

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -8647,10 +8647,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (i32.eqz
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i32.ne
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -9386,6 +9385,26 @@
       (i32.const 1)
       (i32.const 0)
     ))
+  )
+  ;; CHECK:      (func $fold-eqz-eqz (param $x i32) (param $y i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.ne
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.ne
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $fold-eqz-eqz (param $x i32) (param $y i64)
+    ;; i32.eqz(i32.eqz(x))  ->  x != 0
+    (drop (i32.eqz (i32.eqz (local.get $x))))
+    ;; i32.eqz(i64.eqz(y))  ->  y != 0
+    (drop (i32.eqz (i64.eqz (local.get $y))))
   )
   ;; CHECK:      (func $optimize-bitwise-oprations (param $x i32) (param $y i32) (param $z i64) (param $w i64)
   ;; CHECK-NEXT:  (drop
@@ -12026,10 +12045,9 @@
   ;; CHECK-NEXT:   (local.get $w)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (i32.eqz
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (i32.ne
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop


### PR DESCRIPTION
```wat
eqz(eqz(i32(x)))   ->   i32(x) != 0
eqz(eqz(i64(x)))   ->   i64(x) != 0
```
Only when `shrinkLevel == 0` (prefer speed over binary size).

### Motivation

+ This could probably unblock some further optimizations like DeMorgan's rules etc.
+ Currently most of the wasm engines don't optimize such pattern on their side also it may improve perf on lower tiers / interpreters. See [also](https://github.com/WebAssembly/binaryen/pull/4194#issuecomment-931489983)