### PR TITLE
[Wasm GC][NFC] Optimize getStrictSubTypes()

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -37,7 +37,12 @@ struct SubTypes {
   }
 
   const std::vector<HeapType>& getStrictSubTypes(HeapType type) {
-    return typeSubTypes[type];
+    if (auto iter = typeSubTypes.find(type); iter != typeSubTypes.end()) {
+      return iter->second;
+    }
+
+    // No entry exists. Return the canonical empty vec.
+    return emptyVec;
   }
 
   // Get all subtypes of a type, and their subtypes and so forth, recursively.
@@ -75,7 +80,14 @@ private:
   }
 
   // Maps a type to its subtypes.
+  //
+  // After our constructor we never modify this data structure, so we can take
+  // references to the vectors here safely.
   std::unordered_map<HeapType, std::vector<HeapType>> typeSubTypes;
+
+  // Keep a canonical empty vector, so we have something to return without doing
+  // an allocation in getStrictSubTypes.
+  std::vector<HeapType> emptyVec;
 };
 
 } // namespace wasm

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -41,8 +41,9 @@ struct SubTypes {
       return iter->second;
     }
 
-    // No entry exists. Return the canonical empty vec.
-    return emptyVec;
+    // No entry exists. Return a canonical empty vec.
+    static std::vector<HeapType> empty;
+    return empty;
   }
 
   // Get all subtypes of a type, and their subtypes and so forth, recursively.

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -41,7 +41,8 @@ struct SubTypes {
       return iter->second;
     }
 
-    // No entry exists. Return a canonical empty vec.
+    // No entry exists. Return a canonical constant empty vec, to avoid
+    // allocation.
     static std::vector<HeapType> empty;
     return empty;
   }
@@ -85,10 +86,6 @@ private:
   // After our constructor we never modify this data structure, so we can take
   // references to the vectors here safely.
   std::unordered_map<HeapType, std::vector<HeapType>> typeSubTypes;
-
-  // Keep a canonical empty vector, so we have something to return without doing
-  // an allocation in getStrictSubTypes.
-  std::vector<HeapType> emptyVec;
 };
 
 } // namespace wasm

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -43,7 +43,7 @@ struct SubTypes {
 
     // No entry exists. Return a canonical constant empty vec, to avoid
     // allocation.
-    static std::vector<HeapType> empty;
+    static const std::vector<HeapType> empty;
     return empty;
   }
 


### PR DESCRIPTION
Avoid allocating there. This is both faster and also it ensures we never modify
our internal data structure after our constructor.