### PR TITLE
#4822 optmize asyncify to not flatten/optimize unnecessarily

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -251,6 +251,8 @@ struct PassRunner {
   PassRunner(const PassRunner&) = delete;
   PassRunner& operator=(const PassRunner&) = delete;
 
+  virtual ~PassRunner() = default;
+
   // But we can make it easy to create a nested runner
   // TODO: Go through and use this in more places
   explicit PassRunner(const PassRunner* runner)
@@ -333,6 +335,9 @@ struct PassRunner {
   // Returns whether a pass by that name will remove debug info.
   static bool passRemovesDebugInfo(const std::string& name);
 
+protected:
+  virtual void doAdd(std::unique_ptr<Pass> pass);
+
 private:
   // Whether this is a nested pass runner.
   bool isNested = false;
@@ -343,8 +348,6 @@ private:
 
   // Whether this pass runner has run. A pass runner should only be run once.
   bool ran = false;
-
-  void doAdd(std::unique_ptr<Pass> pass);
 
   void runPass(Pass* pass);
   void runPassOnFunction(Pass* pass, Function* func);
@@ -426,8 +429,8 @@ public:
 
   std::string name;
 
-  PassRunner* getPassRunner() { return runner; }
-  void setPassRunner(PassRunner* runner_) {
+  virtual PassRunner* getPassRunner() { return runner; }
+  virtual void setPassRunner(PassRunner* runner_) {
     assert((!runner || runner == runner_) && "Pass already had a runner");
     runner = runner_;
   }

--- a/src/pass.h
+++ b/src/pass.h
@@ -429,8 +429,8 @@ public:
 
   std::string name;
 
-  virtual PassRunner* getPassRunner() { return runner; }
-  virtual void setPassRunner(PassRunner* runner_) {
+  PassRunner* getPassRunner() { return runner; }
+  void setPassRunner(PassRunner* runner_) {
     assert((!runner || runner == runner_) && "Pass already had a runner");
     runner = runner_;
   }

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -860,9 +860,13 @@ struct InstrumentedProxy : public Pass {
   bool isFunctionParallel() override { return pass->isFunctionParallel(); }
 
   void runOnFunction(Module* module, Function* func) override {
-    if (analyzer->needsInstrumentation(func)) {
-      pass->runOnFunction(module, func);
+    if (!analyzer->needsInstrumentation(func)) {
+      return;
     }
+    if (pass->getPassRunner() == nullptr) {
+      pass->setPassRunner(getPassRunner());
+    }
+    pass->runOnFunction(module, func);
   }
 
   bool modifiesBinaryenIR() override { return pass->modifiesBinaryenIR(); }
@@ -871,11 +875,6 @@ struct InstrumentedProxy : public Pass {
 
   bool requiresNonNullableLocalFixups() override {
     return pass->requiresNonNullableLocalFixups();
-  }
-
-  PassRunner* getPassRunner() override { return pass->getPassRunner(); }
-  void setPassRunner(PassRunner* runner_) override {
-    pass->setPassRunner(runner_);
   }
 
 private:

--- a/test/lit/passes/asyncify_enable-multivalue.wast
+++ b/test/lit/passes/asyncify_enable-multivalue.wast
@@ -37,18 +37,10 @@
   ;; CHECK:      (export "asyncify_get_state" (func $asyncify_get_state))
 
   ;; CHECK:      (func $do_sleep
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (global.get $sleeping)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $1
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (local.get $0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (global.get $sleeping)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (global.set $sleeping
   ;; CHECK-NEXT:     (i32.const 1)
@@ -834,14 +826,10 @@
     (drop (call $import2))
   )
   ;; CHECK:      (func $calls-nothing
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
   ;; CHECK-NEXT:    (i32.const 17)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-nothing

--- a/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
@@ -415,14 +415,10 @@
     (drop (call $import2))
   )
   ;; CHECK:      (func $calls-nothing
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
   ;; CHECK-NEXT:    (i32.const 17)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-nothing

--- a/test/lit/passes/asyncify_mod-asyncify-never-unwind.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-never-unwind.wast
@@ -433,14 +433,10 @@
     (drop (call $import2))
   )
   ;; CHECK:      (func $calls-nothing
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
   ;; CHECK-NEXT:    (i32.const 17)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-nothing

--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -301,7 +301,11 @@
     (drop (call $import2))
   )
   ;; CHECK:      (func $calls-nothing
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (i32.const 17)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-nothing
     (drop (i32.eqz (i32.const 17)))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-onlylist@waka.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-onlylist@waka.wast
@@ -39,50 +39,14 @@
   ;; CHECK:      (export "asyncify_get_state" (func $asyncify_get_state))
 
   ;; CHECK:      (func $calls-import
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (global.get $__asyncify_state)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:   (if
-  ;; CHECK-NEXT:    (i32.ne
-  ;; CHECK-NEXT:     (global.get $__asyncify_state)
-  ;; CHECK-NEXT:     (local.get $0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (call $import)
   ;; CHECK-NEXT: )
   (func $calls-import
     (call $import)
   )
   ;; CHECK:      (func $calls-import2-drop
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (local.set $1
-  ;; CHECK-NEXT:   (global.get $__asyncify_state)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (local.set $0
-  ;; CHECK-NEXT:    (block (result i32)
-  ;; CHECK-NEXT:     (local.set $2
-  ;; CHECK-NEXT:      (call $import2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (i32.ne
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (unreachable)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (local.get $2)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (local.get $0)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (call $import2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-import2-drop
@@ -90,49 +54,10 @@
   )
   ;; CHECK:      (func $returns (result i32)
   ;; CHECK-NEXT:  (local $x i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (local $3 i32)
-  ;; CHECK-NEXT:  (local $4 i32)
-  ;; CHECK-NEXT:  (local $5 i32)
-  ;; CHECK-NEXT:  (local $6 i32)
-  ;; CHECK-NEXT:  (local.set $5
-  ;; CHECK-NEXT:   (global.get $__asyncify_state)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (call $import2)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (local.set $6
-  ;; CHECK-NEXT:       (call $import2)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (i32.ne
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:        (local.get $5)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $6)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $x
-  ;; CHECK-NEXT:     (local.get $1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $3
-  ;; CHECK-NEXT:     (local.get $2)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (local.set $4
-  ;; CHECK-NEXT:    (local.get $3)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (return
-  ;; CHECK-NEXT:    (local.get $4)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
   ;; CHECK-NEXT: )
   (func $returns (result i32)
     (local $x i32)
@@ -140,27 +65,8 @@
     (local.get $x)
   )
   ;; CHECK:      (func $calls-indirect (param $x i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (local.set $2
-  ;; CHECK-NEXT:   (global.get $__asyncify_state)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (local.set $1
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (call_indirect (type $f)
-  ;; CHECK-NEXT:     (local.get $1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.ne
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
-  ;; CHECK-NEXT:      (local.get $2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (unreachable)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (call_indirect (type $f)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-indirect (param $x i32)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-ignore-imports.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-ignore-imports.wast
@@ -45,24 +45,16 @@
     (call $import)
   )
   ;; CHECK:      (func $calls-import2-drop
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (call $import2)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
+  ;; CHECK-NEXT:   (call $import2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-import2-drop
     (drop (call $import2))
   )
   ;; CHECK:      (func $calls-import2-if-else (param $x i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local.set $1
-  ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (call $import3
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/asyncify_pass-arg=asyncify-ignore-indirect.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-ignore-indirect.wast
@@ -485,12 +485,8 @@
     )
   )
   ;; CHECK:      (func $calls-indirect (param $x i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local.set $1
-  ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (call_indirect (type $f)
-  ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-indirect (param $x i32)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.wast
@@ -36,18 +36,10 @@
   ;; CHECK:      (export "asyncify_get_state" (func $asyncify_get_state))
 
   ;; CHECK:      (func $do_sleep
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (global.get $sleeping)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $1
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (local.get $0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (global.get $sleeping)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (global.set $sleeping
   ;; CHECK-NEXT:     (i32.const 1)
@@ -826,14 +818,10 @@
     (drop (call $import2))
   )
   ;; CHECK:      (func $calls-nothing
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
   ;; CHECK-NEXT:    (i32.const 17)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-nothing
@@ -1163,12 +1151,8 @@
     )
   )
   ;; CHECK:      (func $calls-import2-if-else (param $x i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local.set $1
-  ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (call $import3
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
@@ -1184,27 +1168,17 @@
     )
   )
   ;; CHECK:      (func $calls-import2-if-else-oneside (param $x i32) (result i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (local $3 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (local.get $1)
-  ;; CHECK-NEXT:     (return
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (call $import3
-  ;; CHECK-NEXT:      (i32.const 2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (return
-  ;; CHECK-NEXT:    (i32.const 3)
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $import3
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (return
+  ;; CHECK-NEXT:   (i32.const 3)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-import2-if-else-oneside (param $x i32) (result i32)
@@ -1215,27 +1189,17 @@
     (return (i32.const 3))
   )
   ;; CHECK:      (func $calls-import2-if-else-oneside2 (param $x i32) (result i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (local $3 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (local.get $1)
-  ;; CHECK-NEXT:     (call $import3
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (return
-  ;; CHECK-NEXT:      (i32.const 2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (call $import3
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (return
-  ;; CHECK-NEXT:    (i32.const 3)
+  ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (return
+  ;; CHECK-NEXT:   (i32.const 3)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-import2-if-else-oneside2 (param $x i32) (result i32)
@@ -1246,30 +1210,18 @@
     (return (i32.const 3))
   )
   ;; CHECK:      (func $calls-loop (param $x i32)
-  ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (loop $l
   ;; CHECK-NEXT:   (call $import3
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (local.set $1
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (local.set $2
+  ;; CHECK-NEXT:   (local.set $x
   ;; CHECK-NEXT:    (i32.add
-  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (local.set $x
-  ;; CHECK-NEXT:    (local.get $2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (local.set $3
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (br_if $l
-  ;; CHECK-NEXT:    (local.get $3)
+  ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )


### PR DESCRIPTION
I tried to do what is described in #4822. I'm not sure if everything is correct, but it seems to work for my case. Compilation time was reduced from 14 minutes to 3.5 minutes and all my tests passed.

It's more like proposal, if idea is correct I can refactor as needed.

--
Related to [discussion](https://groups.google.com/g/emscripten-discuss/c/tpKmW0jLlmw/m/pFB9DSEGBQAJ?utm_medium=email&utm_source=footer)