### PR TITLE
Revert "Pin the emsdk for now"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,8 @@ jobs:
         mkdir $HOME/emsdk
         git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
         $HOME/emsdk/emsdk update-tags
-        # pinned due to https://github.com/emscripten-core/emscripten/pull/17851
-        # TODO: go back to tot
-        $HOME/emsdk/emsdk install latest
-        $HOME/emsdk/emsdk activate latest
+        $HOME/emsdk/emsdk install tot
+        $HOME/emsdk/emsdk activate tot
     - name: update path
       run:  echo "PATH=$PATH:$HOME/emsdk" >> $GITHUB_ENV
     - name: emcc-tests


### PR DESCRIPTION
Reverts WebAssembly/binaryen#5077

#5075 fixes the require() issue, so we don't need the pin.