### PR TITLE
[C API] Add getters and setters for various expressions

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1606,6 +1606,20 @@ BinaryenExpressionRef BinaryenI31Get(BinaryenModuleRef module,
   return static_cast<Expression*>(
     Builder(*(Module*)module).makeI31Get((Expression*)i31, signed_ != 0));
 }
+BinaryenExpressionRef BinaryenCallRef(BinaryenModuleRef module,
+                                      BinaryenExpressionRef target,
+                                      BinaryenExpressionRef* operands,
+                                      BinaryenIndex numOperands,
+                                      BinaryenType type,
+                                      bool isReturn) {
+  std::vector<Expression*> args;
+  for (BinaryenIndex i = 0; i < numOperands; i++) {
+    args.push_back((Expression*)operands[i]);
+  }
+  return static_cast<Expression*>(
+    Builder(*(Module*)module)
+      .makeCallRef((Expression*)target, args, Type(type), isReturn));
+}
 BinaryenExpressionRef BinaryenRefTest(BinaryenModuleRef module,
                                       BinaryenExpressionRef ref,
                                       BinaryenHeapType intendedType) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3902,6 +3902,7 @@ void BinaryenCallRefSetTarget(BinaryenExpressionRef expr,
                               BinaryenExpressionRef targetExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<CallRef>());
+  assert(targetExpr);
   static_cast<CallRef*>(expression)->target = (Expression*)targetExpr;
 }
 bool BinaryenCallRefIsReturn(BinaryenExpressionRef expr) {
@@ -3924,6 +3925,7 @@ void BinaryenRefTestSetRef(BinaryenExpressionRef expr,
                            BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<RefTest>());
+  assert(refExpr);
   static_cast<RefTest*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenHeapType BinaryenRefTestGetIntendedType(BinaryenExpressionRef expr) {
@@ -3947,6 +3949,7 @@ void BinaryenRefCastSetRef(BinaryenExpressionRef expr,
                            BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<RefCast>());
+  assert(refExpr);
   static_cast<RefCast*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenHeapType BinaryenRefCastGetIntendedType(BinaryenExpressionRef expr) {
@@ -3979,6 +3982,7 @@ const char* BinaryenBrOnGetName(BinaryenExpressionRef expr) {
 void BinaryenBrOnSetName(BinaryenExpressionRef expr, const char* nameStr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<BrOn>());
+  assert(nameStr);
   static_cast<BrOn*>(expression)->name = nameStr;
 }
 BinaryenExpressionRef BinaryenBrOnGetRef(BinaryenExpressionRef expr) {
@@ -3990,6 +3994,7 @@ void BinaryenBrOnSetRef(BinaryenExpressionRef expr,
                         BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<BrOn>());
+  assert(refExpr);
   static_cast<BrOn*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenHeapType BinaryenBrOnGetIntendedType(BinaryenExpressionRef expr) {
@@ -4074,6 +4079,7 @@ void BinaryenStructGetSetRef(BinaryenExpressionRef expr,
                              BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StructGet>());
+  assert(refExpr);
   static_cast<StructGet*>(expression)->ref = (Expression*)refExpr;
 }
 bool BinaryenStructGetIsSigned(BinaryenExpressionRef expr) {
@@ -4107,6 +4113,7 @@ void BinaryenStructSetSetRef(BinaryenExpressionRef expr,
                              BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StructSet>());
+  assert(refExpr);
   static_cast<StructSet*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef BinaryenStructSetGetValue(BinaryenExpressionRef expr) {
@@ -4118,6 +4125,7 @@ void BinaryenStructSetSetValue(BinaryenExpressionRef expr,
                                BinaryenExpressionRef valueExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StructSet>());
+  assert(valueExpr);
   static_cast<StructSet*>(expression)->value = (Expression*)valueExpr;
 }
 // ArrayNew
@@ -4130,6 +4138,7 @@ void BinaryenArrayNewSetInit(BinaryenExpressionRef expr,
                              BinaryenExpressionRef initExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayNew>());
+  // may be null
   static_cast<ArrayNew*>(expression)->init = (Expression*)initExpr;
 }
 BinaryenExpressionRef BinaryenArrayNewGetSize(BinaryenExpressionRef expr) {
@@ -4141,6 +4150,7 @@ void BinaryenArrayNewSetSize(BinaryenExpressionRef expr,
                              BinaryenExpressionRef sizeExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayNew>());
+  assert(sizeExpr);
   static_cast<ArrayNew*>(expression)->size = (Expression*)sizeExpr;
 }
 // ArrayInit
@@ -4200,6 +4210,7 @@ void BinaryenArrayGetSetRef(BinaryenExpressionRef expr,
                             BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayGet>());
+  assert(refExpr);
   static_cast<ArrayGet*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef BinaryenArrayGetGetIndex(BinaryenExpressionRef expr) {
@@ -4211,6 +4222,7 @@ void BinaryenArrayGetSetIndex(BinaryenExpressionRef expr,
                               BinaryenExpressionRef indexExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayGet>());
+  assert(indexExpr);
   static_cast<ArrayGet*>(expression)->index = (Expression*)indexExpr;
 }
 bool BinaryenArrayGetIsSigned(BinaryenExpressionRef expr) {
@@ -4233,6 +4245,7 @@ void BinaryenArraySetSetRef(BinaryenExpressionRef expr,
                             BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArraySet>());
+  assert(refExpr);
   static_cast<ArraySet*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef BinaryenArraySetGetIndex(BinaryenExpressionRef expr) {
@@ -4244,6 +4257,7 @@ void BinaryenArraySetSetIndex(BinaryenExpressionRef expr,
                               BinaryenExpressionRef indexExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArraySet>());
+  assert(indexExpr);
   static_cast<ArraySet*>(expression)->index = (Expression*)indexExpr;
 }
 BinaryenExpressionRef BinaryenArraySetGetValue(BinaryenExpressionRef expr) {
@@ -4255,6 +4269,7 @@ void BinaryenArraySetSetValue(BinaryenExpressionRef expr,
                               BinaryenExpressionRef valueExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArraySet>());
+  assert(valueExpr);
   static_cast<ArraySet*>(expression)->value = (Expression*)valueExpr;
 }
 // ArrayLen
@@ -4267,6 +4282,7 @@ void BinaryenArrayLenSetRef(BinaryenExpressionRef expr,
                             BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayLen>());
+  assert(refExpr);
   static_cast<ArrayLen*>(expression)->ref = (Expression*)refExpr;
 }
 // ArrayCopy
@@ -4279,6 +4295,7 @@ void BinaryenArrayCopySetDestRef(BinaryenExpressionRef expr,
                                  BinaryenExpressionRef destRefExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayCopy>());
+  assert(destRefExpr);
   static_cast<ArrayCopy*>(expression)->destRef = (Expression*)destRefExpr;
 }
 BinaryenExpressionRef
@@ -4291,6 +4308,7 @@ void BinaryenArrayCopySetDestIndex(BinaryenExpressionRef expr,
                                    BinaryenExpressionRef destIndexExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayCopy>());
+  assert(destIndexExpr);
   static_cast<ArrayCopy*>(expression)->destIndex = (Expression*)destIndexExpr;
 }
 BinaryenExpressionRef BinaryenArrayCopyGetSrcRef(BinaryenExpressionRef expr) {
@@ -4302,6 +4320,7 @@ void BinaryenArrayCopySetSrcRef(BinaryenExpressionRef expr,
                                 BinaryenExpressionRef srcRefExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayCopy>());
+  assert(srcRefExpr);
   static_cast<ArrayCopy*>(expression)->srcRef = (Expression*)srcRefExpr;
 }
 BinaryenExpressionRef BinaryenArrayCopyGetSrcIndex(BinaryenExpressionRef expr) {
@@ -4313,6 +4332,7 @@ void BinaryenArrayCopySetSrcIndex(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef srcIndexExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayCopy>());
+  assert(srcIndexExpr);
   static_cast<ArrayCopy*>(expression)->srcIndex = (Expression*)srcIndexExpr;
 }
 BinaryenExpressionRef BinaryenArrayCopyGetLength(BinaryenExpressionRef expr) {
@@ -4324,6 +4344,7 @@ void BinaryenArrayCopySetLength(BinaryenExpressionRef expr,
                                 BinaryenExpressionRef lengthExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<ArrayCopy>());
+  assert(lengthExpr);
   static_cast<ArrayCopy*>(expression)->length = (Expression*)lengthExpr;
 }
 // StringNew
@@ -4346,6 +4367,7 @@ void BinaryenStringNewSetPtr(BinaryenExpressionRef expr,
                              BinaryenExpressionRef ptrExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringNew>());
+  assert(ptrExpr);
   static_cast<StringNew*>(expression)->ptr = (Expression*)ptrExpr;
 }
 BinaryenExpressionRef BinaryenStringNewGetLength(BinaryenExpressionRef expr) {
@@ -4357,6 +4379,7 @@ void BinaryenStringNewSetLength(BinaryenExpressionRef expr,
                                 BinaryenExpressionRef lengthExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringNew>());
+  // may be null (linear memory only)
   static_cast<StringNew*>(expression)->length = (Expression*)lengthExpr;
 }
 BinaryenExpressionRef BinaryenStringNewGetStart(BinaryenExpressionRef expr) {
@@ -4368,6 +4391,7 @@ void BinaryenStringNewSetStart(BinaryenExpressionRef expr,
                                BinaryenExpressionRef startExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringNew>());
+  // may be null (GC only)
   static_cast<StringNew*>(expression)->start = (Expression*)startExpr;
 }
 BinaryenExpressionRef BinaryenStringNewGetEnd(BinaryenExpressionRef expr) {
@@ -4379,6 +4403,7 @@ void BinaryenStringNewSetEnd(BinaryenExpressionRef expr,
                              BinaryenExpressionRef endExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringNew>());
+  // may be null (GC only)
   static_cast<StringNew*>(expression)->end = (Expression*)endExpr;
 }
 // StringConst
@@ -4391,6 +4416,7 @@ void BinaryenStringConstSetString(BinaryenExpressionRef expr,
                                   const char* stringStr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringConst>());
+  assert(stringStr);
   static_cast<StringConst*>(expression)->string = stringStr;
 }
 // StringMeasure
