### PR TITLE
Work around possible unsafe MSVC NaN optimization

### DIFF
--- a/src/wasm/wat-lexer.cpp
+++ b/src/wasm/wat-lexer.cpp
@@ -226,8 +226,10 @@ struct LexFloatCtx : LexCtx {
       return {};
     }
     if (nanPayload) {
-      double nan = basic->span[0] == '-' ? negNan : posNan;
-      return LexFloatResult{*basic, nanPayload, nan};
+      if (basic->span[0] == '-') {
+        return LexFloatResult{*basic, nanPayload, negNan};
+      }
+      return LexFloatResult{*basic, nanPayload, posNan};
     }
     // strtod does not return -NAN for "-nan" on all platforms.
     if (basic->span == "-nan"sv) {


### PR DESCRIPTION
MSVC 2019 is getting all parsed NaN signs backwards, even with `/fp:precise` or
`/fp:strict`. Those options only cause floats to conform to the source at
assignments, casts, and on function boundaries, but notably not in intermediate
results. My guess is that the double produced by the ternary statement is
considered an intermediate result, so MSVC considers itself free to perform
unsafe optimizations on it. Avoid the ternary statement to fix this problem if
that hypothesis is correct.