### PR TITLE
Multi-Memories wasm-split

### DIFF
--- a/src/ir/names.h
+++ b/src/ir/names.h
@@ -83,6 +83,10 @@ inline Name getValidElementSegmentName(Module& module, Name root) {
   return getValidName(
     root, [&](Name test) { return !module.getElementSegmentOrNull(test); });
 }
+inline Name getValidMemoryName(Module& module, Name root) {
+  return getValidName(root,
+                      [&](Name test) { return !module.getMemoryOrNull(test); });
+}
 inline Name getValidLocalName(Function& func, Name root) {
   return getValidName(root,
                       [&](Name test) { return !func.hasLocalIndex(test); });

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -78,7 +78,7 @@ void Instrumenter::addSecondaryMemory(size_t numFuncs) {
   secondaryMemory = Names::getValidMemoryName(*wasm, "split_data");
   // Create a memory with enough pages to write into
   size_t pages = (numFuncs + Memory::kPageSize - 1) / Memory::kPageSize;
-  wasm->addMemory(Builder::makeMemory(secondaryMemory, pages, pages));
+  wasm->addMemory(Builder::makeMemory(secondaryMemory, pages, pages, true));
 }
 
 void Instrumenter::instrumentFuncs() {

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -75,7 +75,8 @@ void Instrumenter::addSecondaryMemory(size_t profileSize) {
     return;
   }
   if (!wasm->features.hasMultiMemories()) {
-    Fatal() << "error: --in-secondary-memory requires multi-memories to be enabled";
+    Fatal()
+      << "error: --in-secondary-memory requires multi-memories to be enabled";
   }
 
   secondaryMemory = Names::getValidMemoryName(*wasm, "split_data");
@@ -125,14 +126,18 @@ void Instrumenter::instrumentFuncs() {
       break;
     }
     case WasmSplitOptions::StorageKind::InMemory:
-    case WasmSplitOptions::StorageKind::InSecondaryMemory:{
+    case WasmSplitOptions::StorageKind::InSecondaryMemory: {
       if (!wasm->features.hasAtomics()) {
-        Fatal() << "error: --in-memory and --in-secondary-memory requires atomics to be enabled";
+        Fatal() << "error: --in-memory and --in-secondary-memory requires "
+                   "atomics to be enabled";
       }
       // (i32.atomic.store8 offset=funcidx (i32.const 0) (i32.const 1))
       Index funcIdx = 0;
       assert(!wasm->memories.empty());
-      Name memoryName = options.storageKind == WasmSplitOptions::StorageKind::InMemory ? wasm->memories[0]->name : secondaryMemory;
+      Name memoryName =
+        options.storageKind == WasmSplitOptions::StorageKind::InMemory
+          ? wasm->memories[0]->name
+          : secondaryMemory;
       ModuleUtils::iterDefinedFunctions(*wasm, [&](Function* func) {
         func->body = builder.makeSequence(
           builder.makeAtomicStore(1,
@@ -278,9 +283,13 @@ void Instrumenter::addProfileExport(size_t numFuncs, size_t profileSize) {
     case WasmSplitOptions::StorageKind::InSecondaryMemory: {
       // Copy the secondary memory into main memory for exporting the profile to
       // the user provided buffer
-      writeData = builder.blockify(
-          writeData,
-          builder.makeMemoryCopy(builder.makeConst(8), builder.makeConst(0), builder.makeConst(numFuncs), wasm->memories[0]->name, secondaryMemory));
+      writeData =
+        builder.blockify(writeData,
+                         builder.makeMemoryCopy(builder.makeConst(8),
+                                                builder.makeConst(0),
+                                                builder.makeConst(numFuncs),
+                                                wasm->memories[0]->name,
+                                                secondaryMemory));
       break;
     }
   }

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -128,8 +128,9 @@ void Instrumenter::instrumentFuncs() {
     case WasmSplitOptions::StorageKind::InMemory:
     case WasmSplitOptions::StorageKind::InSecondaryMemory: {
       if (!wasm->features.hasAtomics()) {
-        Fatal() << "error: --in-memory and --in-secondary-memory requires "
-                   "atomics to be enabled";
+        const char* command = options.storageKind == WasmSplitOptions::StorageKind::InMemory ? "in-memory" : "in-secondary-memory";
+        Fatal() << "error: --" << command <<
+                   " requires atomics to be enabled";
       }
       // (i32.atomic.store8 offset=funcidx (i32.const 0) (i32.const 1))
       Index funcIdx = 0;

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -22,7 +22,8 @@
 
 namespace wasm {
 
-Instrumenter::Instrumenter(const InstrumenterConfig& config, uint64_t moduleHash)
+Instrumenter::Instrumenter(const InstrumenterConfig& config,
+                           uint64_t moduleHash)
   : config(config), moduleHash(moduleHash) {}
 
 void Instrumenter::run(PassRunner* runner, Module* wasm) {
@@ -77,7 +78,8 @@ void Instrumenter::addSecondaryMemory(size_t numFuncs) {
       << "error: --in-secondary-memory requires multi-memories to be enabled";
   }
 
-  secondaryMemory = Names::getValidMemoryName(*wasm, config.secondaryMemoryName);
+  secondaryMemory =
+    Names::getValidMemoryName(*wasm, config.secondaryMemoryName);
   // Create a memory with enough pages to write into
   size_t pages = (numFuncs + Memory::kPageSize - 1) / Memory::kPageSize;
   auto mem = Builder::makeMemory(secondaryMemory, pages, pages, true);
@@ -129,9 +131,11 @@ void Instrumenter::instrumentFuncs() {
     case WasmSplitOptions::StorageKind::InMemory:
     case WasmSplitOptions::StorageKind::InSecondaryMemory: {
       if (!wasm->features.hasAtomics()) {
-        const char* command = config.storageKind == WasmSplitOptions::StorageKind::InMemory ? "in-memory" : "in-secondary-memory";
-        Fatal() << "error: --" << command <<
-                   " requires atomics to be enabled";
+        const char* command =
+          config.storageKind == WasmSplitOptions::StorageKind::InMemory
+            ? "in-memory"
+            : "in-secondary-memory";
+        Fatal() << "error: --" << command << " requires atomics to be enabled";
       }
       // (i32.atomic.store8 offset=funcidx (i32.const 0) (i32.const 1))
       Index funcIdx = 0;

--- a/src/tools/wasm-split/instrumenter.h
+++ b/src/tools/wasm-split/instrumenter.h
@@ -44,9 +44,9 @@ struct Instrumenter : public Pass {
 
 private:
   void addGlobals(size_t numFuncs);
-  void addSecondaryMemory(size_t profileSize);
+  void addSecondaryMemory(size_t numFuncs);
   void instrumentFuncs();
-  void addProfileExport(size_t numFuncs, size_t profileSize);
+  void addProfileExport(size_t numFuncs);
 };
 
 } // namespace wasm

--- a/src/tools/wasm-split/instrumenter.h
+++ b/src/tools/wasm-split/instrumenter.h
@@ -36,14 +36,17 @@ struct Instrumenter : public Pass {
   Name counterGlobal;
   std::vector<Name> functionGlobals;
 
+  Name secondaryMemory;
+
   Instrumenter(const WasmSplitOptions& options, uint64_t moduleHash);
 
   void run(PassRunner* runner, Module* wasm) override;
 
 private:
-  void addGlobals();
+  void addGlobals(size_t numFuncs);
+  void addSecondaryMemory(size_t profileSize);
   void instrumentFuncs();
-  void addProfileExport();
+  void addProfileExport(size_t numFuncs, size_t profileSize);
 };
 
 } // namespace wasm

--- a/src/tools/wasm-split/instrumenter.h
+++ b/src/tools/wasm-split/instrumenter.h
@@ -30,7 +30,8 @@ struct InstrumenterConfig {
   // instrumentation
   Name secondaryMemoryName = "profile-data";
   // Where to store the profile data
-  WasmSplitOptions::StorageKind storageKind = WasmSplitOptions::StorageKind::InGlobals;
+  WasmSplitOptions::StorageKind storageKind =
+    WasmSplitOptions::StorageKind::InGlobals;
   // The export name of the function the embedder calls to write the profile
   // into memory
   std::string profileExport = DEFAULT_PROFILE_EXPORT;

--- a/src/tools/wasm-split/instrumenter.h
+++ b/src/tools/wasm-split/instrumenter.h
@@ -23,6 +23,19 @@
 
 namespace wasm {
 
+struct InstrumenterConfig {
+  // The namespace from which to import the secondary memory
+  Name importNamespace = "env";
+  // The name of the secondary memory created to store profile data during
+  // instrumentation
+  Name secondaryMemoryName = "profile-data";
+  // Where to store the profile data
+  WasmSplitOptions::StorageKind storageKind = WasmSplitOptions::StorageKind::InGlobals;
+  // The export name of the function the embedder calls to write the profile
+  // into memory
+  std::string profileExport = DEFAULT_PROFILE_EXPORT;
+};
+
 // Add a global monotonic counter and a timestamp global for each function, code
 // at the beginning of each function to set its timestamp, and a new exported
 // function for dumping the profile data.
@@ -30,7 +43,7 @@ struct Instrumenter : public Pass {
   PassRunner* runner = nullptr;
   Module* wasm = nullptr;
 
-  const WasmSplitOptions& options;
+  const InstrumenterConfig& config;
   uint64_t moduleHash;
 
   Name counterGlobal;
@@ -38,7 +51,7 @@ struct Instrumenter : public Pass {
 
   Name secondaryMemory;
 
-  Instrumenter(const WasmSplitOptions& options, uint64_t moduleHash);
+  Instrumenter(const InstrumenterConfig& config, uint64_t moduleHash);
 
   void run(PassRunner* runner, Module* wasm) override;
 

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -245,18 +245,19 @@ WasmSplitOptions::WasmSplitOptions()
       [&](Options* o, const std::string& argument) {
         storageKind = StorageKind::InMemory;
       })
-    .add("--in-secondary-memory",
-         "",
-         "Store profile information in a separate memory, rather than in module "
-         "main memory or globals (the default). With this option, users do not "
-         "need to reserve the initial memory region for profile data and the "
-         "data can be shared between multiple threads.",
-         WasmSplitOption,
-         {Mode::Instrument},
-         Options::Arguments::Zero,
-         [&](Options* o, const std::string& argument) {
-           storageKind = StorageKind::InSecondaryMemory;
-         })
+    .add(
+      "--in-secondary-memory",
+      "",
+      "Store profile information in a separate memory, rather than in module "
+      "main memory or globals (the default). With this option, users do not "
+      "need to reserve the initial memory region for profile data and the "
+      "data can be shared between multiple threads.",
+      WasmSplitOption,
+      {Mode::Instrument},
+      Options::Arguments::Zero,
+      [&](Options* o, const std::string& argument) {
+        storageKind = StorageKind::InSecondaryMemory;
+      })
     .add(
       "--emit-module-names",
       "",

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -247,11 +247,10 @@ WasmSplitOptions::WasmSplitOptions()
       })
     .add("--in-secondary-memory",
          "",
-         "Store profile information in a separate memory. rather than globals "
-         "(the default) so that "
-         "it can be shared between multiple threads. Users are responsible for "
-         "ensuring that the module does not use the initial memory region for "
-         "anything else.",
+         "Store profile information in a separate memory, rather than in module "
+         "main memory or globals (the default). With this option, users do not "
+         "need to reserve the initial memory region for profile data and the "
+         "data can be shared between multiple threads.",
          WasmSplitOption,
          {Mode::Instrument},
          Options::Arguments::Zero,

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -246,6 +246,19 @@ WasmSplitOptions::WasmSplitOptions()
         storageKind = StorageKind::InMemory;
       })
     .add(
+      "--in-secondary-memory",
+      "",
+      "Store profile information in a separate memory. rather than globals (the default) so that "
+      "it can be shared between multiple threads. Users are responsible for "
+      "ensuring that the module does not use the initial memory region for "
+      "anything else.",
+      WasmSplitOption,
+      {Mode::Instrument},
+      Options::Arguments::Zero,
+      [&](Options* o, const std::string& argument) {
+        storageKind = StorageKind::InSecondaryMemory;
+      })
+    .add(
       "--emit-module-names",
       "",
       "Emit module names, even if not emitting the rest of the names section. "

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -245,19 +245,19 @@ WasmSplitOptions::WasmSplitOptions()
       [&](Options* o, const std::string& argument) {
         storageKind = StorageKind::InMemory;
       })
-    .add(
-      "--in-secondary-memory",
-      "",
-      "Store profile information in a separate memory. rather than globals (the default) so that "
-      "it can be shared between multiple threads. Users are responsible for "
-      "ensuring that the module does not use the initial memory region for "
-      "anything else.",
-      WasmSplitOption,
-      {Mode::Instrument},
-      Options::Arguments::Zero,
-      [&](Options* o, const std::string& argument) {
-        storageKind = StorageKind::InSecondaryMemory;
-      })
+    .add("--in-secondary-memory",
+         "",
+         "Store profile information in a separate memory. rather than globals "
+         "(the default) so that "
+         "it can be shared between multiple threads. Users are responsible for "
+         "ensuring that the module does not use the initial memory region for "
+         "anything else.",
+         WasmSplitOption,
+         {Mode::Instrument},
+         Options::Arguments::Zero,
+         [&](Options* o, const std::string& argument) {
+           storageKind = StorageKind::InSecondaryMemory;
+         })
     .add(
       "--emit-module-names",
       "",

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -185,10 +185,10 @@ WasmSplitOptions::WasmSplitOptions()
       [&](Options* o, const std::string& argument) { placeholderMap = true; })
     .add("--import-namespace",
          "",
-         "The namespace from which to import objects from the primary "
-         "module into the secondary module.",
+         "When provided as an option for module splitting, the namespace from which to import objects from the primary "
+         "module into the secondary module. In instrument mode, refers to the namespace from which to import the secondary memory.",
          WasmSplitOption,
-         {Mode::Split},
+         {Mode::Split, Mode::Instrument},
          Options::Arguments::One,
          [&](Options* o, const std::string& argument) {
            importNamespace = argument;
@@ -258,6 +258,16 @@ WasmSplitOptions::WasmSplitOptions()
       [&](Options* o, const std::string& argument) {
         storageKind = StorageKind::InSecondaryMemory;
       })
+    .add("--secondary-memory-name",
+         "",
+         "The name of the secondary memory created to store profile "
+         "information.",
+         WasmSplitOption,
+         {Mode::Instrument},
+         Options::Arguments::One,
+         [&](Options* o, const std::string& argument) {
+           secondaryMemoryName = argument;
+         })
     .add(
       "--emit-module-names",
       "",

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -188,7 +188,7 @@ WasmSplitOptions::WasmSplitOptions()
          "When provided as an option for module splitting, the namespace from "
          "which to import objects from the primary "
          "module into the secondary module. In instrument mode, refers to the "
-         "namespace from which to import the secondary memory.",
+         "namespace from which to import the secondary memory, if any.",
          WasmSplitOption,
          {Mode::Split, Mode::Instrument},
          Options::Arguments::One,

--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -185,8 +185,10 @@ WasmSplitOptions::WasmSplitOptions()
       [&](Options* o, const std::string& argument) { placeholderMap = true; })
     .add("--import-namespace",
          "",
-         "When provided as an option for module splitting, the namespace from which to import objects from the primary "
-         "module into the secondary module. In instrument mode, refers to the namespace from which to import the secondary memory.",
+         "When provided as an option for module splitting, the namespace from "
+         "which to import objects from the primary "
+         "module into the secondary module. In instrument mode, refers to the "
+         "namespace from which to import the secondary memory.",
          WasmSplitOption,
          {Mode::Split, Mode::Instrument},
          Options::Arguments::One,

--- a/src/tools/wasm-split/split-options.h
+++ b/src/tools/wasm-split/split-options.h
@@ -37,6 +37,7 @@ struct WasmSplitOptions : ToolOptions {
   enum class StorageKind : unsigned {
     InGlobals, // Store profile data in WebAssembly Globals
     InMemory,  // Store profile data in memory, accessible from all threads
+    InSecondaryMemory, // Store profile data in memory separate from main memory
   };
   StorageKind storageKind = StorageKind::InGlobals;
 

--- a/src/tools/wasm-split/split-options.h
+++ b/src/tools/wasm-split/split-options.h
@@ -64,6 +64,7 @@ struct WasmSplitOptions : ToolOptions {
 
   std::string importNamespace;
   std::string placeholderNamespace;
+  std::string secondaryMemoryName;
   std::string exportPrefix;
 
   // A hack to ensure the split and instrumented modules have the same table

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -111,7 +111,16 @@ void instrumentModule(const WasmSplitOptions& options) {
 
   uint64_t moduleHash = hashFile(options.inputFiles[0]);
   PassRunner runner(&wasm, options.passOptions);
-  Instrumenter(options, moduleHash).run(&runner, &wasm);
+  InstrumenterConfig config;
+  if (options.importNamespace.size()) {
+    config.importNamespace = options.importNamespace;
+  }
+  if (options.secondaryMemoryName.size()) {
+    config.secondaryMemoryName = options.secondaryMemoryName;
+  }
+  config.storageKind = options.storageKind;
+  config.profileExport = options.profileExport;
+  Instrumenter(config, moduleHash).run(&runner, &wasm);
 
   adjustTableSize(wasm, options.initialTableSize);
 

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -60,7 +60,7 @@
 ;; CHECK-NEXT:                                       primary module into the secondary module.
 ;; CHECK-NEXT:                                       In instrument mode, refers to the
 ;; CHECK-NEXT:                                       namespace from which to import the
-;; CHECK-NEXT:                                       secondary memory.
+;; CHECK-NEXT:                                       secondary memory, if any.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --placeholder-namespace             [split] The namespace from which to import
 ;; CHECK-NEXT:                                       placeholder functions into the primary

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -85,9 +85,17 @@
 ;; CHECK-NEXT:                                       does not use the initial memory region for
 ;; CHECK-NEXT:                                       anything else.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --in-secondary-memory               [instrument] Store profile information in
+;; CHECK-NEXT:                                       a separate memory, rather than in module
+;; CHECK-NEXT:                                       main memory or globals (the default).
+;; CHECK-NEXT:                                       With this option, users do not need to
+;; CHECK-NEXT:                                       reserve the initial memory region for
+;; CHECK-NEXT:                                       profile data and the data can be shared
+;; CHECK-NEXT:                                       between multiple threads.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --emit-module-names                 [split, instrument] Emit module names,
-;; CHECK-NEXT:                                       even if not emitting the rest of the names
-;; CHECK-NEXT:                                       section. Can help differentiate the
+;; CHECK-NEXT:                                       even if not emitting the rest of the
+;; CHECK-NEXT:                                       names section. Can help differentiate the
 ;; CHECK-NEXT:                                       modules in stack traces. This option will
 ;; CHECK-NEXT:                                       be removed once simpler ways of naming
 ;; CHECK-NEXT:                                       modules are widely available. See

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -55,12 +55,12 @@
 ;; CHECK-NEXT:                                       indices to the function names.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --import-namespace                  [split, instrument] When provided as an
-;; CHECK-NEXT:                                       option for module splitting, the
-;; CHECK-NEXT:                                       namespace from which to import objects
-;; CHECK-NEXT:                                       from the primary module into the
-;; CHECK-NEXT:                                       secondary module. In instrument mode,
-;; CHECK-NEXT:                                       refers to the namespace from which to
-;; CHECK-NEXT:                                       import the secondary memory.
+;; CHECK-NEXT:                                       option for module splitting, the namespace
+;; CHECK-NEXT:                                       from which to import objects from the
+;; CHECK-NEXT:                                       primary module into the secondary module.
+;; CHECK-NEXT:                                       In instrument mode, refers to the
+;; CHECK-NEXT:                                       namespace from which to import the
+;; CHECK-NEXT:                                       secondary memory.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --placeholder-namespace             [split] The namespace from which to import
 ;; CHECK-NEXT:                                       placeholder functions into the primary
@@ -91,33 +91,23 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --in-secondary-memory               [instrument] Store profile information in
 ;; CHECK-NEXT:                                       a separate memory, rather than in module
-;; CHECK-NEXT:                                       main memory or globals (the default).
-;; CHECK-NEXT:                                       With this option, users do not need to
-;; CHECK-NEXT:                                       reserve the initial memory region for
-;; CHECK-NEXT:                                       profile data and the data can be shared
-;; CHECK-NEXT:                                       between multiple threads.
+;; CHECK-NEXT:                                       main memory or globals (the default). With
+;; CHECK-NEXT:                                       this option, users do not need to reserve
+;; CHECK-NEXT:                                       the initial memory region for profile data
+;; CHECK-NEXT:                                       and the data can be shared between
+;; CHECK-NEXT:                                       multiple threads.
 ;; CHECK-NEXT:
-<<<<<<< HEAD
+;; CHECK-NEXT:   --secondary-memory-name             [instrument] The name of the secondary
+;; CHECK-NEXT:                                       memory created to store profile
+;; CHECK-NEXT:                                       information.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --emit-module-names                 [split, instrument] Emit module names,
-;; CHECK-NEXT:                                       even if not emitting the rest of the
-;; CHECK-NEXT:                                       names section. Can help differentiate the
+;; CHECK-NEXT:                                       even if not emitting the rest of the names
+;; CHECK-NEXT:                                       section. Can help differentiate the
 ;; CHECK-NEXT:                                       modules in stack traces. This option will
 ;; CHECK-NEXT:                                       be removed once simpler ways of naming
 ;; CHECK-NEXT:                                       modules are widely available. See
 ;; CHECK-NEXT:                                       https://bugs.chromium.org/p/v8/issues/detail?id=11808.
-=======
-;; CHECK-NEXT:   --secondary-memory-name              [instrument] The name of the secondary
-;; CHECK-NEXT:                                        memory created to store profile
-;; CHECK-NEXT:                                        information.
-;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                  [split, instrument] Emit module names,
-;; CHECK-NEXT:                                        even if not emitting the rest of the
-;; CHECK-NEXT:                                        names section. Can help differentiate the
-;; CHECK-NEXT:                                        modules in stack traces. This option will
-;; CHECK-NEXT:                                        be removed once simpler ways of naming
-;; CHECK-NEXT:                                        modules are widely available. See
-;; CHECK-NEXT:                                        https://bugs.chromium.org/p/v8/issues/detail?id=11808.
->>>>>>> 34014ecd9 (added wasm-split switch)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --initial-table                     [split, instrument] A hack to ensure the
 ;; CHECK-NEXT:                                       split and instrumented modules have the

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -54,9 +54,13 @@
 ;; CHECK-NEXT:   --placeholdermap                    [split] Write a file mapping placeholder
 ;; CHECK-NEXT:                                       indices to the function names.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --import-namespace                  [split] The namespace from which to import
-;; CHECK-NEXT:                                       objects from the primary module into the
-;; CHECK-NEXT:                                       secondary module.
+;; CHECK-NEXT:   --import-namespace                  [split, instrument] When provided as an
+;; CHECK-NEXT:                                       option for module splitting, the
+;; CHECK-NEXT:                                       namespace from which to import objects
+;; CHECK-NEXT:                                       from the primary module into the
+;; CHECK-NEXT:                                       secondary module. In instrument mode,
+;; CHECK-NEXT:                                       refers to the namespace from which to
+;; CHECK-NEXT:                                       import the secondary memory.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --placeholder-namespace             [split] The namespace from which to import
 ;; CHECK-NEXT:                                       placeholder functions into the primary
@@ -93,6 +97,7 @@
 ;; CHECK-NEXT:                                       profile data and the data can be shared
 ;; CHECK-NEXT:                                       between multiple threads.
 ;; CHECK-NEXT:
+<<<<<<< HEAD
 ;; CHECK-NEXT:   --emit-module-names                 [split, instrument] Emit module names,
 ;; CHECK-NEXT:                                       even if not emitting the rest of the
 ;; CHECK-NEXT:                                       names section. Can help differentiate the
@@ -100,6 +105,19 @@
 ;; CHECK-NEXT:                                       be removed once simpler ways of naming
 ;; CHECK-NEXT:                                       modules are widely available. See
 ;; CHECK-NEXT:                                       https://bugs.chromium.org/p/v8/issues/detail?id=11808.
+=======
+;; CHECK-NEXT:   --secondary-memory-name              [instrument] The name of the secondary
+;; CHECK-NEXT:                                        memory created to store profile
+;; CHECK-NEXT:                                        information.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --emit-module-names                  [split, instrument] Emit module names,
+;; CHECK-NEXT:                                        even if not emitting the rest of the
+;; CHECK-NEXT:                                        names section. Can help differentiate the
+;; CHECK-NEXT:                                        modules in stack traces. This option will
+;; CHECK-NEXT:                                        be removed once simpler ways of naming
+;; CHECK-NEXT:                                        modules are widely available. See
+;; CHECK-NEXT:                                        https://bugs.chromium.org/p/v8/issues/detail?id=11808.
+>>>>>>> 34014ecd9 (added wasm-split switch)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --initial-table                     [split, instrument] A hack to ensure the
 ;; CHECK-NEXT:                                       split and instrumented modules have the

--- a/test/lit/wasm-split/instrument-in-secondary-memory-custom-names.wast
+++ b/test/lit/wasm-split/instrument-in-secondary-memory-custom-names.wast
@@ -25,68 +25,7 @@
 ;; And main memory has been exported
 ;; CHECK: (export "profile-memory" (memory $0))
 
-;; Check that the function instrumentation is correct
-
-;; CHECK:      (func $bar
-;; CHECK-NEXT:  (i32.atomic.store8 $custom_name
-;; CHECK-NEXT:   (i32.const 0)
-;; CHECK-NEXT:   (i32.const 1)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (call $foo)
-;; CHECK-NEXT: )
-
-;; CHECK-NEXT: (func $baz (param $0 i32) (result i32)
-;; CHECK-NEXT:  (i32.atomic.store8 $custom_name offset=1
-;; CHECK-NEXT:   (i32.const 0)
-;; CHECK-NEXT:   (i32.const 1)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (local.get $0)
-;; CHECK-NEXT: )
-
-;; Check that the profiling function is correct.
-
-;; CHECK:      (func $__write_profile (param $addr i32) (param $size i32) (result i32)
-;; CHECK-NEXT:  (local $funcIdx i32)
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.ge_u
-;; CHECK-NEXT:    (local.get $size)
-;; CHECK-NEXT:    (i32.const 16)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (block
-;; CHECK-NEXT:    (i64.store $0 align=1
-;; CHECK-NEXT:     (local.get $addr)
-;; CHECK-NEXT:     (i64.const {{.*}})
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (block $outer
-;; CHECK-NEXT:     (loop $l
-;; CHECK-NEXT:      (br_if $outer
-;; CHECK-NEXT:       (i32.eq
-;; CHECK-NEXT:        (local.get $funcIdx)
-;; CHECK-NEXT:        (i32.const 2)
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.store $0 offset=8
-;; CHECK-NEXT:       (i32.add
-;; CHECK-NEXT:        (local.get $addr)
-;; CHECK-NEXT:        (i32.mul
-;; CHECK-NEXT:         (local.get $funcIdx)
-;; CHECK-NEXT:         (i32.const 4)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:       (i32.atomic.load8_u $custom_name
-;; CHECK-NEXT:        (local.get $funcIdx)
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (local.set $funcIdx
-;; CHECK-NEXT:       (i32.add
-;; CHECK-NEXT:        (local.get $funcIdx)
-;; CHECK-NEXT:        (i32.const 1)
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (br $l)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.const 16)
-;; CHECK-NEXT: )
+;; Check that the function instrumentation uses the correct memory name
+;; CHECK:  (i32.atomic.store8 $custom_name
+;; CHECK:  (i32.atomic.store8 $custom_name offset=1
+;; CHECK:  (i32.atomic.load8_u $custom_name

--- a/test/lit/wasm-split/instrument-in-secondary-memory-custom-names.wast
+++ b/test/lit/wasm-split/instrument-in-secondary-memory-custom-names.wast
@@ -1,0 +1,92 @@
+;; RUN: wasm-split %s --instrument --in-secondary-memory --import-namespace=custom_env --secondary-memory-name=custom_name -all -S -o - | filecheck %s
+
+;; Check that the output round trips and validates as well
+;; RUN: wasm-split %s --instrument --in-secondary-memory -all -g -o %t.wasm
+;; RUN: wasm-opt -all %t.wasm -S -o -
+
+(module
+  (import "env" "foo" (func $foo))
+  (export "bar" (func $bar))
+  (memory $0 1 1)
+  (func $bar
+    (call $foo)
+  )
+  (func $baz (param i32) (result i32)
+    (local.get 0)
+  )
+)
+
+;; Check that a memory import has been added for secondary memory
+;; CHECK: (import "custom_env" "custom_name" (memory $custom_name (shared 1 1)))
+
+;; And the profiling function exported
+;; CHECK: (export "__write_profile" (func $__write_profile))
+
+;; And main memory has been exported
+;; CHECK: (export "profile-memory" (memory $0))
+
+;; Check that the function instrumentation is correct
+
+;; CHECK:      (func $bar
+;; CHECK-NEXT:  (i32.atomic.store8 $custom_name
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 1)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (call $foo)
+;; CHECK-NEXT: )
+
+;; CHECK-NEXT: (func $baz (param $0 i32) (result i32)
+;; CHECK-NEXT:  (i32.atomic.store8 $custom_name offset=1
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 1)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (local.get $0)
+;; CHECK-NEXT: )
+
+;; Check that the profiling function is correct.
+
+;; CHECK:      (func $__write_profile (param $addr i32) (param $size i32) (result i32)
+;; CHECK-NEXT:  (local $funcIdx i32)
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.ge_u
+;; CHECK-NEXT:    (local.get $size)
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (block
+;; CHECK-NEXT:    (i64.store $0 align=1
+;; CHECK-NEXT:     (local.get $addr)
+;; CHECK-NEXT:     (i64.const {{.*}})
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (block $outer
+;; CHECK-NEXT:     (loop $l
+;; CHECK-NEXT:      (br_if $outer
+;; CHECK-NEXT:       (i32.eq
+;; CHECK-NEXT:        (local.get $funcIdx)
+;; CHECK-NEXT:        (i32.const 2)
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.store $0 offset=8
+;; CHECK-NEXT:       (i32.add
+;; CHECK-NEXT:        (local.get $addr)
+;; CHECK-NEXT:        (i32.mul
+;; CHECK-NEXT:         (local.get $funcIdx)
+;; CHECK-NEXT:         (i32.const 4)
+;; CHECK-NEXT:        )
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:       (i32.atomic.load8_u $custom_name
+;; CHECK-NEXT:        (local.get $funcIdx)
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (local.set $funcIdx
+;; CHECK-NEXT:       (i32.add
+;; CHECK-NEXT:        (local.get $funcIdx)
+;; CHECK-NEXT:        (i32.const 1)
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (br $l)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.const 16)
+;; CHECK-NEXT: )

--- a/test/lit/wasm-split/instrument-in-secondary-memory.wast
+++ b/test/lit/wasm-split/instrument-in-secondary-memory.wast
@@ -18,7 +18,7 @@
 
 ;; Check that a memory has been added
 ;; CHECK: (memory $0 1 1)
-;; CHECK: (memory $split_data 1 1)
+;; CHECK: (memory $split_data (shared 1 1))
 
 ;; And the profiling function exported
 ;; CHECK: (export "__write_profile" (func $__write_profile))

--- a/test/lit/wasm-split/instrument-in-secondary-memory.wast
+++ b/test/lit/wasm-split/instrument-in-secondary-memory.wast
@@ -1,0 +1,90 @@
+;; RUN: wasm-split %s --instrument --in-secondary-memory -all -S -o - | filecheck %s
+
+;; Check that the output round trips and validates as well
+;; RUN: wasm-split %s --instrument --in-secondary-memory -all -g -o %t.wasm
+;; RUN: wasm-opt -all %t.wasm -S -o -
+
+(module
+  (import "env" "foo" (func $foo))
+  (export "bar" (func $bar))
+  (memory $0 1 1)
+  (func $bar
+    (call $foo)
+  )
+  (func $baz (param i32) (result i32)
+    (local.get 0)
+  )
+)
+
+;; Check that a memory has been added
+;; CHECK: (memory $0 1 1)
+;; CHECK: (memory $split_data 1 1)
+
+;; And the profiling function exported
+;; CHECK: (export "__write_profile" (func $__write_profile))
+
+;; Check that the function instrumentation is correct
+
+;; CHECK:      (func $bar
+;; CHECK-NEXT:  (i32.atomic.store8 $split_data
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 1)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (call $foo)
+;; CHECK-NEXT: )
+
+;; CHECK-NEXT: (func $baz (param $0 i32) (result i32)
+;; CHECK-NEXT:  (i32.atomic.store8 $split_data offset=1
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 1)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (local.get $0)
+;; CHECK-NEXT: )
+
+;; Check that the profiling function is correct.
+
+;; CHECK:      (func $__write_profile (param $addr i32) (param $size i32) (result i32)
+;; CHECK-NEXT:  (local $funcIdx i32)
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.ge_u
+;; CHECK-NEXT:    (local.get $size)
+;; CHECK-NEXT:    (i32.const 16)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (block
+;; CHECK-NEXT:    (i64.store $0 align=1
+;; CHECK-NEXT:     (local.get $addr)
+;; CHECK-NEXT:     (i64.const {{.*}})
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (block $outer
+;; CHECK-NEXT:     (loop $l
+;; CHECK-NEXT:      (br_if $outer
+;; CHECK-NEXT:       (i32.eq
+;; CHECK-NEXT:        (local.get $funcIdx)
+;; CHECK-NEXT:        (i32.const 2)
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.store $0 offset=8
+;; CHECK-NEXT:       (i32.add
+;; CHECK-NEXT:        (local.get $addr)
+;; CHECK-NEXT:        (i32.mul
+;; CHECK-NEXT:         (local.get $funcIdx)
+;; CHECK-NEXT:         (i32.const 4)
+;; CHECK-NEXT:        )
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:       (i32.atomic.load8_u $split_data
+;; CHECK-NEXT:        (local.get $funcIdx)
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (local.set $funcIdx
+;; CHECK-NEXT:       (i32.add
+;; CHECK-NEXT:        (local.get $funcIdx)
+;; CHECK-NEXT:        (i32.const 1)
+;; CHECK-NEXT:       )
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (br $l)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.const 16)
+;; CHECK-NEXT: )

--- a/test/lit/wasm-split/instrument-in-secondary-memory.wast
+++ b/test/lit/wasm-split/instrument-in-secondary-memory.wast
@@ -16,17 +16,19 @@
   )
 )
 
-;; Check that a memory has been added
-;; CHECK: (memory $0 1 1)
-;; CHECK: (memory $split_data (shared 1 1))
+;; Check that a memory import has been added for secondary memory
+;; CHECK: (import "env" "profile-data" (memory $profile-data (shared 1 1)))
 
 ;; And the profiling function exported
 ;; CHECK: (export "__write_profile" (func $__write_profile))
 
+;; And main memory has been exported
+;; CHECK: (export "profile-memory" (memory $0))
+
 ;; Check that the function instrumentation is correct
 
 ;; CHECK:      (func $bar
-;; CHECK-NEXT:  (i32.atomic.store8 $split_data
+;; CHECK-NEXT:  (i32.atomic.store8 $profile-data
 ;; CHECK-NEXT:   (i32.const 0)
 ;; CHECK-NEXT:   (i32.const 1)
 ;; CHECK-NEXT:  )
@@ -34,7 +36,7 @@
 ;; CHECK-NEXT: )
 
 ;; CHECK-NEXT: (func $baz (param $0 i32) (result i32)
-;; CHECK-NEXT:  (i32.atomic.store8 $split_data offset=1
+;; CHECK-NEXT:  (i32.atomic.store8 $profile-data offset=1
 ;; CHECK-NEXT:   (i32.const 0)
 ;; CHECK-NEXT:   (i32.const 1)
 ;; CHECK-NEXT:  )
@@ -71,7 +73,7 @@
 ;; CHECK-NEXT:         (i32.const 4)
 ;; CHECK-NEXT:        )
 ;; CHECK-NEXT:       )
-;; CHECK-NEXT:       (i32.atomic.load8_u $split_data
+;; CHECK-NEXT:       (i32.atomic.load8_u $profile-data
 ;; CHECK-NEXT:        (local.get $funcIdx)
 ;; CHECK-NEXT:       )
 ;; CHECK-NEXT:      )

--- a/test/lit/wasm-split/invalid-options.wast
+++ b/test/lit/wasm-split/invalid-options.wast
@@ -17,14 +17,10 @@
 ;; RUN: not wasm-split %s --instrument --symbolmap 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-SYMBOLMAP
 
-;; --instrument cannot be used with --import-namespace
-;; RUN: not wasm-split %s --instrument --import-namespace=foo 2>&1 \
-;; RUN:   | filecheck %s --check-prefix INSTRUMENT-IMPORT-NS
-
 ;; --instrument cannot be used with --placeholder-namespace
 ;; RUN: not wasm-split %s --instrument --placeholder-namespace=foo 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-PLACEHOLDER-NS
-
+ 
 ;; --instrument cannot be used with --export-prefix
 ;; RUN: not wasm-split %s --instrument --export-prefix=foo 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-EXPORT-PREFIX
@@ -44,6 +40,10 @@
 ;; --instrument is required to use --profile-export
 ;; RUN: not wasm-split %s --profile-export=foo 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix SPLIT-PROFILE-EXPORT
+
+;; --secondary-memory-name cannot be used with Split mode
+;; RUN: not wasm-split %s --secondary-memory-name=foo 2>&1 \
+;; RUN:   | filecheck %s --check-prefix SPLIT-SECONDARY-MEMORY-NAME
 
 ;; -S cannot be used with --merge-profiles
 ;; RUN: not wasm-split %s --merge-profiles -S 2>&1 \
@@ -73,8 +73,6 @@
 
 ;; INSTRUMENT-SYMBOLMAP: error: Option --symbolmap cannot be used in instrument mode.
 
-;; INSTRUMENT-IMPORT-NS: error: Option --import-namespace cannot be used in instrument mode.
-
 ;; INSTRUMENT-PLACEHOLDER-NS: error: Option --placeholder-namespace cannot be used in instrument mode.
 
 ;; INSTRUMENT-EXPORT-PREFIX: error: Option --export-prefix cannot be used in instrument mode.
@@ -86,6 +84,8 @@
 ;; SPLIT-OUT: error: Option --output cannot be used in split mode.
 
 ;; SPLIT-PROFILE-EXPORT: error: Option --profile-export cannot be used in split mode.
+
+;; SPLIT-SECONDARY-MEMORY-NAME: error: Option --secondary-memory-name cannot be used in split mode.
 
 ;; MERGE-EMIT-TEXT: error: Option --emit-text cannot be used in merge-profiles mode.
 

--- a/test/lit/wasm-split/invalid-options.wast
+++ b/test/lit/wasm-split/invalid-options.wast
@@ -20,7 +20,6 @@
 ;; --instrument cannot be used with --placeholder-namespace
 ;; RUN: not wasm-split %s --instrument --placeholder-namespace=foo 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-PLACEHOLDER-NS
- 
 ;; --instrument cannot be used with --export-prefix
 ;; RUN: not wasm-split %s --instrument --export-prefix=foo 2>&1 \
 ;; RUN:   | filecheck %s --check-prefix INSTRUMENT-EXPORT-PREFIX


### PR DESCRIPTION
Adds an --in-secondary-memory switch to wasm-split tool that allows profile data to be stored in a separate memory from module main memory. With this option, users do not need to reserve the initial memory region for profile data and the data can be shared between multiple threads.