@@ -4413,6 +4439,7 @@ void BinaryenStringMeasureSetRef(BinaryenExpressionRef expr,
                                  BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringMeasure>());
+  assert(refExpr);
   static_cast<StringMeasure*>(expression)->ref = (Expression*)refExpr;
 }
 // StringEncode
@@ -4435,6 +4462,7 @@ void BinaryenStringEncodeSetRef(BinaryenExpressionRef expr,
                                 BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringEncode>());
+  assert(refExpr);
   static_cast<StringEncode*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef BinaryenStringEncodeGetPtr(BinaryenExpressionRef expr) {
@@ -4446,6 +4474,7 @@ void BinaryenStringEncodeSetPtr(BinaryenExpressionRef expr,
                                 BinaryenExpressionRef ptrExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringEncode>());
+  assert(ptrExpr);
   static_cast<StringEncode*>(expression)->ptr = (Expression*)ptrExpr;
 }
 BinaryenExpressionRef BinaryenStringEncodeGetStart(BinaryenExpressionRef expr) {
@@ -4457,6 +4486,7 @@ void BinaryenStringEncodeSetStart(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef startExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringEncode>());
+  // may be null (GC only)
   static_cast<StringEncode*>(expression)->start = (Expression*)startExpr;
 }
 // StringConcat
@@ -4469,6 +4499,7 @@ void BinaryenStringConcatSetLeft(BinaryenExpressionRef expr,
                                  BinaryenExpressionRef leftExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringConcat>());
+  assert(leftExpr);
   static_cast<StringConcat*>(expression)->left = (Expression*)leftExpr;
 }
 BinaryenExpressionRef BinaryenStringConcatGetRight(BinaryenExpressionRef expr) {
@@ -4480,6 +4511,7 @@ void BinaryenStringConcatSetRight(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef rightExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringConcat>());
+  assert(rightExpr);
   static_cast<StringConcat*>(expression)->right = (Expression*)rightExpr;
 }
 // StringEq
@@ -4492,6 +4524,7 @@ void BinaryenStringEqSetLeft(BinaryenExpressionRef expr,
                              BinaryenExpressionRef leftExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringEq>());
+  assert(leftExpr);
   static_cast<StringEq*>(expression)->left = (Expression*)leftExpr;
 }
 BinaryenExpressionRef BinaryenStringEqGetRight(BinaryenExpressionRef expr) {
@@ -4503,6 +4536,7 @@ void BinaryenStringEqSetRight(BinaryenExpressionRef expr,
                               BinaryenExpressionRef rightExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringEq>());
+  assert(rightExpr);
   static_cast<StringEq*>(expression)->right = (Expression*)rightExpr;
 }
 // StringAs
@@ -4525,6 +4559,7 @@ void BinaryenStringAsSetRef(BinaryenExpressionRef expr,
                             BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringAs>());
+  assert(refExpr);
   static_cast<StringAs*>(expression)->ref = (Expression*)refExpr;
 }
 // StringWTF8Advance
@@ -4538,6 +4573,7 @@ void BinaryenStringWTF8AdvanceSetRef(BinaryenExpressionRef expr,
                                      BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringWTF8Advance>());
+  assert(refExpr);
   static_cast<StringWTF8Advance*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef
@@ -4550,6 +4586,7 @@ void BinaryenStringWTF8AdvanceSetPos(BinaryenExpressionRef expr,
                                      BinaryenExpressionRef posExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringWTF8Advance>());
+  assert(posExpr);
   static_cast<StringWTF8Advance*>(expression)->pos = (Expression*)posExpr;
 }
 BinaryenExpressionRef
@@ -4562,6 +4599,7 @@ void BinaryenStringWTF8AdvanceSetBytes(BinaryenExpressionRef expr,
                                        BinaryenExpressionRef bytesExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringWTF8Advance>());
