### PR TITLE
Fix bugs with copying expressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,12 +266,14 @@ jobs:
     - name: install ninja
       run: sudo apt-get install ninja-build
     - name: emsdk install
+      # TODO: Go back to tot once problem with
+      # https://github.com/emscripten-core/emscripten/pull/17948 is resolved.
       run: |
         mkdir $HOME/emsdk
         git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
         $HOME/emsdk/emsdk update-tags
-        $HOME/emsdk/emsdk install tot
-        $HOME/emsdk/emsdk activate tot
+        $HOME/emsdk/emsdk install latest
+        $HOME/emsdk/emsdk activate latest
     - name: update path
       run:  echo "PATH=$PATH:$HOME/emsdk" >> $GITHUB_ENV
     - name: emcc-tests

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -182,6 +182,11 @@ protected:
   }
 
 public:
+  ArenaVectorBase() = default;
+
+  // TODO: Implement safe copying.
+  ArenaVectorBase(const ArenaVectorBase& other) = delete;
+
   struct Iterator;
 
   T& operator[](size_t index) const {

--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -182,11 +182,6 @@ protected:
   }
 
 public:
-  ArenaVectorBase() = default;
-
-  // TODO: Implement safe copying.
-  ArenaVectorBase(const ArenaVectorBase& other) = delete;
-
   struct Iterator;
 
   T& operator[](size_t index) const {

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -64,7 +64,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 class Fatal {
 public:
   Fatal() { std::cerr << "Fatal: "; }
-  template<typename T> Fatal& operator<<(T arg) {
+  template<typename T> Fatal& operator<<(T&& arg) {
     std::cerr << arg;
     return *this;
   }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -746,6 +746,15 @@ public:
 
   Expression(Id id) : _id(id) {}
 
+protected:
+  // An expression cannot be constructed without knowing what kind of expression
+  // it should be.
+  Expression(const Expression& other) = default;
+  Expression(Expression&& other) = default;
+  Expression& operator=(Expression& other) = default;
+  Expression& operator=(Expression&& other) = default;
+
+public:
   void finalize() {}
 
   template<class T> bool is() const {


### PR DESCRIPTION
It does not make sense to construct an `Expression` directly because all
expressions must be specific expressions. However, we previously allowed
constructing Expressions, and in particular we allowed them to be copy
constructed. Unrelatedly, `Fatal::operator<<` took its argument by value.

Together, these two facts produced UB when printing Expressions in fatal error
messages because a new Expression would be copy constructed with the original
expression ID but without any of the actual data from the original specific
expression. For example, when trying to print a Block, the printing code would
try to look at the expression list, but the expression list would be junk stack
data because the copied Expression does not contain an expression list.

Fix the problem by making Expression's constructors visible only to its
subclasses and making `Fatal::operator<<` take its argument by forwarding
reference instead of by value. Also delete the unsafe constructors on
`ArenaVectorBase`, making it impossible to copy `Block` (which contains an
`ArenaVectorBase`) as well.