### PR TITLE
[Fuzzing] Allow recombine() to replace with a subtype

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -700,8 +700,7 @@ void TranslateToFuzzReader::recombine(Function* func) {
         auto& candidates = scanner.exprsByType[curr->type];
         assert(!candidates.empty()); // this expression itself must be there
         auto* rep = parent.pick(candidates);
-        replaceCurrent(
-          ExpressionManipulator::copy(rep, wasm));
+        replaceCurrent(ExpressionManipulator::copy(rep, wasm));
         if (rep->type != curr->type) {
           // Subtyping changes require us to finalize later.
           needRefinalize = true;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -647,6 +647,7 @@ void TranslateToFuzzReader::recombine(Function* func) {
 
       while (1) {
         ret.push_back(Type(heapType, nullability));
+        // TODO: handle basic supertypes too
         auto super = heapType.getSuperType();
         if (!super) {
           break;


### PR DESCRIPTION
Previously it would randomly replace an expression with another one with the
exact same type. Allowing a subtype may give us more coverage.