### PR TITLE
[NFC][Parser] Track definition indices

### DIFF
--- a/src/wasm/wat-parser.cpp
+++ b/src/wasm/wat-parser.cpp
@@ -345,8 +345,8 @@ struct ParseInput {
 // Utilities
 // =========
 
-// The location, possible name, and index of a module-level definition in the
-// input.
+// The location, possible name, and index in the respective module index space
+// of a module-level definition in the input.
 struct DefPos {
   Name name;
   Index pos;


### PR DESCRIPTION
For each definition in a module, record that definition's index in the relevant
index space. Previously the index was inferred from its position in a list of
module definitions, but that scheme does not scale to data segments defined
inline inside memory definitions because these data segments occupy a slot in
the data segment index space but do not have their own independent definitions.