### PR TITLE
Fixed fuzzing of closed-world after #5347

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -131,6 +131,14 @@ def randomize_feature_opts():
     if '--disable-gc' not in FEATURE_OPTS:
         FEATURE_OPTS.append(TYPE_SYSTEM_FLAG)
 
+    # Pick closed or open with equal probability as both matter.
+    #
+    # Closed world is not a feature flag, technically, since it only makes sense
+    # to pass to wasm-opt (and not other tools). But decide on whether we'll
+    # be fuzzing in that mode now, as it determinies how we set other things up.
+    global CLOSED_WORLD
+    CLOSED_WORLD = random.random() < 0.5
+
 
 ALL_FEATURE_OPTS = ['--all-features', '-all', '--mvp-features', '-mvp']
 
@@ -402,9 +410,14 @@ def pick_initial_contents():
             return
         test_name = temp_test_name
 
-    # next, test the wasm.
+    # Next, test the wasm. Note that we must check for closed world explicitly
+    # here, as a testcase may only work in an open world, which means we need to
+    # skip it.
+    args = FEATURE_OPTS
+    if CLOSED_WORLD:
+        args += ['--closed-world']
     try:
-        run([in_bin('wasm-opt'), test_name] + FEATURE_OPTS,
+        run([in_bin('wasm-opt'), test_name] + args,
             stderr=subprocess.PIPE,
             silent=True)
     except Exception:
@@ -1381,7 +1394,7 @@ def randomize_opt_flags():
     if random.random() < 0.5:
         ret += ['-fimfs=99999999']
     # test both closed and open world
-    if random.random() < 0.5:
+    if CLOSED_WORLD:
         ret += ['--closed-world']
     assert ret.count('--flatten') <= 1
     return ret

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -416,7 +416,7 @@ def pick_initial_contents():
     # skip it.
     args = FEATURE_OPTS
     if CLOSED_WORLD:
-        args += [CLOSED_WORLD_FLAG]
+        args.append(CLOSED_WORLD_FLAG)
     try:
         run([in_bin('wasm-opt'), test_name] + args,
             stderr=subprocess.PIPE,

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -58,6 +58,7 @@ given_seed = None
 
 CLOSED_WORLD_FLAG = '--closed-world'
 
+
 # utilities
 
 def in_binaryen(*args):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -56,6 +56,7 @@ PRINT_WATS = False
 
 given_seed = None
 
+CLOSED_WORLD_FLAG = '--closed-world'
 
 # utilities
 
@@ -415,7 +416,7 @@ def pick_initial_contents():
     # skip it.
     args = FEATURE_OPTS
     if CLOSED_WORLD:
-        args += ['--closed-world']
+        args += [CLOSED_WORLD_FLAG]
     try:
         run([in_bin('wasm-opt'), test_name] + args,
             stderr=subprocess.PIPE,
@@ -1395,7 +1396,7 @@ def randomize_opt_flags():
         ret += ['-fimfs=99999999']
     # test both closed and open world
     if CLOSED_WORLD:
-        ret += ['--closed-world']
+        ret += [CLOSED_WORLD_FLAG]
     assert ret.count('--flatten') <= 1
     return ret
 


### PR DESCRIPTION
A initial content testcase may only work in open world, so check for that
using the existing mechanism of checking if such testcases work with out
feature flags.