### PR TITLE
Try to fix Alpine breakage on CI

### DIFF
--- a/scripts/test/node-esm-loader.mjs
+++ b/scripts/test/node-esm-loader.mjs
@@ -25,6 +25,8 @@ const specialTestSuiteModules = {
 export async function resolve(specifier, context, defaultResolve) {
   const specialModule = specialTestSuiteModules[specifier];
   if (specialModule) {
+    // This is needed for newer node versions.
+    specialModule.shortCircuit = true;
     return specialModule;
   }
   return defaultResolve(specifier, context, defaultResolve);


### PR DESCRIPTION
```
 "/src/scripts/test/node-esm-loader.mjs 'resolve'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
```
Seems like it might be due to a node update in Alpine?

Hopefully this PR fixes that, but I have no idea...
