### PR TITLE
wasm2js: Stop emitting nan and infinity

### DIFF
--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -919,25 +919,17 @@ struct JSPrinter {
   void printName(Ref node) { emit(node->getCString()); }
 
   static char* numToString(double d, bool finalize = true) {
-    // If this number is NaN or infinite then things are a bit tricky. In JS we
-    // want to eventually use `NaN` and/or `Infinity`, but neither of those
-    // identifiers are valid in asm.js. Instead we have to explicitly import
-    // `NaN` and `Infinity` from the global environment, and those names are
-    // bound locally in an asm function as `nan` and `infinity`.
-    //
-    // TODO: the JS names of `NaN` and `Infinity` should be used once literal
-    // asm.js code isn't generated any more
     if (std::isnan(d)) {
       if (std::signbit(d)) {
-        return (char*)"-nan";
+        return (char*)"-NaN";
       } else {
-        return (char*)"nan";
+        return (char*)"NaN";
       }
     } else if (!std::isfinite(d)) {
       if (std::signbit(d)) {
-        return (char*)"-infinity";
+        return (char*)"-Infinity";
       } else {
-        return (char*)"infinity";
+        return (char*)"Infinity";
       }
     }
     bool neg = d < 0;
@@ -1193,10 +1185,10 @@ struct JSPrinter {
       ensure(1);                  // we temporarily append a 0
       char* curr = buffer + last; // ensure might invalidate
       buffer[used] = 0;
-      if (strstr(curr, "infinity")) {
+      if (strstr(curr, "Infinity")) {
         return;
       }
-      if (strstr(curr, "nan")) {
+      if (strstr(curr, "NaN")) {
         return;
       }
       if (strchr(curr, '.')) {

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -788,13 +788,6 @@ void AssertionEmitter::fixCalls(Ref asmjs, Name asmModule) {
 }
 
 void AssertionEmitter::emit() {
-  // TODO: nan and infinity shouldn't be needed once literal asm.js code isn't
-  // generated
-  out << R"(
-    var nan = NaN;
-    var infinity = Infinity;
-  )";
-
   // When equating floating point values in spec tests we want to use bitwise
   // equality like wasm does. Unfortunately though NaN makes this tricky. JS
   // implementations like Spidermonkey and JSC will canonicalize NaN loads from

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -577,15 +577,6 @@ void Wasm2JSBuilder::addBasics(Ref ast, Module* wasm) {
   addMath(MATH_CEIL, CEIL);
   addMath(MATH_TRUNC, TRUNC);
   addMath(MATH_SQRT, SQRT);
-  // TODO: this shouldn't be needed once we stop generating literal asm.js code
-  // NaN and Infinity variables
-  Ref nanVar = ValueBuilder::makeVar();
-  ast->push_back(nanVar);
-  ValueBuilder::appendToVar(nanVar, "nan", ValueBuilder::makeName("NaN"));
-  Ref infinityVar = ValueBuilder::makeVar();
-  ast->push_back(infinityVar);
-  ValueBuilder::appendToVar(
-    infinityVar, "infinity", ValueBuilder::makeName("Infinity"));
 }
 
 static bool needsQuoting(Name name) {

--- a/test/binaryen.js/emit_asmjs.js.txt
+++ b/test/binaryen.js/emit_asmjs.js.txt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function main($0) {
   $0 = $0 | 0;
   return $0 | 0;

--- a/test/wasm2asm.asserts.js
+++ b/test/wasm2asm.asserts.js
@@ -18,8 +18,6 @@ function asmFunc(global, env, buffer) {
  var Math_ceil = global.Math.ceil;
  var Math_sqrt = global.Math.sqrt;
  var abort = env.abort;
- var nan = global.NaN;
- var infinity = global.Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
   
@@ -54,8 +52,6 @@ function asmFunc(global, env, buffer) {
       var HEAP32 = new Int32Array(__array_buffer);
       var HEAPF32 = new Float32Array(__array_buffer);
       var HEAPF64 = new Float64Array(__array_buffer);
-      var nan = NaN;
-      var infinity = Infinity;
     ;
 
       function f32Equal(a, b) {

--- a/test/wasm2asm.traps.js
+++ b/test/wasm2asm.traps.js
@@ -18,8 +18,6 @@ function asmFunc(global, env, buffer) {
  var Math_ceil = global.Math.ceil;
  var Math_sqrt = global.Math.sqrt;
  var abort = env.abort;
- var nan = global.NaN;
- var infinity = global.Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
   
@@ -54,8 +52,6 @@ function asmFunc(global, env, buffer) {
       var HEAP32 = new Int32Array(__array_buffer);
       var HEAPF32 = new Float32Array(__array_buffer);
       var HEAPF64 = new Float64Array(__array_buffer);
-      var nan = NaN;
-      var infinity = Infinity;
     ;
 
       function f32Equal(a, b) {

--- a/test/wasm2js.asserts.js
+++ b/test/wasm2js.asserts.js
@@ -1,7 +1,4 @@
 
-    var nan = NaN;
-    var infinity = Infinity;
-  
     function f32Equal(a, b) {
        var i = new Int32Array(1);
        var f = new Float32Array(i.buffer);
@@ -41,8 +38,6 @@ function asmFunc0(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   
  }

--- a/test/wasm2js.traps.js
+++ b/test/wasm2js.traps.js
@@ -1,7 +1,4 @@
 
-    var nan = NaN;
-    var infinity = Infinity;
-  
     function f32Equal(a, b) {
        var i = new Int32Array(1);
        var f = new Float32Array(i.buffer);
@@ -41,8 +38,6 @@ function asmFunc0(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   
  }

--- a/test/wasm2js/add_div.2asm.js
+++ b/test/wasm2js/add_div.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo($0) {
   $0 = $0 | 0;
   return (($0 >>> 0) / (100 >>> 0) | 0) + (($0 | 0) / (-100 | 0) | 0) | 0 | 0;

--- a/test/wasm2js/add_div.2asm.js.opt
+++ b/test/wasm2js/add_div.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo($0) {
   $0 = $0 | 0;
   return (($0 | 0) / -100 | 0) + (($0 >>> 0) / 100 | 0) | 0;

--- a/test/wasm2js/atomic_fence.2asm.js
+++ b/test/wasm2js/atomic_fence.2asm.js
@@ -19,8 +19,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   
  }

--- a/test/wasm2js/atomic_fence.2asm.js.opt
+++ b/test/wasm2js/atomic_fence.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   
  }

--- a/test/wasm2js/atomics_32.2asm.js
+++ b/test/wasm2js/atomics_32.2asm.js
@@ -109,8 +109,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   var i64toi32_i32$0 = 0, i64toi32_i32$2 = 0, i64toi32_i32$1 = 0;
   Atomics.compareExchange(HEAP8, 1024, 1, 2) | 0;

--- a/test/wasm2js/atomics_32.2asm.js.opt
+++ b/test/wasm2js/atomics_32.2asm.js.opt
@@ -109,8 +109,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   Atomics.compareExchange(HEAP8, 1024, 1, 2) | 0;
   Atomics.compareExchange(HEAP16, 512, 1, 2) | 0;

--- a/test/wasm2js/base64.2asm.js
+++ b/test/wasm2js/base64.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/base64.2asm.js.opt
+++ b/test/wasm2js/base64.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/br.2asm.js
+++ b/test/wasm2js/br.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/br_table.2asm.js
+++ b/test/wasm2js/br_table.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/br_table_hoisting.2asm.js
+++ b/test/wasm2js/br_table_hoisting.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function zed($0) {
   $0 = $0 | 0;
   zed($0 | 0);

--- a/test/wasm2js/br_table_hoisting.2asm.js.opt
+++ b/test/wasm2js/br_table_hoisting.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function zed($0) {
   zed($0);
  }

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function dummy() {
   
  }

--- a/test/wasm2js/br_table_temp.2asm.js.opt
+++ b/test/wasm2js/br_table_temp.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function dummy() {
   
  }

--- a/test/wasm2js/br_table_to_loop.2asm.js
+++ b/test/wasm2js/br_table_to_loop.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   block : {
    loop : while (1) switch (1 | 0) {

--- a/test/wasm2js/br_table_to_loop.2asm.js.opt
+++ b/test/wasm2js/br_table_to_loop.2asm.js.opt
@@ -12,8 +12,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   wasm2js_trap();
  }

--- a/test/wasm2js/break-drop.2asm.js
+++ b/test/wasm2js/break-drop.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   
  }

--- a/test/wasm2js/bulk-memory.2asm.js
+++ b/test/wasm2js/bulk-memory.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };
@@ -49,8 +47,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1, $1_1, $2) {
   $0_1 = $0_1 | 0;
   $1_1 = $1_1 | 0;
@@ -151,8 +147,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1, $1_1, $2) {
   $0_1 = $0_1 | 0;
   $1_1 = $1_1 | 0;
@@ -231,8 +225,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1, $1_1, $2) {
   $0_1 = $0_1 | 0;
   $1_1 = $1_1 | 0;
@@ -340,8 +332,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   wasm2js_data_drop(0);
  }

--- a/test/wasm2js/bulk-memory.2asm.js.opt
+++ b/test/wasm2js/bulk-memory.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };
@@ -49,8 +47,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1, $1_1, $2) {
   $0_1 = $0_1 | 0;
   $1_1 = $1_1 | 0;
@@ -151,8 +147,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1, $1_1, $2) {
   $0_1 = $0_1 | 0;
   $1_1 = $1_1 | 0;
@@ -231,8 +225,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1, $1_1, $2) {
   $0_1 = $0_1 | 0;
   $1_1 = $1_1 | 0;
@@ -306,8 +298,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   
  }

--- a/test/wasm2js/comments.2asm.js
+++ b/test/wasm2js/comments.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };
@@ -31,8 +29,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/conversions-modified.2asm.js
+++ b/test/wasm2js/conversions-modified.2asm.js
@@ -41,8 +41,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/conversions-modified.2asm.js.opt
+++ b/test/wasm2js/conversions-modified.2asm.js.opt
@@ -41,8 +41,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/deterministic.2asm.js
+++ b/test/wasm2js/deterministic.2asm.js
@@ -24,8 +24,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var global$0 = -44;
  function $0() {
   if ((global$0 >>> 0) / ((HEAP32[0 >> 2] | 0) >>> 0) | 0) {

--- a/test/wasm2js/deterministic.2asm.js.opt
+++ b/test/wasm2js/deterministic.2asm.js.opt
@@ -24,8 +24,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   if (4294967252 / HEAPU32[0] | 0) {
    wasm2js_trap()

--- a/test/wasm2js/dot_import.2asm.js
+++ b/test/wasm2js/dot_import.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var mod_ule = imports["mod.ule"];
  var base = mod_ule["ba.se"];
  function $0() {

--- a/test/wasm2js/dot_import.2asm.js.opt
+++ b/test/wasm2js/dot_import.2asm.js.opt
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var mod_ule = imports["mod.ule"];
  var base = mod_ule["ba.se"];
  function $0() {

--- a/test/wasm2js/dynamicLibrary.2asm.js
+++ b/test/wasm2js/dynamicLibrary.2asm.js
@@ -57,8 +57,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var import$memoryBase = env.memoryBase | 0;
  var import$tableBase = env.tableBase | 0;
  function foo() {

--- a/test/wasm2js/dynamicLibrary.2asm.js.opt
+++ b/test/wasm2js/dynamicLibrary.2asm.js.opt
@@ -57,8 +57,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var import$memoryBase = env.memoryBase | 0;
  var import$tableBase = env.tableBase | 0;
  function foo() {

--- a/test/wasm2js/empty_export.2asm.js
+++ b/test/wasm2js/empty_export.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo() {
   
  }

--- a/test/wasm2js/empty_export.2asm.js.opt
+++ b/test/wasm2js/empty_export.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo() {
   
  }

--- a/test/wasm2js/empty_imported_table.2asm.js
+++ b/test/wasm2js/empty_imported_table.2asm.js
@@ -18,8 +18,6 @@ function asmFunc(global, env, buffer) {
  var Math_ceil = global.Math.ceil;
  var Math_sqrt = global.Math.sqrt;
  var abort = env.abort;
- var nan = global.NaN;
- var infinity = global.Infinity;
  var import$table$0 = env.table;
  var i64toi32_i32$HIGH_BITS = 0;
  return {

--- a/test/wasm2js/empty_table.2asm.js
+++ b/test/wasm2js/empty_table.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/emscripten-grow-no.2asm.js
+++ b/test/wasm2js/emscripten-grow-no.2asm.js
@@ -45,8 +45,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  // EMSCRIPTEN_START_FUNCS
 ;
  // EMSCRIPTEN_END_FUNCS

--- a/test/wasm2js/emscripten-grow-no.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-no.2asm.js.opt
@@ -45,8 +45,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  // EMSCRIPTEN_START_FUNCS
 ;
  // EMSCRIPTEN_END_FUNCS

--- a/test/wasm2js/emscripten-grow-yes.2asm.js
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js
@@ -46,8 +46,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  // EMSCRIPTEN_START_FUNCS
 ;
  function $0() {

--- a/test/wasm2js/emscripten-grow-yes.2asm.js.opt
+++ b/test/wasm2js/emscripten-grow-yes.2asm.js.opt
@@ -46,8 +46,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  // EMSCRIPTEN_START_FUNCS
 ;
  function $0() {

--- a/test/wasm2js/emscripten.2asm.js
+++ b/test/wasm2js/emscripten.2asm.js
@@ -48,8 +48,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var syscall$6 = env.__syscall6;
  var syscall$54 = env.__syscall54;
  // EMSCRIPTEN_START_FUNCS

--- a/test/wasm2js/emscripten.2asm.js.opt
+++ b/test/wasm2js/emscripten.2asm.js.opt
@@ -60,8 +60,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var syscall$6 = env.__syscall6;
  var syscall$54 = env.__syscall54;
  // EMSCRIPTEN_START_FUNCS

--- a/test/wasm2js/endianness.2asm.js
+++ b/test/wasm2js/endianness.2asm.js
@@ -51,8 +51,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/excess_fallthrough.2asm.js
+++ b/test/wasm2js/excess_fallthrough.2asm.js
@@ -12,8 +12,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function bar() {
   
  }

--- a/test/wasm2js/excess_fallthrough.2asm.js.opt
+++ b/test/wasm2js/excess_fallthrough.2asm.js.opt
@@ -12,8 +12,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo($0) {
   $0 = $0 | 0;
   wasm2js_trap();

--- a/test/wasm2js/export_global.2asm.js
+++ b/test/wasm2js/export_global.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var global0 = 655360;
  function $0() {
   return 42 | 0;

--- a/test/wasm2js/export_global.2asm.js.opt
+++ b/test/wasm2js/export_global.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var global0 = 655360;
  function $0() {
   return 42;

--- a/test/wasm2js/f32.2asm.js
+++ b/test/wasm2js/f32.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x, y) {
   x = Math_fround(x);
   y = Math_fround(y);

--- a/test/wasm2js/f32_cmp.2asm.js
+++ b/test/wasm2js/f32_cmp.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x, y) {
   x = Math_fround(x);
   y = Math_fround(y);

--- a/test/wasm2js/f64_cmp.2asm.js
+++ b/test/wasm2js/f64_cmp.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x, y) {
   x = +x;
   y = +y;

--- a/test/wasm2js/fac.2asm.js
+++ b/test/wasm2js/fac.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/float-ops.2asm.js
+++ b/test/wasm2js/float-ops.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0, $1_1) {
   $0 = Math_fround($0);
   $1_1 = Math_fround($1_1);

--- a/test/wasm2js/float-ops.2asm.js.opt
+++ b/test/wasm2js/float-ops.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0, $1_1) {
   $0 = Math_fround($0);
   $1_1 = Math_fround($1_1);

--- a/test/wasm2js/float_literals-modified.2asm.js
+++ b/test/wasm2js/float_literals-modified.2asm.js
@@ -29,57 +29,55 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
  function $0() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $1() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $2() {
-  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $3() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $4() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $5() {
-  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $6() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $7() {
-  return (wasm2js_scratch_store_f32(Math_fround(nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $8() {
-  return (wasm2js_scratch_store_f32(Math_fround(-nan)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-NaN)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $9() {
-  return (wasm2js_scratch_store_f32(Math_fround(infinity)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(Infinity)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $10() {
-  return (wasm2js_scratch_store_f32(Math_fround(infinity)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(Infinity)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $11() {
-  return (wasm2js_scratch_store_f32(Math_fround(-infinity)), wasm2js_scratch_load_i32(2)) | 0;
+  return (wasm2js_scratch_store_f32(Math_fround(-Infinity)), wasm2js_scratch_load_i32(2)) | 0;
  }
  
  function $12() {
@@ -156,7 +154,7 @@ function asmFunc(imports) {
  
  function $30() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(nan));
+  wasm2js_scratch_store_f64(+(NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -165,7 +163,7 @@ function asmFunc(imports) {
  
  function $31() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(nan));
+  wasm2js_scratch_store_f64(+(NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -174,7 +172,7 @@ function asmFunc(imports) {
  
  function $32() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(-nan));
+  wasm2js_scratch_store_f64(+(-NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -183,7 +181,7 @@ function asmFunc(imports) {
  
  function $33() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(nan));
+  wasm2js_scratch_store_f64(+(NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -192,7 +190,7 @@ function asmFunc(imports) {
  
  function $34() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(nan));
+  wasm2js_scratch_store_f64(+(NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -201,7 +199,7 @@ function asmFunc(imports) {
  
  function $35() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(-nan));
+  wasm2js_scratch_store_f64(+(-NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -210,7 +208,7 @@ function asmFunc(imports) {
  
  function $36() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(nan));
+  wasm2js_scratch_store_f64(+(NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -219,7 +217,7 @@ function asmFunc(imports) {
  
  function $37() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(nan));
+  wasm2js_scratch_store_f64(+(NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -228,7 +226,7 @@ function asmFunc(imports) {
  
  function $38() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(-nan));
+  wasm2js_scratch_store_f64(+(-NaN));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -237,7 +235,7 @@ function asmFunc(imports) {
  
  function $39() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(infinity));
+  wasm2js_scratch_store_f64(+(Infinity));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -246,7 +244,7 @@ function asmFunc(imports) {
  
  function $40() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(infinity));
+  wasm2js_scratch_store_f64(+(Infinity));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;
@@ -255,7 +253,7 @@ function asmFunc(imports) {
  
  function $41() {
   var i64toi32_i32$0 = 0, i64toi32_i32$1 = 0;
-  wasm2js_scratch_store_f64(+(-infinity));
+  wasm2js_scratch_store_f64(+(-Infinity));
   i64toi32_i32$0 = wasm2js_scratch_load_i32(1 | 0) | 0;
   i64toi32_i32$1 = wasm2js_scratch_load_i32(0 | 0) | 0;
   i64toi32_i32$HIGH_BITS = i64toi32_i32$0;

--- a/test/wasm2js/float_literals-modified.2asm.js.opt
+++ b/test/wasm2js/float_literals-modified.2asm.js.opt
@@ -25,8 +25,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -104,7 +102,7 @@ function asmFunc(imports) {
  
  function legalstub$30() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(nan);
+  wasm2js_scratch_store_f64(NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -114,7 +112,7 @@ function asmFunc(imports) {
  
  function legalstub$32() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(-nan);
+  wasm2js_scratch_store_f64(-NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -124,7 +122,7 @@ function asmFunc(imports) {
  
  function legalstub$34() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(nan);
+  wasm2js_scratch_store_f64(NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -134,7 +132,7 @@ function asmFunc(imports) {
  
  function legalstub$35() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(-nan);
+  wasm2js_scratch_store_f64(-NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -144,7 +142,7 @@ function asmFunc(imports) {
  
  function legalstub$36() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(nan);
+  wasm2js_scratch_store_f64(NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -154,7 +152,7 @@ function asmFunc(imports) {
  
  function legalstub$37() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(nan);
+  wasm2js_scratch_store_f64(NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -164,7 +162,7 @@ function asmFunc(imports) {
  
  function legalstub$38() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(-nan);
+  wasm2js_scratch_store_f64(-NaN);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -174,7 +172,7 @@ function asmFunc(imports) {
  
  function legalstub$39() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(infinity);
+  wasm2js_scratch_store_f64(Infinity);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;
@@ -184,7 +182,7 @@ function asmFunc(imports) {
  
  function legalstub$41() {
   var $0_1 = 0, $1 = 0;
-  wasm2js_scratch_store_f64(-infinity);
+  wasm2js_scratch_store_f64(-Infinity);
   $0_1 = wasm2js_scratch_load_i32(1) | 0;
   $1 = wasm2js_scratch_load_i32(0) | 0;
   i64toi32_i32$HIGH_BITS = $0_1;

--- a/test/wasm2js/float_misc.2asm.js
+++ b/test/wasm2js/float_misc.2asm.js
@@ -40,8 +40,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x, y) {
   x = Math_fround(x);
   y = Math_fround(y);

--- a/test/wasm2js/forward.2asm.js
+++ b/test/wasm2js/forward.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function even(n) {
   n = n | 0;
   var $10 = 0;

--- a/test/wasm2js/func-ptr-offset.2asm.js
+++ b/test/wasm2js/func-ptr-offset.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function t1() {
   return 1 | 0;
  }

--- a/test/wasm2js/func-ptr-offset.2asm.js.opt
+++ b/test/wasm2js/func-ptr-offset.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function t1() {
   return 1;
  }

--- a/test/wasm2js/func_ptrs.2asm.js
+++ b/test/wasm2js/func_ptrs.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var spectest = imports.spectest;
  var print = spectest.print_i32;
  function $3() {
@@ -61,8 +59,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function t1() {
   return 1 | 0;
  }
@@ -116,8 +112,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function t1() {
   return 1 | 0;
  }

--- a/test/wasm2js/get-set-local.2asm.js
+++ b/test/wasm2js/get-set-local.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0, r, r$hi) {
   $0 = $0 | 0;
   r = r | 0;

--- a/test/wasm2js/get-set-local.2asm.js.opt
+++ b/test/wasm2js/get-set-local.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function legalstub$1($0, $1, $2) {
   return !$2 & ($0 | 0) == ($1 | 0);
  }

--- a/test/wasm2js/get_local.2asm.js
+++ b/test/wasm2js/get_local.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/global_i64.2asm.js
+++ b/test/wasm2js/global_i64.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var f = -1412567121;
  var f$hi = 305419896;
  function call($0, $0$hi) {

--- a/test/wasm2js/global_i64.2asm.js.opt
+++ b/test/wasm2js/global_i64.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1() {
   
  }

--- a/test/wasm2js/grow-memory-tricky.2asm.js
+++ b/test/wasm2js/grow-memory-tricky.2asm.js
@@ -19,8 +19,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   (wasm2js_i32$0 = 0, wasm2js_i32$1 = __wasm_memory_grow(1 | 0)), HEAP32[wasm2js_i32$0 >> 2] = wasm2js_i32$1;

--- a/test/wasm2js/grow-memory-tricky.2asm.js.opt
+++ b/test/wasm2js/grow-memory-tricky.2asm.js.opt
@@ -19,8 +19,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0;
   (wasm2js_i32$0 = 0, wasm2js_i32$1 = __wasm_memory_grow(1)), HEAP32[wasm2js_i32$0 >> 2] = wasm2js_i32$1;

--- a/test/wasm2js/grow_memory.2asm.js
+++ b/test/wasm2js/grow_memory.2asm.js
@@ -19,8 +19,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(var$0) {
   var$0 = var$0 | 0;
   return __wasm_memory_grow(var$0 | 0) | 0;

--- a/test/wasm2js/i32.2asm.js
+++ b/test/wasm2js/i32.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x, y) {
   x = x | 0;
   y = y | 0;

--- a/test/wasm2js/i64-add-sub.2asm.js
+++ b/test/wasm2js/i64-add-sub.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0, $0$hi, $1_1, $1$hi, r, r$hi) {
   $0 = $0 | 0;
   $0$hi = $0$hi | 0;

--- a/test/wasm2js/i64-add-sub.2asm.js.opt
+++ b/test/wasm2js/i64-add-sub.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function legalstub$1($0, $1, $2, $3, $4, $5) {
   $1 = $1 + $3 | 0;
   $0 = $0 + $2 | 0;

--- a/test/wasm2js/i64-ctz.2asm.js
+++ b/test/wasm2js/i64-ctz.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/i64-ctz.2asm.js.opt
+++ b/test/wasm2js/i64-ctz.2asm.js.opt
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/i64-lowering.2asm.js
+++ b/test/wasm2js/i64-lowering.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0, $0$hi, $1_1, $1$hi) {
   $0 = $0 | 0;
   $0$hi = $0$hi | 0;

--- a/test/wasm2js/i64-lowering.2asm.js.opt
+++ b/test/wasm2js/i64-lowering.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function legalstub$1($0, $1, $2, $3) {
   return ($0 | 0) == ($2 | 0) & ($1 | 0) == ($3 | 0);
  }

--- a/test/wasm2js/i64-rotate.2asm.js
+++ b/test/wasm2js/i64-rotate.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
  function $1($0, $0$hi, $1_1, $1$hi, $2_1, $2$hi) {
   $0 = $0 | 0;

--- a/test/wasm2js/i64-rotate.2asm.js.opt
+++ b/test/wasm2js/i64-rotate.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
  function legalstub$1($0, $1, $2, $3, $4, $5) {
   var $6 = 0, $7 = 0, $8 = 0;

--- a/test/wasm2js/i64-select.2asm.js
+++ b/test/wasm2js/i64-select.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/i64-select.2asm.js.opt
+++ b/test/wasm2js/i64-select.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/i64-shifts.2asm.js
+++ b/test/wasm2js/i64-shifts.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0, $0$hi, $1_1, $1$hi, $2_1, $2$hi) {
   $0 = $0 | 0;
   $0$hi = $0$hi | 0;

--- a/test/wasm2js/i64-shifts.2asm.js.opt
+++ b/test/wasm2js/i64-shifts.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function legalstub$1($0, $1, $2, $3, $4, $5) {
   $3 = $0;
   $0 = $2 & 31;

--- a/test/wasm2js/if_unreachable.2asm.js
+++ b/test/wasm2js/if_unreachable.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/if_unreachable.2asm.js.opt
+++ b/test/wasm2js/if_unreachable.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/indirect-select.2asm.js
+++ b/test/wasm2js/indirect-select.2asm.js
@@ -13,8 +13,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x) {
   x = x | 0;
   return FUNCTION_TABLE[(x ? 1 : 0) | 0]() | 0 | 0;

--- a/test/wasm2js/indirect-select.2asm.js.opt
+++ b/test/wasm2js/indirect-select.2asm.js.opt
@@ -13,8 +13,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0($0_1) {
   $0_1 = $0_1 | 0;
   return FUNCTION_TABLE[!!$0_1 | 0]() | 0;

--- a/test/wasm2js/int_exprs.2asm.js
+++ b/test/wasm2js/int_exprs.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x, y) {
   x = x | 0;
   y = y | 0;
@@ -248,8 +246,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -331,8 +327,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -413,8 +407,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -610,8 +602,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -807,8 +797,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -1619,8 +1607,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -2337,8 +2323,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -3037,8 +3021,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -3849,8 +3831,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -4501,8 +4481,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -5135,8 +5113,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -5853,8 +5829,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -6571,8 +6545,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -7289,8 +7261,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -8007,8 +7977,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -8707,8 +8675,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -9407,8 +9373,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;
@@ -10107,8 +10071,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var __wasm_intrinsics_temp_i64 = 0;

--- a/test/wasm2js/labels.2asm.js
+++ b/test/wasm2js/labels.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   var $0_1 = 0;
   exit : {

--- a/test/wasm2js/left-to-right.2asm.js
+++ b/test/wasm2js/left-to-right.2asm.js
@@ -46,8 +46,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/minified-memory.2asm.js
+++ b/test/wasm2js/minified-memory.2asm.js
@@ -22,8 +22,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   return HEAP32[0 >> 2] | 0 | 0;
  }

--- a/test/wasm2js/minified-memory.2asm.js.opt
+++ b/test/wasm2js/minified-memory.2asm.js.opt
@@ -22,8 +22,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   return HEAP32[0];
  }

--- a/test/wasm2js/minus_minus.2asm.js
+++ b/test/wasm2js/minus_minus.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   return ~~- -7094.0 | 0;
  }

--- a/test/wasm2js/minus_minus.2asm.js.opt
+++ b/test/wasm2js/minus_minus.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1() {
   
  }

--- a/test/wasm2js/nested-selects.2asm.js
+++ b/test/wasm2js/nested-selects.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0) {
   $0 = $0 | 0;
   return (($0 | 0) < (0 | 0) ? -1 : ($0 | 0) > (0 | 0) ? 1 : 0) | 0;

--- a/test/wasm2js/nested-selects.2asm.js.opt
+++ b/test/wasm2js/nested-selects.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0) {
   $0 = $0 | 0;
   return (($0 | 0) < 0 ? -1 : ($0 | 0) > 0) | 0;

--- a/test/wasm2js/ordering.2asm.js
+++ b/test/wasm2js/ordering.2asm.js
@@ -13,8 +13,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function main() {
   var wasm2js_i32$0 = 0, wasm2js_i32$1 = 0, wasm2js_i32$2 = 0;
   FUNCTION_TABLE[foo(2 | 0) | 0 | 0](1) | 0;

--- a/test/wasm2js/ordering.2asm.js.opt
+++ b/test/wasm2js/ordering.2asm.js.opt
@@ -13,8 +13,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function main() {
   FUNCTION_TABLE[1](1) | 0;
   FUNCTION_TABLE[4](1) | 0;

--- a/test/wasm2js/reinterpret.2asm.js
+++ b/test/wasm2js/reinterpret.2asm.js
@@ -40,8 +40,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0) {
   $0 = $0 | 0;
   return ((wasm2js_scratch_store_f32((wasm2js_scratch_store_i32(2, $0), wasm2js_scratch_load_f32())), wasm2js_scratch_load_i32(2)) | 0) == ($0 | 0) | 0;

--- a/test/wasm2js/reinterpret.2asm.js.opt
+++ b/test/wasm2js/reinterpret.2asm.js.opt
@@ -32,8 +32,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $1($0) {
   $0 = $0 | 0;
   return 1;

--- a/test/wasm2js/reinterpret_scratch.2asm.js
+++ b/test/wasm2js/reinterpret_scratch.2asm.js
@@ -38,8 +38,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   var i64toi32_i32$1 = 0, i64toi32_i32$0 = 0, $0_1 = Math_fround(0);
   wasm2js_scratch_store_f64(+(305419896.0));

--- a/test/wasm2js/reinterpret_scratch.2asm.js.opt
+++ b/test/wasm2js/reinterpret_scratch.2asm.js.opt
@@ -34,8 +34,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0() {
   var $0_1 = 0;
   wasm2js_scratch_store_f64(305419896.0);

--- a/test/wasm2js/set_local.2asm.js
+++ b/test/wasm2js/set_local.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/sign_ext.2asm.js
+++ b/test/wasm2js/sign_ext.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/sign_ext.2asm.js.opt
+++ b/test/wasm2js/sign_ext.2asm.js.opt
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/stack-modified.2asm.js
+++ b/test/wasm2js/stack-modified.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/stack-modified.2asm.js.opt
+++ b/test/wasm2js/stack-modified.2asm.js.opt
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/start_func.2asm.js
+++ b/test/wasm2js/start_func.2asm.js
@@ -19,8 +19,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo() {
   HEAP32[1 >> 2] = 2;
  }

--- a/test/wasm2js/start_func.2asm.js.opt
+++ b/test/wasm2js/start_func.2asm.js.opt
@@ -19,8 +19,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function foo() {
   HEAP32[0] = 2;
  }

--- a/test/wasm2js/switch.2asm.js
+++ b/test/wasm2js/switch.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/target_js.2asm.js
+++ b/test/wasm2js/target_js.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function func(x) {
   x = x | 0;
   return (1 << x | 0) ^ -1 | 0 | 0;

--- a/test/wasm2js/target_js.2asm.js.opt
+++ b/test/wasm2js/target_js.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function func($0) {
   $0 = $0 | 0;
   return 1 << $0 ^ -1;

--- a/test/wasm2js/tee_local.2asm.js
+++ b/test/wasm2js/tee_local.2asm.js
@@ -11,8 +11,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/traps.2asm.js
+++ b/test/wasm2js/traps.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -742,8 +740,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var __wasm_intrinsics_temp_i64 = 0;
  var __wasm_intrinsics_temp_i64$hi = 0;
  var i64toi32_i32$HIGH_BITS = 0;
@@ -1456,8 +1452,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(x) {
   x = Math_fround(x);
   ~~x;
@@ -1589,8 +1583,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  function $0(i) {
   i = i | 0;
   HEAP32[i >> 2] | 0;

--- a/test/wasm2js/unaligned.2asm.js
+++ b/test/wasm2js/unaligned.2asm.js
@@ -51,8 +51,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/unaligned.2asm.js.opt
+++ b/test/wasm2js/unaligned.2asm.js.opt
@@ -47,8 +47,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var env = imports.env;
  var setTempRet0 = env.setTempRet0;
  var i64toi32_i32$HIGH_BITS = 0;

--- a/test/wasm2js/unary-ops.2asm.js
+++ b/test/wasm2js/unary-ops.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
  function $1($0) {
   $0 = $0 | 0;

--- a/test/wasm2js/unary-ops.2asm.js.opt
+++ b/test/wasm2js/unary-ops.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var i64toi32_i32$HIGH_BITS = 0;
  function $1($0) {
   $0 = $0 | 0;

--- a/test/wasm2js/unreachable-get-cycle.2asm.js
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/unreachable-get-cycle.2asm.js.opt
+++ b/test/wasm2js/unreachable-get-cycle.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/unreachable-insts.2asm.js
+++ b/test/wasm2js/unreachable-insts.2asm.js
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/unreachable-insts.2asm.js.opt
+++ b/test/wasm2js/unreachable-insts.2asm.js.opt
@@ -10,8 +10,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  return {
   
  };

--- a/test/wasm2js/unreachable-later.2asm.js
+++ b/test/wasm2js/unreachable-later.2asm.js
@@ -12,8 +12,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var global$0 = 10;
  function $0($0_1) {
   $0_1 = $0_1 | 0;

--- a/test/wasm2js/unreachable-later.2asm.js.opt
+++ b/test/wasm2js/unreachable-later.2asm.js.opt
@@ -12,8 +12,6 @@ function asmFunc(imports) {
  var Math_ceil = Math.ceil;
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
- var nan = NaN;
- var infinity = Infinity;
  var global$0 = 10;
  function $0($0_1) {
   $0_1 = $0_1 | 0;


### PR DESCRIPTION
As noted in #4739, legacy language emitting nan and infinity exists, with the observation that it can be removed once asm.js is no longer used and global NaN is available.

This commit removes that asm.js-specific code accordingly.

This is a replacement for the draft #4770 proposed earlier.