### PR TITLE
RedundantSetElimination: ReFinalize when needed

### DIFF
--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -67,6 +67,9 @@ struct RedundantSetElimination
 
   Index numLocals;
 
+  // In rare cases we make a change to a type that requires a refinalize.
+  bool refinalize = false;
+
   // cfg traversal work
 
   static void doVisitLocalSet(RedundantSetElimination* self,
@@ -94,6 +97,10 @@ struct RedundantSetElimination
     flowValues(func);
     // remove redundant sets
     optimize();
+
+    if (refinalize) {
+      ReFinalize().walkFunctionInModule(func, this->getModule());
+    }
   }
 
   // Use a value numbering for the values of expressions.
@@ -346,6 +353,20 @@ struct RedundantSetElimination
       drop->value = value;
       drop->finalize();
     } else {
+      // If we are replacing the set with something of a more specific type,
+      // then we need to refinalize, for example:
+      //
+      //  (struct.get $X
+      //    (local.tee $x
+      //      (..something of type $Y, a subtype of $X..)
+      //    )
+      //  )
+      //
+      // After the replacement the struct.get will read from $Y, whose field may
+      // have a more refined type.
+      if (value->type != set->type) {
+        refinalize = true;
+      }
       *setp = value;
     }
   }

--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -356,7 +356,7 @@ struct RedundantSetElimination
       // If we are replacing the set with something of a more specific type,
       // then we need to refinalize, for example:
       //
-      //  (struct.get $X
+      //  (struct.get $X 0
       //    (local.tee $x
       //      (..something of type $Y, a subtype of $X..)
       //    )

--- a/test/lit/passes/rse-gc.wast
+++ b/test/lit/passes/rse-gc.wast
@@ -2,6 +2,9 @@
 ;; RUN: wasm-opt %s --rse --enable-gc-nn-locals -all -S -o - | filecheck %s
 
 (module
+ ;; CHECK:      (type $B (struct (field dataref)))
+
+ ;; CHECK:      (type $A (struct (field (ref null data))))
  (type $A (struct_subtype (field (ref null data)) data))
 
  ;; $B is a subtype of $A, and its field has a more refined type (it is non-
@@ -22,6 +25,15 @@
   (local $tuple ((ref any) (ref any)))
  )
 
+ ;; CHECK:      (func $needs-refinalize (param $b (ref $B)) (result anyref)
+ ;; CHECK-NEXT:  (local $a (ref null $A))
+ ;; CHECK-NEXT:  (local.set $a
+ ;; CHECK-NEXT:   (local.get $b)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (struct.get $B 0
+ ;; CHECK-NEXT:   (local.get $b)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
  (func $needs-refinalize (param $b (ref $B)) (result anyref)
   (local $a (ref null $A))
   ;; Make $a contain $b.


### PR DESCRIPTION
It turns out that even simple passes like that may end up needing to
refinalize. Any time we replace an instruction with a different type, in fact,
that may be necessary.

This is unfortunate, and other passes will need fixes as well. I'm not
sure why the fuzzer never found this - it was only uncovered by a huge
a huge j2wasm binary.