### PR TITLE
Support try-catch blocks in Asyncify.

### DIFF
--- a/src/ir/eh-utils.cpp
+++ b/src/ir/eh-utils.cpp
@@ -32,7 +32,7 @@ namespace EHUtils {
 // no way to get the given expression's address. But that's fine because pop's
 // pointer is only necessary (in handleBlockNestedPops) to fix it up when it is
 // nested, and if 'catchBody' itself is a pop, we don't need to fix it up.
-static Expression*
+Expression*
 getFirstPop(Expression* catchBody, bool& isPopNested, Expression**& popPtr) {
   Expression* firstChild = catchBody;
   isPopNested = false;

--- a/src/ir/eh-utils.h
+++ b/src/ir/eh-utils.h
@@ -24,6 +24,18 @@ namespace wasm {
 
 namespace EHUtils {
 
+// This returns three values, some of them as output parameters:
+// - Return value: 'pop' expression (Expression*), when there is one in
+//   first-descendant line. If there's no such pop, it returns null.
+// - isPopNested: Whether the discovered 'pop' is nested within a block
+// - popPtr: 'pop' expression's pointer (Expression**), when there is one found
+//
+// When 'catchBody' itself is a 'pop', 'pop''s pointer is null, because there is
+// no way to get the given expression's address. But that's fine because pop's
+// pointer is only necessary (in handleBlockNestedPops) to fix it up when it is
+// nested, and if 'catchBody' itself is a pop, we don't need to fix it up.
+Expression* getFirstPop(Expression* catchBody, bool& isPopNested, Expression**& popPtr);
+
 // Returns true if a 'pop' instruction exists in a valid location, which means
 // right after a 'catch' instruction in binary writing order.
 // - This assumes there should be at least a single pop. So given a catch body

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1427,7 +1427,7 @@ class Try : public SpecificExpression<Expression::TryId> {
 public:
   Try(MixedArena& allocator) : catchTags(allocator), catchBodies(allocator) {}
 
-  Name name; // label that can only be targeted by 'delegate's
+  Name name; // label that can only be targeted by 'delegate's or 'rethrow's
   Expression* body;
   ArenaVector<Name> catchTags;
   ExpressionList catchBodies;


### PR DESCRIPTION
Previously, when the Asyncify pass ran on a wasm file that includes try blocks (in a position such that asyncify has to un/re-wind through those try blocks), an error would be produced:
`WASM_UNREACHABLE("unexpected expression type");`

This PR adds support for the try case in Asyncify.

Fixes #4470

I was not sure how to add tests for this feature to the repository; it runs without crashing and produces reasonable-looking output on one sample file I have. This feature deserves tests: if someone will explain how to add them I will.

This should have no effect on previously successful applications of Asyncify (the behavior change here is from a crash to producing code), but if the implementation is wrong could produce broken code.

Convert
```
(try
  (...)
 catch $i
  (...))
```
into
```
(try
  (...)
 catch $i
  (set tag 1))
(if (or (eq tag 1) (rewinding))
 (...))
```