### PR TITLE
Fix nondeterminism in GlobalStructInference

### DIFF
--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -176,12 +176,8 @@ struct GlobalStructInference : public Pass {
     // The above loop on typeGlobalsCopy is on an unsorted data structure, and
     // that can lead to nondeterminism in typeGlobals. Sort the vectors there to
     // ensure determinism.
-    for (auto& [type, globals] : typeGlobalsCopy) {
-std::cout << "pre-sort!\n";
-for (auto name : globals) std::cout << "  " << name << '\n';
+    for (auto& [type, globals] : typeGlobals) {
       std::sort(globals.begin(), globals.end());
-std::cout << "post-sort!\n";
-for (auto name : globals) std::cout << "  " << name << '\n';
     }
 
     // Optimize based on the above.
@@ -230,12 +226,10 @@ for (auto name : globals) std::cout << "  " << name << '\n';
         //   (i32.const 1337)
         //   (i32.const 42)
         //   (ref.eq (ref) $global2))
-        auto& globals = iter->second;
+        const auto& globals = iter->second;
         if (globals.size() < 2) {
           return;
         }
-std::cout << "globls!\n";
-for (auto name : globals) std::cout << "  " << name << '\n';
 
         // Find the constant values and which globals correspond to them.
         // TODO: SmallVectors?
@@ -291,10 +285,8 @@ for (auto name : globals) std::cout << "  " << name << '\n';
         // single comparison. While doing so, ensure that the index we can check
         // on is 0, that is, the first value has a single global.
         if (globalsForValue[0].size() == 1) {
-std::cout << "k1\n";
           // The checked global is already in index 0.
         } else if (globalsForValue[1].size() == 1) {
-std::cout << "k2\n";
           std::swap(values[0], values[1]);
           std::swap(globalsForValue[0], globalsForValue[1]);
         } else {
@@ -302,7 +294,6 @@ std::cout << "k2\n";
           // comparison. Give up.
           return;
         }
-std::cout << "k3\n";
 
         // Excellent, we can optimize here! Emit a select.
         //

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -173,6 +173,13 @@ struct GlobalStructInference : public Pass {
       return;
     }
 
+    // The above loop on typeGlobalsCopy is on an unsorted data structure, and
+    // that can lead to nondeterminism in typeGlobals. Sort the vectors there to
+    // ensure determinism.
+    for (auto& [type, globals] : typeGlobalsCopy) {
+      std::sort(globals.begin(), globals.end());
+    }
+
     // Optimize based on the above.
     struct FunctionOptimizer
       : public WalkerPass<PostWalker<FunctionOptimizer>> {

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -177,7 +177,11 @@ struct GlobalStructInference : public Pass {
     // that can lead to nondeterminism in typeGlobals. Sort the vectors there to
     // ensure determinism.
     for (auto& [type, globals] : typeGlobalsCopy) {
+std::cout << "pre-sort!\n";
+for (auto name : globals) std::cout << "  " << name << '\n';
       std::sort(globals.begin(), globals.end());
+std::cout << "post-sort!\n";
+for (auto name : globals) std::cout << "  " << name << '\n';
     }
 
     // Optimize based on the above.

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -230,6 +230,8 @@ struct GlobalStructInference : public Pass {
         if (globals.size() < 2) {
           return;
         }
+std::cout << "globls!\n";
+for (auto name : globals) std::cout << "  " << name << '\n';
 
         // Find the constant values and which globals correspond to them.
         // TODO: SmallVectors?
@@ -285,8 +287,10 @@ struct GlobalStructInference : public Pass {
         // single comparison. While doing so, ensure that the index we can check
         // on is 0, that is, the first value has a single global.
         if (globalsForValue[0].size() == 1) {
+std::cout << "k1\n";
           // The checked global is already in index 0.
         } else if (globalsForValue[1].size() == 1) {
+std::cout << "k2\n";
           std::swap(values[0], values[1]);
           std::swap(globalsForValue[0], globalsForValue[1]);
         } else {
@@ -294,6 +298,7 @@ struct GlobalStructInference : public Pass {
           // comparison. Give up.
           return;
         }
+std::cout << "k3\n";
 
         // Excellent, we can optimize here! Emit a select.
         //


### PR DESCRIPTION
We append to vectors of globals in a nondeterministically-ordered loop, which can lead to
different orderings of the vectors. This happens quite frequently in very large J2Wasm
files it turns out. As a solution, simply sort them after the nondeterministic stage.