### PR TITLE
wasm2js: Support for flexible module import naming.

### DIFF
--- a/test/binaryen.js/emit_asmjs.js.txt
+++ b/test/binaryen.js/emit_asmjs.js.txt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js.asserts.js
+++ b/test/wasm2js.asserts.js
@@ -30,8 +30,7 @@
        return (actual_lo | 0) == (expected_lo | 0) && (actual_hi | 0) == (expected_hi | 0);
     }
   
-function asmFunc0(importObject) {
- var env = importObject.env || importObject;
+function asmFunc0(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js.traps.js
+++ b/test/wasm2js.traps.js
@@ -30,8 +30,7 @@
        return (actual_lo | 0) == (expected_lo | 0) && (actual_hi | 0) == (expected_hi | 0);
     }
   
-function asmFunc0(importObject) {
- var env = importObject.env || importObject;
+function asmFunc0(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/add_div.2asm.js
+++ b/test/wasm2js/add_div.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/add_div.2asm.js.opt
+++ b/test/wasm2js/add_div.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/atomic_fence.2asm.js
+++ b/test/wasm2js/atomic_fence.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(1507328);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/atomic_fence.2asm.js.opt
+++ b/test/wasm2js/atomic_fence.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/atomics_32.2asm.js
+++ b/test/wasm2js/atomics_32.2asm.js
@@ -89,8 +89,7 @@ memorySegments[1] = base64DecodeToExistingUint8Array(new Uint8Array(6), 0, "d29y
     bufferView.set(memorySegments[segment].subarray(offset, offset + size), dest);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(16777216);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/atomics_32.2asm.js.opt
+++ b/test/wasm2js/atomics_32.2asm.js.opt
@@ -89,8 +89,7 @@ memorySegments[1] = base64DecodeToExistingUint8Array(new Uint8Array(6), 0, "d29y
     bufferView.set(memorySegments[segment].subarray(offset, offset + size), dest);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(16777216);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/base64.2asm.js
+++ b/test/wasm2js/base64.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/base64.2asm.js.opt
+++ b/test/wasm2js/base64.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function dummy() {
@@ -717,7 +717,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var type_i32 = retasmFunc.type_i32;
 export var type_i64 = retasmFunc.type_i64;

--- a/test/wasm2js/br_table.2asm.js
+++ b/test/wasm2js/br_table.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function dummy() {
@@ -13422,7 +13422,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var type_i32 = retasmFunc.type_i32;
 export var type_i64 = retasmFunc.type_i64;

--- a/test/wasm2js/br_table_hoisting.2asm.js
+++ b/test/wasm2js/br_table_hoisting.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/br_table_hoisting.2asm.js.opt
+++ b/test/wasm2js/br_table_hoisting.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/br_table_temp.2asm.js.opt
+++ b/test/wasm2js/br_table_temp.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/br_table_to_loop.2asm.js
+++ b/test/wasm2js/br_table_to_loop.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/br_table_to_loop.2asm.js.opt
+++ b/test/wasm2js/br_table_to_loop.2asm.js.opt
@@ -1,8 +1,7 @@
 
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/break-drop.2asm.js
+++ b/test/wasm2js/break-drop.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/bulk-memory.2asm.js
+++ b/test/wasm2js/bulk-memory.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -30,8 +29,7 @@ var retasmFunc = asmFunc({
     bufferView.fill(value, dest, dest + size);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -133,8 +131,7 @@ function initActiveSegments(imports) {
     bufferView.copyWithin(dest, source, source + size);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -169,7 +166,7 @@ function asmFunc(importObject) {
  }
  
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }
@@ -214,8 +211,7 @@ memorySegments[0] = base64DecodeToExistingUint8Array(new Uint8Array(4), 0, "qrvM
     bufferView.set(memorySegments[segment].subarray(offset, offset + size), dest);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -324,8 +320,7 @@ function initActiveSegments(imports) {
     bufferView.set(memorySegments[segment].subarray(offset, offset + size), dest);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -364,7 +359,7 @@ function asmFunc(importObject) {
  }
  
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }

--- a/test/wasm2js/bulk-memory.2asm.js.opt
+++ b/test/wasm2js/bulk-memory.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -30,8 +29,7 @@ var retasmFunc = asmFunc({
     bufferView.fill(value, dest, dest + size);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -133,8 +131,7 @@ function initActiveSegments(imports) {
     bufferView.copyWithin(dest, source, source + size);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -169,7 +166,7 @@ function asmFunc(importObject) {
  }
  
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }
@@ -214,8 +211,7 @@ memorySegments[0] = base64DecodeToExistingUint8Array(new Uint8Array(4), 0, "qrvM
     bufferView.set(memorySegments[segment].subarray(offset, offset + size), dest);
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -290,8 +286,7 @@ export var load8_u = retasmFunc.load8_u;
   var bufferView;
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/comments.2asm.js
+++ b/test/wasm2js/comments.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -21,8 +20,7 @@ function asmFunc(importObject) {
 var retasmFunc = asmFunc({
 });
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/conversions-modified.2asm.js
+++ b/test/wasm2js/conversions-modified.2asm.js
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
 
   var scratchBuffer = new ArrayBuffer(16);
@@ -30,8 +30,7 @@ import { setTempRet0 } from 'env';
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -44,6 +43,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(x) {
@@ -620,7 +620,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i64_extend_s_i32 = retasmFunc.i64_extend_s_i32;
 export var i64_extend_u_i32 = retasmFunc.i64_extend_u_i32;

--- a/test/wasm2js/conversions-modified.2asm.js.opt
+++ b/test/wasm2js/conversions-modified.2asm.js.opt
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
 
   var scratchBuffer = new ArrayBuffer(16);
@@ -30,8 +30,7 @@ import { setTempRet0 } from 'env';
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -44,6 +43,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $3($0) {
@@ -197,7 +197,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i64_extend_s_i32 = retasmFunc.i64_extend_s_i32;
 export var i64_extend_u_i32 = retasmFunc.i64_extend_u_i32;

--- a/test/wasm2js/deterministic.2asm.js
+++ b/test/wasm2js/deterministic.2asm.js
@@ -2,8 +2,8 @@
   var bufferView;
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  var HEAP8 = new Int8Array(buffer);
@@ -46,6 +46,8 @@ function asmFunc(importObject) {
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({
+  "env": {
     memory: { buffer : memasmFunc }
+  },
 });
 export var foo = retasmFunc.foo;

--- a/test/wasm2js/deterministic.2asm.js.opt
+++ b/test/wasm2js/deterministic.2asm.js.opt
@@ -2,8 +2,8 @@
   var bufferView;
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  var HEAP8 = new Int8Array(buffer);
@@ -45,6 +45,8 @@ function asmFunc(importObject) {
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({
+  "env": {
     memory: { buffer : memasmFunc }
+  },
 });
 export var foo = retasmFunc.foo;

--- a/test/wasm2js/dot_import.2asm.js
+++ b/test/wasm2js/dot_import.2asm.js
@@ -1,7 +1,6 @@
-import { ba_se } from 'mod.ule';
+import * as mod_ule from 'mod.ule';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,7 +13,8 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
- var base = env.ba_se;
+ var mod_ule = imports["mod.ule"];
+ var base = mod_ule["ba.se"];
  function $0() {
   base();
  }
@@ -25,6 +25,6 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    ba_se,
+  "mod.ule": mod_ule,
 });
 export var exported = retasmFunc.exported;

--- a/test/wasm2js/dot_import.2asm.js.opt
+++ b/test/wasm2js/dot_import.2asm.js.opt
@@ -1,7 +1,6 @@
-import { ba_se } from 'mod.ule';
+import * as mod_ule from 'mod.ule';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,7 +13,8 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
- var base = env.ba_se;
+ var mod_ule = imports["mod.ule"];
+ var base = mod_ule["ba.se"];
  function $0() {
   base();
  }
@@ -25,6 +25,6 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    ba_se,
+  "mod.ule": mod_ule,
 });
 export var exported = retasmFunc.exported;

--- a/test/wasm2js/dynamicLibrary.2asm.js
+++ b/test/wasm2js/dynamicLibrary.2asm.js
@@ -1,5 +1,4 @@
-import { memoryBase } from 'env';
-import { tableBase } from 'env';
+import * as env from 'env';
 
 function Table(ret) {
   // grow method not included; table is not growable
@@ -34,10 +33,10 @@ function Table(ret) {
     return uint8Array;
   }
 function initActiveSegments(imports) {
-  base64DecodeToExistingUint8Array(bufferView, imports[memoryBase], "ZHluYW1pYyBkYXRh");
+  base64DecodeToExistingUint8Array(bufferView, imports['env']['memoryBase'], "ZHluYW1pYyBkYXRh");
 }
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  var HEAP8 = new Int8Array(buffer);
@@ -75,7 +74,7 @@ function asmFunc(importObject) {
  }
  
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  var FUNCTION_TABLE = Table(new Array(10));
  FUNCTION_TABLE[import$tableBase + 0] = foo;
  FUNCTION_TABLE[import$tableBase + 1] = bar;
@@ -91,6 +90,8 @@ function asmFunc(importObject) {
 
 var memasmFunc = new ArrayBuffer(16777216);
 var retasmFunc = asmFunc({
+  "env": {
     memory: { buffer : memasmFunc }
+  },
 });
 export var baz = retasmFunc.baz;

--- a/test/wasm2js/dynamicLibrary.2asm.js.opt
+++ b/test/wasm2js/dynamicLibrary.2asm.js.opt
@@ -1,5 +1,4 @@
-import { memoryBase } from 'env';
-import { tableBase } from 'env';
+import * as env from 'env';
 
 function Table(ret) {
   // grow method not included; table is not growable
@@ -34,10 +33,10 @@ function Table(ret) {
     return uint8Array;
   }
 function initActiveSegments(imports) {
-  base64DecodeToExistingUint8Array(bufferView, imports[memoryBase], "ZHluYW1pYyBkYXRh");
+  base64DecodeToExistingUint8Array(bufferView, imports['env']['memoryBase'], "ZHluYW1pYyBkYXRh");
 }
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  var HEAP8 = new Int8Array(buffer);
@@ -67,7 +66,7 @@ function asmFunc(importObject) {
  }
  
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  var FUNCTION_TABLE = Table(new Array(10));
  FUNCTION_TABLE[import$tableBase + 0] = foo;
  FUNCTION_TABLE[import$tableBase + 1] = foo;
@@ -83,6 +82,8 @@ function asmFunc(importObject) {
 
 var memasmFunc = new ArrayBuffer(16777216);
 var retasmFunc = asmFunc({
+  "env": {
     memory: { buffer : memasmFunc }
+  },
 });
 export var baz = retasmFunc.baz;

--- a/test/wasm2js/empty_export.2asm.js
+++ b/test/wasm2js/empty_export.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/empty_export.2asm.js.opt
+++ b/test/wasm2js/empty_export.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/empty_table.2asm.js
+++ b/test/wasm2js/empty_table.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/emscripten-grow-no.2asm.js
+++ b/test/wasm2js/emscripten-grow-no.2asm.js
@@ -23,8 +23,8 @@ function instantiate(info) {
 function initActiveSegments(imports) {
   base64DecodeToExistingUint8Array(bufferView, 1600, "YWJj");
 }
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  var HEAP8 = new Int8Array(buffer);
@@ -52,7 +52,7 @@ function asmFunc(importObject) {
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }

--- a/test/wasm2js/emscripten-grow-no.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-no.2asm.js.opt
@@ -23,8 +23,8 @@ function instantiate(info) {
 function initActiveSegments(imports) {
   base64DecodeToExistingUint8Array(bufferView, 1600, "YWJj");
 }
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  var HEAP8 = new Int8Array(buffer);
@@ -52,7 +52,7 @@ function asmFunc(importObject) {
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }

--- a/test/wasm2js/emscripten-grow-yes.2asm.js
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js
@@ -23,8 +23,8 @@ function instantiate(info) {
 function initActiveSegments(imports) {
   base64DecodeToExistingUint8Array(bufferView, 1600, "YWJj");
 }
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  memory.grow = __wasm_memory_grow;
@@ -57,7 +57,7 @@ function asmFunc(importObject) {
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }

--- a/test/wasm2js/emscripten-grow-yes.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js.opt
@@ -23,8 +23,8 @@ function instantiate(info) {
 function initActiveSegments(imports) {
   base64DecodeToExistingUint8Array(bufferView, 1600, "YWJj");
 }
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.memory;
  var buffer = memory.buffer;
  memory.grow = __wasm_memory_grow;
@@ -57,7 +57,7 @@ function asmFunc(importObject) {
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  function __wasm_memory_size() {
   return buffer.byteLength / 65536 | 0;
  }

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -26,9 +26,9 @@ function initActiveSegments(imports) {
 }
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(16777216);
+ var env = imports.env;
  var FUNCTION_TABLE = env.table;
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -214,7 +214,7 @@ function asmFunc(importObject) {
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
  FUNCTION_TABLE[3] = tabled;

--- a/test/wasm2js/emscripten.2asm.js.opt
+++ b/test/wasm2js/emscripten.2asm.js.opt
@@ -38,9 +38,9 @@ function initActiveSegments(imports) {
 }
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(16777216);
+ var env = imports.env;
  var FUNCTION_TABLE = env.table;
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -209,7 +209,7 @@ function asmFunc(importObject) {
  // EMSCRIPTEN_END_FUNCS
 ;
  bufferView = HEAPU8;
- initActiveSegments(env);
+ initActiveSegments(imports);
  FUNCTION_TABLE[1] = foo;
  FUNCTION_TABLE[2] = bar;
  FUNCTION_TABLE[3] = internal;

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
   var bufferView;
 
@@ -31,8 +31,7 @@ import { setTempRet0 } from 'env';
     return f32ScratchView[2];
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -54,6 +53,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function i16_store_little(address, value) {
@@ -701,7 +701,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_load16_s = retasmFunc.i32_load16_s;
 export var i32_load16_u = retasmFunc.i32_load16_u;

--- a/test/wasm2js/excess_fallthrough.2asm.js
+++ b/test/wasm2js/excess_fallthrough.2asm.js
@@ -1,8 +1,7 @@
 
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/excess_fallthrough.2asm.js.opt
+++ b/test/wasm2js/excess_fallthrough.2asm.js.opt
@@ -1,8 +1,7 @@
 
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/export_global.2asm.js
+++ b/test/wasm2js/export_global.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/export_global.2asm.js.opt
+++ b/test/wasm2js/export_global.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/f32.2asm.js
+++ b/test/wasm2js/f32.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/f32_cmp.2asm.js
+++ b/test/wasm2js/f32_cmp.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/f64_cmp.2asm.js
+++ b/test/wasm2js/f64_cmp.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/fac.2asm.js
+++ b/test/wasm2js/fac.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0($0_1, $0$hi) {
@@ -575,7 +575,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var fac_rec = retasmFunc.fac_rec;
 export var fac_rec_named = retasmFunc.fac_rec_named;

--- a/test/wasm2js/float-ops.2asm.js
+++ b/test/wasm2js/float-ops.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/float-ops.2asm.js.opt
+++ b/test/wasm2js/float-ops.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/float_literals-modified.2asm.js
+++ b/test/wasm2js/float_literals-modified.2asm.js
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
 
   var scratchBuffer = new ArrayBuffer(16);
@@ -18,8 +18,7 @@ import { setTempRet0 } from 'env';
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -32,6 +31,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -1149,7 +1149,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var f32_nan = retasmFunc.f32_nan;
 export var f32_positive_nan = retasmFunc.f32_positive_nan;

--- a/test/wasm2js/float_literals-modified.2asm.js.opt
+++ b/test/wasm2js/float_literals-modified.2asm.js.opt
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
 
   var scratchBuffer = new ArrayBuffer(16);
@@ -14,8 +14,7 @@ import { setTempRet0 } from 'env';
     f64ScratchView[0] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -28,6 +27,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -365,7 +365,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var f32_nan = retasmFunc.f32_nan;
 export var f32_positive_nan = retasmFunc.f32_positive_nan;

--- a/test/wasm2js/float_misc.2asm.js
+++ b/test/wasm2js/float_misc.2asm.js
@@ -29,8 +29,7 @@
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/forward.2asm.js
+++ b/test/wasm2js/forward.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/func-ptr-offset.2asm.js
+++ b/test/wasm2js/func-ptr-offset.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/func-ptr-offset.2asm.js.opt
+++ b/test/wasm2js/func-ptr-offset.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/func_ptrs.2asm.js
+++ b/test/wasm2js/func_ptrs.2asm.js
@@ -1,7 +1,6 @@
-import { print_i32 } from 'spectest';
+import * as spectest from 'spectest';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,7 +13,8 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
- var print = env.print_i32;
+ var spectest = imports.spectest;
+ var print = spectest.print_i32;
  function $3() {
   return 13 | 0;
  }
@@ -43,15 +43,14 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    print_i32,
+  "spectest": spectest,
 });
 export var one = retasmFunc.one;
 export var two = retasmFunc.two;
 export var three = retasmFunc.three;
 export var four = retasmFunc.four;
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -106,8 +105,7 @@ var retasmFunc = asmFunc({
 export var callt = retasmFunc.callt;
 export var callu = retasmFunc.callu;
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/get-set-local.2asm.js
+++ b/test/wasm2js/get-set-local.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/get-set-local.2asm.js.opt
+++ b/test/wasm2js/get-set-local.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/get_local.2asm.js
+++ b/test/wasm2js/get_local.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -239,7 +239,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var type_local_i32 = retasmFunc.type_local_i32;
 export var type_local_i64 = retasmFunc.type_local_i64;

--- a/test/wasm2js/global_i64.2asm.js
+++ b/test/wasm2js/global_i64.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/global_i64.2asm.js.opt
+++ b/test/wasm2js/global_i64.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/grow-memory-tricky.2asm.js
+++ b/test/wasm2js/grow-memory-tricky.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/grow-memory-tricky.2asm.js.opt
+++ b/test/wasm2js/grow-memory-tricky.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/grow_memory.2asm.js
+++ b/test/wasm2js/grow_memory.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/i32.2asm.js
+++ b/test/wasm2js/i32.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-add-sub.2asm.js
+++ b/test/wasm2js/i64-add-sub.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-add-sub.2asm.js.opt
+++ b/test/wasm2js/i64-add-sub.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-ctz.2asm.js
+++ b/test/wasm2js/i64-ctz.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function popcnt64($0, $0$hi) {
@@ -234,7 +234,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var a = retasmFunc.a;
 export var b = retasmFunc.b;

--- a/test/wasm2js/i64-ctz.2asm.js.opt
+++ b/test/wasm2js/i64-ctz.2asm.js.opt
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function legalstub$popcnt64($0, $1) {
@@ -66,7 +66,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var a = retasmFunc.a;
 export var b = retasmFunc.b;

--- a/test/wasm2js/i64-lowering.2asm.js
+++ b/test/wasm2js/i64-lowering.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-lowering.2asm.js.opt
+++ b/test/wasm2js/i64-lowering.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-rotate.2asm.js
+++ b/test/wasm2js/i64-rotate.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-rotate.2asm.js.opt
+++ b/test/wasm2js/i64-rotate.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-select.2asm.js
+++ b/test/wasm2js/i64-select.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-select.2asm.js.opt
+++ b/test/wasm2js/i64-select.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-shifts.2asm.js
+++ b/test/wasm2js/i64-shifts.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/i64-shifts.2asm.js.opt
+++ b/test/wasm2js/i64-shifts.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/if_unreachable.2asm.js
+++ b/test/wasm2js/if_unreachable.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/if_unreachable.2asm.js.opt
+++ b/test/wasm2js/if_unreachable.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/indirect-select.2asm.js
+++ b/test/wasm2js/indirect-select.2asm.js
@@ -1,7 +1,7 @@
-import { table } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var FUNCTION_TABLE = env.table;
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -32,7 +32,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    table,
+  "env": env,
 });
 export var foo_true = retasmFunc.foo_true;
 export var foo_false = retasmFunc.foo_false;

--- a/test/wasm2js/indirect-select.2asm.js.opt
+++ b/test/wasm2js/indirect-select.2asm.js.opt
@@ -1,7 +1,7 @@
-import { table } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var FUNCTION_TABLE = env.table;
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -32,7 +32,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    table,
+  "env": env,
 });
 export var foo_true = retasmFunc.foo_true;
 export var foo_false = retasmFunc.foo_false;

--- a/test/wasm2js/int_exprs.2asm.js
+++ b/test/wasm2js/int_exprs.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -236,10 +235,9 @@ export var i32_no_fold_cmp_s_offset = retasmFunc.i32_no_fold_cmp_s_offset;
 export var i32_no_fold_cmp_u_offset = retasmFunc.i32_no_fold_cmp_u_offset;
 export var i64_no_fold_cmp_s_offset = retasmFunc.i64_no_fold_cmp_s_offset;
 export var i64_no_fold_cmp_u_offset = retasmFunc.i64_no_fold_cmp_u_offset;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -252,6 +250,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(x, x$hi) {
@@ -316,13 +315,12 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i64_no_fold_wrap_extend_s = retasmFunc.i64_no_fold_wrap_extend_s;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -335,6 +333,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(x, x$hi) {
@@ -398,13 +397,12 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i64_no_fold_wrap_extend_u = retasmFunc.i64_no_fold_wrap_extend_u;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -417,6 +415,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(x) {
@@ -592,16 +591,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_shl_shr_s = retasmFunc.i32_no_fold_shl_shr_s;
 export var i32_no_fold_shl_shr_u = retasmFunc.i32_no_fold_shl_shr_u;
 export var i64_no_fold_shl_shr_s = retasmFunc.i64_no_fold_shl_shr_s;
 export var i64_no_fold_shl_shr_u = retasmFunc.i64_no_fold_shl_shr_u;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -614,6 +612,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(x) {
@@ -789,16 +788,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_shr_s_shl = retasmFunc.i32_no_fold_shr_s_shl;
 export var i32_no_fold_shr_u_shl = retasmFunc.i32_no_fold_shr_u_shl;
 export var i64_no_fold_shr_s_shl = retasmFunc.i64_no_fold_shr_s_shl;
 export var i64_no_fold_shr_u_shl = retasmFunc.i64_no_fold_shr_u_shl;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -811,6 +809,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -1601,16 +1600,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_div_s_mul = retasmFunc.i32_no_fold_div_s_mul;
 export var i32_no_fold_div_u_mul = retasmFunc.i32_no_fold_div_u_mul;
 export var i64_no_fold_div_s_mul = retasmFunc.i64_no_fold_div_s_mul;
 export var i64_no_fold_div_u_mul = retasmFunc.i64_no_fold_div_u_mul;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -1623,6 +1621,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -2319,16 +2318,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_div_s_self = retasmFunc.i32_no_fold_div_s_self;
 export var i32_no_fold_div_u_self = retasmFunc.i32_no_fold_div_u_self;
 export var i64_no_fold_div_s_self = retasmFunc.i64_no_fold_div_s_self;
 export var i64_no_fold_div_u_self = retasmFunc.i64_no_fold_div_u_self;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -2341,6 +2339,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -3019,16 +3018,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_rem_s_self = retasmFunc.i32_no_fold_rem_s_self;
 export var i32_no_fold_rem_u_self = retasmFunc.i32_no_fold_rem_u_self;
 export var i64_no_fold_rem_s_self = retasmFunc.i64_no_fold_rem_s_self;
 export var i64_no_fold_rem_u_self = retasmFunc.i64_no_fold_rem_u_self;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -3041,6 +3039,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -3831,16 +3830,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_mul_div_s = retasmFunc.i32_no_fold_mul_div_s;
 export var i32_no_fold_mul_div_u = retasmFunc.i32_no_fold_mul_div_u;
 export var i64_no_fold_mul_div_s = retasmFunc.i64_no_fold_mul_div_s;
 export var i64_no_fold_mul_div_u = retasmFunc.i64_no_fold_mul_div_u;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -3853,6 +3851,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -4485,14 +4484,13 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_div_s_2 = retasmFunc.i32_no_fold_div_s_2;
 export var i64_no_fold_div_s_2 = retasmFunc.i64_no_fold_div_s_2;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -4505,6 +4503,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -5119,14 +5118,13 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_rem_s_2 = retasmFunc.i32_no_fold_rem_s_2;
 export var i64_no_fold_rem_s_2 = retasmFunc.i64_no_fold_rem_s_2;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -5139,6 +5137,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -5835,16 +5834,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_div_s_0 = retasmFunc.i32_div_s_0;
 export var i32_div_u_0 = retasmFunc.i32_div_u_0;
 export var i64_div_s_0 = retasmFunc.i64_div_s_0;
 export var i64_div_u_0 = retasmFunc.i64_div_u_0;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -5857,6 +5855,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -6553,16 +6552,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_div_s_3 = retasmFunc.i32_div_s_3;
 export var i32_div_u_3 = retasmFunc.i32_div_u_3;
 export var i64_div_s_3 = retasmFunc.i64_div_s_3;
 export var i64_div_u_3 = retasmFunc.i64_div_u_3;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -6575,6 +6573,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -7271,16 +7270,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_div_s_5 = retasmFunc.i32_div_s_5;
 export var i32_div_u_5 = retasmFunc.i32_div_u_5;
 export var i64_div_s_5 = retasmFunc.i64_div_s_5;
 export var i64_div_u_5 = retasmFunc.i64_div_u_5;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -7293,6 +7291,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -7989,16 +7988,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_div_s_7 = retasmFunc.i32_div_s_7;
 export var i32_div_u_7 = retasmFunc.i32_div_u_7;
 export var i64_div_s_7 = retasmFunc.i64_div_s_7;
 export var i64_div_u_7 = retasmFunc.i64_div_u_7;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -8011,6 +8009,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -8689,16 +8688,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_rem_s_3 = retasmFunc.i32_rem_s_3;
 export var i32_rem_u_3 = retasmFunc.i32_rem_u_3;
 export var i64_rem_s_3 = retasmFunc.i64_rem_s_3;
 export var i64_rem_u_3 = retasmFunc.i64_rem_u_3;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -8711,6 +8709,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -9389,16 +9388,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_rem_s_5 = retasmFunc.i32_rem_s_5;
 export var i32_rem_u_5 = retasmFunc.i32_rem_u_5;
 export var i64_rem_s_5 = retasmFunc.i64_rem_s_5;
 export var i64_rem_u_5 = retasmFunc.i64_rem_u_5;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -9411,6 +9409,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -10089,16 +10088,15 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_rem_s_7 = retasmFunc.i32_rem_s_7;
 export var i32_rem_u_7 = retasmFunc.i32_rem_u_7;
 export var i64_rem_s_7 = retasmFunc.i64_rem_s_7;
 export var i64_rem_u_7 = retasmFunc.i64_rem_u_7;
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -10111,6 +10109,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
@@ -10743,7 +10742,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_no_fold_div_neg1 = retasmFunc.i32_no_fold_div_neg1;
 export var i64_no_fold_div_neg1 = retasmFunc.i64_no_fold_div_neg1;

--- a/test/wasm2js/labels.2asm.js
+++ b/test/wasm2js/labels.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -26,8 +26,7 @@
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/minified-memory.2asm.js
+++ b/test/wasm2js/minified-memory.2asm.js
@@ -1,6 +1,6 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.a;
  var buffer = memory.buffer;
  memory.grow = __wasm_memory_grow;
@@ -61,6 +61,8 @@ function asmFunc(importObject) {
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({
+  "env": {
     a: { buffer : memasmFunc }
+  },
 });
 export var foo = retasmFunc.foo;

--- a/test/wasm2js/minified-memory.2asm.js.opt
+++ b/test/wasm2js/minified-memory.2asm.js.opt
@@ -1,6 +1,6 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var memory = env.a;
  var buffer = memory.buffer;
  memory.grow = __wasm_memory_grow;
@@ -61,6 +61,8 @@ function asmFunc(importObject) {
 
 var memasmFunc = new ArrayBuffer(65536);
 var retasmFunc = asmFunc({
+  "env": {
     a: { buffer : memasmFunc }
+  },
 });
 export var foo = retasmFunc.foo;

--- a/test/wasm2js/minus_minus.2asm.js
+++ b/test/wasm2js/minus_minus.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/minus_minus.2asm.js.opt
+++ b/test/wasm2js/minus_minus.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/nested-selects.2asm.js
+++ b/test/wasm2js/nested-selects.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/nested-selects.2asm.js.opt
+++ b/test/wasm2js/nested-selects.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/ordering.2asm.js
+++ b/test/wasm2js/ordering.2asm.js
@@ -1,7 +1,7 @@
-import { table } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var FUNCTION_TABLE = env.table;
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -55,6 +55,6 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    table,
+  "env": env,
 });
 export var main = retasmFunc.main;

--- a/test/wasm2js/ordering.2asm.js.opt
+++ b/test/wasm2js/ordering.2asm.js.opt
@@ -1,7 +1,7 @@
-import { table } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
+ var env = imports.env;
  var FUNCTION_TABLE = env.table;
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -46,6 +46,6 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    table,
+  "env": env,
 });
 export var main = retasmFunc.main;

--- a/test/wasm2js/reinterpret.2asm.js
+++ b/test/wasm2js/reinterpret.2asm.js
@@ -29,8 +29,7 @@
     return f32ScratchView[2];
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/reinterpret.2asm.js.opt
+++ b/test/wasm2js/reinterpret.2asm.js.opt
@@ -21,8 +21,7 @@
     f64ScratchView[0] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/reinterpret_scratch.2asm.js
+++ b/test/wasm2js/reinterpret_scratch.2asm.js
@@ -18,8 +18,7 @@
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/reinterpret_scratch.2asm.js.opt
+++ b/test/wasm2js/reinterpret_scratch.2asm.js.opt
@@ -14,8 +14,7 @@
     f64ScratchView[0] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/set_local.2asm.js
+++ b/test/wasm2js/set_local.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -218,7 +218,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var type_local_i32 = retasmFunc.type_local_i32;
 export var type_local_i64 = retasmFunc.type_local_i64;

--- a/test/wasm2js/sign_ext.2asm.js
+++ b/test/wasm2js/sign_ext.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(x) {
@@ -201,7 +201,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var test8 = retasmFunc.test8;
 export var test16 = retasmFunc.test16;

--- a/test/wasm2js/sign_ext.2asm.js.opt
+++ b/test/wasm2js/sign_ext.2asm.js.opt
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0($0_1) {
@@ -56,7 +56,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var test8 = retasmFunc.test8;
 export var test16 = retasmFunc.test16;

--- a/test/wasm2js/stack-modified.2asm.js
+++ b/test/wasm2js/stack-modified.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(var$0, var$0$hi) {
@@ -564,7 +564,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var fac_expr = retasmFunc.fac_expr;
 export var fac_stack = retasmFunc.fac_stack;

--- a/test/wasm2js/stack-modified.2asm.js.opt
+++ b/test/wasm2js/stack-modified.2asm.js.opt
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function legalstub$0($0, $1) {
@@ -61,7 +61,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var fac_expr = retasmFunc.fac_expr;
 export var fac_stack = retasmFunc.fac_stack;

--- a/test/wasm2js/start_func.2asm.js
+++ b/test/wasm2js/start_func.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/start_func.2asm.js.opt
+++ b/test/wasm2js/start_func.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/switch.2asm.js
+++ b/test/wasm2js/switch.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0(i) {
@@ -184,7 +184,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var stmt = retasmFunc.stmt;
 export var expr = retasmFunc.expr;

--- a/test/wasm2js/tee_local.2asm.js
+++ b/test/wasm2js/tee_local.2asm.js
@@ -1,7 +1,6 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -14,6 +13,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -325,7 +325,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var type_local_i32 = retasmFunc.type_local_i32;
 export var type_local_i64 = retasmFunc.type_local_i64;

--- a/test/wasm2js/traps.2asm.js
+++ b/test/wasm2js/traps.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -732,8 +731,7 @@ export var no_dce_i32_div_u = retasmFunc.no_dce_i32_div_u;
 export var no_dce_i64_div_s = retasmFunc.no_dce_i64_div_s;
 export var no_dce_i64_div_u = retasmFunc.no_dce_i64_div_u;
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -1447,8 +1445,7 @@ export var no_dce_i32_rem_u = retasmFunc.no_dce_i32_rem_u;
 export var no_dce_i64_rem_s = retasmFunc.no_dce_i64_rem_s;
 export var no_dce_i64_rem_u = retasmFunc.no_dce_i64_rem_u;
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -1572,8 +1569,7 @@ export var no_dce_i64_trunc_f32_u = retasmFunc.no_dce_i64_trunc_f32_u;
 export var no_dce_i64_trunc_f64_s = retasmFunc.no_dce_i64_trunc_f64_s;
 export var no_dce_i64_trunc_f64_u = retasmFunc.no_dce_i64_trunc_f64_u;
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);

--- a/test/wasm2js/unaligned.2asm.js
+++ b/test/wasm2js/unaligned.2asm.js
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
   var bufferView;
 
@@ -31,8 +31,7 @@ import { setTempRet0 } from 'env';
     f32ScratchView[2] = value;
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -54,6 +53,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -178,7 +178,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_load = retasmFunc.i32_load;
 export var i64_load = retasmFunc.i64_load;

--- a/test/wasm2js/unaligned.2asm.js.opt
+++ b/test/wasm2js/unaligned.2asm.js.opt
@@ -1,4 +1,4 @@
-import { setTempRet0 } from 'env';
+import * as env from 'env';
 
   var bufferView;
 
@@ -27,8 +27,7 @@ import { setTempRet0 } from 'env';
     return f32ScratchView[2];
   }
       
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var buffer = new ArrayBuffer(65536);
  var HEAP8 = new Int8Array(buffer);
  var HEAP16 = new Int16Array(buffer);
@@ -50,6 +49,7 @@ function asmFunc(importObject) {
  var Math_sqrt = Math.sqrt;
  var nan = NaN;
  var infinity = Infinity;
+ var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
@@ -127,7 +127,7 @@ function asmFunc(importObject) {
 }
 
 var retasmFunc = asmFunc({
-    setTempRet0,
+  "env": env,
 });
 export var i32_load = retasmFunc.i32_load;
 export var i64_load = retasmFunc.i64_load;

--- a/test/wasm2js/unary-ops.2asm.js
+++ b/test/wasm2js/unary-ops.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unary-ops.2asm.js.opt
+++ b/test/wasm2js/unary-ops.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unreachable-get-cycle.2asm.js
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unreachable-get-cycle.2asm.js.opt
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unreachable-insts.2asm.js
+++ b/test/wasm2js/unreachable-insts.2asm.js
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unreachable-insts.2asm.js.opt
+++ b/test/wasm2js/unreachable-insts.2asm.js.opt
@@ -1,6 +1,5 @@
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unreachable-later.2asm.js
+++ b/test/wasm2js/unreachable-later.2asm.js
@@ -1,8 +1,7 @@
 
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;

--- a/test/wasm2js/unreachable-later.2asm.js.opt
+++ b/test/wasm2js/unreachable-later.2asm.js.opt
@@ -1,8 +1,7 @@
 
 function wasm2js_trap() { throw new Error('abort'); }
 
-function asmFunc(importObject) {
- var env = importObject.env || importObject;
+function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;


### PR DESCRIPTION
The previous code was making emscripten-specific assumptions about imports basically all coming from the `env` module.

I can't find a way to make this backwards compatible so may do a combined roll with the emscripten-side change:
https://github.com/emscripten-core/emscripten/pull/17806