+  assert(bytesExpr);
   static_cast<StringWTF8Advance*>(expression)->bytes = (Expression*)bytesExpr;
 }
 // StringWTF16Get
@@ -4574,6 +4612,7 @@ void BinaryenStringWTF16GetSetRef(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringWTF16Get>());
+  assert(refExpr);
   static_cast<StringWTF16Get*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef BinaryenStringWTF16GetGetPos(BinaryenExpressionRef expr) {
@@ -4585,6 +4624,7 @@ void BinaryenStringWTF16GetSetPos(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef posExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringWTF16Get>());
+  assert(posExpr);
   static_cast<StringWTF16Get*>(expression)->pos = (Expression*)posExpr;
 }
 // StringIterNext
@@ -4597,6 +4637,7 @@ void BinaryenStringIterNextSetRef(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringIterNext>());
+  assert(refExpr);
   static_cast<StringIterNext*>(expression)->ref = (Expression*)refExpr;
 }
 // StringIterMove
@@ -4619,6 +4660,7 @@ void BinaryenStringIterMoveSetRef(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringIterMove>());
+  assert(refExpr);
   static_cast<StringIterMove*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef BinaryenStringIterMoveGetNum(BinaryenExpressionRef expr) {
@@ -4630,6 +4672,7 @@ void BinaryenStringIterMoveSetNum(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef numExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringIterMove>());
+  assert(numExpr);
   static_cast<StringIterMove*>(expression)->num = (Expression*)numExpr;
 }
 // StringSliceWTF
@@ -4652,6 +4695,7 @@ void BinaryenStringSliceWTFSetRef(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringSliceWTF>());
+  assert(refExpr);
   static_cast<StringSliceWTF*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef
@@ -4664,6 +4708,7 @@ void BinaryenStringSliceWTFSetStart(BinaryenExpressionRef expr,
                                     BinaryenExpressionRef startExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringSliceWTF>());
+  assert(startExpr);
   static_cast<StringSliceWTF*>(expression)->start = (Expression*)startExpr;
 }
 BinaryenExpressionRef BinaryenStringSliceWTFGetEnd(BinaryenExpressionRef expr) {
@@ -4675,6 +4720,7 @@ void BinaryenStringSliceWTFSetEnd(BinaryenExpressionRef expr,
                                   BinaryenExpressionRef endExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringSliceWTF>());
+  assert(endExpr);
   static_cast<StringSliceWTF*>(expression)->end = (Expression*)endExpr;
 }
 // StringSliceIter
@@ -4688,6 +4734,7 @@ void BinaryenStringSliceIterSetRef(BinaryenExpressionRef expr,
                                    BinaryenExpressionRef refExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringSliceIter>());
+  assert(refExpr);
   static_cast<StringSliceIter*>(expression)->ref = (Expression*)refExpr;
 }
 BinaryenExpressionRef
@@ -4700,6 +4747,7 @@ void BinaryenStringSliceIterSetNum(BinaryenExpressionRef expr,
                                    BinaryenExpressionRef numExpr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<StringSliceIter>());
+  assert(numExpr);
   static_cast<StringSliceIter*>(expression)->num = (Expression*)numExpr;
 }
 

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -3846,6 +3846,862 @@ void BinaryenI31GetSetSigned(BinaryenExpressionRef expr, bool signed_) {
   assert(expression->is<I31Get>());
   static_cast<I31Get*>(expression)->signed_ = signed_ != 0;
 }
