### PR TITLE
Fix regression of assertions in asyncify pass

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -886,6 +886,10 @@ struct InstrumentedPassRunner : public PassRunner {
   InstrumentedPassRunner(Module* wasm, ModuleAnalyzer* analyzer)
     : PassRunner(wasm), analyzer(analyzer) {}
 
+  void addForAll(std::unique_ptr<Pass> pass) {
+    PassRunner::doAdd(std::move(pass));
+  }
+
 protected:
   void doAdd(std::unique_ptr<Pass> pass) override {
     PassRunner::doAdd(
@@ -1683,7 +1687,10 @@ struct Asyncify : public Pass {
         runner.add("reorder-locals");
         runner.add("merge-blocks");
       }
-      runner.add(
+      // AsyncifyFlow must run on all functions no matter instrumented them
+      // or not, because it may add assertions for functions that are
+      // not instrumented
+      runner.addForAll(
         make_unique<AsyncifyFlow>(&analyzer, pointerType, asyncifyMemory));
       runner.setIsNested(true);
       runner.setValidateGlobally(false);

--- a/test/lit/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-onlylist@waka.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-onlylist@waka.wast
@@ -39,14 +39,44 @@
   ;; CHECK:      (export "asyncify_get_state" (func $asyncify_get_state))
 
   ;; CHECK:      (func $calls-import
-  ;; CHECK-NEXT:  (call $import)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:   (global.get $__asyncify_state)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (call $import)
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.ne
+  ;; CHECK-NEXT:     (global.get $__asyncify_state)
+  ;; CHECK-NEXT:     (local.get $0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-import
     (call $import)
   )
   ;; CHECK:      (func $calls-import2-drop
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:   (global.get $__asyncify_state)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (call $import2)
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (call $import2)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (if
+  ;; CHECK-NEXT:     (i32.ne
+  ;; CHECK-NEXT:      (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      (local.get $0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (local.get $1)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-import2-drop
@@ -54,10 +84,29 @@
   )
   ;; CHECK:      (func $returns (result i32)
   ;; CHECK-NEXT:  (local $x i32)
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (call $import2)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (local $2 i32)
+  ;; CHECK-NEXT:  (local.set $1
+  ;; CHECK-NEXT:   (global.get $__asyncify_state)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.get $x)
+  ;; CHECK-NEXT:  (block (result i32)
+  ;; CHECK-NEXT:   (local.set $x
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (local.set $2
+  ;; CHECK-NEXT:      (call $import2)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (i32.ne
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $2)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $returns (result i32)
     (local $x i32)
@@ -65,8 +114,21 @@
     (local.get $x)
   )
   ;; CHECK:      (func $calls-indirect (param $x i32)
-  ;; CHECK-NEXT:  (call_indirect (type $f)
-  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (local.set $1
+  ;; CHECK-NEXT:   (global.get $__asyncify_state)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (call_indirect (type $f)
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.ne
+  ;; CHECK-NEXT:     (global.get $__asyncify_state)
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-indirect (param $x i32)


### PR DESCRIPTION
Ohh, I am really sorry but my last PR #5293 have an issue. The code run passes only on functions that are instrumented, because of that injection of assertions is not working.

`AsyncfiyFlow` is not runned for non instrumented functions, but this pass also adds assert messages:

```c++
  void runOnFunction(Module* module_, Function* func_) override {
    module = module_;
    func = func_;
    builder =
      make_unique<AsyncifyBuilder>(*module, pointerType, asyncifyMemory);
    // If the function cannot change our state, we have nothing to do -
    // we will never unwind or rewind the stack here.
    if (!analyzer->needsInstrumentation(func)) {
      if (analyzer->asserts) {
        addAssertsInNonInstrumented(func);
      }
      return;
    }

```

I modified the code to run `AsyncifyFlow` on all functions as before. Maybe is 
better to extract this part of `AsyncifyFlow` to something like `AssyncifyAssertsPass`
to be more precies. What do you think?

--
Seems that asyncify-only lit test was correct :facepalm: