### PR TITLE
Switch from `typedef` to `using` in C++ code. NFC

### DIFF
--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -526,7 +526,7 @@ LoopShape* Relooper::AddLoopShape() {
 
 namespace {
 
-typedef std::list<Block*> BlockList;
+using BlockList = std::list<Block*>;
 
 struct RelooperRecursor {
   Relooper* Parent;
@@ -554,7 +554,7 @@ struct Liveness : public RelooperRecursor {
   }
 };
 
-typedef std::pair<Branch*, Block*> BranchBlock;
+using BranchBlock = std::pair<Branch*, Block*>;
 
 struct Optimizer : public RelooperRecursor {
   Block* Entry;
@@ -1251,7 +1251,7 @@ void Relooper::Calculate(Block* Entry) {
     void FindIndependentGroups(BlockSet& Entries,
                                BlockBlockSetMap& IndependentGroups,
                                BlockSet* Ignore = nullptr) {
-      typedef std::map<Block*, Block*> BlockBlockMap;
+      using BlockBlockMap = std::map<Block*, Block*>;
 
       struct HelperClass {
         BlockBlockSetMap& IndependentGroups;

--- a/src/cfg/Relooper.h
+++ b/src/cfg/Relooper.h
@@ -124,8 +124,8 @@ struct Branch {
   Render(RelooperBuilder& Builder, Block* Target, bool SetLabel);
 };
 
-typedef wasm::InsertOrderedSet<Block*> BlockSet;
-typedef wasm::InsertOrderedMap<Block*, Branch*> BlockBranchMap;
+using BlockSet = wasm::InsertOrderedSet<Block*>;
+using BlockBranchMap = wasm::InsertOrderedMap<Block*, Branch*>;
 
 // Represents a basic block of code - some instructions that end with a
 // control flow modifier (a branch, return or throw).
@@ -241,7 +241,7 @@ struct SimpleShape : public Shape {
   wasm::Expression* Render(RelooperBuilder& Builder, bool InLoop) override;
 };
 
-typedef std::map<int, Shape*> IdShapeMap;
+using IdShapeMap = std::map<int, Shape*>;
 
 struct MultipleShape : public Shape {
   IdShapeMap InnerMap; // entry block ID -> shape
@@ -313,7 +313,7 @@ struct Relooper {
   void SetMinSize(bool MinSize_) { MinSize = MinSize_; }
 };
 
-typedef wasm::InsertOrderedMap<Block*, BlockSet> BlockBlockSetMap;
+using BlockBlockSetMap = wasm::InsertOrderedMap<Block*, BlockSet>;
 
 #ifdef RELOOPER_DEBUG
 struct Debugging {

--- a/src/cfg/liveness-traversal.h
+++ b/src/cfg/liveness-traversal.h
@@ -36,7 +36,7 @@ namespace wasm {
 // may be a great many potential elements but actual sets
 // may be fairly small. Specifically, we use a sorted
 // vector.
-typedef SortedVector SetOfLocals;
+using SetOfLocals = SortedVector;
 
 // A liveness-relevant action. Supports a get, a set, or an
 // "other" which can be used for other purposes, to mark

--- a/src/dataflow/graph.h
+++ b/src/dataflow/graph.h
@@ -84,7 +84,7 @@ struct Graph : public UnifiedExpressionVisitor<Graph, Node*> {
   // When we are in unreachable code (i.e., a path that does not
   // need to be merged in anywhere), we set the length of this
   // vector to 0 to indicate that.
-  typedef std::vector<Node*> Locals;
+  using Locals = std::vector<Node*>;
 
   // The current local state in the control flow path being emitted.
   Locals locals;

--- a/src/dataflow/users.h
+++ b/src/dataflow/users.h
@@ -34,7 +34,7 @@ namespace wasm::DataFlow {
 // where y, z etc. are nodes that use x, that is, x is in their
 // values vector.
 class Users {
-  typedef std::unordered_set<DataFlow::Node*> UserSet;
+  using UserSet = std::unordered_set<DataFlow::Node*>;
 
   std::unordered_map<DataFlow::Node*, UserSet> users;
 

--- a/src/emscripten-optimizer/parser.h
+++ b/src/emscripten-optimizer/parser.h
@@ -426,7 +426,7 @@ template<class NodeRef, class Builder> class Parser {
   // This is a list of the current stack of node-operator-node-operator-etc.
   // this works by each parseExpression call appending to the vector; then
   // recursing out, and the toplevel sorts it all
-  typedef std::vector<ExpressionElement> ExpressionParts;
+  using ExpressionParts = std::vector<ExpressionElement>;
   std::vector<ExpressionParts> expressionPartsStack;
 
   // Parses an element in a list of such elements, e.g. list of statements in a

--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -120,7 +120,7 @@ struct Value {
 
   Type type = Null;
 
-  typedef std::unordered_map<IString, Ref> ObjectStorage;
+  using ObjectStorage = std::unordered_map<IString, Ref>;
 
   // MSVC does not allow unrestricted unions:
   // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf

--- a/src/ir/equivalent_sets.h
+++ b/src/ir/equivalent_sets.h
@@ -26,7 +26,7 @@ namespace wasm {
 //
 struct EquivalentSets {
   // A set of indexes. This is ordered for deterministic iteration.
-  typedef std::set<Index> Set;
+  using Set = std::set<Index>;
 
   std::unordered_map<Index, std::shared_ptr<Set>> indexSets;
 

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -368,10 +368,10 @@ template<typename T,
 struct ParallelFunctionAnalysis {
   Module& wasm;
 
-  typedef MapT<Function*, T> Map;
+  using Map = MapT<Function*, T>;
   Map map;
 
-  typedef std::function<void(Function*, T&)> Func;
+  using Func = std::function<void(Function*, T&)>;
 
   ParallelFunctionAnalysis(Module& wasm, Func work) : wasm(wasm) {
     // Fill in map, as we operate on it in parallel (each function to its own
@@ -438,10 +438,10 @@ template<typename T> struct CallGraphPropertyAnalysis {
     bool hasNonDirectCall = false;
   };
 
-  typedef std::map<Function*, T> Map;
+  using Map = std::map<Function*, T>;
   Map map;
 
-  typedef std::function<void(Function*, T&)> Func;
+  using Func = std::function<void(Function*, T&)>;
 
   CallGraphPropertyAnalysis(Module& wasm, Func work) : wasm(wasm) {
     ParallelFunctionAnalysis<T> analysis(wasm, [&](Function* func, T& info) {

--- a/src/pass.h
+++ b/src/pass.h
@@ -36,7 +36,7 @@ struct PassRegistry {
 
   static PassRegistry* get();
 
-  typedef std::function<Pass*()> Creator;
+  using Creator = std::function<Pass*()>;
 
   void registerPass(const char* name, const char* description, Creator create);
   // Register a pass that's used for internal testing. These passes do not show
@@ -446,7 +446,7 @@ template<typename WalkerType>
 class WalkerPass : public Pass, public WalkerType {
 
 protected:
-  typedef WalkerPass<WalkerType> super;
+  using super = WalkerPass<WalkerType>;
 
 public:
   void run(Module* module) override {

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -520,7 +520,7 @@ class ModuleAnalyzer {
     bool addedFromList = false;
   };
 
-  typedef std::map<Function*, Info> Map;
+  using Map = std::map<Function*, Info>;
   Map map;
 
 public:

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -84,7 +84,7 @@ struct DAEFunctionInfo {
   DAEFunctionInfo() { hasUnseenCalls = false; }
 };
 
-typedef std::unordered_map<Name, DAEFunctionInfo> DAEFunctionInfoMap;
+using DAEFunctionInfoMap = std::unordered_map<Name, DAEFunctionInfo>;
 
 struct DAEScanner
   : public WalkerPass<PostWalker<DAEScanner, Visitor<DAEScanner>>> {

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -133,7 +133,7 @@ static bool canHandleParams(Function* func) {
   return true;
 }
 
-typedef std::unordered_map<Name, FunctionInfo> NameInfoMap;
+using NameInfoMap = std::unordered_map<Name, FunctionInfo>;
 
 struct FunctionInfoScanner
   : public WalkerPass<PostWalker<FunctionInfoScanner>> {

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -41,7 +41,7 @@ struct LoopInvariantCodeMotion
     return std::make_unique<LoopInvariantCodeMotion>();
   }
 
-  typedef std::unordered_set<LocalSet*> LoopSets;
+  using LoopSets = std::unordered_set<LocalSet*>;
 
   // main entry point
 

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -24,7 +24,7 @@
 
 namespace wasm {
 
-typedef std::map<const char*, int> Counts;
+using Counts = std::map<const char*, int>;
 
 static Counts lastCounts;
 

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -102,7 +102,7 @@ struct ReReloop final : public Pass {
     virtual void run() { WASM_UNREACHABLE("unimpl"); }
   };
 
-  typedef std::shared_ptr<Task> TaskPtr;
+  using TaskPtr = std::shared_ptr<Task>;
   std::vector<TaskPtr> stack;
 
   struct TriageTask final : public Task {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -123,7 +123,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
 
   bool anotherCycle;
 
-  typedef std::vector<Expression**> Flows;
+  using Flows = std::vector<Expression**>;
 
   // list of breaks that are currently flowing. if they reach their target
   // without interference, they can be removed (or their value forwarded TODO)

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -35,7 +35,7 @@ namespace wasm {
 // TODO: Add data segment, multiple memories (#5224)
 enum class ModuleElementKind { Function, Global, Tag, Table, ElementSegment };
 
-typedef std::pair<ModuleElementKind, Name> ModuleElement;
+using ModuleElement = std::pair<ModuleElementKind, Name>;
 
 // Finds reachabilities
 // TODO: use Effects to determine if a memory is used

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -35,7 +35,7 @@
 
 namespace wasm {
 
-typedef std::unordered_map<Name, std::atomic<Index>> NameCountMap;
+using NameCountMap = std::unordered_map<Name, std::atomic<Index>>;
 
 struct CallCountScanner : public WalkerPass<PostWalker<CallCountScanner>> {
   bool isFunctionParallel() override { return true; }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -86,7 +86,7 @@ struct SimplifyLocals
   };
 
   // a list of sinkables in a linear execution trace
-  typedef std::map<Index, SinkableInfo> Sinkables;
+  using Sinkables = std::map<Index, SinkableInfo>;
 
   // locals in current linear execution trace, which we try to sink
   Sinkables sinkables;

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -71,7 +71,7 @@ struct SpillPointers
   }
 
   // map pointers to their offset in the spill area
-  typedef std::unordered_map<Index, Index> PointerMap;
+  using PointerMap = std::unordered_map<Index, Index>;
 
   Type pointerType;
 

--- a/src/passes/Strip.cpp
+++ b/src/passes/Strip.cpp
@@ -31,7 +31,7 @@ struct Strip : public Pass {
   bool requiresNonNullableLocalFixups() override { return false; }
 
   // A function that returns true if the method should be removed.
-  typedef std::function<bool(UserSection&)> Decider;
+  using Decider = std::function<bool(UserSection&)>;
   Decider decider;
 
   Strip(Decider decider) : decider(decider) {}

--- a/src/support/insert_ordered.h
+++ b/src/support/insert_ordered.h
@@ -32,7 +32,7 @@ template<typename T> struct InsertOrderedSet {
   std::unordered_map<T, typename std::list<T>::iterator> Map;
   std::list<T> List;
 
-  typedef typename std::list<T>::iterator iterator;
+  using iterator = typename std::list<T>::iterator;
   iterator begin() { return List.begin(); }
   iterator end() { return List.end(); }
 
@@ -87,7 +87,7 @@ template<typename Key, typename T> struct InsertOrderedMap {
     Map;
   std::list<std::pair<const Key, T>> List;
 
-  typedef typename std::list<std::pair<const Key, T>>::iterator iterator;
+  using iterator = typename std::list<std::pair<const Key, T>>::iterator;
   iterator begin() { return List.begin(); }
   iterator end() { return List.end(); }
 

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -65,8 +65,8 @@ struct Value {
 
   Type type = Null;
 
-  typedef std::vector<Ref> ArrayStorage;
-  typedef std::unordered_map<IString, Ref> ObjectStorage;
+  using ArrayStorage = std::vector<Ref>;
+  using ObjectStorage = std::unordered_map<IString, Ref>;
 
   // MSVC does not allow unrestricted unions:
   // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2544.pdf
@@ -403,7 +403,7 @@ struct Value {
   }
 };
 
-typedef Value::Ref Ref;
+using Ref = Value::Ref;
 
 } // namespace json
 

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -148,9 +148,9 @@ public:
   // iteration
 
   template<typename Parent, typename Iterator> struct IteratorBase {
-    typedef T value_type;
-    typedef long difference_type;
-    typedef T& reference;
+    using value_type = T;
+    using difference_type = long;
+    using reference = T&;
 
     Parent* parent;
     size_t index;

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -23,7 +23,7 @@
 
 namespace wasm {
 
-typedef std::vector<Literal> Loggings;
+using Loggings = std::vector<Literal>;
 
 // Logs every relevant import call parameter.
 struct LoggingExternalInterface : public ShellExternalInterface {

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -69,7 +69,7 @@ struct MetaDCEGraph {
   // be imported twice, for example. So we don't map a DCE node to an Import,
   // but rather the module.base pair ("id") for the import.
   // TODO: implement this in a safer way, not a string with a magic separator
-  typedef Name ImportId;
+  using ImportId = Name;
 
   ImportId getImportId(Name module, Name base) {
     if (module == "GOT.func" || module == "GOT.mem") {

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -110,7 +110,7 @@ template<typename T, typename MiniT> struct LEB {
       byte = get();
       bool last = !(byte & 128);
       T payload = byte & 127;
-      typedef typename std::make_unsigned<T>::type mask_type;
+      using mask_type = typename std::make_unsigned<T>::type;
       auto shift_mask = 0 == shift
                           ? ~mask_type(0)
                           : ((mask_type(1) << (sizeof(T) * 8 - shift)) - 1u);
@@ -147,10 +147,10 @@ template<typename T, typename MiniT> struct LEB {
   }
 };
 
-typedef LEB<uint32_t, uint8_t> U32LEB;
-typedef LEB<uint64_t, uint8_t> U64LEB;
-typedef LEB<int32_t, int8_t> S32LEB;
-typedef LEB<int64_t, int8_t> S64LEB;
+using U32LEB = LEB<uint32_t, uint8_t>;
+using U64LEB = LEB<uint64_t, uint8_t>;
+using S32LEB = LEB<int32_t, int8_t>;
+using S64LEB = LEB<int64_t, int8_t>;
 
 //
 // We mostly stream into a buffer as we create the binary format, however,

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1967,7 +1967,7 @@ public:
   // Flags indicating special requirements, for example whether we are just
   // evaluating (default), also going to replace the expression afterwards or
   // executing in a function-parallel scenario. See FlagValues.
-  typedef uint32_t Flags;
+  using Flags = uint32_t;
 
   // Indicates no limit of maxDepth or maxLoopIterations.
   static const Index NO_LIMIT = 0;

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -42,7 +42,7 @@ public:
 // An element in an S-Expression: a list or a string
 //
 class Element {
-  typedef ArenaVector<Element*> List;
+  using List = ArenaVector<Element*>;
 
   bool isList_ = true;
   List list_;

--- a/src/wasm-traversal.h
+++ b/src/wasm-traversal.h
@@ -280,7 +280,7 @@ struct Walker : public VisitorType {
   // nested.
 
   // Tasks receive the this pointer and a pointer to the pointer to operate on
-  typedef void (*TaskFunc)(SubType*, Expression**);
+  using TaskFunc = void (*)(SubType*, Expression**);
 
   struct Task {
     TaskFunc func;
@@ -381,7 +381,7 @@ struct PostWalker : public Walker<SubType, VisitorType> {
 
 // Stacks of expressions tend to be limited in size (although, sometimes
 // super-nested blocks exist for br_table).
-typedef SmallVector<Expression*, 10> ExpressionStack;
+using ExpressionStack = SmallVector<Expression*, 10>;
 
 // Traversal with a control-flow stack.
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -460,7 +460,7 @@ public:
   HeapType operator[](size_t i) const { return *Iterator{{this, i}}; }
 };
 
-typedef std::vector<Type> TypeList;
+using TypeList = std::vector<Type>;
 
 // Passed by reference rather than by value because it can own an unbounded
 // amount of data.
@@ -531,7 +531,7 @@ struct Field {
   unsigned getByteSize() const;
 };
 
-typedef std::vector<Field> FieldList;
+using FieldList = std::vector<Field>;
 
 // Passed by reference rather than by value because it can own an unbounded
 // amount of data.

--- a/src/wasm-validator.h
+++ b/src/wasm-validator.h
@@ -54,7 +54,7 @@ struct WasmValidator {
     Globally = 1 << 1,
     Quiet = 1 << 2
   };
-  typedef uint32_t Flags;
+  using Flags = uint32_t;
 
   // Validate an entire module.
   bool validate(Module& module, Flags flags = Globally);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -43,12 +43,12 @@
 namespace wasm {
 
 // An index in a wasm module
-typedef uint32_t Index;
+using Index = uint32_t;
 
 // An address in linear memory.
 struct Address {
-  typedef uint32_t address32_t;
-  typedef uint64_t address64_t;
+  using address32_t = uint32_t;
+  using address64_t = uint64_t;
   address64_t addr;
   constexpr Address() : addr(0) {}
   constexpr Address(uint64_t a) : addr(a) {}
@@ -805,7 +805,7 @@ const char* getExpressionName(Expression* curr);
 Literal getLiteralFromConstExpression(Expression* curr);
 Literals getLiteralsFromConstExpression(Expression* curr);
 
-typedef ArenaVector<Expression*> ExpressionList;
+using ExpressionList = ArenaVector<Expression*>;
 
 template<Expression::Id SID> class SpecificExpression : public Expression {
 public:

--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -488,7 +488,7 @@ struct LocationUpdater {
   // Map start of line tables in the debug_line section to their new locations.
   std::unordered_map<BinaryLocation, BinaryLocation> debugLineMap;
 
-  typedef std::pair<BinaryLocation, BinaryLocation> OldToNew;
+  using OldToNew = std::pair<BinaryLocation, BinaryLocation>;
 
   // Map of compile unit index => old and new base offsets (i.e., in the
   // original binary and in the new one).


### PR DESCRIPTION
This is more modern and (IMHO) easier to read than that old C typedef syntax.