### PR TITLE
Update reference type Literal constructors to use HeapType

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -110,8 +110,9 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
         case HeapType::func:
         case HeapType::any:
         case HeapType::eq:
-        case HeapType::i31:
         case HeapType::data:
+          assert(false && "Literals must have concrete types");
+        case HeapType::i31:
         case HeapType::string:
         case HeapType::stringview_wtf8:
         case HeapType::stringview_wtf16:

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -108,7 +108,6 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
     if (heapType.isBasic()) {
       switch (heapType.getBasic()) {
         case HeapType::func:
-          return Literal::makeFunc(x.func);
         case HeapType::any:
         case HeapType::eq:
         case HeapType::i31:

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -360,7 +360,9 @@ struct InfoCollector
     addRoot(curr);
   }
   void visitRefFunc(RefFunc* curr) {
-    addRoot(curr, PossibleContents::literal(Literal(curr->func, curr->type)));
+    addRoot(
+      curr,
+      PossibleContents::literal(Literal(curr->func, curr->type.getHeapType())));
   }
   void visitRefEq(RefEq* curr) {
     // TODO: optimize when possible (e.g. when both sides must contain the same

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -106,7 +106,7 @@ inline Literal getLiteral(const Expression* curr) {
   } else if (auto* n = curr->dynCast<RefNull>()) {
     return Literal(n->type);
   } else if (auto* r = curr->dynCast<RefFunc>()) {
-    return Literal(r->func, r->type);
+    return Literal(r->func, r->type.getHeapType());
   } else if (auto* i = curr->dynCast<I31New>()) {
     if (auto* c = i->value->dynCast<Const>()) {
       return Literal::makeI31(c->value.geti32());

--- a/src/literal.h
+++ b/src/literal.h
@@ -94,8 +94,9 @@ public:
   explicit Literal(const std::array<Literal, 8>&);
   explicit Literal(const std::array<Literal, 4>&);
   explicit Literal(const std::array<Literal, 2>&);
-  explicit Literal(Name func, Type type) : func(func), type(type) {}
-  explicit Literal(std::shared_ptr<GCData> gcData, Type type);
+  explicit Literal(Name func, HeapType type)
+    : func(func), type(type, NonNullable) {}
+  explicit Literal(std::shared_ptr<GCData> gcData, HeapType type);
   explicit Literal(std::unique_ptr<RttSupers>&& rttSupers, Type type);
   Literal(const Literal& other);
   Literal& operator=(const Literal& other);
@@ -257,8 +258,7 @@ public:
   static Literal makeNull(HeapType type) {
     return Literal(Type(type, Nullable));
   }
-  static Literal makeFunc(Name func,
-                          Type type = Type(HeapType::func, Nullable)) {
+  static Literal makeFunc(Name func, HeapType type) {
     return Literal(func, type);
   }
   static Literal makeI31(int32_t value) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -190,7 +190,7 @@ public:
     } else {
       *canonical = *newGCData;
     }
-    return Literal(canonical, curr->type);
+    return Literal(canonical, curr->type.getHeapType());
   }
 };
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1362,7 +1362,7 @@ public:
   Flow visitRefFunc(RefFunc* curr) {
     NOTE_ENTER("RefFunc");
     NOTE_NAME(curr->func);
-    return Literal::makeFunc(curr->func, curr->type);
+    return Literal::makeFunc(curr->func, curr->type.getHeapType());
   }
   Flow visitRefEq(RefEq* curr) {
     NOTE_ENTER("RefEq");
@@ -1505,7 +1505,7 @@ public:
     };
     // We have the actual and intended RTTs, so perform the cast.
     if (actualRtt.isSubRtt(intendedRtt)) {
-      Type resultType(intendedRtt.type.getHeapType(), NonNullable);
+      HeapType resultType = intendedRtt.type.getHeapType();
       if (original.isFunction()) {
         return typename Cast::Success{Literal{original.getFunc(), resultType}};
       } else {
@@ -1683,7 +1683,8 @@ public:
     if (!curr->rtt) {
       rttVal = Literal::makeCanonicalRtt(heapType);
     }
-    return Literal(std::make_shared<GCData>(rttVal, data), curr->type);
+    return Literal(std::make_shared<GCData>(rttVal, data),
+                   curr->type.getHeapType());
   }
   Flow visitStructGet(StructGet* curr) {
     NOTE_ENTER("StructGet");
@@ -1770,7 +1771,8 @@ public:
     if (!curr->rtt) {
       rttVal = Literal::makeCanonicalRtt(heapType);
     }
-    return Literal(std::make_shared<GCData>(rttVal, data), curr->type);
+    return Literal(std::make_shared<GCData>(rttVal, data),
+                   curr->type.getHeapType());
   }
   Flow visitArrayInit(ArrayInit* curr) {
     NOTE_ENTER("ArrayInit");
@@ -1810,7 +1812,8 @@ public:
     if (!curr->rtt) {
       rttVal = Literal::makeCanonicalRtt(heapType);
     }
-    return Literal(std::make_shared<GCData>(rttVal, data), curr->type);
+    return Literal(std::make_shared<GCData>(rttVal, data),
+                   curr->type.getHeapType());
   }
   Flow visitArrayGet(ArrayGet* curr) {
     NOTE_ENTER("ArrayGet");

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -65,10 +65,8 @@ Literal::Literal(const uint8_t init[16]) : type(Type::v128) {
   memcpy(&v128, init, 16);
 }
 
-Literal::Literal(std::shared_ptr<GCData> gcData, Type type)
-  : gcData(gcData), type(type) {
-  // Null data is only allowed if nullable.
-  assert(gcData || type.isNullable());
+Literal::Literal(std::shared_ptr<GCData> gcData, HeapType type)
+  : gcData(gcData), type(type, gcData ? NonNullable : Nullable) {
   // The type must be a proper type for GC data.
   assert(isData());
 }

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -84,7 +84,7 @@ protected:
   PossibleContents anyGlobal = PossibleContents::global("anyGlobal", anyref);
 
   PossibleContents nonNullFunc = PossibleContents::literal(
-    Literal("func", Type(Signature(Type::none, Type::none), NonNullable)));
+    Literal("func", Signature(Type::none, Type::none)));
 
   PossibleContents exactI32 = PossibleContents::exactType(Type::i32);
   PossibleContents exactAnyref = PossibleContents::exactType(anyref);


### PR DESCRIPTION
We already require non-null literals to have non-null types, but with this
change we can enforce that constraint by construction. Also remove the default
behavior of creating a function reference literal with heap type `func`, since
there is always a more specific function type to use.