### PR TITLE
[NFC] Simplify binary reading logic for functions

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1511,11 +1511,6 @@ public:
   // We read functions and globals before we know their names, so we need to
   // backpatch the names later
 
-  // we store functions here before wasm.addFunction after we know their names
-  std::vector<Function*> functions;
-  // we store function imports here before wasm.addFunctionImport after we know
-  // their names
-  std::vector<Function*> functionImports;
   // at index i we have all refs to the function i
   std::map<Index, std::vector<Name*>> functionRefs;
   Function* currFunction = nullptr;


### PR DESCRIPTION
We do a call to `updateMaps()` at the end of `processNames` anyhow, and so we
may as well call `addFunction` immediately (and the names will get fixed up in that
`updateMaps` later). The old code for some reason did that for function imports, but
not normal functions. It also stored them separately in temporary storage for some
unclear reason...

I happened to notice this while starting to add support for tag names.