### PR TITLE
[GUFA] [NFC] Remove RefCast special-casing

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -655,9 +655,7 @@ struct InfoCollector
     addRoot(curr);
   }
 
-  void visitRefCast(RefCast* curr) {
-    receiveChildValue(curr->ref, curr);
-  }
+  void visitRefCast(RefCast* curr) { receiveChildValue(curr->ref, curr); }
   void visitRefTest(RefTest* curr) { addRoot(curr); }
   void visitBrOn(BrOn* curr) {
     // TODO: optimize when possible


### PR DESCRIPTION
All that code did was filter contents by the type of the RefCast. We do that for all
expressions now, so it was redundant.