### PR TITLE
[Fuzzer] Fuzz TrapsNeverHappen mode

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -508,8 +508,14 @@ def fix_output(out):
             x = str(float(x))
         return 'f64.const ' + x
     out = re.sub(r'f64\.const (-?[nanN:abcdefxIity\d+-.]+)', fix_double, out)
+
     # mark traps from wasm-opt as exceptions, even though they didn't run in a vm
     out = out.replace(TRAP_PREFIX, 'exception: ' + TRAP_PREFIX)
+
+    # funcref(0) has the index of the function in it, and optimizations can
+    # change that index, so ignore it
+    out = re.sub(r'funcref\(\d+\)', 'funcref()', out)
+
     lines = out.splitlines()
     for i in range(len(lines)):
         line = lines[i]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1039,7 +1039,7 @@ class TrapsNeverHappen(TestCaseHandler):
         before = run_bynterp(before_wasm, ['--fuzz-exec-before'])
         after_wasm_tnh = after_wasm + '.tnh.wasm'
         run([in_bin('wasm-opt'), before_wasm, '-o', after_wasm_tnh, '-tnh'] + opts + FEATURE_OPTS)
-        after = 'waka\n' + run_bynterp(after_wasm_tnh, ['--fuzz-exec-before'])
+        after = run_bynterp(after_wasm_tnh, ['--fuzz-exec-before'])
 
         # if a trap happened, we must stop comparing from that.
         if TRAP_PREFIX in before:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1061,7 +1061,7 @@ class TrapsNeverHappen(TestCaseHandler):
             after_index = after.index(call_line)
             after = after[:after_index]
 
-        compare_between_vms(before, after, 'TrapsNeverHappen')
+        compare_between_vms(fix_output(before), fix_output(after), 'TrapsNeverHappen')
 
 
 # Check that the text format round-trips without error.

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -514,7 +514,7 @@ def fix_output(out):
 
     # funcref(0) has the index of the function in it, and optimizations can
     # change that index, so ignore it
-    out = re.sub(r'funcref\(\d+\)', 'funcref()', out)
+    out = re.sub(r'funcref\([\d\w$+-_:]+\)', 'funcref()', out)
 
     lines = out.splitlines()
     for i in range(len(lines)):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1054,7 +1054,13 @@ class TrapsNeverHappen(TestCaseHandler):
             # (tnh could move the trap around, so even things before the trap
             # are unsafe). erase everything from this function's output and
             # onward, so we only compare the previous trap-free code.
-            call_start = before.rindex(FUZZ_EXEC_CALL_PREFIX, 0, trap_index)
+            call_start = before.rfind(FUZZ_EXEC_CALL_PREFIX, 0, trap_index)
+            if call_start < 0:
+                # the trap happened before we called an export, so it occured
+                # during startup (the start function, or memory segment
+                # operations, etc.). in that case there is nothing for us to
+                # compare here; just leave.
+                return
             call_end = before.index('\n', call_start)
             call_line = before[call_start:call_end]
             before_index = before.index(call_line)


### PR DESCRIPTION
This mode is tricky to fuzz because the mode is basically "assume traps never
happen; if a trap *does* happen, that is undefined behavior". So if any trap occurs
in the random fuzz testcase, we can't optimize with `-tnh` and assume the results
stay to same. To avoid that, we ignore all functions from the first one that traps,
that is, we only compare the code that ran without trapping. That often is a small
subset of the total functions, sadly, but I do see that this ends up with some useful
coverage despite the drawback.

This also requires some fixes to comparing of references, specifically, funcrefs
are printed with the function name/index, but that can change during opts, so
ignore that. This wasn't noticed before because this new fuzzer mode does
comparisons of `--fuzz-exec-before` output, instead of doing `--fuzz-exec` which
runs it before and after and compares it internally in `wasm-opt`. Here we are
comparing the output externally, which we didn't do before.

Fuzzing with this for a few days, it seems stable.