### PR TITLE
Materialize non-null externrefs in the fuzzer

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1969,8 +1969,13 @@ Expression* TranslateToFuzzReader::makeConstBasicRef(Type type) {
   assert(wasm.features.hasReferenceTypes());
   switch (heapType.getBasic()) {
     case HeapType::ext: {
-      assert(type.isNullable() && "Cannot handle non-nullable externref");
-      return builder.makeRefNull(type);
+      auto null = builder.makeRefNull(HeapType::ext);
+      // TODO: support actual non-nullable externrefs via imported globals or
+      // similar.
+      if (!type.isNullable()) {
+        return builder.makeRefAs(RefAsNonNull, null);
+      }
+      return null;
     }
     case HeapType::func: {
       return makeRefFuncConst(type);


### PR DESCRIPTION
Some fuzzer initial contents contain non-nullable externrefs that cause the
fuzzer to try to materialize non-nullable externref values. Perviously the
fuzzer did not support this and crashed with an assertion failure. Fix the
assertion failure by instead returning a null cast to non-null, which will trap
at runtime but at least produce a valid module.