### PR TITLE
Fix the side-effects of the string encode instructions.

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -770,6 +770,19 @@ private:
     void visitStringEncode(StringEncode* curr) {
       // traps when ref is null or we write out of bounds.
       parent.implicitTrap = true;
+      switch (curr->op) {
+        case StringEncodeUTF8:
+        case StringEncodeWTF8:
+        case StringEncodeWTF16:
+          parent.writesMemory = true;
+          break;
+        case StringEncodeUTF8Array:
+        case StringEncodeWTF8Array:
+        case StringEncodeWTF16Array:
+          parent.writesArray = true;
+          break;
+        default: {}
+      }
     }
     void visitStringConcat(StringConcat* curr) {
       // traps when an input is null.


### PR DESCRIPTION
I came across this when I started using string.encode_wtf16_array where the optimized tests started failing. I noticed that the code was removed by binaryen so this seems like the right fix.

I don't have an open-source setup but I tested in google3 and it correctly fixed the issue I was experiencing.