### PR TITLE
[GUFA] Fix readFromData on a function literal

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1567,7 +1567,7 @@ void Flower::readFromData(HeapType declaredHeapType,
   if (refContents.isLiteral()) {
     // The only reference literals we have are nulls (handled above) and
     // ref.func. ref.func will trap in struct|array.get, so nothing will be read
-    // here (when we finish optimizing all instructions like RefAs then
+    // here (when we finish optimizing all instructions like BrOn then
     // ref.funcs should get filtered out before arriving here TODO).
     assert(refContents.getType().isFunction());
     return;

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1564,6 +1564,15 @@ void Flower::readFromData(HeapType declaredHeapType,
     return;
   }
 
+  if (refContents.isLiteral()) {
+    // The only reference literals we have are nulls (handled above) and
+    // ref.func. ref.func will trap in struct|array.get, so nothing will be read
+    // here (when we finish optimizing all instructions like RefAs then
+    // ref.funcs should get filtered out before arriving here TODO).
+    assert(refContents.getType().isFunction());
+    return;
+  }
+
 #if defined(POSSIBLE_CONTENTS_DEBUG) && POSSIBLE_CONTENTS_DEBUG >= 2
   std::cout << "    add special reads\n";
 #endif
@@ -1586,12 +1595,6 @@ void Flower::readFromData(HeapType declaredHeapType,
     //       represent them as ExactType).
     //       See the test TODO with text "We optimize some of this, but stop at
     //       reading from the immutable global"
-    // Note that this cannot be a Literal, since this is a reference, and the
-    // only reference literals we have are nulls (handled above) and ref.func.
-    // ref.func is not valid in struct|array.get, so the code would trap at
-    // runtime, and also it would never reach here as because of wasm validation
-    // it would be cast to a struct/array type, and our special ref.cast code
-    // would filter it out.
     assert(refContents.isMany() || refContents.isGlobal());
 
     // We create a ConeReadLocation for the canonical cone of this type, to

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -977,6 +977,12 @@
   ;; CHECK-NEXT:    (ref.null $struct)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $func
     (local $child (ref null $child))
@@ -1011,6 +1017,16 @@
     (drop
       (struct.get $parent 0
         (local.get $parent)
+      )
+    )
+    ;; A ref.func is cast to a struct type, and then we read from that. The cast
+    ;; will trap at runtime, of course; for here, we should not error and also
+    ;; we can optimize these to unreachables.
+    (drop
+      (struct.get $parent 0
+        (ref.cast_static $parent
+          (ref.func $func)
+        )
       )
     )
   )


### PR DESCRIPTION
A function literal (`ref.func`) should never reach a struct or array get, but
if there is a cast then it can look like they might arrive. We filter in `ref.cast`
which avoids that (since casting a function to a data type will trap), but
there is also `br_on_cast` which is not yet optimized. This PR adds code
to avoid an assert in `readFromData` in that case.