### PR TITLE
Move assert in MultiMemoryLowering

### DIFF
--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -471,14 +471,14 @@ struct MultiMemoryLowering : public Pass {
   void adjustActiveDataSegmentOffsets() {
     Builder builder(*wasm);
     ModuleUtils::iterActiveDataSegments(*wasm, [&](DataSegment* dataSegment) {
-      assert(dataSegment->offset->is<Const>() &&
-             "TODO: handle non-const segment offsets");
       auto idx = memoryIdxMap.at(dataSegment->memory);
       dataSegment->memory = combinedMemory;
       // No need to update the offset of data segments for the first memory
       if (idx != 0) {
-        auto offsetGlobalName = getOffsetGlobal(idx);
+        assert(dataSegment->offset->is<Const>() &&
+             "TODO: handle non-const segment offsets");
         assert(wasm->features.hasExtendedConst());
+        auto offsetGlobalName = getOffsetGlobal(idx);
         dataSegment->offset = builder.makeBinary(
           Abstract::getBinary(pointerType, Abstract::Add),
           builder.makeGlobalGet(offsetGlobalName, pointerType),

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -468,7 +468,9 @@ struct MultiMemoryLowering : public Pass {
     }
   }
 
-  // TODO: Add a trap for segments that have a non-constant offset that would have been out of bounds at runtime but is in bounds after multi-memory lowering
+  // TODO: Add a trap for segments that have a non-constant offset that would
+  // have been out of bounds at runtime but is in bounds after multi-memory
+  // lowering
   void adjustActiveDataSegmentOffsets() {
     Builder builder(*wasm);
     ModuleUtils::iterActiveDataSegments(*wasm, [&](DataSegment* dataSegment) {

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -468,6 +468,7 @@ struct MultiMemoryLowering : public Pass {
     }
   }
 
+  // TODO: Add a trap for segments that have a non-constant offset that would have been out of bounds at runtime but is in bounds after multi-memory lowering
   void adjustActiveDataSegmentOffsets() {
     Builder builder(*wasm);
     ModuleUtils::iterActiveDataSegments(*wasm, [&](DataSegment* dataSegment) {

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -476,7 +476,7 @@ struct MultiMemoryLowering : public Pass {
       // No need to update the offset of data segments for the first memory
       if (idx != 0) {
         assert(dataSegment->offset->is<Const>() &&
-             "TODO: handle non-const segment offsets");
+               "TODO: handle non-const segment offsets");
         assert(wasm->features.hasExtendedConst());
         auto offsetGlobalName = getOffsetGlobal(idx);
         dataSegment->offset = builder.makeBinary(


### PR DESCRIPTION
Moving the assert that checks whether the DataSegment* offset type is Const. This assert only needs to happen when the DataSegment belongs to a memory other than the first.