### PR TITLE
[Strings] Linear memory string operations should emit a memory index

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6984,6 +6984,9 @@ bool WasmBinaryBuilder::maybeVisitStringNew(Expression*& out, uint32_t code) {
   Expression* start = nullptr;
   Expression* end = nullptr;
   if (code == BinaryConsts::StringNewWTF8) {
+    if (getInt8() != 0) {
+      throwError("Unexpected nonzero memory index");
+    }
     auto policy = getU32LEB();
     switch (policy) {
       case BinaryConsts::StringPolicy::UTF8:
@@ -7000,6 +7003,9 @@ bool WasmBinaryBuilder::maybeVisitStringNew(Expression*& out, uint32_t code) {
     }
     length = popNonVoidExpression();
   } else if (code == BinaryConsts::StringNewWTF16) {
+    if (getInt8() != 0) {
+      throwError("Unexpected nonzero memory index");
+    }
     op = StringNewWTF16;
     length = popNonVoidExpression();
   } else if (code == BinaryConsts::StringNewWTF8Array) {
@@ -7080,6 +7086,9 @@ bool WasmBinaryBuilder::maybeVisitStringEncode(Expression*& out,
   Expression* start = nullptr;
   // TODO: share this code with string.measure?
   if (code == BinaryConsts::StringEncodeWTF8) {
+    if (getInt8() != 0) {
+      throwError("Unexpected nonzero memory index");
+    }
     auto policy = getU32LEB();
     switch (policy) {
       case BinaryConsts::StringPolicy::UTF8:
@@ -7092,6 +7101,9 @@ bool WasmBinaryBuilder::maybeVisitStringEncode(Expression*& out,
         throwError("bad policy for string.encode");
     }
   } else if (code == BinaryConsts::StringEncodeWTF16) {
+    if (getInt8() != 0) {
+      throwError("Unexpected nonzero memory index");
+    }
     op = StringEncodeWTF16;
   } else if (code == BinaryConsts::StringEncodeWTF8Array) {
     auto policy = getU32LEB();

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2176,19 +2176,23 @@ void BinaryInstWriter::visitStringNew(StringNew* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   switch (curr->op) {
     case StringNewUTF8:
-      o << int8_t(BinaryConsts::StringNewWTF8)
-        << U32LEB(BinaryConsts::StringPolicy::UTF8);
+      o << int8_t(BinaryConsts::StringNewWTF8);
+      o << int8_t(0); // Memory index.
+      o << U32LEB(BinaryConsts::StringPolicy::UTF8);
       break;
     case StringNewWTF8:
-      o << int8_t(BinaryConsts::StringNewWTF8)
-        << U32LEB(BinaryConsts::StringPolicy::WTF8);
+      o << int8_t(BinaryConsts::StringNewWTF8);
+      o << int8_t(0); // Memory index.
+      o << U32LEB(BinaryConsts::StringPolicy::WTF8);
       break;
     case StringNewReplace:
-      o << int8_t(BinaryConsts::StringNewWTF8)
-        << U32LEB(BinaryConsts::StringPolicy::Replace);
+      o << int8_t(BinaryConsts::StringNewWTF8);
+      o << int8_t(0); // Memory index.
+      o << U32LEB(BinaryConsts::StringPolicy::Replace);
       break;
     case StringNewWTF16:
       o << int8_t(BinaryConsts::StringNewWTF16);
+      o << int8_t(0); // Memory index.
       break;
     case StringNewUTF8Array:
       o << int8_t(BinaryConsts::StringNewWTF8Array)
@@ -2244,19 +2248,22 @@ void BinaryInstWriter::visitStringEncode(StringEncode* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   switch (curr->op) {
     case StringEncodeUTF8:
-      o << int8_t(BinaryConsts::StringEncodeWTF8)
-        << U32LEB(BinaryConsts::StringPolicy::UTF8);
+      o << int8_t(BinaryConsts::StringEncodeWTF8);
+      o << int8_t(0); // Memory index.
+      o << U32LEB(BinaryConsts::StringPolicy::UTF8);
       break;
     case StringEncodeWTF8:
-      o << int8_t(BinaryConsts::StringEncodeWTF8)
-        << U32LEB(BinaryConsts::StringPolicy::WTF8);
+      o << int8_t(BinaryConsts::StringEncodeWTF8);
+      o << int8_t(0); // Memory index.
+      o << U32LEB(BinaryConsts::StringPolicy::WTF8);
       break;
     case StringEncodeWTF16:
       o << int8_t(BinaryConsts::StringEncodeWTF16);
+      o << int8_t(0); // Memory index.
       break;
     case StringEncodeUTF8Array:
-      o << int8_t(BinaryConsts::StringEncodeWTF8Array)
-        << U32LEB(BinaryConsts::StringPolicy::UTF8);
+      o << int8_t(BinaryConsts::StringEncodeWTF8Array);
+      o << U32LEB(BinaryConsts::StringPolicy::UTF8);
       break;
     case StringEncodeWTF8Array:
       o << int8_t(BinaryConsts::StringEncodeWTF8Array)

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -16,7 +16,7 @@
 
   ;; CHECK:      (type $stringref_stringref_=>_none (func (param stringref stringref)))
 
-  ;; CHECK:      (type $array (array i32))
+  ;; CHECK:      (type $array (array i8))
   (type $array (array_subtype i8 data))
 
   ;; CHECK:      (type $stringref_stringview_wtf8_stringview_wtf16_stringview_iter_stringref_stringview_wtf8_stringview_wtf16_stringview_iter_ref|string|_ref|stringview_wtf8|_ref|stringview_wtf16|_ref|stringview_iter|_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter stringref stringview_wtf8 stringview_wtf16 stringview_iter (ref string) (ref stringview_wtf8) (ref stringview_wtf16) (ref stringview_iter))))
@@ -31,6 +31,8 @@
 
   ;; CHECK:      (global $string-const stringref (string.const "string in a global"))
   (global $string-const stringref (string.const "string in a global"))
+
+  ;; CHECK:      (memory $0 10 10)
 
   ;; CHECK:      (func $string.new (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter) (param $e stringref) (param $f stringview_wtf8) (param $g stringview_wtf16) (param $h stringview_iter) (param $i (ref string)) (param $j (ref stringview_wtf8)) (param $k (ref stringview_wtf16)) (param $l (ref stringview_iter))
   ;; CHECK-NEXT:  (drop

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -8,6 +8,8 @@
 ;; RUN: foreach %s %t wasm-opt --enable-strings --enable-reference-types --enable-gc --roundtrip --precompute -S -o - | filecheck %s
 
 (module
+  (memory 10 10)
+
   ;; CHECK:      (type $stringref_=>_none (func (param stringref)))
 
   ;; CHECK:      (type $stringref_stringview_wtf8_stringview_wtf16_stringview_iter_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter)))
@@ -15,7 +17,7 @@
   ;; CHECK:      (type $stringref_stringref_=>_none (func (param stringref stringref)))
 
   ;; CHECK:      (type $array (array i32))
-  (type $array (array_subtype i32 data))
+  (type $array (array_subtype i8 data))
 
   ;; CHECK:      (type $stringref_stringview_wtf8_stringview_wtf16_stringview_iter_stringref_stringview_wtf8_stringview_wtf16_stringview_iter_ref|string|_ref|stringview_wtf8|_ref|stringview_wtf16|_ref|stringview_iter|_=>_none (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter stringref stringview_wtf8 stringview_wtf16 stringview_iter (ref string) (ref stringview_wtf8) (ref stringview_wtf16) (ref stringview_iter))))
 


### PR DESCRIPTION
For now this index is always 0, but we must emit it.

Spec: https://github.com/WebAssembly/stringref/blob/main/proposals/stringref/Overview.md#binary-encoding

Also clean up the wat test a little - we don't have validation yet, but we should
not validate without a memory in that file.