### PR TITLE
Traverse data segments in walkModuleCode

### DIFF
--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -284,6 +284,11 @@ struct Walker : public VisitorType {
         self->walk(item);
       }
     }
+    for (auto& curr : module->dataSegments) {
+      if (curr->offset) {
+        self->walk(curr->offset);
+      }
+    }
     setModule(nullptr);
   }
 


### PR DESCRIPTION
This wasn't noticed since we apparently only use module code scanning to find stuff
like function references atm (which can't be in a data segment). But newer passes will
need to scan everything (#5163).