### PR TITLE
[Parser] Parse instructions with children

### DIFF
--- a/src/wasm/wat-lexer.cpp
+++ b/src/wasm/wat-lexer.cpp
@@ -943,7 +943,7 @@ void Lexer::lexToken() {
 }
 
 TextPos Lexer::position(const char* c) const {
-  assert(size_t(c - buffer.data()) < buffer.size());
+  assert(size_t(c - buffer.data()) <= buffer.size());
   TextPos pos{1, 0};
   for (const char* p = buffer.data(); p != c; ++p) {
     if (*p == '\n') {


### PR DESCRIPTION
Parse unary, binary, drop, and select instructions, properly fixing up stacky
code, unreachable code, and multivalue code so it can be represented in Binaryen
IR.