### PR TITLE
Fixing print-profile.wast test

### DIFF
--- a/test/lit/wasm-split/print-profile.wast
+++ b/test/lit/wasm-split/print-profile.wast
@@ -15,6 +15,7 @@
 ;; UNESCAPED: - bar(double[3])
 
 (module
+  (memory 0 0)
   (export "memory" (memory 0 0))
   (export "foo" (func $foo))
   (export "bar" (func $bar\28double\5b3\5d\29))


### PR DESCRIPTION
In a multi-memories world, memory must be explicitly defined before being exported. Fix CI for 6b3f3af606f2cbe8da29996e5600d174c5653d05.

/cc @sps-gold 