### PR TITLE
Emit call_ref with a type annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ Current Trunk
 -------------
 
 - Add extra `memory64` argument for `BinaryenSetMemory` and new `BinaryenMemoryIs64` C-API method to determine 64-bit memory. (#4963)
-- `TypeBuilderSetSubType` now takes a super type as the second argument.
+- `TypeBuilderSetSubType` now takes a supertype as the second argument.
+- `call_ref` can now take a signature type immediate in the text format. The
+  type immediate will become mandatory in the future.
 
 v110
 ----

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2060,23 +2060,17 @@ struct PrintExpressionContents
   }
 
   void visitCallRef(CallRef* curr) {
-    if (curr->isReturn) {
-      if (printUnreachableReplacement(curr->target)) {
-        return;
-      }
-      printMedium(o, "return_call_ref ");
-      assert(curr->target->type != Type::unreachable);
-      // TODO: Workaround if target has bottom type.
-      printHeapType(o, curr->target->type.getHeapType(), wasm);
-    } else {
-      printMedium(o, "call_ref");
+    // TODO: Workaround if target has bottom type.
+    if (printUnreachableReplacement(curr->target)) {
+      return;
     }
+    printMedium(o, curr->isReturn ? "return_call_ref " : "call_ref ");
+    printHeapType(o, curr->target->type.getHeapType(), wasm);
   }
   void visitRefTest(RefTest* curr) {
     printMedium(o, "ref.test_static ");
     printHeapType(o, curr->intendedType, wasm);
   }
-
   void visitRefCast(RefCast* curr) {
     if (curr->safety == RefCast::Unsafe) {
       printMedium(o, "ref.cast_nop_static ");
@@ -2085,6 +2079,7 @@ struct PrintExpressionContents
     }
     printHeapType(o, curr->intendedType, wasm);
   }
+
   void visitBrOn(BrOn* curr) {
     switch (curr->op) {
       case BrOnNull:
@@ -2139,7 +2134,6 @@ struct PrintExpressionContents
     o << ' ';
     TypeNamePrinter(o, wasm).print(curr->type.getHeapType());
   }
-
   void printFieldName(HeapType type, Index index) {
     processFieldName(wasm, type, index, [&](Name name) {
       if (name.is()) {
@@ -2755,11 +2749,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
     decIndent();
   }
   void visitCallRef(CallRef* curr) {
-    if (curr->isReturn) {
-      maybePrintUnreachableReplacement(curr, curr->target->type);
-    } else {
-      visitExpression(curr);
-    }
+    maybePrintUnreachableReplacement(curr, curr->target->type);
   }
   void visitStructNew(StructNew* curr) {
     maybePrintUnreachableReplacement(curr, curr->type);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1083,7 +1083,8 @@ enum ASTNodes {
 
   // typed function references opcodes
 
-  CallRef = 0x14,
+  CallRefUnannotated = 0x14,
+  CallRef = 0x17,
   RetCallRef = 0x15,
 
   // gc opcodes

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3776,12 +3776,13 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       visitMemoryGrow(grow);
       break;
     }
-    case BinaryConsts::CallRef:
+    case BinaryConsts::CallRefUnannotated:
       visitCallRef((curr = allocator.alloc<CallRef>())->cast<CallRef>());
       break;
+    case BinaryConsts::CallRef:
     case BinaryConsts::RetCallRef: {
       auto call = allocator.alloc<CallRef>();
-      call->isReturn = true;
+      call->isReturn = code == BinaryConsts::RetCallRef;
       curr = call;
       visitCallRef(call, getTypeByIndex(getU32LEB()));
       break;
@@ -6810,11 +6811,7 @@ void WasmBinaryBuilder::visitCallRef(CallRef* curr,
   for (size_t i = 0; i < num; i++) {
     curr->operands[num - i - 1] = popNonVoidExpression();
   }
-  if (maybeType) {
-    curr->finalize();
-  } else {
-    curr->finalize(sig.results);
-  }
+  curr->finalize(sig.results);
 }
 
 bool WasmBinaryBuilder::maybeVisitI31New(Expression*& out, uint32_t code) {

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2013,14 +2013,11 @@ void BinaryInstWriter::visitI31Get(I31Get* curr) {
 }
 
 void BinaryInstWriter::visitCallRef(CallRef* curr) {
-  if (curr->isReturn) {
-    assert(curr->target->type != Type::unreachable);
-    // TODO: `emitUnreachable` if target has bottom type.
-    o << int8_t(BinaryConsts::RetCallRef);
-    parent.writeIndexedHeapType(curr->target->type.getHeapType());
-    return;
-  }
-  o << int8_t(BinaryConsts::CallRef);
+  assert(curr->target->type != Type::unreachable);
+  // TODO: `emitUnreachable` if target has bottom type.
+  o << int8_t(curr->isReturn ? BinaryConsts::RetCallRef
+                             : BinaryConsts::CallRef);
+  parent.writeIndexedHeapType(curr->target->type.getHeapType());
 }
 
 void BinaryInstWriter::visitRefTest(RefTest* curr) {

--- a/test/lit/passes/dae_all-features.wast
+++ b/test/lit/passes/dae_all-features.wast
@@ -504,7 +504,7 @@
   (unreachable)
  )
  ;; CHECK:      (func $1
- ;; CHECK-NEXT:  (call_ref
+ ;; CHECK-NEXT:  (call_ref $i64
  ;; CHECK-NEXT:   (i64.const 0)
  ;; CHECK-NEXT:   (global.get $global$0)
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -831,7 +831,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $y)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $two-params
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:   (struct.new_default $struct)
   ;; CHECK-NEXT:   (ref.func $func-2params-a)
@@ -3744,19 +3744,19 @@
   )
 
   ;; CHECK:      (func $do-calls (type $none_=>_none)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $i1
   ;; CHECK-NEXT:   (i32.const 42)
   ;; CHECK-NEXT:   (ref.func $reffed1)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $i1
   ;; CHECK-NEXT:   (i32.const 42)
   ;; CHECK-NEXT:   (ref.func $reffed1)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $i2
   ;; CHECK-NEXT:   (i32.const 1337)
   ;; CHECK-NEXT:   (ref.func $reffed2)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $i2
   ;; CHECK-NEXT:   (i32.const 99999)
   ;; CHECK-NEXT:   (ref.func $reffed2)
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/inlining-optimizing.wast
+++ b/test/lit/passes/inlining-optimizing.wast
@@ -13,8 +13,10 @@
  )
  ;; CHECK:      (func $1
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (call_ref
- ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (unreachable)
+ ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )

--- a/test/lit/passes/inlining_all-features.wast
+++ b/test/lit/passes/inlining_all-features.wast
@@ -142,7 +142,7 @@
  ;; CHECK:      (func $1
  ;; CHECK-NEXT:  (block $__inlined_func$0
  ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (call_ref
+ ;; CHECK-NEXT:    (call_ref $none_=>_none
  ;; CHECK-NEXT:     (ref.null $none_=>_none)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (br $__inlined_func$0)
@@ -153,7 +153,7 @@
  ;; NOMNL:      (func $1 (type $none_=>_none)
  ;; NOMNL-NEXT:  (block $__inlined_func$0
  ;; NOMNL-NEXT:   (block
- ;; NOMNL-NEXT:    (call_ref
+ ;; NOMNL-NEXT:    (call_ref $none_=>_none
  ;; NOMNL-NEXT:     (ref.null $none_=>_none)
  ;; NOMNL-NEXT:    )
  ;; NOMNL-NEXT:    (br $__inlined_func$0)

--- a/test/lit/passes/intrinsic-lowering.wast
+++ b/test/lit/passes/intrinsic-lowering.wast
@@ -27,7 +27,7 @@
   ;; CHECK-NEXT:    (i32.const 42)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $none
   ;; CHECK-NEXT:   (ref.null $none)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.const 1)

--- a/test/lit/passes/local-cse_all-features.wast
+++ b/test/lit/passes/local-cse_all-features.wast
@@ -12,13 +12,13 @@
 
   ;; CHECK:      (func $calls (param $x i32) (result i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (call_ref
+  ;; CHECK-NEXT:   (call_ref $i32_=>_i32
   ;; CHECK-NEXT:    (i32.const 10)
   ;; CHECK-NEXT:    (ref.func $calls)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (call_ref
+  ;; CHECK-NEXT:   (call_ref $i32_=>_i32
   ;; CHECK-NEXT:    (i32.const 10)
   ;; CHECK-NEXT:    (ref.func $calls)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/merge-similar-functions.wast
+++ b/test/lit/passes/merge-similar-functions.wast
@@ -328,7 +328,7 @@
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
-;; CHECK-NEXT:  (call_ref
+;; CHECK-NEXT:  (call_ref $none_=>_i32
 ;; CHECK-NEXT:   (local.get $0)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
@@ -352,7 +352,7 @@
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
-;; CHECK-NEXT:  (call_ref
+;; CHECK-NEXT:  (call_ref $i32_=>_i32
 ;; CHECK-NEXT:   (local.get $1)
 ;; CHECK-NEXT:   (local.get $0)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/merge-similar-functions_types.wast
+++ b/test/lit/passes/merge-similar-functions_types.wast
@@ -151,7 +151,7 @@
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
-;; CHECK-NEXT:  (call_ref
+;; CHECK-NEXT:  (call_ref $type$0
 ;; CHECK-NEXT:   (local.get $0)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (nop)
@@ -287,7 +287,7 @@
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
 ;; CHECK-NEXT:  (nop)
-;; CHECK-NEXT:  (call_ref
+;; CHECK-NEXT:  (call_ref $type$0
 ;; CHECK-NEXT:   (local.get $0)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (nop)
@@ -309,7 +309,7 @@
 ;; NOMNL-NEXT:  (nop)
 ;; NOMNL-NEXT:  (nop)
 ;; NOMNL-NEXT:  (nop)
-;; NOMNL-NEXT:  (call_ref
+;; NOMNL-NEXT:  (call_ref $type$1
 ;; NOMNL-NEXT:   (local.get $0)
 ;; NOMNL-NEXT:  )
 ;; NOMNL-NEXT:  (nop)

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -158,7 +158,7 @@
  )
 
  ;; CHECK:      (func $fallthrough-bad-type (result i32)
- ;; CHECK-NEXT:  (call_ref
+ ;; CHECK-NEXT:  (call_ref $none_=>_i32
  ;; CHECK-NEXT:   (block (result (ref $none_=>_i32))
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (ref.func $return-nothing)
@@ -188,7 +188,7 @@
  (func $return-nothing)
 
  ;; CHECK:      (func $fallthrough-unreachable
- ;; CHECK-NEXT:  (call_ref
+ ;; CHECK-NEXT:  (call_ref $i32_i32_=>_none
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:   (block (result (ref $i32_i32_=>_none))
@@ -258,7 +258,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call_ref
+ ;; CHECK-NEXT:  (call_ref $i32_i32_=>_none
  ;; CHECK-NEXT:   (local.get $x)
  ;; CHECK-NEXT:   (local.get $y)
  ;; CHECK-NEXT:   (select (result (ref $i32_i32_=>_none))

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -1157,7 +1157,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (call_ref
+ ;; CHECK-NEXT:   (call_ref $func-return-i32
  ;; CHECK-NEXT:    (local.get $temp)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -1169,7 +1169,7 @@
  ;; NOMNL-NEXT:   )
  ;; NOMNL-NEXT:  )
  ;; NOMNL-NEXT:  (drop
- ;; NOMNL-NEXT:   (call_ref
+ ;; NOMNL-NEXT:   (call_ref $func-return-i32
  ;; NOMNL-NEXT:    (local.get $temp)
  ;; NOMNL-NEXT:   )
  ;; NOMNL-NEXT:  )

--- a/test/lit/passes/remove-unused-module-elements-refs.wast
+++ b/test/lit/passes/remove-unused-module-elements-refs.wast
@@ -18,7 +18,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.func $target-B)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (ref.null $A)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (block
@@ -80,7 +80,7 @@
   ;; CHECK:      (export "foo" (func $foo))
 
   ;; CHECK:      (func $foo (type $A)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (ref.null $A)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -119,13 +119,13 @@
   ;; CHECK:      (export "foo" (func $foo))
 
   ;; CHECK:      (func $foo (type $A)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (ref.null $A)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.func $target-A-1)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (ref.null $A)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -181,13 +181,13 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.func $target-A-1)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (ref.null $A)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.func $target-A-2)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (ref.null $A)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -43,7 +43,7 @@
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (f64.const 3)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (i32.const 4)
   ;; CHECK-NEXT:   (f64.const 7)
   ;; CHECK-NEXT:   (ref.func $foo)
@@ -107,7 +107,7 @@
   ;; CHECK-NEXT:   (i64.const 1)
   ;; CHECK-NEXT:   (f32.const 2)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (i64.const 5)
   ;; CHECK-NEXT:   (f32.const 6)
   ;; CHECK-NEXT:   (ref.func $foo)
@@ -174,7 +174,7 @@
   ;; CHECK-NEXT:   (i64.const 1)
   ;; CHECK-NEXT:   (f32.const 2)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (i32.const 4)
   ;; CHECK-NEXT:   (i64.const 5)
   ;; CHECK-NEXT:   (f32.const 6)
@@ -246,7 +246,7 @@
   ;; CHECK-NEXT:   (i64.const 1)
   ;; CHECK-NEXT:   (f32.const 2)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (call $caller)
   ;; CHECK-NEXT:    (i32.const 4)
@@ -301,7 +301,7 @@
 
   ;; CHECK:      (func $caller (type $none_=>_none)
   ;; CHECK-NEXT:  (call $foo)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (ref.func $foo)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -501,10 +501,10 @@
   ;; CHECK:      (func $caller (type $none_=>_none)
   ;; CHECK-NEXT:  (call $foo)
   ;; CHECK-NEXT:  (call $bar)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (ref.func $foo)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (ref.func $bar)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -527,7 +527,7 @@
 
   ;; CHECK:      (func $caller-2 (type $none_=>_none)
   ;; CHECK-NEXT:  (call $bar)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (ref.func $foo)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -53,7 +53,7 @@
   )
 
   ;; CHECK:      (func $caller (type $none_=>_none)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (struct.new_default $struct)
   ;; CHECK-NEXT:   (ref.func $func)
   ;; CHECK-NEXT:  )
@@ -92,7 +92,7 @@
   ;; CHECK-NEXT:  (call $func
   ;; CHECK-NEXT:   (local.get $struct)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (ref.as_data
   ;; CHECK-NEXT:    (struct.new_default $struct)
   ;; CHECK-NEXT:   )
@@ -286,7 +286,7 @@
   ;; CHECK-NEXT:  (call $func
   ;; CHECK-NEXT:   (struct.new_default $struct)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:   (ref.func $func)
   ;; CHECK-NEXT:  )
@@ -322,7 +322,7 @@
   )
 
   ;; CHECK:      (func $caller (type $none_=>_none)
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:   (ref.func $func)
   ;; CHECK-NEXT:  )
@@ -393,7 +393,7 @@
   ;; CHECK-NEXT:   (struct.new_default $struct)
   ;; CHECK-NEXT:   (struct.new_default $struct)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call_ref
+  ;; CHECK-NEXT:  (call_ref $sig-2
   ;; CHECK-NEXT:   (local.get $i31)
   ;; CHECK-NEXT:   (struct.new_default $struct)
   ;; CHECK-NEXT:   (ref.func $func-2)
@@ -547,7 +547,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (if (result (ref $struct))
   ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:    (call_ref
+  ;; CHECK-NEXT:    (call_ref $sig-can-refine
   ;; CHECK-NEXT:     (ref.func $func-can-refine)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (unreachable)

--- a/test/lit/types-function-references.wast
+++ b/test/lit/types-function-references.wast
@@ -58,7 +58,7 @@
   ;; CHECK-BINARY:      (elem declare func $call-ref $call-ref-more)
 
   ;; CHECK-BINARY:      (func $call-ref
-  ;; CHECK-BINARY-NEXT:  (call_ref
+  ;; CHECK-BINARY-NEXT:  (call_ref $void
   ;; CHECK-BINARY-NEXT:   (ref.func $call-ref)
   ;; CHECK-BINARY-NEXT:  )
   ;; CHECK-BINARY-NEXT: )
@@ -69,7 +69,7 @@
   ;; CHECK-TEXT:      (elem declare func $call-ref $call-ref-more)
 
   ;; CHECK-TEXT:      (func $call-ref
-  ;; CHECK-TEXT-NEXT:  (call_ref
+  ;; CHECK-TEXT-NEXT:  (call_ref $void
   ;; CHECK-TEXT-NEXT:   (ref.func $call-ref)
   ;; CHECK-TEXT-NEXT:  )
   ;; CHECK-TEXT-NEXT: )
@@ -90,13 +90,13 @@
     (return_call_ref $void (ref.func $call-ref))
   )
   ;; CHECK-BINARY:      (func $call-ref-more (param $0 i32) (result i32)
-  ;; CHECK-BINARY-NEXT:  (call_ref
+  ;; CHECK-BINARY-NEXT:  (call_ref $i32-i32
   ;; CHECK-BINARY-NEXT:   (i32.const 42)
   ;; CHECK-BINARY-NEXT:   (ref.func $call-ref-more)
   ;; CHECK-BINARY-NEXT:  )
   ;; CHECK-BINARY-NEXT: )
   ;; CHECK-TEXT:      (func $call-ref-more (param $0 i32) (result i32)
-  ;; CHECK-TEXT-NEXT:  (call_ref
+  ;; CHECK-TEXT-NEXT:  (call_ref $i32-i32
   ;; CHECK-TEXT-NEXT:   (i32.const 42)
   ;; CHECK-TEXT-NEXT:   (ref.func $call-ref-more)
   ;; CHECK-TEXT-NEXT:  )
@@ -105,13 +105,13 @@
     (call_ref (i32.const 42) (ref.func $call-ref-more))
   )
   ;; CHECK-BINARY:      (func $call_from-param (param $f (ref $i32-i32)) (result i32)
-  ;; CHECK-BINARY-NEXT:  (call_ref
+  ;; CHECK-BINARY-NEXT:  (call_ref $i32-i32
   ;; CHECK-BINARY-NEXT:   (i32.const 42)
   ;; CHECK-BINARY-NEXT:   (local.get $f)
   ;; CHECK-BINARY-NEXT:  )
   ;; CHECK-BINARY-NEXT: )
   ;; CHECK-TEXT:      (func $call_from-param (param $f (ref $i32-i32)) (result i32)
-  ;; CHECK-TEXT-NEXT:  (call_ref
+  ;; CHECK-TEXT-NEXT:  (call_ref $i32-i32
   ;; CHECK-TEXT-NEXT:   (i32.const 42)
   ;; CHECK-TEXT-NEXT:   (local.get $f)
   ;; CHECK-TEXT-NEXT:  )
@@ -120,13 +120,13 @@
     (call_ref (i32.const 42) (local.get $f))
   )
   ;; CHECK-BINARY:      (func $call_from-param-null (param $f (ref null $i32-i32)) (result i32)
-  ;; CHECK-BINARY-NEXT:  (call_ref
+  ;; CHECK-BINARY-NEXT:  (call_ref $i32-i32
   ;; CHECK-BINARY-NEXT:   (i32.const 42)
   ;; CHECK-BINARY-NEXT:   (local.get $f)
   ;; CHECK-BINARY-NEXT:  )
   ;; CHECK-BINARY-NEXT: )
   ;; CHECK-TEXT:      (func $call_from-param-null (param $f (ref null $i32-i32)) (result i32)
-  ;; CHECK-TEXT-NEXT:  (call_ref
+  ;; CHECK-TEXT-NEXT:  (call_ref $i32-i32
   ;; CHECK-TEXT-NEXT:   (i32.const 42)
   ;; CHECK-TEXT-NEXT:   (local.get $f)
   ;; CHECK-TEXT-NEXT:  )
@@ -139,7 +139,7 @@
   ;; CHECK-BINARY-NEXT:  (local.set $f
   ;; CHECK-BINARY-NEXT:   (ref.func $call-ref-more)
   ;; CHECK-BINARY-NEXT:  )
-  ;; CHECK-BINARY-NEXT:  (call_ref
+  ;; CHECK-BINARY-NEXT:  (call_ref $i32-i32
   ;; CHECK-BINARY-NEXT:   (i32.const 42)
   ;; CHECK-BINARY-NEXT:   (local.get $f)
   ;; CHECK-BINARY-NEXT:  )
@@ -149,7 +149,7 @@
   ;; CHECK-TEXT-NEXT:  (local.set $f
   ;; CHECK-TEXT-NEXT:   (ref.func $call-ref-more)
   ;; CHECK-TEXT-NEXT:  )
-  ;; CHECK-TEXT-NEXT:  (call_ref
+  ;; CHECK-TEXT-NEXT:  (call_ref $i32-i32
   ;; CHECK-TEXT-NEXT:   (i32.const 42)
   ;; CHECK-TEXT-NEXT:   (local.get $f)
   ;; CHECK-TEXT-NEXT:  )
@@ -399,7 +399,7 @@
 ;; CHECK-NODEBUG:      (elem declare func $0 $2)
 
 ;; CHECK-NODEBUG:      (func $0
-;; CHECK-NODEBUG-NEXT:  (call_ref
+;; CHECK-NODEBUG-NEXT:  (call_ref $none_=>_none
 ;; CHECK-NODEBUG-NEXT:   (ref.func $0)
 ;; CHECK-NODEBUG-NEXT:  )
 ;; CHECK-NODEBUG-NEXT: )
@@ -411,21 +411,21 @@
 ;; CHECK-NODEBUG-NEXT: )
 
 ;; CHECK-NODEBUG:      (func $2 (param $0 i32) (result i32)
-;; CHECK-NODEBUG-NEXT:  (call_ref
+;; CHECK-NODEBUG-NEXT:  (call_ref $i32_=>_i32
 ;; CHECK-NODEBUG-NEXT:   (i32.const 42)
 ;; CHECK-NODEBUG-NEXT:   (ref.func $2)
 ;; CHECK-NODEBUG-NEXT:  )
 ;; CHECK-NODEBUG-NEXT: )
 
 ;; CHECK-NODEBUG:      (func $3 (param $0 (ref $i32_=>_i32)) (result i32)
-;; CHECK-NODEBUG-NEXT:  (call_ref
+;; CHECK-NODEBUG-NEXT:  (call_ref $i32_=>_i32
 ;; CHECK-NODEBUG-NEXT:   (i32.const 42)
 ;; CHECK-NODEBUG-NEXT:   (local.get $0)
 ;; CHECK-NODEBUG-NEXT:  )
 ;; CHECK-NODEBUG-NEXT: )
 
 ;; CHECK-NODEBUG:      (func $4 (param $0 (ref null $i32_=>_i32)) (result i32)
-;; CHECK-NODEBUG-NEXT:  (call_ref
+;; CHECK-NODEBUG-NEXT:  (call_ref $i32_=>_i32
 ;; CHECK-NODEBUG-NEXT:   (i32.const 42)
 ;; CHECK-NODEBUG-NEXT:   (local.get $0)
 ;; CHECK-NODEBUG-NEXT:  )
@@ -436,7 +436,7 @@
 ;; CHECK-NODEBUG-NEXT:  (local.set $0
 ;; CHECK-NODEBUG-NEXT:   (ref.func $2)
 ;; CHECK-NODEBUG-NEXT:  )
-;; CHECK-NODEBUG-NEXT:  (call_ref
+;; CHECK-NODEBUG-NEXT:  (call_ref $i32_=>_i32
 ;; CHECK-NODEBUG-NEXT:   (i32.const 42)
 ;; CHECK-NODEBUG-NEXT:   (local.get $0)
 ;; CHECK-NODEBUG-NEXT:  )

--- a/test/passes/duplicate-function-elimination_all-features.txt
+++ b/test/passes/duplicate-function-elimination_all-features.txt
@@ -27,7 +27,7 @@
   (unreachable)
  )
  (func $2 (result i32)
-  (call_ref
+  (call_ref $func
    (global.get $global$0)
   )
  )


### PR DESCRIPTION
Emit call_ref instructions with type annotations and a temporary opcode. Also
implement support for parsing optional type annotations on call_ref in the text
and binary formats. This is part of a multi-part graceful update to switch
Binaryen and all of its users over to using the type-annotated version of
call_ref without there being any breakage.