### PR TITLE
[DWARF] Warn on unsupport DWARF versions and content

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -64,6 +64,9 @@ struct BinaryenDWARFInfo {
     uint8_t addrSize = AddressSize;
     bool isLittleEndian = true;
     context = llvm::DWARFContext::create(sections, addrSize, isLittleEndian);
+    if (context->getMaxVersion() > 4) {
+      std::cerr << "warning: unsupported DWARF version\n";
+    }
   }
 };
 

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -162,8 +162,8 @@ struct LineState {
           }
           default: {
             // An unknown opcode, ignore.
-            std::cerr << "warning: unknown subopcopde " << opcode.SubOpcode
-                      << '\n';
+            std::cerr << "warning: unknown subopcode " << opcode.SubOpcode
+                      << " (this may be an unsupported version of DWARF)\n";
           }
         }
         break;

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -183,7 +183,10 @@ struct LineState {
         return true;
       }
       case llvm::dwarf::DW_LNS_advance_pc: {
-        assert(table.MinInstLength == 1);
+        if (table.MinInstLength != 1) {
+          std::cerr << "warning: bad MinInstLength "
+                       "(this may be an unsupported DWARF version)";
+        }
         addr += opcode.Data;
         break;
       }

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -65,7 +65,8 @@ struct BinaryenDWARFInfo {
     bool isLittleEndian = true;
     context = llvm::DWARFContext::create(sections, addrSize, isLittleEndian);
     if (context->getMaxVersion() > 4) {
-      std::cerr << "warning: unsupported DWARF version\n";
+      std::cerr << "warning: unsupported DWARF version ("
+                << context->getMaxVersion() << ")\n";
     }
   }
 };

--- a/third_party/llvm-project/DWARFEmitter.cpp
+++ b/third_party/llvm-project/DWARFEmitter.cpp
@@ -197,7 +197,8 @@ protected:
   void onEndCompileUnit(const DWARFYAML::Unit &CU) {
     size_t EndPos = OS.tell();
     if (EndPos - StartPos != CU.Length.getLength() && !CU.AddrSizeChanged) {
-      llvm_unreachable("compile unit size was incorrect");
+      llvm_unreachable("compile unit size was incorrect "
+                       "(this may be an unsupported version of DWARF)");
     }
   }
 

--- a/third_party/llvm-project/include/llvm/include/llvm/DebugInfo/DWARFContext.h
+++ b/third_party/llvm-project/include/llvm/include/llvm/DebugInfo/DWARFContext.h
@@ -332,7 +332,8 @@ public:
 
   bool isLittleEndian() const { return DObj->isLittleEndian(); }
   static bool isSupportedVersion(unsigned version) {
-    return version == 2 || version == 3 || version == 4 || version == 5;
+    // XXX BINARYEN: removed version 5, which we do not support
+    return version == 2 || version == 3 || version == 4;
   }
 
   std::shared_ptr<DWARFContext> getDWOContext(StringRef AbsolutePath);


### PR DESCRIPTION
Unfortunately there isn't a single place where an error may occur. I tested on
several files with different flags and added sufficient warnings so that we warn
on them all.