### PR TITLE
Perform proper checks for function subtyping.

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1845,10 +1845,12 @@ bool SubTyper::isSubType(const Field& a, const Field& b) {
 }
 
 bool SubTyper::isSubType(const Signature& a, const Signature& b) {
-  // TODO: Implement proper signature subtyping, covariant in results and
-  // contravariant in params, once V8 implements it.
-  // return isSubType(b.params, a.params) && isSubType(a.results, b.results);
-  return a == b;
+  if (a == b) {
+    return true;
+  }
+
+  // Params are contravariant, and results are covariant.
+  return isSubType(b.params, a.params) && isSubType(a.results, b.results);
 }
 
 bool SubTyper::isSubType(const Struct& a, const Struct& b) {


### PR DESCRIPTION
I'm opening this PR to propose we just actually implement the proper subtyping logic for functions.

Obviously, the TODO appears to indicate we've given this some thought and decided we were waiting for v8 to land its logic. However, I'd like to see if we could just land this now, as it's causing issues for running binaryen on the output of dart2wasm.

In the cases I've run into with dart2wasm output, the function types that are being by `isSubType` and failing are actually *exactly equivalent*. However, the current logic is not actually sufficient even for exact equivalence, because it appears that the IDs of the different types in this case are not unique, so if the IDs do not match we need to actually do a deep check of the results and params if we wanted it to work correctly in all cases.

However, if no one has any objections, I'd like to suggest we just land the actual covariant return/contravariant params logic for functions now anyway. From my reading of the `wasm-subtyping.cc` code in V8 (which may be incorrect, I don't have that much familiarity with this code) it actually seems like V8 itself is *more* permissive than is correct, by which I mean that all functions are considered to be subtypes of each other for validation purposes. And regardless of the state of implementation of V8, many of the utilities in binaryen are useful for inspecting and manipulating wasm binaries even if they aren't ready for V8, so I don't think in needs to have a hard failure if it doesn't have exact type equivalence anyway.

Please let me know what you think. If there are real objections to having this logic land now, I can always land a better strict equivalence check for function types that is invariant in both the params and the results. But I'd prefer to land this covariant results/contravariant params logic if possible.