### PR TITLE
[EH] Pop should be supertype of tag type

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2175,7 +2175,7 @@ void FunctionValidator::visitTry(Try* curr) {
     } else {
       if (shouldBeTrue(pops.size() == 1, curr, "")) {
         auto* pop = *pops.begin();
-        if (!shouldBeSubType(pop->type, tag->sig.params, curr, "")) {
+        if (!shouldBeSubType(tag->sig.params, pop->type, curr, "")) {
           getStream()
             << "catch's tag (" << tagName
             << ")'s pop doesn't have the same type as the tag's params";

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -2,7 +2,7 @@
   (tag $e-i32 (param i32))
   (tag $e-i64 (param i64))
   (tag $e-i32-i64 (param i32 i64))
-  (tag $e-anyref (param anyref))
+  (tag $e-funcref (param funcref))
   (tag $e-empty)
 
   (func $foo)
@@ -330,9 +330,9 @@
 
     (try
       (do)
-      (catch $e-anyref
+      (catch $e-funcref
         (drop
-          (pop funcref) ;; pop can be subtype
+          (pop anyref) ;; pop can be supertype
         )
       )
     )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -3,11 +3,11 @@
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
- (type $anyref_=>_none (func (param anyref)))
+ (type $funcref_=>_none (func (param funcref)))
  (tag $e-i32 (param i32))
  (tag $e-i64 (param i64))
  (tag $e-i32-i64 (param i32 i64))
- (tag $e-anyref (param anyref))
+ (tag $e-funcref (param funcref))
  (tag $e-empty (param))
  (func $foo
   (nop)
@@ -372,9 +372,9 @@
    (do
     (nop)
    )
-   (catch $e-anyref
+   (catch $e-funcref
     (drop
-     (pop funcref)
+     (pop anyref)
     )
    )
   )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -3,11 +3,11 @@
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
- (type $anyref_=>_none (func (param anyref)))
+ (type $funcref_=>_none (func (param funcref)))
  (tag $tag$0 (param i32))
  (tag $tag$1 (param i64))
  (tag $tag$2 (param i32 i64))
- (tag $tag$3 (param anyref))
+ (tag $tag$3 (param funcref))
  (tag $tag$4 (param))
  (func $foo
   (nop)
@@ -403,7 +403,7 @@
    )
    (catch $tag$3
     (drop
-     (pop anyref)
+     (pop funcref)
     )
    )
   )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -3,11 +3,11 @@
  (type $i32_=>_none (func (param i32)))
  (type $i64_=>_none (func (param i64)))
  (type $i32_i64_=>_none (func (param i32 i64)))
- (type $anyref_=>_none (func (param anyref)))
+ (type $funcref_=>_none (func (param funcref)))
  (tag $tag$0 (param i32))
  (tag $tag$1 (param i64))
  (tag $tag$2 (param i32 i64))
- (tag $tag$3 (param anyref))
+ (tag $tag$3 (param funcref))
  (tag $tag$4 (param))
  (func $0
   (nop)
@@ -403,7 +403,7 @@
    )
    (catch $tag$3
     (drop
-     (pop anyref)
+     (pop funcref)
     )
    )
   )


### PR DESCRIPTION
`pop`s type should be a supertype, not a subtype, of the tag's type
within `catch`.

Thanks @tlively for catching this!