### PR TITLE
[NFC] Mark modifiesBinaryenIR=false in more places

### DIFF
--- a/src/ir/flat.h
+++ b/src/ir/flat.h
@@ -116,6 +116,8 @@ inline void verifyFlatness(Module* module) {
         PostWalker<VerifyFlatness, UnifiedExpressionVisitor<VerifyFlatness>>> {
     bool isFunctionParallel() override { return true; }
 
+    bool modifiesBinaryenIR() override { return false; }
+
     VerifyFlatness* create() override { return new VerifyFlatness(); }
 
     void doVisitFunction(Function* func) { verifyFlatness(func); }

--- a/src/ir/hashed.h
+++ b/src/ir/hashed.h
@@ -29,6 +29,8 @@ namespace wasm {
 struct FunctionHasher : public WalkerPass<PostWalker<FunctionHasher>> {
   bool isFunctionParallel() override { return true; }
 
+  bool modifiesBinaryenIR() override { return false; }
+
   struct Map : public std::map<Function*, size_t> {};
 
   FunctionHasher(Map* output, ExpressionAnalyzer::ExprHasher customHasher)

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -130,6 +130,8 @@ struct StructScanner
   : public WalkerPass<PostWalker<StructScanner<T, SubType>>> {
   bool isFunctionParallel() override { return true; }
 
+  bool modifiesBinaryenIR() override { return false; }
+
   StructScanner(FunctionStructValuesMap<T>& functionNewInfos,
                 FunctionStructValuesMap<T>& functionSetGetInfos)
     : functionNewInfos(functionNewInfos),

--- a/src/passes/NameList.cpp
+++ b/src/passes/NameList.cpp
@@ -26,6 +26,8 @@
 namespace wasm {
 
 struct NameList : public Pass {
+  bool modifiesBinaryenIR() override { return false; }
+
   void run(PassRunner* runner, Module* module) override {
     ModuleUtils::iterDefinedFunctions(*module, [&](Function* func) {
       std::cout << "    " << func->name << " : "

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -84,6 +84,8 @@ struct OptInfo {
 struct Scanner : public WalkerPass<PostWalker<Scanner>> {
   bool isFunctionParallel() override { return true; }
 
+  bool modifiesBinaryenIR() override { return false; }
+
   Scanner(OptInfo& optInfo) : optInfo(optInfo) {}
 
   Scanner* create() override { return new Scanner(optInfo); }

--- a/src/passes/PrintFeatures.cpp
+++ b/src/passes/PrintFeatures.cpp
@@ -25,6 +25,8 @@
 namespace wasm {
 
 struct PrintFeatures : public Pass {
+  bool modifiesBinaryenIR() override { return false; }
+
   void run(PassRunner* runner, Module* module) override {
     module->features.iterFeatures([](FeatureSet::Feature f) {
       std::cout << "--enable-" << FeatureSet::toString(f) << std::endl;

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -40,6 +40,8 @@ typedef std::unordered_map<Name, std::atomic<Index>> NameCountMap;
 struct CallCountScanner : public WalkerPass<PostWalker<CallCountScanner>> {
   bool isFunctionParallel() override { return true; }
 
+  bool modifiesBinaryenIR() override { return false; }
+
   CallCountScanner(NameCountMap* counts) : counts(counts) {}
 
   CallCountScanner* create() override { return new CallCountScanner(counts); }


### PR DESCRIPTION
Atm this saves only a super-tiny amount of work. However, with 1a validation
it will save a lot more, since then we will be able to skip any 1a fixup work if
a pass does not modify the IR at all.