### PR TITLE
Warn on too many parameters for Web VMs

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -48,7 +48,8 @@ enum {
 enum WebLimitations : uint32_t {
   MaxDataSegments = 100 * 1000,
   MaxFunctionBodySize = 128 * 1024,
-  MaxFunctionLocals = 50 * 1000
+  MaxFunctionLocals = 50 * 1000,
+  MaxFunctionParams = 1000
 };
 
 template<typename T, typename MiniT> struct LEB {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -453,6 +453,11 @@ void WasmBinaryWriter::writeFunctions() {
     tableOfContents.functionBodies.emplace_back(
       func->name, sizePos + sizeFieldSize, size);
     binaryLocationTrackedExpressionsForFunc.clear();
+
+    if (func->getParams().size() > WebLimitations::MaxFunctionParams) {
+      std::cerr << "Some VMs may not accept this binary because it has a large "
+                << "number of parameters in function " << func->name << ".\n";
+    }
   });
   finishSection(sectionStart);
 }

--- a/test/unit/test_web_limitations.py
+++ b/test/unit/test_web_limitations.py
@@ -1,0 +1,21 @@
+import os
+
+from scripts.test import shared
+from . import utils
+
+"""Test that we warn on large numbers of parameters, which Web VMs disallow."""
+
+
+class WebLimitations(utils.BinaryenTestCase):
+    def test_many_params(self):
+        params = '(param i32) ' * 1001
+        module = '''
+        (module
+         (func $foo %s
+         )
+        )
+        ''' % params
+        p = shared.run_process(shared.WASM_OPT + ['-o', os.devnull],
+                               input=module, check=False, capture_output=True)
+        self.assertEqual(p.returncode, 0)
+        self.assertIn('Some VMs may not accept this binary', p.stderr)

--- a/test/unit/test_web_limitations.py
+++ b/test/unit/test_web_limitations.py
@@ -17,7 +17,6 @@ class WebLimitations(utils.BinaryenTestCase):
         )
         ''' % params
         p = shared.run_process(shared.WASM_OPT + ['-o', os.devnull],
-                               input=module, check=False, capture_output=True)
-        self.assertEqual(p.returncode, 0)
+                               input=module, capture_output=True)
         self.assertIn('Some VMs may not accept this binary because it has a large number of parameters in function foo.',
                       p.stderr)

--- a/test/unit/test_web_limitations.py
+++ b/test/unit/test_web_limitations.py
@@ -3,11 +3,12 @@ import os
 from scripts.test import shared
 from . import utils
 
-"""Test that we warn on large numbers of parameters, which Web VMs disallow."""
-
 
 class WebLimitations(utils.BinaryenTestCase):
     def test_many_params(self):
+        """Test that we warn on large numbers of parameters, which Web VMs
+        disallow."""
+
         params = '(param i32) ' * 1001
         module = '''
         (module
@@ -18,4 +19,5 @@ class WebLimitations(utils.BinaryenTestCase):
         p = shared.run_process(shared.WASM_OPT + ['-o', os.devnull],
                                input=module, check=False, capture_output=True)
         self.assertEqual(p.returncode, 0)
-        self.assertIn('Some VMs may not accept this binary', p.stderr)
+        self.assertIn('Some VMs may not accept this binary because it has a large number of parameters in function foo.',
+                      p.stderr)


### PR DESCRIPTION
Similar to our existing handling of memory segment size:

https://github.com/WebAssembly/binaryen/blob/e6be381b6f5adbd07af080a4e1f74ba04c8eda82/src/wasm/wasm-binary.cpp#L600-L604

Fixes https://github.com/emscripten-core/emscripten/issues/17988