### PR TITLE
[C-/JS-Api] Avoid add imports for existing entities in BinaryenSetMemoryImport and etc

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3743,6 +3743,17 @@ void BinaryenAddMemoryImport(BinaryenModuleRef module,
   memory->shared = shared;
   ((Module*)module)->addMemory(std::move(memory));
 }
+void BinaryenSetMemoryImport(BinaryenModuleRef module,
+                             const char* name,
+                             const char* externalModuleName,
+                             const char* externalBaseName) {
+  auto* memory = ((Module*)module)->getMemoryOrNull(name);
+  if (memory == nullptr) {
+    Fatal() << "invalid memory '" << name << "'.";
+  }
+  memory->module = externalModuleName;
+  memory->base = externalBaseName;
+}
 void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              const char* internalName,
                              const char* externalModuleName,

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3716,13 +3716,13 @@ void BinaryenAddFunctionImport(BinaryenModuleRef module,
                                BinaryenType results) {
   auto* func = ((Module*)module)->getFunctionOrNull(internalName);
   if (func == nullptr) {
-    auto* func = new Function();
+    auto func = make_unique<Function>();
     func->name = internalName;
     func->module = externalModuleName;
     func->base = externalBaseName;
     // TODO: Take a HeapType rather than params and results.
     func->type = Signature(Type(params), Type(results));
-    ((Module*)module)->addFunction(func);
+    ((Module*)module)->addFunction(std::move(func));
   } else {
     // already exists so just set module and base
     func->module = externalModuleName;
@@ -3735,7 +3735,7 @@ void BinaryenAddTableImport(BinaryenModuleRef module,
                             const char* externalBaseName) {
   auto* table = ((Module*)module)->getTableOrNull(internalName);
   if (table == nullptr) {
-    auto table = std::make_unique<Table>();
+    auto table = make_unique<Table>();
     table->name = internalName;
     table->module = externalModuleName;
     table->base = externalBaseName;
@@ -3753,7 +3753,8 @@ void BinaryenAddMemoryImport(BinaryenModuleRef module,
                              uint8_t shared) {
   auto* memory = ((Module*)module)->getMemoryOrNull(internalName);
   if (memory == nullptr) {
-    auto memory = Builder::makeMemory(internalName);
+    auto memory = make_unique<Memory>();
+    memory->name = internalName;
     memory->module = externalModuleName;
     memory->base = externalBaseName;
     memory->shared = shared;
@@ -3772,13 +3773,13 @@ void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              bool mutable_) {
   auto* glob = ((Module*)module)->getGlobalOrNull(internalName);
   if (glob == nullptr) {
-    auto* glob = new Global();
+    auto glob = make_unique<Global>();
     glob->name = internalName;
     glob->module = externalModuleName;
     glob->base = externalBaseName;
     glob->type = Type(globalType);
     glob->mutable_ = mutable_;
-    ((Module*)module)->addGlobal(glob);
+    ((Module*)module)->addGlobal(std::move(glob));
   } else {
     // already exists so just set module and base
     glob->module = externalModuleName;
@@ -3793,12 +3794,12 @@ void BinaryenAddTagImport(BinaryenModuleRef module,
                           BinaryenType results) {
   auto* tag = ((Module*)module)->getGlobalOrNull(internalName);
   if (tag == nullptr) {
-    auto* tag = new Tag();
+    auto tag = make_unique<Tag>();
     tag->name = internalName;
     tag->module = externalModuleName;
     tag->base = externalBaseName;
     tag->sig = Signature(Type(params), Type(results));
-    ((Module*)module)->addTag(tag);
+    ((Module*)module)->addTag(std::move(tag));
   } else {
     // already exists so just set module and base
     tag->module = externalModuleName;

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3757,6 +3757,9 @@ void BinaryenAddMemoryImport(BinaryenModuleRef module,
     memory->name = internalName;
     memory->module = externalModuleName;
     memory->base = externalBaseName;
+    memory->initial = 0;
+    memory->max = Memory::kMaxSize32;
+    memory->indexType = Type::i32;
     memory->shared = shared;
     ((Module*)module)->addMemory(std::move(memory));
   } else {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3714,45 +3714,55 @@ void BinaryenAddFunctionImport(BinaryenModuleRef module,
                                const char* externalBaseName,
                                BinaryenType params,
                                BinaryenType results) {
-  auto* ret = new Function();
-  ret->name = internalName;
-  ret->module = externalModuleName;
-  ret->base = externalBaseName;
-  // TODO: Take a HeapType rather than params and results.
-  ret->type = Signature(Type(params), Type(results));
-  ((Module*)module)->addFunction(ret);
+  auto* func = ((Module*)module)->getFunctionOrNull(internalName);
+  if (func == nullptr) {
+    auto* func = new Function();
+    func->name = internalName;
+    func->module = externalModuleName;
+    func->base = externalBaseName;
+    // TODO: Take a HeapType rather than params and results.
+    func->type = Signature(Type(params), Type(results));
+    ((Module*)module)->addFunction(func);
+  } else {
+    // already exists so just set module and base
+    func->module = externalModuleName;
+    func->base = externalBaseName;
+  }
 }
 void BinaryenAddTableImport(BinaryenModuleRef module,
                             const char* internalName,
                             const char* externalModuleName,
                             const char* externalBaseName) {
-  auto table = std::make_unique<Table>();
-  table->name = internalName;
-  table->module = externalModuleName;
-  table->base = externalBaseName;
-  ((Module*)module)->addTable(std::move(table));
+  auto* table = ((Module*)module)->getTableOrNull(internalName);
+  if (table == nullptr) {
+    auto table = std::make_unique<Table>();
+    table->name = internalName;
+    table->module = externalModuleName;
+    table->base = externalBaseName;
+    ((Module*)module)->addTable(std::move(table));
+  } else {
+    // already exists so just set module and base
+    table->module = externalModuleName;
+    table->base = externalBaseName;
+  }
 }
 void BinaryenAddMemoryImport(BinaryenModuleRef module,
                              const char* internalName,
                              const char* externalModuleName,
                              const char* externalBaseName,
                              uint8_t shared) {
-  auto memory = Builder::makeMemory(internalName);
-  memory->module = externalModuleName;
-  memory->base = externalBaseName;
-  memory->shared = shared;
-  ((Module*)module)->addMemory(std::move(memory));
-}
-void BinaryenSetMemoryImport(BinaryenModuleRef module,
-                             const char* name,
-                             const char* externalModuleName,
-                             const char* externalBaseName) {
-  auto* memory = ((Module*)module)->getMemoryOrNull(name);
+  auto* memory = ((Module*)module)->getMemoryOrNull(internalName);
   if (memory == nullptr) {
-    Fatal() << "invalid memory '" << name << "'.";
+    auto memory = Builder::makeMemory(internalName);
+    memory->module = externalModuleName;
+    memory->base = externalBaseName;
+    memory->shared = shared;
+    ((Module*)module)->addMemory(std::move(memory));
+  } else {
+    // already exists so just set module and base
+    memory->module = externalModuleName;
+    memory->base = externalBaseName;
   }
-  memory->module = externalModuleName;
-  memory->base = externalBaseName;
 }
 void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              const char* internalName,
@@ -3760,13 +3770,20 @@ void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              const char* externalBaseName,
                              BinaryenType globalType,
                              bool mutable_) {
-  auto* ret = new Global();
-  ret->name = internalName;
-  ret->module = externalModuleName;
-  ret->base = externalBaseName;
-  ret->type = Type(globalType);
-  ret->mutable_ = mutable_;
-  ((Module*)module)->addGlobal(ret);
+  auto* glob = ((Module*)module)->getGlobalOrNull(internalName);
+  if (glob == nullptr) {
+    auto* glob = new Global();
+    glob->name = internalName;
+    glob->module = externalModuleName;
+    glob->base = externalBaseName;
+    glob->type = Type(globalType);
+    glob->mutable_ = mutable_;
+    ((Module*)module)->addGlobal(glob);
+  } else {
+    // already exists so just set module and base
+    glob->module = externalModuleName;
+    glob->base = externalBaseName;
+  }
 }
 void BinaryenAddTagImport(BinaryenModuleRef module,
                           const char* internalName,
@@ -3774,12 +3791,19 @@ void BinaryenAddTagImport(BinaryenModuleRef module,
                           const char* externalBaseName,
                           BinaryenType params,
                           BinaryenType results) {
-  auto* ret = new Tag();
-  ret->name = internalName;
-  ret->module = externalModuleName;
-  ret->base = externalBaseName;
-  ret->sig = Signature(Type(params), Type(results));
-  ((Module*)module)->addTag(ret);
+  auto* tag = ((Module*)module)->getGlobalOrNull(internalName);
+  if (tag == nullptr) {
+    auto* tag = new Tag();
+    tag->name = internalName;
+    tag->module = externalModuleName;
+    tag->base = externalBaseName;
+    tag->sig = Signature(Type(params), Type(results));
+    ((Module*)module)->addTag(tag);
+  } else {
+    // already exists so just set module and base
+    tag->module = externalModuleName;
+    tag->base = externalBaseName;
+  }
 }
 
 // Exports

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3757,9 +3757,6 @@ void BinaryenAddMemoryImport(BinaryenModuleRef module,
     memory->name = internalName;
     memory->module = externalModuleName;
     memory->base = externalBaseName;
-    memory->initial = 0;
-    memory->max = Memory::kMaxSize32;
-    memory->indexType = Type::i32;
     memory->shared = shared;
     ((Module*)module)->addMemory(std::move(memory));
   } else {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2185,6 +2185,10 @@ BinaryenGetFunctionByIndex(BinaryenModuleRef module, BinaryenIndex index);
 
 // Imports
 
+// These either create a new entity (function/table/memory/etc.) and
+// mark it as an import, or, if an entity already exists with internalName then
+// the existing entity is turned into an import.
+
 BINARYEN_API void BinaryenAddFunctionImport(BinaryenModuleRef module,
                                             const char* internalName,
                                             const char* externalModuleName,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2212,6 +2212,10 @@ BINARYEN_API void BinaryenAddTagImport(BinaryenModuleRef module,
                                        const char* externalBaseName,
                                        BinaryenType params,
                                        BinaryenType results);
+BINARYEN_API void BinaryenSetMemoryImport(BinaryenModuleRef module,
+                                          const char* internalName,
+                                          const char* externalModuleName,
+                                          const char* externalBaseName);
 
 // Memory
 BINARYEN_REF(Memory);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2212,10 +2212,6 @@ BINARYEN_API void BinaryenAddTagImport(BinaryenModuleRef module,
                                        const char* externalBaseName,
                                        BinaryenType params,
                                        BinaryenType results);
-BINARYEN_API void BinaryenSetMemoryImport(BinaryenModuleRef module,
-                                          const char* internalName,
-                                          const char* externalModuleName,
-                                          const char* externalBaseName);
 
 // Memory
 BINARYEN_REF(Memory);

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2473,6 +2473,11 @@ function wrapModule(module, self = {}) {
       Module['_BinaryenAddMemoryImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), shared)
     );
   };
+  self['setMemoryImport'] = function(internalName, externalModuleName, externalBaseName) {
+    return preserveStack(() =>
+      Module['_BinaryenSetMemoryImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName))
+    );
+  };
   self['addGlobalImport'] = function(internalName, externalModuleName, externalBaseName, globalType, mutable) {
     return preserveStack(() =>
       Module['_BinaryenAddGlobalImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), globalType, mutable)

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2473,11 +2473,6 @@ function wrapModule(module, self = {}) {
       Module['_BinaryenAddMemoryImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), shared)
     );
   };
-  self['setMemoryImport'] = function(internalName, externalModuleName, externalBaseName) {
-    return preserveStack(() =>
-      Module['_BinaryenSetMemoryImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName))
-    );
-  };
   self['addGlobalImport'] = function(internalName, externalModuleName, externalBaseName, globalType, mutable) {
     return preserveStack(() =>
       Module['_BinaryenAddGlobalImport'](module, strToStack(internalName), strToStack(externalModuleName), strToStack(externalBaseName), globalType, mutable)


### PR DESCRIPTION
Fix #4988.

`BinaryenAddMemoryImport`
`BinaryenAddTableImport`
`BinaryenGlobalTableImport`
`BinaryenAddTagImport`

Also use unique pointers for entity creation.

Now carefully check if entry already exists and just modify `module` and `base` if this true.