### PR TITLE
[NFC] Avoid unneeded work in GTO

### DIFF
--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -243,7 +243,9 @@ struct GlobalTypeOptimization : public Pass {
     }
 
     // Update the types in the entire module.
-    updateTypes(*module);
+    if (!indexesAfterRemovals.empty() || !canBecomeImmutable.empty()) {
+      updateTypes(*module);
+    }
   }
 
   void updateTypes(Module& wasm) {

--- a/test/lit/passes/Oz.wast
+++ b/test/lit/passes/Oz.wast
@@ -5,14 +5,13 @@
 
 (module
   (memory 100 100)
-  ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
+  ;; CHECK:      (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
 
-  ;; CHECK:       (type $i32_=>_i32 (func (param i32) (result i32)))
+  ;; CHECK:      (type $i32_=>_i32 (func (param i32) (result i32)))
 
-  ;; CHECK:       (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
+  ;; CHECK:      (type $i32_i32_i32_i32_=>_i32 (func (param i32 i32 i32 i32) (result i32)))
 
-  ;; CHECK:       (type $none_=>_v128 (func (result v128)))
+  ;; CHECK:      (type $none_=>_v128 (func (result v128)))
 
   ;; CHECK:      (memory $0 100 100)
 

--- a/test/passes/Oz_fuzz-exec_all-features.txt
+++ b/test/passes/Oz_fuzz-exec_all-features.txt
@@ -454,10 +454,7 @@ ignoring comparison of ExecutionResults!
 [fuzz-exec] calling foo
 [host limit allocation failure]
 (module
- (rec
-  (type $none_=>_i32 (func (result i32)))
-  (type $[mut:i8] (array (mut i8)))
- )
+ (type $none_=>_i32 (func (result i32)))
  (export "foo" (func $0))
  (func $0 (type $none_=>_i32) (; has Stack IR ;) (result i32)
   (i32.const 0)

--- a/test/reduce/imports.wast.txt
+++ b/test/reduce/imports.wast.txt
@@ -1,8 +1,5 @@
 (module
- (rec
-  (type $none_=>_none (func))
-  (type $none_=>_i32 (func (result i32)))
- )
+ (type $none_=>_i32 (func (result i32)))
  (export "x" (func $0))
  (func $0 (result i32)
   (i32.const 5678)

--- a/test/reduce/memory_table.wast.txt
+++ b/test/reduce/memory_table.wast.txt
@@ -1,8 +1,6 @@
 (module
- (rec
-  (type $none_=>_i32 (func (result i32)))
-  (type $none_=>_none (func))
- )
+ (type $none_=>_i32 (func (result i32)))
+ (type $none_=>_none (func))
  (memory $0 256 256)
  (export "f1" (func $0))
  (export "f2" (func $1))

--- a/test/reduce/simple.wast.txt
+++ b/test/reduce/simple.wast.txt
@@ -1,8 +1,5 @@
 (module
- (rec
-  (type $none_=>_i32 (func (result i32)))
-  (type $none_=>_none (func))
- )
+ (type $none_=>_i32 (func (result i32)))
  (export "x" (func $0))
  (func $0 (result i32)
   (i32.const 5678)


### PR DESCRIPTION
As noticed in #5303, the test changes here are because we did unnecessary work
which created a new rec group, which then led to a rec group being printed out.
