### PR TITLE
Fix a new compiler warning

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -112,6 +112,7 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
         case HeapType::eq:
         case HeapType::data:
           assert(false && "Literals must have concrete types");
+          WASM_UNREACHABLE("no fallthrough here");
         case HeapType::i31:
         case HeapType::string:
         case HeapType::stringview_wtf8:


### PR DESCRIPTION
Avoids a "may fall through" warning.