### PR TITLE
Handles memory.grow failure in MultiMemoryLowering Pass

### DIFF
--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -304,12 +304,12 @@ struct MultiMemoryLowering : public Pass {
           sizeLocal, builder.makeMemorySize(combinedMemory, memoryInfo)));
     }
 
-    // TODO: Check the result of makeMemoryGrow for errors and return the error
-    // instead
+    // Attempt to grow the combinedMemory. If -1 returns, enough memory could
+    // not be allocated, so return -1.
     functionBody = builder.blockify(
       functionBody,
-      builder.makeDrop(builder.makeMemoryGrow(
-        builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo)));
+      builder.makeIf(builder.makeBinary(EqInt32, builder.makeMemoryGrow(
+        builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo), builder.makeConst(-1)), builder.makeReturn(builder.makeConst(-1)), nullptr);
 
     // If we are not growing the last memory, then we need to copy data,
     // shifting it over to accomodate the increase from page_delta

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -309,7 +309,7 @@ struct MultiMemoryLowering : public Pass {
     functionBody = builder.blockify(
       functionBody,
       builder.makeIf(builder.makeBinary(EqInt32, builder.makeMemoryGrow(
-        builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo), builder.makeConst(-1)), builder.makeReturn(builder.makeConst(-1)), nullptr);
+        builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo), builder.makeConst(-1)), builder.makeReturn(builder.makeConst(-1)), nullptr));
 
     // If we are not growing the last memory, then we need to copy data,
     // shifting it over to accomodate the increase from page_delta

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -308,8 +308,14 @@ struct MultiMemoryLowering : public Pass {
     // not be allocated, so return -1.
     functionBody = builder.blockify(
       functionBody,
-      builder.makeIf(builder.makeBinary(EqInt32, builder.makeMemoryGrow(
-        builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo), builder.makeConst(-1)), builder.makeReturn(builder.makeConst(-1)), nullptr));
+      builder.makeIf(
+        builder.makeBinary(
+          EqInt32,
+          builder.makeMemoryGrow(
+            builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo),
+          builder.makeConst(-1)),
+        builder.makeReturn(builder.makeConst(-1)),
+        nullptr));
 
     // If we are not growing the last memory, then we need to copy data,
     // shifting it over to accomodate the increase from page_delta

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -314,8 +314,7 @@ struct MultiMemoryLowering : public Pass {
           builder.makeMemoryGrow(
             builder.makeLocalGet(0, pointerType), combinedMemory, memoryInfo),
           builder.makeConst(-1)),
-        builder.makeReturn(builder.makeConst(-1)),
-        nullptr));
+        builder.makeReturn(builder.makeConst(-1))));
 
     // If we are not growing the last memory, then we need to copy data,
     // shifting it over to accomodate the increase from page_delta

--- a/test/lit/passes/multi-memory-lowering.wast
+++ b/test/lit/passes/multi-memory-lowering.wast
@@ -147,9 +147,15 @@
 ;; CHECK-NEXT:  (local.set $memory_size
 ;; CHECK-NEXT:   (memory.size)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (memory.grow
-;; CHECK-NEXT:    (local.get $page_delta)
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.eq
+;; CHECK-NEXT:    (memory.grow
+;; CHECK-NEXT:     (local.get $page_delta)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const -1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (return
+;; CHECK-NEXT:    (i32.const -1)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (memory.copy
@@ -199,9 +205,15 @@
 ;; CHECK-NEXT:  (local.set $memory_size
 ;; CHECK-NEXT:   (memory.size)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (memory.grow
-;; CHECK-NEXT:    (local.get $page_delta)
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.eq
+;; CHECK-NEXT:    (memory.grow
+;; CHECK-NEXT:     (local.get $page_delta)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const -1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (return
+;; CHECK-NEXT:    (i32.const -1)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (memory.copy
@@ -238,9 +250,15 @@
 ;; CHECK-NEXT:  (local.set $return_size
 ;; CHECK-NEXT:   (call $memory3_size)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (memory.grow
-;; CHECK-NEXT:    (local.get $page_delta)
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.eq
+;; CHECK-NEXT:    (memory.grow
+;; CHECK-NEXT:     (local.get $page_delta)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const -1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (return
+;; CHECK-NEXT:    (i32.const -1)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (local.get $return_size)


### PR DESCRIPTION
Per the [wasm spec](https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-instr-memory), memory.grow instructions should return -1 when there is a failure to allocate enough memory. This PR adds support for returning this error code.