### PR TITLE
Fix some Closure warnings in Emscripten builds

### DIFF
--- a/src/js/binaryen.js-extern-pre.js
+++ b/src/js/binaryen.js-extern-pre.js
@@ -2,3 +2,10 @@
 // we are building to ES6 (where it doesn't exist) and the .wasm blob is inlined
 // see: https://github.com/emscripten-core/emscripten/issues/11792
 var __dirname = "";
+
+// FIXME: The Emscripten shell requires this function to be present, even though
+// we are building to ESM (where it doesn't exist) and the result is not used
+// see: https://github.com/emscripten-core/emscripten/pull/17851
+function require() {
+  return {};
+}


### PR DESCRIPTION
Instructs Closure about the types in play so the warnings go away. <del>Didn't encounter the externs warning regarding the `WebAssembly` object (need to see what CI states)</del>. Generally it looks that we could refactor the code slightly to use `class`es, then we'd not need to annotate in comments so much (except the dynamically generated expression methods).

Related #5062

Update: Seen the `WebAssembly` object externs warning now, which might require a fix to the externs provided by Emscripten.