### PR TITLE
[Effects] Fix hasAnything on mutable global state

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -188,8 +188,7 @@ public:
   }
 
   bool hasAnything() const {
-    return hasSideEffects() || accessesLocal() || readsMemory || readsTable ||
-           accessesMutableGlobal();
+    return hasSideEffects() || accessesLocal() || readsMutableGlobalState();
   }
 
   // check if we break to anything external from ourselves


### PR DESCRIPTION
We explicitly wrote out memory, table, and globals, but did not add structs. This switches
us to use `readsMutableGlobalState` which has the full list of all relevant global state,
including the memory, table, and globals as well as structs.