### PR TITLE
Temporarily restore the typed-function-references flags as no-ops

### DIFF
--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -99,7 +99,7 @@ struct ToolOptions : public Options {
            "Deprecated compatibility flag",
            ToolOptionsCategory,
            Options::Arguments::Zero,
-           [this](Options* o, const std::string& argument) {
+           [](Options* o, const std::string& argument) {
              std::cerr
                << "Warning: Typed function references have been made part of "
                   "GC and --enable-typed-function-references is deprecated\n";
@@ -109,7 +109,7 @@ struct ToolOptions : public Options {
            "Deprecated compatibility flag",
            ToolOptionsCategory,
            Options::Arguments::Zero,
-           [this](Options* o, const std::string& argument) {
+           [](Options* o, const std::string& argument) {
              std::cerr
                << "Warning: Typed function references have been made part of "
                   "GC and --disable-typed-function-references is deprecated\n";

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -94,6 +94,26 @@ struct ToolOptions : public Options {
       .addFeature(FeatureSet::ExtendedConst, "extended const expressions")
       .addFeature(FeatureSet::Strings, "strings")
       .addFeature(FeatureSet::MultiMemories, "multi-memories")
+      .add("--enable-typed-function-references",
+           "",
+           "Deprecated compatibility flag",
+           ToolOptionsCategory,
+           Options::Arguments::Zero,
+           [this](Options* o, const std::string& argument) {
+             std::cerr
+               << "Warning: Typed function references have been made part of "
+                  "GC and --enable-typed-function-references is deprecated\n";
+           })
+      .add("--disable-typed-function-references",
+           "",
+           "Deprecated compatibility flag",
+           ToolOptionsCategory,
+           Options::Arguments::Zero,
+           [this](Options* o, const std::string& argument) {
+             std::cerr
+               << "Warning: Typed function references have been made part of "
+                  "GC and --disable-typed-function-references is deprecated\n";
+           })
       .add("--no-validation",
            "-n",
            "Disables validation, assumes inputs are correct",

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -10,127 +10,133 @@
 ;; CHECK-NEXT: wasm-as options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                         Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --validate,-v                       Control validation of the output module
+;; CHECK-NEXT:   --validate,-v                        Control validation of the output module
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debuginfo,-g                      Emit names section and debug info
+;; CHECK-NEXT:   --debuginfo,-g                       Emit names section and debug info
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --source-map,-sm                    Emit source map to the specified file
+;; CHECK-NEXT:   --source-map,-sm                     Emit source map to the specified file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --source-map-url,-su                Use specified string as source map URL
+;; CHECK-NEXT:   --source-map-url,-su                 Use specified string as source map URL
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --symbolmap,-s                      Emit a symbol map (indexes => names)
+;; CHECK-NEXT:   --symbolmap,-s                       Emit a symbol map (indexes => names)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -9,132 +9,138 @@
 ;; CHECK-NEXT: wasm-ctor-eval options:
 ;; CHECK-NEXT: -----------------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                         Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-text,-S                      Emit text instead of binary for the output
-;; CHECK-NEXT:                                       file
+;; CHECK-NEXT:   --emit-text,-S                       Emit text instead of binary for the
+;; CHECK-NEXT:                                        output file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debuginfo,-g                      Emit names section and debug info
+;; CHECK-NEXT:   --debuginfo,-g                       Emit names section and debug info
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --ctors,-c                          Comma-separated list of global constructor
-;; CHECK-NEXT:                                       functions to evaluate
+;; CHECK-NEXT:   --ctors,-c                           Comma-separated list of global
+;; CHECK-NEXT:                                        constructor functions to evaluate
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --kept-exports,-ke                  Comma-separated list of ctors whose
-;; CHECK-NEXT:                                       exports we keep around even if we eval
-;; CHECK-NEXT:                                       those ctors
+;; CHECK-NEXT:   --kept-exports,-ke                   Comma-separated list of ctors whose
+;; CHECK-NEXT:                                        exports we keep around even if we eval
+;; CHECK-NEXT:                                        those ctors
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --ignore-external-input,-ipi        Assumes no env vars are to be read, stdin
-;; CHECK-NEXT:                                       is empty, etc.
+;; CHECK-NEXT:   --ignore-external-input,-ipi         Assumes no env vars are to be read, stdin
+;; CHECK-NEXT:                                        is empty, etc.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -10,120 +10,126 @@
 ;; CHECK-NEXT: wasm-dis options:
 ;; CHECK-NEXT: -----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                         Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --source-map,-sm                    Consume source map from the specified file
-;; CHECK-NEXT:                                       to add location information
+;; CHECK-NEXT:   --source-map,-sm                     Consume source map from the specified
+;; CHECK-NEXT:                                        file to add location information
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -9,53 +9,54 @@
 ;; CHECK-NEXT: wasm-emscripten-finalize options:
 ;; CHECK-NEXT: ---------------------------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                         Output file
+;; CHECK-NEXT:   --output,-o                          Output file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debuginfo,-g                      Emit names section in wasm binary (or full
-;; CHECK-NEXT:                                       debuginfo in wast)
+;; CHECK-NEXT:   --debuginfo,-g                       Emit names section in wasm binary (or
+;; CHECK-NEXT:                                        full debuginfo in wast)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --dwarf                             Update DWARF debug info
+;; CHECK-NEXT:   --dwarf                              Update DWARF debug info
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-text,-S                      Emit text instead of binary for the output
-;; CHECK-NEXT:                                       file. In this mode if no output file is
-;; CHECK-NEXT:                                       specified, we write to stdout.
+;; CHECK-NEXT:   --emit-text,-S                       Emit text instead of binary for the
+;; CHECK-NEXT:                                        output file. In this mode if no output
+;; CHECK-NEXT:                                        file is specified, we write to stdout.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --global-base                       The address at which static globals were
-;; CHECK-NEXT:                                       placed
+;; CHECK-NEXT:   --global-base                        The address at which static globals were
+;; CHECK-NEXT:                                        placed
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --side-module                       Input is an emscripten side module
+;; CHECK-NEXT:   --side-module                        Input is an emscripten side module
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --input-source-map,-ism             Consume source map from the specified file
+;; CHECK-NEXT:   --input-source-map,-ism              Consume source map from the specified
+;; CHECK-NEXT:                                        file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-legalize-javascript-ffi,-nj    Do not fully legalize (i64->i32, f32->f64)
-;; CHECK-NEXT:                                       the imports and exports for interfacing
-;; CHECK-NEXT:                                       with JS
+;; CHECK-NEXT:   --no-legalize-javascript-ffi,-nj     Do not fully legalize (i64->i32,
+;; CHECK-NEXT:                                        f32->f64) the imports and exports for
+;; CHECK-NEXT:                                        interfacing with JS
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --bigint,-bi                        Assume JS will use wasm/JS BigInt
-;; CHECK-NEXT:                                       integration, so wasm i64s will turn into
-;; CHECK-NEXT:                                       JS BigInts, and there is no need for any
-;; CHECK-NEXT:                                       legalization at all (not even minimal
-;; CHECK-NEXT:                                       legalization of dynCalls)
+;; CHECK-NEXT:   --bigint,-bi                         Assume JS will use wasm/JS BigInt
+;; CHECK-NEXT:                                        integration, so wasm i64s will turn into
+;; CHECK-NEXT:                                        JS BigInts, and there is no need for any
+;; CHECK-NEXT:                                        legalization at all (not even minimal
+;; CHECK-NEXT:                                        legalization of dynCalls)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output-source-map,-osm            Emit source map to the specified file
+;; CHECK-NEXT:   --output-source-map,-osm             Emit source map to the specified file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output-source-map-url,-osu        Emit specified string as source map URL
+;; CHECK-NEXT:   --output-source-map-url,-osu         Emit specified string as source map URL
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --separate-data-segments            Separate data segments to a file
+;; CHECK-NEXT:   --separate-data-segments             Separate data segments to a file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --check-stack-overflow              Check for stack overflows every time the
-;; CHECK-NEXT:                                       stack is extended
+;; CHECK-NEXT:   --check-stack-overflow               Check for stack overflows every time the
+;; CHECK-NEXT:                                        stack is extended
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --standalone-wasm                   Emit a wasm file that does not depend on
-;; CHECK-NEXT:                                       JS, as much as possible, using wasi and
-;; CHECK-NEXT:                                       other standard conventions etc. where
-;; CHECK-NEXT:                                       possible
+;; CHECK-NEXT:   --standalone-wasm                    Emit a wasm file that does not depend on
+;; CHECK-NEXT:                                        JS, as much as possible, using wasi and
+;; CHECK-NEXT:                                        other standard conventions etc. where
+;; CHECK-NEXT:                                        possible
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --minimize-wasm-changes             Modify the wasm as little as possible.
-;; CHECK-NEXT:                                       This is useful during development as we
-;; CHECK-NEXT:                                       reduce the number of changes to the wasm,
-;; CHECK-NEXT:                                       as it lets emscripten control how much
-;; CHECK-NEXT:                                       modifications to do.
+;; CHECK-NEXT:   --minimize-wasm-changes              Modify the wasm as little as possible.
+;; CHECK-NEXT:                                        This is useful during development as we
+;; CHECK-NEXT:                                        reduce the number of changes to the wasm,
+;; CHECK-NEXT:                                        as it lets emscripten control how much
+;; CHECK-NEXT:                                        modifications to do.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --no-dyncalls
 ;; CHECK-NEXT:
@@ -65,111 +66,117 @@
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -51,127 +51,133 @@
 ;; CHECK-NEXT: wasm-opt options:
 ;; CHECK-NEXT: -----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                         Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-text,-S                      Emit text instead of binary for the output
-;; CHECK-NEXT:                                       file
+;; CHECK-NEXT:   --emit-text,-S                       Emit text instead of binary for the
+;; CHECK-NEXT:                                        output file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debuginfo,-g                      Emit names section and debug info
+;; CHECK-NEXT:   --debuginfo,-g                       Emit names section and debug info
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --graph-file,-f                     Filename of the graph description file
+;; CHECK-NEXT:   --graph-file,-f                      Filename of the graph description file
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --dump,-d                           Dump the combined graph file (useful for
-;; CHECK-NEXT:                                       debugging)
+;; CHECK-NEXT:   --dump,-d                            Dump the combined graph file (useful for
+;; CHECK-NEXT:                                        debugging)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -630,6 +630,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-multi-memories                      Disable multi-memories
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --no-validation,-n                            Disables validation, assumes
 ;; CHECK-NEXT:                                                 inputs are correct
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -10,155 +10,162 @@
 ;; CHECK-NEXT: wasm-reduce options:
 ;; CHECK-NEXT: --------------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --command,-cmd                      The command to run on the test, that we
-;; CHECK-NEXT:                                       want to reduce while keeping the command's
-;; CHECK-NEXT:                                       output identical. We look at the command's
-;; CHECK-NEXT:                                       return code and stdout here (TODO:
-;; CHECK-NEXT:                                       stderr), and we reduce while keeping those
-;; CHECK-NEXT:                                       unchanged.
+;; CHECK-NEXT:   --command,-cmd                       The command to run on the test, that we
+;; CHECK-NEXT:                                        want to reduce while keeping the
+;; CHECK-NEXT:                                        command's output identical. We look at
+;; CHECK-NEXT:                                        the command's return code and stdout here
+;; CHECK-NEXT:                                        (TODO: stderr), and we reduce while
+;; CHECK-NEXT:                                        keeping those unchanged.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --test,-t                           Test file (this will be written to to
-;; CHECK-NEXT:                                       test, the given command should read it
-;; CHECK-NEXT:                                       when we call it)
+;; CHECK-NEXT:   --test,-t                            Test file (this will be written to to
+;; CHECK-NEXT:                                        test, the given command should read it
+;; CHECK-NEXT:                                        when we call it)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --working,-w                        Working file (this will contain the
-;; CHECK-NEXT:                                       current good state while doing temporary
-;; CHECK-NEXT:                                       computations, and will contain the final
-;; CHECK-NEXT:                                       best result at the end)
+;; CHECK-NEXT:   --working,-w                         Working file (this will contain the
+;; CHECK-NEXT:                                        current good state while doing temporary
+;; CHECK-NEXT:                                        computations, and will contain the final
+;; CHECK-NEXT:                                        best result at the end)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --binaries,-b                       binaryen binaries location (bin/
-;; CHECK-NEXT:                                       directory)
+;; CHECK-NEXT:   --binaries,-b                        binaryen binaries location (bin/
+;; CHECK-NEXT:                                        directory)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --text,-S                           Emit intermediate files as text, instead
-;; CHECK-NEXT:                                       of binary (also make sure the test and
-;; CHECK-NEXT:                                       working files have a .wat or .wast suffix)
+;; CHECK-NEXT:   --text,-S                            Emit intermediate files as text, instead
+;; CHECK-NEXT:                                        of binary (also make sure the test and
+;; CHECK-NEXT:                                        working files have a .wat or .wast
+;; CHECK-NEXT:                                        suffix)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --denan                             Avoid nans when reducing
+;; CHECK-NEXT:   --denan                              Avoid nans when reducing
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --verbose,-v                        Verbose output mode
+;; CHECK-NEXT:   --verbose,-v                         Verbose output mode
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debugInfo,-g                      Keep debug info in binaries
+;; CHECK-NEXT:   --debugInfo,-g                       Keep debug info in binaries
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --force,-f                          Force the reduction attempt, ignoring
-;; CHECK-NEXT:                                       problems that imply it is unlikely to
-;; CHECK-NEXT:                                       succeed
+;; CHECK-NEXT:   --force,-f                           Force the reduction attempt, ignoring
+;; CHECK-NEXT:                                        problems that imply it is unlikely to
+;; CHECK-NEXT:                                        succeed
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --timeout,-to                       A timeout to apply to each execution of
-;; CHECK-NEXT:                                       the command, in seconds (default: 2)
+;; CHECK-NEXT:   --timeout,-to                        A timeout to apply to each execution of
+;; CHECK-NEXT:                                        the command, in seconds (default: 2)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --extra-flags,-ef                   Extra commandline flags to pass to
-;; CHECK-NEXT:                                       wasm-opt while reducing. (default:
-;; CHECK-NEXT:                                       --enable-all)
+;; CHECK-NEXT:   --extra-flags,-ef                    Extra commandline flags to pass to
+;; CHECK-NEXT:                                        wasm-opt while reducing. (default:
+;; CHECK-NEXT:                                        --enable-all)
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -12,234 +12,240 @@
 ;; CHECK-NEXT: wasm-split options:
 ;; CHECK-NEXT: -------------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --split                             Split an input module into two output
-;; CHECK-NEXT:                                       modules. The default mode.
+;; CHECK-NEXT:   --split                              Split an input module into two output
+;; CHECK-NEXT:                                        modules. The default mode.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --instrument                        Instrument an input module to allow it to
-;; CHECK-NEXT:                                       generate a profile that can be used to
-;; CHECK-NEXT:                                       guide splitting.
+;; CHECK-NEXT:   --instrument                         Instrument an input module to allow it to
+;; CHECK-NEXT:                                        generate a profile that can be used to
+;; CHECK-NEXT:                                        guide splitting.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --merge-profiles                    Merge multiple profiles for the same
-;; CHECK-NEXT:                                       module into a single profile.
+;; CHECK-NEXT:   --merge-profiles                     Merge multiple profiles for the same
+;; CHECK-NEXT:                                        module into a single profile.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --print-profile                     [print-profile] Print profile contents in
-;; CHECK-NEXT:                                       a human-readable format.
+;; CHECK-NEXT:   --print-profile                      [print-profile] Print profile contents in
+;; CHECK-NEXT:                                        a human-readable format.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --profile                           [split] The profile to use to guide
-;; CHECK-NEXT:                                       splitting.
+;; CHECK-NEXT:   --profile                            [split] The profile to use to guide
+;; CHECK-NEXT:                                        splitting.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --keep-funcs                        [split] Comma-separated list of functions
-;; CHECK-NEXT:                                       to keep in the primary module. The rest
-;; CHECK-NEXT:                                       will be split out. Cannot be used with
-;; CHECK-NEXT:                                       --profile or --split-funcs. You can also
-;; CHECK-NEXT:                                       pass a file with one function per line by
-;; CHECK-NEXT:                                       passing @filename.
+;; CHECK-NEXT:   --keep-funcs                         [split] Comma-separated list of functions
+;; CHECK-NEXT:                                        to keep in the primary module. The rest
+;; CHECK-NEXT:                                        will be split out. Cannot be used with
+;; CHECK-NEXT:                                        --profile or --split-funcs. You can also
+;; CHECK-NEXT:                                        pass a file with one function per line by
+;; CHECK-NEXT:                                        passing @filename.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --split-funcs                       [split] Comma-separated list of functions
-;; CHECK-NEXT:                                       to split out to the secondary module. The
-;; CHECK-NEXT:                                       rest will be kept. Cannot be used with
-;; CHECK-NEXT:                                       --profile or --keep-funcs. You can also
-;; CHECK-NEXT:                                       pass a file with one function per line by
-;; CHECK-NEXT:                                       passing @filename.
+;; CHECK-NEXT:   --split-funcs                        [split] Comma-separated list of functions
+;; CHECK-NEXT:                                        to split out to the secondary module. The
+;; CHECK-NEXT:                                        rest will be kept. Cannot be used with
+;; CHECK-NEXT:                                        --profile or --keep-funcs. You can also
+;; CHECK-NEXT:                                        pass a file with one function per line by
+;; CHECK-NEXT:                                        passing @filename.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --primary-output,-o1                [split] Output file for the primary
-;; CHECK-NEXT:                                       module.
+;; CHECK-NEXT:   --primary-output,-o1                 [split] Output file for the primary
+;; CHECK-NEXT:                                        module.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --secondary-output,-o2              [split] Output file for the secondary
-;; CHECK-NEXT:                                       module.
+;; CHECK-NEXT:   --secondary-output,-o2               [split] Output file for the secondary
+;; CHECK-NEXT:                                        module.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --symbolmap                         [split] Write a symbol map file for each
-;; CHECK-NEXT:                                       of the output modules.
+;; CHECK-NEXT:   --symbolmap                          [split] Write a symbol map file for each
+;; CHECK-NEXT:                                        of the output modules.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --placeholdermap                    [split] Write a file mapping placeholder
-;; CHECK-NEXT:                                       indices to the function names.
+;; CHECK-NEXT:   --placeholdermap                     [split] Write a file mapping placeholder
+;; CHECK-NEXT:                                        indices to the function names.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --import-namespace                  [split, instrument] When provided as an
-;; CHECK-NEXT:                                       option for module splitting, the namespace
-;; CHECK-NEXT:                                       from which to import objects from the
-;; CHECK-NEXT:                                       primary module into the secondary module.
-;; CHECK-NEXT:                                       In instrument mode, refers to the
-;; CHECK-NEXT:                                       namespace from which to import the
-;; CHECK-NEXT:                                       secondary memory, if any.
+;; CHECK-NEXT:   --import-namespace                   [split, instrument] When provided as an
+;; CHECK-NEXT:                                        option for module splitting, the
+;; CHECK-NEXT:                                        namespace from which to import objects
+;; CHECK-NEXT:                                        from the primary module into the
+;; CHECK-NEXT:                                        secondary module. In instrument mode,
+;; CHECK-NEXT:                                        refers to the namespace from which to
+;; CHECK-NEXT:                                        import the secondary memory, if any.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --placeholder-namespace             [split] The namespace from which to import
-;; CHECK-NEXT:                                       placeholder functions into the primary
-;; CHECK-NEXT:                                       module.
+;; CHECK-NEXT:   --placeholder-namespace              [split] The namespace from which to
+;; CHECK-NEXT:                                        import placeholder functions into the
+;; CHECK-NEXT:                                        primary module.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --asyncify                          [split] Transform the module to support
-;; CHECK-NEXT:                                       unwinding the stack from placeholder
-;; CHECK-NEXT:                                       functions and rewinding it once the
-;; CHECK-NEXT:                                       secondary module has been loaded.
+;; CHECK-NEXT:   --asyncify                           [split] Transform the module to support
+;; CHECK-NEXT:                                        unwinding the stack from placeholder
+;; CHECK-NEXT:                                        functions and rewinding it once the
+;; CHECK-NEXT:                                        secondary module has been loaded.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --export-prefix                     [split] An identifying prefix to prepend
-;; CHECK-NEXT:                                       to new export names created by module
-;; CHECK-NEXT:                                       splitting.
+;; CHECK-NEXT:   --export-prefix                      [split] An identifying prefix to prepend
+;; CHECK-NEXT:                                        to new export names created by module
+;; CHECK-NEXT:                                        splitting.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --profile-export                    [instrument] The export name of the
-;; CHECK-NEXT:                                       function the embedder calls to write the
-;; CHECK-NEXT:                                       profile into memory. Defaults to
-;; CHECK-NEXT:                                       `__write_profile`.
+;; CHECK-NEXT:   --profile-export                     [instrument] The export name of the
+;; CHECK-NEXT:                                        function the embedder calls to write the
+;; CHECK-NEXT:                                        profile into memory. Defaults to
+;; CHECK-NEXT:                                        `__write_profile`.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --in-memory                         [instrument] Store profile information in
-;; CHECK-NEXT:                                       memory (starting at address 0 and taking
-;; CHECK-NEXT:                                       one byte per function) rather than globals
-;; CHECK-NEXT:                                       (the default) so that it can be shared
-;; CHECK-NEXT:                                       between multiple threads. Users are
-;; CHECK-NEXT:                                       responsible for ensuring that the module
-;; CHECK-NEXT:                                       does not use the initial memory region for
-;; CHECK-NEXT:                                       anything else.
+;; CHECK-NEXT:   --in-memory                          [instrument] Store profile information in
+;; CHECK-NEXT:                                        memory (starting at address 0 and taking
+;; CHECK-NEXT:                                        one byte per function) rather than
+;; CHECK-NEXT:                                        globals (the default) so that it can be
+;; CHECK-NEXT:                                        shared between multiple threads. Users
+;; CHECK-NEXT:                                        are responsible for ensuring that the
+;; CHECK-NEXT:                                        module does not use the initial memory
+;; CHECK-NEXT:                                        region for anything else.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --in-secondary-memory               [instrument] Store profile information in
-;; CHECK-NEXT:                                       a separate memory, rather than in module
-;; CHECK-NEXT:                                       main memory or globals (the default). With
-;; CHECK-NEXT:                                       this option, users do not need to reserve
-;; CHECK-NEXT:                                       the initial memory region for profile data
-;; CHECK-NEXT:                                       and the data can be shared between
-;; CHECK-NEXT:                                       multiple threads.
+;; CHECK-NEXT:   --in-secondary-memory                [instrument] Store profile information in
+;; CHECK-NEXT:                                        a separate memory, rather than in module
+;; CHECK-NEXT:                                        main memory or globals (the default).
+;; CHECK-NEXT:                                        With this option, users do not need to
+;; CHECK-NEXT:                                        reserve the initial memory region for
+;; CHECK-NEXT:                                        profile data and the data can be shared
+;; CHECK-NEXT:                                        between multiple threads.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --secondary-memory-name             [instrument] The name of the secondary
-;; CHECK-NEXT:                                       memory created to store profile
-;; CHECK-NEXT:                                       information.
+;; CHECK-NEXT:   --secondary-memory-name              [instrument] The name of the secondary
+;; CHECK-NEXT:                                        memory created to store profile
+;; CHECK-NEXT:                                        information.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-module-names                 [split, instrument] Emit module names,
-;; CHECK-NEXT:                                       even if not emitting the rest of the names
-;; CHECK-NEXT:                                       section. Can help differentiate the
-;; CHECK-NEXT:                                       modules in stack traces. This option will
-;; CHECK-NEXT:                                       be removed once simpler ways of naming
-;; CHECK-NEXT:                                       modules are widely available. See
-;; CHECK-NEXT:                                       https://bugs.chromium.org/p/v8/issues/detail?id=11808.
+;; CHECK-NEXT:   --emit-module-names                  [split, instrument] Emit module names,
+;; CHECK-NEXT:                                        even if not emitting the rest of the
+;; CHECK-NEXT:                                        names section. Can help differentiate the
+;; CHECK-NEXT:                                        modules in stack traces. This option will
+;; CHECK-NEXT:                                        be removed once simpler ways of naming
+;; CHECK-NEXT:                                        modules are widely available. See
+;; CHECK-NEXT:                                        https://bugs.chromium.org/p/v8/issues/detail?id=11808.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --initial-table                     [split, instrument] A hack to ensure the
-;; CHECK-NEXT:                                       split and instrumented modules have the
-;; CHECK-NEXT:                                       same table size when using Emscripten's
-;; CHECK-NEXT:                                       SPLIT_MODULE mode with dynamic linking.
-;; CHECK-NEXT:                                       TODO: Figure out a more elegant solution
-;; CHECK-NEXT:                                       for that use case and remove this.
+;; CHECK-NEXT:   --initial-table                      [split, instrument] A hack to ensure the
+;; CHECK-NEXT:                                        split and instrumented modules have the
+;; CHECK-NEXT:                                        same table size when using Emscripten's
+;; CHECK-NEXT:                                        SPLIT_MODULE mode with dynamic linking.
+;; CHECK-NEXT:                                        TODO: Figure out a more elegant solution
+;; CHECK-NEXT:                                        for that use case and remove this.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --emit-text,-S                      [split, instrument] Emit text instead of
-;; CHECK-NEXT:                                       binary for the output file or files.
+;; CHECK-NEXT:   --emit-text,-S                       [split, instrument] Emit text instead of
+;; CHECK-NEXT:                                        binary for the output file or files.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debuginfo,-g                      [split, instrument] Emit names section in
-;; CHECK-NEXT:                                       wasm binary (or full debuginfo in wast)
+;; CHECK-NEXT:   --debuginfo,-g                       [split, instrument] Emit names section in
+;; CHECK-NEXT:                                        wasm binary (or full debuginfo in wast)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                         [instrument, merge-profiles] Output file.
+;; CHECK-NEXT:   --output,-o                          [instrument, merge-profiles] Output file.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --unescape,-u                       Un-escape function names (in print-profile
-;; CHECK-NEXT:                                       output)
+;; CHECK-NEXT:   --unescape,-u                        Un-escape function names (in
+;; CHECK-NEXT:                                        print-profile output)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --verbose,-v                        Verbose output mode. Prints the functions
-;; CHECK-NEXT:                                       that will be kept and split out when
-;; CHECK-NEXT:                                       splitting a module.
+;; CHECK-NEXT:   --verbose,-v                         Verbose output mode. Prints the functions
+;; CHECK-NEXT:                                        that will be kept and split out when
+;; CHECK-NEXT:                                        splitting a module.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --mvp-features,-mvp                 Disable all non-MVP features
+;; CHECK-NEXT:   --mvp-features,-mvp                  Disable all non-MVP features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --all-features,-all                 Enable all features
+;; CHECK-NEXT:   --all-features,-all                  Enable all features
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --detect-features                   (deprecated - this flag does nothing)
+;; CHECK-NEXT:   --detect-features                    (deprecated - this flag does nothing)
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --quiet,-q                          Emit less verbose output and hide trivial
-;; CHECK-NEXT:                                       warnings.
+;; CHECK-NEXT:   --quiet,-q                           Emit less verbose output and hide trivial
+;; CHECK-NEXT:                                        warnings.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --experimental-poppy                Parse wast files as Poppy IR for testing
-;; CHECK-NEXT:                                       purposes.
+;; CHECK-NEXT:   --experimental-poppy                 Parse wast files as Poppy IR for testing
+;; CHECK-NEXT:                                        purposes.
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-sign-ext                   Enable sign extension operations
+;; CHECK-NEXT:   --enable-sign-ext                    Enable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-sign-ext                  Disable sign extension operations
+;; CHECK-NEXT:   --disable-sign-ext                   Disable sign extension operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-threads                    Enable atomic operations
+;; CHECK-NEXT:   --enable-threads                     Enable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-threads                   Disable atomic operations
+;; CHECK-NEXT:   --disable-threads                    Disable atomic operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-mutable-globals            Enable mutable globals
+;; CHECK-NEXT:   --enable-mutable-globals             Enable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-mutable-globals           Disable mutable globals
+;; CHECK-NEXT:   --disable-mutable-globals            Disable mutable globals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-nontrapping-float-to-int   Enable nontrapping float-to-int operations
+;; CHECK-NEXT:   --enable-nontrapping-float-to-int    Enable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-nontrapping-float-to-int  Disable nontrapping float-to-int
-;; CHECK-NEXT:                                       operations
+;; CHECK-NEXT:   --disable-nontrapping-float-to-int   Disable nontrapping float-to-int
+;; CHECK-NEXT:                                        operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-simd                       Enable SIMD operations and types
+;; CHECK-NEXT:   --enable-simd                        Enable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-simd                      Disable SIMD operations and types
+;; CHECK-NEXT:   --disable-simd                       Disable SIMD operations and types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-bulk-memory                Enable bulk memory operations
+;; CHECK-NEXT:   --enable-bulk-memory                 Enable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-bulk-memory               Disable bulk memory operations
+;; CHECK-NEXT:   --disable-bulk-memory                Disable bulk memory operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-exception-handling         Enable exception handling operations
+;; CHECK-NEXT:   --enable-exception-handling          Enable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-exception-handling        Disable exception handling operations
+;; CHECK-NEXT:   --disable-exception-handling         Disable exception handling operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-tail-call                  Enable tail call operations
+;; CHECK-NEXT:   --enable-tail-call                   Enable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-tail-call                 Disable tail call operations
+;; CHECK-NEXT:   --disable-tail-call                  Disable tail call operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-reference-types            Enable reference types
+;; CHECK-NEXT:   --enable-reference-types             Enable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-reference-types           Disable reference types
+;; CHECK-NEXT:   --disable-reference-types            Disable reference types
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multivalue                 Enable multivalue functions
+;; CHECK-NEXT:   --enable-multivalue                  Enable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multivalue                Disable multivalue functions
+;; CHECK-NEXT:   --disable-multivalue                 Disable multivalue functions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc                         Enable garbage collection
+;; CHECK-NEXT:   --enable-gc                          Enable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc                        Disable garbage collection
+;; CHECK-NEXT:   --disable-gc                         Disable garbage collection
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-memory64                   Enable memory64
+;; CHECK-NEXT:   --enable-memory64                    Enable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-memory64                  Disable memory64
+;; CHECK-NEXT:   --disable-memory64                   Disable memory64
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-gc-nn-locals               Enable GC non-null locals
+;; CHECK-NEXT:   --enable-gc-nn-locals                Enable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-gc-nn-locals              Disable GC non-null locals
+;; CHECK-NEXT:   --disable-gc-nn-locals               Disable GC non-null locals
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-relaxed-simd               Enable relaxed SIMD
+;; CHECK-NEXT:   --enable-relaxed-simd                Enable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-relaxed-simd              Disable relaxed SIMD
+;; CHECK-NEXT:   --disable-relaxed-simd               Disable relaxed SIMD
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-extended-const             Enable extended const expressions
+;; CHECK-NEXT:   --enable-extended-const              Enable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-extended-const            Disable extended const expressions
+;; CHECK-NEXT:   --disable-extended-const             Disable extended const expressions
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-strings                    Enable strings
+;; CHECK-NEXT:   --enable-strings                     Enable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-strings                   Disable strings
+;; CHECK-NEXT:   --disable-strings                    Disable strings
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-multi-memories             Enable multi-memories
+;; CHECK-NEXT:   --enable-multi-memories              Enable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-multi-memories            Disable multi-memories
+;; CHECK-NEXT:   --disable-multi-memories             Disable multi-memories
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --no-validation,-n                  Disables validation, assumes inputs are
-;; CHECK-NEXT:                                       correct
+;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --pass-arg,-pa                      An argument passed along to optimization
-;; CHECK-NEXT:                                       passes being run. Must be in the form
-;; CHECK-NEXT:                                       KEY@VALUE
+;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --nominal                           Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as nominal.
+;; CHECK-NEXT:   --no-validation,-n                   Disables validation, assumes inputs are
+;; CHECK-NEXT:                                        correct
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --structural                        Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       as structural (i.e. equirecursive). This
-;; CHECK-NEXT:                                       is the default.
+;; CHECK-NEXT:   --pass-arg,-pa                       An argument passed along to optimization
+;; CHECK-NEXT:                                        passes being run. Must be in the form
+;; CHECK-NEXT:                                        KEY@VALUE
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --hybrid                            Force all GC type definitions to be parsed
-;; CHECK-NEXT:                                       using the isorecursive hybrid type system.
+;; CHECK-NEXT:   --nominal                            Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as nominal.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --structural                         Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed as structural (i.e.
+;; CHECK-NEXT:                                        equirecursive). This is the default.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --hybrid                             Force all GC type definitions to be
+;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
+;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --version                           Output version information and exit
+;; CHECK-NEXT:   --version                            Output version information and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --help,-h                           Show this help message and exit
+;; CHECK-NEXT:   --help,-h                            Show this help message and exit
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --debug,-d                          Print debug information to stderr
+;; CHECK-NEXT:   --debug,-d                           Print debug information to stderr
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -589,6 +589,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-multi-memories                      Disable multi-memories
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --no-validation,-n                            Disables validation, assumes
 ;; CHECK-NEXT:                                                 inputs are correct
 ;; CHECK-NEXT:


### PR DESCRIPTION
This allows a three-step upgrade process where binaryen is updated with this
change, then users remove their use of these flags, then binaryen can remove the
flags permanently.