### PR TITLE
RedundantSetElimination: Look at fallthrough values

### DIFF
--- a/src/passes/RedundantSetElimination.cpp
+++ b/src/passes/RedundantSetElimination.cpp
@@ -298,7 +298,9 @@ struct RedundantSetElimination
       auto& setps = curr->contents.setps;
       for (auto** setp : setps) {
         auto* set = (*setp)->cast<LocalSet>();
-        currValues[set->index] = getValue(set->value, currValues);
+        auto* value = Properties::getFallthrough(
+          set->value, getPassOptions(), *getModule());
+        currValues[set->index] = getValue(value, currValues);
       }
       if (currValues == curr->contents.end) {
         // nothing changed, so no more work to do
@@ -335,7 +337,9 @@ struct RedundantSetElimination
       for (auto** setp : setps) {
         auto* set = (*setp)->cast<LocalSet>();
         auto oldValue = currValues[set->index];
-        auto newValue = getValue(set->value, currValues);
+        auto* value = Properties::getFallthrough(
+          set->value, getPassOptions(), *getModule());
+        auto newValue = getValue(value, currValues);
         auto index = set->index;
         if (newValue == oldValue) {
           remove(setp);

--- a/test/lit/passes/inlining-optimizing_optimize-level=3.wast
+++ b/test/lit/passes/inlining-optimizing_optimize-level=3.wast
@@ -4523,9 +4523,6 @@
  ;; CHECK-NEXT:            (i32.const 32)
  ;; CHECK-NEXT:           )
  ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (local.set $6
- ;; CHECK-NEXT:           (local.get $1)
- ;; CHECK-NEXT:          )
  ;; CHECK-NEXT:          (local.get $9)
  ;; CHECK-NEXT:         )
  ;; CHECK-NEXT:        )


### PR DESCRIPTION
This can help in rare cases in MVP wasm, say for the return value of a block. But for
wasm GC it is very important due to casts.

Similar logic was added as part of #5194 for SimplifyLocals. It should probably have
been in a separate PR then. This does the right thing for RedundantSetElimination,
as a separate PR. Full tests will appear in that later PR (it is not really possible to test
the GC side yet - we need the logic in the later PR that actually switches to a more
refined local index when available).