### PR TITLE
Add remaining GC and string instructions to C API

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -900,6 +900,8 @@ BinaryenOp BinaryenRefAsNonNull(void) { return RefAsNonNull; }
 BinaryenOp BinaryenRefAsFunc(void) { return RefAsFunc; }
 BinaryenOp BinaryenRefAsData(void) { return RefAsData; }
 BinaryenOp BinaryenRefAsI31(void) { return RefAsI31; }
+BinaryenOp BinaryenRefAsExternInternalize(void) { return ExternInternalize; }
+BinaryenOp BinaryenRefAsExternExternalize(void) { return ExternExternalize; }
 BinaryenOp BinaryenBrOnNull(void) { return BrOnNull; }
 BinaryenOp BinaryenBrOnNonNull(void) { return BrOnNonNull; }
 BinaryenOp BinaryenBrOnCast(void) { return BrOnCast; }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -896,10 +896,50 @@ BinaryenOp BinaryenRefIsNull(void) { return RefIsNull; }
 BinaryenOp BinaryenRefIsFunc(void) { return RefIsFunc; }
 BinaryenOp BinaryenRefIsData(void) { return RefIsData; }
 BinaryenOp BinaryenRefIsI31(void) { return RefIsI31; }
-BinaryenOp BinaryenRefAsNonNull(void) { return RefAsNonNull; };
+BinaryenOp BinaryenRefAsNonNull(void) { return RefAsNonNull; }
 BinaryenOp BinaryenRefAsFunc(void) { return RefAsFunc; }
