### PR TITLE
[Wasm GC] Fix GlobalStructInference on unrefined globals

### DIFF
--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -123,14 +123,12 @@ struct GlobalStructInference : public Pass {
 
       auto type = global->init->type.getHeapType();
 
-      // The global's type must be a subtype of |eq| for us to do a comparison
-      // check on it later. For example a global declared as type |any| but that
-      // contains (ref $A) is not something we can optimize, as ref.eq on a
-      // global.get of that global will not validate. (This should not be a
-      // problem after GlobalSubtyping runs, which will specialize the type of
-      // the global.)
-      if (!global->type.isRef() ||
-          !HeapType::isSubType(global->type.getHeapType(), HeapType::eq)) {
+      // The global's declared type must match the init's type. If not, say if
+      // we had a global declared as type |any| but that contains (ref $A), then
+      // that is not something we can optimize, as ref.eq on a global.get of
+      // that global will not validate. (This should not be a problem after
+      // GlobalSubtyping runs, which will specialize the type of the global.)
+      if (global->type != global->init.type) {
         unoptimizable.insert(type);
         continue;
       }

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -211,14 +211,14 @@ struct GlobalStructInference : public Pass {
         // type (which is all that is left after we've already ruled out
         // unreachable).
         auto heapType = type.getHeapType();
-        if (!heapType.isStruct()) {
-          return;
-        }
-
-        auto iter = parent.typeGlobals.find(type.getHeapType());
+        auto iter = parent.typeGlobals.find(heapType);
         if (iter == parent.typeGlobals.end()) {
           return;
         }
+
+        // This cannot be a bottom type as we found it in the typeGlobals map,
+        // which only contains types of struct.news.
+        assert(heapType.isStruct());
 
         // The field must be immutable.
         auto fieldIndex = curr->index;

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -128,7 +128,7 @@ struct GlobalStructInference : public Pass {
       // that is not something we can optimize, as ref.eq on a global.get of
       // that global will not validate. (This should not be a problem after
       // GlobalSubtyping runs, which will specialize the type of the global.)
-      if (global->type != global->init.type) {
+      if (global->type != global->init->type) {
         unoptimizable.insert(type);
         continue;
       }

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -1239,3 +1239,32 @@
     )
   )
 )
+
+(module
+  ;; CHECK:      (type $A (struct (field i32)))
+  (type $A (struct (field i32)))
+
+  ;; CHECK:      (type $ref?|$A|_=>_i32 (func (param (ref null $A)) (result i32)))
+
+  ;; CHECK:      (global $A0 (ref $A) (struct.new $A
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $A0 (ref $A) (struct.new $A
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (func $func (type $ref?|$A|_=>_i32) (param $ref (ref null $A)) (result i32)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $func (param $ref (ref null $A)) (result i32)
+    ;; Test that we do not error when we see a struct.get of a bottom type.
+    (struct.get $A 0
+      (ref.null none)
+    )
+  )
+)

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -1175,3 +1175,67 @@
     )
   )
 )
+
+;; One global is declared as heap type |any|, which we cannot do a ref.eq on, so
+;; we do not optimize.
+(module
+  ;; CHECK:      (type $A (struct (field i32)))
+  (type $A (struct (field i32)))
+
+  ;; CHECK:      (type $ref?|$A|_=>_i32 (func (param (ref null $A)) (result i32)))
+
+  ;; CHECK:      (global $A0 (ref any) (struct.new $A
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $A0 (ref any) (struct.new $A
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $A1 (ref $A) (struct.new $A
+  ;; CHECK-NEXT:  (i32.const 9999)
+  ;; CHECK-NEXT: ))
+  (global $A1 (ref $A) (struct.new $A
+    (i32.const 9999)
+  ))
+
+  ;; CHECK:      (func $func (type $ref?|$A|_=>_i32) (param $ref (ref null $A)) (result i32)
+  ;; CHECK-NEXT:  (struct.get $A 0
+  ;; CHECK-NEXT:   (local.get $ref)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $func (param $ref (ref null $A)) (result i32)
+    (struct.get $A 0
+      (local.get $ref)
+    )
+  )
+)
+
+;; As above, but now there is just a single global. Again, we should not
+;; optimize because the global is not declared as a struct type (which means we
+;; cannot do a struct.get on a global.get of that global - we'd need a cast; it
+;; is simpler to not optimize here and let other passes first refine the global
+;; type).
+(module
+  ;; CHECK:      (type $A (struct (field i32)))
+  (type $A (struct (field i32)))
+
+  ;; CHECK:      (type $ref?|$A|_=>_i32 (func (param (ref null $A)) (result i32)))
+
+  ;; CHECK:      (global $A0 (ref any) (struct.new $A
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $A0 (ref any) (struct.new $A
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (func $func (type $ref?|$A|_=>_i32) (param $ref (ref null $A)) (result i32)
+  ;; CHECK-NEXT:  (struct.get $A 0
+  ;; CHECK-NEXT:   (local.get $ref)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $func (param $ref (ref null $A)) (result i32)
+    (struct.get $A 0
+      (local.get $ref)
+    )
+  )
+)


### PR DESCRIPTION
If a global's type is not fully refined, then when `--gsi` replaces a reference with
a `global.get`, we end up with a type that might not be good enough. For example,
if the type is `any` then it is not a subtype of `eq` and we can't do `ref.eq` on it, which
this pass requires. We also can't just do `struct.get` on it if it is a too-distant parent
or such.

Found by the fuzzer.