### PR TITLE
Use non-nullable ref.cast for non-nullable input

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2116,7 +2116,12 @@ struct PrintExpressionContents
     if (curr->safety == RefCast::Unsafe) {
       printMedium(o, "ref.cast_nop ");
     } else {
-      printMedium(o, "ref.cast null ");
+      // Emulate legacy polymorphic behavior for now.
+      if (curr->ref->type.isNullable()) {
+        printMedium(o, "ref.cast null ");
+      } else {
+        printMedium(o, "ref.cast ");
+      }
     }
     printHeapType(o, curr->intendedType, wasm);
   }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1118,18 +1118,18 @@ enum ASTNodes {
   I31GetS = 0x21,
   I31GetU = 0x22,
   RefTest = 0x40,
-  // TODO: RefTestNull
-  RefCastNull = 0x49,
-  // TODO: RefCastNull
+  RefCast = 0x41,
   BrOnCast = 0x42,
-  // TODO: BrOnCastNull
   BrOnCastFail = 0x43,
-  // TODO: BrOnCastFailNull
   RefTestStatic = 0x44,
   RefCastStatic = 0x45,
   BrOnCastStatic = 0x46,
   BrOnCastStaticFail = 0x47,
   RefCastNop = 0x48,
+  // TODO: RefTestNull
+  RefCastNull = 0x49,
+  // TODO: BrOnCastNull
+  // TODO: BrOnCastFailNull
   RefIsFunc = 0x50,
   RefIsData = 0x51,
   RefIsI31 = 0x52,

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6915,7 +6915,8 @@ bool WasmBinaryBuilder::maybeVisitRefCast(Expression*& out, uint32_t code) {
     if (ref->type.isRef()) {
       if (code == BinaryConsts::RefCast && ref->type.isNullable()) {
         throwError("ref.cast on nullable input not yet supported");
-      } else if (code == BinaryConsts::RefCastNull && !ref->type.isNullable()) {
+      } else if (code == BinaryConsts::RefCastNull &&
+                 ref->type.isNonNullable()) {
         throwError("ref.cast null on non-nullable input not yet supported");
       }
     }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6904,12 +6904,21 @@ bool WasmBinaryBuilder::maybeVisitRefTest(Expression*& out, uint32_t code) {
 }
 
 bool WasmBinaryBuilder::maybeVisitRefCast(Expression*& out, uint32_t code) {
-  if (code == BinaryConsts::RefCastStatic ||
+  if (code == BinaryConsts::RefCastStatic || code == BinaryConsts::RefCast ||
       code == BinaryConsts::RefCastNull || code == BinaryConsts::RefCastNop) {
     bool legacy =
       code == BinaryConsts::RefCastStatic || code == BinaryConsts::RefCastNop;
     auto intendedType = legacy ? getIndexedHeapType() : getHeapType();
     auto* ref = popNonVoidExpression();
+    // Even though we're parsing new instructions, we only support those that
+    // emulate the legacy polymorphic behavior for now.
+    if (ref->type.isRef()) {
+      if (code == BinaryConsts::RefCast && ref->type.isNullable()) {
+        throwError("ref.cast on nullable input not yet supported");
+      } else if (code == BinaryConsts::RefCastNull && !ref->type.isNullable()) {
+        throwError("ref.cast null on non-nullable input not yet supported");
+      }
+    }
     auto safety =
       code == BinaryConsts::RefCastNop ? RefCast::Unsafe : RefCast::Safe;
     out = Builder(wasm).makeRefCast(ref, intendedType, safety);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2797,7 +2797,7 @@ Expression* SExpressionWasmBuilder::makeRefCast(Element& s) {
     if (*nullability == NonNullable && ref->type.isNullable()) {
       throw ParseException(
         "ref.cast on nullable input not yet supported", s.line, s.col);
-    } else if (*nullability == Nullable && !ref->type.isNullable()) {
+    } else if (*nullability == Nullable && ref->type.isNonNullable()) {
       throw ParseException(
         "ref.cast null on non-nullable input not yet supported", s.line, s.col);
     }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2033,10 +2033,16 @@ void BinaryInstWriter::visitRefCast(RefCast* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   if (curr->safety == RefCast::Unsafe) {
     o << U32LEB(BinaryConsts::RefCastNop);
+    parent.writeIndexedHeapType(curr->intendedType);
   } else {
-    o << U32LEB(BinaryConsts::RefCastNull);
+    // Emulate legacy polymorphic behavior for now.
+    if (curr->ref->type.isNullable()) {
+      o << U32LEB(BinaryConsts::RefCastNull);
+    } else {
+      o << U32LEB(BinaryConsts::RefCast);
+    }
+    parent.writeHeapType(curr->intendedType);
   }
-  parent.writeHeapType(curr->intendedType);
 }
 
 void BinaryInstWriter::visitBrOn(BrOn* curr) {

--- a/test/ctor-eval/gc-2.wast
+++ b/test/ctor-eval/gc-2.wast
@@ -38,7 +38,7 @@
   (func "keepalive" (result i32)
     (select
       (struct.get $struct 0
-        (ref.cast null $struct
+        (ref.cast $struct
           (global.get $global1)
         )
       )
@@ -51,4 +51,3 @@
     )
   )
 )
-

--- a/test/ctor-eval/gc-2.wast.out
+++ b/test/ctor-eval/gc-2.wast.out
@@ -14,7 +14,7 @@
  (func $1 (type $none_=>_i32) (result i32)
   (select
    (struct.get $struct 0
-    (ref.cast null $struct
+    (ref.cast $struct
      (global.get $global1)
     )
    )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -1089,7 +1089,7 @@
     ;; trapping contents in ref.cast, but not br_on_cast, so test both.
     (drop
       (struct.get $parent 0
-        (ref.cast null $parent
+        (ref.cast $parent
           (struct.new $unrelated)
         )
       )
@@ -1706,7 +1706,7 @@
     (drop
       (ref.as_non_null
         (array.get $something-child
-          (ref.cast null $something-child
+          (ref.cast $something-child
             (array.new_default $something
               (i32.const 10)
             )
@@ -2528,7 +2528,7 @@
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $substruct
+  ;; CHECK-NEXT:   (ref.cast $substruct
   ;; CHECK-NEXT:    (struct.new $substruct
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
@@ -2536,7 +2536,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $substruct
+  ;; CHECK-NEXT:   (ref.cast $substruct
   ;; CHECK-NEXT:    (struct.new $subsubstruct
   ;; CHECK-NEXT:     (i32.const 3)
   ;; CHECK-NEXT:     (i32.const 4)
@@ -2549,7 +2549,7 @@
     ;; The cast here will fail, and the ref.cast null allows nothing through, so we
     ;; can emit an unreachable here.
     (drop
-      (ref.cast null $substruct
+      (ref.cast $substruct
         (struct.new $struct
           (i32.const 0)
         )
@@ -2558,7 +2558,7 @@
     ;; This cast of a type to itself can succeed (in fact, it will), so we make
     ;; no changes here.
     (drop
-      (ref.cast null $substruct
+      (ref.cast $substruct
         (struct.new $substruct
           (i32.const 1)
           (i32.const 2)
@@ -2567,7 +2567,7 @@
     )
     ;; This cast of a subtype will also succeed. As above, we make no changes.
     (drop
-      (ref.cast null $substruct
+      (ref.cast $substruct
         (struct.new $subsubstruct
           (i32.const 3)
           (i32.const 4)
@@ -2672,7 +2672,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $struct
+  ;; CHECK-NEXT:   (ref.cast $struct
   ;; CHECK-NEXT:    (select (result (ref $struct))
   ;; CHECK-NEXT:     (struct.new $struct
   ;; CHECK-NEXT:      (i32.const 1)
@@ -2686,7 +2686,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $substruct
+  ;; CHECK-NEXT:   (ref.cast $substruct
   ;; CHECK-NEXT:    (select (result (ref $struct))
   ;; CHECK-NEXT:     (struct.new $struct
   ;; CHECK-NEXT:      (i32.const 4)
@@ -2716,10 +2716,10 @@
         )
       )
     )
-    ;; The input to the ref.cast null is either $struct or $substruct, both of which
+    ;; The input to the ref.cast is either $struct or $substruct, both of which
     ;; work, so we cannot optimize anything here away.
     (drop
-      (ref.cast null $struct
+      (ref.cast $struct
         (select
           (struct.new $struct
             (i32.const 1)
@@ -2735,7 +2735,7 @@
     ;; As above, but now we test with $substruct, so one possibility fails and
     ;; one succeeds. We cannot infer here either.
     (drop
-      (ref.cast null $substruct
+      (ref.cast $substruct
         (select
           (struct.new $struct
             (i32.const 4)
@@ -2752,7 +2752,7 @@
     ;; can infer an unreachable. The combination of these two is a cone from
     ;; $struct of depth 1, which does not overlap with $subsubstruct.
     (drop
-      (ref.cast null $subsubstruct
+      (ref.cast $subsubstruct
         (select
           (struct.new $struct
             (i32.const 7)
@@ -3633,7 +3633,7 @@
 
   ;; CHECK:      (func $foo (type $none_=>_ref|$B|) (result (ref $B))
   ;; CHECK-NEXT:  (local $A (ref null $A))
-  ;; CHECK-NEXT:  (ref.cast null $B
+  ;; CHECK-NEXT:  (ref.cast $B
   ;; CHECK-NEXT:   (ref.as_non_null
   ;; CHECK-NEXT:    (local.tee $A
   ;; CHECK-NEXT:     (struct.new $B
@@ -3649,9 +3649,9 @@
 
     ;; Read the following from the most nested comment first.
 
-    (ref.cast null $B ;; if we mistakenly think this contains content of
-                        ;; type $A, it would trap, but it should not, and we
-                        ;; have nothing to optimize here
+    (ref.cast $B ;; if we mistakenly think this contains content of
+                 ;; type $A, it would trap, but it should not, and we
+                 ;; have nothing to optimize here
       (ref.as_non_null ;; also $B, based on the child's *contents* (not type!)
         (local.tee $A ;; flows out a $B, but has type $A
           (struct.new $B ;; returns a $B

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -529,7 +529,7 @@
     ;; As the get must trap, we can optimize to an unreachable here.
     (drop
       (struct.get $substruct 0
-        (ref.cast null $substruct
+        (ref.cast $substruct
           (call $create)
         )
       )
@@ -588,7 +588,7 @@
   (func $get
     (drop
       (struct.get $substruct 0
-        (ref.cast null $substruct
+        (ref.cast $substruct
           (call $create)
         )
       )
@@ -802,7 +802,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.cast null $substruct
+  ;; CHECK-NEXT:     (ref.cast $substruct
   ;; CHECK-NEXT:      (select (result (ref $struct))
   ;; CHECK-NEXT:       (struct.new $struct
   ;; CHECK-NEXT:        (i32.const 10)
@@ -823,7 +823,7 @@
     (drop
       (struct.get $struct 0
         ;; This cast is added, ensuring only a $substruct can reach the get.
-        (ref.cast null $substruct
+        (ref.cast $substruct
           (select
             (struct.new $struct
               (i32.const 10)
@@ -2041,7 +2041,7 @@
   )
   ;; CHECK:      (func $set (type $none_=>_none)
   ;; CHECK-NEXT:  (struct.set $A 0
-  ;; CHECK-NEXT:   (ref.cast null $A
+  ;; CHECK-NEXT:   (ref.cast $A
   ;; CHECK-NEXT:    (call $create-C)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.const 20)
@@ -2052,7 +2052,7 @@
     ;; the type is $A, which should not confuse us: this set does alias the data
     ;; in $C, which means we cannot optimize in the function $get below.
     (struct.set $A 0
-      (ref.cast null $A
+      (ref.cast $A
         (call $create-C)
       )
       (i32.const 20) ;; different value than in $create

--- a/test/lit/passes/inlining-optimizing.wast
+++ b/test/lit/passes/inlining-optimizing.wast
@@ -33,7 +33,7 @@
   (call $0)
   (drop
    (call_ref $none_=>_i32
-    (ref.cast null $none_=>_i32
+    (ref.cast $none_=>_i32
      (ref.func $0)
     )
    )

--- a/test/lit/passes/inlining_vacuum_optimize-instructions.wast
+++ b/test/lit/passes/inlining_vacuum_optimize-instructions.wast
@@ -19,7 +19,7 @@
 
  ;; CHECK:      (func $target (type $ref?|$A|_=>_none) (param $0 (ref null $A))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (ref.cast null $B
+ ;; CHECK-NEXT:   (ref.cast $B
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/monomorphize.wast
+++ b/test/lit/passes/monomorphize.wast
@@ -405,7 +405,7 @@
   ;; ALWAYS:      (func $refinable (type $ref|$A|_=>_none) (param $ref (ref $A))
   ;; ALWAYS-NEXT:  (local $x (ref $A))
   ;; ALWAYS-NEXT:  (call $import
-  ;; ALWAYS-NEXT:   (ref.cast null $B
+  ;; ALWAYS-NEXT:   (ref.cast $B
   ;; ALWAYS-NEXT:    (local.get $ref)
   ;; ALWAYS-NEXT:   )
   ;; ALWAYS-NEXT:  )
@@ -417,17 +417,17 @@
   ;; ALWAYS-NEXT:   )
   ;; ALWAYS-NEXT:  )
   ;; ALWAYS-NEXT:  (call $import
-  ;; ALWAYS-NEXT:   (ref.cast null $B
+  ;; ALWAYS-NEXT:   (ref.cast $B
   ;; ALWAYS-NEXT:    (local.get $x)
   ;; ALWAYS-NEXT:   )
   ;; ALWAYS-NEXT:  )
   ;; ALWAYS-NEXT:  (call $import
-  ;; ALWAYS-NEXT:   (ref.cast null $B
+  ;; ALWAYS-NEXT:   (ref.cast $B
   ;; ALWAYS-NEXT:    (local.get $x)
   ;; ALWAYS-NEXT:   )
   ;; ALWAYS-NEXT:  )
   ;; ALWAYS-NEXT:  (call $import
-  ;; ALWAYS-NEXT:   (ref.cast null $B
+  ;; ALWAYS-NEXT:   (ref.cast $B
   ;; ALWAYS-NEXT:    (local.get $ref)
   ;; ALWAYS-NEXT:   )
   ;; ALWAYS-NEXT:  )
@@ -435,12 +435,12 @@
   ;; CAREFUL:      (func $refinable (type $ref|$A|_=>_none) (param $0 (ref $A))
   ;; CAREFUL-NEXT:  (local $1 (ref $A))
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast null $B
+  ;; CAREFUL-NEXT:   (ref.cast $B
   ;; CAREFUL-NEXT:    (local.get $0)
   ;; CAREFUL-NEXT:   )
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast null $B
+  ;; CAREFUL-NEXT:   (ref.cast $B
   ;; CAREFUL-NEXT:    (local.tee $1
   ;; CAREFUL-NEXT:     (select (result (ref $A))
   ;; CAREFUL-NEXT:      (local.get $0)
@@ -451,12 +451,12 @@
   ;; CAREFUL-NEXT:   )
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast null $B
+  ;; CAREFUL-NEXT:   (ref.cast $B
   ;; CAREFUL-NEXT:    (local.get $1)
   ;; CAREFUL-NEXT:   )
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast null $B
+  ;; CAREFUL-NEXT:   (ref.cast $B
   ;; CAREFUL-NEXT:    (local.get $0)
   ;; CAREFUL-NEXT:   )
   ;; CAREFUL-NEXT:  )
@@ -470,7 +470,7 @@
     ;; cast will remain since we monomorphize without bothering to optimize and
     ;; see if there is any benefit.)
     (call $import
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $ref)
       )
     )
@@ -485,18 +485,18 @@
       )
     )
     (call $import
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $x)
       )
     )
     (call $import
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $x)
       )
     )
     ;; Another use of $ref, also to avoid opts merging $x and $ref.
     (call $import
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $ref)
       )
     )
@@ -506,7 +506,7 @@
 ;; ALWAYS:      (func $refinable_0 (type $ref|$B|_=>_none) (param $ref (ref $B))
 ;; ALWAYS-NEXT:  (local $x (ref $A))
 ;; ALWAYS-NEXT:  (call $import
-;; ALWAYS-NEXT:   (ref.cast null $B
+;; ALWAYS-NEXT:   (ref.cast $B
 ;; ALWAYS-NEXT:    (local.get $ref)
 ;; ALWAYS-NEXT:   )
 ;; ALWAYS-NEXT:  )
@@ -518,17 +518,17 @@
 ;; ALWAYS-NEXT:   )
 ;; ALWAYS-NEXT:  )
 ;; ALWAYS-NEXT:  (call $import
-;; ALWAYS-NEXT:   (ref.cast null $B
+;; ALWAYS-NEXT:   (ref.cast $B
 ;; ALWAYS-NEXT:    (local.get $x)
 ;; ALWAYS-NEXT:   )
 ;; ALWAYS-NEXT:  )
 ;; ALWAYS-NEXT:  (call $import
-;; ALWAYS-NEXT:   (ref.cast null $B
+;; ALWAYS-NEXT:   (ref.cast $B
 ;; ALWAYS-NEXT:    (local.get $x)
 ;; ALWAYS-NEXT:   )
 ;; ALWAYS-NEXT:  )
 ;; ALWAYS-NEXT:  (call $import
-;; ALWAYS-NEXT:   (ref.cast null $B
+;; ALWAYS-NEXT:   (ref.cast $B
 ;; ALWAYS-NEXT:    (local.get $ref)
 ;; ALWAYS-NEXT:   )
 ;; ALWAYS-NEXT:  )

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -96,7 +96,7 @@
   ;; CHECK-NEXT:  (local $1 (ref $A))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $1
-  ;; CHECK-NEXT:    (ref.cast null $A
+  ;; CHECK-NEXT:    (ref.cast $A
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -112,7 +112,7 @@
     ;; As $ref.as but with ref.casts: we should use the cast value after it has
     ;; been computed, in both gets.
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $x)
       )
     )
@@ -128,7 +128,7 @@
   ;; CHECK-NEXT:  (local $1 (ref $A))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $1
-  ;; CHECK-NEXT:    (ref.cast null $A
+  ;; CHECK-NEXT:    (ref.cast $A
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -145,7 +145,7 @@
   ;; CHECK-NEXT: )
   (func $not-past-set (param $x (ref struct))
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $x)
       )
     )
@@ -166,7 +166,7 @@
   ;; CHECK-NEXT:  (local $2 (ref $B))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $1
-  ;; CHECK-NEXT:    (ref.cast null $A
+  ;; CHECK-NEXT:    (ref.cast $A
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -176,7 +176,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $2
-  ;; CHECK-NEXT:    (ref.cast null $B
+  ;; CHECK-NEXT:    (ref.cast $B
   ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -187,7 +187,7 @@
   ;; CHECK-NEXT: )
   (func $best (param $x (ref struct))
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $x)
       )
     )
@@ -196,7 +196,7 @@
       (local.get $x)
     )
     (drop
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $x)
       )
     )
@@ -210,7 +210,7 @@
   ;; CHECK-NEXT:  (local $1 (ref $B))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $1
-  ;; CHECK-NEXT:    (ref.cast null $B
+  ;; CHECK-NEXT:    (ref.cast $B
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -219,7 +219,7 @@
   ;; CHECK-NEXT:   (local.get $1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $A
+  ;; CHECK-NEXT:   (ref.cast $A
   ;; CHECK-NEXT:    (local.get $1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -231,7 +231,7 @@
     ;; As above, but with the casts reversed. Now we should use $B in both
     ;; gets.
     (drop
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $x)
       )
     )
@@ -239,7 +239,7 @@
       (local.get $x)
     )
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $x)
       )
     )
@@ -252,7 +252,7 @@
   ;; CHECK-NEXT:  (local $1 (ref $A))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $1
-  ;; CHECK-NEXT:    (ref.cast null $A
+  ;; CHECK-NEXT:    (ref.cast $A
   ;; CHECK-NEXT:     (block (result (ref data))
   ;; CHECK-NEXT:      (local.get $x)
   ;; CHECK-NEXT:     )
@@ -265,7 +265,7 @@
   ;; CHECK-NEXT: )
   (func $fallthrough (param $x (ref struct))
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         ;; We look through the block, and optimize.
         (block (result (ref struct))
           (local.get $x)
@@ -279,7 +279,7 @@
 
   ;; CHECK:      (func $past-basic-block (type $ref|data|_=>_none) (param $x (ref data))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $A
+  ;; CHECK-NEXT:   (ref.cast $A
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -293,7 +293,7 @@
   ;; CHECK-NEXT: )
   (func $past-basic-block (param $x (ref struct))
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $x)
       )
     )
@@ -321,14 +321,14 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $4
-  ;; CHECK-NEXT:    (ref.cast null $A
+  ;; CHECK-NEXT:    (ref.cast $A
   ;; CHECK-NEXT:     (local.get $a)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $5
-  ;; CHECK-NEXT:    (ref.cast null $A
+  ;; CHECK-NEXT:    (ref.cast $A
   ;; CHECK-NEXT:     (local.get $b)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -360,12 +360,12 @@
       (local.get $y)
     )
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $a)
       )
     )
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (local.get $b)
       )
     )

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -175,7 +175,7 @@
   ;; call_ref that returns nothing with a call that returns an i32. In fact, we
   ;; end up optimizing the cast into an unreachable.
   (call_ref $none_=>_i32
-   (ref.cast null $none_=>_i32
+   (ref.cast $none_=>_i32
     (ref.func $return-nothing)
    )
   )

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -41,7 +41,7 @@
   ;; CHECK-NEXT:   (local.get $child)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $child
+  ;; CHECK-NEXT:   (ref.cast $child
   ;; CHECK-NEXT:    (local.get $parent)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -62,7 +62,7 @@
   ;; NOMNL-NEXT:   (local.get $child)
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast null $child
+  ;; NOMNL-NEXT:   (ref.cast $child
   ;; NOMNL-NEXT:    (local.get $parent)
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
@@ -83,7 +83,7 @@
   ;; NOMNL-TNH-NEXT:   (local.get $child)
   ;; NOMNL-TNH-NEXT:  )
   ;; NOMNL-TNH-NEXT:  (drop
-  ;; NOMNL-TNH-NEXT:   (ref.cast null $child
+  ;; NOMNL-TNH-NEXT:   (ref.cast $child
   ;; NOMNL-TNH-NEXT:    (local.get $parent)
   ;; NOMNL-TNH-NEXT:   )
   ;; NOMNL-TNH-NEXT:  )
@@ -104,13 +104,13 @@
     ;; a cast of parent to parent. We can optimize this as the new type will be
     ;; valid.
     (drop
-      (ref.cast null $parent
+      (ref.cast $parent
         (local.get $parent)
       )
     )
     ;; a cast of child to a supertype: again, we replace with a valid type.
     (drop
-      (ref.cast null $parent
+      (ref.cast $parent
         (local.get $child)
       )
     )
@@ -118,13 +118,13 @@
     ;; $child with one that is not equal or more specific, like $parent, so we
     ;; cannot optimize here.
     (drop
-      (ref.cast null $child
+      (ref.cast $child
         (local.get $parent)
       )
     )
     ;; a cast of child to an unrelated type: it will trap anyhow
     (drop
-      (ref.cast null $other
+      (ref.cast $other
         (local.get $child)
       )
     )
@@ -138,7 +138,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $parent
+  ;; CHECK-NEXT:   (ref.cast $parent
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -151,7 +151,7 @@
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast null $parent
+  ;; NOMNL-NEXT:   (ref.cast $parent
   ;; NOMNL-NEXT:    (unreachable)
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
@@ -164,7 +164,7 @@
   ;; NOMNL-TNH-NEXT:   )
   ;; NOMNL-TNH-NEXT:  )
   ;; NOMNL-TNH-NEXT:  (drop
-  ;; NOMNL-TNH-NEXT:   (ref.cast null $parent
+  ;; NOMNL-TNH-NEXT:   (ref.cast $parent
   ;; NOMNL-TNH-NEXT:    (unreachable)
   ;; NOMNL-TNH-NEXT:   )
   ;; NOMNL-TNH-NEXT:  )
@@ -174,7 +174,7 @@
 
     ;; optimizing this cast away requires reordering.
     (drop
-      (ref.cast null $parent
+      (ref.cast $parent
         (block (result (ref $parent))
           (call $foo)
           (local.get $parent)
@@ -280,14 +280,14 @@
   ;; NOMNL-TNH-NEXT: )
   (func $test (param $C (ref $C)) (result anyref)
     (struct.get $B 0
-      (ref.cast null $B ;; Try to cast a $C to its parent, $B. That always
-                          ;; works, so the cast can be removed.
-                          ;; Then once the cast is removed, the outer struct.get
-                          ;; will have a reference with a different type,
-                          ;; making it a (struct.get $C ..) instead of $B.
-                          ;; But $B and $C have different types on field 0, and
-                          ;; so the struct.get must be refinalized so the node
-                          ;; has the expected type.
+      (ref.cast $B ;; Try to cast a $C to its parent, $B. That always
+                   ;; works, so the cast can be removed.
+                   ;; Then once the cast is removed, the outer struct.get
+                   ;; will have a reference with a different type,
+                   ;; making it a (struct.get $C ..) instead of $B.
+                   ;; But $B and $C have different types on field 0, and
+                   ;; so the struct.get must be refinalized so the node
+                   ;; has the expected type.
         (local.get $C)
       )
     )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -85,7 +85,7 @@
 
   ;; TNH:      (func $ref.is (type $eqref_=>_i32) (param $a eqref) (result i32)
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (ref.cast null $struct
+  ;; TNH-NEXT:   (ref.cast $struct
   ;; TNH-NEXT:    (ref.as_data
   ;; TNH-NEXT:     (local.get $a)
   ;; TNH-NEXT:    )
@@ -95,7 +95,7 @@
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $ref.is (type $eqref_=>_i32) (param $a eqref) (result i32)
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (ref.cast null $struct
+  ;; NO_TNH-NEXT:   (ref.cast $struct
   ;; NO_TNH-NEXT:    (ref.as_data
   ;; NO_TNH-NEXT:     (local.get $a)
   ;; NO_TNH-NEXT:    )
@@ -107,7 +107,7 @@
     ;; In this case non-nullability is enough to tell that the ref.is will
     ;; return 0. TNH does not help here.
     (ref.is_null
-      (ref.cast null $struct
+      (ref.cast $struct
         (ref.as_non_null
           (ref.as_data
             (local.get $a)

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -999,7 +999,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $struct
+  ;; CHECK-NEXT:   (ref.cast $struct
   ;; CHECK-NEXT:    (ref.as_i31
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
@@ -1022,7 +1022,7 @@
   ;; NOMNL-NEXT:   )
   ;; NOMNL-NEXT:  )
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast null $struct
+  ;; NOMNL-NEXT:   (ref.cast $struct
   ;; NOMNL-NEXT:    (ref.as_i31
   ;; NOMNL-NEXT:     (local.get $x)
   ;; NOMNL-NEXT:    )
@@ -1031,7 +1031,7 @@
   ;; NOMNL-NEXT: )
   (func $flip-cast-of-as-non-null (param $x anyref)
     (drop
-      (ref.cast null $struct
+      (ref.cast $struct
         ;; this can be moved through the ref.cast null outward.
         (ref.as_non_null
           (local.get $x)
@@ -1041,7 +1041,7 @@
     (drop
       ;; an example of how this helps: the struct.get will trap on null anyhow
       (struct.get_u $struct 0
-        (ref.cast null $struct
+        (ref.cast $struct
           ;; this can be moved through the ref.cast null outward.
           (ref.as_non_null
             (local.get $x)
@@ -1051,7 +1051,7 @@
     )
     ;; other ref.as* operations are ignored for now
     (drop
-      (ref.cast null $struct
+      (ref.cast $struct
         (ref.as_i31
           (local.get $x)
         )
@@ -1585,7 +1585,7 @@
     ;; equal, and the result must be 0.
     (drop
       (ref.eq
-        (ref.cast null $struct
+        (ref.cast $struct
           (ref.as_non_null
             (local.get $x)
           )
@@ -1601,7 +1601,7 @@
         (ref.cast null $struct
           (local.get $x)
         )
-        (ref.cast null $array
+        (ref.cast $array
           (ref.as_non_null
             (local.get $y)
           )
@@ -1611,12 +1611,12 @@
     ;; As above but the cast is both.
     (drop
       (ref.eq
-        (ref.cast null $struct
+        (ref.cast $struct
           (ref.as_non_null
             (local.get $x)
           )
         )
-        (ref.cast null $array
+        (ref.cast $array
           (ref.as_non_null
             (local.get $y)
           )
@@ -1690,12 +1690,12 @@
     ;; subtype of A, so we cannot optimize.
     (drop
       (ref.eq
-        (ref.cast null $A
+        (ref.cast $A
           (ref.as_non_null
             (local.get $x)
           )
         )
-        (ref.cast null $B
+        (ref.cast $B
           (ref.as_non_null
             (local.get $y)
           )
@@ -1705,12 +1705,12 @@
     ;; As above but flipped.
     (drop
       (ref.eq
-        (ref.cast null $B
+        (ref.cast $B
           (ref.as_non_null
             (local.get $x)
           )
         )
-        (ref.cast null $A
+        (ref.cast $A
           (ref.as_non_null
             (local.get $y)
           )
@@ -1783,7 +1783,7 @@
   ;; NOMNL-NEXT: )
   (func $incompatible-cast-of-non-null (param $struct (ref $struct))
     (drop
-      (ref.cast null $array
+      (ref.cast $array
         (local.get $struct)
       )
     )
@@ -1840,7 +1840,7 @@
       )
     )
     (drop
-      (ref.cast null $array
+      (ref.cast $array
         ;; The fallthrough is null, but the node's child's type is non-nullable,
         ;; so we must add a ref.as_non_null on the outside to keep the type
         ;; identical.
@@ -1966,7 +1966,7 @@
 
   ;; CHECK:      (func $consecutive-opts-with-unreachable (type $funcref_=>_none) (param $func funcref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $struct
+  ;; CHECK-NEXT:   (ref.cast $struct
   ;; CHECK-NEXT:    (block (result (ref i31))
   ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (local.get $func)
@@ -1978,7 +1978,7 @@
   ;; CHECK-NEXT: )
   ;; NOMNL:      (func $consecutive-opts-with-unreachable (type $funcref_=>_none) (param $func funcref)
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast null $struct
+  ;; NOMNL-NEXT:   (ref.cast $struct
   ;; NOMNL-NEXT:    (block (result (ref i31))
   ;; NOMNL-NEXT:     (drop
   ;; NOMNL-NEXT:      (local.get $func)
@@ -1990,7 +1990,7 @@
   ;; NOMNL-NEXT: )
   (func $consecutive-opts-with-unreachable (param $func funcref)
     (drop
-      (ref.cast null $struct
+      (ref.cast $struct
         ;; Casting a funcref to i31 will definitely fail, so this will be
         ;; replaced with an unreachable. But it should be enclosed in a block of
         ;; the previous type, so that the outside ref.cast null is not confused. This
@@ -2503,7 +2503,7 @@
   ;; CHECK-NEXT:      (call $ref-cast-static-fallthrough-remaining-impossible
   ;; CHECK-NEXT:       (local.get $x)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (ref.cast null $struct
+  ;; CHECK-NEXT:      (ref.cast $struct
   ;; CHECK-NEXT:       (local.get $x)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
@@ -2520,7 +2520,7 @@
   ;; NOMNL-NEXT:      (call $ref-cast-static-fallthrough-remaining-impossible
   ;; NOMNL-NEXT:       (local.get $x)
   ;; NOMNL-NEXT:      )
-  ;; NOMNL-NEXT:      (ref.cast null $struct
+  ;; NOMNL-NEXT:      (ref.cast $struct
   ;; NOMNL-NEXT:       (local.get $x)
   ;; NOMNL-NEXT:      )
   ;; NOMNL-NEXT:     )
@@ -2534,12 +2534,12 @@
       ;; As above, but with an impossible cast of an array to a struct. The
       ;; block with the side effects and the inner cast must be kept around and
       ;; dropped, and then we replace the outer cast with an unreachable.
-      (ref.cast null $array
+      (ref.cast $array
         (block (result (ref eq))
           (call $ref-cast-static-fallthrough-remaining-impossible
             (local.get $x)
           )
-          (ref.cast null $struct
+          (ref.cast $struct
             (local.get $x)
           )
         )
@@ -2549,12 +2549,12 @@
 
   ;; CHECK:      (func $ref-cast-static-fallthrough-remaining-nonnull (type $ref|eq|_=>_none) (param $x (ref eq))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $A
+  ;; CHECK-NEXT:   (ref.cast $A
   ;; CHECK-NEXT:    (block (result (ref eq))
   ;; CHECK-NEXT:     (call $ref-cast-static-fallthrough-remaining
   ;; CHECK-NEXT:      (local.get $x)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (ref.cast null $B
+  ;; CHECK-NEXT:     (ref.cast $B
   ;; CHECK-NEXT:      (local.get $x)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -2563,12 +2563,12 @@
   ;; CHECK-NEXT: )
   ;; NOMNL:      (func $ref-cast-static-fallthrough-remaining-nonnull (type $ref|eq|_=>_none) (param $x (ref eq))
   ;; NOMNL-NEXT:  (drop
-  ;; NOMNL-NEXT:   (ref.cast null $A
+  ;; NOMNL-NEXT:   (ref.cast $A
   ;; NOMNL-NEXT:    (block (result (ref eq))
   ;; NOMNL-NEXT:     (call $ref-cast-static-fallthrough-remaining
   ;; NOMNL-NEXT:      (local.get $x)
   ;; NOMNL-NEXT:     )
-  ;; NOMNL-NEXT:     (ref.cast null $B
+  ;; NOMNL-NEXT:     (ref.cast $B
   ;; NOMNL-NEXT:      (local.get $x)
   ;; NOMNL-NEXT:     )
   ;; NOMNL-NEXT:    )
@@ -2582,12 +2582,12 @@
     ;; the middle block prevents us from seeing that (after other opts run,
     ;; however, we would).
     (drop
-      (ref.cast null $A
+      (ref.cast $A
         (block (result (ref eq))
           (call $ref-cast-static-fallthrough-remaining
             (local.get $x)
           )
-          (ref.cast null $B
+          (ref.cast $B
             (local.get $x)
           )
         )
@@ -2647,8 +2647,8 @@
       )
     )
     (drop
-      (ref.cast null $struct
-        (ref.cast null $array
+      (ref.cast $struct
+        (ref.cast $array
           (ref.as_non_null (local.get $x))
         )
       )

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -1166,7 +1166,7 @@
 
  ;; CHECK:      (func $odd-cast-and-get-non-null (type $ref|$func-return-i32|_=>_none) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (ref.cast null $func-return-i32
+ ;; CHECK-NEXT:   (ref.cast $func-return-i32
  ;; CHECK-NEXT:    (ref.func $receive-f64)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -1178,7 +1178,7 @@
  ;; CHECK-NEXT: )
  ;; NOMNL:      (func $odd-cast-and-get-non-null (type $ref|$func-return-i32|_=>_none) (param $temp (ref $func-return-i32))
  ;; NOMNL-NEXT:  (local.set $temp
- ;; NOMNL-NEXT:   (ref.cast null $func-return-i32
+ ;; NOMNL-NEXT:   (ref.cast $func-return-i32
  ;; NOMNL-NEXT:    (ref.func $receive-f64)
  ;; NOMNL-NEXT:   )
  ;; NOMNL-NEXT:  )
@@ -1191,7 +1191,7 @@
  (func $odd-cast-and-get-non-null (param $temp (ref $func-return-i32))
   ;; Try to cast a function to an incompatible type.
   (local.set $temp
-   (ref.cast null $func-return-i32
+   (ref.cast $func-return-i32
     (ref.func $receive-f64)
    )
   )

--- a/test/lit/passes/rse-gc.wast
+++ b/test/lit/passes/rse-gc.wast
@@ -113,7 +113,7 @@
  ;; CHECK:      (func $pick-refined-nn (type $ref|$A|_=>_none) (param $A (ref $A))
  ;; CHECK-NEXT:  (local $B (ref $B))
  ;; CHECK-NEXT:  (local.set $B
- ;; CHECK-NEXT:   (ref.cast null $B
+ ;; CHECK-NEXT:   (ref.cast $B
  ;; CHECK-NEXT:    (local.get $A)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -129,7 +129,7 @@
   ;; As above, but now the types are both non-nullable. We should still switch
   ;; to $B.
   (local.set $B
-   (ref.cast null $B
+   (ref.cast $B
     (local.get $A)
    )
   )
@@ -144,7 +144,7 @@
  ;; CHECK:      (func $avoid-unrefined (type $ref|$A|_=>_none) (param $A (ref $A))
  ;; CHECK-NEXT:  (local $B (ref null $B))
  ;; CHECK-NEXT:  (local.set $B
- ;; CHECK-NEXT:   (ref.cast null $B
+ ;; CHECK-NEXT:   (ref.cast $B
  ;; CHECK-NEXT:    (local.get $A)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -161,7 +161,7 @@
   ;; nullable, that means neither is a subtype of the other, and we will make
   ;; no changes.
   (local.set $B
-   (ref.cast null $B
+   (ref.cast $B
     (local.get $A)
    )
   )

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -793,7 +793,7 @@
   (type $A (struct))
   ;; CHECK:      (func $0 (type $none_=>_none)
   ;; CHECK-NEXT:  (local $0 f32)
-  ;; CHECK-NEXT:  (ref.cast null $A
+  ;; CHECK-NEXT:  (ref.cast $A
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )

--- a/test/lit/passes/simplify-locals-gc.wast
+++ b/test/lit/passes/simplify-locals-gc.wast
@@ -604,7 +604,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (struct.get $B 0
   ;; CHECK-NEXT:    (local.tee $B
-  ;; CHECK-NEXT:     (ref.cast null $B
+  ;; CHECK-NEXT:     (ref.cast $B
   ;; CHECK-NEXT:      (local.get $A)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -632,7 +632,7 @@
   ;; NOMNL-NEXT:  (drop
   ;; NOMNL-NEXT:   (struct.get $B 0
   ;; NOMNL-NEXT:    (local.tee $B
-  ;; NOMNL-NEXT:     (ref.cast null $B
+  ;; NOMNL-NEXT:     (ref.cast $B
   ;; NOMNL-NEXT:      (local.get $A)
   ;; NOMNL-NEXT:     )
   ;; NOMNL-NEXT:    )
@@ -655,7 +655,7 @@
     ;; nullability but not the heap type.
     (local $B (ref null $B))
     (local.set $B
-      (ref.cast null $B
+      (ref.cast $B
         (local.get $A)
       )
     )

--- a/test/passes/Oz_fuzz-exec_all-features.wast
+++ b/test/passes/Oz_fuzz-exec_all-features.wast
@@ -199,12 +199,12 @@
   (call $log (i32.const 0))
   ;; a valid cast
   (call_ref $void_func
-   (ref.cast null $void_func (ref.func $a-void-func))
+   (ref.cast $void_func (ref.func $a-void-func))
   )
   (call $log (i32.const 1))
   ;; an invalid cast
   (drop (call_ref $int_func
-   (ref.cast null $int_func (ref.func $a-void-func))
+   (ref.cast $int_func (ref.func $a-void-func))
   ))
   ;; will never be reached
   (call $log (i32.const 2))

--- a/test/spec/ref_cast.wast
+++ b/test/spec/ref_cast.wast
@@ -76,7 +76,7 @@
 
   (func (export "test-ref-cast-struct")
     (drop
-      (ref.cast null struct (struct.new $t0))
+      (ref.cast struct (struct.new $t0))
     )
   )
 


### PR DESCRIPTION
We switched from emitting the legacy `ref.cast_static` instruction to emitting
`ref.cast null` in #5331, but that wasn't quite correct. The legacy instruction
had polymorphic typing so that its output type was nullable if and only if its
input type was nullable. In contrast, `ref.cast null` always has a a nullable
output type.

Fix our output by instead emitting non-nullable `ref.cast` if the output should
be non-nullable. Parse `ref.cast` in binary and text forms as well. Since the IR
can only represent the legacy polymorphic semantics, disallow unsupported casts
from nullable to non-nullable references or vice versa for now.