+// CallRef
+BinaryenIndex BinaryenCallRefGetNumOperands(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  return static_cast<CallRef*>(expression)->operands.size();
+}
+BinaryenExpressionRef BinaryenCallRefGetOperandAt(BinaryenExpressionRef expr,
+                                                  BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  assert(index < static_cast<CallRef*>(expression)->operands.size());
+  return static_cast<CallRef*>(expression)->operands[index];
+}
+void BinaryenCallRefSetOperandAt(BinaryenExpressionRef expr,
+                                 BinaryenIndex index,
+                                 BinaryenExpressionRef operandExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  assert(index < static_cast<CallRef*>(expression)->operands.size());
+  assert(operandExpr);
+  static_cast<CallRef*>(expression)->operands[index] = (Expression*)operandExpr;
+}
+BinaryenIndex BinaryenCallRefAppendOperand(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef operandExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  assert(operandExpr);
+  auto& list = static_cast<CallRef*>(expression)->operands;
+  auto index = list.size();
+  list.push_back((Expression*)operandExpr);
+  return index;
+}
+void BinaryenCallRefInsertOperandAt(BinaryenExpressionRef expr,
+                                    BinaryenIndex index,
+                                    BinaryenExpressionRef operandExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  assert(operandExpr);
+  static_cast<CallRef*>(expression)
+    ->operands.insertAt(index, (Expression*)operandExpr);
+}
+BinaryenExpressionRef BinaryenCallRefRemoveOperandAt(BinaryenExpressionRef expr,
+                                                     BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  return static_cast<CallRef*>(expression)->operands.removeAt(index);
+}
+BinaryenExpressionRef BinaryenCallRefGetTarget(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  return static_cast<CallRef*>(expression)->target;
+}
+void BinaryenCallRefSetTarget(BinaryenExpressionRef expr,
+                              BinaryenExpressionRef targetExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  static_cast<CallRef*>(expression)->target = (Expression*)targetExpr;
+}
+bool BinaryenCallRefIsReturn(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  return static_cast<CallRef*>(expression)->isReturn;
+}
+void BinaryenCallRefSetReturn(BinaryenExpressionRef expr, bool isReturn) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<CallRef>());
+  static_cast<CallRef*>(expression)->isReturn = isReturn;
+}
+// RefTest
+BinaryenExpressionRef BinaryenRefTestGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefTest>());
+  return static_cast<RefTest*>(expression)->ref;
+}
+void BinaryenRefTestSetRef(BinaryenExpressionRef expr,
+                           BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefTest>());
+  static_cast<RefTest*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenHeapType BinaryenRefTestGetIntendedType(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefTest>());
+  return static_cast<RefTest*>(expression)->intendedType.getID();
+}
+void BinaryenRefTestSetIntendedType(BinaryenExpressionRef expr,
+                                    BinaryenHeapType intendedType) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefTest>());
+  static_cast<RefTest*>(expression)->intendedType = HeapType(intendedType);
+}
+// RefCast
+BinaryenExpressionRef BinaryenRefCastGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefCast>());
+  return static_cast<RefCast*>(expression)->ref;
+}
+void BinaryenRefCastSetRef(BinaryenExpressionRef expr,
+                           BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefCast>());
+  static_cast<RefCast*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenHeapType BinaryenRefCastGetIntendedType(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefCast>());
+  return static_cast<RefCast*>(expression)->intendedType.getID();
+}
+void BinaryenRefCastSetIntendedType(BinaryenExpressionRef expr,
+                                    BinaryenHeapType intendedType) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<RefCast>());
+  static_cast<RefCast*>(expression)->intendedType = HeapType(intendedType);
+}
+// BrOn
+BinaryenOp BinaryenBrOnGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  return static_cast<BrOn*>(expression)->op;
+}
+void BinaryenBrOnSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  static_cast<BrOn*>(expression)->op = BrOnOp(op);
+}
+const char* BinaryenBrOnGetName(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  return static_cast<BrOn*>(expression)->name.c_str();
+}
+void BinaryenBrOnSetName(BinaryenExpressionRef expr, const char* nameStr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  static_cast<BrOn*>(expression)->name = nameStr;
+}
+BinaryenExpressionRef BinaryenBrOnGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  return static_cast<BrOn*>(expression)->ref;
+}
+void BinaryenBrOnSetRef(BinaryenExpressionRef expr,
+                        BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  static_cast<BrOn*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenHeapType BinaryenBrOnGetIntendedType(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  return static_cast<BrOn*>(expression)->intendedType.getID();
+}
+void BinaryenBrOnSetIntendedType(BinaryenExpressionRef expr,
+                                 BinaryenHeapType intendedType) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<BrOn>());
+  static_cast<BrOn*>(expression)->intendedType = HeapType(intendedType);
+}
+// StructNew
+BinaryenIndex BinaryenStructNewGetNumOperands(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructNew>());
+  return static_cast<StructNew*>(expression)->operands.size();
+}
+BinaryenExpressionRef BinaryenStructNewGetOperandAt(BinaryenExpressionRef expr,
+                                                    BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructNew>());
+  assert(index < static_cast<StructNew*>(expression)->operands.size());
+  return static_cast<StructNew*>(expression)->operands[index];
+}
+void BinaryenStructNewSetOperandAt(BinaryenExpressionRef expr,
+                                   BinaryenIndex index,
+                                   BinaryenExpressionRef operandExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructNew>());
+  assert(index < static_cast<StructNew*>(expression)->operands.size());
+  assert(operandExpr);
+  static_cast<StructNew*>(expression)->operands[index] =
+    (Expression*)operandExpr;
+}
+BinaryenIndex
+BinaryenStructNewAppendOperand(BinaryenExpressionRef expr,
+                               BinaryenExpressionRef operandExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructNew>());
+  assert(operandExpr);
+  auto& list = static_cast<StructNew*>(expression)->operands;
+  auto index = list.size();
+  list.push_back((Expression*)operandExpr);
+  return index;
+}
+void BinaryenStructNewInsertOperandAt(BinaryenExpressionRef expr,
+                                      BinaryenIndex index,
+                                      BinaryenExpressionRef operandExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructNew>());
+  assert(operandExpr);
+  static_cast<StructNew*>(expression)
+    ->operands.insertAt(index, (Expression*)operandExpr);
+}
+BinaryenExpressionRef
+BinaryenStructNewRemoveOperandAt(BinaryenExpressionRef expr,
+                                 BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructNew>());
+  return static_cast<StructNew*>(expression)->operands.removeAt(index);
+}
+// StructGet
+BinaryenIndex BinaryenStructGetGetIndex(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructGet>());
+  return static_cast<StructGet*>(expression)->index;
+}
+void BinaryenStructGetSetIndex(BinaryenExpressionRef expr,
+                               BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructGet>());
+  static_cast<StructGet*>(expression)->index = index;
+}
+BinaryenExpressionRef BinaryenStructGetGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructGet>());
+  return static_cast<StructGet*>(expression)->ref;
+}
+void BinaryenStructGetSetRef(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructGet>());
+  static_cast<StructGet*>(expression)->ref = (Expression*)refExpr;
+}
+bool BinaryenStructGetIsSigned(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructGet>());
+  return static_cast<StructGet*>(expression)->signed_;
+}
+void BinaryenStructGetSetSigned(BinaryenExpressionRef expr, bool signed_) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructGet>());
+  static_cast<StructGet*>(expression)->signed_ = signed_;
+}
+// StructSet
+BinaryenIndex BinaryenStructSetGetIndex(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructSet>());
+  return static_cast<StructSet*>(expression)->index;
+}
+void BinaryenStructSetSetIndex(BinaryenExpressionRef expr,
+                               BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructSet>());
+  static_cast<StructSet*>(expression)->index = index;
+}
+BinaryenExpressionRef BinaryenStructSetGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructSet>());
+  return static_cast<StructSet*>(expression)->ref;
+}
+void BinaryenStructSetSetRef(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructSet>());
+  static_cast<StructSet*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef BinaryenStructSetGetValue(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructSet>());
+  return static_cast<StructSet*>(expression)->value;
+}
+void BinaryenStructSetSetValue(BinaryenExpressionRef expr,
+                               BinaryenExpressionRef valueExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StructSet>());
+  static_cast<StructSet*>(expression)->value = (Expression*)valueExpr;
+}
+// ArrayNew
+BinaryenExpressionRef BinaryenArrayNewGetInit(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayNew>());
+  return static_cast<ArrayNew*>(expression)->init;
+}
+void BinaryenArrayNewSetInit(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef initExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayNew>());
+  static_cast<ArrayNew*>(expression)->init = (Expression*)initExpr;
+}
+BinaryenExpressionRef BinaryenArrayNewGetSize(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayNew>());
+  return static_cast<ArrayNew*>(expression)->size;
+}
+void BinaryenArrayNewSetSize(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef sizeExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayNew>());
+  static_cast<ArrayNew*>(expression)->size = (Expression*)sizeExpr;
+}
+// ArrayInit
+BinaryenIndex BinaryenArrayInitGetNumValues(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayInit>());
+  return static_cast<ArrayInit*>(expression)->values.size();
+}
+BinaryenExpressionRef BinaryenArrayInitGetValueAt(BinaryenExpressionRef expr,
+                                                  BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayInit>());
+  assert(index < static_cast<ArrayInit*>(expression)->values.size());
+  return static_cast<ArrayInit*>(expression)->values[index];
+}
+void BinaryenArrayInitSetValueAt(BinaryenExpressionRef expr,
+                                 BinaryenIndex index,
+                                 BinaryenExpressionRef valueExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayInit>());
+  assert(index < static_cast<ArrayInit*>(expression)->values.size());
+  assert(valueExpr);
+  static_cast<ArrayInit*>(expression)->values[index] = (Expression*)valueExpr;
+}
+BinaryenIndex BinaryenArrayInitAppendValue(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef valueExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayInit>());
+  assert(valueExpr);
+  auto& list = static_cast<ArrayInit*>(expression)->values;
+  auto index = list.size();
+  list.push_back((Expression*)valueExpr);
+  return index;
+}
+void BinaryenArrayInitInsertValueAt(BinaryenExpressionRef expr,
+                                    BinaryenIndex index,
+                                    BinaryenExpressionRef valueExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayInit>());
+  assert(valueExpr);
+  static_cast<ArrayInit*>(expression)
+    ->values.insertAt(index, (Expression*)valueExpr);
+}
+BinaryenExpressionRef BinaryenArrayInitRemoveValueAt(BinaryenExpressionRef expr,
+                                                     BinaryenIndex index) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayInit>());
+  return static_cast<ArrayInit*>(expression)->values.removeAt(index);
+}
+// ArrayGet
+BinaryenExpressionRef BinaryenArrayGetGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayGet>());
+  return static_cast<ArrayGet*>(expression)->ref;
+}
+void BinaryenArrayGetSetRef(BinaryenExpressionRef expr,
+                            BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayGet>());
+  static_cast<ArrayGet*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef BinaryenArrayGetGetIndex(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayGet>());
+  return static_cast<ArrayGet*>(expression)->index;
+}
+void BinaryenArrayGetSetIndex(BinaryenExpressionRef expr,
+                              BinaryenExpressionRef indexExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayGet>());
+  static_cast<ArrayGet*>(expression)->index = (Expression*)indexExpr;
+}
+bool BinaryenArrayGetIsSigned(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayGet>());
+  return static_cast<ArrayGet*>(expression)->signed_;
+}
+void BinaryenArrayGetSetSigned(BinaryenExpressionRef expr, bool signed_) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayGet>());
+  static_cast<ArrayGet*>(expression)->signed_ = signed_;
+}
+// ArraySet
+BinaryenExpressionRef BinaryenArraySetGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArraySet>());
+  return static_cast<ArraySet*>(expression)->ref;
+}
+void BinaryenArraySetSetRef(BinaryenExpressionRef expr,
+                            BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArraySet>());
+  static_cast<ArraySet*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef BinaryenArraySetGetIndex(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArraySet>());
+  return static_cast<ArraySet*>(expression)->index;
+}
+void BinaryenArraySetSetIndex(BinaryenExpressionRef expr,
+                              BinaryenExpressionRef indexExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArraySet>());
+  static_cast<ArraySet*>(expression)->index = (Expression*)indexExpr;
+}
+BinaryenExpressionRef BinaryenArraySetGetValue(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArraySet>());
+  return static_cast<ArraySet*>(expression)->value;
+}
+void BinaryenArraySetSetValue(BinaryenExpressionRef expr,
+                              BinaryenExpressionRef valueExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArraySet>());
+  static_cast<ArraySet*>(expression)->value = (Expression*)valueExpr;
+}
+// ArrayLen
+BinaryenExpressionRef BinaryenArrayLenGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayLen>());
+  return static_cast<ArrayLen*>(expression)->ref;
+}
+void BinaryenArrayLenSetRef(BinaryenExpressionRef expr,
+                            BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayLen>());
+  static_cast<ArrayLen*>(expression)->ref = (Expression*)refExpr;
+}
+// ArrayCopy
+BinaryenExpressionRef BinaryenArrayCopyGetDestRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  return static_cast<ArrayCopy*>(expression)->destRef;
+}
+void BinaryenArrayCopySetDestRef(BinaryenExpressionRef expr,
+                                 BinaryenExpressionRef destRefExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  static_cast<ArrayCopy*>(expression)->destRef = (Expression*)destRefExpr;
+}
+BinaryenExpressionRef
+BinaryenArrayCopyGetDestIndex(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  return static_cast<ArrayCopy*>(expression)->destIndex;
+}
+void BinaryenArrayCopySetDestIndex(BinaryenExpressionRef expr,
+                                   BinaryenExpressionRef destIndexExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  static_cast<ArrayCopy*>(expression)->destIndex = (Expression*)destIndexExpr;
+}
+BinaryenExpressionRef BinaryenArrayCopyGetSrcRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  return static_cast<ArrayCopy*>(expression)->srcRef;
+}
+void BinaryenArrayCopySetSrcRef(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef srcRefExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  static_cast<ArrayCopy*>(expression)->srcRef = (Expression*)srcRefExpr;
+}
+BinaryenExpressionRef BinaryenArrayCopyGetSrcIndex(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  return static_cast<ArrayCopy*>(expression)->srcIndex;
+}
+void BinaryenArrayCopySetSrcIndex(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef srcIndexExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  static_cast<ArrayCopy*>(expression)->srcIndex = (Expression*)srcIndexExpr;
+}
+BinaryenExpressionRef BinaryenArrayCopyGetLength(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  return static_cast<ArrayCopy*>(expression)->length;
+}
+void BinaryenArrayCopySetLength(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef lengthExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<ArrayCopy>());
+  static_cast<ArrayCopy*>(expression)->length = (Expression*)lengthExpr;
+}
+// StringNew
+BinaryenOp BinaryenStringNewGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  return static_cast<StringNew*>(expression)->op;
+}
+void BinaryenStringNewSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  static_cast<StringNew*>(expression)->op = StringNewOp(op);
+}
+BinaryenExpressionRef BinaryenStringNewGetPtr(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  return static_cast<StringNew*>(expression)->ptr;
+}
+void BinaryenStringNewSetPtr(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef ptrExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  static_cast<StringNew*>(expression)->ptr = (Expression*)ptrExpr;
+}
+BinaryenExpressionRef BinaryenStringNewGetLength(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  return static_cast<StringNew*>(expression)->length;
+}
+void BinaryenStringNewSetLength(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef lengthExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  static_cast<StringNew*>(expression)->length = (Expression*)lengthExpr;
+}
+BinaryenExpressionRef BinaryenStringNewGetStart(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  return static_cast<StringNew*>(expression)->start;
+}
+void BinaryenStringNewSetStart(BinaryenExpressionRef expr,
+                               BinaryenExpressionRef startExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  static_cast<StringNew*>(expression)->start = (Expression*)startExpr;
+}
+BinaryenExpressionRef BinaryenStringNewGetEnd(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  return static_cast<StringNew*>(expression)->end;
+}
+void BinaryenStringNewSetEnd(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef endExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringNew>());
+  static_cast<StringNew*>(expression)->end = (Expression*)endExpr;
+}
+// StringConst
+const char* BinaryenStringConstGetString(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringConst>());
+  return static_cast<StringConst*>(expression)->string.c_str();
+}
+void BinaryenStringConstSetString(BinaryenExpressionRef expr,
+                                  const char* stringStr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringConst>());
+  static_cast<StringConst*>(expression)->string = stringStr;
+}
+// StringMeasure
+BinaryenOp BinaryenStringMeasureGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringMeasure>());
+  return static_cast<StringMeasure*>(expression)->op;
+}
+void BinaryenStringMeasureSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringMeasure>());
+  static_cast<StringMeasure*>(expression)->op = StringMeasureOp(op);
+}
+BinaryenExpressionRef BinaryenStringMeasureGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringMeasure>());
+  return static_cast<StringMeasure*>(expression)->ref;
+}
+void BinaryenStringMeasureSetRef(BinaryenExpressionRef expr,
+                                 BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringMeasure>());
+  static_cast<StringMeasure*>(expression)->ref = (Expression*)refExpr;
+}
+// StringEncode
+BinaryenOp BinaryenStringEncodeGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  return static_cast<StringEncode*>(expression)->op;
+}
+void BinaryenStringEncodeSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  static_cast<StringEncode*>(expression)->op = StringEncodeOp(op);
+}
+BinaryenExpressionRef BinaryenStringEncodeGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  return static_cast<StringEncode*>(expression)->ref;
+}
+void BinaryenStringEncodeSetRef(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  static_cast<StringEncode*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef BinaryenStringEncodeGetPtr(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  return static_cast<StringEncode*>(expression)->ptr;
+}
+void BinaryenStringEncodeSetPtr(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef ptrExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  static_cast<StringEncode*>(expression)->ptr = (Expression*)ptrExpr;
+}
+BinaryenExpressionRef BinaryenStringEncodeGetStart(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  return static_cast<StringEncode*>(expression)->start;
+}
+void BinaryenStringEncodeSetStart(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef startExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEncode>());
+  static_cast<StringEncode*>(expression)->start = (Expression*)startExpr;
+}
+// StringConcat
+BinaryenExpressionRef BinaryenStringConcatGetLeft(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringConcat>());
+  return static_cast<StringConcat*>(expression)->left;
+}
+void BinaryenStringConcatSetLeft(BinaryenExpressionRef expr,
+                                 BinaryenExpressionRef leftExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringConcat>());
+  static_cast<StringConcat*>(expression)->left = (Expression*)leftExpr;
+}
+BinaryenExpressionRef BinaryenStringConcatGetRight(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringConcat>());
+  return static_cast<StringConcat*>(expression)->right;
+}
+void BinaryenStringConcatSetRight(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef rightExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringConcat>());
+  static_cast<StringConcat*>(expression)->right = (Expression*)rightExpr;
+}
+// StringEq
+BinaryenExpressionRef BinaryenStringEqGetLeft(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEq>());
+  return static_cast<StringEq*>(expression)->left;
+}
+void BinaryenStringEqSetLeft(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef leftExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEq>());
+  static_cast<StringEq*>(expression)->left = (Expression*)leftExpr;
+}
+BinaryenExpressionRef BinaryenStringEqGetRight(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEq>());
+  return static_cast<StringEq*>(expression)->right;
+}
+void BinaryenStringEqSetRight(BinaryenExpressionRef expr,
+                              BinaryenExpressionRef rightExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringEq>());
+  static_cast<StringEq*>(expression)->right = (Expression*)rightExpr;
+}
+// StringAs
+BinaryenOp BinaryenStringAsGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringAs>());
+  return static_cast<StringAs*>(expression)->op;
+}
+void BinaryenStringAsSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringAs>());
+  static_cast<StringAs*>(expression)->op = StringAsOp(op);
+}
+BinaryenExpressionRef BinaryenStringAsGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringAs>());
+  return static_cast<StringAs*>(expression)->ref;
+}
+void BinaryenStringAsSetRef(BinaryenExpressionRef expr,
+                            BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringAs>());
+  static_cast<StringAs*>(expression)->ref = (Expression*)refExpr;
+}
+// StringWTF8Advance
+BinaryenExpressionRef
+BinaryenStringWTF8AdvanceGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF8Advance>());
+  return static_cast<StringWTF8Advance*>(expression)->ref;
+}
+void BinaryenStringWTF8AdvanceSetRef(BinaryenExpressionRef expr,
+                                     BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF8Advance>());
+  static_cast<StringWTF8Advance*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef
+BinaryenStringWTF8AdvanceGetPos(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF8Advance>());
+  return static_cast<StringWTF8Advance*>(expression)->pos;
+}
+void BinaryenStringWTF8AdvanceSetPos(BinaryenExpressionRef expr,
+                                     BinaryenExpressionRef posExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF8Advance>());
+  static_cast<StringWTF8Advance*>(expression)->pos = (Expression*)posExpr;
+}
+BinaryenExpressionRef
+BinaryenStringWTF8AdvanceGetBytes(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF8Advance>());
+  return static_cast<StringWTF8Advance*>(expression)->bytes;
+}
+void BinaryenStringWTF8AdvanceSetBytes(BinaryenExpressionRef expr,
+                                       BinaryenExpressionRef bytesExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF8Advance>());
+  static_cast<StringWTF8Advance*>(expression)->bytes = (Expression*)bytesExpr;
+}
+// StringWTF16Get
+BinaryenExpressionRef BinaryenStringWTF16GetGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF16Get>());
+  return static_cast<StringWTF16Get*>(expression)->ref;
+}
+void BinaryenStringWTF16GetSetRef(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF16Get>());
+  static_cast<StringWTF16Get*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef BinaryenStringWTF16GetGetPos(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF16Get>());
+  return static_cast<StringWTF16Get*>(expression)->pos;
+}
+void BinaryenStringWTF16GetSetPos(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef posExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringWTF16Get>());
+  static_cast<StringWTF16Get*>(expression)->pos = (Expression*)posExpr;
+}
+// StringIterNext
+BinaryenExpressionRef BinaryenStringIterNextGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterNext>());
+  return static_cast<StringIterNext*>(expression)->ref;
+}
+void BinaryenStringIterNextSetRef(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterNext>());
+  static_cast<StringIterNext*>(expression)->ref = (Expression*)refExpr;
+}
+// StringIterMove
+BinaryenOp BinaryenStringIterMoveGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterMove>());
+  return static_cast<StringIterMove*>(expression)->op;
+}
+void BinaryenStringIterMoveSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterMove>());
+  static_cast<StringIterMove*>(expression)->op = StringIterMoveOp(op);
+}
+BinaryenExpressionRef BinaryenStringIterMoveGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterMove>());
+  return static_cast<StringIterMove*>(expression)->ref;
+}
+void BinaryenStringIterMoveSetRef(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterMove>());
+  static_cast<StringIterMove*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef BinaryenStringIterMoveGetNum(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterMove>());
+  return static_cast<StringIterMove*>(expression)->num;
+}
+void BinaryenStringIterMoveSetNum(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef numExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringIterMove>());
+  static_cast<StringIterMove*>(expression)->num = (Expression*)numExpr;
+}
+// StringSliceWTF
+BinaryenOp BinaryenStringSliceWTFGetOp(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  return static_cast<StringSliceWTF*>(expression)->op;
+}
+void BinaryenStringSliceWTFSetOp(BinaryenExpressionRef expr, BinaryenOp op) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  static_cast<StringSliceWTF*>(expression)->op = StringSliceWTFOp(op);
+}
+BinaryenExpressionRef BinaryenStringSliceWTFGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  return static_cast<StringSliceWTF*>(expression)->ref;
+}
+void BinaryenStringSliceWTFSetRef(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  static_cast<StringSliceWTF*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef
+BinaryenStringSliceWTFGetStart(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  return static_cast<StringSliceWTF*>(expression)->start;
+}
+void BinaryenStringSliceWTFSetStart(BinaryenExpressionRef expr,
+                                    BinaryenExpressionRef startExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  static_cast<StringSliceWTF*>(expression)->start = (Expression*)startExpr;
+}
+BinaryenExpressionRef BinaryenStringSliceWTFGetEnd(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  return static_cast<StringSliceWTF*>(expression)->end;
+}
+void BinaryenStringSliceWTFSetEnd(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef endExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceWTF>());
+  static_cast<StringSliceWTF*>(expression)->end = (Expression*)endExpr;
+}
+// StringSliceIter
+BinaryenExpressionRef
+BinaryenStringSliceIterGetRef(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceIter>());
+  return static_cast<StringSliceIter*>(expression)->ref;
+}
+void BinaryenStringSliceIterSetRef(BinaryenExpressionRef expr,
+                                   BinaryenExpressionRef refExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceIter>());
+  static_cast<StringSliceIter*>(expression)->ref = (Expression*)refExpr;
+}
+BinaryenExpressionRef
+BinaryenStringSliceIterGetNum(BinaryenExpressionRef expr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceIter>());
+  return static_cast<StringSliceIter*>(expression)->num;
+}
+void BinaryenStringSliceIterSetNum(BinaryenExpressionRef expr,
+                                   BinaryenExpressionRef numExpr) {
+  auto* expression = (Expression*)expr;
+  assert(expression->is<StringSliceIter>());
+  static_cast<StringSliceIter*>(expression)->num = (Expression*)numExpr;
+}
 
 // Functions
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2285,6 +2285,378 @@ BINARYEN_API bool BinaryenI31GetIsSigned(BinaryenExpressionRef expr);
 BINARYEN_API void BinaryenI31GetSetSigned(BinaryenExpressionRef expr,
                                           bool signed_);
 
