### PR TITLE
Refactor interaction between Pass and PassRunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,12 +266,14 @@ jobs:
     - name: install ninja
       run: sudo apt-get install ninja-build
     - name: emsdk install
+      # TODO: Go back to tot once problem with
+      # https://github.com/emscripten-core/emscripten/pull/17948 is resolved.
       run: |
         mkdir $HOME/emsdk
         git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
         $HOME/emsdk/emsdk update-tags
-        $HOME/emsdk/emsdk install tot
-        $HOME/emsdk/emsdk activate tot
+        $HOME/emsdk/emsdk install latest
+        $HOME/emsdk/emsdk activate latest
     - name: update path
       run:  echo "PATH=$PATH:$HOME/emsdk" >> $GITHUB_ENV
     - name: emcc-tests

--- a/src/ir/flat.h
+++ b/src/ir/flat.h
@@ -118,7 +118,9 @@ inline void verifyFlatness(Module* module) {
 
     bool modifiesBinaryenIR() override { return false; }
 
-    VerifyFlatness* create() override { return new VerifyFlatness(); }
+    std::unique_ptr<Pass> create() override {
+      return std::make_unique<VerifyFlatness>();
+    }
 
     void doVisitFunction(Function* func) { verifyFlatness(func); }
   };

--- a/src/ir/hashed.h
+++ b/src/ir/hashed.h
@@ -38,8 +38,8 @@ struct FunctionHasher : public WalkerPass<PostWalker<FunctionHasher>> {
   FunctionHasher(Map* output)
     : output(output), customHasher(ExpressionAnalyzer::nothingHasher) {}
 
-  FunctionHasher* create() override {
-    return new FunctionHasher(output, customHasher);
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<FunctionHasher>(output, customHasher);
   }
 
   static Map createMap(Module* module) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -201,7 +201,9 @@ template<typename T> inline void renameFunctions(Module& wasm, T& map) {
 
     Updater(T& map) : map(map) {}
 
-    Updater* create() override { return new Updater(map); }
+    std::unique_ptr<Pass> create() override {
+      return std::make_unique<Updater>(map);
+    }
 
     void visitCall(Call* curr) { maybeUpdate(curr->target); }
 
@@ -392,7 +394,9 @@ struct ParallelFunctionAnalysis {
       Mapper(Module& module, Map& map, Func work)
         : module(module), map(map), work(work) {}
 
-      Mapper* create() override { return new Mapper(module, map, work); }
+      std::unique_ptr<Pass> create() override {
+        return std::make_unique<Mapper>(module, map, work);
+      }
 
       void doWalkFunction(Function* curr) {
         assert(map.count(curr));

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -113,7 +113,9 @@ void GlobalTypeRewriter::update() {
 
     CodeUpdater(OldToNewTypes& oldToNewTypes) : oldToNewTypes(oldToNewTypes) {}
 
-    CodeUpdater* create() override { return new CodeUpdater(oldToNewTypes); }
+    std::unique_ptr<Pass> create() override {
+      return std::make_unique<CodeUpdater>(oldToNewTypes);
+    }
 
     Type getNew(Type type) {
       if (type.isRef()) {

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -123,7 +123,9 @@ struct ReFinalize
   // preserved.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  Pass* create() override { return new ReFinalize; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<ReFinalize>();
+  }
 
   ReFinalize() { name = "refinalize"; }
 
@@ -189,7 +191,9 @@ struct ReFinalizeNode : public OverriddenVisitor<ReFinalizeNode> {
 struct AutoDrop : public WalkerPass<ExpressionStackWalker<AutoDrop>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new AutoDrop; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<AutoDrop>();
+  }
 
   AutoDrop() { name = "autodrop"; }
 

--- a/src/pass.h
+++ b/src/pass.h
@@ -450,7 +450,10 @@ public:
     assert(getPassRunner());
     // Parallel pass running is implemented in the PassRunner.
     if (isFunctionParallel()) {
-      PassRunner runner(module, getPassOptions());
+      // TODO: We should almost certainly be propagating pass options here, but
+      // that is a widespread change, so make sure it doesn't unacceptably
+      // regress compile times.
+      PassRunner runner(module /*, getPassOptions()*/);
       runner.setIsNested(true);
       runner.add(create());
       runner.run();

--- a/src/pass.h
+++ b/src/pass.h
@@ -425,7 +425,10 @@ public:
   std::string name;
 
   PassRunner* getPassRunner() { return runner; }
-  void setPassRunner(PassRunner* runner_) { runner = runner_; }
+  void setPassRunner(PassRunner* runner_) {
+    assert((!runner || runner == runner_) && "Pass already had a runner");
+    runner = runner_;
+  }
 
   PassOptions& getPassOptions() { return runner->options; }
 

--- a/src/pass.h
+++ b/src/pass.h
@@ -271,9 +271,7 @@ struct PassRunner {
   }
 
   // Add a pass given an instance.
-  template<class P> void add(std::unique_ptr<P> pass) {
-    doAdd(std::move(pass));
-  }
+  void add(std::unique_ptr<Pass> pass) { doAdd(std::move(pass)); }
 
   // Adds the pass if there are no DWARF-related issues. There is an issue if
   // there is DWARF and if the pass does not support DWARF (as defined by the
@@ -311,9 +309,6 @@ struct PassRunner {
 
   // Run the passes on a specific function
   void runOnFunction(Function* func);
-
-  // Get the last pass that was already executed of a certain type.
-  template<class P> P* getLast();
 
   // When running a pass runner within another pass runner, this
   // flag should be set. This influences how pass debugging works,
@@ -367,18 +362,18 @@ private:
 // Core pass class
 //
 class Pass {
+  PassRunner* runner = nullptr;
+  friend PassRunner;
+
 public:
   virtual ~Pass() = default;
 
   // Implement this with code to run the pass on the whole module
-  virtual void run(PassRunner* runner, Module* module) {
-    WASM_UNREACHABLE("unimplemented");
-  }
+  virtual void run(Module* module) { WASM_UNREACHABLE("unimplemented"); }
 
   // Implement this with code to run the pass on a single function, for
   // a function-parallel pass
-  virtual void
-  runOnFunction(PassRunner* runner, Module* module, Function* function) {
+  virtual void runOnFunction(Module* module, Function* function) {
     WASM_UNREACHABLE("unimplemented");
   }
 
@@ -404,7 +399,7 @@ public:
   // This method is used to create instances per function for a
   // function-parallel pass. You may need to override this if you subclass a
   // Walker, as otherwise this will create the parent class.
-  virtual Pass* create() { WASM_UNREACHABLE("unimplenented"); }
+  virtual std::unique_ptr<Pass> create() { WASM_UNREACHABLE("unimplenented"); }
 
   // Whether this pass modifies the Binaryen IR in the module. This is true for
   // most passes, except for passes that have no side effects, or passes that
@@ -429,6 +424,11 @@ public:
 
   std::string name;
 
+  PassRunner* getPassRunner() { return runner; }
+  void setPassRunner(PassRunner* runner_) { runner = runner_; }
+
+  PassOptions& getPassOptions() { return runner->options; }
+
 protected:
   Pass() = default;
   Pass(Pass&) = default;
@@ -441,44 +441,46 @@ protected:
 //
 template<typename WalkerType>
 class WalkerPass : public Pass, public WalkerType {
-  PassRunner* runner = nullptr;
 
 protected:
   typedef WalkerPass<WalkerType> super;
 
 public:
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
+    assert(getPassRunner());
     // Parallel pass running is implemented in the PassRunner.
     if (isFunctionParallel()) {
-      PassRunner runner(module);
+      PassRunner runner(module, getPassOptions());
       runner.setIsNested(true);
-      std::unique_ptr<Pass> copy;
-      copy.reset(create());
-      runner.add(std::move(copy));
+      runner.add(create());
       runner.run();
       return;
     }
     // Single-thread running just calls the walkModule traversal.
-    setPassRunner(runner);
     WalkerType::walkModule(module);
   }
 
-  void
-  runOnFunction(PassRunner* runner, Module* module, Function* func) override {
+  // Utility for ad-hoc running.
+  void run(PassRunner* runner, Module* module) {
     setPassRunner(runner);
+    run(module);
+  }
+
+  void runOnFunction(Module* module, Function* func) override {
+    assert(getPassRunner());
     WalkerType::walkFunctionInModule(func, module);
+  }
+
+  // Utility for ad-hoc running.
+  void runOnFunction(PassRunner* runner, Module* module, Function* func) {
+    setPassRunner(runner);
+    runOnFunction(module, func);
   }
 
   void runOnModuleCode(PassRunner* runner, Module* module) {
     setPassRunner(runner);
     WalkerType::walkModuleCode(module);
   }
-
-  PassRunner* getPassRunner() { return runner; }
-
-  PassOptions& getPassOptions() { return runner->options; }
-
-  void setPassRunner(PassRunner* runner_) { runner = runner_; }
 };
 
 } // namespace wasm

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -839,12 +839,13 @@ struct AsyncifyFlow : public Pass {
 
   ModuleAnalyzer* analyzer;
 
-  AsyncifyFlow* create() override { return new AsyncifyFlow(analyzer); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<AsyncifyFlow>(analyzer);
+  }
 
   AsyncifyFlow(ModuleAnalyzer* analyzer) : analyzer(analyzer) {}
 
-  void
-  runOnFunction(PassRunner* runner, Module* module_, Function* func_) override {
+  void runOnFunction(Module* module_, Function* func_) override {
     module = module_;
     func = func_;
     builder = make_unique<AsyncifyBuilder>(*module);
@@ -1213,7 +1214,9 @@ struct AsyncifyLocals : public WalkerPass<PostWalker<AsyncifyLocals>> {
 
   ModuleAnalyzer* analyzer;
 
-  AsyncifyLocals* create() override { return new AsyncifyLocals(analyzer); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<AsyncifyLocals>(analyzer);
+  }
 
   AsyncifyLocals(ModuleAnalyzer* analyzer) : analyzer(analyzer) {}
 
@@ -1491,52 +1494,52 @@ static std::string getFullImportName(Name module, Name base) {
 }
 
 struct Asyncify : public Pass {
-  void run(PassRunner* runner, Module* module) override {
-    bool optimize = runner->options.optimizeLevel > 0;
+  void run(Module* module) override {
+    bool optimize = getPassOptions().optimizeLevel > 0;
 
     // Ensure there is a memory, as we need it.
     MemoryUtils::ensureExists(module);
 
     // Find which things can change the state.
     auto stateChangingImports = String::trim(read_possible_response_file(
-      runner->options.getArgumentOrDefault("asyncify-imports", "")));
+      getPassOptions().getArgumentOrDefault("asyncify-imports", "")));
     auto ignoreImports =
-      runner->options.getArgumentOrDefault("asyncify-ignore-imports", "");
+      getPassOptions().getArgumentOrDefault("asyncify-ignore-imports", "");
     bool allImportsCanChangeState =
       stateChangingImports == "" && ignoreImports == "";
     String::Split listedImports(stateChangingImports, ",");
     // TODO: consider renaming asyncify-ignore-indirect to
     //       asyncify-ignore-nondirect, but that could break users.
-    auto ignoreNonDirect = runner->options.getArgumentOrDefault(
+    auto ignoreNonDirect = getPassOptions().getArgumentOrDefault(
                              "asyncify-ignore-indirect", "") == "";
     std::string removeListInput =
-      runner->options.getArgumentOrDefault("asyncify-removelist", "");
+      getPassOptions().getArgumentOrDefault("asyncify-removelist", "");
     if (removeListInput.empty()) {
       // Support old name for now to avoid immediate breakage TODO remove
       removeListInput =
-        runner->options.getArgumentOrDefault("asyncify-blacklist", "");
+        getPassOptions().getArgumentOrDefault("asyncify-blacklist", "");
     }
     String::Split removeList(
       String::trim(read_possible_response_file(removeListInput)), ",");
     String::Split addList(
       String::trim(read_possible_response_file(
-        runner->options.getArgumentOrDefault("asyncify-addlist", ""))),
+        getPassOptions().getArgumentOrDefault("asyncify-addlist", ""))),
       ",");
     std::string onlyListInput =
-      runner->options.getArgumentOrDefault("asyncify-onlylist", "");
+      getPassOptions().getArgumentOrDefault("asyncify-onlylist", "");
     if (onlyListInput.empty()) {
       // Support old name for now to avoid immediate breakage TODO remove
       onlyListInput =
-        runner->options.getArgumentOrDefault("asyncify-whitelist", "");
+        getPassOptions().getArgumentOrDefault("asyncify-whitelist", "");
     }
     String::Split onlyList(
       String::trim(read_possible_response_file(onlyListInput)), ",");
     auto asserts =
-      runner->options.getArgumentOrDefault("asyncify-asserts", "") != "";
+      getPassOptions().getArgumentOrDefault("asyncify-asserts", "") != "";
     auto verbose =
-      runner->options.getArgumentOrDefault("asyncify-verbose", "") != "";
+      getPassOptions().getArgumentOrDefault("asyncify-verbose", "") != "";
     auto relocatable =
-      runner->options.getArgumentOrDefault("asyncify-relocatable", "") != "";
+      getPassOptions().getArgumentOrDefault("asyncify-relocatable", "") != "";
 
     removeList = handleBracketingOperators(removeList);
     addList = handleBracketingOperators(addList);
@@ -1716,8 +1719,9 @@ struct ModAsyncify
       ModAsyncify<neverRewind, neverUnwind, importsAlwaysUnwind>>> {
   bool isFunctionParallel() override { return true; }
 
-  ModAsyncify* create() override {
-    return new ModAsyncify<neverRewind, neverUnwind, importsAlwaysUnwind>();
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<
+      ModAsyncify<neverRewind, neverUnwind, importsAlwaysUnwind>>();
   }
 
   void doWalkFunction(Function* func) {
@@ -1840,7 +1844,7 @@ Pass* createModAsyncifyAlwaysOnlyUnwindPass() {
 // Assume that we never unwind, but may still rewind.
 //
 struct ModAsyncifyNeverUnwind : public Pass {
-  void run(PassRunner* runner, Module* module) override {}
+  void run(Module* module) override {}
 };
 
 Pass* createModAsyncifyNeverUnwindPass() {

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1495,51 +1495,48 @@ static std::string getFullImportName(Name module, Name base) {
 
 struct Asyncify : public Pass {
   void run(Module* module) override {
-    bool optimize = getPassOptions().optimizeLevel > 0;
+    auto& options = getPassOptions();
+    bool optimize = options.optimizeLevel > 0;
 
     // Ensure there is a memory, as we need it.
     MemoryUtils::ensureExists(module);
 
     // Find which things can change the state.
     auto stateChangingImports = String::trim(read_possible_response_file(
-      getPassOptions().getArgumentOrDefault("asyncify-imports", "")));
+      options.getArgumentOrDefault("asyncify-imports", "")));
     auto ignoreImports =
-      getPassOptions().getArgumentOrDefault("asyncify-ignore-imports", "");
+      options.getArgumentOrDefault("asyncify-ignore-imports", "");
     bool allImportsCanChangeState =
       stateChangingImports == "" && ignoreImports == "";
     String::Split listedImports(stateChangingImports, ",");
     // TODO: consider renaming asyncify-ignore-indirect to
     //       asyncify-ignore-nondirect, but that could break users.
-    auto ignoreNonDirect = getPassOptions().getArgumentOrDefault(
-                             "asyncify-ignore-indirect", "") == "";
+    auto ignoreNonDirect =
+      options.getArgumentOrDefault("asyncify-ignore-indirect", "") == "";
     std::string removeListInput =
-      getPassOptions().getArgumentOrDefault("asyncify-removelist", "");
+      options.getArgumentOrDefault("asyncify-removelist", "");
     if (removeListInput.empty()) {
       // Support old name for now to avoid immediate breakage TODO remove
-      removeListInput =
-        getPassOptions().getArgumentOrDefault("asyncify-blacklist", "");
+      removeListInput = options.getArgumentOrDefault("asyncify-blacklist", "");
     }
     String::Split removeList(
       String::trim(read_possible_response_file(removeListInput)), ",");
     String::Split addList(
       String::trim(read_possible_response_file(
-        getPassOptions().getArgumentOrDefault("asyncify-addlist", ""))),
+        options.getArgumentOrDefault("asyncify-addlist", ""))),
       ",");
     std::string onlyListInput =
-      getPassOptions().getArgumentOrDefault("asyncify-onlylist", "");
+      options.getArgumentOrDefault("asyncify-onlylist", "");
     if (onlyListInput.empty()) {
       // Support old name for now to avoid immediate breakage TODO remove
-      onlyListInput =
-        getPassOptions().getArgumentOrDefault("asyncify-whitelist", "");
+      onlyListInput = options.getArgumentOrDefault("asyncify-whitelist", "");
     }
     String::Split onlyList(
       String::trim(read_possible_response_file(onlyListInput)), ",");
-    auto asserts =
-      getPassOptions().getArgumentOrDefault("asyncify-asserts", "") != "";
-    auto verbose =
-      getPassOptions().getArgumentOrDefault("asyncify-verbose", "") != "";
+    auto asserts = options.getArgumentOrDefault("asyncify-asserts", "") != "";
+    auto verbose = options.getArgumentOrDefault("asyncify-verbose", "") != "";
     auto relocatable =
-      getPassOptions().getArgumentOrDefault("asyncify-relocatable", "") != "";
+      options.getArgumentOrDefault("asyncify-relocatable", "") != "";
 
     removeList = handleBracketingOperators(removeList);
     addList = handleBracketingOperators(addList);

--- a/src/passes/AvoidReinterprets.cpp
+++ b/src/passes/AvoidReinterprets.cpp
@@ -76,7 +76,9 @@ static bool isReinterpret(Unary* curr) {
 struct AvoidReinterprets : public WalkerPass<PostWalker<AvoidReinterprets>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new AvoidReinterprets; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<AvoidReinterprets>();
+  }
 
   struct Info {
     // Info used when analyzing.

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -51,7 +51,9 @@ struct CoalesceLocals
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
 
-  Pass* create() override { return new CoalesceLocals; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<CoalesceLocals>();
+  }
 
   // main entry point
 
@@ -580,7 +582,9 @@ void CoalesceLocals::applyIndices(std::vector<Index>& indices,
 }
 
 struct CoalesceLocalsWithLearning : public CoalesceLocals {
-  virtual Pass* create() override { return new CoalesceLocalsWithLearning; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<CoalesceLocalsWithLearning>();
+  }
 
   virtual void pickIndices(std::vector<Index>& indices) override;
 };

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -86,7 +86,9 @@ struct ExpressionMarker
 struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new CodeFolding; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<CodeFolding>();
+  }
 
   // information about a "tail" - code that reaches a point that we can
   // merge (e.g., a branch and some code leading up to it)

--- a/src/passes/CodePushing.cpp
+++ b/src/passes/CodePushing.cpp
@@ -249,7 +249,9 @@ struct CodePushing : public WalkerPass<PostWalker<CodePushing>> {
   // way), so validation will be preserved.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  Pass* create() override { return new CodePushing; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<CodePushing>();
+  }
 
   LocalAnalyzer analyzer;
 

--- a/src/passes/ConstHoisting.cpp
+++ b/src/passes/ConstHoisting.cpp
@@ -44,7 +44,9 @@ static const Index MIN_USES = 2;
 struct ConstHoisting : public WalkerPass<PostWalker<ConstHoisting>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new ConstHoisting; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<ConstHoisting>();
+  }
 
   InsertOrderedMap<Literal, std::vector<Expression**>> uses;
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -195,8 +195,9 @@ struct ConstantFieldPropagation : public Pass {
     PCVFunctionStructValuesMap functionNewInfos(*module),
       functionSetInfos(*module);
     PCVScanner scanner(functionNewInfos, functionSetInfos);
-    scanner.run(getPassRunner(), module);
-    scanner.runOnModuleCode(getPassRunner(), module);
+    auto* runner = getPassRunner();
+    scanner.run(runner, module);
+    scanner.runOnModuleCode(runner, module);
 
     // Combine the data from the functions.
     PCVStructValuesMap combinedNewInfos, combinedSetInfos;
@@ -247,7 +248,7 @@ struct ConstantFieldPropagation : public Pass {
 
     // Optimize.
     // TODO: Skip this if we cannot optimize anything
-    FunctionOptimizer(combinedInfos).run(getPassRunner(), module);
+    FunctionOptimizer(combinedInfos).run(runner, module);
 
     // TODO: Actually remove the field from the type, where possible? That might
     //       be best in another pass.

--- a/src/passes/DWARF.cpp
+++ b/src/passes/DWARF.cpp
@@ -30,9 +30,7 @@
 namespace wasm {
 
 struct DWARFDump : public Pass {
-  void run(PassRunner* runner, Module* module) override {
-    Debug::dumpDWARF(*module);
-  }
+  void run(Module* module) override { Debug::dumpDWARF(*module); }
 };
 
 Pass* createDWARFDumpPass() { return new DWARFDump(); }

--- a/src/passes/DataFlowOpts.cpp
+++ b/src/passes/DataFlowOpts.cpp
@@ -39,7 +39,9 @@ namespace wasm {
 struct DataFlowOpts : public WalkerPass<PostWalker<DataFlowOpts>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new DataFlowOpts; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<DataFlowOpts>();
+  }
 
   DataFlow::Users nodeUsers;
 

--- a/src/passes/DeAlign.cpp
+++ b/src/passes/DeAlign.cpp
@@ -27,7 +27,9 @@ namespace wasm {
 struct DeAlign : public WalkerPass<PostWalker<DeAlign>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new DeAlign(); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<DeAlign>();
+  }
 
   void visitLoad(Load* curr) { curr->align = 1; }
 

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -48,7 +48,9 @@ struct DeadCodeElimination
   // local.get might have prevented validation).
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  Pass* create() override { return new DeadCodeElimination; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<DeadCodeElimination>();
+  }
 
   // as we remove code, we must keep the types of other nodes valid
   TypeUpdater typeUpdater;

--- a/src/passes/DuplicateFunctionElimination.cpp
+++ b/src/passes/DuplicateFunctionElimination.cpp
@@ -37,11 +37,11 @@ struct DuplicateFunctionElimination : public Pass {
   // This pass merges functions but does not alter their contents.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     // Multiple iterations may be necessary: A and B may be identical only after
     // we see the functions C1 and C2 that they call are in fact identical.
     // Rarely, such "chains" can be very long, so we limit how many we do.
-    auto& options = runner->options;
+    auto& options = getPassOptions();
     Index limit;
     if (options.optimizeLevel >= 3 || options.shrinkLevel >= 1) {
       limit = module->functions.size(); // no limit
@@ -56,7 +56,7 @@ struct DuplicateFunctionElimination : public Pass {
       limit--;
       // Hash all the functions
       auto hashes = FunctionHasher::createMap(module);
-      FunctionHasher(&hashes).run(runner, module);
+      FunctionHasher(&hashes).run(getPassRunner(), module);
       // Find hash-equal groups
       std::map<uint32_t, std::vector<Function*>> hashGroups;
       ModuleUtils::iterDefinedFunctions(*module, [&](Function* func) {
@@ -96,7 +96,7 @@ struct DuplicateFunctionElimination : public Pass {
         // remove the duplicates
         module->removeFunctions(
           [&](Function* func) { return duplicates.count(func->name) > 0; });
-        OptUtils::replaceFunctions(runner, *module, replacements);
+        OptUtils::replaceFunctions(getPassRunner(), *module, replacements);
       } else {
         break;
       }

--- a/src/passes/DuplicateImportElimination.cpp
+++ b/src/passes/DuplicateImportElimination.cpp
@@ -31,7 +31,7 @@ struct DuplicateImportElimination : public Pass {
   // This pass does not alter function contents.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     ImportInfo imports(*module);
     std::map<Name, Name> replacements;
     std::map<std::pair<Name, Name>, Name> seen;
@@ -54,7 +54,7 @@ struct DuplicateImportElimination : public Pass {
     }
     if (!replacements.empty()) {
       module->updateMaps();
-      OptUtils::replaceFunctions(runner, *module, replacements);
+      OptUtils::replaceFunctions(getPassRunner(), *module, replacements);
       for (auto name : toRemove) {
         module->removeFunction(name);
       }

--- a/src/passes/ExtractFunction.cpp
+++ b/src/passes/ExtractFunction.cpp
@@ -54,25 +54,24 @@ static void extract(PassRunner* runner, Module* module, Name name) {
   // Remove unneeded things.
   PassRunner postRunner(runner);
   postRunner.add("remove-unused-module-elements");
-  postRunner.setIsNested(true);
   postRunner.run();
 }
 
 struct ExtractFunction : public Pass {
-  void run(PassRunner* runner, Module* module) override {
-    Name name = runner->options.getArgument(
+  void run(Module* module) override {
+    Name name = getPassOptions().getArgument(
       "extract-function",
       "ExtractFunction usage:  wasm-opt --extract-function=FUNCTION_NAME");
-    extract(runner, module, name);
+    extract(getPassRunner(), module, name);
   }
 };
 
 struct ExtractFunctionIndex : public Pass {
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     std::string index =
-      runner->options.getArgument("extract-function-index",
-                                  "ExtractFunctionIndex usage: wasm-opt "
-                                  "--extract-function-index=FUNCTION_INDEX");
+      getPassOptions().getArgument("extract-function-index",
+                                   "ExtractFunctionIndex usage: wasm-opt "
+                                   "--extract-function-index=FUNCTION_INDEX");
     for (char c : index) {
       if (!std::isdigit(c)) {
         Fatal() << "Expected numeric function index";
@@ -85,7 +84,7 @@ struct ExtractFunctionIndex : public Pass {
     }
     // Assumes imports are at the beginning
     Name name = module->functions[i]->name;
-    extract(runner, module, name);
+    extract(getPassRunner(), module, name);
   }
 };
 

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -76,7 +76,9 @@ struct Flatten
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
 
-  Pass* create() override { return new Flatten; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<Flatten>();
+  }
 
   // For each expression, a bunch of expressions that should execute right
   // before it

--- a/src/passes/GUFA.cpp
+++ b/src/passes/GUFA.cpp
@@ -63,8 +63,8 @@ struct GUFAOptimizer
   GUFAOptimizer(ContentOracle& oracle, bool optimizing)
     : oracle(oracle), optimizing(optimizing) {}
 
-  GUFAOptimizer* create() override {
-    return new GUFAOptimizer(oracle, optimizing);
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<GUFAOptimizer>(oracle, optimizing);
   }
 
   bool optimized = false;
@@ -289,8 +289,7 @@ struct GUFAOptimizer
       return;
     }
 
-    PassRunner runner(getModule(), getPassOptions());
-    runner.setIsNested(true);
+    PassRunner runner(getPassRunner());
     // New unreachables we added have created dead code we can remove. If we do
     // not do this, then running GUFA repeatedly can actually increase code size
     // (by adding multiple unneeded unreachables).
@@ -329,9 +328,9 @@ struct GUFAPass : public Pass {
 
   GUFAPass(bool optimizing) : optimizing(optimizing) {}
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     ContentOracle oracle(*module);
-    GUFAOptimizer(oracle, optimizing).run(runner, module);
+    GUFAOptimizer(oracle, optimizing).run(getPassRunner(), module);
   }
 };
 

--- a/src/passes/GlobalEffects.cpp
+++ b/src/passes/GlobalEffects.cpp
@@ -26,11 +26,11 @@
 namespace wasm {
 
 struct GenerateGlobalEffects : public Pass {
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     // TODO: Full transitive closure of effects. For now, we just look at each
     //       function by itself.
 
-    auto& funcEffectsMap = runner->options.funcEffectsMap;
+    auto& funcEffectsMap = getPassOptions().funcEffectsMap;
 
     // First, clear any previous effects.
     funcEffectsMap.reset();
@@ -50,7 +50,7 @@ struct GenerateGlobalEffects : public Pass {
 
         // Gather the effects.
         auto effects =
-          std::make_unique<EffectAnalyzer>(runner->options, *module, func);
+          std::make_unique<EffectAnalyzer>(getPassOptions(), *module, func);
 
         // If the body has a call, give up - that means we can't infer a more
         // specific set of effects than the pessimistic case of just assuming
@@ -80,9 +80,7 @@ struct GenerateGlobalEffects : public Pass {
 };
 
 struct DiscardGlobalEffects : public Pass {
-  void run(PassRunner* runner, Module* module) override {
-    runner->options.funcEffectsMap.reset();
-  }
+  void run(Module* module) override { getPassOptions().funcEffectsMap.reset(); }
 };
 
 Pass* createGenerateGlobalEffectsPass() { return new GenerateGlobalEffects(); }

--- a/src/passes/GlobalRefining.cpp
+++ b/src/passes/GlobalRefining.cpp
@@ -34,7 +34,7 @@ struct GlobalRefining : public Pass {
   // Only modifies globals and global.get operations.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     if (!module->features.hasGC()) {
       return;
     }
@@ -114,7 +114,9 @@ struct GlobalRefining : public Pass {
       GetUpdater(GlobalRefining& parent, Module& wasm)
         : parent(parent), wasm(wasm) {}
 
-      GetUpdater* create() override { return new GetUpdater(parent, wasm); }
+      std::unique_ptr<Pass> create() override {
+        return std::make_unique<GetUpdater>(parent, wasm);
+      }
 
       // If we modify anything in a function then we must refinalize so that
       // types propagate outwards.
@@ -135,7 +137,7 @@ struct GlobalRefining : public Pass {
         }
       }
     };
-    GetUpdater(*this, *module).run(runner, module);
+    GetUpdater(*this, *module).run(getPassRunner(), module);
   }
 };
 

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -64,7 +64,7 @@ struct GlobalStructInference : public Pass {
   // them. If a global is not present here, it cannot be optimized.
   std::unordered_map<HeapType, std::vector<Name>> typeGlobals;
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     if (!module->features.hasGC()) {
       return;
     }
@@ -178,7 +178,9 @@ struct GlobalStructInference : public Pass {
       : public WalkerPass<PostWalker<FunctionOptimizer>> {
       bool isFunctionParallel() override { return true; }
 
-      Pass* create() override { return new FunctionOptimizer(parent); }
+      std::unique_ptr<Pass> create() override {
+        return std::make_unique<FunctionOptimizer>(parent);
+      }
 
       FunctionOptimizer(GlobalStructInference& parent) : parent(parent) {}
 
@@ -305,7 +307,7 @@ struct GlobalStructInference : public Pass {
       GlobalStructInference& parent;
     };
 
-    FunctionOptimizer(*this).run(runner, module);
+    FunctionOptimizer(*this).run(getPassRunner(), module);
   }
 };
 

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -62,8 +62,9 @@ struct FieldInfo {
 
 struct FieldInfoScanner
   : public StructUtils::StructScanner<FieldInfo, FieldInfoScanner> {
-  Pass* create() override {
-    return new FieldInfoScanner(functionNewInfos, functionSetGetInfos);
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<FieldInfoScanner>(functionNewInfos,
+                                              functionSetGetInfos);
   }
 
   FieldInfoScanner(
@@ -112,7 +113,7 @@ struct GlobalTypeOptimization : public Pass {
   static const Index RemovedField = Index(-1);
   std::unordered_map<HeapType, std::vector<Index>> indexesAfterRemovals;
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     if (!module->features.hasGC()) {
       return;
     }
@@ -124,8 +125,8 @@ struct GlobalTypeOptimization : public Pass {
     StructUtils::FunctionStructValuesMap<FieldInfo> functionNewInfos(*module),
       functionSetGetInfos(*module);
     FieldInfoScanner scanner(functionNewInfos, functionSetGetInfos);
-    scanner.run(runner, module);
-    scanner.runOnModuleCode(runner, module);
+    scanner.run(getPassRunner(), module);
+    scanner.runOnModuleCode(getPassRunner(), module);
 
     // Combine the data from the functions.
     functionSetGetInfos.combineInto(combinedSetGetInfos);
@@ -241,7 +242,7 @@ struct GlobalTypeOptimization : public Pass {
     // that we can identify, and only after this should we update all the types
     // throughout the module.)
     if (!indexesAfterRemovals.empty()) {
-      removeFieldsInInstructions(runner, *module);
+      removeFieldsInInstructions(*module);
     }
 
     // Update the types in the entire module.
@@ -314,7 +315,7 @@ struct GlobalTypeOptimization : public Pass {
 
   // After updating the types to remove certain fields, we must also remove
   // them from struct instructions.
-  void removeFieldsInInstructions(PassRunner* runner, Module& wasm) {
+  void removeFieldsInInstructions(Module& wasm) {
     struct FieldRemover : public WalkerPass<PostWalker<FieldRemover>> {
       bool isFunctionParallel() override { return true; }
 
@@ -322,7 +323,9 @@ struct GlobalTypeOptimization : public Pass {
 
       FieldRemover(GlobalTypeOptimization& parent) : parent(parent) {}
 
-      FieldRemover* create() override { return new FieldRemover(parent); }
+      std::unique_ptr<Pass> create() override {
+        return std::make_unique<FieldRemover>(parent);
+      }
 
       void visitStructNew(StructNew* curr) {
         if (curr->type == Type::unreachable) {
@@ -433,8 +436,8 @@ struct GlobalTypeOptimization : public Pass {
     };
 
     FieldRemover remover(*this);
-    remover.run(runner, &wasm);
-    remover.runOnModuleCode(runner, &wasm);
+    remover.run(getPassRunner(), &wasm);
+    remover.runOnModuleCode(getPassRunner(), &wasm);
   }
 };
 

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -732,7 +732,9 @@ struct Heap2LocalOptimizer {
 struct Heap2Local : public WalkerPass<PostWalker<Heap2Local>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new Heap2Local(); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<Heap2Local>();
+  }
 
   void doWalkFunction(Function* func) {
     // Multiple rounds of optimization may work in theory, as once we turn one

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -99,7 +99,9 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
   // TODO: allow module-level transformations in parallel passes
   bool isFunctionParallel() override { return false; }
 
-  Pass* create() override { return new I64ToI32Lowering; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<I64ToI32Lowering>();
+  }
 
   void doWalkModule(Module* module) {
     if (!builder) {

--- a/src/passes/Intrinsics.cpp
+++ b/src/passes/Intrinsics.cpp
@@ -24,7 +24,9 @@ namespace wasm {
 struct IntrinsicLowering : public WalkerPass<PostWalker<IntrinsicLowering>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new IntrinsicLowering; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<IntrinsicLowering>();
+  }
 
   void visitCall(Call* curr) {
     if (Intrinsics(*getModule()).isCallWithoutEffects(curr)) {

--- a/src/passes/JSPI.cpp
+++ b/src/passes/JSPI.cpp
@@ -40,7 +40,7 @@ struct JSPI : public Pass {
 
   Type externref = Type(HeapType::ext, Nullable);
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     Builder builder(*module);
     // Create a global to store the suspender that is passed into exported
     // functions and will then need to be passed out to the imported functions.

--- a/src/passes/LimitSegments.cpp
+++ b/src/passes/LimitSegments.cpp
@@ -21,7 +21,7 @@
 namespace wasm {
 
 struct LimitSegments : public Pass {
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     if (!MemoryUtils::ensureLimitedSegments(*module)) {
       std::cerr << "Unable to merge segments. "
                 << "wasm VMs may not accept this binary" << std::endl;

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -526,7 +526,9 @@ struct LocalCSE : public WalkerPass<PostWalker<LocalCSE>> {
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
 
-  Pass* create() override { return new LocalCSE(); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<LocalCSE>();
+  }
 
   void doWalkFunction(Function* func) {
     auto& options = getPassOptions();

--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -41,7 +41,9 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
   // type to be non-nullable if it would validate.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  Pass* create() override { return new LocalSubtyping(); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<LocalSubtyping>();
+  }
 
   void doWalkFunction(Function* func) {
     if (!getModule()->features.hasGC()) {

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -37,7 +37,9 @@ struct LoopInvariantCodeMotion
   : public WalkerPass<ExpressionStackWalker<LoopInvariantCodeMotion>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new LoopInvariantCodeMotion; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<LoopInvariantCodeMotion>();
+  }
 
   typedef std::unordered_set<LocalSet*> LoopSets;
 

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -403,7 +403,9 @@ struct MergeBlocks
       PostWalker<MergeBlocks, UnifiedExpressionVisitor<MergeBlocks>>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new MergeBlocks; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<MergeBlocks>();
+  }
 
   BranchUtils::BranchSeekerCache branchInfo;
 

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -62,7 +62,9 @@ struct MergeLocals
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
 
-  Pass* create() override { return new MergeLocals(); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<MergeLocals>();
+  }
 
   void doWalkFunction(Function* func) {
     // first, instrument the graph by modifying each copy

--- a/src/passes/MergeSimilarFunctions.cpp
+++ b/src/passes/MergeSimilarFunctions.cpp
@@ -174,7 +174,7 @@ struct EquivalentClass {
 struct MergeSimilarFunctions : public Pass {
   bool invalidatesDWARF() override { return true; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     std::vector<EquivalentClass> classes;
     collectEquivalentClasses(classes, module);
     std::sort(

--- a/src/passes/MinifyImportsAndExports.cpp
+++ b/src/passes/MinifyImportsAndExports.cpp
@@ -59,7 +59,7 @@ private:
   // Generates minified names that are valid in JS.
   // Names are computed lazily.
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     // Minify the imported names.
     Names::MinifiedNameGenerator names;
     std::map<Name, Name> oldToNew;

--- a/src/passes/NameList.cpp
+++ b/src/passes/NameList.cpp
@@ -28,7 +28,7 @@ namespace wasm {
 struct NameList : public Pass {
   bool modifiesBinaryenIR() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     ModuleUtils::iterDefinedFunctions(*module, [&](Function* func) {
       std::cout << "    " << func->name << " : "
                 << Measurer::measure(func->body) << '\n';

--- a/src/passes/NameTypes.cpp
+++ b/src/passes/NameTypes.cpp
@@ -30,7 +30,7 @@ static const size_t NameLenLimit = 20;
 struct NameTypes : public Pass {
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     // Find all the types.
     std::vector<HeapType> types = ModuleUtils::collectHeapTypes(*module);
 

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -88,7 +88,9 @@ struct Scanner : public WalkerPass<PostWalker<Scanner>> {
 
   Scanner(OptInfo& optInfo) : optInfo(optInfo) {}
 
-  Scanner* create() override { return new Scanner(optInfo); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<Scanner>(optInfo);
+  }
 
   // All the globals we read from. Any read of a global prevents us from
   // optimizing, unless it is the single read at the top of an "only" function
@@ -219,7 +221,9 @@ struct Optimizer
 
   Optimizer(OptInfo& optInfo) : optInfo(optInfo) {}
 
-  Optimizer* create() override { return new Optimizer(optInfo); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<Optimizer>(optInfo);
+  }
 
   void visitGlobalSet(GlobalSet* curr) {
     if (currBasicBlock) {
@@ -344,7 +348,7 @@ private:
 } // anonymous namespace
 
 struct OnceReduction : public Pass {
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     OptInfo optInfo;
 
     // Fill out the initial data.
@@ -374,7 +378,7 @@ struct OnceReduction : public Pass {
     }
 
     // Scan the module to find out which globals and functions are "once".
-    Scanner(optInfo).run(runner, module);
+    Scanner(optInfo).run(getPassRunner(), module);
 
     // Combine the information. We found which globals appear to be "once", but
     // other information may have proven they are not so, in fact. Specifically,
@@ -419,7 +423,7 @@ struct OnceReduction : public Pass {
         optInfo.newOnceGlobalsSetInFuncs[func->name];
       }
 
-      Optimizer(optInfo).run(runner, module);
+      Optimizer(optInfo).run(getPassRunner(), module);
 
       optInfo.onceGlobalsSetInFuncs =
         std::move(optInfo.newOnceGlobalsSetInFuncs);

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -264,7 +264,9 @@ struct OptimizeAddedConstants
 
   OptimizeAddedConstants(bool propagate) : propagate(propagate) {}
 
-  Pass* create() override { return new OptimizeAddedConstants(propagate); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<OptimizeAddedConstants>(propagate);
+  }
 
   void visitLoad(Load* curr) {
     MemoryAccessOptimizer<OptimizeAddedConstants, Load> optimizer(

--- a/src/passes/OptimizeForJS.cpp
+++ b/src/passes/OptimizeForJS.cpp
@@ -28,7 +28,9 @@ namespace wasm {
 struct OptimizeForJSPass : public WalkerPass<PostWalker<OptimizeForJSPass>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new OptimizeForJSPass; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<OptimizeForJSPass>();
+  }
 
   void visitBinary(Binary* curr) {
     using namespace Abstract;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -201,7 +201,9 @@ struct OptimizeInstructions
   : public WalkerPass<PostWalker<OptimizeInstructions>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new OptimizeInstructions; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<OptimizeInstructions>();
+  }
 
   bool fastMath;
 

--- a/src/passes/PickLoadSigns.cpp
+++ b/src/passes/PickLoadSigns.cpp
@@ -28,7 +28,9 @@ namespace wasm {
 struct PickLoadSigns : public WalkerPass<ExpressionStackWalker<PickLoadSigns>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new PickLoadSigns; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<PickLoadSigns>();
+  }
 
   struct Usage {
     Index signedUsages = 0;

--- a/src/passes/Poppify.cpp
+++ b/src/passes/Poppify.cpp
@@ -447,21 +447,22 @@ void Poppifier::poppify(Expression* expr) {
 
 class PoppifyFunctionsPass : public Pass {
   bool isFunctionParallel() override { return true; }
-  void
-  runOnFunction(PassRunner* runner, Module* module, Function* func) override {
+  void runOnFunction(Module* module, Function* func) override {
     if (func->profile != IRProfile::Poppy) {
       Poppifier(func, module).write();
       func->profile = IRProfile::Poppy;
     }
   }
-  Pass* create() override { return new PoppifyFunctionsPass; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<PoppifyFunctionsPass>();
+  }
 };
 
 } // anonymous namespace
 
 class PoppifyPass : public Pass {
-  void run(PassRunner* runner, Module* module) {
-    PassRunner subRunner(runner);
+  void run(Module* module) {
+    PassRunner subRunner(getPassRunner());
     subRunner.add(std::make_unique<PoppifyFunctionsPass>());
     // TODO: Enable this once it handles Poppy blocks correctly
     // subRunner.add(std::make_unique<ReFinalize>());

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -199,7 +199,9 @@ struct Precompute
       PostWalker<Precompute, UnifiedExpressionVisitor<Precompute>>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new Precompute(propagate); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<Precompute>(propagate);
+  }
 
   bool propagate = false;
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3365,9 +3365,9 @@ public:
 
   bool modifiesBinaryenIR() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     PrintSExpression print(o);
-    print.setDebugInfo(runner->options.debugInfo);
+    print.setDebugInfo(getPassOptions().debugInfo);
     print.visitModule(module);
   }
 };
@@ -3381,10 +3381,10 @@ public:
   MinifiedPrinter() = default;
   MinifiedPrinter(std::ostream* o) : Printer(o) {}
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     PrintSExpression print(o);
     print.setMinify(true);
-    print.setDebugInfo(runner->options.debugInfo);
+    print.setDebugInfo(getPassOptions().debugInfo);
     print.visitModule(module);
   }
 };
@@ -3398,10 +3398,10 @@ public:
   FullPrinter() = default;
   FullPrinter(std::ostream* o) : Printer(o) {}
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     PrintSExpression print(o);
     print.setFull(true);
-    print.setDebugInfo(runner->options.debugInfo);
+    print.setDebugInfo(getPassOptions().debugInfo);
     print.currModule = module;
     print.visitModule(module);
   }
@@ -3416,9 +3416,9 @@ public:
   PrintStackIR() = default;
   PrintStackIR(std::ostream* o) : Printer(o) {}
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     PrintSExpression print(o);
-    print.setDebugInfo(runner->options.debugInfo);
+    print.setDebugInfo(getPassOptions().debugInfo);
     print.setStackIR(true);
     print.currModule = module;
     print.visitModule(module);
@@ -3603,7 +3603,8 @@ namespace std {
 
 std::ostream& operator<<(std::ostream& o, wasm::Module& module) {
   wasm::PassRunner runner(&module);
-  wasm::Printer(&o).run(&runner, &module);
+  runner.add(std::make_unique<wasm::Printer>(&o));
+  runner.run();
   return o;
 }
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3603,8 +3603,12 @@ namespace std {
 
 std::ostream& operator<<(std::ostream& o, wasm::Module& module) {
   wasm::PassRunner runner(&module);
-  runner.add(std::make_unique<wasm::Printer>(&o));
-  runner.run();
+  wasm::Printer printer(&o);
+  // Do not use runner.run(), since that will cause an infinite recursion in
+  // BINARYEN_PASS_DEBUG=3, which prints modules (using this function) as part
+  // of running passes.
+  printer.setPassRunner(&runner);
+  printer.run(&module);
   return o;
 }
 

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -33,7 +33,7 @@ namespace wasm {
 struct PrintCallGraph : public Pass {
   bool modifiesBinaryenIR() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     std::ostream& o = std::cout;
     o << "digraph call {\n"
          "  rankdir = LR;\n"

--- a/src/passes/PrintFeatures.cpp
+++ b/src/passes/PrintFeatures.cpp
@@ -27,7 +27,7 @@ namespace wasm {
 struct PrintFeatures : public Pass {
   bool modifiesBinaryenIR() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     module->features.iterFeatures([](FeatureSet::Feature f) {
       std::cout << "--enable-" << FeatureSet::toString(f) << std::endl;
     });

--- a/src/passes/PrintFunctionMap.cpp
+++ b/src/passes/PrintFunctionMap.cpp
@@ -34,10 +34,10 @@ namespace wasm {
 struct PrintFunctionMap : public Pass {
   bool modifiesBinaryenIR() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     // If an argument is provided, write to that file; otherwise write to
     // stdout.
-    auto outFile = runner->options.getArgumentOrDefault("symbolmap", "");
+    auto outFile = getPassOptions().getArgumentOrDefault("symbolmap", "");
     Output output(outFile, Flags::Text);
     auto& o = output.getStream();
     Index i = 0;

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -36,7 +36,9 @@ namespace wasm {
 struct ReReloop final : public Pass {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new ReReloop; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<ReReloop>();
+  }
 
   std::unique_ptr<CFG::Relooper> relooper;
   std::unique_ptr<Builder> builder;
@@ -291,9 +293,7 @@ struct ReReloop final : public Pass {
     // TODO: optimize with this?
   }
 
-  void runOnFunction(PassRunner* runner,
-                     Module* module,
-                     Function* function) override {
+  void runOnFunction(Module* module, Function* function) override {
     Flat::verifyFlatness(function);
 
     // since control flow is flattened, this is pretty simple

--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -63,7 +63,9 @@ struct RedundantSetElimination
                                 Info>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new RedundantSetElimination(); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<RedundantSetElimination>();
+  }
 
   Index numLocals;
 

--- a/src/passes/RemoveMemory.cpp
+++ b/src/passes/RemoveMemory.cpp
@@ -24,7 +24,7 @@
 namespace wasm {
 
 struct RemoveMemory : public Pass {
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     module->removeDataSegments([&](DataSegment* curr) { return true; });
   }
 };

--- a/src/passes/RemoveNonJSOps.cpp
+++ b/src/passes/RemoveNonJSOps.cpp
@@ -56,7 +56,9 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
 
   bool isFunctionParallel() override { return false; }
 
-  Pass* create() override { return new RemoveNonJSOpsPass; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<RemoveNonJSOpsPass>();
+  }
 
   void doWalkModule(Module* module) {
     // Intrinsics may use scratch memory, ensure it.
@@ -339,7 +341,9 @@ struct StubUnsupportedJSOpsPass
   : public WalkerPass<PostWalker<StubUnsupportedJSOpsPass>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new StubUnsupportedJSOpsPass; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<StubUnsupportedJSOpsPass>();
+  }
 
   void visitUnary(Unary* curr) {
     switch (curr->op) {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -117,7 +117,9 @@ static bool tooCostlyToRunUnconditionally(const PassOptions& passOptions,
 struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new RemoveUnusedBrs; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<RemoveUnusedBrs>();
+  }
 
   bool anotherCycle;
 

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -239,7 +239,7 @@ struct RemoveUnusedModuleElements : public Pass {
   RemoveUnusedModuleElements(bool rootAllFunctions)
     : rootAllFunctions(rootAllFunctions) {}
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     std::vector<ModuleElement> roots;
     // Module start is a root.
     if (module->start.is()) {

--- a/src/passes/RemoveUnusedNames.cpp
+++ b/src/passes/RemoveUnusedNames.cpp
@@ -35,7 +35,9 @@ struct RemoveUnusedNames
   // without names are ignored, see the README section on non-nullable locals).
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  Pass* create() override { return new RemoveUnusedNames; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<RemoveUnusedNames>();
+  }
 
   // We maintain a list of branches that we saw in children, then when we reach
   // a parent block, we know if it was branched to

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -35,7 +35,9 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
   // Sorting and removing unused locals cannot affect validation.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  Pass* create() override { return new ReorderLocals; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<ReorderLocals>();
+  }
 
   // local index => times it is used
   std::vector<Index> counts;

--- a/src/passes/RoundTrip.cpp
+++ b/src/passes/RoundTrip.cpp
@@ -28,7 +28,7 @@
 namespace wasm {
 
 struct RoundTrip : public Pass {
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     BufferWithRandomAccess buffer;
     // Save features, which would not otherwise make it through a round trip if
     // the target features section has been stripped. We also need them in order
@@ -39,7 +39,7 @@ struct RoundTrip : public Pass {
     ModuleUtils::clearModule(*module);
     auto input = buffer.getAsChars();
     WasmBinaryBuilder parser(*module, features, input);
-    parser.setDWARF(runner->options.debugInfo);
+    parser.setDWARF(getPassOptions().debugInfo);
     try {
       parser.read();
     } catch (ParseException& p) {

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -73,7 +73,9 @@ struct SSAify : public Pass {
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
 
-  Pass* create() override { return new SSAify(allowMerges); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<SSAify>(allowMerges);
+  }
 
   SSAify(bool allowMerges) : allowMerges(allowMerges) {}
 
@@ -84,8 +86,7 @@ struct SSAify : public Pass {
   // things we add to the function prologue
   std::vector<Expression*> functionPrepends;
 
-  void
-  runOnFunction(PassRunner* runner, Module* module_, Function* func_) override {
+  void runOnFunction(Module* module_, Function* func_) override {
     module = module_;
     func = func_;
     LocalGraph graph(func);

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -393,9 +393,8 @@ struct SafeHeap : public Pass {
                               bool is64,
                               Name memory) {
     bool lowMemUnused = getPassOptions().lowMemoryUnused;
-    auto upperOp = is64           ? lowMemUnused ? LtUInt64 : EqInt64
-                   : lowMemUnused ? LtUInt32
-                                  : EqInt32;
+    auto upperOp = is64 ? lowMemUnused ? LtUInt64 : EqInt64
+                        : lowMemUnused ? LtUInt32 : EqInt32;
     auto upperBound = lowMemUnused ? PassOptions::LowMemoryBound : 0;
     Expression* brkLocation;
     if (sbrk.is()) {

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -69,8 +69,8 @@ struct AccessInstrumenter : public WalkerPass<PostWalker<AccessInstrumenter>> {
 
   bool isFunctionParallel() override { return true; }
 
-  AccessInstrumenter* create() override {
-    return new AccessInstrumenter(ignoreFunctions);
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<AccessInstrumenter>(ignoreFunctions);
   }
 
   AccessInstrumenter(std::set<Name> ignoreFunctions)
@@ -131,10 +131,8 @@ static std::set<Name> findCalledFunctions(Module* module, Name startFunc) {
 }
 
 struct SafeHeap : public Pass {
-  PassOptions options;
 
-  void run(PassRunner* runner, Module* module) override {
-    options = runner->options;
+  void run(Module* module) override {
     assert(!module->memories.empty());
     // add imports
     addImports(module);
@@ -147,7 +145,7 @@ struct SafeHeap : public Pass {
     // not available until after it has run.
     std::set<Name> ignoreFunctions = findCalledFunctions(module, module->start);
     ignoreFunctions.insert(getSbrkPtr);
-    AccessInstrumenter(ignoreFunctions).run(runner, module);
+    AccessInstrumenter(ignoreFunctions).run(getPassRunner(), module);
     // add helper checking funcs and imports
     addGlobals(module, module->features);
   }
@@ -394,9 +392,11 @@ struct SafeHeap : public Pass {
                               Type indexType,
                               bool is64,
                               Name memory) {
-    auto upperOp = is64 ? options.lowMemoryUnused ? LtUInt64 : EqInt64
-                        : options.lowMemoryUnused ? LtUInt32 : EqInt32;
-    auto upperBound = options.lowMemoryUnused ? PassOptions::LowMemoryBound : 0;
+    bool lowMemUnused = getPassOptions().lowMemoryUnused;
+    auto upperOp = is64           ? lowMemUnused ? LtUInt64 : EqInt64
+                   : lowMemUnused ? LtUInt32
+                                  : EqInt32;
+    auto upperBound = lowMemUnused ? PassOptions::LowMemoryBound : 0;
     Expression* brkLocation;
     if (sbrk.is()) {
       brkLocation =

--- a/src/passes/SetGlobals.cpp
+++ b/src/passes/SetGlobals.cpp
@@ -28,8 +28,8 @@ struct SetGlobals : public Pass {
   // Only modifies globals.
   bool requiresNonNullableLocalFixups() override { return false; }
 
-  void run(PassRunner* runner, Module* module) override {
-    Name input = runner->options.getArgument(
+  void run(Module* module) override {
+    Name input = getPassRunner()->options.getArgument(
       "set-globals",
       "SetGlobals usage:  wasm-opt --pass-arg=set-globals@x=y,z=w");
 

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -48,7 +48,7 @@ struct SignaturePruning : public Pass {
   // type has no improvement that we can find, it will not appear in this map.
   std::unordered_map<HeapType, Signature> newSignatures;
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     if (!module->features.hasGC()) {
       return;
     }
@@ -193,8 +193,12 @@ struct SignaturePruning : public Pass {
       }
 
       auto oldParams = sig.params;
-      auto removedIndexes = ParamUtils::removeParameters(
-        funcs, unusedParams, info.calls, info.callRefs, module, runner);
+      auto removedIndexes = ParamUtils::removeParameters(funcs,
+                                                         unusedParams,
+                                                         info.calls,
+                                                         info.callRefs,
+                                                         module,
+                                                         getPassRunner());
       if (removedIndexes.empty()) {
         continue;
       }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -71,8 +71,9 @@ struct SimplifyLocals
       SimplifyLocals<allowTee, allowStructure, allowNesting>>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override {
-    return new SimplifyLocals<allowTee, allowStructure, allowNesting>();
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<
+      SimplifyLocals<allowTee, allowStructure, allowNesting>>();
   }
 
   // information for a local.set we can sink

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -37,7 +37,9 @@ struct SpillPointers
   : public WalkerPass<LivenessWalker<SpillPointers, Visitor<SpillPointers>>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new SpillPointers; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<SpillPointers>();
+  }
 
   // a mapping of the pointers to all the spillable things. We need to know
   // how to replace them, and as we spill we may modify them. This map

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -31,7 +31,9 @@ namespace wasm {
 struct GenerateStackIR : public WalkerPass<PostWalker<GenerateStackIR>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new GenerateStackIR; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<GenerateStackIR>();
+  }
 
   bool modifiesBinaryenIR() override { return false; }
 
@@ -336,7 +338,9 @@ private:
 struct OptimizeStackIR : public WalkerPass<PostWalker<OptimizeStackIR>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new OptimizeStackIR; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<OptimizeStackIR>();
+  }
 
   bool modifiesBinaryenIR() override { return false; }
 

--- a/src/passes/Strip.cpp
+++ b/src/passes/Strip.cpp
@@ -36,7 +36,7 @@ struct Strip : public Pass {
 
   Strip(Decider decider) : decider(decider) {}
 
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     // Remove name and debug sections.
     auto& sections = module->userSections;
     sections.erase(std::remove_if(sections.begin(), sections.end(), decider),

--- a/src/passes/StripTargetFeatures.cpp
+++ b/src/passes/StripTargetFeatures.cpp
@@ -23,7 +23,7 @@ struct StripTargetFeatures : public Pass {
 
   bool isStripped = false;
   StripTargetFeatures(bool isStripped) : isStripped(isStripped) {}
-  void run(PassRunner* runner, Module* module) override {
+  void run(Module* module) override {
     module->hasFeaturesSection = !isStripped;
   }
 };

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -306,7 +306,9 @@ public:
 
   TrapModePass(TrapMode mode) : mode(mode) { assert(mode != TrapMode::Allow); }
 
-  Pass* create() override { return new TrapModePass(mode); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<TrapModePass>(mode);
+  }
 
   void visitUnary(Unary* curr) {
     replaceCurrent(makeTrappingUnary(curr, *trappingFunctions));

--- a/src/passes/Untee.cpp
+++ b/src/passes/Untee.cpp
@@ -31,7 +31,7 @@ namespace wasm {
 struct Untee : public WalkerPass<PostWalker<Untee>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new Untee; }
+  std::unique_ptr<Pass> create() override { return std::make_unique<Untee>(); }
 
   void visitLocalSet(LocalSet* curr) {
     if (curr->isTee()) {

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -33,7 +33,7 @@ namespace wasm {
 struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new Vacuum; }
+  std::unique_ptr<Pass> create() override { return std::make_unique<Vacuum>(); }
 
   TypeUpdater typeUpdater;
 

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -64,8 +64,8 @@ struct FunctionRefReplacer
 
   FunctionRefReplacer(MaybeReplace maybeReplace) : maybeReplace(maybeReplace) {}
 
-  FunctionRefReplacer* create() override {
-    return new FunctionRefReplacer(maybeReplace);
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<FunctionRefReplacer>(maybeReplace);
   }
 
   void visitCall(Call* curr) { maybeReplace(curr->target); }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -896,6 +896,8 @@ void PassRunner::runPass(Pass* pass) {
     checker = std::unique_ptr<AfterEffectModuleChecker>(
       new AfterEffectModuleChecker(wasm));
   }
+  // Passes can only be run once and we deliberately do not clear the pass
+  // runner after running the pass, so there must not already be a runner here.
   assert(!pass->getPassRunner());
   pass->setPassRunner(this);
   pass->run(wasm);
@@ -934,7 +936,6 @@ void PassRunner::runPassOnFunction(Pass* pass, Function* func) {
 
   // Function-parallel passes get a new instance per function
   auto instance = pass->create();
-  assert(instance);
   instance->setPassRunner(this);
   instance->runOnFunction(wasm, func);
   handleAfterEffects(pass, func);

--- a/src/passes/test_passes.cpp
+++ b/src/passes/test_passes.cpp
@@ -31,12 +31,13 @@ namespace {
 // Pass to test EHUtil::handleBlockNestedPops function
 struct CatchPopFixup : public WalkerPass<PostWalker<CatchPopFixup>> {
   bool isFunctionParallel() override { return true; }
-  Pass* create() override { return new CatchPopFixup; }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<CatchPopFixup>();
+  }
 
   void doWalkFunction(Function* func) {
     EHUtils::handleBlockNestedPops(func, *getModule());
   }
-  void run(PassRunner* runner, Module* module) override {}
 };
 
 } // anonymous namespace

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -244,7 +244,9 @@ struct MetaDCEGraph {
 
       Scanner(MetaDCEGraph* parent) : parent(parent) {}
 
-      Scanner* create() override { return new Scanner(parent); }
+      std::unique_ptr<Pass> create() override {
+        return std::make_unique<Scanner>(parent);
+      }
 
       void visitCall(Call* curr) {
         if (!getModule()->getFunction(curr->target)->imported()) {

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -26,8 +26,7 @@ Instrumenter::Instrumenter(const InstrumenterConfig& config,
                            uint64_t moduleHash)
   : config(config), moduleHash(moduleHash) {}
 
-void Instrumenter::run(PassRunner* runner, Module* wasm) {
-  this->runner = runner;
+void Instrumenter::run(Module* wasm) {
   this->wasm = wasm;
 
   size_t numFuncs = 0;

--- a/src/tools/wasm-split/instrumenter.h
+++ b/src/tools/wasm-split/instrumenter.h
@@ -41,7 +41,6 @@ struct InstrumenterConfig {
 // at the beginning of each function to set its timestamp, and a new exported
 // function for dumping the profile data.
 struct Instrumenter : public Pass {
-  PassRunner* runner = nullptr;
   Module* wasm = nullptr;
 
   const InstrumenterConfig& config;
@@ -54,7 +53,7 @@ struct Instrumenter : public Pass {
 
   Instrumenter(const InstrumenterConfig& config, uint64_t moduleHash);
 
-  void run(PassRunner* runner, Module* wasm) override;
+  void run(Module* wasm) override;
 
 private:
   void addGlobals(size_t numFuncs);

--- a/src/tools/wasm-split/wasm-split.cpp
+++ b/src/tools/wasm-split/wasm-split.cpp
@@ -110,7 +110,6 @@ void instrumentModule(const WasmSplitOptions& options) {
   }
 
   uint64_t moduleHash = hashFile(options.inputFiles[0]);
-  PassRunner runner(&wasm, options.passOptions);
   InstrumenterConfig config;
   if (options.importNamespace.size()) {
     config.importNamespace = options.importNamespace;
@@ -120,7 +119,10 @@ void instrumentModule(const WasmSplitOptions& options) {
   }
   config.storageKind = options.storageKind;
   config.profileExport = options.profileExport;
-  Instrumenter(config, moduleHash).run(&runner, &wasm);
+
+  PassRunner runner(&wasm, options.passOptions);
+  runner.add(std::make_unique<Instrumenter>(config, moduleHash));
+  runner.run();
 
   adjustTableSize(wasm, options.initialTableSize);
 

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -39,7 +39,9 @@ static void optimizeWasm(Module& wasm, PassOptions options) {
   struct OptimizeForJS : public WalkerPass<PostWalker<OptimizeForJS>> {
     bool isFunctionParallel() override { return true; }
 
-    Pass* create() override { return new OptimizeForJS; }
+    std::unique_ptr<Pass> create() override {
+      return std::make_unique<OptimizeForJS>();
+    }
 
     void visitBinary(Binary* curr) {
       // x - -c (where c is a constant) is larger than x + c, in js (but not

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -208,7 +208,9 @@ struct ValidationInfo {
 struct FunctionValidator : public WalkerPass<PostWalker<FunctionValidator>> {
   bool isFunctionParallel() override { return true; }
 
-  Pass* create() override { return new FunctionValidator(*getModule(), &info); }
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<FunctionValidator>(*getModule(), &info);
+  }
 
   bool modifiesBinaryenIR() override { return false; }
 

--- a/test/passes/converge_O3_metrics.bin.txt
+++ b/test/passes/converge_O3_metrics.bin.txt
@@ -8,20 +8,20 @@ total
  [table-data]   : 429     
  [tables]       : 0       
  [tags]         : 0       
- [total]        : 551     
+ [total]        : 550     
  [vars]         : 2       
  Binary         : 12      
  Block          : 6       
  Break          : 3       
  Call           : 1       
  CallIndirect   : 4       
- Const          : 46      
+ Const          : 48      
  Drop           : 3       
  GlobalSet      : 1       
  If             : 2       
  Load           : 16      
- LocalGet       : 16      
- LocalSet       : 6       
+ LocalGet       : 14      
+ LocalSet       : 5       
  Loop           : 1       
  RefFunc        : 429     
  Store          : 5       
@@ -164,19 +164,17 @@ total
    (local.get $2)
   )
   (i32.store
-   (local.tee $0
-    (i32.const 32)
-   )
+   (i32.const 32)
    (i32.const 1)
   )
-  (i32.store offset=8
-   (local.get $0)
+  (i32.store
+   (i32.const 40)
    (i32.const 2)
   )
   (drop
    (call $import$0
     (i32.const 146)
-    (local.get $0)
+    (i32.const 32)
    )
   )
   (i32.const 1)
@@ -235,19 +233,19 @@ total
  [table-data]   : 429     
  [tables]       : 0       
  [tags]         : 0       
- [total]        : 547           -4
+ [total]        : 547           -3
  [vars]         : 2       
  Binary         : 12      
  Block          : 6       
  Break          : 3       
  Call           : 1       
  CallIndirect   : 4       
- Const          : 46      
+ Const          : 46            -2
  Drop           : 3       
  If             : 2       
  Load           : 16      
- LocalGet       : 14            -2
- LocalSet       : 5             -1
+ LocalGet       : 14      
+ LocalSet       : 5       
  Loop           : 1       
  RefFunc        : 429     
  Store          : 5       

--- a/test/passes/converge_O3_metrics.bin.txt
+++ b/test/passes/converge_O3_metrics.bin.txt
@@ -8,20 +8,20 @@ total
  [table-data]   : 429     
  [tables]       : 0       
  [tags]         : 0       
- [total]        : 550     
+ [total]        : 551     
  [vars]         : 2       
  Binary         : 12      
  Block          : 6       
  Break          : 3       
  Call           : 1       
  CallIndirect   : 4       
- Const          : 48      
+ Const          : 46      
  Drop           : 3       
  GlobalSet      : 1       
  If             : 2       
  Load           : 16      
- LocalGet       : 14      
- LocalSet       : 5       
+ LocalGet       : 16      
+ LocalSet       : 6       
  Loop           : 1       
  RefFunc        : 429     
  Store          : 5       
@@ -164,17 +164,19 @@ total
    (local.get $2)
   )
   (i32.store
-   (i32.const 32)
+   (local.tee $0
+    (i32.const 32)
+   )
    (i32.const 1)
   )
-  (i32.store
-   (i32.const 40)
+  (i32.store offset=8
+   (local.get $0)
    (i32.const 2)
   )
   (drop
    (call $import$0
     (i32.const 146)
-    (i32.const 32)
+    (local.get $0)
    )
   )
   (i32.const 1)
@@ -233,19 +235,19 @@ total
  [table-data]   : 429     
  [tables]       : 0       
  [tags]         : 0       
- [total]        : 547           -3
+ [total]        : 547           -4
  [vars]         : 2       
  Binary         : 12      
  Block          : 6       
  Break          : 3       
  Call           : 1       
  CallIndirect   : 4       
- Const          : 46            -2
+ Const          : 46      
  Drop           : 3       
  If             : 2       
  Load           : 16      
- LocalGet       : 14      
- LocalSet       : 5       
+ LocalGet       : 14            -2
+ LocalSet       : 5             -1
  Loop           : 1       
  RefFunc        : 429     
  Store          : 5       


### PR DESCRIPTION
Previously only WalkerPasses had access to the `getPassRunner` and
`getPassOptions` methods. Move those methods to `Pass` so all passes can use
them. As a result, the `PassRunner` passed to `Pass::run` and
`Pass::runOnFunction` is no longer necessary, so remove it.

Also update `Pass::create` to return a unique_ptr, which is more efficient than
having it return a raw pointer only to have the `PassRunner` wrap that raw
pointer in a `unique_ptr`.

Delete the unused template `PassRunner::getLast()`, which looks like it was
intended to enable retrieving previous analyses and has been in the code base
since 2015 but is not implemented anywhere.

This is nearly an NFC change, but I fixed a few places where pass options were
not being passed to nested `PassRunner`s and it looks like that had a very small
effect on the O3_converge test.