### PR TITLE
Bail out of fuzz_shell.js if instantiation fails

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -175,7 +175,15 @@ var imports = {
 imports = Asyncify.instrumentImports(imports);
 
 // Create the wasm.
-var instance = new WebAssembly.Instance(new WebAssembly.Module(binary), imports);
+var module = new WebAssembly.Module(binary);
+
+var instance;
+try {
+  instance = new WebAssembly.Instance(module, imports);
+} catch (e) {
+  console.log('Failed to instantiate module');
+  quit();
+}
 
 // Handle the exports.
 var exports = instance.exports;
@@ -216,4 +224,3 @@ sortedExports.forEach(function(e) {
 
 // Finish up
 Asyncify.finish();
-


### PR DESCRIPTION
Sometimes the fuzzer produces valid modules that trap during instantiation. When
that happens, the JS harness used to run the fuzzer output in d8 would
previously throw an error, creating spurious fuzzer failures on valid modules.
Update fuzz_shell.js to catch and supress errors during instantiation (but not
validation) to avoid these spurious failures.

Fixes #4865.