### PR TITLE
Fix fuzzer default contents after #5212

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -182,7 +182,7 @@ def randomize_fuzz_settings():
 def init_important_initial_contents():
     FIXED_IMPORTANT_INITIAL_CONTENTS = [
         # Perenially-important passes
-        os.path.join('lit', 'passes', 'optimize-instructions.wast'),
+        os.path.join('lit', 'passes', 'optimize-instructions-mvp.wast'),
         os.path.join('passes', 'optimize-instructions_fuzz-exec.wast'),
     ]
     MANUAL_RECENT_INITIAL_CONTENTS = [


### PR DESCRIPTION
That PR renamed test/lit/optimize-instructions.wast to
test/lit/optimize-instructions-mvp.wast. However, the fuzzer was explicitly
adding the test to the list of important initial contents under the old name, so
it was failing an assertion that the initial contents existed.  Update the fuzzer
to use the new test name.