### PR TITLE
Add /fp:precise under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,9 @@ if(MSVC)
   # Don't warn about using "strdup" as a reserved name.
   add_compile_flag("/D_CRT_NONSTDC_NO_DEPRECATE")
 
+  # We depend on NaN bits not changing unexpectedly in the parser.
+  add_compile_flag("/fp:precise")
+
   if(BYN_ENABLE_ASSERTIONS)
     # On non-Debug builds cmake automatically defines NDEBUG, so we
     # explicitly undefine it:


### PR DESCRIPTION
This will prevent MSVC from unexpectedly changing NaN bits, which is important
for the wat parser because it needs to produce precise NaN payloads mandated by
the Wasm spec.