### PR TITLE
Fuzzing: Work around canonicalization of function types in fuzzer for closed world

### DIFF
--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -2,6 +2,7 @@ FILE(GLOB ir_HEADERS *.h)
 set(ir_SOURCES
   ExpressionAnalyzer.cpp
   ExpressionManipulator.cpp
+  closed-world.cpp
   drop.cpp
   eh-utils.cpp
   intrinsics.cpp

--- a/src/ir/closed-world.cpp
+++ b/src/ir/closed-world.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_closed_world_h
+#define wasm_ir_closed_world_h
+
+#include "ir/closed-world.h"
+#include "wasm.h"
+
+namespace wasm {
+
+namespace {
+
+void ensurePrivateType(HeapType& type) {
+  // When a type is public, we assume all the types it refers to are public as
+  // well, which means all supertypes are. There is therefore a chance that if
+  // we use a supertype instead of a subtype then we will be using a private
+  // type instead of a public one. In closed world that is fine to do, so long
+  // as the types are structurally equal, which is the case for now until we get
+  // function subtyping. Note that even so it may not be enough, however, so we
+  // may need to add a method here that creates a fresh type in some cases.
+  while (1) {
+    if (auto super = type.getSuperType()) {
+      if (super->getSignature() == type.getSignature()) {
+        // These are structurally similar, so use the super.
+        type = *super;
+        continue;
+      }
+    }
+    break;
+  }
+}
+
+} // anonymous namespace
+
+void ensureClosedWorld(Module& module) {
+  for (auto& exp : module.exports) {
+    if (exp->kind == ExternalKind::Function) {
+      ensurePrivateType(module.getFunction(exp->value)->type);
+    }
+  }
+}
+
+} // namespace wasm
+
+#endif // wasm_ir_closed_world_h

--- a/src/ir/closed-world.h
+++ b/src/ir/closed-world.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_closed_world_h
+#define wasm_ir_closed_world_h
+
+#include "wasm.h"
+
+namespace wasm {
+
+// Modifies the module to make it validate in closed-world mode. Specifically
+// this will look for types on the boundary with the outside (public types) and
+// replace with with private types. It is up to the caller to ensure that such
+// changes are valid, but in general they should be in closed world mode.
+void ensureClosedWorld(Module& module);
+
+} // namespace wasm
+
+#endif // wasm_ir_closed_world_h

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -31,6 +31,7 @@
 //
 
 #include "asmjs/shared-constants.h"
+#include "ir/closed-world.h"
 #include "ir/element-utils.h"
 #include "ir/import-utils.h"
 #include "ir/literal-utils.h"
@@ -168,6 +169,11 @@ struct LegalizeJSInterface : public Pass {
 
     module->removeExport(GET_TEMP_RET_EXPORT);
     module->removeExport(SET_TEMP_RET_EXPORT);
+
+    // Fix up our new exports for closed world, if we need to.
+    if (getPassOptions().closedWorld) {
+      ensureClosedWorld(*module);
+    }
   }
 
 private:

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -23,22 +23,6 @@ namespace wasm {
 
 namespace {
 
-// Construct a fresh signature type for a given signature, and return its heap
-// type. This is useful when we do not want to get the default behavior of
-// reusing the "canonical" heap type for a signature, which can cause problems
-// in closed-world mode - in that mode the canonical heap type may be private,
-// so we should use a fresh type whenever we construct a function that will be
-// exported.
-static HeapType getFreshSignatureHeapType(Signature sig) {
-  TypeBuilder builder(1);
-  builder.setHeapType(0, sig);
-  return (*builder.build())[0];
-}
-
-static HeapType getFreshSignatureHeapType(Type params, Type results) {
-  return getFreshSignatureHeapType(Signature(params, results));
-}
-
 // Weighting for the core make* methods. Some nodes are important enough that
 // we should do them quite often.
 
@@ -270,11 +254,8 @@ void TranslateToFuzzReader::setupMemory() {
   }
   contents.push_back(builder.makeLocalGet(0, Type::i32));
   auto* body = builder.makeBlock(contents);
-  auto* hasher = wasm.addFunction(
-    builder.makeFunction("hashMemory",
-                         getFreshSignatureHeapType(Type::none, Type::i32),
-                         {Type::i32},
-                         body));
+  auto* hasher = wasm.addFunction(builder.makeFunction(
+    "hashMemory", Signature(Type::none, Type::i32), {Type::i32}, body));
   wasm.addExport(
     builder.makeExport(hasher->name, hasher->name, ExternalKind::Function));
   // Export memory so JS fuzzing can use it
@@ -445,7 +426,7 @@ void TranslateToFuzzReader::addHangLimitSupport() {
   auto funcName = Names::getValidFunctionName(wasm, exportName);
   auto* func = new Function;
   func->name = funcName;
-  func->type = getFreshSignatureHeapType(Type::none, Type::none);
+  func->type = Signature(Type::none, Type::none);
   func->body = builder.makeGlobalSet(HANG_LIMIT_GLOBAL,
                                      builder.makeConst(int32_t(HANG_LIMIT)));
   wasm.addFunction(func);
@@ -527,7 +508,7 @@ Function* TranslateToFuzzReader::addFunction() {
   }
   auto paramType = Type(params);
   auto resultType = getControlFlowType();
-  func->type = getFreshSignatureHeapType(paramType, resultType);
+  func->type = Signature(paramType, resultType);
   Index numVars = upToSquared(MAX_VARS);
   for (Index i = 0; i < numVars; i++) {
     auto type = getConcreteType();
@@ -912,8 +893,7 @@ void TranslateToFuzzReader::addInvocations(Function* func) {
   if (wasm.getFunctionOrNull(name) || wasm.getExportOrNull(name)) {
     return;
   }
-  auto invoker =
-    builder.makeFunction(name, getFreshSignatureHeapType(Signature()), {});
+  auto invoker = builder.makeFunction(name, Signature(), {});
   Block* body = builder.makeBlock();
   invoker->body = body;
   FunctionCreationContext context(*this, invoker.get());

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -23,6 +23,7 @@
 
 #include "execution-results.h"
 #include "fuzzing.h"
+#include "ir/closed-world.h"
 #include "js-wrapper.h"
 #include "optimization-options.h"
 #include "pass.h"
@@ -308,6 +309,11 @@ int main(int argc, const char* argv[]) {
     reader.setAllowMemory(fuzzMemory);
     reader.setAllowOOB(fuzzOOB);
     reader.build();
+    // The fuzzer creates various exports, some of whom may need fixups in
+    // closed world.
+    if (options.passOptions.closedWorld) {
+      ensureClosedWorld(wasm);
+    }
     if (options.passOptions.validate) {
       if (!WasmValidator().validate(wasm, options.passOptions)) {
         std::cout << wasm << '\n';


### PR DESCRIPTION
If the canonical heap type for a signature is private, then if we create a new
function with that type and export it we'd be exporting a private type, and
error in closed world.

The error is slightly more complex, in that that function type itself will
actually be accepted in closed world since it ignores types of exported
functions. But subtypes and supertypes of that type can cause problems.

To avoid that, create fresh types in the fuzzer.