### PR TITLE
Fix SmallVector's resize() method

### DIFF
--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -116,6 +116,8 @@ public:
     usedFixed = std::min(N, newSize);
     if (newSize > N) {
       flexible.resize(newSize - N);
+    } else {
+      flexible.clear();
     }
   }
 

--- a/test/example/small_vector.cpp
+++ b/test/example/small_vector.cpp
@@ -66,12 +66,47 @@ template<typename T> void test(size_t N) {
     t.reserve(t.capacity() + 100);
     assert(t.capacity() >= N + 100);
   }
+  {
+    // Test resizing.
+    T t;
+
+    assert(t.empty());
+    t.resize(1);
+    assert(t.size() == 1);
+    t.resize(2);
+    assert(t.size() == 2);
+    t.resize(3);
+    assert(t.size() == 3);
+    t.resize(6);
+    assert(t.size() == 6);
+
+    // Now go in reverse.
+    t.resize(6);
+    assert(t.size() == 6);
+    t.resize(3);
+    assert(t.size() == 3);
+    t.resize(2);
+    assert(t.size() == 2);
+    t.resize(1);
+    assert(t.size() == 1);
+
+    // Test a big leap from nothing (rather than gradual increase as before).
+    t.clear();
+    assert(t.empty());
+    t.resize(6);
+    assert(t.size() == 6);
+    t.resize(2);
+    assert(t.size() == 2);
+    t.clear();
+    assert(t.empty());
+  }
 }
 
 int main() {
   test<SmallVector<int, 0>>(0);
   test<SmallVector<int, 1>>(1);
   test<SmallVector<int, 2>>(2);
+  test<SmallVector<int, 3>>(3);
   test<SmallVector<int, 10>>(10);
   std::cout << "ok.\n";
 }


### PR DESCRIPTION
A resize from a large amount to a small amount would sometimes not clear
the flexible storage, if we used it before but not after.