### PR TITLE
Avoid unreachable exception

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1216,8 +1216,7 @@ public:
   }
   Flow visitUnreachable(Unreachable* curr) {
     NOTE_ENTER("Unreachable");
-    trap("unreachable");
-    WASM_UNREACHABLE("unreachable");
+    return Flow(NONCONSTANT_FLOW);
   }
 
   Literal truncSFloat(Unary* curr, Literal value) {


### PR DESCRIPTION
Hi all,

as mentioned in #4165, a small (but insignificant in the grand scheme of things) performance improvement can be gained from avoiding the exception here, since when it gets thrown, it blocks all threads for 1-2 ms. Since unreachable is not that common in most code (we might have 20-40 instances of it), that means the savings could be `40*1ms*8 = 320 ms` for 8 threads here.
In the benchmarks I did for the SmallSet in EffectsAnalyzer, this gets drowned out by noise.

Depending how risky it is to make this change, you might consider discarding the PR. It looks like the wasm-fuzz-types.exe is pretty happy so far, though (1376658 iterations). I wasn't sure what change needed to be made in `execution-results.h` 🤔 

Best,
Jonathan

