### PR TITLE
[Parser] Avoid calling `strtod` on NaNs entirely

### DIFF
--- a/src/wasm/wat-lexer.cpp
+++ b/src/wasm/wat-lexer.cpp
@@ -227,12 +227,13 @@ struct LexFloatCtx : LexCtx {
     if (!basic) {
       return {};
     }
-    if (nanPayload) {
-      double nan = basic->span[0] == '-' ? negNan : posNan;
-      return LexFloatResult{*basic, nanPayload, nan};
+    // strtod does not return NaNs with the expected signs on all platforms.
+    // TODO: use starts_with once we have C++20.
+    if (basic->span.substr(0, 3) == "nan"sv ||
+        basic->span.substr(0, 4) == "+nan"sv) {
+      return LexFloatResult{*basic, nanPayload, posNan};
     }
-    // strtod does not return -NAN for "-nan" on all platforms.
-    if (basic->span == "-nan"sv) {
+    if (basic->span.substr(0, 4) == "-nan"sv) {
       return LexFloatResult{*basic, nanPayload, negNan};
     }
     // Do not try to implement fully general and precise float parsing


### PR DESCRIPTION
MSVC's implementation of `strtod` doesn't return a negative Nan for "-nan", so
we already had a workaround to explicitly handle that case without calling
`strtod`. Unfortunately the workaround was not used for negative NaNs with
payloads, so there were still bugs. Fix the problem and make the code even more
portable by avoiding `strtod` completely for any kind of nan, positive or
negative, with or without payload.