### PR TITLE
Fix/constant expression runner visit drop

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -278,7 +278,7 @@ struct Precompute
       return;
     }
     if (flow.breaking()) {
-      if (flow.breakTo == NONCONSTANT_FLOW) {
+      if (flow.breakTo == NONCONSTANT_FLOW || flow.breakTo == RECOVERABLE_NONCONSTANT_FLOW) {
         return;
       }
       if (flow.breakTo == RETURN_FLOW) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -278,7 +278,8 @@ struct Precompute
       return;
     }
     if (flow.breaking()) {
-      if (flow.breakTo == NONCONSTANT_FLOW || flow.breakTo == RECOVERABLE_NONCONSTANT_FLOW) {
+      if (flow.breakTo == NONCONSTANT_FLOW ||
+          flow.breakTo == RECOVERABLE_NONCONSTANT_FLOW) {
         return;
       }
       if (flow.breakTo == RETURN_FLOW) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -25,6 +25,7 @@ namespace wasm {
 Name WASM("wasm");
 Name RETURN_FLOW("*return:)*");
 Name NONCONSTANT_FLOW("*nonconstant:)*");
+Name RECOVERABLE_NONCONSTANT_FLOW("*recoverable_nonconstant:)*");
 
 namespace BinaryConsts {
 namespace UserSections {

--- a/test/lit/passes/dae-optimizing.wast
+++ b/test/lit/passes/dae-optimizing.wast
@@ -14,9 +14,11 @@
  (type $2 (func (param f64 f32 f32 f64 f32 i32 i32 f64) (result i32)))
  ;; CHECK:      (global $global$0 (mut i32) (i32.const 10))
  (global $global$0 (mut i32) (i32.const 10))
+ ;; CHECK:      (global $global$1 (mut f32) (f32.const 10))
+ (global $global$1 (mut f32) (f32.const 10))
  ;; CHECK:      (func $0 (result i32)
  ;; CHECK-NEXT:  (local $0 i32)
- ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:  (global.set $global$1
  ;; CHECK-NEXT:   (if (result f32)
  ;; CHECK-NEXT:    (local.tee $0
  ;; CHECK-NEXT:     (i32.const 33554432)
@@ -28,7 +30,7 @@
  ;; CHECK-NEXT:       (local.get $0)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (f32.const 0)
+ ;; CHECK-NEXT:     (f32.const 1)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (call $1)
  ;; CHECK-NEXT:   )
@@ -42,7 +44,7 @@
    (local.tee $7
     (i32.const 33554432)
    )
-   (drop
+   (global.set $global$1
     (loop $label$2 (result f32)
      (if
       (global.get $global$0)
@@ -66,7 +68,7 @@
      (f32.const 1)
     )
    )
-   (drop
+   (global.set $global$1
     (call $1
      (f32.const 1)
     )

--- a/test/lit/passes/dae-optimizing.wast
+++ b/test/lit/passes/dae-optimizing.wast
@@ -16,29 +16,19 @@
  (global $global$0 (mut i32) (i32.const 10))
  ;; CHECK:      (func $0 (result i32)
  ;; CHECK-NEXT:  (local $0 i32)
- ;; CHECK-NEXT:  (local $1 i32)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (if (result f32)
  ;; CHECK-NEXT:    (local.tee $0
  ;; CHECK-NEXT:     (i32.const 33554432)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (loop $label$2 (result f32)
+ ;; CHECK-NEXT:    (block (result f32)
  ;; CHECK-NEXT:     (if
  ;; CHECK-NEXT:      (global.get $global$0)
  ;; CHECK-NEXT:      (return
  ;; CHECK-NEXT:       (local.get $0)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (local.set $0
- ;; CHECK-NEXT:      (local.get $1)
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (local.set $1
- ;; CHECK-NEXT:      (i32.const 0)
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (br_if $label$2
- ;; CHECK-NEXT:      (local.get $0)
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (f32.const 1)
+ ;; CHECK-NEXT:     (f32.const 0)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (call $1)
  ;; CHECK-NEXT:   )


### PR DESCRIPTION
fix: #5015

- Add a override of `visitDrop` in `ConstantExpressionRunner`
- Testcase result changed due to this code can be infer to `i32.const 0`
```wasm
  (block $label$4 (result i32)
   (drop
    (local.tee $7
     (local.get $8)
    )
   )
   (i32.const 0)
  )
```