### PR TITLE
Change `exit()` to `Fatal()`; make it possible to throw on `Fatal()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Current Trunk
 - `TypeBuilderSetSubType` now takes a supertype as the second argument.
 - `call_ref` can now take a signature type immediate in the text format. The
   type immediate will become mandatory in the future.
+- If `THROW_ON_FATAL` is defined at compile-time, then fatal errors will throw a
+  `std::runtime_error` instead of terminating the process. This may be used by
+  embedders of Binaryen to recover from errors.
 
 v110
 ----

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -16,6 +16,7 @@
 
 #include "support/file.h"
 #include "support/debug.h"
+#include "support/utilities.h"
 
 #include <cstdint>
 #include <cstdlib>
@@ -58,18 +59,16 @@ T wasm::read_file(const std::string& filename, Flags::BinaryOption binary) {
   }
   infile.open(filename, flags);
   if (!infile.is_open()) {
-    std::cerr << "Failed opening '" << filename << "'" << std::endl;
-    exit(EXIT_FAILURE);
+    Fatal() << "Failed opening '" << filename << "'";
   }
   infile.seekg(0, std::ios::end);
   std::streampos insize = infile.tellg();
   if (uint64_t(insize) >= std::numeric_limits<size_t>::max()) {
     // Building a 32-bit executable where size_t == 32 bits, we are not able to
     // create strings larger than 2^32 bytes in length, so must abort here.
-    std::cerr << "Failed opening '" << filename
-              << "': Input file too large: " << insize
-              << " bytes. Try rebuilding in 64-bit mode." << std::endl;
-    exit(EXIT_FAILURE);
+    Fatal() << "Failed opening '" << filename
+            << "': Input file too large: " << insize
+            << " bytes. Try rebuilding in 64-bit mode.";
   }
   T input(size_t(insize) + (binary == Flags::Binary ? 0 : 1), '\0');
   if (size_t(insize) == 0) {
@@ -115,8 +114,7 @@ wasm::Output::Output(const std::string& filename, Flags::BinaryOption binary)
         }
         outfile.open(filename, flags);
         if (!outfile.is_open()) {
-          std::cerr << "Failed opening '" << filename << "'" << std::endl;
-          exit(EXIT_FAILURE);
+          Fatal() << "Failed opening '" << filename << "'";
         }
         buffer = outfile.rdbuf();
       }

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -24,6 +24,7 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <type_traits>
 
 #include "support/bits.h"
@@ -62,14 +63,16 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 
 // For fatal errors which could arise from input (i.e. not assertion failures)
 class Fatal {
+private:
+  std::stringstream buffer;
 public:
-  Fatal() { std::cerr << "Fatal: "; }
+  Fatal() { buffer << "Fatal: "; }
   template<typename T> Fatal& operator<<(T arg) {
-    std::cerr << arg;
+    buffer << arg;
     return *this;
   }
   [[noreturn]] ~Fatal() {
-    std::cerr << "\n";
+    std::cerr << buffer.str() << std::endl;
     // Use _Exit here to avoid calling static destructors. This avoids deadlocks
     // in (for example) the thread worker pool, where workers hold a lock while
     // performing their work.

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -73,7 +73,7 @@ public:
     // Use _Exit here to avoid calling static destructors. This avoids deadlocks
     // in (for example) the thread worker pool, where workers hold a lock while
     // performing their work.
-    _Exit(1);
+    _Exit(EXIT_FAILURE);
   }
 };
 

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -65,6 +65,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 class Fatal {
 private:
   std::stringstream buffer;
+
 public:
   Fatal() { buffer << "Fatal: "; }
   template<typename T> Fatal& operator<<(T arg) {


### PR DESCRIPTION
This patch makes binaryen easier to call from other applications by making more errors recoverable instead of early-exiting.

The main thing it does is change three calls to `exit` on I/O errors into calls to `Fatal()`, which is an existing custom abstraction for handling unrecoverable errors. Currently `Fatal`'s destructor calls `_Exit(1)`.

My intent is to make it possible for `Fatal` to not exit, but to throw, allowing an embedding application to catch the exception.

Because the previous early exits were exiting with error code `EXIT_FAILURE`, I also changed `Fatal` to exit with `EXIT_FAILURE`. The test suite continues to pass so I assume this is ok.

Next I changed `Fatal` to buffer its error message until the destructor instead of immediately printing it to stderr. This is for ease of patching `Fatal` to throw instead.

Finally, I also included the patch I need to make `Fatal` throw when `THROW_ON_FATAL` is defined at compile time. I can carry this patch out of tree, but it is a small patch, so perhaps you will be willing to take it. I am happy to remove it.

The aforementioned patch throws in a dtor, which is so strongly discouraged that it requires a special `noexcept(false)` annotation in c++17, the pitfall being that it is easy to throw during unwinding, which causes an abort. This is a special type though that only exists on error paths, and this solution is the smallest solution that might work for my use case. I have accounted for double throws by inserting an explicit abort in that case.

I have run the test suite successfully, but have not manually tested that fatal errors print the same as previously. I have tested that the patch throws exceptions that can be recovered in my project https://github.com/brson/wasm-opt-rs

Fixes https://github.com/WebAssembly/binaryen/issues/4938