### PR TITLE
[NFC] Simplify binary reading logic for tables

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1518,11 +1518,6 @@ public:
   // function to check
   Index endOfFunction = -1;
 
-  // we store tables here before wasm.addTable after we know their names
-  std::vector<std::unique_ptr<Table>> tables;
-  // we store table imports here before wasm.addTableImport after we know
-  // their names
-  std::vector<Table*> tableImports;
   // at index i we have all references to the table i
   std::map<Index, std::vector<Name*>> tableRefs;
 


### PR DESCRIPTION
Similar to #4969 but for tables.

(After this, we have these to clean up: globals, memories, and segments.)