### PR TITLE
[C API] Add essential heap type utilities

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -315,11 +315,26 @@ BinaryenHeapType BinaryenHeapTypeNofunc() {
   return static_cast<BinaryenHeapType>(HeapType::BasicHeapType::nofunc);
 }
 
+bool BinaryenHeapTypeIsBasic(BinaryenHeapType heapType) {
+  return HeapType(heapType).isBasic();
+}
+bool BinaryenHeapTypeIsSignature(BinaryenHeapType heapType) {
+  return HeapType(heapType).isSignature();
+}
+bool BinaryenHeapTypeIsStruct(BinaryenHeapType heapType) {
+  return HeapType(heapType).isStruct();
+}
+bool BinaryenHeapTypeIsArray(BinaryenHeapType heapType) {
+  return HeapType(heapType).isArray();
+}
 bool BinaryenHeapTypeIsBottom(BinaryenHeapType heapType) {
   return HeapType(heapType).isBottom();
 }
 BinaryenHeapType BinaryenHeapTypeGetBottom(BinaryenHeapType heapType) {
   return static_cast<BinaryenHeapType>(HeapType(heapType).getBottom());
+}
+bool BinaryenHeapTypeIsSubType(BinaryenHeapType left, BinaryenHeapType right) {
+  return HeapType::isSubType(HeapType(left), HeapType(right));
 }
 
 BinaryenHeapType BinaryenTypeGetHeapType(BinaryenType type) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -156,9 +156,15 @@ BINARYEN_API BinaryenHeapType BinaryenHeapTypeNone(void);
 BINARYEN_API BinaryenHeapType BinaryenHeapTypeNoext(void);
 BINARYEN_API BinaryenHeapType BinaryenHeapTypeNofunc(void);
 
+BINARYEN_API bool BinaryenHeapTypeIsBasic(BinaryenHeapType heapType);
+BINARYEN_API bool BinaryenHeapTypeIsSignature(BinaryenHeapType heapType);
+BINARYEN_API bool BinaryenHeapTypeIsStruct(BinaryenHeapType heapType);
+BINARYEN_API bool BinaryenHeapTypeIsArray(BinaryenHeapType heapType);
 BINARYEN_API bool BinaryenHeapTypeIsBottom(BinaryenHeapType heapType);
 BINARYEN_API BinaryenHeapType
 BinaryenHeapTypeGetBottom(BinaryenHeapType heapType);
