### PR TITLE
[Wasm GC] Fix the depth of the new array heap type

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -116,13 +116,12 @@ struct SubTypes {
     // TODO: update when we get structtype
     for (auto type : types) {
       HeapType basic;
-      if (type.isData()) {
-        if (type.isArray()) {
-          basic = HeapType::array;
-        } else {
-          basic = HeapType::data;
-        }
+      if (type.isStruct()) {
+        basic = HeapType::data;
+      } else if (type.isArray()) {
+        basic = HeapType::array;
       } else {
+        assert(type.isSignature());
         basic = HeapType::func;
       }
       depths[basic] = std::max(depths[basic], depths[type] + 1);

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -113,12 +113,23 @@ struct SubTypes {
     }
 
     // Add the max depths of basic types.
-    // TODO: update when we get structtype and arraytype
+    // TODO: update when we get structtype
     for (auto type : types) {
-      HeapType basic = type.isData() ? HeapType::data : HeapType::func;
+      HeapType basic;
+      if (type.isData()) {
+        if (type.isArray()) {
+          basic = HeapType::array;
+        } else {
+          basic = HeapType::data;
+        }
+      } else {
+        basic = HeapType::func;
+      }
       depths[basic] = std::max(depths[basic], depths[type] + 1);
     }
 
+    depths[HeapType::data] = std::max(depths[HeapType::data],
+                                      depths[HeapType::array] + 1);
     depths[HeapType::eq] = std::max(Index(1), depths[HeapType::data] + 1);
     depths[HeapType::any] = depths[HeapType::eq] + 1;
 

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -128,8 +128,8 @@ struct SubTypes {
       depths[basic] = std::max(depths[basic], depths[type] + 1);
     }
 
-    depths[HeapType::data] = std::max(depths[HeapType::data],
-                                      depths[HeapType::array] + 1);
+    depths[HeapType::data] =
+      std::max(depths[HeapType::data], depths[HeapType::array] + 1);
     depths[HeapType::eq] = std::max(Index(1), depths[HeapType::data] + 1);
     depths[HeapType::any] = depths[HeapType::eq] + 1;
 

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -498,6 +498,12 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
                                                   coneFuncref,
                                                   coneFuncref1};
 
+  // Add some additional interesting types.
+  auto structType = Type(HeapType(Struct({Field(Type::i32, Immutable)})), NonNullable);
+  initial.insert(PossibleContents::coneType(structType, 0));
+  //auto arrayType = Type(HeapType(Array(Field(Type::i32, Immutable))), NonNullable);
+  //initial.insert(PossibleContents::coneType(arrayType, 0));
+
   // After testing on the initial contents, also test using anything new that
   // showed up while combining them.
   auto subsequent = doTest(initial);

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -419,7 +419,8 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
           // the intersection. That is, normalization must not have a bug that
           // results in cones that are too shallow.
           auto normalizedDepth = maxDepths[type.getHeapType()];
-          auto normalizedCone = PossibleContents::coneType(type, normalizedDepth);
+          auto normalizedCone =
+            PossibleContents::coneType(type, normalizedDepth);
           assertHaveIntersection(normalizedCone, item);
         }
 
@@ -499,9 +500,11 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
                                                   coneFuncref1};
 
   // Add some additional interesting types.
-  auto structType = Type(HeapType(Struct({Field(Type::i32, Immutable)})), NonNullable);
+  auto structType =
+    Type(HeapType(Struct({Field(Type::i32, Immutable)})), NonNullable);
   initial.insert(PossibleContents::coneType(structType, 0));
-  auto arrayType = Type(HeapType(Array(Field(Type::i32, Immutable))), NonNullable);
+  auto arrayType =
+    Type(HeapType(Array(Field(Type::i32, Immutable))), NonNullable);
   initial.insert(PossibleContents::coneType(arrayType, 0));
 
   // After testing on the initial contents, also test using anything new that

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -430,8 +430,9 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
           }
 #endif
 
