### PR TITLE
[Parser] Validate type annotations on `select`

### DIFF
--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -739,7 +739,7 @@ template<typename Ctx> struct InstrParserCtx : TypeParserCtx<Ctx> {
     CHECK_ERR(val);
     return push(pos, builder.makeUnary(op, *val));
   }
-  Result<> makeSelect(Index pos, typename TypeParserCtx<Ctx>::ResultsT* res) {
+  Result<> makeSelect(Index pos, std::vector<Type>* res) {
     if (res && res->size() > 1) {
       return self().in.err(pos,
                            "select may not have more than one result type");
@@ -750,6 +750,10 @@ template<typename Ctx> struct InstrParserCtx : TypeParserCtx<Ctx> {
     CHECK_ERR(ifFalse);
     auto ifTrue = pop(pos);
     CHECK_ERR(ifTrue);
+    auto select = builder.makeSelect(*cond, *ifTrue, *ifFalse);
+    if (res && !res->empty() && !Type::isSubType(select->type, res->front())) {
+      return self().in.err(pos, "select type annotation is incorrect");
+    }
     return push(pos, builder.makeSelect(*cond, *ifTrue, *ifFalse));
   }
   Result<> makeDrop(Index pos) {

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -689,7 +689,7 @@
   local.get 0
   local.get 1
   local.get 2
-  select (result) (result i64) (result)
+  select (result) (result i32) (result)
   drop
  )
 


### PR DESCRIPTION
Since the type annotations are not stored explicitly in Binaryen IR, we have to
validate them in the parser. Implement this and fix a newly-caught incorrect
annotation in the tests.