-BinaryenOp BinaryenRefAsData(void) { return RefAsData; };
-BinaryenOp BinaryenRefAsI31(void) { return RefAsI31; };
+BinaryenOp BinaryenRefAsData(void) { return RefAsData; }
+BinaryenOp BinaryenRefAsI31(void) { return RefAsI31; }
+BinaryenOp BinaryenBrOnNull(void) { return BrOnNull; }
+BinaryenOp BinaryenBrOnNonNull(void) { return BrOnNonNull; }
+BinaryenOp BinaryenBrOnCast(void) { return BrOnCast; }
+BinaryenOp BinaryenBrOnCastFail(void) { return BrOnCastFail; };
+BinaryenOp BinaryenBrOnFunc(void) { return BrOnFunc; }
+BinaryenOp BinaryenBrOnNonFunc(void) { return BrOnNonFunc; }
+BinaryenOp BinaryenBrOnData(void) { return BrOnData; }
+BinaryenOp BinaryenBrOnNonData(void) { return BrOnNonData; }
+BinaryenOp BinaryenBrOnI31(void) { return BrOnI31; }
+BinaryenOp BinaryenBrOnNonI31(void) { return BrOnNonI31; }
+BinaryenOp BinaryenStringNewUTF8(void) { return StringNewUTF8; }
+BinaryenOp BinaryenStringNewWTF8(void) { return StringNewWTF8; }
+BinaryenOp BinaryenStringNewReplace(void) { return StringNewReplace; }
+BinaryenOp BinaryenStringNewWTF16(void) { return StringNewWTF16; }
+BinaryenOp BinaryenStringNewUTF8Array(void) { return StringNewUTF8Array; }
+BinaryenOp BinaryenStringNewWTF8Array(void) { return StringNewWTF8Array; }
+BinaryenOp BinaryenStringNewReplaceArray(void) { return StringNewReplaceArray; }
+BinaryenOp BinaryenStringNewWTF16Array(void) { return StringNewWTF16Array; }
+BinaryenOp BinaryenStringMeasureUTF8(void) { return StringMeasureUTF8; }
+BinaryenOp BinaryenStringMeasureWTF8(void) { return StringMeasureWTF8; }
+BinaryenOp BinaryenStringMeasureWTF16(void) { return StringMeasureWTF16; }
+BinaryenOp BinaryenStringMeasureIsUSV(void) { return StringMeasureIsUSV; }
+BinaryenOp BinaryenStringMeasureWTF16View(void) {
+  return StringMeasureWTF16View;
+}
+BinaryenOp BinaryenStringEncodeUTF8(void) { return StringEncodeUTF8; }
+BinaryenOp BinaryenStringEncodeWTF8(void) { return StringEncodeWTF8; }
+BinaryenOp BinaryenStringEncodeWTF16(void) { return StringEncodeWTF16; }
+BinaryenOp BinaryenStringEncodeUTF8Array(void) { return StringEncodeUTF8Array; }
+BinaryenOp BinaryenStringEncodeWTF8Array(void) { return StringEncodeWTF8Array; }
+BinaryenOp BinaryenStringEncodeWTF16Array(void) {
+  return StringEncodeWTF16Array;
+}
+BinaryenOp BinaryenStringAsWTF8(void) { return StringAsWTF8; }
+BinaryenOp BinaryenStringAsWTF16(void) { return StringAsWTF16; }
+BinaryenOp BinaryenStringAsIter(void) { return StringAsIter; }
+BinaryenOp BinaryenStringIterMoveAdvance(void) { return StringIterMoveAdvance; }
+BinaryenOp BinaryenStringIterMoveRewind(void) { return StringIterMoveRewind; }
+BinaryenOp BinaryenStringSliceWTF8(void) { return StringSliceWTF8; }
+BinaryenOp BinaryenStringSliceWTF16(void) { return StringSliceWTF16; }
 
 BinaryenExpressionRef BinaryenBlock(BinaryenModuleRef module,
                                     const char* name,
@@ -1567,17 +1607,219 @@ BinaryenExpressionRef BinaryenI31Get(BinaryenModuleRef module,
   return static_cast<Expression*>(
     Builder(*(Module*)module).makeI31Get((Expression*)i31, signed_ != 0));
 }
-
-// TODO (gc): ref.test
-// TODO (gc): ref.cast
-// TODO (gc): br_on_cast
-// TODO (gc): struct.new
-// TODO (gc): struct.get
-// TODO (gc): struct.set
-// TODO (gc): array.new
-// TODO (gc): array.get
-// TODO (gc): array.set
-// TODO (gc): array.len
+BinaryenExpressionRef BinaryenRefTest(BinaryenModuleRef module,
+                                      BinaryenExpressionRef ref,
+                                      BinaryenHeapType intendedType) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeRefTest((Expression*)ref, HeapType(intendedType)));
+}
+BinaryenExpressionRef BinaryenRefCast(BinaryenModuleRef module,
+                                      BinaryenExpressionRef ref,
+                                      BinaryenType intendedType) {
+  return static_cast<Expression*>(Builder(*(Module*)module)
+                                    .makeRefCast((Expression*)ref,
+                                                 HeapType(intendedType),
+                                                 RefCast::Safety::Safe));
+}
+BinaryenExpressionRef BinaryenBrOn(BinaryenModuleRef module,
+                                   BinaryenOp op,
+                                   const char* name,
+                                   BinaryenExpressionRef ref,
+                                   BinaryenHeapType intendedType) {
+  Builder builder(*(Module*)module);
+  return static_cast<Expression*>(
+    intendedType ? builder.makeBrOn(
+                     BrOnOp(op), name, (Expression*)ref, HeapType(intendedType))
+                 : builder.makeBrOn(BrOnOp(op), name, (Expression*)ref));
+}
+BinaryenExpressionRef BinaryenStructNew(BinaryenModuleRef module,
+                                        BinaryenExpressionRef* operands,
+                                        BinaryenIndex numOperands,
+                                        BinaryenHeapType type) {
+  std::vector<Expression*> args;
+  for (BinaryenIndex i = 0; i < numOperands; i++) {
+    args.push_back((Expression*)operands[i]);
+  }
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeStructNew(HeapType(type), args));
+}
+BinaryenExpressionRef BinaryenStructGet(BinaryenModuleRef module,
+                                        BinaryenIndex index,
+                                        BinaryenExpressionRef ref,
+                                        BinaryenType type,
+                                        bool signed_) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStructGet(index, (Expression*)ref, Type(type), signed_));
+}
+BinaryenExpressionRef BinaryenStructSet(BinaryenModuleRef module,
+                                        BinaryenIndex index,
+                                        BinaryenExpressionRef ref,
+                                        BinaryenExpressionRef value) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStructSet(index, (Expression*)ref, (Expression*)value));
+}
+BinaryenExpressionRef BinaryenArrayNew(BinaryenModuleRef module,
+                                       BinaryenHeapType type,
+                                       BinaryenExpressionRef size,
+                                       BinaryenExpressionRef init) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeArrayNew(HeapType(type), (Expression*)size, (Expression*)init));
+}
+BinaryenExpressionRef BinaryenArrayInit(BinaryenModuleRef module,
+                                        BinaryenHeapType type,
+                                        BinaryenExpressionRef* values,
+                                        BinaryenIndex numValues) {
+  std::vector<Expression*> vals;
+  for (BinaryenIndex i = 0; i < numValues; i++) {
+    vals.push_back((Expression*)values[i]);
+  }
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeArrayInit(HeapType(type), vals));
+}
+BinaryenExpressionRef BinaryenArrayGet(BinaryenModuleRef module,
+                                       BinaryenExpressionRef ref,
+                                       BinaryenExpressionRef index,
+                                       bool signed_) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeArrayGet((Expression*)ref, (Expression*)index, signed_));
+}
+BinaryenExpressionRef BinaryenArraySet(BinaryenModuleRef module,
+                                       BinaryenExpressionRef ref,
+                                       BinaryenExpressionRef index,
+                                       BinaryenExpressionRef value) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeArraySet((Expression*)ref, (Expression*)index, (Expression*)value));
+}
+BinaryenExpressionRef BinaryenArrayLen(BinaryenModuleRef module,
+                                       BinaryenExpressionRef ref) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeArrayLen((Expression*)ref));
+}
+BinaryenExpressionRef BinaryenArrayCopy(BinaryenModuleRef module,
+                                        BinaryenExpressionRef destRef,
+                                        BinaryenExpressionRef destIndex,
+                                        BinaryenExpressionRef srcRef,
+                                        BinaryenExpressionRef srcIndex,
+                                        BinaryenExpressionRef length) {
+  return static_cast<Expression*>(Builder(*(Module*)module)
+                                    .makeArrayCopy((Expression*)destRef,
+                                                   (Expression*)destIndex,
+                                                   (Expression*)srcRef,
+                                                   (Expression*)srcIndex,
+                                                   (Expression*)length));
+}
+BinaryenExpressionRef BinaryenStringNew(BinaryenModuleRef module,
+                                        BinaryenOp op,
+                                        BinaryenExpressionRef ptr,
+                                        BinaryenExpressionRef length,
+                                        BinaryenExpressionRef start,
+                                        BinaryenExpressionRef end) {
+  Builder builder(*(Module*)module);
+  return static_cast<Expression*>(
+    length ? builder.makeStringNew(
+               StringNewOp(op), (Expression*)ptr, (Expression*)length)
+           : builder.makeStringNew(StringNewOp(op),
+                                   (Expression*)ptr,
+                                   (Expression*)start,
+                                   (Expression*)end));
+}
+BinaryenExpressionRef BinaryenStringConst(BinaryenModuleRef module,
+                                          const char* name) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeStringConst(name));
+}
+BinaryenExpressionRef BinaryenStringMeasure(BinaryenModuleRef module,
+                                            BinaryenOp op,
+                                            BinaryenExpressionRef ref) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStringMeasure(StringMeasureOp(op), (Expression*)ref));
+}
+BinaryenExpressionRef BinaryenStringEncode(BinaryenModuleRef module,
+                                           BinaryenOp op,
+                                           BinaryenExpressionRef ref,
+                                           BinaryenExpressionRef ptr,
+                                           BinaryenExpressionRef start) {
+  return static_cast<Expression*>(Builder(*(Module*)module)
+                                    .makeStringEncode(StringEncodeOp(op),
+                                                      (Expression*)ref,
+                                                      (Expression*)ptr,
+                                                      (Expression*)start));
+}
+BinaryenExpressionRef BinaryenStringConcat(BinaryenModuleRef module,
+                                           BinaryenExpressionRef left,
+                                           BinaryenExpressionRef right) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStringConcat((Expression*)left, (Expression*)right));
+}
+BinaryenExpressionRef BinaryenStringEq(BinaryenModuleRef module,
+                                       BinaryenExpressionRef left,
+                                       BinaryenExpressionRef right) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStringEq((Expression*)left, (Expression*)right));
+}
+BinaryenExpressionRef BinaryenStringAs(BinaryenModuleRef module,
+                                       BinaryenOp op,
+                                       BinaryenExpressionRef ref) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeStringAs(StringAsOp(op), (Expression*)ref));
+}
+BinaryenExpressionRef BinaryenStringWTF8Advance(BinaryenModuleRef module,
+                                                BinaryenExpressionRef ref,
+                                                BinaryenExpressionRef pos,
+                                                BinaryenExpressionRef bytes) {
+  return static_cast<Expression*>(Builder(*(Module*)module)
+                                    .makeStringWTF8Advance((Expression*)ref,
+                                                           (Expression*)pos,
+                                                           (Expression*)bytes));
+}
+BinaryenExpressionRef BinaryenStringWTF16Get(BinaryenModuleRef module,
+                                             BinaryenExpressionRef ref,
+                                             BinaryenExpressionRef pos) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStringWTF16Get((Expression*)ref, (Expression*)pos));
+}
+BinaryenExpressionRef BinaryenStringIterNext(BinaryenModuleRef module,
+                                             BinaryenExpressionRef ref) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module).makeStringIterNext((Expression*)ref));
+}
+BinaryenExpressionRef BinaryenStringIterMove(BinaryenModuleRef module,
+                                             BinaryenOp op,
+                                             BinaryenExpressionRef ref,
+                                             BinaryenExpressionRef num) {
+  return static_cast<Expression*>(Builder(*(Module*)module)
+                                    .makeStringIterMove(StringIterMoveOp(op),
+                                                        (Expression*)ref,
+                                                        (Expression*)num));
+}
+BinaryenExpressionRef BinaryenStringSliceWTF(BinaryenModuleRef module,
+                                             BinaryenOp op,
+                                             BinaryenExpressionRef ref,
+                                             BinaryenExpressionRef start,
+                                             BinaryenExpressionRef end) {
+  return static_cast<Expression*>(Builder(*(Module*)module)
+                                    .makeStringSliceWTF(StringSliceWTFOp(op),
+                                                        (Expression*)ref,
+                                                        (Expression*)start,
+                                                        (Expression*)end));
+}
+BinaryenExpressionRef BinaryenStringSliceIter(BinaryenModuleRef module,
+                                              BinaryenExpressionRef ref,
+                                              BinaryenExpressionRef num) {
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeStringSliceIter((Expression*)ref, (Expression*)num));
+}
 
 // Expression utility
 

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1618,7 +1618,7 @@ BinaryenExpressionRef BinaryenRefTest(BinaryenModuleRef module,
 }
 BinaryenExpressionRef BinaryenRefCast(BinaryenModuleRef module,
                                       BinaryenExpressionRef ref,
-                                      BinaryenType intendedType) {
+                                      BinaryenHeapType intendedType) {
   return static_cast<Expression*>(Builder(*(Module*)module)
                                     .makeRefCast((Expression*)ref,
                                                  HeapType(intendedType),

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -644,6 +644,8 @@ BINARYEN_API BinaryenOp BinaryenRefAsNonNull(void);
 BINARYEN_API BinaryenOp BinaryenRefAsFunc(void);
 BINARYEN_API BinaryenOp BinaryenRefAsData(void);
 BINARYEN_API BinaryenOp BinaryenRefAsI31(void);
+BINARYEN_API BinaryenOp BinaryenRefAsExternInternalize(void);
+BINARYEN_API BinaryenOp BinaryenRefAsExternExternalize(void);
 BINARYEN_API BinaryenOp BinaryenBrOnNull(void);
 BINARYEN_API BinaryenOp BinaryenBrOnNonNull(void);
 BINARYEN_API BinaryenOp BinaryenBrOnCast(void);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -644,6 +644,42 @@ BINARYEN_API BinaryenOp BinaryenRefAsNonNull(void);
 BINARYEN_API BinaryenOp BinaryenRefAsFunc(void);
 BINARYEN_API BinaryenOp BinaryenRefAsData(void);
 BINARYEN_API BinaryenOp BinaryenRefAsI31(void);
+BINARYEN_API BinaryenOp BinaryenBrOnNull(void);
+BINARYEN_API BinaryenOp BinaryenBrOnNonNull(void);
+BINARYEN_API BinaryenOp BinaryenBrOnCast(void);
+BINARYEN_API BinaryenOp BinaryenBrOnCastFail(void);
+BINARYEN_API BinaryenOp BinaryenBrOnFunc(void);
+BINARYEN_API BinaryenOp BinaryenBrOnNonFunc(void);
+BINARYEN_API BinaryenOp BinaryenBrOnData(void);
+BINARYEN_API BinaryenOp BinaryenBrOnNonData(void);
+BINARYEN_API BinaryenOp BinaryenBrOnI31(void);
+BINARYEN_API BinaryenOp BinaryenBrOnNonI31(void);
+BINARYEN_API BinaryenOp BinaryenStringNewUTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringNewWTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringNewReplace(void);
+BINARYEN_API BinaryenOp BinaryenStringNewWTF16(void);
+BINARYEN_API BinaryenOp BinaryenStringNewUTF8Array(void);
+BINARYEN_API BinaryenOp BinaryenStringNewWTF8Array(void);
+BINARYEN_API BinaryenOp BinaryenStringNewReplaceArray(void);
+BINARYEN_API BinaryenOp BinaryenStringNewWTF16Array(void);
+BINARYEN_API BinaryenOp BinaryenStringMeasureUTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringMeasureWTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringMeasureWTF16(void);
+BINARYEN_API BinaryenOp BinaryenStringMeasureIsUSV(void);
+BINARYEN_API BinaryenOp BinaryenStringMeasureWTF16View(void);
+BINARYEN_API BinaryenOp BinaryenStringEncodeUTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringEncodeWTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringEncodeWTF16(void);
+BINARYEN_API BinaryenOp BinaryenStringEncodeUTF8Array(void);
+BINARYEN_API BinaryenOp BinaryenStringEncodeWTF8Array(void);
+BINARYEN_API BinaryenOp BinaryenStringEncodeWTF16Array(void);
+BINARYEN_API BinaryenOp BinaryenStringAsWTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringAsWTF16(void);
+BINARYEN_API BinaryenOp BinaryenStringAsIter(void);
+BINARYEN_API BinaryenOp BinaryenStringIterMoveAdvance(void);
+BINARYEN_API BinaryenOp BinaryenStringIterMoveRewind(void);
+BINARYEN_API BinaryenOp BinaryenStringSliceWTF8(void);
+BINARYEN_API BinaryenOp BinaryenStringSliceWTF16(void);
 
 BINARYEN_REF(Expression);
 
@@ -959,16 +995,115 @@ BINARYEN_API BinaryenExpressionRef BinaryenI31New(BinaryenModuleRef module,
 BINARYEN_API BinaryenExpressionRef BinaryenI31Get(BinaryenModuleRef module,
                                                   BinaryenExpressionRef i31,
                                                   bool signed_);
-// TODO (gc): ref.test
-// TODO (gc): ref.cast
-// TODO (gc): br_on_cast
-// TODO (gc): struct.new
-// TODO (gc): struct.get
-// TODO (gc): struct.set
-// TODO (gc): array.new
-// TODO (gc): array.get
-// TODO (gc): array.set
-// TODO (gc): array.len
+BINARYEN_API BinaryenExpressionRef
+BinaryenRefTest(BinaryenModuleRef module,
+                BinaryenExpressionRef ref,
+                BinaryenHeapType intendedType);
+BINARYEN_API BinaryenExpressionRef
+BinaryenRefCast(BinaryenModuleRef module,
+                BinaryenExpressionRef ref,
+                BinaryenHeapType intendedType);
+BINARYEN_API BinaryenExpressionRef BinaryenBrOn(BinaryenModuleRef module,
+                                                BinaryenOp op,
+                                                const char* name,
+                                                BinaryenExpressionRef ref,
+                                                BinaryenHeapType intendedType);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStructNew(BinaryenModuleRef module,
+                  BinaryenExpressionRef* operands,
+                  BinaryenIndex numOperands,
+                  BinaryenHeapType type);
+BINARYEN_API BinaryenExpressionRef BinaryenStructGet(BinaryenModuleRef module,
+                                                     BinaryenIndex index,
+                                                     BinaryenExpressionRef ref,
+                                                     BinaryenType type,
+                                                     bool signed_);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStructSet(BinaryenModuleRef module,
+                  BinaryenIndex index,
+                  BinaryenExpressionRef ref,
+                  BinaryenExpressionRef value);
+BINARYEN_API BinaryenExpressionRef BinaryenArrayNew(BinaryenModuleRef module,
+                                                    BinaryenHeapType type,
+                                                    BinaryenExpressionRef size,
+                                                    BinaryenExpressionRef init);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayInit(BinaryenModuleRef module,
+                  BinaryenHeapType type,
+                  BinaryenExpressionRef* values,
+                  BinaryenIndex numValues);
+BINARYEN_API BinaryenExpressionRef BinaryenArrayGet(BinaryenModuleRef module,
+                                                    BinaryenExpressionRef ref,
+                                                    BinaryenExpressionRef index,
+                                                    bool signed_);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArraySet(BinaryenModuleRef module,
+                 BinaryenExpressionRef ref,
+                 BinaryenExpressionRef index,
+                 BinaryenExpressionRef value);
+BINARYEN_API BinaryenExpressionRef BinaryenArrayLen(BinaryenModuleRef module,
+                                                    BinaryenExpressionRef ref);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayCopy(BinaryenModuleRef module,
+                  BinaryenExpressionRef destRef,
+                  BinaryenExpressionRef destIndex,
+                  BinaryenExpressionRef srcRef,
+                  BinaryenExpressionRef srcIndex,
+                  BinaryenExpressionRef length);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringNew(BinaryenModuleRef module,
+                  BinaryenOp op,
+                  BinaryenExpressionRef ptr,
+                  BinaryenExpressionRef length,
+                  BinaryenExpressionRef start,
+                  BinaryenExpressionRef end);
+BINARYEN_API BinaryenExpressionRef BinaryenStringConst(BinaryenModuleRef module,
+                                                       const char* name);
+BINARYEN_API BinaryenExpressionRef BinaryenStringMeasure(
+  BinaryenModuleRef module, BinaryenOp op, BinaryenExpressionRef ref);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEncode(BinaryenModuleRef module,
+                     BinaryenOp op,
+                     BinaryenExpressionRef ref,
+                     BinaryenExpressionRef ptr,
+                     BinaryenExpressionRef start);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringConcat(BinaryenModuleRef module,
+                     BinaryenExpressionRef left,
+                     BinaryenExpressionRef right);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEq(BinaryenModuleRef module,
+                 BinaryenExpressionRef left,
+                 BinaryenExpressionRef right);
+BINARYEN_API BinaryenExpressionRef BinaryenStringAs(BinaryenModuleRef module,
+                                                    BinaryenOp op,
+                                                    BinaryenExpressionRef ref);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF8Advance(BinaryenModuleRef module,
+                          BinaryenExpressionRef ref,
+                          BinaryenExpressionRef pos,
+                          BinaryenExpressionRef bytes);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF16Get(BinaryenModuleRef module,
+                       BinaryenExpressionRef ref,
+                       BinaryenExpressionRef pos);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringIterNext(BinaryenModuleRef module, BinaryenExpressionRef ref);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringIterMove(BinaryenModuleRef module,
+                       BinaryenOp op,
+                       BinaryenExpressionRef ref,
+                       BinaryenExpressionRef num);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceWTF(BinaryenModuleRef module,
+                       BinaryenOp op,
+                       BinaryenExpressionRef ref,
+                       BinaryenExpressionRef start,
+                       BinaryenExpressionRef end);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceIter(BinaryenModuleRef module,
+                        BinaryenExpressionRef ref,
+                        BinaryenExpressionRef num);
 
 // Expression
 

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -557,6 +557,8 @@ function initializeConstants() {
     'RefAsFunc',
     'RefAsData',
     'RefAsI31',
+    'RefAsExternInternalize',
+    'RefAsExternExternalize',
     'BrOnNull',
     'BrOnNonNull',
     'BrOnCast',
@@ -2433,6 +2435,8 @@ function wrapModule(module, self = {}) {
     }
   };
 
+  // TODO: extern.internalize
+  // TODO: extern.externalize
   // TODO: ref.test
   // TODO: ref.cast
   // TODO: br_on_*

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -118,7 +118,22 @@ function initializeConstants() {
     'ArrayInit',
     'ArrayGet',
     'ArraySet',
-    'ArrayLen'
+    'ArrayLen',
+    'ArrayCopy',
+    'RefAs',
+    'StringNew',
+    'StringConst',
+    'StringMeasure',
+    'StringEncode',
+    'StringConcat',
+    'StringEq',
+    'StringAs',
+    'StringWTF8Advance',
+    'StringWTF16Get',
+    'StringIterNext',
+    'StringIterMove',
+    'StringSliceWTF',
+    'StringSliceIter'
   ].forEach(name => {
     Module['ExpressionIds'][name] = Module[name + 'Id'] = Module['_Binaryen' + name + 'Id']();
   });
@@ -542,6 +557,42 @@ function initializeConstants() {
     'RefAsFunc',
     'RefAsData',
     'RefAsI31',
+    'BrOnNull',
+    'BrOnNonNull',
+    'BrOnCast',
+    'BrOnCastFail',
+    'BrOnFunc',
+    'BrOnNonFunc',
+    'BrOnData',
+    'BrOnNonData',
+    'BrOnI31',
+    'BrOnNonI31',
+    'StringNewUTF8',
+    'StringNewWTF8',
+    'StringNewReplace',
+    'StringNewWTF16',
+    'StringNewUTF8Array',
+    'StringNewWTF8Array',
+    'StringNewReplaceArray',
+    'StringNewWTF16Array',
+    'StringMeasureUTF8',
+    'StringMeasureWTF8',
+    'StringMeasureWTF16',
+    'StringMeasureIsUSV',
+    'StringMeasureWTF16View',
+    'StringEncodeUTF8',
+    'StringEncodeWTF8',
+    'StringEncodeWTF16',
+    'StringEncodeUTF8Array',
+    'StringEncodeWTF8Array',
+    'StringEncodeWTF16Array',
+    'StringAsWTF8',
+    'StringAsWTF16',
+    'StringAsIter',
+    'StringIterMoveAdvance',
+    'StringIterMoveRewind',
+    'StringSliceWTF8',
+    'StringSliceWTF16'
   ].forEach(name => {
     Module['Operations'][name] = Module[name] = Module['_Binaryen' + name]();
   });
@@ -2381,6 +2432,16 @@ function wrapModule(module, self = {}) {
       return Module['_BinaryenI31Get'](module, i31, 0);
     }
   };
+
+  // TODO: ref.test
+  // TODO: ref.cast
+  // TODO: br_on_*
+  // TODO: struct.*
+  // TODO: array.*
+  // TODO: string.*
+  // TODO: stringview_wtf8.*
+  // TODO: stringview_wtf16.*
+  // TODO: stringview_iter.*
 
   // 'Module' operations
   self['addFunction'] = function(name, params, results, varTypes, body) {

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -171,6 +171,21 @@ function test_ids() {
   console.log("ArrayGetId: " + binaryen.ArrayGetId);
   console.log("ArraySetId: " + binaryen.ArraySetId);
   console.log("ArrayLenId: " + binaryen.ArrayLenId);
+  console.log("ArrayCopy: " + binaryen.ArrayCopyId);
+  console.log("RefAs: " + binaryen.RefAsId);
+  console.log("StringNew: " + binaryen.StringNewId);
+  console.log("StringConst: " + binaryen.StringConstId);
+  console.log("StringMeasure: " + binaryen.StringMeasureId);
+  console.log("StringEncode: " + binaryen.StringEncodeId);
+  console.log("StringConcat: " + binaryen.StringConcatId);
+  console.log("StringEq: " + binaryen.StringEqId);
+  console.log("StringAs: " + binaryen.StringAsId);
+  console.log("StringWTF8Advance: " + binaryen.StringWTF8AdvanceId);
+  console.log("StringWTF16Get: " + binaryen.StringWTF16GetId);
+  console.log("StringIterNext: " + binaryen.StringIterNextId);
+  console.log("StringIterMove: " + binaryen.StringIterMoveId);
+  console.log("StringSliceWTF: " + binaryen.StringSliceWTFId);
+  console.log("StringSliceIter: " + binaryen.StringSliceIterId);
 }
 
 function test_core() {

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -101,6 +101,21 @@ ArrayInitId: 64
 ArrayGetId: 65
 ArraySetId: 66
 ArrayLenId: 67
+ArrayCopy: 68
+RefAs: 69
+StringNew: 70
+StringConst: 71
+StringMeasure: 72
+StringEncode: 73
+StringConcat: 74
+StringEq: 75
+StringAs: 76
+StringWTF8Advance: 77
+StringWTF16Get: 78
+StringIterNext: 79
+StringIterMove: 80
+StringSliceWTF: 81
+StringSliceIter: 82
 getExpressionInfo={"id":15,"type":4,"op":6}
 (f32.neg
  (f32.const -33.61199951171875)

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -1002,6 +1002,12 @@ void test_core() {
     BinaryenRefAs(module,
                   BinaryenRefAsI31(),
                   BinaryenRefNull(module, BinaryenTypeAnyref())),
+    BinaryenRefAs(module,
+                  BinaryenRefAsExternInternalize(),
+                  BinaryenRefNull(module, BinaryenTypeExternref())),
+    BinaryenRefAs(module,
+                  BinaryenRefAsExternExternalize(),
+                  BinaryenRefNull(module, BinaryenTypeAnyref())),
     // Exception handling
     BinaryenTry(module, NULL, tryBody, catchTags, 1, catchBodies, 2, NULL),
     // (try $try_outer

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -365,6 +365,7 @@ void test_features() {
          BinaryenFeatureTypedFunctionReferences());
   printf("BinaryenFeatureRelaxedSIMD: %d\n", BinaryenFeatureRelaxedSIMD());
   printf("BinaryenFeatureExtendedConst: %d\n", BinaryenFeatureExtendedConst());
+  printf("BinaryenFeatureStrings: %d\n", BinaryenFeatureStrings());
   printf("BinaryenFeatureAll: %d\n", BinaryenFeatureAll());
 }
 
@@ -472,6 +473,28 @@ void test_core() {
   BinaryenType f32 = BinaryenTypeFloat32();
   BinaryenType f64 = BinaryenTypeFloat64();
   BinaryenType v128 = BinaryenTypeVec128();
+  BinaryenType i8Array;
+  BinaryenType i16Array;
+  BinaryenType i32Struct;
+  {
+    TypeBuilderRef tb = TypeBuilderCreate(3);
+    TypeBuilderSetArrayType(
+      tb, 0, BinaryenTypeInt32(), BinaryenPackedTypeInt8(), true);
+    TypeBuilderSetArrayType(
+      tb, 1, BinaryenTypeInt32(), BinaryenPackedTypeInt16(), true);
+    TypeBuilderSetStructType(
+      tb,
+      2,
+      (BinaryenType[]){BinaryenTypeInt32()},
+      (BinaryenPackedType[]){BinaryenPackedTypeNotPacked()},
+      (bool[]){true},
+      1);
+    BinaryenHeapType builtHeapTypes[3];
+    TypeBuilderBuildAndDispose(tb, (BinaryenHeapType*)&builtHeapTypes, 0, 0);
+    i8Array = BinaryenTypeFromHeapType(builtHeapTypes[0], true);
+    i16Array = BinaryenTypeFromHeapType(builtHeapTypes[1], true);
+    i32Struct = BinaryenTypeFromHeapType(builtHeapTypes[2], true);
+  }
 
   // Memory. Add it before creating any memory-using instructions.
 
@@ -1040,6 +1063,249 @@ void test_core() {
     BinaryenI31New(module, makeInt32(module, 0)),
     BinaryenI31Get(module, i31refExpr, 1),
     BinaryenI31Get(module, BinaryenI31New(module, makeInt32(module, 2)), 0),
+    BinaryenRefTest(module,
+                    BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                    BinaryenTypeGetHeapType(i8Array)),
+    BinaryenRefCast(module,
+                    BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                    BinaryenTypeGetHeapType(i8Array)),
+    BinaryenStructNew(module, 0, 0, BinaryenTypeGetHeapType(i32Struct)),
+    BinaryenStructNew(module,
+                      (BinaryenExpressionRef[]){makeInt32(module, 0)},
+                      1,
+                      BinaryenTypeGetHeapType(i32Struct)),
+    BinaryenStructGet(module,
+                      0,
+                      BinaryenGlobalGet(module, "i32Struct-global", i32Struct),
+                      BinaryenTypeInt32(),
+                      false),
+    BinaryenStructSet(module,
+                      0,
+                      BinaryenGlobalGet(module, "i32Struct-global", i32Struct),
+                      makeInt32(module, 0)),
+    BinaryenArrayNew(
+      module, BinaryenTypeGetHeapType(i8Array), makeInt32(module, 3), 0),
+    BinaryenArrayNew(module,
+                     BinaryenTypeGetHeapType(i8Array),
+                     makeInt32(module, 3),
+                     makeInt32(module, 42)),
+    BinaryenArrayInit(module,
+                      BinaryenTypeGetHeapType(i8Array),
+                      (BinaryenExpressionRef[]){makeInt32(module, 1),
+                                                makeInt32(module, 2),
+                                                makeInt32(module, 3)},
+                      3),
+    BinaryenArrayGet(module,
+                     BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                     makeInt32(module, 0),
+                     true),
+    BinaryenArrayGet(module,
+                     BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                     makeInt32(module, 0),
+                     false),
+    BinaryenArraySet(module,
+                     BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                     makeInt32(module, 0),
+                     makeInt32(module, 42)),
+    BinaryenArrayLen(module,
+                     BinaryenGlobalGet(module, "i8Array-global", i8Array)),
+    BinaryenArrayCopy(module,
+                      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                      makeInt32(module, 0),
+                      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                      makeInt32(module, 1),
+                      makeInt32(module, 2)),
+    // Strings
+    BinaryenStringNew(module,
+                      BinaryenStringNewUTF8(),
+                      makeInt32(module, 0),
+                      makeInt32(module, 0),
+                      0,
+                      0),
+    BinaryenStringNew(module,
+                      BinaryenStringNewWTF8(),
+                      makeInt32(module, 0),
+                      makeInt32(module, 0),
+                      0,
+                      0),
+    BinaryenStringNew(module,
+                      BinaryenStringNewReplace(),
+                      makeInt32(module, 0),
+                      makeInt32(module, 0),
+                      0,
+                      0),
+    BinaryenStringNew(module,
+                      BinaryenStringNewWTF16(),
+                      makeInt32(module, 0),
+                      makeInt32(module, 0),
+                      0,
+                      0),
+    BinaryenStringNew(module,
+                      BinaryenStringNewUTF8Array(),
+                      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                      0,
+                      makeInt32(module, 0),
+                      makeInt32(module, 0)),
+    BinaryenStringNew(module,
+                      BinaryenStringNewWTF8Array(),
+                      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                      0,
+                      makeInt32(module, 0),
+                      makeInt32(module, 0)),
+    BinaryenStringNew(module,
+                      BinaryenStringNewReplaceArray(),
+                      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+                      0,
+                      makeInt32(module, 0),
+                      makeInt32(module, 0)),
+    BinaryenStringNew(module,
+                      BinaryenStringNewWTF16Array(),
+                      BinaryenGlobalGet(module, "i16Array-global", i8Array),
+                      0,
+                      makeInt32(module, 0),
+                      makeInt32(module, 0)),
+    BinaryenStringConst(module, "hello world"),
+    BinaryenStringMeasure(
+      module,
+      BinaryenStringMeasureUTF8(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringMeasure(
+      module,
+      BinaryenStringMeasureWTF8(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringMeasure(
+      module,
+      BinaryenStringMeasureWTF16(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringMeasure(
+      module,
+      BinaryenStringMeasureIsUSV(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringMeasure(
+      module,
+      BinaryenStringMeasureWTF16View(),
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsWTF16(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()))),
+    BinaryenStringEncode(
+      module,
+      BinaryenStringEncodeUTF8(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      makeInt32(module, 0),
+      0),
+    BinaryenStringEncode(
+      module,
+      BinaryenStringEncodeWTF8(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      makeInt32(module, 0),
+      0),
+    BinaryenStringEncode(
+      module,
+      BinaryenStringEncodeWTF16(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      makeInt32(module, 0),
+      0),
+    BinaryenStringEncode(
+      module,
+      BinaryenStringEncodeUTF8Array(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+      makeInt32(module, 0)),
+    BinaryenStringEncode(
+      module,
+      BinaryenStringEncodeWTF8Array(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      BinaryenGlobalGet(module, "i8Array-global", i8Array),
+      makeInt32(module, 0)),
+    BinaryenStringEncode(
+      module,
+      BinaryenStringEncodeWTF16Array(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      BinaryenGlobalGet(module, "i16Array-global", i16Array),
+      makeInt32(module, 0)),
+    BinaryenStringConcat(
+      module,
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringEq(
+      module,
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringAs(
+      module,
+      BinaryenStringAsWTF8(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringAs(
+      module,
+      BinaryenStringAsWTF16(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringAs(
+      module,
+      BinaryenStringAsIter(),
+      BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+    BinaryenStringWTF8Advance(
+      module,
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsWTF8(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 0),
+      makeInt32(module, 0)),
+    BinaryenStringWTF16Get(
+      module,
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsWTF16(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 0)),
+    BinaryenStringIterNext(
+      module,
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsIter(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref()))),
+    BinaryenStringIterMove(
+      module,
+      BinaryenStringIterMoveAdvance(),
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsIter(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 1)),
+    BinaryenStringIterMove(
+      module,
+      BinaryenStringIterMoveRewind(),
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsIter(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 1)),
+    BinaryenStringSliceWTF(
+      module,
+      BinaryenStringSliceWTF8(),
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsWTF8(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 0),
+      makeInt32(module, 0)),
+    BinaryenStringSliceWTF(
+      module,
+      BinaryenStringSliceWTF16(),
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsWTF16(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 0),
+      makeInt32(module, 0)),
+    BinaryenStringSliceIter(
+      module,
+      BinaryenStringAs(
+        module,
+        BinaryenStringAsIter(),
+        BinaryenGlobalGet(module, "string-global", BinaryenTypeStringref())),
+      makeInt32(module, 0)),
     // Other
     BinaryenNop(module),
     BinaryenUnreachable(module),
@@ -1077,6 +1343,31 @@ void test_core() {
                     BinaryenTypeFloat32(),
                     1,
                     makeFloat32(module, 7.5));
+  BinaryenAddGlobal(
+    module,
+    "i8Array-global",
+    i8Array,
+    true,
+    BinaryenArrayNew(
+      module, BinaryenTypeGetHeapType(i8Array), makeInt32(module, 0), 0));
+  BinaryenAddGlobal(
+    module,
+    "i16Array-global",
+    i16Array,
+    true,
+    BinaryenArrayNew(
+      module, BinaryenTypeGetHeapType(i16Array), makeInt32(module, 0), 0));
+  BinaryenAddGlobal(
+    module,
+    "i32Struct-global",
+    i32Struct,
+    true,
+    BinaryenStructNew(module, 0, 0, BinaryenTypeGetHeapType(i32Struct)));
+  BinaryenAddGlobal(module,
+                    "string-global",
+                    BinaryenTypeStringref(),
+                    true,
+                    BinaryenStringConst(module, ""));
 
   // Imports
 
@@ -1830,7 +2121,7 @@ void test_typebuilder() {
     TypeBuilderSetSignatureType(
       builder,
       tempSignatureIndex,
-      TypeBuilderGetTempTupleType(builder, &paramTypes, 2),
+      TypeBuilderGetTempTupleType(builder, (BinaryenType*)&paramTypes, 2),
       tempSignatureType);
   }
 
@@ -1908,8 +2199,8 @@ void test_typebuilder() {
       arrayType, structType, signatureType, basicType, subStructType};
     BinaryenAddFunction(module,
                         "test",
-                        BinaryenNone(),
-                        BinaryenNone(),
+                        BinaryenTypeNone(),
+                        BinaryenTypeNone(),
                         varTypes,
                         5,
                         BinaryenNop(module));

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -45,6 +45,7 @@ BinaryenFeatureMemory64: 2048
 BinaryenFeatureTypedFunctionReferences: 4096
 BinaryenFeatureRelaxedSIMD: 16384
 BinaryenFeatureExtendedConst: 32768
+BinaryenFeatureStrings: 65536
 BinaryenFeatureAll: 253951
 (f32.neg
  (f32.const -33.61199951171875)
@@ -62,13 +63,24 @@ BinaryenFeatureAll: 253951
  (i32.const 0)
 )
 (module
+ (type $[mut:i8] (array (mut i8)))
+ (type ${mut:i32} (struct (field (mut i32))))
  (type $i32_i64_f32_f64_=>_i32 (func (param i32 i64 f32 f64) (result i32)))
+ (type $[mut:i16] (array (mut i16)))
  (type $i32_=>_none (func (param i32)))
  (type $i32_f64_=>_f32 (func (param i32 f64) (result f32)))
  (type $none_=>_none (func))
  (import "module" "base" (func $an-imported (param i32 f64) (result f32)))
  (global $a-global i32 (i32.const 7))
  (global $a-mutable-global (mut f32) (f32.const 7.5))
+ (global $i8Array-global (mut (ref null $[mut:i8])) (array.new_default $[mut:i8]
+  (i32.const 0)
+ ))
+ (global $i16Array-global (mut (ref null $[mut:i16])) (array.new_default $[mut:i16]
+  (i32.const 0)
+ ))
+ (global $i32Struct-global (mut (ref null ${mut:i32})) (struct.new_default ${mut:i32}))
+ (global $string-global (mut stringref) (string.const ""))
  (memory $0 (shared 1 256))
  (data (i32.const 10) "hello, world")
  (data "I am passive")
@@ -2133,6 +2145,294 @@ BinaryenFeatureAll: 253951
         (i31.new
          (i32.const 2)
         )
+       )
+      )
+      (drop
+       (ref.test_static $[mut:i8]
+        (global.get $i8Array-global)
+       )
+      )
+      (drop
+       (ref.cast_static $[mut:i8]
+        (global.get $i8Array-global)
+       )
+      )
+      (drop
+       (struct.new_default ${mut:i32})
+      )
+      (drop
+       (struct.new ${mut:i32}
+        (i32.const 0)
+       )
+      )
+      (drop
+       (struct.get ${mut:i32} 0
+        (global.get $i32Struct-global)
+       )
+      )
+      (struct.set ${mut:i32} 0
+       (global.get $i32Struct-global)
+       (i32.const 0)
+      )
+      (drop
+       (array.new_default $[mut:i8]
+        (i32.const 3)
+       )
+      )
+      (drop
+       (array.new $[mut:i8]
+        (i32.const 42)
+        (i32.const 3)
+       )
+      )
+      (drop
+       (array.init_static $[mut:i8]
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+       )
+      )
+      (drop
+       (array.get_s $[mut:i8]
+        (global.get $i8Array-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (array.get_u $[mut:i8]
+        (global.get $i8Array-global)
+        (i32.const 0)
+       )
+      )
+      (array.set $[mut:i8]
+       (global.get $i8Array-global)
+       (i32.const 0)
+       (i32.const 42)
+      )
+      (drop
+       (array.len $[mut:i8]
+        (global.get $i8Array-global)
+       )
+      )
+      (array.copy $[mut:i8] $[mut:i8]
+       (global.get $i8Array-global)
+       (i32.const 0)
+       (global.get $i8Array-global)
+       (i32.const 1)
+       (i32.const 2)
+      )
+      (drop
+       (string.new_wtf8 utf8
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf8 wtf8
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf8 replace
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf16
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf8_array utf8
+        (global.get $i8Array-global)
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf8_array wtf8
+        (global.get $i8Array-global)
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf8_array replace
+        (global.get $i8Array-global)
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.new_wtf16_array
+        (global.get $i16Array-global)
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.const "hello world")
+      )
+      (drop
+       (string.measure_wtf8 utf8
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.measure_wtf8 wtf8
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.measure_wtf16
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.is_usv_sequence
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (stringview_wtf16.length
+        (string.as_wtf16
+         (global.get $string-global)
+        )
+       )
+      )
+      (drop
+       (string.encode_wtf8 utf8
+        (global.get $string-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.encode_wtf8 wtf8
+        (global.get $string-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.encode_wtf16
+        (global.get $string-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.encode_wtf8_array utf8
+        (global.get $string-global)
+        (global.get $i8Array-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.encode_wtf8_array wtf8
+        (global.get $string-global)
+        (global.get $i8Array-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.encode_wtf16_array
+        (global.get $string-global)
+        (global.get $i16Array-global)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (string.concat
+        (global.get $string-global)
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.eq
+        (global.get $string-global)
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.as_wtf8
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.as_wtf16
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (string.as_iter
+        (global.get $string-global)
+       )
+      )
+      (drop
+       (stringview_wtf8.advance
+        (string.as_wtf8
+         (global.get $string-global)
+        )
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (stringview_wtf16.get_codeunit
+        (string.as_wtf16
+         (global.get $string-global)
+        )
+        (i32.const 0)
+       )
+      )
+      (drop
+       (stringview_iter.next
+        (string.as_iter
+         (global.get $string-global)
+        )
+       )
+      )
+      (drop
+       (stringview_iter.advance
+        (string.as_iter
+         (global.get $string-global)
+        )
+        (i32.const 1)
+       )
+      )
+      (drop
+       (stringview_iter.rewind
+        (string.as_iter
+         (global.get $string-global)
+        )
+        (i32.const 1)
+       )
+      )
+      (drop
+       (stringview_wtf8.slice
+        (string.as_wtf8
+         (global.get $string-global)
+        )
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (stringview_wtf16.slice
+        (string.as_wtf16
+         (global.get $string-global)
+        )
+        (i32.const 0)
+        (i32.const 0)
+       )
+      )
+      (drop
+       (stringview_iter.slice
+        (string.as_iter
+         (global.get $string-global)
+        )
+        (i32.const 0)
        )
       )
       (nop)

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -2031,6 +2031,16 @@ BinaryenFeatureAll: 253951
         (ref.null any)
        )
       )
+      (drop
+       (extern.internalize
+        (ref.null extern)
+       )
+      )
+      (drop
+       (extern.externalize
+        (ref.null any)
+       )
+      )
       (try
        (do
         (throw $a-tag


### PR DESCRIPTION
Adds C-API bindings for the expression classes

* `RefTest`
* `RefCast`
* `BrOn` with operations `BrOnNull`, `BrOnNonNull`, `BrOnCast`, `BrOnCastFail`, `BrOnFunc`, `BrOnNonFunc`, `BrOnData`, `BrOnNonData`, `BrOnI31`, `BrOnNonI31`
* `StructNew` with operations `StringNewUTF8`, `StringNewWTF8`, `StringNewReplace`, `StringNewWTF16`, `StringNewUTF8Array`, `StringNewWTF8Array`, `StringNewReplaceArray`, `StringNewWTF16Array`
* `StructGet`
* `StructSet`
* `ArrayNew`
* `ArrayInit`
* `ArrayGet`
* `ArraySet`
* `ArrayLen`
* `ArrayCopy`
* `StringNew`
* `StringConst`
* `StringMeasure` with operations `StringMeasureUTF8`, `StringMeasureWTF8`, `StringMeasureWTF16`, `StringMeasureIsUSV`, `StringMeasureWTF16View`
* `StringEncode` with operations `StringEncodeUTF8`, `StringEncodeWTF8`, `StringEncodeWTF16`, `StringEncodeUTF8Array`, `StringEncodeWTF8Array`, `StringEncodeWTF16Array`
* `StringConcat`
* `StringEq`
* `StringAs` with operations `StringAsWTF8`, `StringAsWTF16`, `StringAsIter`
* `StringWTF8Advance`
* `StringWTF16Get`
* `StringIterNext`
* `StringIterMove` with operations `StringIterMoveAdvance`, `StringIterMoveRewind`
* `StringSliceWTF` with operations `StringSliceWTF8`, `StringSliceWTF16`
* `StringSliceIter`

incl. tests. Updates expression and operation ids in the JS bindings accordingly and adds a TODO for the concrete JS bindings still to be added. Drive-by fixes a few minor but related code style issues respectively test warnings.
