### PR TITLE
[NFC] Add a generic hash implementation for tuples

### DIFF
--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -531,8 +531,8 @@ template<> struct hash<wasm::ResultLocation> {
 
 template<> struct hash<wasm::BreakTargetLocation> {
   size_t operator()(const wasm::BreakTargetLocation& loc) const {
-    return std::hash<std::pair<size_t, std::pair<wasm::Name, wasm::Index>>>{}(
-      {size_t(loc.func), {loc.target, loc.tupleIndex}});
+    return std::hash<std::tuple<size_t, wasm::Name, wasm::Index>>{}(
+      {size_t(loc.func), loc.target, loc.tupleIndex});
   }
 };
 

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -578,9 +578,8 @@ template<> struct hash<wasm::NullLocation> {
 
 template<> struct hash<wasm::ConeReadLocation> {
   size_t operator()(const wasm::ConeReadLocation& loc) const {
-    return std::hash<
-      std::pair<wasm::HeapType, std::pair<wasm::Index, wasm::Index>>>{}(
-      {loc.type, {loc.depth, loc.index}});
+    return std::hash<std::tuple<wasm::HeapType, wasm::Index, wasm::Index>>{}(
+      {loc.type, loc.depth, loc.index});
   }
 };
 

--- a/src/support/hash.h
+++ b/src/support/hash.h
@@ -61,6 +61,24 @@ template<typename T1, typename T2> struct hash<pair<T1, T2>> {
   }
 };
 
+// And hashing tuples is useful, too.
+template<typename T, typename... Ts> struct hash<tuple<T, Ts...>> {
+private:
+  template<size_t... I>
+  static void rehash(const tuple<T, Ts...>& tup,
+                     size_t& digest,
+                     std::index_sequence<I...>) {
+    (wasm::rehash(digest, std::get<1 + I>(tup)), ...);
+  }
+
+public:
+  size_t operator()(const tuple<T, Ts...>& tup) const {
+    auto digest = wasm::hash(std::get<0>(tup));
+    rehash(tup, digest, std::index_sequence_for<Ts...>{});
+    return digest;
+  }
+};
+
 } // namespace std
 
 #endif // wasm_support_hash_h


### PR DESCRIPTION
We already provided a specialization of `std::hash` for arbitrary pairs, so add
one for `std::tuple` as well. Use the new specialization where we were
previously using nested pairs just to be able to use the pair specialization.