### PR TITLE
[NFC] Inherit from Visitor in OverriddenVisitor

### DIFF
--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -74,7 +74,7 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
 // A visitor which must be overridden for each visitor that is reached.
 
 template<typename SubType, typename ReturnType = void>
-struct OverriddenVisitor {
+struct OverriddenVisitor : public Visitor<SubType, ReturnType> {
 // Expression visitors, which must be overridden
 #define DELEGATE(CLASS_TO_VISIT)                                               \
   ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
@@ -86,22 +86,6 @@ struct OverriddenVisitor {
   }
 
 #include "wasm-delegations.def"
-
-  ReturnType visit(Expression* curr) {
-    assert(curr);
-
-    switch (curr->_id) {
-#define DELEGATE(CLASS_TO_VISIT)                                               \
-  case Expression::Id::CLASS_TO_VISIT##Id:                                     \
-    return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                 \
-      static_cast<CLASS_TO_VISIT*>(curr))
-
-#include "wasm-delegations.def"
-
-      default:
-        WASM_UNREACHABLE("unexpected expression type");
-    }
-  }
 };
 
 // Visit with a single unified visitor, called on every node, instead of


### PR DESCRIPTION
Doing so shortens the code by removing duplicate logic.

Also this will avoid a compile error in a future PR, as by inheriting from
Visitor we include functions like `visitFunction` which were otherwise
missing from OverriddenVisitor. We could duplicate those like we
duplicated the expression logic, but just removing all the duplication
seems best.

I manually verified OverriddenVisitor still provides the same error messages
as before.