### PR TITLE
Validator: Validate intrinsics

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -820,7 +820,7 @@ void FunctionValidator::visitCall(Call* curr) {
     if (!curr->operands.empty()) {
       auto* target = curr->operands.back();
       // Ignore unreachable here, and leave other validation issues here for the
-      // global scope which already does this..
+      // global scope which already does this.
       if (target->type.isFunction()) {
         // Copy the original call and remove the reference. It must then match
         // the expected signature.

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -443,15 +443,17 @@ private:
                  "return_call* requires tail calls to be enabled");
   }
 
+  // |printable| is the expression to print in case of an error. That may differ
+  // from |curr| which we are validating.
   template<typename T>
-  void validateCallParamsAndResult(T* curr, HeapType sigType) {
+  void validateCallParamsAndResult(T* curr, HeapType sigType, Expression* printable) {
     if (!shouldBeTrue(
-          sigType.isSignature(), curr, "Heap type must be a signature type")) {
+          sigType.isSignature(), printable, "Heap type must be a signature type")) {
       return;
     }
     auto sig = sigType.getSignature();
     if (!shouldBeTrue(curr->operands.size() == sig.params.size(),
-                      curr,
+                      printable,
                       "call* param number must match")) {
       return;
     }
@@ -459,7 +461,7 @@ private:
     for (const auto& param : sig.params) {
       if (!shouldBeSubType(curr->operands[i]->type,
                            param,
-                           curr,
+                           printable,
                            "call param types must match") &&
           !info.quiet) {
         getStream() << "(on argument " << i << ")\n";
@@ -469,20 +471,26 @@ private:
     if (curr->isReturn) {
       shouldBeEqual(curr->type,
                     Type(Type::unreachable),
-                    curr,
+                    printable,
                     "return_call* should have unreachable type");
       shouldBeSubType(
         sig.results,
         getFunction()->getResults(),
-        curr,
+        printable,
         "return_call* callee return type must match caller return type");
     } else {
       shouldBeEqualOrFirstIsUnreachable(
         curr->type,
         sig.results,
-        curr,
+        printable,
         "call* type must match callee return type");
     }
+  }
+
+  // In the common case, we use |curr| as |printable|.
+  template<typename T>
+  void validateCallParamsAndResult(T* curr, HeapType sigType) {
+    validateCallParamsAndResult(curr, sigType, curr);
   }
 
   Type indexType() { return getModule()->memory.indexType; }
@@ -796,6 +804,37 @@ void FunctionValidator::visitCall(Call* curr) {
     return;
   }
   validateCallParamsAndResult(curr, target->type);
+
+  if (Intrinsics(*getModule()).isCallWithoutEffects(curr)) {
+    // call.without.effects has the specific form of the last argument being a
+    // function reference, which will be called with all the previous arguments.
+    // The type must be consistent with that. This, for example, is not:
+    //
+    //  (call $call.without.effects
+    //    (i32.const 1)
+    //    (.. some function reference that expects an f64 param and not i32 ..)
+    //  )
+    if (!curr->operands.empty()) {
+      auto* target = curr->operands.back();
+      // Ignore unreachable here, and leave other validation issues here for the
+      // global scope which already does this..
+      if (target->type.isFunction()) {
+        // Copy the original call and remove the reference. It must then match
+        // the expected signature.
+        struct Copy {
+          std::vector<Expression*> operands;
+          bool isReturn;
+          Type type;
+        } copy;
+        for (Index i = 0; i < curr->operands.size() - 1; i++) {
+          copy.operands.push_back(curr->operands[i]);
+        }
+        copy.isReturn = curr->isReturn;
+        copy.type = curr->type;
+        validateCallParamsAndResult(&copy, target->type.getHeapType(), curr);
+      }
+    }
+  }
 }
 
 void FunctionValidator::visitCallIndirect(CallIndirect* curr) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -446,9 +446,12 @@ private:
   // |printable| is the expression to print in case of an error. That may differ
   // from |curr| which we are validating.
   template<typename T>
-  void validateCallParamsAndResult(T* curr, HeapType sigType, Expression* printable) {
-    if (!shouldBeTrue(
-          sigType.isSignature(), printable, "Heap type must be a signature type")) {
+  void validateCallParamsAndResult(T* curr,
+                                   HeapType sigType,
+                                   Expression* printable) {
+    if (!shouldBeTrue(sigType.isSignature(),
+                      printable,
+                      "Heap type must be a signature type")) {
       return;
     }
     auto sig = sigType.getSignature();

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -817,10 +817,15 @@ void FunctionValidator::visitCall(Call* curr) {
     //    (i32.const 1)
     //    (.. some function reference that expects an f64 param and not i32 ..)
     //  )
-    if (!curr->operands.empty()) {
+    if (shouldBeTrue(!curr->operands.empty(),
+                     curr,
+                     "call.without.effects must have a target operand")) {
       auto* target = curr->operands.back();
-      // Ignore unreachable here, and leave other validation issues here for the
-      // global scope which already does this.
+      // Validate only in the case that the target is a function. If it isn't,
+      // it might be unreachable (which is fine, and we can ignore this), or if
+      // the call.without.effects import doesn't have a function as the last
+      // parameter, then validateImports() will handle that later (and it's
+      // better to emit a single error there than one per callsite here).
       if (target->type.isFunction()) {
         // Copy the original call and remove the reference. It must then match
         // the expected signature.

--- a/test/lit/validation/intrinsics.wast
+++ b/test/lit/validation/intrinsics.wast
@@ -1,0 +1,23 @@
+;; Test for non-nullable types in tuples
+
+;; RUN: not wasm-opt -all %s 2>&1 | filecheck %s
+
+;; CHECK: param number must match
+
+(module
+  (import "binaryen-intrinsics" "call.without.effects" (func $cwe (param i32 funcref) (result i32)))
+
+  (func "get-ref" (result i32)
+    ;; This call-without-effects is done to a $func, but $func has the wrong
+    ;; signature - it lacks the i32 parameter.
+    (call $cwe
+      (i32.const 41)
+      (ref.func $func)
+    )
+  )
+
+  (func $func (result i32)
+    (i32.const 1)
+  )
+)
+

--- a/test/lit/validation/intrinsics.wast
+++ b/test/lit/validation/intrinsics.wast
@@ -1,4 +1,4 @@
-;; Test for non-nullable types in tuples
+;; Test for a validation error on bad usage of call.without.effects
 
 ;; RUN: not wasm-opt -all %s 2>&1 | filecheck %s
 


### PR DESCRIPTION
`call.without.effects` has a specific form, where the last parameter is a
function reference, and that function reference must have the right type
for the other parameters if called with them:

```wat
(call $call.without.effects
  (..i32..)
  (..f64..)
  (..function reference, which takes params i32 and f64..)
)
````