### PR TITLE
[NFC] Rewrite PossibleContents::combine to be static

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1629,7 +1629,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
   std::cout << '\n';
 #endif
 
-  contents = PossibleContents::combine(contents, newContents);
+  contents.combine(newContents);
 
   if (contents.isNone()) {
     // There is still nothing here. There is nothing more to do here but to

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -42,7 +42,8 @@ std::ostream& operator<<(std::ostream& stream,
 
 namespace wasm {
 
-PossibleContents PossibleContents::combine(const PossibleContents& a, const PossibleContents& b) {
+PossibleContents PossibleContents::combine(const PossibleContents& a,
+                                           const PossibleContents& b) {
   auto aType = a.getType();
   auto bType = b.getType();
   // First handle the trivial cases of them being equal, or one of them is
@@ -133,8 +134,7 @@ PossibleContents PossibleContents::combine(const PossibleContents& a, const Poss
     assert(lubDepthFromRoot <= aDepthFromRoot);
     assert(lubDepthFromRoot <= bDepthFromRoot);
     Index aDepthUnderLub = aDepthFromRoot - lubDepthFromRoot + aDepth;
-    Index bDepthUnderLub =
-      bDepthFromRoot - lubDepthFromRoot + bDepth;
+    Index bDepthUnderLub = bDepthFromRoot - lubDepthFromRoot + bDepth;
 
     // The total cone must be big enough to contain all the above.
     newDepth = std::max(aDepthUnderLub, bDepthUnderLub);

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -103,8 +103,7 @@ class PossibleContents {
   // full cone of all subtypes for that type.
   static ConeType FullConeType(Type type) { return ConeType{type, FullDepth}; }
 
-  template<typename T>
-  PossibleContents(T value) : value(value) {}
+  template<typename T> PossibleContents(T value) : value(value) {}
 
 public:
   PossibleContents() : value(None()) {}
@@ -164,7 +163,8 @@ public:
 
   // Combine the information in a given PossibleContents to this one. The
   // contents here will then include whatever content was possible in |other|.
-  static PossibleContents combine(const PossibleContents& a, const PossibleContents& b);
+  static PossibleContents combine(const PossibleContents& a,
+                                  const PossibleContents& b);
 
   // Removes anything not in |other| from this object, so that it ends up with
   // only their intersection. Currently this only handles an intersection with a

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -163,8 +163,12 @@ public:
 
   // Combine the information in a given PossibleContents to this one. The
   // contents here will then include whatever content was possible in |other|.
-  static PossibleContents combine(const PossibleContents& a,
-                                  const PossibleContents& b);
+  [[nodiscard]] static PossibleContents combine(const PossibleContents& a,
+                                                const PossibleContents& b);
+
+  void combine(const PossibleContents& other) {
+    *this = PossibleContents::combine(*this, other);
+  }
 
   // Removes anything not in |other| from this object, so that it ends up with
   // only their intersection. Currently this only handles an intersection with a

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -103,11 +103,12 @@ class PossibleContents {
   // full cone of all subtypes for that type.
   static ConeType FullConeType(Type type) { return ConeType{type, FullDepth}; }
 
+  template<typename T>
+  PossibleContents(T value) : value(value) {}
+
 public:
   PossibleContents() : value(None()) {}
   PossibleContents(const PossibleContents& other) = default;
-
-  template<typename T> explicit PossibleContents(T val) : value(val) {}
 
   // Most users will use one of the following static functions to construct a
   // new instance:
@@ -163,7 +164,7 @@ public:
 
   // Combine the information in a given PossibleContents to this one. The
   // contents here will then include whatever content was possible in |other|.
-  void combine(const PossibleContents& other);
+  static PossibleContents combine(const PossibleContents& a, const PossibleContents& b);
 
   // Removes anything not in |other| from this object, so that it ends up with
   // only their intersection. Currently this only handles an intersection with a

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -24,15 +24,13 @@ template<typename T> void assertNotEqualSymmetric(const T& a, const T& b) {
 // Asserts a combined with b (in any order) is equal to c.
 template<typename T>
 void assertCombination(const T& a, const T& b, const T& c) {
-  T temp1 = a;
-  temp1.combine(b);
+  T temp1 = PossibleContents::combine(a, b);
   assertEqualSymmetric(temp1, c);
   // Also check the type, as nulls will compare equal even if their types
   // differ. We want to make sure even the types are identical.
   assertEqualSymmetric(temp1.getType(), c.getType());
 
-  T temp2 = b;
-  temp2.combine(a);
+  T temp2 = PossibleContents::combine(b, a);
   assertEqualSymmetric(temp2, c);
   assertEqualSymmetric(temp2.getType(), c.getType());
 }
@@ -362,14 +360,14 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
       // check they all have an intersection.
       PossibleContents combination;
       for (auto index : indexes) {
-        combination.combine(vec[index]);
+        combination = PossibleContents::combine(combination, vec[index]);
       }
       // Note the combination in the set.
       set.insert(combination);
 #if BINARYEN_TEST_DEBUG
       for (auto index : indexes) {
         std::cout << index << ' ';
-        combination.combine(vec[index]);
+        combination = PossibleContents::combine(combination, vec[index]);
       }
       std::cout << '\n';
 #endif

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -33,6 +33,15 @@ void assertCombination(const T& a, const T& b, const T& c) {
   T temp2 = PossibleContents::combine(b, a);
   assertEqualSymmetric(temp2, c);
   assertEqualSymmetric(temp2.getType(), c.getType());
+
+  // Verify the shorthand API works like the static one.
+  T temp3 = a;
+  temp3.combine(b);
+  assertEqualSymmetric(temp3, temp1);
+
+  T temp4 = b;
+  temp4.combine(a);
+  assertEqualSymmetric(temp4, temp2);
 }
 
 // Parse a module from text and return it.
@@ -360,14 +369,14 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
       // check they all have an intersection.
       PossibleContents combination;
       for (auto index : indexes) {
-        combination = PossibleContents::combine(combination, vec[index]);
+        combination.combine(vec[index]);
       }
       // Note the combination in the set.
       set.insert(combination);
 #if BINARYEN_TEST_DEBUG
       for (auto index : indexes) {
         std::cout << index << ' ';
-        combination = PossibleContents::combine(combination, vec[index]);
+        combination.combine(vec[index]);
       }
       std::cout << '\n';
 #endif


### PR DESCRIPTION
As suggested by @tlively in the past. This makes the method symmetric.

Measuring speed, this seems identical to before, so that concern seems fine.

However, after writing this I'm not sure this is worth it. Perhaps the `combine()` method itself is a little easier to read, but using the API gets more cumbersome in the common case:

```diff
-contents.combine(newContents);
+contents = PossibleContents::combine(contents, newContents);
```

(There is also some risk of using it without realizing it is static, `contents.combine(.., ..)` can be written, but it does not modify `contents`. I guess `[[nodiscard]]` could help there though.)