### PR TITLE
Adds assert to RemoveUnusedModuleElements

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -236,6 +236,8 @@ struct RemoveUnusedModuleElements : public Pass {
     : rootAllFunctions(rootAllFunctions) {}
 
   void run(PassRunner* runner, Module* module) override {
+    assert(module->memories.size() <= 1);
+
     std::vector<ModuleElement> roots;
     // Module start is a root.
     if (module->start.is()) {


### PR DESCRIPTION
Pass RemoveUnusedModuleElements does not have multi-memories support. This adds an assert to ensure the pass is not run if the module has multiple memories.