### PR TITLE
binaryen.js: Properly export malloc/free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ if(EMSCRIPTEN)
   # make the tools immediately usable on Node.js
   add_link_flag("-sNODERAWFS")
   # in opt builds, LTO helps so much (>20%) it's worth slow compile times
-  add_nondebug_compile_flag("-flto")
+  # add_nondebug_compile_flag("-flto")
 endif()
 
 # clang doesn't print colored diagnostics when invoked from Ninja
@@ -418,6 +418,7 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_wasm "-sNODERAWFS=0")
   target_link_libraries(binaryen_wasm "-sEXPORT_ES6")
   target_link_libraries(binaryen_wasm "-sEXPORTED_RUNTIME_METHODS=allocateUTF8OnStack")
+  target_link_libraries(binaryen_wasm "-sEXPORTED_FUNCTIONS=_malloc,_free")
   target_link_libraries(binaryen_wasm "--post-js=${CMAKE_CURRENT_SOURCE_DIR}/src/js/binaryen.js-post.js")
   target_link_libraries(binaryen_wasm "-msign-ext")
   target_link_libraries(binaryen_wasm "-mbulk-memory")
@@ -456,6 +457,7 @@ if(EMSCRIPTEN)
     target_link_libraries(binaryen_js "-sEXPORT_ES6=1")
   endif()
   target_link_libraries(binaryen_js "-sEXPORTED_RUNTIME_METHODS=allocateUTF8OnStack")
+  target_link_libraries(binaryen_js "-sEXPORTED_FUNCTIONS=_malloc,_free")
   target_link_libraries(binaryen_js "--post-js=${CMAKE_CURRENT_SOURCE_DIR}/src/js/binaryen.js-post.js")
   # js_of_ocaml needs a specified variable with special comment to provide the library to consumers
   if(JS_OF_OCAML)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ if(EMSCRIPTEN)
   # make the tools immediately usable on Node.js
   add_link_flag("-sNODERAWFS")
   # in opt builds, LTO helps so much (>20%) it's worth slow compile times
-  # add_nondebug_compile_flag("-flto")
+  add_nondebug_compile_flag("-flto")
 endif()
 
 # clang doesn't print colored diagnostics when invoked from Ninja


### PR DESCRIPTION
This should unbreak the build. This is an old problem but was just noticed due to
a recent emscripten change (https://github.com/emscripten-core/emscripten/pull/18292).