### PR TITLE
Allow `BINARYEN_DEBUG` environment variable to be used in place of `--debug`. NFC

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,11 @@ the [`name-types` pass](https://github.com/WebAssembly/binaryen/blob/main/src/pa
 Some more notes:
 
  * See `bin/wasm-opt --help` for the full list of options and passes.
- * Passing `--debug` will emit some debugging info.
+ * Passing `--debug` will emit some debugging info.  Individual debug channels
+   (defined in the source code via `#define DEBUG_TYPE xxx`) can be enabled by
+   passing them as list of comma-separated strings.  For example: `bin/wasm-opt
+   --debug=binary`.  These debug channels can also be enabled via the
+   `BINARYEN_DEBUG` environment variable.
 
 ### wasm2js
 

--- a/src/support/command-line.cpp
+++ b/src/support/command-line.cpp
@@ -55,6 +55,10 @@ Options::Options(const std::string& command, const std::string& description)
   : debug(false), positional(Arguments::Zero) {
   std::string GeneralOption = "General options";
 
+  if (getenv("BINARYEN_DEBUG")) {
+    setDebugEnabled(getenv("BINARYEN_DEBUG"));
+  }
+
   add("--version",
       "",
       "Output version information and exit",


### PR DESCRIPTION
For example I found it useful to able to do something like this:

```
$ BINARYEN_DEBUG=post-emscripten ./test/runner sometest
```