### PR TITLE
[NFC] Add nullptr init for ElementSegment offset

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2017,7 +2017,7 @@ public:
 class ElementSegment : public Named {
 public:
   Name table;
-  Expression* offset;
+  Expression* offset = nullptr;
   Type type = Type(HeapType::func, Nullable);
   std::vector<Expression*> data;
 


### PR DESCRIPTION
I believe all locations that create one already set it (or else we'd see errors), but it's not
easy to see that when reading the code. And other similar locations (like DataSegment)
do initialize to null, so do so for consistency.