### PR TITLE
[Wasm GC] Filter GUFA expression locations by their type

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1872,19 +1872,21 @@ void Flower::filterExpressionContents(PossibleContents& contents,
   //
   // Note that the intersection may also not be a cone type, if it is a global
   // or literal. In that case we don't have anything more to do here.
-  if (contents.isConeType()) {
-    normalizeConeType(contents);
+  if (!contents.isConeType()) {
+    return;
+  }
 
-    // There is a chance that the intersection is equal to the maximal contents,
-    // which would mean nothing more can arrive here. (Note that we can't
-    // normalize |maximalContents| before the intersection as
-    // intersectWithFullCone assumes a full/infinite cone.)
-    normalizeConeType(maximalContents);
+  normalizeConeType(contents);
 
-    if (contents == maximalContents) {
-      // We already contain everything possible, so this is the worst case.
-      worthSendingMore = false;
-    }
+  // There is a chance that the intersection is equal to the maximal contents,
+  // which would mean nothing more can arrive here. (Note that we can't
+  // normalize |maximalContents| before the intersection as
+  // intersectWithFullCone assumes a full/infinite cone.)
+  normalizeConeType(maximalContents);
+
+  if (contents == maximalContents) {
+    // We already contain everything possible, so this is the worst case.
+    worthSendingMore = false;
   }
 }
 

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1696,9 +1696,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
     filtered = true;
   }
 
-  // If we think more might arrive, and we filtered, the filtering might have
-  // changed that, so check.
-  if (worthSendingMore && filtered && contents == oldContents &&
+  if (filtered && contents == oldContents &&
       contents.getType() == oldContents.getType()) {
     // Nothing actually changed after filtering, so just return.
     return worthSendingMore;

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1840,8 +1840,9 @@ void Flower::filterExpressionContents(PossibleContents& contents,
   if (!type.isRef()) {
     return;
   }
-  // The maximal contents here are the declared type and all subtypes.
-  // Nothing else can pass through, so filter such things out.
+
+  // The maximal contents here are the declared type and all subtypes. Nothing
+  // else can pass through, so filter such things out.
   auto maximalContents = PossibleContents::fullConeType(type);
   contents.intersectWithFullCone(maximalContents);
   if (contents.isNone()) {
@@ -1850,8 +1851,8 @@ void Flower::filterExpressionContents(PossibleContents& contents,
     return;
   }
 
-  // Normalize the intersection. We want to check later if any more content
-  // can arrive here, and also we want to avoid flowing around anything non-
+  // Normalize the intersection. We want to check later if any more content can
+  // arrive here, and also we want to avoid flowing around anything non-
   // normalized, as explained earlier.
   //
   // Note that this normalization is necessary even though |contents| was
@@ -1863,20 +1864,20 @@ void Flower::filterExpressionContents(PossibleContents& contents,
   //        |
   //        D
   */
-  // Consider the case where |maximalContents| is Cone(B, Infinity) and
-  // the original |contents| was Cone(A, 2) (which is normalized). The naive
+  // Consider the case where |maximalContents| is Cone(B, Infinity) and the
+  // original |contents| was Cone(A, 2) (which is normalized). The naive
   // intersection is Cone(B, 1), since the core intersection logic makes no
   // assumptions about the rest of the types. That is then normalized to
   // Cone(B, 0) since there happens to be no subtypes for B.
   //
-  // Note that the intersection may also not be a cone type, if it is a
-  // global or literal. In that case we don't have anything more to do here.
+  // Note that the intersection may also not be a cone type, if it is a global
+  // or literal. In that case we don't have anything more to do here.
   if (contents.isConeType()) {
     normalizeConeType(contents);
 
-    // There is a chance that the intersection is equal to the maximal
-    // contents, which would mean nothing more can arrive here. (Note that
-    // we can't normalize |maximalContents| before the intersection as
+    // There is a chance that the intersection is equal to the maximal contents,
+    // which would mean nothing more can arrive here. (Note that we can't
+    // normalize |maximalContents| before the intersection as
     // intersectWithFullCone assumes a full/infinite cone.)
     normalizeConeType(maximalContents);
 

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1563,7 +1563,7 @@ Flower::Flower(Module& wasm) : wasm(wasm) {
   if (getTypeSystem() == TypeSystem::Nominal ||
       getTypeSystem() == TypeSystem::Isorecursive) {
     subTypes = std::make_unique<SubTypes>(wasm);
-    maxDepths = std::move(subTypes->getMaxDepths());
+    maxDepths = subTypes->getMaxDepths();
   }
 
 #ifdef POSSIBLE_CONTENTS_DEBUG

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -5209,6 +5209,8 @@
 
   ;; CHECK:      (type $none_=>_ref|$A| (func_subtype (result (ref $A)) func))
 
+  ;; CHECK:      (type $none_=>_none (func_subtype func))
+
   ;; CHECK:      (import "a" "b" (global $A (ref $A)))
   (import "a" "b" (global $A (ref $A)))
 
@@ -5321,6 +5323,82 @@
     (drop
       (ref.test_static $B
         (global.get $A)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $filtering (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block $B (result (ref $B))
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_on_cast_static $B $B
+  ;; CHECK-NEXT:        (struct.new $A
+  ;; CHECK-NEXT:         (i32.const 100)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block $A (result (ref $A))
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (br_on_cast_static $A $A
+  ;; CHECK-NEXT:        (struct.new $A
+  ;; CHECK-NEXT:         (i32.const 200)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $filtering
+    ;; Check for filtering of values by the declared type in the wasm. We do not
+    ;; have specific filtering or flowing for br_on_* yet, so it will always
+    ;; send the value to the branch target. But the target has a declared type
+    ;; of $B, which means the exact $A gets filtered out, and nothing remains,
+    ;; so we can append an unreachable.
+    ;;
+    ;; When we add filtering/flowing for br_on_* this test should continue to
+    ;; pass and only the comment will need to be updated, so if you are reading
+    ;; this and it is stale, please fix that :)
+    (drop
+      (block $B (result (ref $B))
+        (drop
+          (br_on_cast_static $B $B
+            (struct.new $A
+              (i32.const 100)
+            )
+          )
+        )
+        (unreachable)
+      )
+    )
+    ;; But casting to $A will succeed, so the block is reachable, and also the
+    ;; cast will return 1.
+    (drop
+      (ref.test_static $A
+        (block $A (result (ref $A))
+          (drop
+            (br_on_cast_static $A $A
+              (struct.new $A
+                (i32.const 200)
+              )
+            )
+          )
+          (unreachable)
+        )
       )
     )
   )


### PR DESCRIPTION
Now that we have a cone type, we are able to represent in PossibleContents the
natural content of a wasm location: a type or any of its subtypes. This allows us to
enforce the wasm typing rules, that is, to filter the data arriving at a location by the
wasm type of the location.

Technically this could be unnecessary if we had full implementations of flowFoo
and so forth, that is, tailored code for each wasm expression that makes sure we
only contain and flow content that fits in the wasm type. Atm we don't have that,
and until the wasm spec stabilizes it's probably not worth the effort. Instead,
simply filter based on the type, which gives the same result (though it does take
a little more work; I measured it at 3% or so of runtime).

While doing so normalize cones to their actual maximum depth, which simplifies
things and will help more later as well.