### PR TITLE
Add a way to run a pass on module-level code

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -304,11 +304,14 @@ struct PassRunner {
   // afterwards.
   void addDefaultGlobalOptimizationPostPasses();
 
-  // Run the passes on the module
+  // Run the passes on the module.
   void run();
 
-  // Run the passes on a specific function
+  // Run the passes on a specific function.
   void runOnFunction(Function* func);
+
+  // Run the passes on module-level code.
+  void runOnModuleCode(Module* module);
 
   // When running a pass runner within another pass runner, this
   // flag should be set. This influences how pass debugging works,
@@ -346,6 +349,7 @@ private:
 
   void runPass(Pass* pass);
   void runPassOnFunction(Pass* pass, Function* func);
+  void runPassOnModuleCode(Pass* pass, Module* module);
 
   // After running a pass, handle any changes due to
   // how the pass is defined, such as clearing away any
@@ -374,6 +378,11 @@ public:
   // Implement this with code to run the pass on a single function, for
   // a function-parallel pass
   virtual void runOnFunction(Module* module, Function* function) {
+    WASM_UNREACHABLE("unimplemented");
+  }
+
+  // Implement this with code to run the pass on module-level code.
+  virtual void runOnModuleCode(Module* module) {
     WASM_UNREACHABLE("unimplemented");
   }
 
@@ -483,9 +492,15 @@ public:
     runOnFunction(module, func);
   }
 
+  void runOnModuleCode(Module* module) override {
+    assert(getPassRunner());
+    WalkerType::walkModuleCode(module);
+  }
+
+  // Utility for ad-hoc running.
   void runOnModuleCode(PassRunner* runner, Module* module) {
     setPassRunner(runner);
-    WalkerType::walkModuleCode(module);
+    runOnModuleCode(module);
   }
 };
 

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -785,6 +785,15 @@ void PassRunner::runOnFunction(Function* func) {
   }
 }
 
+void PassRunner::runOnModuleCode(Module* module) {
+  if (options.debug) {
+    std::cerr << "[PassRunner] running passes on module code\n";
+  }
+  for (auto& pass : passes) {
+    runPassOnModuleCode(pass.get(), module);
+  }
+}
+
 void PassRunner::doAdd(std::unique_ptr<Pass> pass) {
   if (pass->invalidatesDWARF() && shouldPreserveDWARF()) {
     std::cerr << "warning: running pass '" << pass->name
@@ -953,6 +962,11 @@ void PassRunner::runPassOnFunction(Pass* pass, Function* func) {
               << *func->body << '\n';
     }
   }
+}
+
+void PassRunner::runPassOnModuleCode(Pass* pass, Module* module) {
+  pass->setPassRunner(this);
+  pass->runOnModuleCode(module);
 }
 
 void PassRunner::handleAfterEffects(Pass* pass, Function* func) {


### PR DESCRIPTION
This is basically similar to `runOnFunction` which runs on a function.

This will be useful in #5163 