### PR TITLE
Code Pushing: Ignore unreachable sets

### DIFF
--- a/test/lit/passes/code-pushing-gc.wast
+++ b/test/lit/passes/code-pushing-gc.wast
@@ -77,4 +77,19 @@
       (local.get $x)
     )
   )
+
+  (func $unreachable-value
+    (local $x i32)
+    ;; We should not push this into the if. (If we did, we'd need to refinalize
+    ;; the block, or we'd error; instead, leave this to DCE.)
+    (local.set $x
+      (unreachable)
+    )
+    (if
+      (i32.const 0)
+      (drop
+        (local.get $x)
+      )
+    )
+  )
 )

--- a/test/lit/passes/code-pushing-gc.wast
+++ b/test/lit/passes/code-pushing-gc.wast
@@ -77,19 +77,4 @@
       (local.get $x)
     )
   )
-
-  (func $unreachable-value
-    (local $x i32)
-    ;; We should not push this into the if. (If we did, we'd need to refinalize
-    ;; the block, or we'd error; instead, leave this to DCE.)
-    (local.set $x
-      (unreachable)
-    )
-    (if
-      (i32.const 0)
-      (drop
-        (local.get $x)
-      )
-    )
-  )
 )

--- a/test/lit/passes/code-pushing_tnh.wast
+++ b/test/lit/passes/code-pushing_tnh.wast
@@ -6,6 +6,8 @@
 (module
   ;; CHECK:      (type $i32_i32_=>_none (func (param i32 i32)))
 
+  ;; CHECK:      (type $none_=>_none (func))
+
   ;; CHECK:      (func $div (param $x i32) (param $y i32)
   ;; CHECK-NEXT:  (local $temp i32)
   ;; CHECK-NEXT:  (block $block
@@ -44,5 +46,31 @@
       )
     )
   )
-)
 
+  ;; CHECK:      (func $unreachable-value
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local.tee $x
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $unreachable-value
+    (local $x i32)
+    ;; We should not push this into the if. (If we did, we'd need to refinalize
+    ;; the block, or we'd error; instead, leave this to DCE.)
+    (local.set $x
+      (unreachable)
+    )
+    (if
+      (i32.const 0)
+      (drop
+        (local.get $x)
+      )
+    )
+  )
+)


### PR DESCRIPTION
Normally we ignore them anyhow (unreachability is an effect, either a trap or
a control flow switch), but in traps-never-happen mode we can ignore a trap, so
we need to check this manually.

Found by the fuzzer over the weekend after 500K iterations...