### PR TITLE
wasm-emscripten-finalize: Remove __start/__stop_em_js exports

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -339,6 +339,9 @@ EmJsWalker findEmJsFuncsAndReturnWalker(Module& wasm) {
     wasm.removeExport(exp.name);
   }
 
+  wasm.removeExport("__start_em_js");
+  wasm.removeExport("__stop_em_js");
+
   // With newer versions of emscripten/llvm we pack all EM_JS strings into
   // single segment.
   // We can detect this by checking for segments that contain only JS strings.


### PR DESCRIPTION
We already remove `__start_em_asm` and `__stop_em_asm`.  This change
is needed since I want to start exporting `__start_em_js` and
`__stop_em_js` from emscripten without causing regressions.

As a followup I'm planning on moving all of the em_js and em_asm
stripping code it PostEmscripten.cpp.. which itself is needed in order
to completely remove the metadata extraction code from binaryen.