### PR TITLE
Pin v8 10.8.104

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -201,7 +201,10 @@ NATIVEXX = (os.environ.get('CXX') or which('mingw32-g++') or
             which('g++') or which('clang++'))
 NODEJS = os.getenv('NODE', which('node') or which('nodejs'))
 MOZJS = which('mozjs') or which('spidermonkey')
-V8 = which('v8') or which('d8')
+
+# TODO: Remove the specific v8 version once we implement structref and can run
+# on recent v8.
+V8 = which('v8-10.8.104') or which('v8') or which('d8')
 
 BINARYEN_INSTALL_DIR = os.path.dirname(options.binaryen_bin)
 WASM_OPT = [os.path.join(options.binaryen_bin, 'wasm-opt')]


### PR DESCRIPTION
More recent version of V8 include a change from `dataref` to `structref` that
prevent WasmGC modules produced by the fuzzer from validating. Use the last
compatible v8 version if it is in the path until we can update Binaryen to be
compatible with newer v8.