### PR TITLE
[Wasm GC] Fix SignaturePruning on CallWithoutEffects

### DIFF
--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -112,7 +112,7 @@ struct SignaturePruning : public Pass {
           // The last operand is the actual call target.
           auto* target = call->operands.back();
           if (target->type != Type::unreachable) {
-//            allInfo[target->type.getHeapType()].optimizable = false;
+            allInfo[target->type.getHeapType()].optimizable = false;
           }
         }
       }

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -28,6 +28,7 @@
 //
 
 #include "ir/find_all.h"
+#include "ir/intrinsics.h"
 #include "ir/lubs.h"
 #include "ir/module-utils.h"
 #include "ir/type-updating.h"

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -103,6 +103,18 @@ struct SignaturePruning : public Pass {
       // called.
       for (auto* call : info.calls) {
         allInfo[module->getFunction(call->target)->type].calls.push_back(call);
+
+        // Intrinsics limit our ability to optimize in some cases. We will avoid
+        // modifying any type that is used by call.without.effects, to avoid
+        // the complexity of handling that. After intrinsics are lowered,
+        // this optimization will be able to run at full power anyhow.
+        if (Intrinsics(*module).isCallWithoutEffects(call)) {
+          // The last operand is the actual call target.
+          auto* target = call->operands.back();
+          if (target->type != Type::unreachable) {
+//            allInfo[target->type.getHeapType()].optimizable = false;
+          }
+        }
       }
 
       // For indirect calls, add each call_ref to the type the call_ref uses.

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -812,7 +812,6 @@
 )
 
 ;; Do not prune signatures used in the call.without.effects intrinsic.
-
 (module
   ;; CHECK:      (type $i32_funcref_=>_i32 (func_subtype (param i32 funcref) (result i32) func))
 

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -816,7 +816,7 @@
 (module
   ;; CHECK:      (type $i32_funcref_=>_i32 (func_subtype (param i32 funcref) (result i32) func))
 
-  ;; CHECK:      (type $none_=>_i32 (func_subtype (result i32) func))
+  ;; CHECK:      (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
 
   ;; CHECK:      (type $none_=>_i32 (func_subtype (result i32) func))
 
@@ -825,8 +825,7 @@
 
   ;; CHECK:      (elem declare func $func)
 
-  ;; CHECK:      (func $func (type $none_=>_i32) (result i32)
-  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK:      (func $func (type $i32_=>_i32) (param $0 i32) (result i32)
   ;; CHECK-NEXT:  (i32.const 1)
   ;; CHECK-NEXT: )
   (func $func (param i32) (result i32)

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -828,7 +828,8 @@
   ;; CHECK-NEXT:  (i32.const 1)
   ;; CHECK-NEXT: )
   (func $func (param i32) (result i32)
-    ;; The parameter is unused, so we want to prune it.
+    ;; The parameter is unused, so we want to prune it. We won't because of the
+    ;; situation in the calling function, below.
     (i32.const 1)
   )
 


### PR DESCRIPTION
`call.without.effects` will turn into a normal call of the last parameter later,
```wat
(call $call.without.effects
  A
  B
  (ref.func $foo)
)
;; => intrinsic lowering
(call $foo
  A
  B
)
```
SignaturePruning needs to be aware of that: we can't remove a parameter from `$foo` without
also updating relevant calls to `$call.without.effects`. Rather than handle that, just skip such
cases, and leave them to be optimized after intrinsics are lowered away.