+BINARYEN_API bool BinaryenHeapTypeIsSubType(BinaryenHeapType left,
+                                            BinaryenHeapType right);
 
 BINARYEN_API BinaryenHeapType BinaryenTypeGetHeapType(BinaryenType type);
 BINARYEN_API bool BinaryenTypeIsNullable(BinaryenType type);

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -2203,32 +2203,65 @@ void test_typebuilder() {
   bool didBuildAndDispose = TypeBuilderBuildAndDispose(
     builder, (BinaryenHeapType*)&heapTypes, &errorIndex, &errorReason);
   assert(didBuildAndDispose);
-  BinaryenType arrayType =
-    BinaryenTypeFromHeapType(heapTypes[tempArrayIndex], true);
-  BinaryenType structType =
-    BinaryenTypeFromHeapType(heapTypes[tempStructIndex], true);
+
+  BinaryenHeapType arrayHeapType = heapTypes[tempArrayIndex];
+  assert(!BinaryenHeapTypeIsBasic(arrayHeapType));
+  assert(!BinaryenHeapTypeIsSignature(arrayHeapType));
+  assert(!BinaryenHeapTypeIsStruct(arrayHeapType));
+  assert(BinaryenHeapTypeIsArray(arrayHeapType));
+  assert(!BinaryenHeapTypeIsBottom(arrayHeapType));
+  assert(BinaryenHeapTypeIsSubType(arrayHeapType, BinaryenHeapTypeArray()));
+  BinaryenType arrayType = BinaryenTypeFromHeapType(arrayHeapType, true);
+
+  BinaryenHeapType structHeapType = heapTypes[tempStructIndex];
+  assert(!BinaryenHeapTypeIsBasic(structHeapType));
+  assert(!BinaryenHeapTypeIsSignature(structHeapType));
+  assert(BinaryenHeapTypeIsStruct(structHeapType));
+  assert(!BinaryenHeapTypeIsArray(structHeapType));
+  assert(!BinaryenHeapTypeIsBottom(structHeapType));
+  assert(BinaryenHeapTypeIsSubType(structHeapType, BinaryenHeapTypeData()));
+  BinaryenType structType = BinaryenTypeFromHeapType(structHeapType, true);
+
+  BinaryenHeapType signatureHeapType = heapTypes[tempSignatureIndex];
+  assert(!BinaryenHeapTypeIsBasic(signatureHeapType));
+  assert(BinaryenHeapTypeIsSignature(signatureHeapType));
+  assert(!BinaryenHeapTypeIsStruct(signatureHeapType));
+  assert(!BinaryenHeapTypeIsArray(signatureHeapType));
+  assert(!BinaryenHeapTypeIsBottom(signatureHeapType));
+  assert(BinaryenHeapTypeIsSubType(signatureHeapType, BinaryenHeapTypeFunc()));
   BinaryenType signatureType =
-    BinaryenTypeFromHeapType(heapTypes[tempSignatureIndex], true);
-  BinaryenType basicType =
-    BinaryenTypeFromHeapType(heapTypes[tempBasicIndex], true);
+    BinaryenTypeFromHeapType(signatureHeapType, true);
+
+  BinaryenHeapType basicHeapType = heapTypes[tempBasicIndex]; // = eq
+  assert(BinaryenHeapTypeIsBasic(basicHeapType));
+  assert(!BinaryenHeapTypeIsSignature(basicHeapType));
+  assert(!BinaryenHeapTypeIsStruct(basicHeapType));
+  assert(!BinaryenHeapTypeIsArray(basicHeapType));
+  assert(!BinaryenHeapTypeIsBottom(basicHeapType));
+  assert(BinaryenHeapTypeIsSubType(basicHeapType, BinaryenHeapTypeAny()));
+  BinaryenType basicType = BinaryenTypeFromHeapType(basicHeapType, true);
+
+  BinaryenHeapType subStructHeapType = heapTypes[tempSubStructIndex];
+  assert(!BinaryenHeapTypeIsBasic(subStructHeapType));
+  assert(!BinaryenHeapTypeIsSignature(subStructHeapType));
+  assert(BinaryenHeapTypeIsStruct(subStructHeapType));
+  assert(!BinaryenHeapTypeIsArray(subStructHeapType));
+  assert(!BinaryenHeapTypeIsBottom(subStructHeapType));
+  assert(BinaryenHeapTypeIsSubType(subStructHeapType, BinaryenHeapTypeData()));
+  assert(BinaryenHeapTypeIsSubType(subStructHeapType, structHeapType));
   BinaryenType subStructType =
-    BinaryenTypeFromHeapType(heapTypes[tempSubStructIndex], true);
+    BinaryenTypeFromHeapType(subStructHeapType, true);
 
   // Build a simple test module, validate and print it
   BinaryenModuleRef module = BinaryenModuleCreate();
-  BinaryenModuleSetTypeName(module, heapTypes[tempArrayIndex], "SomeArray");
-  BinaryenModuleSetTypeName(module, heapTypes[tempStructIndex], "SomeStruct");
-  BinaryenModuleSetFieldName(
-    module, heapTypes[tempStructIndex], 0, "SomeField");
-  BinaryenModuleSetTypeName(
-    module, heapTypes[tempSignatureIndex], "SomeSignature");
-  BinaryenModuleSetTypeName(module, heapTypes[tempBasicIndex], "does-nothing");
-  BinaryenModuleSetTypeName(
-    module, heapTypes[tempSubStructIndex], "SomeSubStruct");
-  BinaryenModuleSetFieldName(
-    module, heapTypes[tempSubStructIndex], 0, "SomeField");
-  BinaryenModuleSetFieldName(
-    module, heapTypes[tempSubStructIndex], 1, "SomePackedField");
+  BinaryenModuleSetTypeName(module, arrayHeapType, "SomeArray");
+  BinaryenModuleSetTypeName(module, structHeapType, "SomeStruct");
+  BinaryenModuleSetFieldName(module, structHeapType, 0, "SomeField");
+  BinaryenModuleSetTypeName(module, signatureHeapType, "SomeSignature");
+  BinaryenModuleSetTypeName(module, basicHeapType, "does-nothing");
+  BinaryenModuleSetTypeName(module, subStructHeapType, "SomeSubStruct");
+  BinaryenModuleSetFieldName(module, subStructHeapType, 0, "SomeField");
+  BinaryenModuleSetFieldName(module, subStructHeapType, 1, "SomePackedField");
   BinaryenModuleSetFeatures(
     module, BinaryenFeatureReferenceTypes() | BinaryenFeatureGC());
   {


### PR DESCRIPTION
Adds heap type utility to the C API:

* `BinaryenHeapTypeIsBasic`
* `BinaryenHeapTypeIsSignature`
* `BinaryenHeapTypeIsStruct`
* `BinaryenHeapTypeIsArray`
* `BinaryenHeapTypeIsSubType`

Does not implement `BinaryenHeapTypeIsFunction` and `BinaryenHeapTypeIsData`, as these seem redundant, respectively are about to change in the case of `data`.

Note that it is theoretically possible to implement `IsSignature`, `IsStruct` and `IsArray` using `IsSubType` with additional comparisons to exclude the basic / bottom types in user code, reducing API surface at the expense of some complexity, if preferable? Example:

```
BinaryenHeapTypeIsSignature(ht)
  -> BinaryenHeapTypeIsSubType(ht, BinaryenHeapTypeFunc()) && !BinaryenHeapTypeIsBasic(ht)

BinaryenHeapTypeIsStruct(ht)
  -> BinaryenHeapTypeIsSubType(ht, BinaryenHeapTypeStruct()) && !BinaryenHeapTypeIsBasic(ht)

BinaryenHeapTypeIsArray(ht)
  -> BinaryenHeapTypeIsSubType(ht, BinaryenHeapTypeArray()) && !BinaryenHeapTypeIsBasic(ht)
```

It is also possible to implement `BinaryenHeapTypeIsBasic` manually

```
BinaryenHeapTypeIsBasic(ht)
  -> ht <= BinaryenHeapTypeNofunc()
```

so the only really necessary API that cannot otherwise be implemented is `BinaryenHeapTypeIsSubType`.

Lmk :)