### PR TITLE
Update fuzzer to newer GC spec regarding JS interop

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -560,6 +560,11 @@ Function* TranslateToFuzzReader::addFunction() {
     std::all_of(paramType.begin(), paramType.end(), [&](Type t) {
       return validExportType(t) && t.isDefaultable();
     });
+  // Note: spec discussions around JS API integration are still ongoing, and it
+  // is not clear if we should allow nondefaultable types in exports or not
+  // (in imports, we cannot allow them in the fuzzer anyhow, since it can't
+  // construct such values in JS to send over to the wasm from the fuzzer
+  // harness).
   bool validExportResults =
     std::all_of(resultType.begin(), resultType.end(), validExportType);
   if (validExportParams && validExportResults &&

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -503,7 +503,8 @@ Function* TranslateToFuzzReader::addFunction() {
     params.push_back(type);
   }
   auto paramType = Type(params);
-  auto resultType = getControlFlowType() func->type =
+  auto resultType = getControlFlowType();
+  func->type =
     Signature(paramType, resultType);
   Index numVars = upToSquared(MAX_VARS);
   for (Index i = 0; i < numVars; i++) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -504,8 +504,7 @@ Function* TranslateToFuzzReader::addFunction() {
   }
   auto paramType = Type(params);
   auto resultType = getControlFlowType();
-  func->type =
-    Signature(paramType, resultType);
+  func->type = Signature(paramType, resultType);
   Index numVars = upToSquared(MAX_VARS);
   for (Index i = 0; i < numVars; i++) {
     auto type = getConcreteType();
@@ -554,7 +553,8 @@ Function* TranslateToFuzzReader::addFunction() {
       return true;
     }
     auto heapType = t.getHeapType();
-    return heapType == HeapType::ext || heapType == HeapType::func || heapType == HeapType::string;
+    return heapType == HeapType::ext || heapType == HeapType::func ||
+           heapType == HeapType::string;
   };
   bool validExportParams =
     std::all_of(paramType.begin(), paramType.end(), [&](Type t) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -561,7 +561,7 @@ Function* TranslateToFuzzReader::addFunction() {
         // Anyref is not allowed in JS interop in the current GC spec.
         return false;
       }
-      return true
+      return true;
     });
   if (validExportParams && validExportReturns &&
       (numAddedFunctions == 0 || oneIn(2)) &&

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -561,9 +561,7 @@ Function* TranslateToFuzzReader::addFunction() {
       return validExportType(t) && t.isDefaultable();
     });
   bool validExportResults =
-    std::all_of(resultType.begin(), resultType.end(), [](Type t) {
-      return validExportType(t);
-    });
+    std::all_of(resultType.begin(), resultType.end(), validExportType);
   if (validExportParams && validExportResults &&
       (numAddedFunctions == 0 || oneIn(2)) &&
       !wasm.getExportOrNull(func->name)) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -549,19 +549,21 @@ Function* TranslateToFuzzReader::addFunction() {
   // at least one, though, to keep each testcase interesting. Only functions
   // with valid params and returns can be exported because the trap fuzzer
   // depends on that (TODO: fix this).
-  bool validExportType = [](Type t) {
+  auto validExportType = [](Type t) {
     if (!t.isRef()) {
       return true;
     }
     auto heapType = t.getHeapType();
-    return heapType == HeapType::ext || heapType ==HeapType::func || heapType == HeapType::string;
+    return heapType == HeapType::ext || heapType == HeapType::func || heapType == HeapType::string;
   };
   bool validExportParams =
     std::all_of(paramType.begin(), paramType.end(), [&](Type t) {
       return validExportType(t) && t.isDefaultable();
     });
   bool validExportResults =
-    std::all_of(resultType.begin(), resultType.end(), validExportType);
+    std::all_of(resultType.begin(), resultType.end(), [](Type t) {
+      return validExportType(t);
+    });
   if (validExportParams && validExportResults &&
       (numAddedFunctions == 0 || oneIn(2)) &&
       !wasm.getExportOrNull(func->name)) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -545,13 +545,17 @@ Function* TranslateToFuzzReader::addFunction() {
   wasm.addFunction(func);
   // Export some functions, but not all (to allow inlining etc.). Try to export
   // at least one, though, to keep each testcase interesting. Only functions
-  // with defaultable params can be exported because the trap fuzzer depends on
-  // that (TODO: fix this).
-  bool defaultableParams =
+  // with valid params can be exported because the trap fuzzer depends on that
+  // (TODO: fix this).
+  bool validExportParams =
     std::all_of(paramType.begin(), paramType.end(), [](Type t) {
+      if (t.isRef() && t.getHeapType() == HeapType::any) {
+        // Anyref is not allowed in JS interop in the current GC spec.
+        return false;
+      }
       return t.isDefaultable();
     });
-  if (defaultableParams && (numAddedFunctions == 0 || oneIn(2)) &&
+  if (validExportParams && (numAddedFunctions == 0 || oneIn(2)) &&
       !wasm.getExportOrNull(func->name)) {
     auto* export_ = new Export;
     export_->name = func->name;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -503,8 +503,8 @@ Function* TranslateToFuzzReader::addFunction() {
     params.push_back(type);
   }
   auto paramType = Type(params);
-  auto resultType = getControlFlowType()
-  func->type = Signature(paramType, resultType);
+  auto resultType = getControlFlowType() func->type =
+    Signature(paramType, resultType);
   Index numVars = upToSquared(MAX_VARS);
   for (Index i = 0; i < numVars; i++) {
     auto type = getConcreteType();

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -557,7 +557,7 @@ Function* TranslateToFuzzReader::addFunction() {
     return heapType == HeapType::ext || heapType ==HeapType::func || heapType == HeapType::string;
   };
   bool validExportParams =
-    std::all_of(paramType.begin(), paramType.end(), [](Type t) {
+    std::all_of(paramType.begin(), paramType.end(), [&](Type t) {
       return validExportType(t) && t.isDefaultable();
     });
   bool validExportResults =

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -503,7 +503,8 @@ Function* TranslateToFuzzReader::addFunction() {
     params.push_back(type);
   }
   auto paramType = Type(params);
-  func->type = Signature(paramType, getControlFlowType());
+  auto resultType = getControlFlowType()
+  func->type = Signature(paramType, resultType);
   Index numVars = upToSquared(MAX_VARS);
   for (Index i = 0; i < numVars; i++) {
     auto type = getConcreteType();
@@ -555,15 +556,15 @@ Function* TranslateToFuzzReader::addFunction() {
       }
       return t.isDefaultable();
     });
-  bool validExportReturns =
-    std::all_of(paramType.begin(), paramType.end(), [](Type t) {
+  bool validExportResults =
+    std::all_of(resultType.begin(), resultType.end(), [](Type t) {
       if (t.isRef() && t.getHeapType() == HeapType::any) {
         // Anyref is not allowed in JS interop in the current GC spec.
         return false;
       }
       return true;
     });
-  if (validExportParams && validExportReturns &&
+  if (validExportParams && validExportResults &&
       (numAddedFunctions == 0 || oneIn(2)) &&
       !wasm.getExportOrNull(func->name)) {
     auto* export_ = new Export;

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,42 +1,42 @@
 total
- [exports]      : 5       
- [funcs]        : 8       
+ [exports]      : 12      
+ [funcs]        : 20      
  [globals]      : 6       
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 22      
- [table-data]   : 2       
+ [table-data]   : 7       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 495     
- [vars]         : 23      
- ArrayInit      : 2       
- AtomicNotify   : 1       
- Binary         : 64      
- Block          : 52      
+ [total]        : 707     
+ [vars]         : 37      
+ ArrayInit      : 8       
+ Binary         : 78      
+ Block          : 78      
  Break          : 7       
- Call           : 28      
- CallRef        : 1       
- Const          : 126     
- Drop           : 3       
- GlobalGet      : 25      
- GlobalSet      : 12      
- I31Get         : 1       
- I31New         : 11      
- If             : 19      
- Load           : 22      
- LocalGet       : 33      
- LocalSet       : 20      
- Loop           : 4       
- Nop            : 5       
- RefFunc        : 3       
+ Call           : 22      
+ CallRef        : 3       
+ Const          : 176     
+ Drop           : 13      
+ GlobalGet      : 51      
+ GlobalSet      : 26      
+ I31New         : 10      
+ If             : 28      
+ Load           : 20      
+ LocalGet       : 38      
+ LocalSet       : 24      
+ Loop           : 6       
+ MemoryCopy     : 1       
+ MemoryFill     : 1       
+ Nop            : 10      
+ RefEq          : 1       
+ RefFunc        : 12      
  RefNull        : 4       
- Return         : 17      
+ Return         : 28      
  SIMDExtract    : 3       
- Select         : 3       
- Store          : 1       
- StructNew      : 1       
+ Store          : 2       
+ StructNew      : 2       
  TupleExtract   : 1       
- TupleMake      : 11      
- Unary          : 13      
+ TupleMake      : 14      
+ Unary          : 38      
  Unreachable    : 2       


### PR DESCRIPTION
Do not export functions that have types not allowed in the rules for
JS interop. Only very few GC types can be on the JS boundary atm.