### PR TITLE
Dump only the binary in pass-debug mode 3

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -652,7 +652,7 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   }
 }
 
-static void dumpWast(Name name, Module* wasm) {
+static void dumpWasm(Name name, Module* wasm) {
   // write out the wat
   static int counter = 0;
   std::string numstr = std::to_string(counter++);
@@ -667,7 +667,6 @@ static void dumpWast(Name name, Module* wasm) {
   fullName += numstr + "-" + name.toString();
   Colors::setEnabled(false);
   ModuleWriter writer;
-  writer.writeText(*wasm, fullName + ".wast");
   writer.writeBinary(*wasm, fullName + ".wasm");
 }
 
@@ -696,7 +695,7 @@ void PassRunner::run() {
       padding = std::max(padding, pass->name.size());
     }
     if (passDebug >= 3 && !isNested) {
-      dumpWast("before", wasm);
+      dumpWasm("before", wasm);
     }
     for (auto& pass : passes) {
       // ignoring the time, save a printout of the module before, in case this
@@ -740,7 +739,7 @@ void PassRunner::run() {
         }
       }
       if (passDebug >= 3) {
-        dumpWast(pass->name, wasm);
+        dumpWasm(pass->name, wasm);
       }
     }
     std::cerr << "[PassRunner] " << what << " took " << totalTime.count()


### PR DESCRIPTION
Dumping the text is nice sometimes, but on huge testcases the wat can be 1 GB
in size (!), and so dumping one per pass can lead to using 20 GB or so for the full
optimization pipeline. Emit just the binary to avoid that.