-          // The intersection is contained in each of the things we intersected.
-          EXPECT_TRUE(PossibleContents::isSubContents(intersection, item));
+          // The intersection is contained in each of the things we intersected
+          // (but we can only compare to the full cone, as the API is restricted
+          // to that).
           EXPECT_TRUE(
             PossibleContents::isSubContents(intersection, combination));
         }

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -501,8 +501,8 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
   // Add some additional interesting types.
   auto structType = Type(HeapType(Struct({Field(Type::i32, Immutable)})), NonNullable);
   initial.insert(PossibleContents::coneType(structType, 0));
-  //auto arrayType = Type(HeapType(Array(Field(Type::i32, Immutable))), NonNullable);
-  //initial.insert(PossibleContents::coneType(arrayType, 0));
+  auto arrayType = Type(HeapType(Array(Field(Type::i32, Immutable))), NonNullable);
+  initial.insert(PossibleContents::coneType(arrayType, 0));
 
   // After testing on the initial contents, also test using anything new that
   // showed up while combining them.

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -429,8 +429,8 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
 
           // The intersection is contained in each of the things we intersected.
           EXPECT_TRUE(PossibleContents::isSubContents(intersection, item));
-          EXPECT_TRUE(PossibleContents::isSubContents(intersection,
-                                                      combination));
+          EXPECT_TRUE(
+            PossibleContents::isSubContents(intersection, combination));
         }
       }
 

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -413,6 +413,16 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
 #endif
         assertHaveIntersection(combination, item);
 
+        auto type = combination.getType();
+        if (type.isRef()) {
+          // If we normalize the combination's depth, the item must still be in
+          // the intersection. That is, normalization must not have a bug that
+          // results in cones that are too shallow.
+          auto normalizedDepth = maxDepths[type.getHeapType()];
+          auto normalizedCone = PossibleContents::coneType(type, normalizedDepth);
+          assertHaveIntersection(normalizedCone, item);
+        }
+
         // Test intersectWithFullCone() method, which is supported with a full
         // cone type. In that case we can test that the intersection of A with
         // A + B is simply A.

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -353,7 +353,10 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
     for (auto& contents : set) {
       auto type = contents.getType();
       if (type.isRef()) {
-        heapTypes.insert(type.getHeapType());
+        auto heapType = type.getHeapType();
+        if (!heapType.isBasic()) {
+          heapTypes.insert(heapType);
+        }
       }
     }
     std::vector<HeapType> heapTypesVec(heapTypes.begin(), heapTypes.end());

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -415,8 +415,8 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
 
         auto type = combination.getType();
         if (type.isRef()) {
-          // If we normalize the combination's depth, the item must still be in
-          // the intersection. That is, normalization must not have a bug that
+          // If we normalize the combination's depth, the item must still have
+          // an intersection. That is, normalization must not have a bug that
           // results in cones that are too shallow.
           auto normalizedDepth = maxDepths[type.getHeapType()];
           auto normalizedCone =

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -839,7 +839,7 @@ TEST_F(IsorecursiveTest, TestExistingSuperType) {
 }
 
 // Test .getMaxDepths() helper.
-TEST_F(NominalTest, TestMaxDepths) {
+TEST_F(NominalTest, TestMaxStructDepths) {
   /*
       A
       |
@@ -863,6 +863,26 @@ TEST_F(NominalTest, TestMaxDepths) {
 
   EXPECT_EQ(maxDepths[B], Index(0));
   EXPECT_EQ(maxDepths[A], Index(1));
+  EXPECT_EQ(maxDepths[HeapType::data], Index(2));
+  EXPECT_EQ(maxDepths[HeapType::eq], Index(3));
+}
+
+TEST_F(NominalTest, TestMaxArrayDepths) {
+  HeapType A;
+  {
+    TypeBuilder builder(1);
+    builder[0] = Array(Field(Type::i32, Immutable));
+    auto result = builder.build();
+    ASSERT_TRUE(result);
+    auto built = *result;
+    A = built[0];
+  }
+
+  SubTypes subTypes({A});
+  auto maxDepths = subTypes.getMaxDepths();
+
+  EXPECT_EQ(maxDepths[A], Index(0));
+  EXPECT_EQ(maxDepths[HeapType::array], Index(1));
   EXPECT_EQ(maxDepths[HeapType::data], Index(2));
   EXPECT_EQ(maxDepths[HeapType::eq], Index(3));
 }


### PR DESCRIPTION
Found by the fuzzer. Add some automatic testing that would have found this,
and also a dedicated test.