### PR TITLE
Validator: More carefully check for stale types

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -480,10 +480,11 @@ private:
         curr,
         "return_call* callee return type must match caller return type");
     } else {
-      shouldBeEqualOrFirstIsUnreachable(curr->type,
-                    sig.results,
-                    curr,
-                    "call* type must match callee return type");
+      shouldBeEqualOrFirstIsUnreachable(
+        curr->type,
+        sig.results,
+        curr,
+        "call* type must match callee return type");
     }
   }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -485,6 +485,16 @@ private:
         sig.results,
         curr,
         "call* type must match callee return type");
+      if (curr->type == Type::unreachable) {
+        // An unreachable is only allowed if one of the children is unreachable,
+        // since this is not a return call (which is always unreachable).
+        bool hasUnreachableChild = false;
+        for (auto* child : ChildIterator(curr)) {
+          hasUnreachableChild = true;
+          break;
+        }
+        shouldBeTrue(hasUnreachableChild, curr, "unreachable call* must have unreachable child");
+      }
     }
   }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -485,18 +485,6 @@ private:
         sig.results,
         curr,
         "call* type must match callee return type");
-      if (curr->type == Type::unreachable) {
-        // An unreachable is only allowed if one of the children is unreachable,
-        // since this is not a return call (which is always unreachable).
-        bool hasUnreachableChild = false;
-        for (auto* child : ChildIterator(curr)) {
-          hasUnreachableChild = true;
-          break;
-        }
-        shouldBeTrue(hasUnreachableChild,
-                     curr,
-                     "unreachable call* must have unreachable child");
-      }
     }
   }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -480,25 +480,10 @@ private:
         curr,
         "return_call* callee return type must match caller return type");
     } else {
-      if (curr->type == Type::unreachable) {
-        // One of the children must be unreachable: otherwise, the type of the
-        // call is the result of the called function, and function signatures
-        // cannot have unreachable as their type.
-        shouldBeTrue(
-          !curr->operands.empty() && std::any_of(curr->operands.begin(),
-                                                 curr->operands.end(),
-                                                 [&](Expression* operand) {
-                                                   return operand->type ==
-                                                          Type::unreachable;
-                                                 }),
-          curr,
-          "unreachable non-return call* must have unreachable child");
-      } else {
-        shouldBeEqual(curr->type,
-                      sig.results,
-                      curr,
-                      "call* type must match callee return type");
-      }
+      shouldBeEqualOrFirstIsUnreachable(curr->type,
+                    sig.results,
+                    curr,
+                    "call* type must match callee return type");
     }
   }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -480,11 +480,25 @@ private:
         curr,
         "return_call* callee return type must match caller return type");
     } else {
-      shouldBeEqualOrFirstIsUnreachable(
-        curr->type,
-        sig.results,
-        curr,
-        "call* type must match callee return type");
+      if (curr->type == Type::unreachable) {
+        // One of the children must be unreachable: otherwise, the type of the
+        // call is the result of the called function, and function signatures
+        // cannot have unreachable as their type.
+        shouldBeTrue(
+          !curr->operands.empty() && std::any_of(curr->operands.begin(),
+                                                 curr->operands.end(),
+                                                 [&](Expression* operand) {
+                                                   return operand->type ==
+                                                          Type::unreachable;
+                                                 }),
+          curr,
+          "unreachable non-return call* must have unreachable child");
+      } else {
+        shouldBeEqual(curr->type,
+                      sig.results,
+                      curr,
+                      "call* type must match callee return type");
+      }
     }
   }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2790,8 +2790,8 @@ static void validateBinaryenIR(Module& wasm, ValidationInfo& info) {
         // contents have a concrete type. Refinalize will make it unreachable,
         // so both are valid here.
         bool validControlFlowStructureChange =
-          Properties::isControlFlowStructure(curr) && oldType.isConcrete()
-              && newType == Type::unreachable;
+          Properties::isControlFlowStructure(curr) && oldType.isConcrete() &&
+          newType == Type::unreachable;
         if (!Type::isSubType(newType, oldType) &&
             !validControlFlowStructureChange) {
           std::ostringstream ss;

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2781,15 +2781,19 @@ static void validateBinaryenIR(Module& wasm, ValidationInfo& info) {
       ReFinalizeNode().visit(curr);
       auto newType = curr->type;
       if (newType != oldType) {
-        // We accept concrete => undefined,
+        // We accept concrete => undefined on control flow structures:
         // e.g.
         //
         //  (drop (block (result i32) (unreachable)))
         //
-        // The block has an added type, not derived from the ast itself, so it
-        // is ok for it to be either i32 or unreachable.
+        // The block has a type annotated on it, which can make its unreachable
+        // contents have a concrete type. Refinalize will make it unreachable,
+        // so both are valid here.
+        bool validControlFlowStructureChange =
+          Properties::isControlFlowStructure(curr) && oldType.isConcrete()
+              && newType == Type::unreachable;
         if (!Type::isSubType(newType, oldType) &&
-            !(oldType.isConcrete() && newType == Type::unreachable)) {
+            !validControlFlowStructureChange) {
           std::ostringstream ss;
           ss << "stale type found in " << scope << " on " << curr
              << "\n(marked as " << oldType << ", should be " << newType

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -493,7 +493,9 @@ private:
           hasUnreachableChild = true;
           break;
         }
-        shouldBeTrue(hasUnreachableChild, curr, "unreachable call* must have unreachable child");
+        shouldBeTrue(hasUnreachableChild,
+                     curr,
+                     "unreachable call* must have unreachable child");
       }
     }
   }


### PR DESCRIPTION
The validation logic to check for stale types (code where we forgot to run
refinalize) had a workaround for a control flow issue. That workaround meant
we didn't catch errors where a type was concrete but it should be unreachable.
This PR makes that workaround only apply for control flow structures, so we can
catch more errors.