### PR TITLE
wasm-emscripten-finalize: Remove em_js/em_asm start/stop symbols when stripping data segments.

### DIFF
--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -445,6 +445,15 @@ void EmscriptenGlueGenerator::separateDataSegments(Output* outfile,
     lastEnd = offset + seg->data.size();
   }
   wasm.dataSegments.clear();
+  // Remove the start/stop symbols that the PostEmscripten uses to remove
+  // em_asm/em_js data.  Since we just removed all the data segments from the
+  // file there is nothing more for that pass to do.
+  // TODO(sbc): Fix the ordering so that the removal the EM_ASM/EM_JS data comes
+  // before this pass.
+  wasm.removeExport("__start_em_asm");
+  wasm.removeExport("__stop_em_asm");
+  wasm.removeExport("__start_em_js");
+  wasm.removeExport("__stop_em_js");
 }
 
 } // namespace wasm

--- a/test/lld/em_asm.wat.mem.out
+++ b/test/lld/em_asm.wat.mem.out
@@ -12,8 +12,6 @@
  (export "memory" (memory $0))
  (export "__wasm_call_ctors" (func $__wasm_call_ctors))
  (export "main" (func $main))
- (export "__start_em_asm" (global $global$1))
- (export "__stop_em_asm" (global $global$2))
  (func $__wasm_call_ctors
   (nop)
  )


### PR DESCRIPTION
This avoid a fatal crash in `--post-emscripten` where it tries to remove
data that is no longer part of the file.

This fixes bug introduced by #4871 that causes emscripten tests to fail.