### PR TITLE
Fix ModuleUtils::renameFunctions on RefFunc

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -204,13 +204,9 @@ template<typename T> inline void renameFunctions(Module& wasm, T& map) {
 
     Updater* create() override { return new Updater(map); }
 
-    void visitCall(Call* curr) {
-      maybeUpdate(curr->target);
-    }
+    void visitCall(Call* curr) { maybeUpdate(curr->target); }
 
-    void visitRefFunc(RefFunc* curr) {
-      maybeUpdate(curr->func);
-    }
+    void visitRefFunc(RefFunc* curr) { maybeUpdate(curr->func); }
   };
 
   Updater updater(map);

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -176,13 +176,13 @@ inline void clearModule(Module& wasm) {
 // Rename functions along with all their uses.
 // Note that for this to work the functions themselves don't necessarily need
 // to exist.  For example, it is possible to remove a given function and then
-// call this redirect all of its uses.
+// call this to redirect all of its uses.
 template<typename T> inline void renameFunctions(Module& wasm, T& map) {
   // Update the function itself.
   for (auto& [oldName, newName] : map) {
-    if (Function* F = wasm.getFunctionOrNull(oldName)) {
-      assert(!wasm.getFunctionOrNull(newName) || F->name == newName);
-      F->name = newName;
+    if (Function* func = wasm.getFunctionOrNull(oldName)) {
+      assert(!wasm.getFunctionOrNull(newName) || func->name == newName);
+      func->name = newName;
     }
   }
   wasm.updateMaps();

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -194,8 +194,7 @@ template<typename T> inline void renameFunctions(Module& wasm, T& map) {
     T& map;
 
     void maybeUpdate(Name& name) {
-      auto iter = map.find(name);
-      if (iter != map.end()) {
+      if (auto iter = map.find(name); iter != map.end()) {
         name = iter->second;
       }
     }


### PR DESCRIPTION
It had hardcoded handling of the table, but was missing RefFunc (and maybe more?)

Also rewrite it to be clearer (avoid special-casing the table) and faster (parallel).