### PR TITLE
[Wasm GC] Fix nondeterminism in GUFA due to ordering

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1341,7 +1341,8 @@ private:
 #ifdef POSSIBLE_CONTENTS_INSERT_ORDERED
   InsertOrderedSet<LocationIndex> workQueue;
 #else
-  std::unordered_set<LocationIndex> workQueue;
+  //std::unordered_set<LocationIndex> workQueue;
+  UniqueDeferredQueue<LocationIndex> workQueue;
 #endif
 
   // All existing links in the graph. We keep this to know when a link we want
@@ -1634,9 +1635,7 @@ Flower::Flower(Module& wasm) : wasm(wasm) {
     }
 #endif
 
-    auto iter = workQueue.begin();
-    auto locationIndex = *iter;
-    workQueue.erase(iter);
+    auto locationIndex = workQueue.pop();
 
     flowAfterUpdate(locationIndex);
   }
@@ -1734,7 +1733,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
 #endif
 
   // Add a work item if there isn't already.
-  workQueue.insert(locationIndex);
+  workQueue.push(locationIndex);
 
   return worthSendingMore;
 }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -22,13 +22,8 @@
 #include "ir/local-graph.h"
 #include "ir/module-utils.h"
 #include "ir/possible-contents.h"
-#include "wasm.h"
-
-#ifdef POSSIBLE_CONTENTS_INSERT_ORDERED
-// Use an insert-ordered set for easier debugging with deterministic queue
-// ordering.
 #include "support/insert_ordered.h"
-#endif
+#include "wasm.h"
 
 namespace std {
 
@@ -1338,12 +1333,19 @@ private:
   // possible is helpful as anything reading them meanwhile (before we get to
   // their work item in the queue) will see the newer value, possibly avoiding
   // flowing an old value that would later be overwritten.
-#ifdef POSSIBLE_CONTENTS_INSERT_ORDERED
+  //
+  // This must be ordered to avoid nondeterminism. The problem is that our
+  // operations are imprecise and so the transitive property does not hold:
+  // (AvB)vC may differ from Av(BvC). Likewise (AvB)^C may differ from
+  // (A^C)v(B^C). An example of the latter is if a location is sent a null func
+  // and an i31, and the location can only contain funcref. If the null func
+  // arrives first, then later we'd merge null func + i31 which ends up as Many,
+  // and then we filter that to funcref and get funcref. But if the i31 arrived
+  // first, we'd filter it into nothing, and then the null func that arrives
+  // later would be the final result. This would not happen if our operations
+  // were precise, but we only make approximations here to avoid unacceptable
+  // overhead, such as cone types but not arbitrary unions, etc.
   InsertOrderedSet<LocationIndex> workQueue;
-#else
-  //std::unordered_set<LocationIndex> workQueue;
-  UniqueDeferredQueue<LocationIndex> workQueue;
-#endif
 
   // All existing links in the graph. We keep this to know when a link we want
   // to add is new or not.
@@ -1635,7 +1637,9 @@ Flower::Flower(Module& wasm) : wasm(wasm) {
     }
 #endif
 
-    auto locationIndex = workQueue.pop();
+    auto iter = workQueue.begin();
+    auto locationIndex = *iter;
+    workQueue.erase(iter);
 
     flowAfterUpdate(locationIndex);
   }
@@ -1733,7 +1737,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
 #endif
 
   // Add a work item if there isn't already.
-  workQueue.push(locationIndex);
+  workQueue.insert(locationIndex);
 
   return worthSendingMore;
 }

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -14,6 +14,8 @@
 
   ;; CHECK:      (type $none_=>_ref|any| (func_subtype (result (ref any)) func))
 
+  ;; CHECK:      (type $none_=>_funcref (func_subtype (result funcref) func))
+
   ;; CHECK:      (import "a" "b" (func $import (result i32)))
   (import "a" "b" (func $import (result i32)))
 
@@ -359,6 +361,18 @@
     )
   )
 
+  ;; CHECK:      (func $nondeterminism (type $none_=>_funcref) (result funcref)
+  ;; CHECK-NEXT:  (block $label$1 (result funcref)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_on_func $label$1
+  ;; CHECK-NEXT:     (i31.new
+  ;; CHECK-NEXT:      (i32.const 1337)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (ref.null nofunc)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $nondeterminism (result funcref)
     ;; This block is sent an i31 and a null. The null is compatible with the
     ;; type and the i31 is not. The order in which we process this matters:
@@ -371,13 +385,14 @@
     ;;    incompatible). We then filter that to the block's type, ending up with
     ;;    a cone of funcref. We cannot optimize in that case, unlike before.
     ;;
-    ;; Ideally we'd optimize here, but at minimum we should be deterministic in
-    ;; how we handle this.
+    ;; Ideally we'd optimize here, but atm we do not since the order in
+    ;; practice is a less ideal one. At minimum we should be deterministic in
+    ;; how we handle this, which this test enforces at least.
     ;;
-    ;; TODO: Ensure we optimize by filtering contents before sending them, or
-    ;;       something like that? But out operations on sets are imprecise, so
-    ;;       it seems impossible to ensure the transitive property, so the order
-    ;;       can end up mattering.
+    ;; TODO: Find a way to actually optimize such cases, perhaps by filtering
+    ;;       when sending as well and not just when receiving (the br_on_func
+    ;;       here should not send anything, as what it sends should be first
+    ;;       intersected with funcref).
     (block $label$1 (result funcref)
       (drop
         (br_on_func $label$1


### PR DESCRIPTION
We don't actually have the transitive and distributive properties since our
PossibleContents representation is an approximation, and the fuzzer found
a case where that is noticeable. See more details in the new comment +
testcase.

I measured speed and memory usage and this actually causes almost no
noticeable change.