### PR TITLE
[OptimizeInstruction] Reorder rules in optimizeSelect

### DIFF
--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -752,8 +752,14 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (select
-  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     (i32.and
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (select
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $2)
@@ -762,11 +768,6 @@
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (select
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -906,8 +907,10 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (select
-  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     (i32.and
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $1)
@@ -917,7 +920,6 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (return
   ;; CHECK-NEXT:      (i32.const 2)

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -732,6 +732,25 @@
       )
     )
   )
+  ;; CHECK:      (func $select-and-eqz (param $x i32) (param $y i32) (result i32)
+  ;; CHECK-NEXT:  (i32.eqz
+  ;; CHECK-NEXT:   (i32.or
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $select-and-eqz (param $x i32) (param $y i32) (result i32)
+    (select
+      (i32.eqz
+        (local.get $x)
+      )
+      (i32.const 0)
+      (i32.eqz
+        (local.get $y)
+      )
+    )
+  )
   ;; CHECK:      (func $select-or-side-effects (param $x i32) (param $y i32) (result i32)
   ;; CHECK-NEXT:  (i32.or
   ;; CHECK-NEXT:   (i32.eq


### PR DESCRIPTION
It's just reordering some rules in `optimizeSelect` which unblock some optimizations.
For example this:
```wat
(select
 (i32.eqz (local.get $x))
 (i32.const 0)
 (i32.eqz (local.get $y))
)
```
Optimized Before as:
```wat
(i32.eqz
 (select
  (i32.const 1)
  (local.get $x)
  (local.get $y)
 )
)
```
Due to `optimizeSelect` apply `!x ? !y : 0  ->  x ? 0 : !y` first and `!(x ? 1 : y)` in second stage which block next rules which can fold this to `or` / `and`.

After this PR same example will optimize more optimal:
```wat
(i32.eqz
 (i32.or
  (local.get $x)
  (local.get $y)
 )
)
```