### PR TITLE
Update tests ahead of transition from `data` to `struct`

### DIFF
--- a/test/gc.wast
+++ b/test/gc.wast
@@ -16,7 +16,7 @@
 
   (func $test
     (param $local_i31ref i31ref)
-    (param $local_dataref dataref)
+    (param $local_structref structref)
 
     (local $local_i32 i32)
     (local $local_anyref anyref)
@@ -74,7 +74,7 @@
   (func $test-variants
     (param $local_i31refnull (ref null i31))
     (param $local_i31refnonnull (ref i31))
-    (param $local_datarefnull (ref null data))
-    (param $local_datarefnonnull (ref data))
+    (param $local_structrefnull (ref null struct))
+    (param $local_structrefnonnull (ref struct))
   )
 )

--- a/test/gc.wast.from-wast
+++ b/test/gc.wast.from-wast
@@ -13,7 +13,7 @@
  (global $global_eqref2 (mut eqref) (i31.new
   (i32.const 0)
  ))
- (func $test (type $i31ref_dataref_=>_none) (param $local_i31ref i31ref) (param $local_dataref dataref)
+ (func $test (type $i31ref_dataref_=>_none) (param $local_i31ref i31ref) (param $local_structref dataref)
   (local $local_i32 i32)
   (local $local_anyref anyref)
   (local $local_eqref eqref)
@@ -148,7 +148,7 @@
    )
   )
  )
- (func $test-variants (type $i31ref_ref|i31|_dataref_ref|data|_=>_none) (param $local_i31refnull i31ref) (param $local_i31refnonnull (ref i31)) (param $local_datarefnull dataref) (param $local_datarefnonnull (ref data))
+ (func $test-variants (type $i31ref_ref|i31|_dataref_ref|data|_=>_none) (param $local_i31refnull i31ref) (param $local_i31refnonnull (ref i31)) (param $local_structrefnull dataref) (param $local_structrefnonnull (ref data))
   (nop)
  )
 )

--- a/test/gc.wast.fromBinary
+++ b/test/gc.wast.fromBinary
@@ -13,7 +13,7 @@
  (global $global_eqref2 (mut eqref) (i31.new
   (i32.const 0)
  ))
- (func $test (type $i31ref_dataref_=>_none) (param $local_i31ref i31ref) (param $local_dataref dataref)
+ (func $test (type $i31ref_dataref_=>_none) (param $local_i31ref i31ref) (param $local_structref dataref)
   (local $local_i32 i32)
   (local $local_anyref anyref)
   (local $local_eqref eqref)
@@ -148,7 +148,7 @@
    )
   )
  )
- (func $test-variants (type $i31ref_ref|i31|_dataref_ref|data|_=>_none) (param $local_i31refnull i31ref) (param $local_i31refnonnull (ref i31)) (param $local_datarefnull dataref) (param $local_datarefnonnull (ref data))
+ (func $test-variants (type $i31ref_ref|i31|_dataref_ref|data|_=>_none) (param $local_i31refnull i31ref) (param $local_i31refnonnull (ref i31)) (param $local_structrefnull dataref) (param $local_structrefnonnull (ref data))
   (nop)
  )
 )

--- a/test/heap-types.wast
+++ b/test/heap-types.wast
@@ -196,7 +196,6 @@
     (local $y anyref)
     (local $z (ref null any))
     (local $temp-func (ref null func))
