### PR TITLE
[Wasm GC] Add a method to traverse subtypes

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -62,6 +62,45 @@ struct SubTypes {
     return ret;
   }
 
+  // Efficiently traverse subtypes of a type, up to a particular depth (depth =
+  // 0 means not to traverse subtypes, etc.). The callback function receives
+  // (type, depth).
+  template<typename F>
+  void traverseSubTypes(HeapType type, Index depth, F func) {
+    // Start by traversing the type itself.
+    func(type, 0);
+
+    // getStrictSubTypes() returns vectors of subtypes, so for efficiency store
+    // pointers to those in our work queue to avoid allocations. See the note
+    // below on typeSubTypes for why this is safe.
+    struct Item {
+      const std::vector<HeapType>* vec;
+      Index depth;
+    };
+
+    // Real-world type hierarchies tend to have a limited depth, so try to avoid
+    // allocations in our work queue with a SmallVector.
+    SmallVector<Item, 10> work;
+
+    // Start with the subtypes of the base type. Those have depth 1.
+    work.push_back({&getStrictSubTypes(type), 1});
+
+    while (!work.empty()) {
+      auto& item = work.back();
+      work.pop_back();
+      auto currDepth = item.depth;
+      auto& vec = *item.vec;
+      if (currDepth > depth || vec.empty()) {
+        // Nothing we need to traverse here.
+        continue;
+      }
+      for (auto type : (*item.vec)) {
+        func(type, currDepth);
+        work.push_back({&getStrictSubTypes(type), currDepth + 1});
+      }
+    }
+  }
+
   // All the types in the program. This is computed here anyhow, and can be
   // useful for callers to iterate on, so it is public.
   std::vector<HeapType> types;

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -69,8 +69,7 @@ struct SubTypes {
   // Efficiently iterate on subtypes of a type, up to a particular depth (depth
   // 0 means not to traverse subtypes, etc.). The callback function receives
   // (type, depth).
-  template<typename F>
-  void iterSubTypes(HeapType type, Index depth, F func) {
+  template<typename F> void iterSubTypes(HeapType type, Index depth, F func) {
     // Start by traversing the type itself.
     func(type, 0);
 

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -74,6 +74,11 @@ struct SubTypes {
     // Start by traversing the type itself.
     func(type, 0);
 
+    if (depth == 0) {
+      // Nothing else to scan.
+      return;
+    }
+
     // getStrictSubTypes() returns vectors of subtypes, so for efficiency store
     // pointers to those in our work queue to avoid allocations. See the note
     // below on typeSubTypes for why this is safe.
@@ -94,13 +99,13 @@ struct SubTypes {
       work.pop_back();
       auto currDepth = item.depth;
       auto& vec = *item.vec;
-      if (currDepth > depth || vec.empty()) {
-        // Nothing we need to traverse here.
-        continue;
-      }
-      for (auto type : (*item.vec)) {
+      assert(currDepth <= depth && !vec.empty());
+      for (auto type : vec) {
         func(type, currDepth);
-        work.push_back({&getStrictSubTypes(type), currDepth + 1});
+        auto* subVec = &getStrictSubTypes(type);
+        if (currDepth + 1 <= depth && !subVec->empty()) {
+          work.push_back({subVec, currDepth + 1});
+        }
       }
     }
   }

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -99,7 +99,7 @@ struct SubTypes {
       work.pop_back();
       auto currDepth = item.depth;
       auto& vec = *item.vec;
-      assert(currDepth <= depth && !vec.empty());
+      assert(currDepth <= depth);
       for (auto type : vec) {
         func(type, currDepth);
         auto* subVec = &getStrictSubTypes(type);

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -66,11 +66,11 @@ struct SubTypes {
     return ret;
   }
 
-  // Efficiently traverse subtypes of a type, up to a particular depth (depth =
+  // Efficiently iterate on subtypes of a type, up to a particular depth (depth
   // 0 means not to traverse subtypes, etc.). The callback function receives
   // (type, depth).
   template<typename F>
-  void traverseSubTypes(HeapType type, Index depth, F func) {
+  void iterSubTypes(HeapType type, Index depth, F func) {
     // Start by traversing the type itself.
     func(type, 0);
 

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -24,6 +24,8 @@ namespace wasm {
 
 // Analyze subtyping relationships and provide useful interfaces to discover
 // them.
+//
+// This only scans user types, and not basic types like HeapType::eq.
 struct SubTypes {
   SubTypes(const std::vector<HeapType>& types) {
     if (getTypeSystem() != TypeSystem::Nominal &&
@@ -38,6 +40,7 @@ struct SubTypes {
   SubTypes(Module& wasm) : SubTypes(ModuleUtils::collectHeapTypes(wasm)) {}
 
   const std::vector<HeapType>& getStrictSubTypes(HeapType type) {
+    assert(!type.isBasic());
     return typeSubTypes[type];
   }
 

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -27,7 +27,7 @@ namespace wasm {
 //
 // This only scans user types, and not basic types like HeapType::eq.
 struct SubTypes {
-  SubTypes(const std::vector<HeapType>& types) {
+  SubTypes(const std::vector<HeapType>& types) : types(types) {
     if (getTypeSystem() != TypeSystem::Nominal &&
         getTypeSystem() != TypeSystem::Isorecursive) {
       Fatal() << "SubTypes requires explicit supers";

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -25,16 +25,17 @@ namespace wasm {
 // Analyze subtyping relationships and provide useful interfaces to discover
 // them.
 struct SubTypes {
-  SubTypes(Module& wasm) {
+  SubTypes(const std::vector<HeapType>& types) {
     if (getTypeSystem() != TypeSystem::Nominal &&
         getTypeSystem() != TypeSystem::Isorecursive) {
       Fatal() << "SubTypes requires explicit supers";
     }
-    types = ModuleUtils::collectHeapTypes(wasm);
     for (auto type : types) {
       note(type);
     }
   }
+
+  SubTypes(Module& wasm) : SubTypes(ModuleUtils::collectHeapTypes(wasm)) {}
 
   const std::vector<HeapType>& getStrictSubTypes(HeapType type) {
     return typeSubTypes[type];

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -98,9 +98,9 @@ struct SubTypes {
       auto& item = work.back();
       work.pop_back();
       auto currDepth = item.depth;
-      auto& vec = *item.vec;
+      auto& currVec = *item.vec;
       assert(currDepth <= depth);
-      for (auto type : vec) {
+      for (auto type : currVec) {
         func(type, currDepth);
         auto* subVec = &getStrictSubTypes(type);
         if (currDepth + 1 <= depth && !subVec->empty()) {

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -691,9 +691,8 @@ TEST_F(NominalTest, TestTraverse) {
 
   auto getSubTypes = [&](HeapType type, Index depth) {
     TypeSet ret;
-    subTypes.traverseSubTypes(type, depth, [&](HeapType subType, Index depth) {
-      ret.insert(subType);
-    });
+    subTypes.traverseSubTypes(
+      type, depth, [&](HeapType subType, Index depth) { ret.insert(subType); });
     return ret;
   };
 

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -662,8 +662,8 @@ TEST_F(NominalTest, TestDepth) {
   EXPECT_EQ(HeapType(HeapType::noext).getDepth(), size_t(-1));
 }
 
-// Test .traverseSubTypes() helper.
-TEST_F(NominalTest, TestTraverse) {
+// Test .iterSubTypes() helper.
+TEST_F(NominalTest, TestIterSubTypes) {
   /*
         A
        / \
@@ -697,7 +697,7 @@ TEST_F(NominalTest, TestTraverse) {
 
   auto getSubTypes = [&](HeapType type, Index depth) {
     TypeDepths ret;
-    subTypes.traverseSubTypes(type, depth, [&](HeapType subType, Index depth) {
+    subTypes.iterSubTypes(type, depth, [&](HeapType subType, Index depth) {
       ret.insert({subType, depth});
     });
     return ret;

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -692,32 +692,22 @@ TEST_F(NominalTest, TestTraverse) {
 
   SubTypes subTypes({A, B, C, D});
 
-  using TypeSet = std::unordered_set<HeapType>;
+  // Helper for comparing sets of types + their corresponding depth.
+  using TypeDepths = std::unordered_set<std::pair<HeapType, Index>>;
 
   auto getSubTypes = [&](HeapType type, Index depth) {
-    TypeSet ret;
+    TypeDepths ret;
     subTypes.traverseSubTypes(
-      type, depth, [&](HeapType subType, Index depth) { ret.insert(subType); });
+      type, depth, [&](HeapType subType, Index depth) { ret.insert({subType, depth}); });
     return ret;
   };
 
-  EXPECT_EQ(getSubTypes(A, 0), TypeSet({A}));
-  EXPECT_EQ(getSubTypes(A, 1), TypeSet({A, B, C}));
-  EXPECT_EQ(getSubTypes(A, 2), TypeSet({A, B, C, D}));
-  EXPECT_EQ(getSubTypes(A, 3), TypeSet({A, B, C, D}));
+  EXPECT_EQ(getSubTypes(A, 0), TypeDepths({{A, 0}}));
+  EXPECT_EQ(getSubTypes(A, 1), TypeDepths({{A, 0}, {B, 1}, {C, 1}}));
+  EXPECT_EQ(getSubTypes(A, 2), TypeDepths({{A, 0}, {B, 1}, {C, 1}, {D, 2}}));
+  EXPECT_EQ(getSubTypes(A, 3), TypeDepths({{A, 0}, {B, 1}, {C, 1}, {D, 2}}));
 
-  EXPECT_EQ(getSubTypes(C, 0), TypeSet({C}));
-  EXPECT_EQ(getSubTypes(C, 1), TypeSet({C, D}));
-  EXPECT_EQ(getSubTypes(C, 2), TypeSet({C, D}));
-
-  // Manually test the depth parameter
-  subTypes.traverseSubTypes(A, 1, [&](HeapType subType, Index depth) {
-    if (subType == A) {
-      EXPECT_EQ(depth, Index(0));
-    } else if (subType == B || subType == C) {
-      EXPECT_EQ(depth, Index(1));
-    } else {
-      FAIL() << "unexpected type";
-    }
-  });
+  EXPECT_EQ(getSubTypes(C, 0), TypeDepths({{C, 0}}));
+  EXPECT_EQ(getSubTypes(C, 1), TypeDepths({{C, 0}, {D, 1}}));
+  EXPECT_EQ(getSubTypes(C, 2), TypeDepths({{C, 0}, {D, 1}}));
 }

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -668,24 +668,29 @@ TEST_F(NominalTest, TestTraverse) {
         A
        / \
       B   C
+           \
+            D
   */
-  HeapType A, B, C;
+  HeapType A, B, C, D;
   {
-    TypeBuilder builder(3);
+    TypeBuilder builder(4);
     builder[0] = Struct();
     builder[1] = Struct();
     builder[2] = Struct();
+    builder[3] = Struct();
     builder.setSubType(1, builder.getTempHeapType(0));
     builder.setSubType(2, builder.getTempHeapType(0));
+    builder.setSubType(3, builder.getTempHeapType(2));
     auto result = builder.build();
     ASSERT_TRUE(result);
     auto built = *result;
     A = built[0];
     B = built[1];
     C = built[2];
+    D = built[3];
   }
 
-  SubTypes subTypes({A, B, C});
+  SubTypes subTypes({A, B, C, D});
 
   using TypeSet = std::unordered_set<HeapType>;
 
@@ -698,7 +703,12 @@ TEST_F(NominalTest, TestTraverse) {
 
   EXPECT_EQ(getSubTypes(A, 0), TypeSet({A}));
   EXPECT_EQ(getSubTypes(A, 1), TypeSet({A, B, C}));
-  EXPECT_EQ(getSubTypes(A, 2), TypeSet({A, B, C}));
+  EXPECT_EQ(getSubTypes(A, 2), TypeSet({A, B, C, D}));
+  EXPECT_EQ(getSubTypes(A, 3), TypeSet({A, B, C, D}));
+
+  EXPECT_EQ(getSubTypes(C, 0), TypeSet({C}));
+  EXPECT_EQ(getSubTypes(C, 1), TypeSet({C, D}));
+  EXPECT_EQ(getSubTypes(C, 2), TypeSet({C, D}));
 
   // Manually test the depth parameter
   subTypes.traverseSubTypes(A, 1, [&](HeapType subType, Index depth) {

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -697,8 +697,9 @@ TEST_F(NominalTest, TestTraverse) {
 
   auto getSubTypes = [&](HeapType type, Index depth) {
     TypeDepths ret;
-    subTypes.traverseSubTypes(
-      type, depth, [&](HeapType subType, Index depth) { ret.insert({subType, depth}); });
+    subTypes.traverseSubTypes(type, depth, [&](HeapType subType, Index depth) {
+      ret.insert({subType, depth});
+    });
     return ret;
   };
 

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -685,7 +685,6 @@ TEST_F(NominalTest, TestTraverse) {
     C = built[2];
   }
 
-  // Add the types to wasm so we scan them.
   SubTypes subTypes({A, B, C});
 
   using TypeSet = std::unordered_set<HeapType>;
@@ -698,5 +697,18 @@ TEST_F(NominalTest, TestTraverse) {
     return ret;
   };
 
-  EXPECT_EQ(getSubTypes(A, 0), TypeSet{A});
+  EXPECT_EQ(getSubTypes(A, 0), TypeSet({A}));
+  EXPECT_EQ(getSubTypes(A, 1), TypeSet({A, B, C}));
+  EXPECT_EQ(getSubTypes(A, 2), TypeSet({A, B, C}));
+
+  // Manually test the depth parameter
+  subTypes.traverseSubTypes(A, 1, [&](HeapType subType, Index depth) {
+    if (subType == A) {
+      EXPECT_EQ(depth, Index(0));
+    } else if (subType == B || subType == C) {
+      EXPECT_EQ(depth, Index(1));
+    } else {
+      FAIL() << "unexpected type";
+    }
+  });
 }


### PR DESCRIPTION
This will be useful in further cone type optimizations.

Depends on #5130