+// CallRef
+
+BINARYEN_API BinaryenIndex
+BinaryenCallRefGetNumOperands(BinaryenExpressionRef expr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenCallRefGetOperandAt(BinaryenExpressionRef expr, BinaryenIndex index);
+BINARYEN_API void
+BinaryenCallRefSetOperandAt(BinaryenExpressionRef expr,
+                            BinaryenIndex index,
+                            BinaryenExpressionRef operandExpr);
+BINARYEN_API BinaryenIndex BinaryenCallRefAppendOperand(
+  BinaryenExpressionRef expr, BinaryenExpressionRef operandExpr);
+BINARYEN_API void
+BinaryenCallRefInsertOperandAt(BinaryenExpressionRef expr,
+                               BinaryenIndex index,
+                               BinaryenExpressionRef operandExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenCallRefRemoveOperandAt(BinaryenExpressionRef expr, BinaryenIndex index);
+BINARYEN_API BinaryenExpressionRef
+BinaryenCallRefGetTarget(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenCallRefSetTarget(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef targetExpr);
+BINARYEN_API bool BinaryenCallRefIsReturn(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenCallRefSetReturn(BinaryenExpressionRef expr,
+                                           bool isReturn);
+
+// RefTest
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenRefTestGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenRefTestSetRef(BinaryenExpressionRef expr,
+                                        BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenHeapType
+BinaryenRefTestGetIntendedType(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenRefTestSetIntendedType(BinaryenExpressionRef expr,
+                                                 BinaryenHeapType intendedType);
+
+// RefCast
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenRefCastGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenRefCastSetRef(BinaryenExpressionRef expr,
+                                        BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenHeapType
+BinaryenRefCastGetIntendedType(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenRefCastSetIntendedType(BinaryenExpressionRef expr,
+                                                 BinaryenHeapType intendedType);
+
+// BrOn
+
+BINARYEN_API BinaryenOp BinaryenBrOnGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenBrOnSetOp(BinaryenExpressionRef expr, BinaryenOp op);
+BINARYEN_API const char* BinaryenBrOnGetName(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenBrOnSetName(BinaryenExpressionRef expr,
+                                      const char* nameStr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenBrOnGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenBrOnSetRef(BinaryenExpressionRef expr,
+                                     BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenHeapType
+BinaryenBrOnGetIntendedType(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenBrOnSetIntendedType(BinaryenExpressionRef expr,
+                                              BinaryenHeapType intendedType);
+
+// StructNew
+
+BINARYEN_API BinaryenIndex
+BinaryenStructNewGetNumOperands(BinaryenExpressionRef expr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStructNewGetOperandAt(BinaryenExpressionRef expr, BinaryenIndex index);
+BINARYEN_API void
+BinaryenStructNewSetOperandAt(BinaryenExpressionRef expr,
+                              BinaryenIndex index,
+                              BinaryenExpressionRef operandExpr);
+BINARYEN_API BinaryenIndex BinaryenStructNewAppendOperand(
+  BinaryenExpressionRef expr, BinaryenExpressionRef operandExpr);
+BINARYEN_API void
+BinaryenStructNewInsertOperandAt(BinaryenExpressionRef expr,
+                                 BinaryenIndex index,
+                                 BinaryenExpressionRef operandExpr);
+BINARYEN_API BinaryenExpressionRef BinaryenStructNewRemoveOperandAt(
+  BinaryenExpressionRef expr, BinaryenIndex index);
+
+// StructGet
+
+BINARYEN_API BinaryenIndex
+BinaryenStructGetGetIndex(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStructGetSetIndex(BinaryenExpressionRef expr,
+                                            BinaryenIndex index);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStructGetGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStructGetSetRef(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef refExpr);
+BINARYEN_API bool BinaryenStructGetIsSigned(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStructGetSetSigned(BinaryenExpressionRef expr,
+                                             bool signed_);
+
+// StructSet
+
+BINARYEN_API BinaryenIndex
+BinaryenStructSetGetIndex(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStructSetSetIndex(BinaryenExpressionRef expr,
+                                            BinaryenIndex index);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStructSetGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStructSetSetRef(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStructSetGetValue(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStructSetSetValue(BinaryenExpressionRef expr,
+                                            BinaryenExpressionRef valueExpr);
+
+// ArrayNew
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayNewGetInit(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayNewSetInit(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef initExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayNewGetSize(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayNewSetSize(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef sizeExpr);
+
+// ArrayInit
+
+BINARYEN_API BinaryenIndex
+BinaryenArrayInitGetNumValues(BinaryenExpressionRef expr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayInitGetValueAt(BinaryenExpressionRef expr, BinaryenIndex index);
+BINARYEN_API void BinaryenArrayInitSetValueAt(BinaryenExpressionRef expr,
+                                              BinaryenIndex index,
+                                              BinaryenExpressionRef valueExpr);
+BINARYEN_API BinaryenIndex BinaryenArrayInitAppendValue(
+  BinaryenExpressionRef expr, BinaryenExpressionRef valueExpr);
+BINARYEN_API void
+BinaryenArrayInitInsertValueAt(BinaryenExpressionRef expr,
+                               BinaryenIndex index,
+                               BinaryenExpressionRef valueExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayInitRemoveValueAt(BinaryenExpressionRef expr, BinaryenIndex index);
+
+// ArrayGet
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayGetGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayGetSetRef(BinaryenExpressionRef expr,
+                                         BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayGetGetIndex(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayGetSetIndex(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef indexExpr);
+BINARYEN_API bool BinaryenArrayGetIsSigned(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayGetSetSigned(BinaryenExpressionRef expr,
+                                            bool signed_);
+
+// ArraySet
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenArraySetGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArraySetSetRef(BinaryenExpressionRef expr,
+                                         BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArraySetGetIndex(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArraySetSetIndex(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef indexExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArraySetGetValue(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArraySetSetValue(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef valueExpr);
+
+// ArrayLen
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayLenGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayLenSetRef(BinaryenExpressionRef expr,
+                                         BinaryenExpressionRef refExpr);
+
+// ArrayCopy
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayCopyGetDestRef(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenArrayCopySetDestRef(BinaryenExpressionRef expr,
+                            BinaryenExpressionRef destRefExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayCopyGetDestIndex(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenArrayCopySetDestIndex(BinaryenExpressionRef expr,
+                              BinaryenExpressionRef destIndexExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayCopyGetSrcRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayCopySetSrcRef(BinaryenExpressionRef expr,
+                                             BinaryenExpressionRef srcRefExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayCopyGetSrcIndex(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenArrayCopySetSrcIndex(BinaryenExpressionRef expr,
+                             BinaryenExpressionRef srcIndexExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenArrayCopyGetLength(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenArrayCopySetLength(BinaryenExpressionRef expr,
+                                             BinaryenExpressionRef lengthExpr);
+
+// StringNew
+
+BINARYEN_API BinaryenOp BinaryenStringNewGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringNewSetOp(BinaryenExpressionRef expr,
+                                         BinaryenOp op);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringNewGetPtr(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringNewSetPtr(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef ptrExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringNewGetLength(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringNewSetLength(BinaryenExpressionRef expr,
+                                             BinaryenExpressionRef lengthExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringNewGetStart(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringNewSetStart(BinaryenExpressionRef expr,
+                                            BinaryenExpressionRef startExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringNewGetEnd(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringNewSetEnd(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef endExpr);
+
+// StringConst
+
+BINARYEN_API const char*
+BinaryenStringConstGetString(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringConstSetString(BinaryenExpressionRef expr,
+                                               const char* stringStr);
+
+// StringMeasure
+
+BINARYEN_API BinaryenOp BinaryenStringMeasureGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringMeasureSetOp(BinaryenExpressionRef expr,
+                                             BinaryenOp op);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringMeasureGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringMeasureSetRef(BinaryenExpressionRef expr,
+                                              BinaryenExpressionRef refExpr);
+
+// StringEncode
+
+BINARYEN_API BinaryenOp BinaryenStringEncodeGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringEncodeSetOp(BinaryenExpressionRef expr,
+                                            BinaryenOp op);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEncodeGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringEncodeSetRef(BinaryenExpressionRef expr,
+                                             BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEncodeGetPtr(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringEncodeSetPtr(BinaryenExpressionRef expr,
+                                             BinaryenExpressionRef ptrExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEncodeGetStart(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringEncodeSetStart(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef startExpr);
+
+// StringConcat
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringConcatGetLeft(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringConcatSetLeft(BinaryenExpressionRef expr,
+                                              BinaryenExpressionRef leftExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringConcatGetRight(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringConcatSetRight(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef rightExpr);
+
+// StringEq
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEqGetLeft(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringEqSetLeft(BinaryenExpressionRef expr,
+                                          BinaryenExpressionRef leftExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringEqGetRight(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringEqSetRight(BinaryenExpressionRef expr,
+                                           BinaryenExpressionRef rightExpr);
+
+// StringAs
+
+BINARYEN_API BinaryenOp BinaryenStringAsGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringAsSetOp(BinaryenExpressionRef expr,
+                                        BinaryenOp op);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringAsGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringAsSetRef(BinaryenExpressionRef expr,
+                                         BinaryenExpressionRef refExpr);
+
+// StringWTF8Advance
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF8AdvanceGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenStringWTF8AdvanceSetRef(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF8AdvanceGetPos(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenStringWTF8AdvanceSetPos(BinaryenExpressionRef expr,
+                                BinaryenExpressionRef posExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF8AdvanceGetBytes(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenStringWTF8AdvanceSetBytes(BinaryenExpressionRef expr,
+                                  BinaryenExpressionRef bytesExpr);
+
+// StringWTF16Get
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF16GetGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringWTF16GetSetRef(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringWTF16GetGetPos(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringWTF16GetSetPos(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef posExpr);
+
+// StringIterNext
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringIterNextGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringIterNextSetRef(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef refExpr);
+
+// StringIterMove
+
+BINARYEN_API BinaryenOp BinaryenStringIterMoveGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringIterMoveSetOp(BinaryenExpressionRef expr,
+                                              BinaryenOp op);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringIterMoveGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringIterMoveSetRef(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringIterMoveGetNum(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringIterMoveSetNum(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef numExpr);
+
+// StringSliceWTF
+
+BINARYEN_API BinaryenOp BinaryenStringSliceWTFGetOp(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringSliceWTFSetOp(BinaryenExpressionRef expr,
+                                              BinaryenOp op);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceWTFGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringSliceWTFSetRef(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceWTFGetStart(BinaryenExpressionRef expr);
+BINARYEN_API void
+BinaryenStringSliceWTFSetStart(BinaryenExpressionRef expr,
+                               BinaryenExpressionRef startExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceWTFGetEnd(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringSliceWTFSetEnd(BinaryenExpressionRef expr,
+                                               BinaryenExpressionRef endExpr);
+
+// StringSliceIter
+
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceIterGetRef(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringSliceIterSetRef(BinaryenExpressionRef expr,
+                                                BinaryenExpressionRef refExpr);
+BINARYEN_API BinaryenExpressionRef
+BinaryenStringSliceIterGetNum(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenStringSliceIterSetNum(BinaryenExpressionRef expr,
+                                                BinaryenExpressionRef numExpr);
+
 // Functions
 
 BINARYEN_REF(Function);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -997,6 +997,13 @@ BINARYEN_API BinaryenExpressionRef BinaryenI31Get(BinaryenModuleRef module,
                                                   BinaryenExpressionRef i31,
                                                   bool signed_);
 BINARYEN_API BinaryenExpressionRef
+BinaryenCallRef(BinaryenModuleRef module,
+                BinaryenExpressionRef target,
+                BinaryenExpressionRef* operands,
+                BinaryenIndex numOperands,
+                BinaryenType type,
+                bool isReturn);
+BINARYEN_API BinaryenExpressionRef
 BinaryenRefTest(BinaryenModuleRef module,
                 BinaryenExpressionRef ref,
                 BinaryenHeapType intendedType);


### PR DESCRIPTION
Covers `CallRef`, `RefTest`, `RefCast`, `BrOn`, `StructNew`, `StructGet`, `StructSet`, `ArrayNew`, `ArrayInit`, `ArrayGet`, `ArraySet`, `ArrayLen`, `ArrayCopy`, `StringNew`, `StringConst`, `StringMeasure`, `StringEncode`, `StringConcat`, `StringEq`, `StringAs`, `StringWTF8Advance`, `StringWTF16Get`, `StringIterNext`, `StringIterMove`, `StringSliceWTF`, `StringSliceIter`.