### PR TITLE
[GUFA] Fix haveIntersection on comparing nullable with non-nullable

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -164,6 +164,12 @@ bool PossibleContents::haveIntersection(const PossibleContents& a,
     return true;
   }
 
+  // We ruled out a null on both sides, so at least one is non-nullable. If the
+  // other is a null then no chance for an intersection remains.
+  if (a.isNull() || b.isNull()) {
+    return false;
+  }
+
   // From here on we focus on references and can ignore the case of null - any
   // intersection must be of a non-null value, so we can focus on the heap
   // types.

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -148,6 +148,14 @@ bool PossibleContents::haveIntersection(const PossibleContents& a,
   auto aType = a.getType();
   auto bType = b.getType();
 
+  if (!aType.isRef() || !bType.isRef()) {
+    // At least one is not a reference. The only way they can intersect is if
+    // the type is identical.
+    return aType == bType;
+  }
+
+  // From here on we focus on references.
+
   if (aType.isNullable() && bType.isNullable()) {
     // Null is possible on both sides. Assume that an intersection can exist,
     // but we could be more precise here and check if the types belong to
@@ -156,12 +164,18 @@ bool PossibleContents::haveIntersection(const PossibleContents& a,
     return true;
   }
 
-  if (a.hasExactType() && b.hasExactType() && a.getType() != b.getType()) {
+  // From here on we focus on references and can ignore the case of null - any
+  // intersection must be of a non-null value, so we can focus on the heap
+  // types.
+  auto aHeapType = aType.getHeapType();
+  auto bHeapType = bType.getHeapType();
+
+  if (a.hasExactType() && b.hasExactType() && aHeapType != bHeapType) {
     // The values must be different since their types are different.
     return false;
   }
 
-  if (!Type::isSubType(aType, bType) && !Type::isSubType(bType, aType)) {
+  if (!HeapType::isSubType(aHeapType, bHeapType) && !HeapType::isSubType(bHeapType, aHeapType)) {
     // No type can appear in both a and b, so the types differ, so the values
     // differ.
     return false;

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -175,7 +175,8 @@ bool PossibleContents::haveIntersection(const PossibleContents& a,
     return false;
   }
 
-  if (!HeapType::isSubType(aHeapType, bHeapType) && !HeapType::isSubType(bHeapType, aHeapType)) {
+  if (!HeapType::isSubType(aHeapType, bHeapType) &&
+      !HeapType::isSubType(bHeapType, aHeapType)) {
     // No type can appear in both a and b, so the types differ, so the values
     // differ.
     return false;

--- a/src/passes/GUFA.cpp
+++ b/src/passes/GUFA.cpp
@@ -211,6 +211,8 @@ struct GUFAOptimizer
   }
 
   void visitRefEq(RefEq* curr) {
+// manually call visitExpression if we made no changes
+
     if (curr->type == Type::unreachable) {
       // Leave this for DCE.
       return;

--- a/src/passes/GUFA.cpp
+++ b/src/passes/GUFA.cpp
@@ -211,8 +211,6 @@ struct GUFAOptimizer
   }
 
   void visitRefEq(RefEq* curr) {
-// manually call visitExpression if we made no changes
-
     if (curr->type == Type::unreachable) {
       // Leave this for DCE.
       return;

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -287,6 +287,9 @@ TEST_F(PossibleContentsTest, TestIntersection) {
   // Due to subtyping, an intersection might exist.
   assertHaveIntersection(funcGlobal, funcGlobal);
   assertHaveIntersection(funcGlobal, exactFuncSignatureType);
+  assertHaveIntersection(nonNullFuncGlobal, exactFuncSignatureType);
+  assertHaveIntersection(funcGlobal, exactNonNullFuncSignatureType);
+  assertHaveIntersection(nonNullFuncGlobal, exactNonNullFuncSignatureType);
 
   // Neither is a subtype of the other, but nulls are possible, so a null can be
   // the intersection.

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -280,6 +280,10 @@ TEST_F(PossibleContentsTest, TestIntersection) {
   assertHaveIntersection(exactFuncSignatureType, exactFuncSignatureType);
   assertHaveIntersection(i32Zero, i32One); // TODO: this could be inferred false
 
+  // Exact types only differing by nullability can intersect (not on the null,
+  // but on something else).
+  assertHaveIntersection(exactAnyref, exactNonNullAnyref);
+
   // Due to subtyping, an intersection might exist.
   assertHaveIntersection(funcGlobal, funcGlobal);
   assertHaveIntersection(funcGlobal, exactFuncSignatureType);

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2766,6 +2766,9 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $ref.eq-zero (export "ref.eq-zero")
     ;; We do not track specific references, so only the types can be used here.
@@ -2789,6 +2792,14 @@
         (struct.new $struct
           (i32.const 5)
         )
+      )
+    )
+    (drop
+      (ref.eq
+        (struct.new $struct
+          (i32.const 5)
+        )
+        (ref.null $struct)
       )
     )
   )


### PR DESCRIPTION
We compared types and not heap types, so a difference in nullability
confused us. But at that point in the code, we've ruled out nulls, so we
should focus on heap types only.

This should unblock the binaryen roll into J2Wasm.