### PR TITLE
GUFA: Mutable exported globals are roots

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1234,6 +1234,13 @@ Flower::Flower(Module& wasm) : wasm(wasm) {
           }
         }
       }
+    } else if (ex->kind == ExternalKind::Global) {
+      // Exported mutable globals are roots, since the outside may write any
+      // value to them.
+      auto name = ex->value;
+      if (wasm.getGlobal(name)->mutable_) {
+//        roots[GlobalLocation{name}] = PossibleContents::many();
+      }
     }
   }
 

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1239,7 +1239,7 @@ Flower::Flower(Module& wasm) : wasm(wasm) {
       // value to them.
       auto name = ex->value;
       if (wasm.getGlobal(name)->mutable_) {
-//        roots[GlobalLocation{name}] = PossibleContents::many();
+        roots[GlobalLocation{name}] = PossibleContents::many();
       }
     }
   }

--- a/test/lit/passes/gufa.wast
+++ b/test/lit/passes/gufa.wast
@@ -1088,7 +1088,7 @@
 
   ;; CHECK:      (func $test
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:   (global.get $exported-mutable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 42)

--- a/test/lit/passes/gufa.wast
+++ b/test/lit/passes/gufa.wast
@@ -1066,3 +1066,54 @@
     )
   )
 )
+
+;; Exported mutable globals can contain any value, as the outside can write to
+;; them.
+(module
+  ;; CHECK:      (type $none_=>_none (func))
+
+  ;; CHECK:      (global $exported-mutable (mut i32) (i32.const 42))
+  (global $exported-mutable (mut i32) (i32.const 42))
+  ;; CHECK:      (global $exported-immutable i32 (i32.const 42))
+  (global $exported-immutable i32 (i32.const 42))
+  ;; CHECK:      (global $mutable (mut i32) (i32.const 42))
+  (global $mutable (mut i32) (i32.const 42))
+  ;; CHECK:      (global $immutable i32 (i32.const 42))
+  (global $immutable i32 (i32.const 42))
+
+  ;; CHECK:      (export "exported-mutable" (global $exported-mutable))
+  (export "exported-mutable" (global $exported-mutable))
+  ;; CHECK:      (export "exported-immutable" (global $exported-immutable))
+  (export "exported-immutable" (global $exported-immutable))
+
+  ;; CHECK:      (func $test
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    ;; This should not be optimized to a constant.
+    (drop
+      (global.get $exported-mutable)
+    )
+    ;; All the rest can be optimized.
+    (drop
+      (global.get $exported-immutable)
+    )
+    (drop
+      (global.get $mutable)
+    )
+    (drop
+      (global.get $immutable)
+    )
+  )
+)


### PR DESCRIPTION
Such globals can be written to from the outside, so we cannot infer anything about
their contents.

Fixes #4932