### PR TITLE
[Wasm GC][GUFA] Avoid Many in roots

### DIFF
--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -131,6 +131,26 @@ public:
   }
   static PossibleContents many() { return PossibleContents{Many()}; }
 
+  // Helper for creating a PossibleContents based on a wasm type, that is, where
+  // all we know is the wasm type.
+  static PossibleContents fromType(Type type) {
+    assert(type != Type::none);
+
+    if (type.isRef()) {
+      // For a reference, subtyping matters.
+      return fullConeType(type);
+    }
+
+    if (type == Type::unreachable) {
+      // Nothing is possible here.
+      return none();
+    }
+
+    // Otherwise, this is a concrete MVP type.
+    assert(type.isConcrete());
+    return exactType(type);
+  }
+
   PossibleContents& operator=(const PossibleContents& other) = default;
 
   bool operator==(const PossibleContents& other) const {

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2552,14 +2552,19 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_static $struct
-  ;; CHECK-NEXT:    (select (result i31ref)
-  ;; CHECK-NEXT:     (ref.null none)
-  ;; CHECK-NEXT:     (i31.new
-  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:   (block (result nullref)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.cast_static $struct
+  ;; CHECK-NEXT:      (select (result i31ref)
+  ;; CHECK-NEXT:       (ref.null none)
+  ;; CHECK-NEXT:       (i31.new
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (call $import)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -2948,10 +2953,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.eq
-  ;; CHECK-NEXT:    (local.get $nn-struct)
-  ;; CHECK-NEXT:    (local.get $nn-other)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.eq
@@ -3022,9 +3024,7 @@
         (local.get $nn-struct2)
       )
     )
-    ;; Non-null on both sides, and incompatible types, so we should be able to
-    ;; infer 0, but we need cone types for that. Until we have them, these are
-    ;; Many and so we infer nothing. TODO
+    ;; Non-null on both sides, and incompatible types. We can infer 0 here.
     (drop
       (ref.eq
         (local.get $nn-struct)


### PR DESCRIPTION
Instead of `Many`, use a proper Cone Type for the data, as appropriate.

This helps some existing tests. I'm not adding comprehensive tests for this as
a later PR will simply assert on `Many` not appearing anywhere.