### PR TITLE
Remove excessive validation that is not in the wasm spec

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2909,27 +2909,7 @@ static bool checkSegmentOffset(Expression* curr,
                                Address add,
                                Address max,
                                FeatureSet features) {
-  if (!Properties::isValidInConstantExpression(curr, features)) {
-    return false;
-  }
-  auto* c = curr->dynCast<Const>();
-  if (!c) {
-    // Unless the instruction is actually a const instruction, we don't
-    // currently try to evaluate it.
-    // TODO: Attempt to evaluate other expressions that might also be const
-    // such as `global.get` or more complex instruction sequences involving
-    // add/sub/mul/etc.
-    return true;
-  }
-  uint64_t raw = c->value.getInteger();
-  if (raw > std::numeric_limits<Address::address32_t>::max()) {
-    return false;
-  }
-  if (raw + uint64_t(add) > std::numeric_limits<Address::address32_t>::max()) {
-    return false;
-  }
-  Address offset = raw;
-  return offset + add <= max;
+  return Properties::isValidInConstantExpression(curr, features);
 }
 
 void FunctionValidator::validateAlignment(
@@ -3231,13 +3211,6 @@ static void validateDataSegments(Module& module, ValidationInfo& info) {
                                            module.features),
                         segment->offset,
                         "memory segment offset should be reasonable");
-      if (segment->offset->is<Const>()) {
-        auto start = segment->offset->cast<Const>()->value.getUnsigned();
-        auto end = start + size;
-        info.shouldBeTrue(end <= memory->initial * Memory::kPageSize,
-                          segment->data.size(),
-                          "segment size should fit in memory (end)");
-      }
       FunctionValidator(module, &info).validate(segment->offset);
       // If the memory is imported we don't actually know its initial size.
       // Specifically wasm dll's import a zero sized memory which is perfectly


### PR DESCRIPTION
Specifically if a segment offset was a const, we checked that it made sense. But the
wasm spec doesn't do that, and it actually causes some issues (https://github.com/WebAssembly/binaryen/pull/5163).

In theory this extra validation might be useful - compile-time error rather than runtime -
but if we want this it should probably be an optional thing, like an opt-in flag or a `--lint`
pass or such. I'm not sure it's worth it.