### PR TITLE
[NFC] Allow TypeBuilder::Entry::subTypeOf to take any HeapType

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -679,8 +679,7 @@ struct TypeBuilder {
       builder.setHeapType(index, array);
       return *this;
     }
-    Entry& subTypeOf(Entry other) {
-      assert(&builder == &other.builder);
+    Entry& subTypeOf(HeapType other) {
       builder.setSubType(index, other);
       return *this;
     }


### PR DESCRIPTION
We generalized the underlying API, TypeBuilder::setSubType, to allow it to take
any HeapType as the supertype in #5045. Make the same change now in the helper.