### PR TITLE
[NFC] Add `TypeBuilder::buildRelaxed`

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -647,11 +647,12 @@ struct TypeBuilder {
   };
 
   // Returns all of the newly constructed heap types. May only be called once
-  // all of the heap types have been initialized with `setHeapType`. In nominal
-  // mode, all of the constructed HeapTypes will be fresh and distinct. In
-  // nominal mode, will also produce a fatal error if the declared subtype
-  // relationships are not valid.
+  // all of the heap types have been initialized with `setHeapType`. In relaxed
+  // mode, the types are allowed to appear in any order and be arbitrarily
+  // mututally recursive because they will be implicitly reordered and put into
+  // a single rec group, so there should not be any existing rec groups.
   BuildResult build();
+  BuildResult buildRelaxed();
 
   // Utility for ergonomically using operator[] instead of explicit setHeapType
   // and getTempHeapType methods.


### PR DESCRIPTION
Add a new method for building types that implicitly creates a single large rec
group and does not require that the supertypes appear before their subtypes. Use
this method to simplify type-updating.cpp, which does not really care about type
validation. This is also a step toward removing the nominal type system, since
using `buildRelaxed` from the text and binary parsers will emulate the current
nominal behavior even if the internal type representation is isorecursive.