### PR TITLE
JPSI - Support re-entering a suspended Wasm module.

### DIFF
--- a/test/lit/passes/jspi.wast
+++ b/test/lit/passes/jspi.wast
@@ -14,10 +14,16 @@
 
   ;; CHECK:      (type $i32_=>_i32 (func (param i32) (result i32)))
 
+  ;; CHECK:      (type $i32_=>_none (func (param i32)))
+
+  ;; CHECK:      (type $externref_i32_=>_none (func (param externref i32)))
+
   ;; CHECK:      (import "js" "compute_delta" (func $import$compute_delta (param externref f64) (result i32)))
   (import "js" "compute_delta" (func $compute_delta (param f64) (result i32)))
   ;; CHECK:      (import "js" "import_and_export" (func $import$import_and_export (param externref i32) (result i32)))
   (import "js" "import_and_export" (func $import_and_export (param i32) (result i32)))
+  ;; CHECK:      (import "js" "import_void_return" (func $import$import_void_return (param externref i32)))
+  (import "js" "import_void_return" (func $import_void_return (param i32)))
   ;; CHECK:      (global $suspender (mut externref) (ref.null extern))
 
   ;; CHECK:      (export "update_state_void" (func $export$update_state_void))
@@ -110,15 +116,51 @@
 ;; CHECK-NEXT: )
 
 ;; CHECK:      (func $compute_delta (param $0 f64) (result i32)
-;; CHECK-NEXT:  (call $import$compute_delta
+;; CHECK-NEXT:  (local $1 externref)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $1
 ;; CHECK-NEXT:   (global.get $suspender)
-;; CHECK-NEXT:   (local.get $0)
 ;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (call $import$compute_delta
+;; CHECK-NEXT:    (global.get $suspender)
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (global.set $suspender
+;; CHECK-NEXT:   (local.get $1)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (local.get $2)
 ;; CHECK-NEXT: )
 
 ;; CHECK:      (func $import_and_export (param $0 i32) (result i32)
-;; CHECK-NEXT:  (call $import$import_and_export
+;; CHECK-NEXT:  (local $1 externref)
+;; CHECK-NEXT:  (local $2 i32)
+;; CHECK-NEXT:  (local.set $1
+;; CHECK-NEXT:   (global.get $suspender)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (local.set $2
+;; CHECK-NEXT:   (call $import$import_and_export
+;; CHECK-NEXT:    (global.get $suspender)
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (global.set $suspender
+;; CHECK-NEXT:   (local.get $1)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (local.get $2)
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $import_void_return (param $0 i32)
+;; CHECK-NEXT:  (local $1 externref)
+;; CHECK-NEXT:  (local.set $1
+;; CHECK-NEXT:   (global.get $suspender)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (call $import$import_void_return
 ;; CHECK-NEXT:   (global.get $suspender)
 ;; CHECK-NEXT:   (local.get $0)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (global.set $suspender
+;; CHECK-NEXT:   (local.get $1)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )


### PR DESCRIPTION
Fixes: https://github.com/emscripten-core/emscripten/issues/17846

More detailed explanation of the issue from Thibaud:
- A promising export is entered, generating a suspender s1, which is stored in the global
- The wasm code calls a wrapped import, passing it the value in the global (s1) and suspends
- Another export is entered, generating suspender s2, which is stored in the global
- We call another wrapped import, which suspends s2 (so far so good)
- We return to the event loop and s1 is resumed

And now we are in an inconsistent state: the active suspender is "s1", but the object in the global is "s2". So the next time we call a wrapped import, there is a mismatch, which is what this runtime error reports.