### PR TITLE
Avoid calling back() on an empty string in setBinaryenBinDir

### DIFF
--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -81,7 +81,7 @@ std::string getBinaryenBinDir() {
 
 void setBinaryenBinDir(const std::string& dir) {
   binDir = dir;
-  if (binDir.back() != getPathSeparator()) {
+  if (binDir.empty() || binDir.back() != getPathSeparator()) {
     binDir += getPathSeparator();
   }
 }


### PR DESCRIPTION
std::string::back() is only well defined for non-empty strings.
Without the change, wasm-reduce fails if it is called from
$PATH, because then, the parent directory is an empty string.
A workaround is to explicitly set the binaryen path with -b,
but if wasm-reduce is in the $PATH, it can be reasonably assumed
that other binaryen binaries are available too, so an empty
path is inherently correct.


Example before the fix:
```
[sarna@sarna-pc binaryen]$ wasm-reduce -t test.wasm -w work.wasm
/usr/include/c++/12.2.0/bits/basic_string.h:1304: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::back() [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; reference = char&]: Assertion '!empty()' failed.
Aborted (core dumped)
```

After the fix, it just works.
