### PR TITLE
Fix warnings that make build fail with -Werror,-Wheader-hygiene,-Wimplicit-const-int-float-conversion

### DIFF
--- a/src/emscripten-optimizer/optimizer-shared.cpp
+++ b/src/emscripten-optimizer/optimizer-shared.cpp
@@ -19,6 +19,8 @@
 #include "optimizer.h"
 #include "support/safe_integer.h"
 
+using namespace cashew;
+
 IString JS_FLOAT_ZERO;
 
 IString SIMD_INT8X16_CHECK("SIMD_Int8x16_check");

--- a/src/emscripten-optimizer/optimizer.h
+++ b/src/emscripten-optimizer/optimizer.h
@@ -19,7 +19,6 @@
 
 #include "simple_ast.h"
 
-using namespace cashew;
 using IString = wasm::IString;
 
 extern IString JS_FLOAT_ZERO;
@@ -51,8 +50,8 @@ enum JsSign {
   JS_NONSIGNED,
 };
 
-Ref makeJsCoercedZero(JsType type);
-Ref makeJsCoercion(Ref node, JsType type);
-Ref makeSigning(Ref node, JsSign sign);
+cashew::Ref makeJsCoercedZero(JsType type);
+cashew::Ref makeJsCoercion(cashew::Ref node, JsType type);
+cashew::Ref makeSigning(cashew::Ref node, JsSign sign);
 
 #endif // wasm_optimizer_h

--- a/src/support/safe_integer.cpp
+++ b/src/support/safe_integer.cpp
@@ -51,12 +51,12 @@ int32_t wasm::toSInteger32(double x) {
 
 bool wasm::isUInteger64(double x) {
   return !std::signbit(x) && isInteger(x) &&
-         x <= std::numeric_limits<uint64_t>::max();
+         x <= static_cast<double>(std::numeric_limits<uint64_t>::max());
 }
 
 bool wasm::isSInteger64(double x) {
   return isInteger(x) && x >= std::numeric_limits<int64_t>::min() &&
-         x <= std::numeric_limits<int64_t>::max();
+         x <= static_cast<double>(std::numeric_limits<int64_t>::max());
 }
 
 uint64_t wasm::toUInteger64(double x) {


### PR DESCRIPTION
When `-Wheader-hygiene` is enabled, C compiler will warn when using namespace directive in global context in header file.

When `-Wimplicit-const-int-float-conversion` is enabled C compiler will warn on implicit integer to double conversions that change values.