### PR TITLE
Validate memory initial < max only if memory hasMax

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3145,8 +3145,10 @@ static void validateMemories(Module& module, ValidationInfo& info) {
       "multiple memories present, but multi-memories is disabled");
   }
   for (auto& memory : module.memories) {
-    info.shouldBeFalse(
-      memory->initial > memory->max, "memory", "memory max >= initial");
+    if (memory->hasMax()) {
+      info.shouldBeFalse(
+        memory->initial > memory->max, "memory", "memory max >= initial");
+    }
     if (memory->is64()) {
       info.shouldBeTrue(module.features.hasMemory64(),
                         "memory",


### PR DESCRIPTION
Making a change to wasm-validator so that Memory::kUnlimitedSize is treated properly like an unlimited case. The check for whether memory.initial < memory.max will only happen if memory.hasMax() — meaning if memory.max is not set to kUnlimitedSize.