### PR TITLE
[Parser] Parse `return`

### DIFF
--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -39,6 +39,16 @@
 
   ;; CHECK:      (type $i32_i32_i64_i64_=>_none (func_subtype (param i32 i32 i64 i64) func))
 
+  ;; CHECK:      (type $i32_=>_i32 (func_subtype (param i32) (result i32) func))
+
+  ;; CHECK:      (type $i32_i64_=>_i32_i64 (func_subtype (param i32 i64) (result i32 i64) func))
+
+  ;; CHECK:      (type $i64_=>_i32_i64 (func_subtype (param i64) (result i32 i64) func))
+
+  ;; CHECK:      (type $i32_=>_i32_i64 (func_subtype (param i32) (result i32 i64) func))
+
+  ;; CHECK:      (type $none_=>_i32_i64 (func_subtype (result i32 i64) func))
+
   ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $s0 (struct_subtype  data))
   (type $s0 (sub (struct)))
@@ -466,15 +476,9 @@
  )
 
  ;; CHECK:      (func $add-twice-unreachable (type $ret2) (result i32 i32)
- ;; CHECK-NEXT:  (tuple.make
- ;; CHECK-NEXT:   (i32.add
- ;; CHECK-NEXT:    (unreachable)
- ;; CHECK-NEXT:    (i32.const 2)
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (i32.add
- ;; CHECK-NEXT:    (i32.const 3)
- ;; CHECK-NEXT:    (i32.const 4)
- ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  (i32.add
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:   (i32.const 2)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $add-twice-unreachable (type $ret2)
@@ -493,13 +497,7 @@
  ;; CHECK-NEXT:    (i32.const 2)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
- ;; CHECK-NEXT:   (unreachable)
- ;; CHECK-NEXT:   (i32.add
- ;; CHECK-NEXT:    (i32.const 3)
- ;; CHECK-NEXT:    (i32.const 4)
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $add-twice-unreachable-2 (type $ret2)
   i32.const 1
@@ -524,10 +522,7 @@
  ;; CHECK-NEXT:    (i32.const 4)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
- ;; CHECK-NEXT:   (unreachable)
- ;; CHECK-NEXT:   (unreachable)
- ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $add-twice-unreachable-3 (type $ret2)
   i32.const 1
@@ -1121,6 +1116,68 @@
   i32.const 5
   i64.const 6
   memory.fill $mem-i64
+ )
+
+ ;; CHECK:      (func $return-none (type $void)
+ ;; CHECK-NEXT:  (return)
+ ;; CHECK-NEXT: )
+ (func $return-none
+  return
+ )
+
+ ;; CHECK:      (func $return-one (type $i32_=>_i32) (param $0 i32) (result i32)
+ ;; CHECK-NEXT:  (return
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $return-one (param i32) (result i32)
+  local.get 0
+  return
+ )
+
+ ;; CHECK:      (func $return-two (type $i32_i64_=>_i32_i64) (param $0 i32) (param $1 i64) (result i32 i64)
+ ;; CHECK-NEXT:  (return
+ ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:    (local.get $1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $return-two (param i32 i64) (result i32 i64)
+  local.get 0
+  local.get 1
+  return
+ )
+
+ ;; CHECK:      (func $return-two-first-unreachable (type $i64_=>_i32_i64) (param $0 i64) (result i32 i64)
+ ;; CHECK-NEXT:  (return
+ ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $return-two-first-unreachable (param i64) (result i32 i64)
+  unreachable
+  local.get 0
+  return
+ )
+
+ ;; CHECK:      (func $return-two-second-unreachable (type $i32_=>_i32_i64) (param $0 i32) (result i32 i64)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return
+ ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $return-two-second-unreachable (param i32) (result i32 i64)
+  local.get 0
+  unreachable
+  return
  )
 
  ;; CHECK:      (func $use-types (type $ref|$s0|_ref|$s1|_ref|$s2|_ref|$s3|_ref|$s4|_ref|$s5|_ref|$s6|_ref|$s7|_ref|$s8|_ref|$a0|_ref|$a1|_ref|$a2|_ref|$a3|_ref|$subvoid|_ref|$submany|_=>_none) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany))


### PR DESCRIPTION
Unlike in the legacy parser, we cannot depend on the folded text format to
determine how many values to return, so we determine that solely based on the
current function context.

To handle multivalue return correctly, fix a bug in which we could synthesize
new `unreachable`s and place them before existing unreachable instructions (like
returns) at the end of instruction sequences.