### PR TITLE
[NFC] Add an explicit deduction guide for `WithPosition`

### DIFF
--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -325,6 +325,9 @@ template<typename Ctx> struct WithPosition {
   ~WithPosition() { ctx.in.lexer.setIndex(original); }
 };
 
+// Deduction guide to satisfy -Wctad-maybe-unsupported.
+template<typename Ctx> WithPosition(Ctx& ctx, Index) -> WithPosition<Ctx>;
+
 using IndexMap = std::unordered_map<Name, Index>;
 
 void applyImportNames(Importable& item,


### PR DESCRIPTION
Since our usage of `WithPosition` depends on C++17 class template argument
deduction, it triggers a clang warning `-Wctad-maybe-unsupported`. Silence the
warning by providing an explicit deduction guide.