### PR TITLE
Remove more uses of NAN

### DIFF
--- a/src/wasm/wat-lexer.cpp
+++ b/src/wasm/wat-lexer.cpp
@@ -221,6 +221,8 @@ struct LexFloatCtx : LexCtx {
   std::optional<LexFloatResult> lexed() {
     const double posNan = std::copysign(NAN, 1.0);
     const double negNan = std::copysign(NAN, -1.0);
+    assert(!std::signbit(posNan) && "expected positive NaN to be positive");
+    assert(std::signbit(negNan) && "expected negative NaN to be negative");
     auto basic = LexCtx::lexed();
     if (!basic) {
       return {};

--- a/test/gtest/wat-lexer.cpp
+++ b/test/gtest/wat-lexer.cpp
@@ -1094,53 +1094,55 @@ TEST(LexerTest, LexInfinity) {
 }
 
 TEST(LexerTest, LexNan) {
+  const double posNan = std::copysign(NAN, 1.0);
+  const double negNan = std::copysign(NAN, -1.0);
   {
     Lexer lexer("nan"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"nan"sv, FloatTok{{}, NAN}};
+    Token expected{"nan"sv, FloatTok{{}, posNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("+nan"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"+nan"sv, FloatTok{{}, NAN}};
+    Token expected{"+nan"sv, FloatTok{{}, posNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("-nan"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"-nan"sv, FloatTok{{}, -NAN}};
+    Token expected{"-nan"sv, FloatTok{{}, negNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("nan:0x01"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"nan:0x01"sv, FloatTok{{1}, NAN}};
+    Token expected{"nan:0x01"sv, FloatTok{{1}, posNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("+nan:0x01"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"+nan:0x01"sv, FloatTok{{1}, NAN}};
+    Token expected{"+nan:0x01"sv, FloatTok{{1}, posNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("-nan:0x01"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"-nan:0x01"sv, FloatTok{{1}, -NAN}};
+    Token expected{"-nan:0x01"sv, FloatTok{{1}, negNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("nan:0x1234"sv);
     ASSERT_FALSE(lexer.empty());
-    Token expected{"nan:0x1234"sv, FloatTok{{0x1234}, NAN}};
+    Token expected{"nan:0x1234"sv, FloatTok{{0x1234}, posNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {
     Lexer lexer("nan:0xf_ffff_ffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
     Token expected{"nan:0xf_ffff_ffff_ffff"sv,
-                   FloatTok{{0xfffffffffffff}, NAN}};
+                   FloatTok{{0xfffffffffffff}, posNan}};
     EXPECT_EQ(*lexer, expected);
   }
   {


### PR DESCRIPTION
In favor of the more portable code snippet using `std::copysign`. Also
reintroduce assertions that the NaNs have the expected signs. This continues
work started in #5302.