### PR TITLE
Fix multi-memory + C API for MemoryGrow and MemorySize

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1162,18 +1162,26 @@ BinaryenExpressionRef BinaryenReturn(BinaryenModuleRef module,
   auto* ret = Builder(*(Module*)module).makeReturn((Expression*)value);
   return static_cast<Expression*>(ret);
 }
+
+static Builder::MemoryInfo getMemoryInfo(bool memoryIs64) {
+  return memoryIs64 ? Builder::MemoryInfo::Memory64
+                    : Builder::MemoryInfo::Memory32;
+}
+
 BinaryenExpressionRef BinaryenMemorySize(BinaryenModuleRef module,
-                                         const char* memoryName) {
+                                         const char* memoryName,
+                                         bool memoryIs64) {
   auto* ret =
-    Builder(*(Module*)module).makeMemorySize(getMemoryName(module, memoryName));
+    Builder(*(Module*)module).makeMemorySize(getMemoryName(module, memoryName), getMemoryInfo(memoryIs64));
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenMemoryGrow(BinaryenModuleRef module,
                                          BinaryenExpressionRef delta,
-                                         const char* memoryName) {
+                                         const char* memoryName,
+                                         bool memoryIs64) {
   auto* ret =
     Builder(*(Module*)module)
-      .makeMemoryGrow((Expression*)delta, getMemoryName(module, memoryName));
+      .makeMemoryGrow((Expression*)delta, getMemoryName(module, memoryName), getMemoryInfo(memoryIs64));
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1171,17 +1171,19 @@ static Builder::MemoryInfo getMemoryInfo(bool memoryIs64) {
 BinaryenExpressionRef BinaryenMemorySize(BinaryenModuleRef module,
                                          const char* memoryName,
                                          bool memoryIs64) {
-  auto* ret =
-    Builder(*(Module*)module).makeMemorySize(getMemoryName(module, memoryName), getMemoryInfo(memoryIs64));
+  auto* ret = Builder(*(Module*)module)
+                .makeMemorySize(getMemoryName(module, memoryName),
+                                getMemoryInfo(memoryIs64));
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenMemoryGrow(BinaryenModuleRef module,
                                          BinaryenExpressionRef delta,
                                          const char* memoryName,
                                          bool memoryIs64) {
-  auto* ret =
-    Builder(*(Module*)module)
-      .makeMemoryGrow((Expression*)delta, getMemoryName(module, memoryName), getMemoryInfo(memoryIs64));
+  auto* ret = Builder(*(Module*)module)
+                .makeMemoryGrow((Expression*)delta,
+                                getMemoryName(module, memoryName),
+                                getMemoryInfo(memoryIs64));
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -780,11 +780,13 @@ BINARYEN_API BinaryenExpressionRef BinaryenDrop(BinaryenModuleRef module,
 BINARYEN_API BinaryenExpressionRef BinaryenReturn(BinaryenModuleRef module,
                                                   BinaryenExpressionRef value);
 BINARYEN_API BinaryenExpressionRef BinaryenMemorySize(BinaryenModuleRef module,
-                                                      const char* memoryName);
+                                                      const char* memoryName,
+                                                      bool memoryIs64);
 BINARYEN_API BinaryenExpressionRef
 BinaryenMemoryGrow(BinaryenModuleRef module,
                    BinaryenExpressionRef delta,
-                   const char* memoryName);
+                   const char* memoryName,
+                   bool memoryIs64);
 BINARYEN_API BinaryenExpressionRef BinaryenNop(BinaryenModuleRef module);
 BINARYEN_API BinaryenExpressionRef
 BinaryenUnreachable(BinaryenModuleRef module);

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -687,11 +687,12 @@ function wrapModule(module, self = {}) {
   }
 
   self['memory'] = {
-    'size'(name) {
-      return Module['_BinaryenMemorySize'](module, strToStack(name));
+    // memory64 defaults to undefined/false.
+    'size'(name, memory64) {
+      return Module['_BinaryenMemorySize'](module, strToStack(name), memory64);
     },
-    'grow'(value, name) {
-      return Module['_BinaryenMemoryGrow'](module, value, strToStack(name));
+    'grow'(value, name, memory64) {
+      return Module['_BinaryenMemoryGrow'](module, value, strToStack(name), memory64);
     },
     'init'(segment, dest, offset, size, name) {
       return Module['_BinaryenMemoryInit'](module, segment, dest, offset, size, strToStack(name));

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -670,14 +670,14 @@ public:
   // information fetched from there.
   enum MemoryInfo { Memory32, Memory64, Unspecified };
 
-  bool isMemory64(MemoryInfo info) {
+  bool isMemory64(Name memoryName, MemoryInfo info) {
     return info == MemoryInfo::Memory64 || (info == MemoryInfo::Unspecified &&
                                             wasm.getMemory(memoryName).is64());
   }
 
   MemorySize* makeMemorySize(Name memoryName, MemoryInfo info) {
     auto* ret = wasm.allocator.alloc<MemorySize>();
-    if (isMemory64(info)) {
+    if (isMemory64(memoryName, info)) {
       ret->make64();
     }
     ret->memory = memoryName;
@@ -687,7 +687,7 @@ public:
   MemoryGrow*
   makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info) {
     auto* ret = wasm.allocator.alloc<MemoryGrow>();
-    if (isMemory64(info)) {
+    if (isMemory64(memoryName, info)) {
       ret->make64();
     }
     ret->delta = delta;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -672,7 +672,7 @@ public:
 
   bool isMemory64(Name memoryName, MemoryInfo info) {
     return info == MemoryInfo::Memory64 || (info == MemoryInfo::Unspecified &&
-                                            wasm.getMemory(memoryName).is64());
+                                            wasm.getMemory(memoryName)->is64());
   }
 
   MemorySize* makeMemorySize(Name memoryName, MemoryInfo info) {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -664,20 +664,32 @@ public:
     ret->value = value;
     return ret;
   }
-  MemorySize* makeMemorySize(Name memoryName) {
-    auto memory = wasm.getMemory(memoryName);
+
+  // Some APIs can be told if the memory is 32 or 64-bit. If they are not
+  // informed of that, then the memory they refer to is looked up and that
+  // information fetched from there.
+  enum MemoryInfo {
+    Memory32,
+    Memory64,
+    Unspecified
+  };
+
+  bool isMemory64(MemoryInfo info) {
+    return info == MemoryInfo::Memory64 || (info == MemoryInfo::Unspecified && wasm.getMemory(memoryName).is64());
+  }
+
+  MemorySize* makeMemorySize(Name memoryName, MemoryInfo info) {
     auto* ret = wasm.allocator.alloc<MemorySize>();
-    if (memory->is64()) {
+    if (isMemory64(info)) {
       ret->make64();
     }
     ret->memory = memoryName;
     ret->finalize();
     return ret;
   }
-  MemoryGrow* makeMemoryGrow(Expression* delta, Name memoryName) {
-    auto memory = wasm.getMemory(memoryName);
+  MemoryGrow* makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info) {
     auto* ret = wasm.allocator.alloc<MemoryGrow>();
-    if (memory->is64()) {
+    if (isMemory64(info)) {
       ret->make64();
     }
     ret->delta = delta;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -675,7 +675,7 @@ public:
                                             wasm.getMemory(memoryName)->is64());
   }
 
-  MemorySize* makeMemorySize(Name memoryName, MemoryInfo info) {
+  MemorySize* makeMemorySize(Name memoryName, MemoryInfo info = MemoryInfo::Unspecified) {
     auto* ret = wasm.allocator.alloc<MemorySize>();
     if (isMemory64(memoryName, info)) {
       ret->make64();
@@ -685,7 +685,7 @@ public:
     return ret;
   }
   MemoryGrow*
-  makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info) {
+  makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info = MemoryInfo::Unspecified) {
     auto* ret = wasm.allocator.alloc<MemoryGrow>();
     if (isMemory64(memoryName, info)) {
       ret->make64();

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -668,14 +668,11 @@ public:
   // Some APIs can be told if the memory is 32 or 64-bit. If they are not
   // informed of that, then the memory they refer to is looked up and that
   // information fetched from there.
-  enum MemoryInfo {
-    Memory32,
-    Memory64,
-    Unspecified
-  };
+  enum MemoryInfo { Memory32, Memory64, Unspecified };
 
   bool isMemory64(MemoryInfo info) {
-    return info == MemoryInfo::Memory64 || (info == MemoryInfo::Unspecified && wasm.getMemory(memoryName).is64());
+    return info == MemoryInfo::Memory64 || (info == MemoryInfo::Unspecified &&
+                                            wasm.getMemory(memoryName).is64());
   }
 
   MemorySize* makeMemorySize(Name memoryName, MemoryInfo info) {
@@ -687,7 +684,8 @@ public:
     ret->finalize();
     return ret;
   }
-  MemoryGrow* makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info) {
+  MemoryGrow*
+  makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info) {
     auto* ret = wasm.allocator.alloc<MemoryGrow>();
     if (isMemory64(info)) {
       ret->make64();

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -675,7 +675,8 @@ public:
                                             wasm.getMemory(memoryName)->is64());
   }
 
-  MemorySize* makeMemorySize(Name memoryName, MemoryInfo info = MemoryInfo::Unspecified) {
+  MemorySize* makeMemorySize(Name memoryName,
+                             MemoryInfo info = MemoryInfo::Unspecified) {
     auto* ret = wasm.allocator.alloc<MemorySize>();
     if (isMemory64(memoryName, info)) {
       ret->make64();
@@ -684,8 +685,9 @@ public:
     ret->finalize();
     return ret;
   }
-  MemoryGrow*
-  makeMemoryGrow(Expression* delta, Name memoryName, MemoryInfo info = MemoryInfo::Unspecified) {
+  MemoryGrow* makeMemoryGrow(Expression* delta,
+                             Name memoryName,
+                             MemoryInfo info = MemoryInfo::Unspecified) {
     auto* ret = wasm.allocator.alloc<MemoryGrow>();
     if (isMemory64(memoryName, info)) {
       ret->make64();

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -1034,8 +1034,8 @@ void test_core() {
     BinaryenPop(module, BinaryenTypeExternref()),
     BinaryenPop(module, iIfF),
     // Memory
-    BinaryenMemorySize(module, "0"),
-    BinaryenMemoryGrow(module, makeInt32(module, 0), "0"),
+    BinaryenMemorySize(module, "0", false),
+    BinaryenMemoryGrow(module, makeInt32(module, 0), "0", false),
     // GC
     BinaryenI31New(module, makeInt32(module, 0)),
     BinaryenI31Get(module, i31refExpr, 1),


### PR DESCRIPTION
Those instructions need to know if the memory is 64-bit or not. We looked that
up on the module globally, which is convenient, but in the C API this was actually
a breaking change, it turns out. To keep things working, provide that information
when creating a MemoryGrow or MemorySize, as another parameter in the C
API. In the C++ API (wasm-builder), support both modes, and default to the
automatic lookup.

We already require a bunch of other explicit info when creating expressions, like
making a Call requires the return type (we don't look it up globally), and even a
LocalGet requires the local type (we don't look it up on the function), so this is
consistent with those.

Fixes #4946