### PR TITLE
Write debug info in Pass-Debug mode 3

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -671,7 +671,6 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
 }
 
 static void dumpWasm(Name name, Module* wasm) {
-  // write out the wat
   static int counter = 0;
   std::string numstr = std::to_string(counter++);
   while (numstr.size() < 3) {
@@ -685,6 +684,7 @@ static void dumpWasm(Name name, Module* wasm) {
   fullName += numstr + "-" + name.toString();
   Colors::setEnabled(false);
   ModuleWriter writer;
+  writer.setDebugInfo(true);
   writer.writeBinary(*wasm, fullName + ".wasm");
 }
 


### PR DESCRIPTION
Without the names section debugging can be hard sometimes, on the binaries
that that mode emits for each pass.

Perhaps other cases are better without the names section, so maybe we'll need
a flag? But for now hopefully this will be ok.