### PR TITLE
Fix test spacing after recent update

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3253,7 +3253,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
         nontrivialGroup = currGroup->size() > 1;
         if (nontrivialGroup) {
           doIndent(o, indent);
-          o << "(rec ";
+          o << "(rec";
           incIndent();
         }
       }

--- a/test/lit/isorecursive-good.wast
+++ b/test/lit/isorecursive-good.wast
@@ -8,7 +8,7 @@
 
 
   (rec
-    ;; HYBRID:      (rec 
+    ;; HYBRID:      (rec
     ;; HYBRID-NEXT:  (type $super-struct (struct_subtype (field i32) data))
     ;; NOMINAL:      (type $super-struct (struct_subtype (field i32) data))
     (type $super-struct (struct i32))
@@ -18,7 +18,7 @@
   )
 
   (rec
-    ;; HYBRID:      (rec 
+    ;; HYBRID:      (rec
     ;; HYBRID-NEXT:  (type $super-array (array_subtype (ref $super-struct) data))
     ;; NOMINAL:      (type $super-array (array_subtype (ref $super-struct) data))
     (type $super-array (array (ref $super-struct)))

--- a/test/lit/isorecursive-output-ordering.wast
+++ b/test/lit/isorecursive-output-ordering.wast
@@ -8,12 +8,12 @@
 
 
  (rec
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $unused-6 (struct_subtype  data))
 
   ;; CHECK:       (type $used-a-bit (struct_subtype  data))
 
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $unused-1 (struct_subtype  data))
   (type $unused-1 (struct_subtype data))
   ;; CHECK:       (type $unused-2 (struct_subtype  data))
@@ -46,7 +46,7 @@
 
 
  (rec
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $leaf (struct_subtype  data))
   (type $leaf (struct_subtype data))
   ;; CHECK:       (type $unused (struct_subtype  data))
@@ -54,12 +54,12 @@
  )
 
  (rec
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $shrub (struct_subtype  $leaf))
 
   ;; CHECK:       (type $used-a-ton (struct_subtype  data))
 
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $twig (struct_subtype  data))
   (type $twig (struct_subtype data))
   ;; CHECK:       (type $used-a-bit (struct_subtype (field (ref $leaf)) data))
@@ -72,7 +72,7 @@
  )
 
  (rec
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $root (struct_subtype  data))
   (type $root (struct_subtype data))
   ;; CHECK:       (type $used-a-lot (struct_subtype  $twig))

--- a/test/lit/isorecursive-whole-group.wast
+++ b/test/lit/isorecursive-whole-group.wast
@@ -10,7 +10,7 @@
 
 
  (rec
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $used (struct_subtype  data))
   (type $used (struct_subtype data))
   ;; CHECK:       (type $unused (struct_subtype  data))

--- a/test/lit/nominal-to-isorecursive.wast
+++ b/test/lit/nominal-to-isorecursive.wast
@@ -7,7 +7,7 @@
 ;; single recursion group.
 
 (module
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $make-super-t (func_subtype (result (ref $super)) func))
 
   ;; CHECK:       (type $make-sub-t (func_subtype (result (ref $sub)) func))

--- a/test/lit/passes/signature-refining-isorecursive.wast
+++ b/test/lit/passes/signature-refining-isorecursive.wast
@@ -30,7 +30,7 @@
 (module
  ;; The signatures should be refined to a pair of mutually self-referential types.
 
- ;; CHECK:      (rec 
+ ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $0 (func_subtype (param i32 (ref $0)) (result (ref $1)) func))
  (type $0 (func (param i32 funcref) (result funcref)))
  ;; CHECK:       (type $1 (func_subtype (param f32 (ref $1)) (result (ref $0)) func))
@@ -83,7 +83,7 @@
  ;; even though they are refined to the same structure.
 
  (rec
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $0 (func_subtype (param (ref $0)) func))
   (type $0 (func (param funcref)))
   ;; CHECK:       (type $1 (func_subtype (param (ref $0)) func))
@@ -119,7 +119,7 @@
  ;; The signatures should be refined to a pair of mutually recursive types and
  ;; another type that refers to them.
 
- ;; CHECK:      (rec 
+ ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $1 (func_subtype (param f32 (ref $1)) (result (ref $0)) func))
 
  ;; CHECK:       (type $0 (func_subtype (param i32 (ref $0)) (result (ref $1)) func))

--- a/test/lit/passes/type-refining-isorecursive.wast
+++ b/test/lit/passes/type-refining-isorecursive.wast
@@ -4,7 +4,7 @@
 (module
  ;; The types should be refined to a set of three mutually recursive types.
 
- ;; CHECK:      (rec 
+ ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $0 (struct_subtype (field anyref) (field (ref $1)) data))
  (type $0 (struct_subtype (ref null any) anyref data))
  ;; CHECK:       (type $1 (struct_subtype (field eqref) (field (ref $2)) data))
@@ -61,7 +61,7 @@
  ;; referenced by $all, but now we need to worry about ordering supertypes
  ;; correctly.
 
- ;; CHECK:      (rec 
+ ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $all (struct_subtype (field i32) (field (ref $0)) (field (ref $1)) (field (ref $2)) data))
  (type $all (struct_subtype i32 anyref anyref anyref data))
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -9,7 +9,7 @@
 
   ;; CHECK:      (type $i32_=>_none (func_subtype (param i32) func))
 
-  ;; CHECK:      (rec
+  ;; CHECK:      (rec 
   ;; CHECK-NEXT:  (type $s0 (struct_subtype  data))
   (type $s0 (sub (struct)))
   ;; CHECK:       (type $s1 (struct_subtype  data))

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -9,7 +9,7 @@
 
   ;; CHECK:      (type $i32_=>_none (func_subtype (param i32) func))
 
-  ;; CHECK:      (rec 
+  ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $s0 (struct_subtype  data))
   (type $s0 (sub (struct)))
   ;; CHECK:       (type $s1 (struct_subtype  data))


### PR DESCRIPTION
A recent test update seems to have added or removed a space here. Running
the auto-updater script keeps showing this diff.