### PR TITLE
[Wasm GC] Externalize/Internalize allow nulls

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2040,6 +2040,12 @@ struct OptimizeInstructions
       return;
     }
 
+    if (curr->op == ExternExternalize || curr->op == ExternInternalize) {
+      // We can't optimize these. Even removing a non-null cast is not valid as
+      // they allow nulls to filter through, unlike other RefAs*
+      return;
+    }
+
     skipNonNullCast(curr->value);
 
     // Check if the type is the kind we are checking for.

--- a/test/lit/passes/optimize-instructions-gc-heap.wast
+++ b/test/lit/passes/optimize-instructions-gc-heap.wast
@@ -766,4 +766,58 @@
   (func $helper-i32 (param $x i32) (result i32)
     (i32.const 42)
   )
+
+  ;; CHECK:      (func $extern.externalize (param $x anyref) (param $y externref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (extern.externalize
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (extern.externalize
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (extern.internalize
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (extern.internalize
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $extern.externalize (export "ext") (param $x (ref null any)) (param $y (ref null extern))
+    ;; We should not change anything here, and also not hit an internal error.
+    (drop
+      (extern.externalize
+        (local.get $x)
+      )
+    )
+    (drop
+      (extern.externalize
+        (ref.as_non_null
+          (local.get $x)
+        )
+      )
+    )
+    (drop
+      (extern.internalize
+        (local.get $y)
+      )
+    )
+    (drop
+      (extern.internalize
+        (ref.as_non_null
+          (local.get $y)
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
These are encoded as RefAs operations, and we have optimizations that assume those
trap on null, but Externalize/Internalize do not. Skip them there to avoid an error on the
type being incorrect later.

Noticed on a [dart testcase](https://github.com/dart-lang/sdk/issues/50268).