### PR TITLE
[Parser] Parse folded instructions

### DIFF
--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -121,6 +121,66 @@
  (func $f4 (type 13) (local i32 i64) (local $l f32))
  (func (export "f5.0") (export "f5.1") (import "mod" "f5"))
 
+ ;; CHECK:      (func $nop-skate (type $void)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT: )
+ (func $nop-skate
+  nop
+  nop
+  nop
+  nop
+  nop
+ )
+
+ ;; CHECK:      (func $nop-ski (type $void)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT: )
+ (func $nop-ski
+  (nop
+   (nop
+    (nop)
+    (nop)
+    (nop
+     (nop)
+    )
+   )
+   (nop)
+  )
+  (nop)
+ )
+
+ ;; CHECK:      (func $nop-sled (type $void)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT: )
+ (func $nop-sled
+  nop
+  (nop
+   (nop
+    (nop)
+   )
+  )
+  nop
+  (nop)
+  nop
+ )
+
  ;; CHECK:      (func $use-types (type $ref|$s0|_ref|$s1|_ref|$s2|_ref|$s3|_ref|$s4|_ref|$s5|_ref|$s6|_ref|$s7|_ref|$s8|_ref|$a0|_ref|$a1|_ref|$a2|_ref|$a3|_ref|$subvoid|_ref|$submany|_=>_none) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -124,14 +124,14 @@
  ;; CHECK:      (func $nop-skate (type $void)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)
- ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $nop-skate
   nop
   nop
-  nop
+  unreachable
   nop
   nop
  )
@@ -143,11 +143,11 @@
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)
- ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $nop-ski
-  (nop
+  (unreachable
    (nop
     (nop)
     (nop)
@@ -162,22 +162,22 @@
 
  ;; CHECK:      (func $nop-sled (type $void)
  ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)
- ;; CHECK-NEXT:  (nop)
- ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $nop-sled
   nop
   (nop
    (nop
-    (nop)
+    (unreachable)
    )
   )
   nop
-  (nop)
+  (unreachable)
   nop
  )
 


### PR DESCRIPTION
Parse folded expressions as described in the spec:
https://webassembly.github.io/spec/core/text/instructions.html#folded-instructions.
The old binaryen parser _only_ parses folded expressions, and furthermore
requires them to be folded such that a parent instruction consumes the values
produced by its children and only those values. The standard format is much more
general and allows folded instructions to have an arbitrary number of children
independent of dataflow.

To prevent the rest of the parser from having to know or care about the
difference between folded and unfolded instructions, parse folded instructions
after their children have been parsed. This means that a sequence of
instructions is always parsed in the order they would appear in a binary no
matter how they are folded (or not folded).