### PR TITLE
[NFC] Remove unneeded check

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -147,11 +147,9 @@ void GlobalTypeRewriter::mapTypes(const TypeMap& oldToNewTypes) {
       if (type.isBasic()) {
         return type;
       }
-      if (type.isFunction() || type.isData()) {
-        auto iter = oldToNewTypes.find(type);
-        if (iter != oldToNewTypes.end()) {
-          return iter->second;
-        }
+      auto iter = oldToNewTypes.find(type);
+      if (iter != oldToNewTypes.end()) {
+        return iter->second;
       }
       return type;
     }


### PR DESCRIPTION
The caller fills the map with what is relevant anyhow, so we don't need to check
before looking for an item in the map.