### PR TITLE
Add -D_LIBCPP_ENABLE_ASSERTIONS=1 to ASAN/UBSAN CI configurations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ASAN_OPTIONS: "symbolize=1"
-      COMPILER_FLAGS: "-fsanitize=address"
+      COMPILER_FLAGS: "-fsanitize=address -D_LIBCPP_ENABLE_ASSERTIONS=1"
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -202,7 +202,7 @@ jobs:
     name: ubsan
     runs-on: ubuntu-latest
     env:
-      COMPILER_FLAGS: "-fsanitize=undefined -fno-sanitize-recover=all"
+      COMPILER_FLAGS: "-fsanitize=undefined -fno-sanitize-recover=all -D_LIBCPP_ENABLE_ASSERTIONS=1"
       CC: "clang"
       CXX: "clang++"
     steps:


### PR DESCRIPTION
-D_LIBCPP_ENABLE_ASSERTIONS=1 enables container checking for C++ STL types, like std::vector, std::string, and std::optional. Note, it does not do any validation for iterators. This should address #5245.

I suspect there will be many test failures here before this can be merged. 