### PR TITLE
Fix compilation errors with C++20

### DIFF
--- a/src/support/parent_index_iterator.h
+++ b/src/support/parent_index_iterator.h
@@ -49,10 +49,10 @@ template<typename Parent, typename Iterator> struct ParentIndexIterator {
 
   Iterator& self() { return *static_cast<Iterator*>(this); }
 
-  bool operator==(const Iterator& other) const {
+  bool operator==(const ParentIndexIterator& other) const {
     return index == other.index && parent == other.parent;
   }
-  bool operator!=(const Iterator& other) const { return !(*this == other); }
+  bool operator!=(const ParentIndexIterator& other) const { return !(*this == other); }
   Iterator& operator++() {
     ++index;
     return self();


### PR DESCRIPTION
In C++20 makes operator calls become ambiguous wrt to a rewritten version of itself with swapped candidates.

See https://gcc.godbolt.org/z/5q7GTr3bM for an example.

This commit fixes an occurence of this breakage in `parent_index_iterator.h`. Note that the actual breakage is in `passes/Poppify.cpp` that exposes the constraints of comparison operator for `std::reverse_iteratot<Iterator>`.