-    (local $temp-data (ref null data))
     (local $temp-i31 (ref null i31))
     (block $null
       (local.set $z
@@ -209,14 +208,6 @@
           (br_on_func $func (local.get $x))
         )
         (ref.null func)
-      )
-    )
-    (drop
-      (block $data (result (ref null data))
-        (local.set $y
-          (br_on_data $data (local.get $x))
-        )
-        (ref.null data)
       )
     )
     (drop
@@ -237,14 +228,6 @@
       (block $non-func (result anyref)
         (local.set $temp-func
           (br_on_non_func $non-func (local.get $x))
-        )
-        (ref.null any)
-      )
-    )
-    (drop
-      (block $non-data (result anyref)
-        (local.set $temp-data
-          (br_on_non_data $non-data (local.get $x))
         )
         (ref.null any)
       )

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -221,7 +221,6 @@
   (local $y anyref)
   (local $z anyref)
   (local $temp-func funcref)
-  (local $temp-data dataref)
   (local $temp-i31 i31ref)
   (block $null
    (local.set $z
@@ -238,16 +237,6 @@
      )
     )
     (ref.null nofunc)
-   )
-  )
-  (drop
-   (block $data (result dataref)
-    (local.set $y
-     (br_on_data $data
-      (local.get $x)
-     )
-    )
-    (ref.null none)
    )
   )
   (drop
@@ -272,16 +261,6 @@
    (block $non-func (result anyref)
     (local.set $temp-func
      (br_on_non_func $non-func
-      (local.get $x)
-     )
-    )
-    (ref.null none)
-   )
-  )
-  (drop
-   (block $non-data (result anyref)
-    (local.set $temp-data
-     (br_on_non_data $non-data
       (local.get $x)
      )
     )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -219,7 +219,6 @@
   (local $y anyref)
   (local $z anyref)
   (local $temp-func funcref)
-  (local $temp-data dataref)
   (local $temp-i31 i31ref)
   (block $label$1
    (local.set $z
@@ -239,9 +238,9 @@
    )
   )
   (drop
-   (block $label$3 (result dataref)
+   (block $label$3 (result i31ref)
     (local.set $y
-     (br_on_data $label$3
+     (br_on_i31 $label$3
       (local.get $x)
      )
     )
@@ -249,27 +248,17 @@
    )
   )
   (drop
-   (block $label$4 (result i31ref)
-    (local.set $y
-     (br_on_i31 $label$4
-      (local.get $x)
-     )
-    )
-    (ref.null none)
-   )
-  )
-  (drop
-   (block $label$5 (result (ref any))
-    (br_on_non_null $label$5
+   (block $label$4 (result (ref any))
+    (br_on_non_null $label$4
      (local.get $x)
     )
     (unreachable)
    )
   )
   (drop
-   (block $label$6 (result anyref)
+   (block $label$5 (result anyref)
     (local.set $temp-func
-     (br_on_non_func $label$6
+     (br_on_non_func $label$5
       (local.get $x)
      )
     )
@@ -277,19 +266,9 @@
    )
   )
   (drop
-   (block $label$7 (result anyref)
-    (local.set $temp-data
-     (br_on_non_data $label$7
-      (local.get $x)
-     )
-    )
-    (ref.null none)
-   )
-  )
-  (drop
-   (block $label$8 (result anyref)
+   (block $label$6 (result anyref)
     (local.set $temp-i31
-     (br_on_non_i31 $label$8
+     (br_on_non_i31 $label$6
       (local.get $x)
      )
     )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -219,8 +219,7 @@
   (local $1 anyref)
   (local $2 anyref)
   (local $3 funcref)
-  (local $4 dataref)
-  (local $5 i31ref)
+  (local $4 i31ref)
   (block $label$1
    (local.set $2
     (br_on_null $label$1
@@ -239,9 +238,9 @@
    )
   )
   (drop
-   (block $label$3 (result dataref)
+   (block $label$3 (result i31ref)
     (local.set $1
-     (br_on_data $label$3
+     (br_on_i31 $label$3
       (local.get $0)
      )
     )
@@ -249,27 +248,17 @@
    )
   )
   (drop
-   (block $label$4 (result i31ref)
-    (local.set $1
-     (br_on_i31 $label$4
-      (local.get $0)
-     )
-    )
-    (ref.null none)
-   )
-  )
-  (drop
-   (block $label$5 (result (ref any))
-    (br_on_non_null $label$5
+   (block $label$4 (result (ref any))
+    (br_on_non_null $label$4
      (local.get $0)
     )
     (unreachable)
    )
   )
   (drop
-   (block $label$6 (result anyref)
+   (block $label$5 (result anyref)
     (local.set $3
-     (br_on_non_func $label$6
+     (br_on_non_func $label$5
       (local.get $0)
      )
     )
@@ -277,19 +266,9 @@
    )
   )
   (drop
-   (block $label$7 (result anyref)
+   (block $label$6 (result anyref)
     (local.set $4
-     (br_on_non_data $label$7
-      (local.get $0)
-     )
-    )
-    (ref.null none)
-   )
-  )
-  (drop
-   (block $label$8 (result anyref)
-    (local.set $5
-     (br_on_non_i31 $label$8
+     (br_on_non_i31 $label$6
       (local.get $0)
      )
     )

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -13,10 +13,10 @@
  ;; CHECK:      (type $array (array (mut i8)))
  (type $array (array (mut i8)))
 
- (type $A (struct_subtype (field (ref null data)) data))
+ (type $A (struct_subtype (field (ref null struct)) data))
 
  ;; CHECK:      (type $B (struct_subtype (field (ref data)) $A))
- (type $B (struct_subtype (field (ref data)) $A))
+ (type $B (struct_subtype (field (ref struct)) $A))
 
  ;; CHECK:      (global $global (ref null $array) (ref.null none))
  (global $global (ref null $array) (ref.null $array))
@@ -29,7 +29,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $test-dead-get-non-nullable (param $func (ref data))
+ (func $test-dead-get-non-nullable (param $func (ref struct))
   (unreachable)
   (drop
    ;; A useless get (that does not read from any set, or from the inputs to the
@@ -184,7 +184,7 @@
  (func $remove-tee-refinalize
   (param $a (ref null $A))
   (param $b (ref null $B))
-  (result (ref null data))
+  (result (ref null struct))
   ;; The local.tee receives a $B and flows out an $A. We want to avoid changing
   ;; types here, so we'll wrap it in a block, and leave further improvements
   ;; for other passes.
@@ -205,7 +205,7 @@
  (func $remove-tee-refinalize-2
   (param $a (ref null $A))
   (param $b (ref null $B))
-  (result (ref null data))
+  (result (ref null struct))
   ;; As above, but with an extra tee in the middle. The result should be the
   ;; same.
   (struct.get $A 0

--- a/test/lit/passes/dae-gc-refine-params.wast
+++ b/test/lit/passes/dae-gc-refine-params.wast
@@ -475,7 +475,7 @@
  ;; NOMNL-NEXT:  (local $0 dataref)
  ;; NOMNL-NEXT:  (nop)
  ;; NOMNL-NEXT: )
- (func $unused-and-refinable (param $0 dataref)
+ (func $unused-and-refinable (param $0 structref)
   ;; This function does not use $0. It is called with ${}, so it is also
   ;; a parameter whose type we can refine. Do not do both operations: instead,
   ;; just remove it because it is ignored, without altering the type (handling
@@ -517,7 +517,7 @@
  ;; NOMNL-NEXT:   (local.get $1)
  ;; NOMNL-NEXT:  )
  ;; NOMNL-NEXT: )
- (func $non-nullable-fixup (param $0 dataref)
+ (func $non-nullable-fixup (param $0 structref)
   ;; Use the param to avoid other opts removing it, and to force us to do a
   ;; fixup when we refine the param's type. When doing so, we must handle the
   ;; fact that the new local's type is non-nullable.

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -230,7 +230,7 @@
  ;; CHECK:      (func $refine-return-many-lub (type $none_=>_eqref) (result eqref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local $i31 i31ref)
- ;; CHECK-NEXT:  (local $data dataref)
+ ;; CHECK-NEXT:  (local $struct dataref)
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (call $refine-return-many-lub)
  ;; CHECK-NEXT:  )
@@ -243,7 +243,7 @@
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (i32.const 2)
  ;; CHECK-NEXT:   (return
- ;; CHECK-NEXT:    (local.get $data)
+ ;; CHECK-NEXT:    (local.get $struct)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (local.get $i31)
@@ -251,7 +251,7 @@
  ;; NOMNL:      (func $refine-return-many-lub (type $none_=>_eqref) (result eqref)
  ;; NOMNL-NEXT:  (local $temp anyref)
  ;; NOMNL-NEXT:  (local $i31 i31ref)
- ;; NOMNL-NEXT:  (local $data dataref)
+ ;; NOMNL-NEXT:  (local $struct dataref)
  ;; NOMNL-NEXT:  (local.set $temp
  ;; NOMNL-NEXT:   (call $refine-return-many-lub)
  ;; NOMNL-NEXT:  )
@@ -264,7 +264,7 @@
  ;; NOMNL-NEXT:  (if
  ;; NOMNL-NEXT:   (i32.const 2)
  ;; NOMNL-NEXT:   (return
- ;; NOMNL-NEXT:    (local.get $data)
+ ;; NOMNL-NEXT:    (local.get $struct)
  ;; NOMNL-NEXT:   )
  ;; NOMNL-NEXT:  )
  ;; NOMNL-NEXT:  (local.get $i31)
@@ -272,7 +272,7 @@
  (func $refine-return-many-lub (result anyref)
   (local $temp anyref)
   (local $i31 (ref null i31))
-  (local $data (ref null data))
+  (local $struct (ref null struct))
 
   (local.set $temp (call $refine-return-many-lub))
 
@@ -282,8 +282,8 @@
   )
   (if
    (i32.const 2)
-   ;; The refined return type has to be a supertype of data.
-   (return (local.get $data))
+   ;; The refined return type has to be a supertype of struct.
+   (return (local.get $struct))
   )
   (local.get $i31)
  )
@@ -291,7 +291,7 @@
  ;; CHECK:      (func $refine-return-many-lub-2 (type $none_=>_eqref) (result eqref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local $i31 i31ref)
- ;; CHECK-NEXT:  (local $data dataref)
+ ;; CHECK-NEXT:  (local $struct dataref)
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (call $refine-return-many-lub-2)
  ;; CHECK-NEXT:  )
@@ -307,12 +307,12 @@
  ;; CHECK-NEXT:    (local.get $i31)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (local.get $data)
+ ;; CHECK-NEXT:  (local.get $struct)
  ;; CHECK-NEXT: )
  ;; NOMNL:      (func $refine-return-many-lub-2 (type $none_=>_eqref) (result eqref)
  ;; NOMNL-NEXT:  (local $temp anyref)
  ;; NOMNL-NEXT:  (local $i31 i31ref)
- ;; NOMNL-NEXT:  (local $data dataref)
+ ;; NOMNL-NEXT:  (local $struct dataref)
  ;; NOMNL-NEXT:  (local.set $temp
  ;; NOMNL-NEXT:   (call $refine-return-many-lub-2)
  ;; NOMNL-NEXT:  )
@@ -328,12 +328,12 @@
  ;; NOMNL-NEXT:    (local.get $i31)
  ;; NOMNL-NEXT:   )
  ;; NOMNL-NEXT:  )
- ;; NOMNL-NEXT:  (local.get $data)
+ ;; NOMNL-NEXT:  (local.get $struct)
  ;; NOMNL-NEXT: )
  (func $refine-return-many-lub-2 (result anyref)
   (local $temp anyref)
   (local $i31 (ref null i31))
-  (local $data (ref null data))
+  (local $struct (ref null struct))
 
   (local.set $temp (call $refine-return-many-lub-2))
 
@@ -345,8 +345,8 @@
    (i32.const 2)
    (return (local.get $i31))
   )
-  ;; The refined return type has to be a supertype of data.
-  (local.get $data)
+  ;; The refined return type has to be a supertype of struct.
+  (local.get $struct)
  )
 
  ;; We can refine the return types of tuples.

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -211,15 +211,15 @@
  ;; NOMNL-NEXT:  )
  ;; NOMNL-NEXT: )
  (func $call-bar
-  ;; Call with nulls. Mixing nulls is fine as they all have the same value, and
-  ;; we can optimize (to the LUB of the nulls). However, mixing a null with a
-  ;; reference stops us in the second param.
+  ;; Call with nulls. Mixing nulls is fine as they all have the same type and
+  ;; value. However, mixing a null with a reference stops us in the second
+  ;; param.
   (call $bar
-   (ref.null i31)
-   (ref.null data)
+   (ref.null none)
+   (ref.null none)
   )
   (call $bar
-   (ref.null any)
+   (ref.null none)
    (i31.new (i32.const 0))
   )
  )

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -363,7 +363,7 @@
     (i64.const 1)
     (f32.const 2.2)
     (f64.const 3.3)
-    (ref.null data)
+    (ref.null none)
   ))
 
   ;; CHECK:      (func $test (type $none_=>_none)

--- a/test/lit/passes/inlining_splitting.wast
+++ b/test/lit/passes/inlining_splitting.wast
@@ -9,10 +9,10 @@
 
   ;; CHECK:      (type $anyref_=>_anyref (func (param anyref) (result anyref)))
 
-  ;; CHECK:      (type $anyref_=>_none (func (param anyref)))
-
   ;; CHECK:      (type $struct (struct ))
   (type $struct (struct))
+
+  ;; CHECK:      (type $anyref_=>_none (func (param anyref)))
 
   ;; CHECK:      (type $i64_i32_f64_=>_none (func (param i64 i32 f64)))
 
@@ -1178,12 +1178,9 @@
 
   ;; CHECK:      (func $call-multi-if (type $none_=>_none)
   ;; CHECK-NEXT:  (local $0 anyref)
-  ;; CHECK-NEXT:  (local $1 anyref)
-  ;; CHECK-NEXT:  (local $2 anyref)
-  ;; CHECK-NEXT:  (local $3 anyref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$multi-if (result anyref)
+  ;; CHECK-NEXT:    (block $__inlined_func$multi-if (result anyref)
   ;; CHECK-NEXT:     (local.set $0
   ;; CHECK-NEXT:      (ref.null none)
   ;; CHECK-NEXT:     )
@@ -1192,19 +1189,17 @@
   ;; CHECK-NEXT:       (ref.is_null
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (block $__inlined_func$byn-split-outlined-B$multi-if
-  ;; CHECK-NEXT:        (local.set $2
-  ;; CHECK-NEXT:         (local.get $0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (call $import)
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
   ;; CHECK-NEXT:       (ref.is_func
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $byn-split-outlined-B$multi-if_0
-  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       (loop $x
+  ;; CHECK-NEXT:        (call $import)
+  ;; CHECK-NEXT:        (br_if $x
+  ;; CHECK-NEXT:         (global.get $glob)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (local.get $0)
@@ -1212,76 +1207,11 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$multi-if0 (result anyref)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (block $__inlined_func$byn-split-outlined-B$multi-if0
-  ;; CHECK-NEXT:        (local.set $3
-  ;; CHECK-NEXT:         (local.get $1)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (call $import)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_func
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $byn-split-outlined-B$multi-if_0
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-multi-if
-    (drop (call $multi-if (ref.null any)))
-    (drop (call $multi-if (ref.null data)))
+    (drop (call $multi-if (ref.null none)))
   )
 
-  ;; CHECK:      (func $too-many-ifs (type $anyref_=>_anyref) (param $x anyref) (result anyref)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (ref.is_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (ref.is_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (ref.is_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (ref.is_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (ref.is_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.get $x)
-  ;; CHECK-NEXT: )
   (func $too-many-ifs (param $x anyref) (result anyref)
     ;; 5 ifs, which is too many.
     (if
@@ -1318,20 +1248,52 @@
   )
 
   ;; CHECK:      (func $call-too-many-ifs (type $none_=>_none)
+  ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (call $too-many-ifs
-  ;; CHECK-NEXT:    (ref.null none)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (call $too-many-ifs
-  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   (block (result anyref)
+  ;; CHECK-NEXT:    (block $__inlined_func$too-many-ifs (result anyref)
+  ;; CHECK-NEXT:     (local.set $0
+  ;; CHECK-NEXT:      (ref.null none)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block (result anyref)
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-too-many-ifs
-    (drop (call $too-many-ifs (ref.null any)))
-    (drop (call $too-many-ifs (ref.null data)))
+    (drop (call $too-many-ifs (ref.null none)))
   )
 )
 
@@ -1401,15 +1363,6 @@
 ;; CHECK:      (func $byn-split-outlined-B$unreachable-if-body-no-result (type $anyref_=>_none) (param $x anyref)
 ;; CHECK-NEXT:  (call $import)
 ;; CHECK-NEXT:  (unreachable)
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $byn-split-outlined-B$multi-if_0 (type $anyref_=>_none) (param $x anyref)
-;; CHECK-NEXT:  (loop $x
-;; CHECK-NEXT:   (call $import)
-;; CHECK-NEXT:   (br_if $x
-;; CHECK-NEXT:    (global.get $glob)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 (module
   ;; CHECK:      (type $none_=>_none (func))

--- a/test/lit/passes/inlining_splitting.wast
+++ b/test/lit/passes/inlining_splitting.wast
@@ -1249,6 +1249,39 @@
     (drop (call $multi-if (ref.null none)))
   )
 
+  ;; CHECK:      (func $too-many-ifs (type $anyref_=>_anyref) (param $x anyref) (result anyref)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (ref.is_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $import)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (ref.is_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $import)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (ref.is_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $import)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (ref.is_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $import)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (ref.is_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $import)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT: )
   (func $too-many-ifs (param $x anyref) (result anyref)
     ;; 5 ifs, which is too many.
     (if
@@ -1285,51 +1318,19 @@
   )
 
   ;; CHECK:      (func $call-too-many-ifs (type $none_=>_none)
-  ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$too-many-ifs (result anyref)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $import)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $import)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $import)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $import)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $import)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (call $too-many-ifs
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (call $too-many-ifs
+  ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-too-many-ifs
+    (drop (call $too-many-ifs (ref.null none)))
     (drop (call $too-many-ifs (ref.null none)))
   )
 )

--- a/test/lit/passes/inlining_splitting.wast
+++ b/test/lit/passes/inlining_splitting.wast
@@ -9,10 +9,10 @@
 
   ;; CHECK:      (type $anyref_=>_anyref (func (param anyref) (result anyref)))
 
+  ;; CHECK:      (type $anyref_=>_none (func (param anyref)))
+
   ;; CHECK:      (type $struct (struct ))
   (type $struct (struct))
-
-  ;; CHECK:      (type $anyref_=>_none (func (param anyref)))
 
   ;; CHECK:      (type $i64_i32_f64_=>_none (func (param i64 i32 f64)))
 
@@ -1178,9 +1178,12 @@
 
   ;; CHECK:      (func $call-multi-if (type $none_=>_none)
   ;; CHECK-NEXT:  (local $0 anyref)
+  ;; CHECK-NEXT:  (local $1 anyref)
+  ;; CHECK-NEXT:  (local $2 anyref)
+  ;; CHECK-NEXT:  (local $3 anyref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$multi-if (result anyref)
+  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$multi-if (result anyref)
   ;; CHECK-NEXT:     (local.set $0
   ;; CHECK-NEXT:      (ref.null none)
   ;; CHECK-NEXT:     )
@@ -1189,17 +1192,19 @@
   ;; CHECK-NEXT:       (ref.is_null
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:       (block $__inlined_func$byn-split-outlined-B$multi-if
+  ;; CHECK-NEXT:        (local.set $2
+  ;; CHECK-NEXT:         (local.get $0)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (call $import)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
   ;; CHECK-NEXT:       (ref.is_func
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (loop $x
-  ;; CHECK-NEXT:        (call $import)
-  ;; CHECK-NEXT:        (br_if $x
-  ;; CHECK-NEXT:         (global.get $glob)
-  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       (call $byn-split-outlined-B$multi-if_0
+  ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (local.get $0)
@@ -1207,8 +1212,40 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result anyref)
+  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$multi-if0 (result anyref)
+  ;; CHECK-NEXT:     (local.set $1
+  ;; CHECK-NEXT:      (ref.null none)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block (result anyref)
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (block $__inlined_func$byn-split-outlined-B$multi-if0
+  ;; CHECK-NEXT:        (local.set $3
+  ;; CHECK-NEXT:         (local.get $1)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (call $import)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (if
+  ;; CHECK-NEXT:       (ref.is_func
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (call $byn-split-outlined-B$multi-if_0
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-multi-if
+    (drop (call $multi-if (ref.null none)))
     (drop (call $multi-if (ref.null none)))
   )
 
@@ -1363,6 +1400,15 @@
 ;; CHECK:      (func $byn-split-outlined-B$unreachable-if-body-no-result (type $anyref_=>_none) (param $x anyref)
 ;; CHECK-NEXT:  (call $import)
 ;; CHECK-NEXT:  (unreachable)
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $byn-split-outlined-B$multi-if_0 (type $anyref_=>_none) (param $x anyref)
+;; CHECK-NEXT:  (loop $x
+;; CHECK-NEXT:   (call $import)
+;; CHECK-NEXT:   (br_if $x
+;; CHECK-NEXT:    (global.get $glob)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 (module
   ;; CHECK:      (type $none_=>_none (func))

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -8,7 +8,6 @@
 ;; testcases.
 
 (module
-  ;; CHECK:      (type ${} (struct ))
   (type ${} (struct_subtype data))
 
   (type ${i32} (struct_subtype (field i32) data))
@@ -89,7 +88,7 @@
     )
   )
 
-  ;; CHECK:      (func $locals-with-multiple-assignments (type $dataref_=>_none) (param $data dataref)
+  ;; CHECK:      (func $locals-with-multiple-assignments (type $dataref_=>_none) (param $struct dataref)
   ;; CHECK-NEXT:  (local $x eqref)
   ;; CHECK-NEXT:  (local $y (ref i31))
   ;; CHECK-NEXT:  (local $z dataref)
@@ -100,7 +99,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (local.get $data)
+  ;; CHECK-NEXT:   (local.get $struct)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $y
   ;; CHECK-NEXT:   (i31.new
@@ -113,10 +112,10 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $z
-  ;; CHECK-NEXT:   (local.get $data)
+  ;; CHECK-NEXT:   (local.get $struct)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $z
-  ;; CHECK-NEXT:   (local.get $data)
+  ;; CHECK-NEXT:   (local.get $struct)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $w
   ;; CHECK-NEXT:   (ref.func $i32)
@@ -125,7 +124,7 @@
   ;; CHECK-NEXT:   (ref.func $i64)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $locals-with-multiple-assignments (param $data (ref null data))
+  (func $locals-with-multiple-assignments (param $struct (ref null struct))
     (local $x anyref)
     (local $y anyref)
     (local $z anyref)
@@ -135,7 +134,7 @@
       (i31.new (i32.const 0))
     )
     (local.set $x
-      (local.get $data)
+      (local.get $struct)
     )
     ;; y and z are assigned the same more specific type twice
     (local.set $y
@@ -145,10 +144,10 @@
       (i31.new (i32.const 1))
     )
     (local.set $z
-      (local.get $data)
+      (local.get $struct)
     )
     (local.set $z
-      (local.get $data)
+      (local.get $struct)
     )
     ;; w is assigned two different types *without* a new LUB heap type possible,
     ;; as it already had the optimal LUB heap type (but it can become non-
@@ -359,49 +358,6 @@
       (ref.null func)
     )
     (unreachable)
-  )
-
-  ;; CHECK:      (func $update-nulls (type $none_=>_none)
-  ;; CHECK-NEXT:  (local $x (ref null ${}))
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (struct.new_default ${})
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $update-nulls
-    (local $x anyref)
-    (local.set $x (ref.null any))
-    (local.set $x (ref.null eq))
-    ;; All the nulls can be changed into other nulls here, for the new LUB,
-    ;; which will be ${}
-    (local.set $x (struct.new ${}))
-    (local.set $x (ref.null data))
-    ;; Note that this func null is even of a type that is incompatible with the
-    ;; new lub (array vs struct). Still, we can just update it along with the
-    ;; others.
-    (local.set $x (ref.null $array))
-    ;; This null is equal to the LUB we'll find, and will not change.
-    (local.set $x (ref.null ${}))
-    ;; This null is more specific than the LUB we'll find, and will not change,
-    ;; as there is no point to making something less specific in type.
-    (local.set $x (ref.null ${i32}))
   )
 
   ;; CHECK:      (func $become-non-nullable (type $none_=>_none)

--- a/test/lit/passes/merge-similar-functions_all-features.wast
+++ b/test/lit/passes/merge-similar-functions_all-features.wast
@@ -5,10 +5,10 @@
   ;; CHECK:      (type $[i8] (array i8))
   (type $[i8] (array i8))
 
-  ;; CHECK:      (func $take-ref-null-data (type $dataref_=>_none) (param $0 dataref)
+  ;; CHECK:      (func $take-ref-null-array (type $arrayref_=>_none) (param $0 arrayref)
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
-  (func $take-ref-null-data (param (ref null data))
+  (func $take-ref-null-array (param (ref null array))
     (unreachable)
   )
   ;; CHECK:      (func $take-ref-eq (type $ref|eq|_=>_none) (param $0 (ref eq))
@@ -43,7 +43,7 @@
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (nop)
-  ;; CHECK-NEXT:  (call $take-ref-null-data
+  ;; CHECK-NEXT:  (call $take-ref-null-array
   ;; CHECK-NEXT:   (array.init_static $[i8])
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -51,7 +51,7 @@
     (nop) (nop) (nop) (nop) (nop) (nop)
     (nop) (nop) (nop) (nop) (nop) (nop)
     (nop) (nop) (nop) (nop) (nop) (nop)
-    (call $take-ref-null-data
+    (call $take-ref-null-array
       (array.init_static $[i8])
     )
   )

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -108,7 +108,7 @@
   ;; CHECK-NEXT:   (local.get $1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $ref.cast (param $x (ref data))
+  (func $ref.cast (param $x (ref struct))
     ;; As $ref.as but with ref.casts: we should use the cast value after it has
     ;; been computed, in both gets.
     (drop
@@ -143,7 +143,7 @@
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $not-past-set (param $x (ref data))
+  (func $not-past-set (param $x (ref struct))
     (drop
       (ref.cast_static $A
         (local.get $x)
@@ -185,7 +185,7 @@
   ;; CHECK-NEXT:   (local.get $2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $best (param $x (ref data))
+  (func $best (param $x (ref struct))
     (drop
       (ref.cast_static $A
         (local.get $x)
@@ -227,7 +227,7 @@
   ;; CHECK-NEXT:   (local.get $1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $best-2 (param $x (ref data))
+  (func $best-2 (param $x (ref struct))
     ;; As above, but with the casts reversed. Now we should use $B in both
     ;; gets.
     (drop
@@ -263,11 +263,11 @@
   ;; CHECK-NEXT:   (local.get $1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $fallthrough (param $x (ref data))
+  (func $fallthrough (param $x (ref struct))
     (drop
       (ref.cast_static $A
         ;; We look through the block, and optimize.
-        (block (result (ref data))
+        (block (result (ref struct))
           (local.get $x)
         )
       )
@@ -291,7 +291,7 @@
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $past-basic-block (param $x (ref data))
+  (func $past-basic-block (param $x (ref struct))
     (drop
       (ref.cast_static $A
         (local.get $x)
@@ -349,9 +349,9 @@
   ;; CHECK-NEXT:   (local.get $b)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $multiple (param $x (ref data)) (param $y (ref data))
-    (local $a (ref data))
-    (local $b (ref data))
+  (func $multiple (param $x (ref struct)) (param $y (ref struct))
+    (local $a (ref struct))
+    (local $b (ref struct))
     ;; Two different locals, with overlapping lives.
     (local.set $a
       (local.get $x)
@@ -391,7 +391,7 @@
   ;; CHECK:      (func $get (type $none_=>_ref|data|) (result (ref data))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
-  (func $get (result (ref data))
+  (func $get (result (ref struct))
     ;; Helper for the above.
     (unreachable)
   )

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -16,8 +16,8 @@
 
  ;; CHECK:      (type $i32_=>_none (func (param i32)))
 
- ;; CHECK:      (type $data_=>_none (func (param (ref data))))
- (type $data_=>_none (func (param (ref data))))
+ ;; CHECK:      (type $struct_=>_none (func (param (ref data))))
+ (type $struct_=>_none (func (param (ref struct))))
 
  ;; CHECK:      (type $i32_i32_i32_ref|$i32_i32_=>_none|_=>_none (func (param i32 i32 i32 (ref $i32_i32_=>_none))))
 
@@ -124,7 +124,7 @@
   )
  )
 
- ;; CHECK:      (func $fallthrough-non-nullable (type $data_=>_none) (param $x (ref data))
+ ;; CHECK:      (func $fallthrough-non-nullable (type $struct_=>_none) (param $x (ref data))
  ;; CHECK-NEXT:  (local $1 dataref)
  ;; CHECK-NEXT:  (call $fallthrough-non-nullable
  ;; CHECK-NEXT:   (block (result (ref data))
@@ -132,7 +132,7 @@
  ;; CHECK-NEXT:     (local.get $x)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (block (result (ref $data_=>_none))
+ ;; CHECK-NEXT:     (block (result (ref $struct_=>_none))
  ;; CHECK-NEXT:      (nop)
  ;; CHECK-NEXT:      (ref.func $fallthrough-non-nullable)
  ;; CHECK-NEXT:     )
@@ -143,14 +143,14 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $fallthrough-non-nullable (param $x (ref data))
+ (func $fallthrough-non-nullable (param $x (ref struct))
   ;; A fallthrough appears here, and in addition the last operand is non-
   ;; nullable, which means we must be careful when we create a temp local for
   ;; it: the local should be nullable, and gets of it should use a
   ;; ref.as_non_null so that we validate.
-  (call_ref $data_=>_none
+  (call_ref $struct_=>_none
    (local.get $x)
-   (block (result (ref $data_=>_none))
+   (block (result (ref $struct_=>_none))
     (nop)
     (ref.func $fallthrough-non-nullable)
    )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -85,7 +85,7 @@
   (func $if-arms-subtype-nofold (param $i31ref i31ref) (result anyref)
     (if (result anyref)
       (i32.const 0)
-      (ref.null data)
+      (ref.null none)
       (local.get $i31ref)
     )
   )
@@ -162,7 +162,7 @@
 
   ;; ref.is_null is not needed on a non-nullable value, and if something is
   ;; a func we don't need that either etc. if we know the result
-  ;; CHECK:      (func $unneeded_is (type $ref|$struct|_ref|func|_ref|data|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $data (ref data)) (param $i31 (ref i31))
+  ;; CHECK:      (func $unneeded_is (type $ref|$struct|_ref|func|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $i31 (ref i31))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
@@ -182,21 +182,13 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $data)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $i31)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $unneeded_is (type $ref|$struct|_ref|func|_ref|data|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $data (ref data)) (param $i31 (ref i31))
+  ;; NOMNL:      (func $unneeded_is (type $ref|$struct|_ref|func|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $i31 (ref i31))
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result i32)
   ;; NOMNL-NEXT:    (drop
@@ -216,14 +208,6 @@
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result i32)
   ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $data)
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:    (i32.const 1)
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (block (result i32)
-  ;; NOMNL-NEXT:    (drop
   ;; NOMNL-NEXT:     (local.get $i31)
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:    (i32.const 1)
@@ -233,7 +217,6 @@
   (func $unneeded_is
     (param $struct (ref $struct))
     (param $func (ref func))
-    (param $data (ref data))
     (param $i31 (ref i31))
     (drop
       (ref.is_null (local.get $struct))
@@ -242,16 +225,13 @@
        (ref.is_func (local.get $func))
      )
     (drop
-      (ref.is_data (local.get $data))
-    )
-    (drop
       (ref.is_i31 (local.get $i31))
     )
   )
 
   ;; similar to $unneeded_is, but the values are nullable. we can at least
   ;; leave just the null check.
-  ;; CHECK:      (func $unneeded_is_null (type $ref?|$struct|_funcref_dataref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; CHECK:      (func $unneeded_is_null (type $ref?|$struct|_funcref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $i31 i31ref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.is_null
   ;; CHECK-NEXT:    (local.get $struct)
@@ -267,19 +247,12 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
   ;; CHECK-NEXT:    (ref.is_null
-  ;; CHECK-NEXT:     (local.get $data)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (ref.is_null
   ;; CHECK-NEXT:     (local.get $i31)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $unneeded_is_null (type $ref?|$struct|_funcref_dataref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; NOMNL:      (func $unneeded_is_null (type $ref?|$struct|_funcref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $i31 i31ref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.is_null
   ;; NOMNL-NEXT:    (local.get $struct)
@@ -295,13 +268,6 @@
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (i32.eqz
   ;; NOMNL-NEXT:    (ref.is_null
-  ;; NOMNL-NEXT:     (local.get $data)
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (i32.eqz
-  ;; NOMNL-NEXT:    (ref.is_null
   ;; NOMNL-NEXT:     (local.get $i31)
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:   )
@@ -310,7 +276,6 @@
   (func $unneeded_is_null
    (param $struct (ref null $struct))
     (param $func (ref null func))
-    (param $data (ref null data))
     (param $i31 (ref null i31))
     (drop
       (ref.is_null (local.get $struct))
@@ -319,28 +284,17 @@
       (ref.is_func (local.get $func))
     )
     (drop
-      (ref.is_data (local.get $data))
-    )
-    (drop
       (ref.is_i31 (local.get $i31))
     )
   )
 
   ;; similar to $unneeded_is, but the values are of mixed kind (is_func of
-  ;; data, etc.). regardless of nullability the result here is always 0.
-  ;; CHECK:      (func $unneeded_is_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; struct, etc.). regardless of nullability the result here is always 0.
+  ;; CHECK:      (func $unneeded_is_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $struct dataref) (param $i31 i31ref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $data)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $i31)
+  ;; CHECK-NEXT:     (local.get $struct)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
@@ -357,17 +311,7 @@
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.as_non_null
-  ;; CHECK-NEXT:      (local.get $data)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 0)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.as_non_null
-  ;; CHECK-NEXT:      (local.get $i31)
+  ;; CHECK-NEXT:      (local.get $struct)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (i32.const 0)
@@ -384,19 +328,11 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $unneeded_is_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; NOMNL:      (func $unneeded_is_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $struct dataref) (param $i31 i31ref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result i32)
   ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $data)
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:    (i32.const 0)
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (block (result i32)
-  ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $i31)
+  ;; NOMNL-NEXT:     (local.get $struct)
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:    (i32.const 0)
   ;; NOMNL-NEXT:   )
@@ -413,17 +349,7 @@
   ;; NOMNL-NEXT:   (block (result i32)
   ;; NOMNL-NEXT:    (drop
   ;; NOMNL-NEXT:     (ref.as_non_null
-  ;; NOMNL-NEXT:      (local.get $data)
-  ;; NOMNL-NEXT:     )
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:    (i32.const 0)
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (block (result i32)
-  ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (ref.as_non_null
-  ;; NOMNL-NEXT:      (local.get $i31)
+  ;; NOMNL-NEXT:      (local.get $struct)
   ;; NOMNL-NEXT:     )
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:    (i32.const 0)
@@ -442,23 +368,17 @@
   ;; NOMNL-NEXT: )
   (func $unneeded_is_bad_kinds
     (param $func (ref null func))
-    (param $data (ref null data))
+    (param $struct (ref null struct))
     (param $i31 (ref null i31))
     (drop
-      (ref.is_func (local.get $data))
-    )
-    (drop
-      (ref.is_data (local.get $i31))
+      (ref.is_func (local.get $struct))
     )
     (drop
       (ref.is_i31 (local.get $func))
     )
     ;; also check non-nullable types as inputs
     (drop
-      (ref.is_func (ref.as_non_null (local.get $data)))
-    )
-    (drop
-      (ref.is_data (ref.as_non_null (local.get $i31)))
+      (ref.is_func (ref.as_non_null (local.get $struct)))
     )
     (drop
       (ref.is_i31 (ref.as_non_null (local.get $func)))
@@ -467,7 +387,7 @@
 
   ;; ref.as_non_null is not needed on a non-nullable value, and if something is
   ;; a func we don't need that either etc., and can just return the value.
-  ;; CHECK:      (func $unneeded_as (type $ref|$struct|_ref|func|_ref|data|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $data (ref data)) (param $i31 (ref i31))
+  ;; CHECK:      (func $unneeded_as (type $ref|$struct|_ref|func|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $i31 (ref i31))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $struct)
   ;; CHECK-NEXT:  )
@@ -475,21 +395,15 @@
   ;; CHECK-NEXT:   (local.get $func)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $data)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $i31)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $unneeded_as (type $ref|$struct|_ref|func|_ref|data|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $data (ref data)) (param $i31 (ref i31))
+  ;; NOMNL:      (func $unneeded_as (type $ref|$struct|_ref|func|_ref|i31|_=>_none) (param $struct (ref $struct)) (param $func (ref func)) (param $i31 (ref i31))
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (local.get $struct)
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (local.get $func)
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (local.get $data)
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (local.get $i31)
@@ -498,7 +412,6 @@
   (func $unneeded_as
     (param $struct (ref $struct))
     (param $func (ref func))
-    (param $data (ref data))
     (param $i31 (ref i31))
     (drop
       (ref.as_non_null (local.get $struct))
@@ -507,16 +420,13 @@
       (ref.as_func (local.get $func))
     )
     (drop
-      (ref.as_data (local.get $data))
-    )
-    (drop
       (ref.as_i31 (local.get $i31))
     )
   )
 
   ;; similar to $unneeded_as, but the values are nullable. we can turn the
   ;; more specific things into ref.as_non_null.
-  ;; CHECK:      (func $unneeded_as_null (type $ref?|$struct|_funcref_dataref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; CHECK:      (func $unneeded_as_null (type $ref?|$struct|_funcref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $i31 i31ref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
   ;; CHECK-NEXT:    (local.get $struct)
@@ -529,16 +439,11 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (local.get $data)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_non_null
   ;; CHECK-NEXT:    (local.get $i31)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $unneeded_as_null (type $ref?|$struct|_funcref_dataref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; NOMNL:      (func $unneeded_as_null (type $ref?|$struct|_funcref_i31ref_=>_none) (param $struct (ref null $struct)) (param $func funcref) (param $i31 i31ref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.as_non_null
   ;; NOMNL-NEXT:    (local.get $struct)
@@ -551,11 +456,6 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.as_non_null
-  ;; NOMNL-NEXT:    (local.get $data)
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.as_non_null
   ;; NOMNL-NEXT:    (local.get $i31)
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
@@ -563,7 +463,6 @@
   (func $unneeded_as_null
     (param $struct (ref null $struct))
     (param $func (ref null func))
-    (param $data (ref null data))
     (param $i31 (ref null i31))
     (drop
       (ref.as_non_null (local.get $struct))
@@ -572,28 +471,17 @@
       (ref.as_func (local.get $func))
     )
     (drop
-      (ref.as_data (local.get $data))
-    )
-    (drop
       (ref.as_i31 (local.get $i31))
     )
   )
 
   ;; similar to $unneeded_as, but the values are of mixed kind (as_func of
   ;; data, etc.), so we know we will trap
-  ;; CHECK:      (func $unneeded_as_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; CHECK:      (func $unneeded_as_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $struct dataref) (param $i31 i31ref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result (ref func))
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $data)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref data))
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $i31)
+  ;; CHECK-NEXT:     (local.get $struct)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -609,15 +497,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result (ref func))
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $data)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref data))
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $i31)
+  ;; CHECK-NEXT:     (local.get $struct)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -631,19 +511,11 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  ;; NOMNL:      (func $unneeded_as_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $data dataref) (param $i31 i31ref)
+  ;; NOMNL:      (func $unneeded_as_bad_kinds (type $funcref_dataref_i31ref_=>_none) (param $func funcref) (param $struct dataref) (param $i31 i31ref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result (ref func))
   ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $data)
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:    (unreachable)
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (block (result (ref data))
-  ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $i31)
+  ;; NOMNL-NEXT:     (local.get $struct)
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:    (unreachable)
   ;; NOMNL-NEXT:   )
@@ -659,15 +531,7 @@
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (block (result (ref func))
   ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $data)
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:    (unreachable)
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (block (result (ref data))
-  ;; NOMNL-NEXT:    (drop
-  ;; NOMNL-NEXT:     (local.get $i31)
+  ;; NOMNL-NEXT:     (local.get $struct)
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:    (unreachable)
   ;; NOMNL-NEXT:   )
@@ -683,23 +547,17 @@
   ;; NOMNL-NEXT: )
   (func $unneeded_as_bad_kinds
     (param $func (ref null func))
-    (param $data (ref null data))
+    (param $struct (ref null struct))
     (param $i31 (ref null i31))
     (drop
-      (ref.as_func (local.get $data))
-    )
-    (drop
-      (ref.as_data (local.get $i31))
+      (ref.as_func (local.get $struct))
     )
     (drop
       (ref.as_i31 (local.get $func))
     )
     ;; also check non-nullable types as inputs
     (drop
-      (ref.as_func (ref.as_non_null (local.get $data)))
-    )
-    (drop
-      (ref.as_data (ref.as_non_null (local.get $i31)))
+      (ref.as_func (ref.as_non_null (local.get $struct)))
     )
     (drop
       (ref.as_i31 (ref.as_non_null (local.get $func)))
@@ -1149,13 +1007,6 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast_static $struct
-  ;; CHECK-NEXT:    (ref.as_data
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_static $struct
   ;; CHECK-NEXT:    (ref.as_i31
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
@@ -1180,13 +1031,6 @@
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.cast_static $struct
   ;; NOMNL-NEXT:    (ref.as_func
-  ;; NOMNL-NEXT:     (local.get $x)
-  ;; NOMNL-NEXT:    )
-  ;; NOMNL-NEXT:   )
-  ;; NOMNL-NEXT:  )
-  ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast_static $struct
-  ;; NOMNL-NEXT:    (ref.as_data
   ;; NOMNL-NEXT:     (local.get $x)
   ;; NOMNL-NEXT:    )
   ;; NOMNL-NEXT:   )
@@ -1223,13 +1067,6 @@
     (drop
       (ref.cast_static $struct
         (ref.as_func
-          (local.get $x)
-        )
-      )
-    )
-    (drop
-      (ref.cast_static $struct
-        (ref.as_data
           (local.get $x)
         )
       )
@@ -2151,7 +1988,7 @@
   ;; CHECK:      (func $consecutive-opts-with-unreachable (type $funcref_=>_none) (param $func funcref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast_static $struct
-  ;; CHECK-NEXT:    (block (result (ref data))
+  ;; CHECK-NEXT:    (block (result (ref i31))
   ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (local.get $func)
   ;; CHECK-NEXT:     )
@@ -2163,7 +2000,7 @@
   ;; NOMNL:      (func $consecutive-opts-with-unreachable (type $funcref_=>_none) (param $func funcref)
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (ref.cast_static $struct
-  ;; NOMNL-NEXT:    (block (result (ref data))
+  ;; NOMNL-NEXT:    (block (result (ref i31))
   ;; NOMNL-NEXT:     (drop
   ;; NOMNL-NEXT:      (local.get $func)
   ;; NOMNL-NEXT:     )
@@ -2173,22 +2010,22 @@
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT: )
   (func $consecutive-opts-with-unreachable (param $func funcref)
-   (drop
-     (ref.cast_static $struct
-       ;; Casting a funcref to data will definitely fail, so this will be
-       ;; replaced with an unreachable. But it should be enclosed in a block of
-       ;; the previous type, so that the outside ref.cast is not confused. This
-       ;; is a regression test for a bug where we replace this node with an
-       ;; unreachable one, but we left refinalize til the end of all the other
-       ;; opts - and that meant that we got to our parent, the ref.cast, with
-       ;; one unreachable child but before it itself was refinalized, so its
-       ;; type was *not* unreachable yet, which meant it saw inconsistent IR
-       ;; that then led to an assertion.
-       (ref.as_data
-         (local.get $func)
-       )
-     )
-   )
+    (drop
+      (ref.cast_static $struct
+        ;; Casting a funcref to i31 will definitely fail, so this will be
+        ;; replaced with an unreachable. But it should be enclosed in a block of
+        ;; the previous type, so that the outside ref.cast is not confused. This
+        ;; is a regression test for a bug where we replace this node with an
+        ;; unreachable one, but we left refinalize til the end of all the other
+        ;; opts - and that meant that we got to our parent, the ref.cast, with
+        ;; one unreachable child but before it itself was refinalized, so its
+        ;; type was *not* unreachable yet, which meant it saw inconsistent IR
+        ;; that then led to an assertion.
+        (ref.as_i31
+          (local.get $func)
+        )
+      )
+    )
   )
 
   ;; CHECK:      (func $ref-cast-static-null (type $void)

--- a/test/lit/passes/precompute-gc-immutable.wast
+++ b/test/lit/passes/precompute-gc-immutable.wast
@@ -4,10 +4,10 @@
 
 (module
   ;; CHECK:      (type $struct-imm (struct (field i32)))
-  (type $struct-imm (struct_subtype i32 data))
+  (type $struct-imm (struct i32))
 
   ;; CHECK:      (type $struct-mut (struct (field (mut i32))))
-  (type $struct-mut (struct_subtype (mut i32) data))
+  (type $struct-mut (struct (mut i32)))
 
   ;; CHECK:      (func $propagate (type $none_=>_none)
   ;; CHECK-NEXT:  (local $ref-imm (ref null $struct-imm))
@@ -359,7 +359,7 @@
   ;; One field is immutable, the other is not, so we can only propagate the
   ;; former.
   ;; CHECK:      (type $struct (struct (field (mut i32)) (field i32)))
-  (type $struct (struct_subtype (mut i32) i32 data))
+  (type $struct (struct (mut i32) i32))
 
   ;; CHECK:      (func $propagate (type $none_=>_none)
   ;; CHECK-NEXT:  (local $ref (ref null $struct))
@@ -413,8 +413,8 @@
   ;; CHECK:      (type $object (struct (field (ref $vtable))))
 
   ;; CHECK:      (type $vtable (struct (field funcref)))
-  (type $vtable (struct_subtype funcref data))
-  (type $object (struct_subtype (ref $vtable) data))
+  (type $vtable (struct funcref))
+  (type $object (struct (ref $vtable)))
 
   ;; CHECK:      (func $nested-creations (type $none_=>_none)
   ;; CHECK-NEXT:  (local $ref (ref null $object))
@@ -461,8 +461,8 @@
   ;; CHECK:      (type $object (struct (field (ref $vtable))))
 
   ;; CHECK:      (type $vtable (struct (field (mut funcref))))
-  (type $vtable (struct_subtype (mut funcref) data))
-  (type $object (struct_subtype (ref $vtable) data))
+  (type $vtable (struct (mut funcref)))
+  (type $object (struct (ref $vtable)))
 
   ;; CHECK:      (func $nested-creations (type $none_=>_none)
   ;; CHECK-NEXT:  (local $ref (ref null $object))
@@ -514,8 +514,8 @@
   ;; CHECK:      (type $object (struct (field (mut (ref $vtable)))))
 
   ;; CHECK:      (type $vtable (struct (field funcref)))
-  (type $vtable (struct_subtype funcref data))
-  (type $object (struct_subtype (mut (ref $vtable)) data))
+  (type $vtable (struct funcref))
+  (type $object (struct (mut (ref $vtable))))
 
   ;; CHECK:      (func $nested-creations (type $none_=>_none)
   ;; CHECK-NEXT:  (local $ref (ref null $object))
@@ -563,9 +563,9 @@
   ;; with.
 
   ;; CHECK:      (type $vtable (struct (field funcref)))
-  (type $vtable (struct_subtype funcref data))
+  (type $vtable (struct funcref))
   ;; CHECK:      (type $object (struct (field (ref $vtable))))
-  (type $object (struct_subtype (ref $vtable) data))
+  (type $object (struct (ref $vtable)))
 
   ;; CHECK:      (global $vtable (ref $vtable) (struct.new $vtable
   ;; CHECK-NEXT:  (ref.func $nested-creations)
@@ -614,9 +614,9 @@
   ;; optimization.
 
   ;; CHECK:      (type $vtable (struct (field funcref)))
-  (type $vtable (struct_subtype funcref data))
+  (type $vtable (struct funcref))
   ;; CHECK:      (type $object (struct (field (ref $vtable))))
-  (type $object (struct_subtype (ref $vtable) data))
+  (type $object (struct (ref $vtable)))
 
   ;; CHECK:      (global $vtable (mut (ref $vtable)) (struct.new $vtable
   ;; CHECK-NEXT:  (ref.func $nested-creations)
@@ -669,9 +669,9 @@
   ;; instead of a struct.
 
   ;; CHECK:      (type $vtable (array funcref))
-  (type $vtable (array_subtype funcref data))
+  (type $vtable (array funcref))
   ;; CHECK:      (type $object (struct (field (ref $vtable))))
-  (type $object (struct_subtype (ref $vtable) data))
+  (type $object (struct (ref $vtable)))
 
   ;; CHECK:      (global $vtable (ref $vtable) (array.init_static $vtable
   ;; CHECK-NEXT:  (ref.func $nested-creations)
@@ -740,16 +740,16 @@
   ;; cast of the vtable type.
 
   ;; CHECK:      (type $itable (array dataref))
-  (type $itable (array_subtype (ref null data) data))
+  (type $itable (array (ref null struct)))
 
   ;; CHECK:      (type $object (struct (field (ref $itable))))
-  (type $object (struct_subtype (ref $itable) data))
+  (type $object (struct (ref $itable)))
 
   ;; CHECK:      (type $vtable-0 (struct (field funcref)))
-  (type $vtable-0 (struct_subtype funcref data))
+  (type $vtable-0 (struct funcref))
 
   ;; CHECK:      (type $vtable-1 (struct (field funcref)))
-  (type $vtable-1 (struct_subtype funcref data))
+  (type $vtable-1 (struct funcref))
 
   ;; CHECK:      (global $itable (ref $itable) (array.init_static $itable
   ;; CHECK-NEXT:  (struct.new $vtable-0

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -6,50 +6,50 @@
  ;; CHECK:      (type $struct (struct ))
  (type $struct (struct ))
 
- ;; CHECK:      (func $br_on_non_data-1 (type $none_=>_none)
+ ;; CHECK:      (func $br_on_non_i31-1 (type $none_=>_none)
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block $any (result i31ref)
+ ;; CHECK-NEXT:   (block $any (result (ref null $struct))
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (br $any
- ;; CHECK-NEXT:      (i31.new
- ;; CHECK-NEXT:       (i32.const 0)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (struct.new_default $struct)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $br_on_non_data-1
+ (func $br_on_non_i31-1
   (drop
    (block $any (result anyref)
     (drop
-     ;; An i31 is not data, and so we should branch.
-     (br_on_non_data $any
-      (i31.new (i32.const 0))
+     ;; An struct is not an i31, and so we should branch.
+     (br_on_non_i31 $any
+      (struct.new $struct)
      )
     )
     (ref.null any)
    )
   )
  )
- ;; CHECK:      (func $br_on_non_data-2 (type $ref|data|_=>_none) (param $data (ref data))
+ ;; CHECK:      (func $br_on_non_i31-2 (type $none_=>_none)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block $any (result nullref)
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (local.get $data)
+ ;; CHECK-NEXT:     (i31.new
+ ;; CHECK-NEXT:      (i32.const 0)
+ ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $br_on_non_data-2 (param $data (ref data))
+ (func $br_on_non_i31-2
   (drop
    (block $any (result anyref)
     (drop
-     ;; Data is provided here, and so we will not branch.
-     (br_on_non_data $any
-      (local.get $data)
+     ;; An i31 is provided here, and so we will not branch.
+     (br_on_non_i31 $any
+      (i31.new (i32.const 0))
      )
     )
     (ref.null any)
@@ -68,7 +68,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $br_on-if (param $0 (ref data))
+ (func $br_on-if (param $0 (ref struct))
   (block $label
    (drop
     ;; This br is never taken, as the input is non-nullable, so we can remove
@@ -78,7 +78,7 @@
     (br_on_null $label
      ;; This if can also be turned into a select, separately from the above
      ;; (that is not specifically intended to be tested here).
-     (if (result (ref data))
+     (if (result (ref struct))
       (i32.const 0)
       (local.get $0)
       (local.get $0)
@@ -88,25 +88,27 @@
   )
  )
 
- ;; CHECK:      (func $nested_br_on (type $none_=>_dataref) (result dataref)
- ;; CHECK-NEXT:  (block $label$1 (result (ref $struct))
+ ;; CHECK:      (func $nested_br_on (type $none_=>_i31ref) (result i31ref)
+ ;; CHECK-NEXT:  (block $label$1 (result (ref i31))
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (br $label$1
- ;; CHECK-NEXT:     (struct.new_default $struct)
+ ;; CHECK-NEXT:     (i31.new
+ ;; CHECK-NEXT:      (i32.const 0)
+ ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $nested_br_on (result dataref)
-  (block $label$1 (result dataref)
+ (func $nested_br_on (result i31ref)
+  (block $label$1 (result i31ref)
    (drop
-    ;; The inner br_on_data will become a direct br since the type proves it
+    ;; The inner br_on_i31 will become a direct br since the type proves it
     ;; is in fact data. That then becomes unreachable, and the parent must
     ;; handle that properly (do nothing without hitting an assertion).
-    (br_on_data $label$1
-     (br_on_data $label$1
-      (struct.new_default $struct)
+    (br_on_i31 $label$1
+     (br_on_i31 $label$1
+      (i31.new (i32.const 0))
      )
     )
    )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -6,9 +6,11 @@
 (module
   ;; Regression test in which we need to calculate a proper LUB.
   ;; CHECK:      (func $selectify-fresh-lub (type $i32_=>_anyref) (param $x i32) (result anyref)
-  ;; CHECK-NEXT:  (select (result nullref)
+  ;; CHECK-NEXT:  (select (result i31ref)
   ;; CHECK-NEXT:   (ref.null none)
-  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:   (i31.new
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -16,10 +18,10 @@
     (if
       (local.get $x)
       (return
-        (ref.null i31)
+        (ref.null none)
       )
       (return
-        (ref.null data)
+        (i31.new (i32.const 0))
       )
     )
   )

--- a/test/lit/passes/rse-gc.wast
+++ b/test/lit/passes/rse-gc.wast
@@ -3,12 +3,12 @@
 
 (module
  ;; CHECK:      (type $A (struct (field dataref)))
- (type $A (struct_subtype (field (ref null data)) data))
+ (type $A (struct (field (ref null struct))))
 
  ;; $B is a subtype of $A, and its field has a more refined type (it is non-
  ;; nullable).
  ;; CHECK:      (type $B (struct_subtype (field (ref data)) $A))
- (type $B (struct_subtype (field (ref data)) $A))
+ (type $B (struct_subtype (field (ref struct)) $A))
 
  ;; CHECK:      (func $test (type $none_=>_none)
  ;; CHECK-NEXT:  (local $single (ref func))

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -735,8 +735,7 @@
   )
 )
 
-;; As above, but the values are now ref.nulls. All nulls compare equal, so we
-;; can still optimize even though the types differ.
+;; As above, but the values are now ref.nulls.
 (module
   ;; CHECK:      (type $sig-foo (func))
   (type $sig-foo (func_subtype (param anyref) func))
@@ -762,8 +761,8 @@
   ;; CHECK-NEXT: )
   (func $foo (type $sig-foo) (param $anyref anyref)
     (drop (local.get $anyref))
-    (call $foo (ref.null any))
-    (call $foo (ref.null data))
+    (call $foo (ref.null none))
+    (call $foo (ref.null none))
   )
 
   ;; CHECK:      (func $bar (type $sig-bar) (param $anyref anyref)
@@ -783,7 +782,7 @@
     (drop (local.get $anyref))
     ;; Mixing a null with something else prevents optimization, of course.
     (call $bar (i31.new (i32.const 0)))
-    (call $bar (ref.null data))
+    (call $bar (ref.null none))
   )
 )
 
@@ -791,7 +790,7 @@
   ;; CHECK:      (type $none_=>_none (func))
 
   ;; CHECK:      (type $A (struct ))
-  (type $A (struct_subtype data))
+  (type $A (struct))
   ;; CHECK:      (func $0 (type $none_=>_none)
   ;; CHECK-NEXT:  (local $0 f32)
   ;; CHECK-NEXT:  (ref.cast_static $A

--- a/test/lit/passes/simplify-locals-gc.wast
+++ b/test/lit/passes/simplify-locals-gc.wast
@@ -21,11 +21,11 @@
   ;; NOMNL:      (type $struct-immutable (struct (field i32)))
   (type $struct-immutable (struct (field i32)))
 
-  (type $A (struct_subtype (field (ref null data)) data))
+  (type $A (struct_subtype (field (ref null struct)) data))
 
   ;; $B is a subtype of $A, and its field has a more refined type (it is non-
   ;; nullable).
-  (type $B (struct_subtype (field (ref data)) $A))
+  (type $B (struct_subtype (field (ref struct)) $A))
 
   ;; Writes to heap objects cannot be reordered with reads.
   ;; CHECK:      (func $no-reorder-past-write (type $ref|$struct|_=>_i32) (param $x (ref $struct)) (result i32)
@@ -716,7 +716,7 @@
   (func $remove-tee-refinalize
     (param $a (ref null $A))
     (param $b (ref null $B))
-    (result (ref null data))
+    (result (ref null struct))
 
     ;; The local.tee receives a $B and flows out an $A. After we remove it (it is
     ;; obviously unnecessary), the struct.get will be reading from the more

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -82,20 +82,20 @@
 
 (module
   ;; Multiple writes to a field, with a LUB that is not equal to any of them.
-  ;; We can at least improve from dataref to a ref of $struct here. Note also
+  ;; We can at least improve from structref to a ref of $struct here. Note also
   ;; that we do so in all three types, not just the parent to which we write
   ;; (the children have no writes, but must still be updated).
 
   ;; CHECK:      (type $struct (struct (field (mut (ref $struct)))))
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child-A|_ref|$child-B|_=>_none (func (param (ref $struct) (ref $child-A) (ref $child-B))))
 
   ;; CHECK:      (type $child-A (struct_subtype (field (mut (ref $struct))) $struct))
-  (type $child-A (struct_subtype (field (mut dataref)) $struct))
+  (type $child-A (struct_subtype (field (mut structref)) $struct))
 
   ;; CHECK:      (type $child-B (struct_subtype (field (mut (ref $struct))) $struct))
-  (type $child-B (struct_subtype (field (mut dataref)) $struct))
+  (type $child-B (struct_subtype (field (mut structref)) $struct))
 
   ;; CHECK:      (func $work (type $ref|$struct|_ref|$child-A|_ref|$child-B|_=>_none) (param $struct (ref $struct)) (param $child-A (ref $child-A)) (param $child-B (ref $child-B))
   ;; CHECK-NEXT:  (struct.set $struct 0
@@ -126,16 +126,16 @@
   ;; CHECK:      (type $struct (struct (field (mut (ref $child-A)))))
 
   ;; CHECK:      (type $child-A (struct_subtype (field (mut (ref $child-A))) $struct))
-  (type $child-A (struct_subtype (field (mut dataref)) $struct))
+  (type $child-A (struct_subtype (field (mut structref)) $struct))
 
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child-A|_=>_none (func (param (ref $struct) (ref $child-A))))
 
   ;; CHECK:      (type $none_=>_none (func))
 
   ;; CHECK:      (type $child-B (struct_subtype (field (mut (ref $child-A))) $struct))
-  (type $child-B (struct_subtype (field (mut dataref)) $struct))
+  (type $child-B (struct_subtype (field (mut structref)) $struct))
 
   ;; CHECK:      (func $work (type $ref|$struct|_ref|$child-A|_=>_none) (param $struct (ref $struct)) (param $child-A (ref $child-A))
   ;; CHECK-NEXT:  (struct.set $struct 0
@@ -176,10 +176,10 @@
   ;; $struct but not to $child.
 
   ;; CHECK:      (type $struct (struct (field (mut (ref $struct)))))
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref $struct))) $struct))
-  (type $child (struct_subtype (field (mut dataref)) $struct))
+  (type $child (struct_subtype (field (mut structref)) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -211,9 +211,9 @@
   ;; CHECK:      (type $struct (struct (field (mut (ref $child)))))
 
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref $child))) $struct))
-  (type $child (struct_subtype (field (mut dataref)) $struct))
+  (type $child (struct_subtype (field (mut structref)) $struct))
 
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -246,10 +246,10 @@
   ;; child's.
 
   ;; CHECK:      (type $struct (struct (field (mut (ref $struct)))))
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref $struct))) $struct))
-  (type $child (struct_subtype (field (mut dataref)) $struct))
+  (type $child (struct_subtype (field (mut structref)) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -290,10 +290,10 @@
   ;; testcase after this.)
 
   ;; CHECK:      (type $struct (struct (field (ref $struct))))
-  (type $struct (struct_subtype (field dataref) data))
+  (type $struct (struct_subtype (field structref) data))
 
   ;; CHECK:      (type $child (struct_subtype (field (ref $child)) $struct))
-  (type $child (struct_subtype (field dataref) $struct))
+  (type $child (struct_subtype (field structref) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -329,10 +329,10 @@
   ;; improvement!)
 
   ;; CHECK:      (type $struct (struct (field (mut (ref $struct)))))
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref $struct))) $struct))
-  (type $child (struct_subtype (field (mut dataref)) $struct))
+  (type $child (struct_subtype (field (mut structref)) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -368,10 +368,10 @@
   ;; to $child.
 
   ;; CHECK:      (type $struct (struct (field (mut (ref $struct)))))
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref $struct))) (field (mut (ref $child))) $struct))
-  (type $child (struct_subtype (field (mut dataref)) (field (mut dataref)) $struct))
+  (type $child (struct_subtype (field (mut structref)) (field (mut structref)) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -408,7 +408,7 @@
   ;; the old type).
 
   ;; CHECK:      (type $struct (struct (field (mut (ref $struct)))))
-  (type $struct (struct_subtype (field (mut dataref)) data))
+  (type $struct (struct_subtype (field (mut structref)) data))
 
   ;; CHECK:      (type $ref|$struct|_=>_none (func (param (ref $struct))))
 
@@ -456,7 +456,7 @@
 
   (type $A (struct_subtype (field (ref $X)) data))
 
-  (type $X (struct_subtype data))
+  (type $X (struct))
 
   ;; CHECK:      (func $foo (type $none_=>_none)
   ;; CHECK-NEXT:  (local $unused (ref null $C))
@@ -491,7 +491,7 @@
   ;; no writes to them. There are no optimizations to do here.
 
   ;; CHECK:      (type $X (struct ))
-  (type $X (struct_subtype data))
+  (type $X (struct))
 
   ;; CHECK:      (type $none_=>_none (func))
 
@@ -524,7 +524,7 @@
 
 (module
   ;; CHECK:      (type $X (struct ))
-  (type $X (struct_subtype data))
+  (type $X (struct))
   ;; CHECK:      (type $none_=>_none (func))
 
   ;; CHECK:      (type $A (struct (field (ref $X))))
@@ -562,7 +562,7 @@
 
 (module
   ;; CHECK:      (type $struct (struct (field (mut (ref null $struct)))))
-  (type $struct (struct_subtype (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) data))
 
   ;; CHECK:      (type $ref|$struct|_=>_none (func (param (ref $struct))))
 
@@ -584,9 +584,8 @@
     )
     (struct.set $struct 0
       (local.get $struct)
-      ;; This null can be updated, allowing us to refine the type of the field
-      ;; to a null of $struct.
-      (ref.null data)
+      ;; This null does not prevent refinement.
+      (ref.null none)
     )
   )
 )
@@ -596,9 +595,9 @@
   ;; refine the field to nullable $struct.
 
   ;; CHECK:      (type $struct (struct (field (mut (ref null $struct)))))
-  (type $struct (struct_subtype (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) data))
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref null $struct))) $struct))
-  (type $child (struct_subtype (field (mut (ref null data))) $struct))
+  (type $child (struct_subtype (field (mut (ref null struct))) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -619,7 +618,7 @@
     )
     (struct.set $child 0
       (local.get $child)
-      (ref.null data)
+      (ref.null none)
     )
   )
 )
@@ -628,9 +627,9 @@
   ;; As above, but now the null is in a parent. The result should be the same.
 
   ;; CHECK:      (type $struct (struct (field (mut (ref null $struct)))))
-  (type $struct (struct_subtype (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) data))
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref null $struct))) $struct))
-  (type $child (struct_subtype (field (mut (ref null data))) $struct))
+  (type $child (struct_subtype (field (mut (ref null struct))) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -647,7 +646,7 @@
   (func $update-null (param $struct (ref $struct)) (param $child (ref $child))
     (struct.set $struct 0
       (local.get $struct)
-      (ref.null data)
+      (ref.null none)
     )
     (struct.set $child 0
       (local.get $child)
@@ -658,7 +657,7 @@
 
 (module
   ;; CHECK:      (type $struct (struct (field (mut nullref))))
-  (type $struct (struct_subtype (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) data))
 
   ;; CHECK:      (type $ref|$struct|_=>_none (func (param (ref $struct))))
 
@@ -678,7 +677,7 @@
 
 (module
   ;; CHECK:      (type $struct (struct (field (mut (ref null $struct)))))
-  (type $struct (struct_subtype (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) data))
 
   ;; CHECK:      (type $ref|$struct|_=>_none (func (param (ref $struct))))
 
@@ -706,7 +705,7 @@
 
 (module
   ;; CHECK:      (type $struct (struct (field (mut (ref null $struct)))))
-  (type $struct (struct_subtype (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) data))
 
   ;; CHECK:      (type $ref|$struct|_=>_none (func (param (ref $struct))))
 
@@ -723,10 +722,10 @@
   ;; CHECK-NEXT: )
   (func $work (param $struct (ref $struct))
     ;; As before, but instead of new_default, new, and use a null in the given
-    ;; value, which should be updated.
+    ;; value.
     (drop
       (struct.new $struct
-        (ref.null data)
+        (ref.null none)
       )
     )
     (struct.set $struct 0
@@ -738,10 +737,10 @@
 
 (module
   ;; CHECK:      (type $struct (struct (field (mut (ref null $child))) (field (mut (ref null $struct)))))
-  (type $struct (struct_subtype (field (mut (ref null data))) (field (mut (ref null data))) data))
+  (type $struct (struct_subtype (field (mut (ref null struct))) (field (mut (ref null struct))) data))
 
   ;; CHECK:      (type $child (struct_subtype (field (mut (ref null $child))) (field (mut (ref null $struct))) $struct))
-  (type $child (struct_subtype (field (mut (ref null data))) (field (mut (ref null data))) $struct))
+  (type $child (struct_subtype (field (mut (ref null struct))) (field (mut (ref null struct))) $struct))
 
   ;; CHECK:      (type $ref|$struct|_ref|$child|_=>_none (func (param (ref $struct) (ref $child))))
 
@@ -765,12 +764,12 @@
     (drop
       (struct.new $struct
         (local.get $child)
-        (ref.null data)
+        (ref.null none)
       )
     )
     (drop
       (struct.new $struct
-        (ref.null data)
+        (ref.null none)
         (local.get $struct)
       )
     )
@@ -810,7 +809,7 @@
 
   (type $Root-Outer (struct_subtype (field (ref $Root-Inner)) data))
 
-  (type $Root-Inner (struct_subtype  data))
+  (type $Root-Inner (struct))
 
   (type $Leaf1-Inner (struct_subtype (field i32) $Root-Inner))
 

--- a/test/passes/Oz_fuzz-exec_all-features.txt
+++ b/test/passes/Oz_fuzz-exec_all-features.txt
@@ -18,19 +18,10 @@
 [LoggingExternalInterface logging 999]
 [fuzz-exec] calling cast-null-anyref-to-gc
 [LoggingExternalInterface logging 0]
-[fuzz-exec] calling br_on_data
-[LoggingExternalInterface logging 1]
-[fuzz-exec] calling br_on_non_data-null
-[fuzz-exec] calling br_on_non_data-data
-[LoggingExternalInterface logging 1]
-[fuzz-exec] calling br_on_non_data-other
 [fuzz-exec] calling br-on_non_null
 [fuzz-exec] calling br-on_non_null-2
 [LoggingExternalInterface logging 1]
 [trap unreachable]
-[fuzz-exec] calling ref-as-data-of-func
-[trap not a data]
-[fuzz-exec] calling ref-as-data-of-data
 [fuzz-exec] calling ref-as-func-of-data
 [trap not a func]
 [fuzz-exec] calling ref-as-func-of-func
@@ -74,7 +65,6 @@
  (type $struct (struct (field (mut i32))))
  (type $i32_=>_none (func (param i32)))
  (type $extendedstruct (struct (field (mut i32)) (field f64)))
- (type $anyref_=>_none (func (param anyref)))
  (type $int_func (func (result i32)))
  (import "fuzzing-support" "log-i32" (func $log (param i32)))
  (export "structs" (func $0))
@@ -83,26 +73,20 @@
  (export "br_on_failed_cast-1" (func $3))
  (export "br_on_failed_cast-2" (func $4))
  (export "cast-null-anyref-to-gc" (func $5))
- (export "br_on_data" (func $7))
- (export "br_on_non_data-null" (func $8))
- (export "br_on_non_data-data" (func $9))
- (export "br_on_non_data-other" (func $8))
- (export "br-on_non_null" (func $8))
- (export "br-on_non_null-2" (func $12))
- (export "ref-as-data-of-func" (func $13))
- (export "ref-as-data-of-data" (func $8))
- (export "ref-as-func-of-data" (func $13))
- (export "ref-as-func-of-func" (func $8))
- (export "cast-on-func" (func $18))
- (export "array-alloc-failure" (func $8))
- (export "init-array-packed" (func $20))
- (export "cast-func-to-struct" (func $13))
- (export "array-copy" (func $23))
- (export "array.init" (func $24))
- (export "array.init-packed" (func $25))
- (export "static-casts" (func $26))
+ (export "br-on_non_null" (func $7))
+ (export "br-on_non_null-2" (func $8))
+ (export "ref-as-func-of-data" (func $9))
+ (export "ref-as-func-of-func" (func $7))
+ (export "cast-on-func" (func $12))
+ (export "array-alloc-failure" (func $7))
+ (export "init-array-packed" (func $14))
+ (export "cast-func-to-struct" (func $9))
+ (export "array-copy" (func $17))
+ (export "array.init" (func $18))
+ (export "array.init-packed" (func $19))
+ (export "static-casts" (func $20))
  (export "static-br_on_cast" (func $2))
- (export "static-br_on_cast_fail" (func $28))
+ (export "static-br_on_cast_fail" (func $22))
  (func $0 (type $void_func) (; has Stack IR ;)
   (local $0 i32)
   (call $log
@@ -202,30 +186,10 @@
    (i32.const 0)
   )
  )
- (func $7 (type $anyref_=>_none) (; has Stack IR ;) (param $0 anyref)
-  (drop
-   (block $data (result (ref data))
-    (drop
-     (br_on_data $data
-      (local.get $0)
-     )
-    )
-    (call $log
-     (i32.const 1)
-    )
-    (struct.new_default $struct)
-   )
-  )
- )
- (func $8 (type $void_func) (; has Stack IR ;)
+ (func $7 (type $void_func) (; has Stack IR ;)
   (nop)
  )
- (func $9 (type $void_func) (; has Stack IR ;)
-  (call $log
-   (i32.const 1)
-  )
- )
- (func $12 (type $void_func) (; has Stack IR ;)
+ (func $8 (type $void_func) (; has Stack IR ;)
   (drop
    (block
     (call $log
@@ -235,12 +199,12 @@
    )
   )
  )
- (func $13 (type $void_func) (; has Stack IR ;)
+ (func $9 (type $void_func) (; has Stack IR ;)
   (drop
    (unreachable)
   )
  )
- (func $18 (type $void_func) (; has Stack IR ;)
+ (func $12 (type $void_func) (; has Stack IR ;)
   (call $log
    (i32.const 0)
   )
@@ -252,7 +216,7 @@
   )
   (unreachable)
  )
- (func $20 (type $int_func) (; has Stack IR ;) (result i32)
+ (func $14 (type $int_func) (; has Stack IR ;) (result i32)
   (array.get_u $bytes
    (array.new $bytes
     (i32.const -43)
@@ -261,7 +225,7 @@
    (i32.const 10)
   )
  )
- (func $23 (type $void_func) (; has Stack IR ;)
+ (func $17 (type $void_func) (; has Stack IR ;)
   (local $0 (ref $bytes))
   (local $1 (ref $bytes))
   (array.set $bytes
@@ -316,7 +280,7 @@
    )
   )
  )
- (func $24 (type $void_func) (; has Stack IR ;)
+ (func $18 (type $void_func) (; has Stack IR ;)
   (local $0 (ref $bytes))
   (call $log
    (array.len
@@ -341,7 +305,7 @@
    )
   )
  )
- (func $25 (type $void_func) (; has Stack IR ;)
+ (func $19 (type $void_func) (; has Stack IR ;)
   (call $log
    (array.get_u $bytes
     (array.init_static $bytes
@@ -351,7 +315,7 @@
    )
   )
  )
- (func $26 (type $void_func) (; has Stack IR ;)
+ (func $20 (type $void_func) (; has Stack IR ;)
   (call $log
    (i32.const 1)
   )
@@ -371,7 +335,7 @@
    (i32.const 0)
   )
  )
- (func $28 (type $void_func) (; has Stack IR ;)
+ (func $22 (type $void_func) (; has Stack IR ;)
   (call $log
    (i32.const -2)
   )
@@ -397,19 +361,10 @@
 [LoggingExternalInterface logging 999]
 [fuzz-exec] calling cast-null-anyref-to-gc
 [LoggingExternalInterface logging 0]
-[fuzz-exec] calling br_on_data
-[LoggingExternalInterface logging 1]
-[fuzz-exec] calling br_on_non_data-null
-[fuzz-exec] calling br_on_non_data-data
-[LoggingExternalInterface logging 1]
-[fuzz-exec] calling br_on_non_data-other
 [fuzz-exec] calling br-on_non_null
 [fuzz-exec] calling br-on_non_null-2
 [LoggingExternalInterface logging 1]
 [trap unreachable]
-[fuzz-exec] calling ref-as-data-of-func
-[trap unreachable]
-[fuzz-exec] calling ref-as-data-of-data
 [fuzz-exec] calling ref-as-func-of-data
 [trap unreachable]
 [fuzz-exec] calling ref-as-func-of-func

--- a/test/passes/Oz_fuzz-exec_all-features.wast
+++ b/test/passes/Oz_fuzz-exec_all-features.wast
@@ -153,70 +153,8 @@
    )
   )
  )
- (func $get_data (result dataref)
+ (func $get_struct (result structref)
   (struct.new_default $struct)
- )
- (func "br_on_data" (param $x anyref)
-  (local $y anyref)
-  (drop
-   (block $data (result dataref)
-    (local.set $y
-     (br_on_data $data (local.get $x))
-    )
-    (call $log (i32.const 1))
-    (call $get_data)
-   )
-  )
- )
- (func "br_on_non_data-null"
-  (local $x anyref)
-  (drop
-   (block $any (result anyref)
-    (drop
-     (br_on_non_data $any (local.get $x))
-    )
-    ;; $x is a null, and so it is not data, and the branch will be taken, and no
-    ;; logging will occur.
-    (call $log (i32.const 1))
-    (ref.null any)
-   )
-  )
- )
- (func "br_on_non_data-data"
-  (local $x anyref)
-  ;; set x to valid data
-  (local.set $x
-   (struct.new_default $struct)
-  )
-  (drop
-   (block $any (result anyref)
-    (drop
-     (br_on_non_data $any (local.get $x))
-    )
-    ;; $x refers to valid data, and so we will not branch, and will log.
-    (call $log (i32.const 1))
-    (ref.null any)
-   )
-  )
- )
- (func "br_on_non_data-other"
-  (local $x anyref)
-  ;; set x to something that is not null, but also not data
-  (local.set $x
-   (i31.new
-    (i32.const 0)
-   )
-  )
-  (drop
-   (block $any (result anyref)
-    (drop
-     (br_on_non_data $any (local.get $x))
-    )
-    ;; $x refers to an i31, so we will branch, and not log
-    (call $log (i32.const 1))
-    (ref.null any)
-   )
-  )
  )
  (func "br-on_non_null"
   (drop
@@ -236,21 +174,6 @@
     ;; $x is null, and so we will not branch, and log and then trap
     (call $log (i32.const 1))
     (unreachable)
-   )
-  )
- )
- (func "ref-as-data-of-func"
-  (drop
-   ;; This should trap.
-   (ref.as_data
-    (ref.func $0)
-   )
-  )
- )
- (func "ref-as-data-of-data"
-  (drop
-   (ref.as_data
-    (struct.new_default $struct)
    )
   )
  )

--- a/test/passes/remove-unused-brs_all-features.txt
+++ b/test/passes/remove-unused-brs_all-features.txt
@@ -83,26 +83,6 @@
    (i32.const 4)
   )
   (drop
-   (block $data (result (ref $vector))
-    (drop
-     (br $data
-      (array.new_default $vector
-       (i32.const 1)
-      )
-     )
-    )
-    (call $log
-     (i32.const 5)
-    )
-    (array.new_default $vector
-     (i32.const 2)
-    )
-   )
-  )
-  (call $log
-   (i32.const 6)
-  )
-  (drop
    (block $i31 (result (ref i31))
     (drop
      (br $i31
@@ -112,7 +92,7 @@
      )
     )
     (call $log
-     (i32.const 7)
+     (i32.const 5)
     )
     (i31.new
      (i32.const 1337)
@@ -120,7 +100,7 @@
    )
   )
   (call $log
-   (i32.const 8)
+   (i32.const 6)
   )
   (drop
    (block $non-null (result (ref $ref|func|_=>_none))
@@ -128,31 +108,13 @@
      (ref.func $br_on-to-br)
     )
     (call $log
-     (i32.const 9)
+     (i32.const 7)
     )
     (ref.func $br_on-to-br)
    )
   )
  )
  (func $br_on-to-flow (type $none_=>_none)
-  (drop
-   (block $data (result nullref)
-    (drop
-     (ref.func $br_on-to-flow)
-    )
-    (ref.null none)
-   )
-  )
-  (drop
-   (block $datab (result nullref)
-    (drop
-     (i31.new
-      (i32.const 1337)
-     )
-    )
-    (ref.null none)
-   )
-  )
   (drop
    (block $func (result nullfuncref)
     (drop

--- a/test/passes/remove-unused-brs_all-features.wast
+++ b/test/passes/remove-unused-brs_all-features.wast
@@ -75,23 +75,6 @@
   )
   (call $log (i32.const 4))
   (drop
-   (block $data (result dataref)
-    ;; a non-null data reference means we always take the br
-    (drop
-     (br_on_data $data
-      (array.new_default $vector
-       (i32.const 1)
-      )
-     )
-    )
-    (call $log (i32.const 5))
-    (array.new_default $vector
-     (i32.const 2)
-    )
-   )
-  )
-  (call $log (i32.const 6))
-  (drop
    (block $i31 (result i31ref)
     ;; a non-null i31 reference means we always take the br
     (drop
@@ -99,16 +82,16 @@
       (i31.new (i32.const 42))
      )
     )
-    (call $log (i32.const 7))
+    (call $log (i32.const 5))
     (i31.new (i32.const 1337))
    )
   )
-  (call $log (i32.const 8))
+  (call $log (i32.const 6))
   (drop
    (block $non-null (result (ref func))
     ;; a non-null reference is not null, and the br is always taken
     (br_on_non_null $non-null (ref.func $br_on-to-br))
-    (call $log (i32.const 9))
+    (call $log (i32.const 7))
     (ref.func $br_on-to-br)
    )
   )
@@ -117,27 +100,6 @@
  ;; a br_on of the obviously incorrect kind can just flow out the value as the
  ;; break is never taken
  (func $br_on-to-flow
-  ;; brs to data
-  (drop
-   (block $data (result (ref null data))
-    (drop
-     (br_on_data $data
-      (ref.func $br_on-to-flow)
-     )
-    )
-    (ref.null data)
-   )
-  )
-  (drop
-   (block $datab (result (ref null data))
-    (drop
-     (br_on_data $datab
-      (i31.new (i32.const 1337))
-     )
-    )
-    (ref.null data)
-   )
-  )
   ;; brs to func
   (drop
    (block $func (result (ref null func))

--- a/test/passes/vacuum_all-features.wast
+++ b/test/passes/vacuum_all-features.wast
@@ -802,7 +802,7 @@
  (type $A (struct (field (mut i32))))
  (func $foo
   (drop
-   (block (result dataref)
+   (block (result structref)
     ;; this dropped item can be vacuumed out in principle, but it is a non-
     ;; nullable reference type and we don't have a type to put in its place, so
     ;; don't try to replace it. (later operations will remove all the body of


### PR DESCRIPTION
The upstream WasmGC spec has removed `data` and introduced `struct`. To make the
migration easier, we have been supporting `struct` as an `alias` for `data` and
`structref` as an alias for `dataref`.

Update the tests to prefer the `struct` aliases over `data` for test input to
make the future migration easier. Also update some tests that had stale comments
about ref.null types being updated and remove some tests for instructions like
br_on_data and ref.as_data that do not make sense without a `data` type.