### PR TITLE
[OptimizeInstructions] More canonizations for floating points

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -42,8 +42,12 @@ inline bool isSymmetric(Binary* binary) {
     case EqInt64:
     case NeInt64:
 
+    case MinFloat32:
+    case MaxFloat32:
     case EqFloat32:
     case NeFloat32:
+    case MinFloat64:
+    case MaxFloat64:
     case EqFloat64:
     case NeFloat64:
       return true;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3505,20 +3505,6 @@ private:
       }
     }
     {
-      double value;
-      if (matches(curr, binary(Sub, any(), fval(&value))) && value == 0.0) {
-        // x - (-0.0)   ==>   x + 0.0
-        if (std::signbit(value)) {
-          curr->op = Abstract::getBinary(type, Add);
-          right->value = right->value.neg();
-          return curr;
-        } else if (fastMath) {
-          // x - 0.0   ==>   x
-          return curr->left;
-        }
-      }
-    }
-    {
       // x * 2.0  ==>  x + x
       // but we apply this only for simple expressions like
       // local.get and global.get for avoid using extra local

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -4596,8 +4596,10 @@ private:
     }
     switch (binary->op) {
       case AddFloat32:
+      case SubFloat32:
       case MulFloat32:
       case AddFloat64:
+      case SubFloat64:
       case MulFloat64: {
         // If the LHS is known to be non-NaN, the operands can commute.
         // We don't care about the RHS because right now we only know if

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -4595,11 +4595,14 @@ private:
       return true;
     }
     switch (binary->op) {
-      case AddFloat32:
       case SubFloat32:
+      case SubFloat64: {
+        // Should apply  x - C  ->  x + (-C)
+        return binary->right->is<Const>();
+      }
+      case AddFloat32:
       case MulFloat32:
       case AddFloat64:
-      case SubFloat64:
       case MulFloat64: {
         // If the LHS is known to be non-NaN, the operands can commute.
         // We don't care about the RHS because right now we only know if

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -2036,6 +2036,115 @@
     (drop (i32.add (i32.ctz (local.get $x)) (i32.eqz (local.get $y))))
     (drop (i32.add (i32.eqz (local.get $x)) (i32.ctz (local.get $y))))
   )
+  ;; CHECK:      (func $canonicalize-consts-floats (param $x f32) (param $y f64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (f32.const -1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (f64.const -1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.mul
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (f32.const 3.4000000953674316)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.mul
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (f64.const 3.4)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.min
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (f32.const 3.4000000953674316)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.min
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (f64.const 3.4)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.max
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (f32.const 3.4000000953674316)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.max
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (f64.const 3.4)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.min
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (f32.const nan:0x400000)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.min
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (f64.const nan:0x8000000000000)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.max
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (f32.const nan:0x400000)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.max
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (f64.const nan:0x8000000000000)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.copysign
+  ;; CHECK-NEXT:    (f32.const 1)
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.copysign
+  ;; CHECK-NEXT:    (f64.const 1)
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $canonicalize-consts-floats (param $x f32) (param $y f64)
+    (drop (f32.sub (local.get $x) (f32.const 1.0)))
+    (drop (f64.sub (local.get $y) (f64.const 1.0)))
+
+    (drop (f32.mul (f32.const 3.4) (local.get $x)))
+    (drop (f64.mul (f64.const 3.4) (local.get $y)))
+
+    (drop (f32.min (f32.const 3.4) (local.get $x)))
+    (drop (f64.min (f64.const 3.4) (local.get $y)))
+
+    (drop (f32.max (f32.const 3.4) (local.get $x)))
+    (drop (f64.max (f64.const 3.4) (local.get $y)))
+
+    (drop (f32.min (f32.const nan) (local.get $x)))
+    (drop (f64.min (f64.const nan) (local.get $y)))
+
+    (drop (f32.max (f32.const nan) (local.get $x)))
+    (drop (f64.max (f64.const nan) (local.get $y)))
+
+    ;; skips
+    (drop (f32.copysign (f32.const 1.0) (local.get $x)))
+    (drop (f64.copysign (f64.const 1.0) (local.get $y)))
+  )
   ;; CHECK:      (func $ne0 (result i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (call $ne0)
@@ -8376,15 +8485,15 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:   (f32.sub
+  ;; CHECK-NEXT:    (f32.const -0)
   ;; CHECK-NEXT:    (local.get $y32)
-  ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:   (f64.sub
+  ;; CHECK-NEXT:    (f64.const -0)
   ;; CHECK-NEXT:    (local.get $y64)
-  ;; CHECK-NEXT:    (f64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -10329,27 +10438,51 @@
   )
   ;; CHECK:      (func $const-float-zero (param $fx f32) (param $fy f64)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.sub
+  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:    (local.get $fx)
+  ;; CHECK-NEXT:    (f32.const -0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:    (local.get $fy)
+  ;; CHECK-NEXT:    (f64.const -0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:    (local.get $fx)
+  ;; CHECK-NEXT:    (f32.const -0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:    (local.get $fy)
+  ;; CHECK-NEXT:    (f64.const -0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.add
   ;; CHECK-NEXT:    (local.get $fx)
   ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:    (local.get $fy)
+  ;; CHECK-NEXT:    (f64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f32.sub
+  ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:    (local.get $fx)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f64.sub
-  ;; CHECK-NEXT:    (local.get $fy)
   ;; CHECK-NEXT:    (f64.const 0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.add
-  ;; CHECK-NEXT:    (local.get $fx)
-  ;; CHECK-NEXT:    (f32.const -0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.add
   ;; CHECK-NEXT:    (local.get $fy)
-  ;; CHECK-NEXT:    (f64.const -0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -10366,32 +10499,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.add
-  ;; CHECK-NEXT:    (local.get $fx)
-  ;; CHECK-NEXT:    (f32.const -0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.add
-  ;; CHECK-NEXT:    (local.get $fy)
-  ;; CHECK-NEXT:    (f64.const -0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.add
-  ;; CHECK-NEXT:    (local.get $fx)
-  ;; CHECK-NEXT:    (f32.const 0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.add
-  ;; CHECK-NEXT:    (local.get $fy)
-  ;; CHECK-NEXT:    (f64.const 0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.sub
   ;; CHECK-NEXT:    (f32.const -nan:0x34546d)
-  ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:    (f32.const -0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -10537,15 +10646,15 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:   (f32.sub
+  ;; CHECK-NEXT:    (f32.const -0)
   ;; CHECK-NEXT:    (local.get $fx)
-  ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.add
+  ;; CHECK-NEXT:   (f64.sub
+  ;; CHECK-NEXT:    (f64.const -0)
   ;; CHECK-NEXT:    (local.get $fy)
-  ;; CHECK-NEXT:    (f64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -10823,9 +10932,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.add
+  ;; CHECK-NEXT:   (f32.sub
+  ;; CHECK-NEXT:    (f32.const -0)
   ;; CHECK-NEXT:    (local.get $fx)
-  ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -13646,17 +13755,17 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f64.abs
-  ;; CHECK-NEXT:    (f64.add
+  ;; CHECK-NEXT:    (f64.sub
+  ;; CHECK-NEXT:     (f64.const 0)
   ;; CHECK-NEXT:     (local.get $x0)
-  ;; CHECK-NEXT:     (f64.const -0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.abs
-  ;; CHECK-NEXT:    (f32.add
+  ;; CHECK-NEXT:    (f32.sub
+  ;; CHECK-NEXT:     (f32.const 0)
   ;; CHECK-NEXT:     (local.get $y0)
-  ;; CHECK-NEXT:     (f32.const -0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -8376,15 +8376,15 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.sub
-  ;; CHECK-NEXT:    (f32.const -0)
+  ;; CHECK-NEXT:   (f32.add
   ;; CHECK-NEXT:    (local.get $y32)
+  ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.sub
-  ;; CHECK-NEXT:    (f64.const -0)
+  ;; CHECK-NEXT:   (f64.add
   ;; CHECK-NEXT:    (local.get $y64)
+  ;; CHECK-NEXT:    (f64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -10365,15 +10365,15 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.sub
-  ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:   (f32.add
   ;; CHECK-NEXT:    (local.get $fx)
+  ;; CHECK-NEXT:    (f32.const -0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.sub
-  ;; CHECK-NEXT:    (f64.const 0)
+  ;; CHECK-NEXT:   (f64.add
   ;; CHECK-NEXT:    (local.get $fy)
+  ;; CHECK-NEXT:    (f64.const -0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -10537,15 +10537,15 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.sub
-  ;; CHECK-NEXT:    (f32.const -0)
+  ;; CHECK-NEXT:   (f32.add
   ;; CHECK-NEXT:    (local.get $fx)
+  ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.sub
-  ;; CHECK-NEXT:    (f64.const -0)
+  ;; CHECK-NEXT:   (f64.add
   ;; CHECK-NEXT:    (local.get $fy)
+  ;; CHECK-NEXT:    (f64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -10823,9 +10823,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.sub
-  ;; CHECK-NEXT:    (f32.const -0)
+  ;; CHECK-NEXT:   (f32.add
   ;; CHECK-NEXT:    (local.get $fx)
+  ;; CHECK-NEXT:    (f32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -13646,17 +13646,17 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f64.abs
-  ;; CHECK-NEXT:    (f64.sub
-  ;; CHECK-NEXT:     (f64.const 0)
+  ;; CHECK-NEXT:    (f64.add
   ;; CHECK-NEXT:     (local.get $x0)
+  ;; CHECK-NEXT:     (f64.const -0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.abs
-  ;; CHECK-NEXT:    (f32.sub
-  ;; CHECK-NEXT:     (f32.const 0)
+  ;; CHECK-NEXT:    (f32.add
   ;; CHECK-NEXT:     (local.get $y0)
+  ;; CHECK-NEXT:     (f32.const -0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/optimize-instructions.wast
+++ b/test/lit/passes/optimize-instructions.wast
@@ -2066,28 +2066,16 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.min
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (f32.const nan:0x400000)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (f32.const nan:0x400000)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.min
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (f64.const nan:0x8000000000000)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (f64.const nan:0x8000000000000)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f32.max
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (f32.const nan:0x400000)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (f32.const nan:0x400000)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.max
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (f64.const nan:0x8000000000000)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (f64.const nan:0x8000000000000)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f32.copysign

--- a/test/passes/optimize-instructions_fuzz-exec.txt
+++ b/test/passes/optimize-instructions_fuzz-exec.txt
@@ -77,18 +77,18 @@
   )
   (call $logf32
    (f32.min
-    (f32.const -nan:0x7fff82)
     (f32.neg
      (f32.const -nan:0x7ff622)
     )
+    (f32.const -nan:0x7fff82)
    )
   )
   (call $logf32
    (f32.max
-    (f32.const -nan:0x7fff82)
     (f32.neg
      (f32.const -nan:0x7ff622)
     )
+    (f32.const -nan:0x7fff82)
    )
   )
  )
@@ -133,18 +133,18 @@
   )
   (call $logf64
    (f64.min
-    (f64.const -nan:0xfffffffffff82)
     (f64.neg
      (f64.const -nan:0xfffffffffa622)
     )
+    (f64.const -nan:0xfffffffffff82)
    )
   )
   (call $logf64
    (f64.max
-    (f64.const -nan:0xfffffffffff82)
     (f64.neg
      (f64.const -nan:0xfffffffffa622)
     )
+    (f64.const -nan:0xfffffffffff82)
    )
   )
  )

--- a/test/passes/optimize-instructions_fuzz-exec.txt
+++ b/test/passes/optimize-instructions_fuzz-exec.txt
@@ -73,20 +73,10 @@
    )
   )
   (call $logf32
-   (f32.min
-    (f32.neg
-     (f32.const -nan:0x7ff622)
-    )
-    (f32.const -nan:0x7fff82)
-   )
+   (f32.const nan:0x400000)
   )
   (call $logf32
-   (f32.max
-    (f32.neg
-     (f32.const -nan:0x7ff622)
-    )
-    (f32.const -nan:0x7fff82)
-   )
+   (f32.const nan:0x400000)
   )
  )
  (func $1
@@ -126,20 +116,10 @@
    )
   )
   (call $logf64
-   (f64.min
-    (f64.neg
-     (f64.const -nan:0xfffffffffa622)
-    )
-    (f64.const -nan:0xfffffffffff82)
-   )
+   (f64.const nan:0x8000000000000)
   )
   (call $logf64
-   (f64.max
-    (f64.neg
-     (f64.const -nan:0xfffffffffa622)
-    )
-    (f64.const -nan:0xfffffffffff82)
-   )
+   (f64.const nan:0x8000000000000)
   )
  )
  (func $2


### PR DESCRIPTION
```rust
x - C       ->    x + (-C)
min(C, x)   ->    min(x, C)
max(C, x)   ->    max(x, C)
```
And remove redundant rules