### PR TITLE
Fuzzer: Run Asyncify less

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -965,7 +965,9 @@ class Wasm2JS(TestCaseHandler):
 
 
 class Asyncify(TestCaseHandler):
-    frequency = 0.6
+    # run this at low frequency for now, as there is at least one known long-
+    # standing issue, https://github.com/WebAssembly/binaryen/issues/4865
+    frequency = 0.06
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):
         # we must legalize in order to run in JS


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/issues/4865 is not new, and will
likely show up more. As the actual bug is likely very old (there have been no
changes to Asyncify for a while) this is low priority. Run Asyncify less in the
fuzzer for now (0.6 meant it ran 60% of the time, which is too high anyhow).