### PR TITLE
[Wasm GC] Fix the intersection of a bottom type null

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -195,11 +195,17 @@ void PossibleContents::intersectWithFullCone(const PossibleContents& other) {
   }
 
   // If the heap types are not compatible then they are in separate hierarchies
-  // and there is no intersection.
+  // and there is no intersection, aside from possibly a null of the bottom
+  // type.
   auto isSubType = HeapType::isSubType(heapType, otherHeapType);
   auto otherIsSubType = HeapType::isSubType(otherHeapType, heapType);
   if (!isSubType && !otherIsSubType) {
-    value = None();
+    if (nullability == Nullable &&
+        heapType.getBottom() == otherHeapType.getBottom()) {
+      value = Literal::makeNull(heapType.getBottom());
+    } else {
+      value = None();
+    }
     return;
   }
 

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -481,6 +481,8 @@ void assertIntersection(PossibleContents a,
   auto intersection = a;
   intersection.intersectWithFullCone(b);
   EXPECT_EQ(intersection, result);
+
+  EXPECT_EQ(PossibleContents::haveIntersection(a, b), !result.isNone());
 }
 
 TEST_F(PossibleContentsTest, TestStructCones) {
@@ -712,6 +714,12 @@ TEST_F(PossibleContentsTest, TestStructCones) {
                      PossibleContents::literal(Literal::makeNull(B)));
   assertIntersection(nnExactA, PossibleContents::fullConeType(nullB), none);
   assertIntersection(exactA, PossibleContents::fullConeType(nnB), none);
+
+  // A and E have no intersection, so the only possibility is a null, and that
+  // null must be the bottom type.
+  assertIntersection(exactA,
+                     PossibleContents::fullConeType(nullE),
+                     PossibleContents::literal(Literal::makeNull(HeapType::none)));
 
   assertIntersection(PossibleContents::coneType(nnA, 1),
                      PossibleContents::fullConeType(nnB),

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -717,9 +717,10 @@ TEST_F(PossibleContentsTest, TestStructCones) {
 
   // A and E have no intersection, so the only possibility is a null, and that
   // null must be the bottom type.
-  assertIntersection(exactA,
-                     PossibleContents::fullConeType(nullE),
-                     PossibleContents::literal(Literal::makeNull(HeapType::none)));
+  assertIntersection(
+    exactA,
+    PossibleContents::fullConeType(nullE),
+    PossibleContents::literal(Literal::makeNull(HeapType::none)));
 
   assertIntersection(PossibleContents::coneType(nnA, 1),
                      PossibleContents::fullConeType(nnB),


### PR DESCRIPTION
When the heap types are not subtypes of each other, but a null is possible, the
intersection exists and is a null. That null must be the shared bottom type.

Found by the fuzzer.