### PR TITLE
[NFC] Remove an ancient hack in ReFinalize

### DIFF
--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -188,15 +188,6 @@ void ReFinalize::visitStringSliceIter(StringSliceIter* curr) {
   curr->finalize();
 }
 
-void ReFinalize::visitFunction(Function* curr) {
-  // we may have changed the body from unreachable to none, which might be bad
-  // if the function has a return value
-  if (curr->getResults() != Type::none && curr->body->type == Type::none) {
-    Builder builder(*getModule());
-    curr->body = builder.blockify(curr->body, builder.makeUnreachable());
-  }
-}
-
 void ReFinalize::visitExport(Export* curr) { WASM_UNREACHABLE("unimp"); }
 void ReFinalize::visitGlobal(Global* curr) { WASM_UNREACHABLE("unimp"); }
 void ReFinalize::visitTable(Table* curr) { WASM_UNREACHABLE("unimp"); }

--- a/src/ir/utils.h
+++ b/src/ir/utils.h
@@ -138,8 +138,6 @@ struct ReFinalize
 
 #include "wasm-delegations.def"
 
-  void visitFunction(Function* curr);
-
   void visitExport(Export* curr);
   void visitGlobal(Global* curr);
   void visitTable(Table* curr);

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -74,7 +74,7 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
 // A visitor which must be overridden for each visitor that is reached.
 
 template<typename SubType, typename ReturnType = void>
-struct OverriddenVisitor : public Visitor<SubType, ReturnType> {
+struct OverriddenVisitor {
 // Expression visitors, which must be overridden
 #define DELEGATE(CLASS_TO_VISIT)                                               \
   ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
@@ -86,6 +86,22 @@ struct OverriddenVisitor : public Visitor<SubType, ReturnType> {
   }
 
 #include "wasm-delegations.def"
+
+  ReturnType visit(Expression* curr) {
+    assert(curr);
+
+    switch (curr->_id) {
+#define DELEGATE(CLASS_TO_VISIT)                                               \
+  case Expression::Id::CLASS_TO_VISIT##Id:                                     \
+    return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                 \
+      static_cast<CLASS_TO_VISIT*>(curr))
+
+#include "wasm-delegations.def"
+
+      default:
+        WASM_UNREACHABLE("unexpected expression type");
+    }
+  }
 };
 
 // Visit with a single unified visitor, called on every node, instead of

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -74,7 +74,7 @@ template<typename SubType, typename ReturnType = void> struct Visitor {
 // A visitor which must be overridden for each visitor that is reached.
 
 template<typename SubType, typename ReturnType = void>
-struct OverriddenVisitor {
+struct OverriddenVisitor : public Visitor<SubType, ReturnType> {
 // Expression visitors, which must be overridden
 #define DELEGATE(CLASS_TO_VISIT)                                               \
   ReturnType visit##CLASS_TO_VISIT(CLASS_TO_VISIT* curr) {                     \
@@ -86,22 +86,6 @@ struct OverriddenVisitor {
   }
 
 #include "wasm-delegations.def"
-
-  ReturnType visit(Expression* curr) {
-    assert(curr);
-
-    switch (curr->_id) {
-#define DELEGATE(CLASS_TO_VISIT)                                               \
-  case Expression::Id::CLASS_TO_VISIT##Id:                                     \
-    return static_cast<SubType*>(this)->visit##CLASS_TO_VISIT(                 \
-      static_cast<CLASS_TO_VISIT*>(curr))
-
-#include "wasm-delegations.def"
-
-      default:
-        WASM_UNREACHABLE("unexpected expression type");
-    }
-  }
 };
 
 // Visit with a single unified visitor, called on every node, instead of


### PR DESCRIPTION
Poking in the git history, this was some kind of hack for a problem that appears to
no longer exist since at least 5 years ago.

Logically, refinalize should never change a type from unreachable to none, or at
least if we have a place that does this, we should manually do the necessary things
around that, like updating the function's return type. The opposite, none (or anything
else) to unreachable is the common case, where we use refinalize to propagate
that type upwards.

Fuzzing also finds no issues.

This will unblock a future PR where this hack just got in the way.