### PR TITLE
Skip some new initial content in the fuzzer, with imported memories

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -307,6 +307,9 @@ INITIAL_CONTENTS_IGNORE = [
     # TODO: fuzzer support for internalize/externalize
     'optimize-instructions-gc-extern.wast',
     'gufa-extern.wast',
+    # the fuzzer does not support imported memories
+    'multi-memory-lowering-import.wast',
+    'multi-memory-lowering-import-error.wast',
 ]
 
 


### PR DESCRIPTION
Do not fuzz some new testcases that have imported memories. The fuzzer doesn't seem
to have support for that (it errors when it tries to do operations on them, since the
import hasn't been created).
