### PR TITLE
[Exceptions] Optimize in CodePushing even with exceptions thrown

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -881,9 +881,19 @@ public:
     return effects;
   }
 
-  void ignoreBranches() {
+  // Ignores all forms of control flow transfers: breaks, returns, and
+  // exceptions. (Note that traps are not considered relevant here - a trap does
+  // not just transfer control flow, but can be seen as halting the entire
+  // program.)
+  //
+  // This function matches transfersControlFlow(), that is, after calling this
+  // method transfersControlFlow() will always return false.
+  void ignoreControlFlowTransfers() {
     branchesOut = false;
     breakTargets.clear();
+    throws_ = false;
+    delegateTargets.clear();
+    assert(!transfersControlFlow());
   }
 
 private:

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -174,7 +174,9 @@ private:
     // and reach some outer scope, and in that case we never need x at all
     // (since we've proven before that x is not used outside of this block, see
     // numGetsSoFar which we use for that). Similarly, the break could be a
-    // return and that would be ok as well, and also an exception.
+    // return and that would be ok as well, and also an exception (if the
+    // exception is caught in the function, it must be outside the block, which
+    // is just like a break; and if it is not caught, it is just like a return).
     cumulativeEffects.ignoreBranches();
     cumulativeEffects.throws_ = false;
     std::vector<LocalSet*> toPush;

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -173,12 +173,9 @@ private:
     // If the branch is taken, then that's fine, it will jump out of this block
     // and reach some outer scope, and in that case we never need x at all
     // (since we've proven before that x is not used outside of this block, see
-    // numGetsSoFar which we use for that). Similarly, the break could be a
-    // return and that would be ok as well, and also an exception (if the
-    // exception is caught in the function, it must be outside the block, which
-    // is just like a break; and if it is not caught, it is just like a return).
-    cumulativeEffects.ignoreBranches();
-    cumulativeEffects.throws_ = false;
+    // numGetsSoFar which we use for that). Similarly, control flow could
+    // transfer away via a return or an exception and that would be ok as well.
+    cumulativeEffects.ignoreControlFlowTransfers();
     std::vector<LocalSet*> toPush;
     Index i = pushPoint - 1;
     while (1) {

--- a/test/lit/passes/code-pushing-eh.wast
+++ b/test/lit/passes/code-pushing-eh.wast
@@ -322,4 +322,33 @@
       (drop (local.get $x))
     )
   )
+
+  ;; CHECK:      (func $can-push-past-throw (param $a i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (block $out
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:    (throw $e
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $x
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $can-push-past-throw (param $a i32)
+    (local $x i32)
+    (block $out
+      (local.set $x (i32.const 1))
+      (if
+        (local.get $a)
+        (throw $e (i32.const 0))
+      )
+      (drop (local.get $x))
+    )
+  )
 )

--- a/test/lit/passes/code-pushing-eh.wast
+++ b/test/lit/passes/code-pushing-eh.wast
@@ -60,7 +60,8 @@
   (func $cannot-push-past-throw
     (local $x i32)
     (block $out
-      ;; This local.set cannot be pushed down, because there is 'throw' below
+      ;; This local.set cannot be pushed down, because there is 'throw' below.
+      ;; This pass only pushes past conditional control flow atm.
       (local.set $x (i32.const 1))
       (throw $e (i32.const 0))
       (drop (i32.const 1))
@@ -323,11 +324,11 @@
     )
   )
 
-  ;; CHECK:      (func $can-push-past-throw (param $a i32)
+  ;; CHECK:      (func $can-push-past-conditional-throw (param $param i32)
   ;; CHECK-NEXT:  (local $x i32)
-  ;; CHECK-NEXT:  (block $out
+  ;; CHECK-NEXT:  (block $block
   ;; CHECK-NEXT:   (if
-  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:    (local.get $param)
   ;; CHECK-NEXT:    (throw $e
   ;; CHECK-NEXT:     (i32.const 0)
   ;; CHECK-NEXT:    )
@@ -340,15 +341,54 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $can-push-past-throw (param $a i32)
+  (func $can-push-past-conditional-throw (param $param i32)
     (local $x i32)
-    (block $out
+    (block $block
+      ;; We can push past an if containing a throw. The if is conditional
+      ;; control flow, which is what we look for in this optimization, and a
+      ;; throw is like a break - it will jump out of the current block - so we
+      ;; can push the set past it, as the set is only needed in this block.
       (local.set $x (i32.const 1))
       (if
-        (local.get $a)
+        (local.get $param)
         (throw $e (i32.const 0))
       )
       (drop (local.get $x))
     )
+  )
+
+  ;; CHECK:      (func $cannot-push-past-conditional-throw-extra-use (param $param i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (block $block
+  ;; CHECK-NEXT:   (local.set $x
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.get $param)
+  ;; CHECK-NEXT:    (throw $e
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $cannot-push-past-conditional-throw-extra-use (param $param i32)
+    (local $x i32)
+    ;; As above, but now there is another local.get outside of the block. That
+    ;; means the local.set cannot be pushed to a place it might not execute.
+    (block $block
+      (local.set $x (i32.const 1))
+      (if
+        (local.get $param)
+        (throw $e (i32.const 0))
+      )
+      (drop (local.get $x))
+    )
+    (drop (local.get $x))
   )
 )


### PR DESCRIPTION
We had some concerns about this not working in the past, but thinking about it
now, I believe it is safe to do. Specifically, a throw is either like a break or a return -
either it jumps out to an outer scope (like a break) or it jumps out of the function
(like a return), and both breaks and returns have already been handled here.

This change has some nice effects on J2Wasm output, where there are quite a
lot of throws, which we can now optimize around.