### PR TITLE
Refactor Multi-Memory Lowering pass to support additional instructions

### DIFF
--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -170,7 +170,6 @@ struct MultiMemoryLowering : public Pass {
       return boundsCheck;
     }
 
-
     template<typename T> Expression* getPtr(T* curr, Index bytes) {
       Expression* ptrValue = addOffsetGlobal(curr->ptr, curr->memory);
       if (parent.checkBounds) {


### PR DESCRIPTION
This PR breaks up the two main functions involved in each memory instruction (getPtr, makeBoundsCheck) into several smaller functions. This is a first step in adding support for bounds checks in the instructions memory: init, copy, and fill. Each of these instructions is a more unique case than the other memory instructions that have already been added to the Multi-Memory Lowering pass.