### PR TITLE
Add a placeholder closed-world flag

### DIFF
--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -250,7 +250,7 @@ struct OptimizationOptions : public ToolOptions {
         "contents or call them.",
         OptimizationOptionsCategory,
         Options::Arguments::Zero,
-        [this](Options*, const std::string&) {
+        [](Options*, const std::string&) {
           // TODO: Implement this.
         })
       .add("--zero-filled-memory",

--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -241,6 +241,18 @@ struct OptimizationOptions : public ToolOptions {
         OptimizationOptionsCategory,
         Options::Arguments::Zero,
         [this](Options*, const std::string&) { passOptions.fastMath = true; })
+      .add(
+        "--closed-world",
+        "-cw",
+        "Assume code outside of the module does not inspect or interact with "
+        "GC and function references, even if they are passed out. The outside "
+        "may hold on to them and pass them back in, but not inspect their "
+        "contents or call them.",
+        OptimizationOptionsCategory,
+        Options::Arguments::Zero,
+        [this](Options*, const std::string&) {
+          // TODO: Implement this.
+        })
       .add("--zero-filled-memory",
            "-uim",
            "Assume that an imported memory will be zero-initialized",

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -551,6 +551,15 @@
 ;; CHECK-NEXT:                                                 corner cases of NaNs and
 ;; CHECK-NEXT:                                                 rounding
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                            Assume code outside of the
+;; CHECK-NEXT:                                                 module does not inspect or
+;; CHECK-NEXT:                                                 interact with GC and function
+;; CHECK-NEXT:                                                 references, even if they are
+;; CHECK-NEXT:                                                 passed out. The outside may hold
+;; CHECK-NEXT:                                                 on to them and pass them back
+;; CHECK-NEXT:                                                 in, but not inspect their
+;; CHECK-NEXT:                                                 contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory
 ;; CHECK-NEXT:                                                 will be zero-initialized
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -510,6 +510,15 @@
 ;; CHECK-NEXT:                                                 corner cases of NaNs and
 ;; CHECK-NEXT:                                                 rounding
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                            Assume code outside of the
+;; CHECK-NEXT:                                                 module does not inspect or
+;; CHECK-NEXT:                                                 interact with GC and function
+;; CHECK-NEXT:                                                 references, even if they are
+;; CHECK-NEXT:                                                 passed out. The outside may hold
+;; CHECK-NEXT:                                                 on to them and pass them back
+;; CHECK-NEXT:                                                 in, but not inspect their
+;; CHECK-NEXT:                                                 contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory
 ;; CHECK-NEXT:                                                 will be zero-initialized
 ;; CHECK-NEXT:


### PR DESCRIPTION
The flag does nothing so far. My thinking is that we'll do this:

* Land this no-op flag.
* Get partners to pass the flag in (which will not error as there is this placeholder).
* Implement the flag, that is, make us open-world by default and make the flag switch to closed-world. This will not regress partners' performance since they pass the flag and so they are opting in to closed-world, making this part NFC for them.

See #5292