### PR TITLE
[NFC] Simplify binary reading logic for data segments

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1529,9 +1529,6 @@ public:
   // at index i we have all references to the memory i
   std::map<Index, std::vector<wasm::Name*>> memoryRefs;
 
-  // we store data here after being read from binary, before we know their names
-  std::vector<std::unique_ptr<DataSegment>> dataSegments;
-
   // at index i we have all refs to the global i
   std::map<Index, std::vector<Name*>> globalRefs;
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2977,9 +2977,6 @@ void WasmBinaryBuilder::validateBinary() {
 }
 
 void WasmBinaryBuilder::processNames() {
-  for (auto& segment : dataSegments) {
-    wasm.addDataSegment(std::move(segment));
-  }
   // now that we have names, apply things
 
   if (startIndex != static_cast<Index>(-1)) {
@@ -3072,7 +3069,7 @@ void WasmBinaryBuilder::readDataSegments() {
     auto size = getU32LEB();
     auto data = getByteView(size);
     curr->data = {data.first, data.second};
-    dataSegments.push_back(std::move(curr));
+    wasm.addDataSegment(std::move(curr));
   }
 }
 
@@ -3398,8 +3395,8 @@ void WasmBinaryBuilder::readNames(size_t payloadLen) {
         auto index = getU32LEB();
         auto rawName = getInlineString();
         auto name = processor.process(rawName);
-        if (index < dataSegments.size()) {
-          dataSegments[i]->setExplicitName(name);
+        if (index < wasm.dataSegments.size()) {
+          wasm.dataSegments[i]->setExplicitName(name);
         } else {
           std::cerr << "warning: data index out of bounds in name section, "
                        "data subsection: "

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2971,7 +2971,7 @@ Expression* WasmBinaryBuilder::popTypedExpression(Type type) {
 }
 
 void WasmBinaryBuilder::validateBinary() {
-  if (hasDataCount && dataSegments.size() != dataCount) {
+  if (hasDataCount && wasm.dataSegments.size() != dataCount) {
     throwError("Number of segments does not agree with DataCount section");
   }
 }


### PR DESCRIPTION
Similar to #4969 but for data segments.

This is the last of this sequence of cleanups.