### PR TITLE
[GUFA] Track exact types on global types

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1535,23 +1535,23 @@ void Flower::filterGlobalContents(PossibleContents& contents,
     // This is an immutable global. We never need to consider this value as
     // "Many", since in the worst case we can just use the immutable value. That
     // is, we can always replace this value with (global.get $name) which will
-    // get the right value. Likewise, using the immutable global value is often
-    // better than an exact type, but TODO: we could note both an exact type
-    // *and* that something is equal to a global, in some cases.
-    if (contents.isMany() || contents.isExactType()) {
-      contents = PossibleContents::global(global->name, global->type);
-
-      // TODO: We could do better here, to set global->init->type instead of
-      //       global->type, or even the contents.getType() - either of those
-      //       may be more refined. But other passes will handle that in
-      //       general (by refining the global's type).
+    // get the right value.
+    bool changed = false;
+    if (contents.isMany()) {
+      contents = PossibleContents::inexactGlobal(global->name, global->type);
+      changed = true;
+    } else if (contents.isExactType()) {
+      contents = PossibleContents::exactGlobal(global->name, contents.getType());
+      changed = true;
+    }
 
 #if defined(POSSIBLE_CONTENTS_DEBUG) && POSSIBLE_CONTENTS_DEBUG >= 2
+    if (changed) {
       std::cout << "  setting immglobal to ImmutableGlobal\n";
       contents.dump(std::cout, &wasm);
       std::cout << '\n';
-#endif
     }
+#endif
   }
 }
 

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1549,7 +1549,7 @@ void Flower::filterGlobalContents(PossibleContents& contents,
     if (contents.isMany()) {
       contents = PossibleContents::inexactGlobal(global->name, global->type);
       changed = true;
-    } else if (contents.isExactType()) {
+    } else if (contents.isExactType()) { // TODO
       contents = PossibleContents::exactGlobal(global->name, contents.getType());
       changed = true;
     }
@@ -1613,7 +1613,7 @@ void Flower::readFromData(HeapType declaredHeapType,
   std::cout << "    add special reads\n";
 #endif
 
-  if (refContents.isExactType()) {
+  if (refContents.hasExactType()) {
     // Add a single link to the exact location the reference points to.
     connectDuringFlow(
       DataLocation{refContents.getType().getHeapType(), fieldIndex},

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1549,7 +1549,7 @@ void Flower::filterGlobalContents(PossibleContents& contents,
     if (contents.isMany()) {
       contents = PossibleContents::inexactGlobal(global->name, global->type);
       changed = true;
-    } else if (contents.isExactType()) { // TODO
+    } else if (contents.isExactType()) { // TODO waka
       contents = PossibleContents::exactGlobal(global->name, contents.getType());
       changed = true;
     }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1552,6 +1552,7 @@ void Flower::filterGlobalContents(PossibleContents& contents,
       std::cout << '\n';
     }
 #endif
+    WASM_UNUSED(changed);
   }
 }
 

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1549,7 +1549,10 @@ void Flower::filterGlobalContents(PossibleContents& contents,
     if (contents.isMany()) {
       contents = PossibleContents::inexactGlobal(global->name, global->type);
       changed = true;
-    } else if (contents.isExactType()) { // TODO waka
+    } else if (contents.hasExactType() && !contents.isLiteral()) {
+      // If the contents have an exact type, then we can use an exact global
+      // instead. Note that we don't do this for a literal, which is even more
+      // precise than a global.
       contents = PossibleContents::exactGlobal(global->name, contents.getType());
       changed = true;
     }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -104,7 +104,11 @@ void PossibleContents::combine(const PossibleContents& other) {
     assert(!isNull() || !other.isNull());
     // If only one is a null, but the other's type is known exactly, then the
     // combination is to add nullability (if the type is *not* known exactly,
-    // like for a global, then we cannot do anything useful here).
+    // then we cannot do anything useful here).
+    //
+    // Note that the non-null value is a global with exact type then we still
+    // need to turn this into an ExactType: the possible contents are no longer
+    // identical necessarily to the global.
     if (!isNull() && hasExactType()) {
       value = ExactType(Type(type.getHeapType(), Nullable));
       return;
@@ -122,6 +126,11 @@ void PossibleContents::combine(const PossibleContents& other) {
     // Literal; or both might be ExactTypes and only one might be nullable).
     // In these cases we can emit a proper ExactType here, adding nullability
     // if we need to.
+    //
+    // Note that if one or both are globals with exact type then we still need
+    // to turn this into an ExactType: if it was the same global then we would
+    // have exited before, and if not then the result can no longer be a global
+    // anyhow, and must be an ExactType.
     value = ExactType(Type(
       type.getHeapType(),
       type.isNullable() || otherType.isNullable() ? Nullable : NonNullable));

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1553,7 +1553,8 @@ void Flower::filterGlobalContents(PossibleContents& contents,
       // If the contents have an exact type, then we can use an exact global
       // instead. Note that we don't do this for a literal, which is even more
       // precise than a global.
-      contents = PossibleContents::exactGlobal(global->name, contents.getType());
+      contents =
+        PossibleContents::exactGlobal(global->name, contents.getType());
       changed = true;
     }
 

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -81,7 +81,8 @@ class PossibleContents {
     bool hasExactType;
 
     bool operator==(const GlobalInfo& other) const {
-      return name == other.name && type == other.type && hasExactType == other.hasExactType;
+      return name == other.name && type == other.type &&
+             hasExactType == other.hasExactType;
     }
   };
 
@@ -211,7 +212,8 @@ public:
     } else if (isLiteral()) {
       return size_t(1) | (std::hash<Literal>()(getLiteral()) << 3);
     } else if (isGlobal()) {
-      return size_t(hasExactType() ? 2 : 3) | (std::hash<Name>()(getGlobal()) << 3);
+      return size_t(hasExactType() ? 2 : 3) |
+             (std::hash<Name>()(getGlobal()) << 3);
     } else if (isExactType()) {
       return size_t(4) | (std::hash<Type>()(getType()) << 3);
     } else if (isMany()) {

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -211,11 +211,11 @@ public:
     } else if (isLiteral()) {
       return size_t(1) | (std::hash<Literal>()(getLiteral()) << 3);
     } else if (isGlobal()) {
-      return size_t(2) | (std::hash<Name>()(getGlobal()) << 3);
+      return size_t(hasExactType() ? 2 : 3) | (std::hash<Name>()(getGlobal()) << 3);
     } else if (isExactType()) {
-      return size_t(3) | (std::hash<Type>()(getType()) << 3);
+      return size_t(4) | (std::hash<Type>()(getType()) << 3);
     } else if (isMany()) {
-      return 4;
+      return 5;
     } else {
       WASM_UNREACHABLE("bad variant");
     }
@@ -234,6 +234,9 @@ public:
       }
     } else if (isGlobal()) {
       o << "GlobalInfo $" << getGlobal();
+      if (hasExactType()) {
+        o << " exact";
+      }
     } else if (isExactType()) {
       o << "ExactType " << getType();
       auto t = getType();

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -80,11 +80,11 @@ protected:
     PossibleContents::literal(Literal::makeNull(HeapType::i31));
 
   PossibleContents i32Global1 =
-    PossibleContents::exactGlobal("i32Global1", Type::i32);
+    PossibleContents::inexactGlobal("i32Global1", Type::i32);
   PossibleContents i32Global2 =
-    PossibleContents::exactGlobal("i32Global2", Type::i32);
-  PossibleContents f64Global = PossibleContents::exactGlobal("f64Global", Type::f64);
-  PossibleContents anyGlobal = PossibleContents::exactGlobal("anyGlobal", anyref);
+    PossibleContents::inexactGlobal("i32Global2", Type::i32);
+  PossibleContents f64Global = PossibleContents::inexactGlobal("f64Global", Type::f64);
+  PossibleContents anyGlobal = PossibleContents::inexactGlobal("anyGlobal", anyref);
 
   PossibleContents nonNullFunc = PossibleContents::literal(
     Literal("func", Signature(Type::none, Type::none)));

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -83,8 +83,10 @@ protected:
     PossibleContents::inexactGlobal("i32Global1", Type::i32);
   PossibleContents i32Global2 =
     PossibleContents::inexactGlobal("i32Global2", Type::i32);
-  PossibleContents f64Global = PossibleContents::inexactGlobal("f64Global", Type::f64);
-  PossibleContents anyGlobal = PossibleContents::inexactGlobal("anyGlobal", anyref);
+  PossibleContents f64Global =
+    PossibleContents::inexactGlobal("f64Global", Type::f64);
+  PossibleContents anyGlobal =
+    PossibleContents::inexactGlobal("anyGlobal", anyref);
 
   PossibleContents nonNullFunc = PossibleContents::literal(
     Literal("func", Signature(Type::none, Type::none)));

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -80,11 +80,11 @@ protected:
     PossibleContents::literal(Literal::makeNull(HeapType::i31));
 
   PossibleContents i32Global1 =
-    PossibleContents::global("i32Global1", Type::i32);
+    PossibleContents::exactGlobal("i32Global1", Type::i32);
   PossibleContents i32Global2 =
-    PossibleContents::global("i32Global2", Type::i32);
-  PossibleContents f64Global = PossibleContents::global("f64Global", Type::f64);
-  PossibleContents anyGlobal = PossibleContents::global("anyGlobal", anyref);
+    PossibleContents::exactGlobal("i32Global2", Type::i32);
+  PossibleContents f64Global = PossibleContents::exactGlobal("f64Global", Type::f64);
+  PossibleContents anyGlobal = PossibleContents::exactGlobal("anyGlobal", anyref);
 
   PossibleContents nonNullFunc = PossibleContents::literal(
     Literal("func", Signature(Type::none, Type::none)));

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -3819,9 +3819,7 @@
   ;; CHECK-NEXT:   (i32.const 10)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.get $struct 0
-  ;; CHECK-NEXT:    (global.get $global)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 10)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 20)

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -3784,7 +3784,7 @@
   )
 )
 
-;; Test for exact types in globals
+;; Test for exact types in globals.
 (module
   ;; CHECK:      (type $struct (struct_subtype (field i32) data))
   (type $struct (struct_subtype (field i32) data))


### PR DESCRIPTION
With this a PossibleContents can be both known equal to a global and to have an exact type.

This helps on the tests in the PR but I see no benefit on j2wasm at all. Leaving as draft for now. Might be worth investigating more here.