### PR TITLE
[Wasm GC] Fix optimizations on ref.cast of null, and optimize to ref.as_non_null

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -901,7 +901,7 @@ void TranslateToFuzzReader::addInvocations(Function* func) {
   while (oneIn(2) && !random.finished()) {
     std::vector<Expression*> args;
     for (const auto& type : func->getParams()) {
-      args.push_back(makeConst(type)); // maek smart stuff for struct types here
+      args.push_back(makeConst(type));
     }
     Expression* invoke = builder.makeCall(func->name, args, func->getResults());
     if (func->getResults().isConcrete()) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -901,7 +901,7 @@ void TranslateToFuzzReader::addInvocations(Function* func) {
   while (oneIn(2) && !random.finished()) {
     std::vector<Expression*> args;
     for (const auto& type : func->getParams()) {
-      args.push_back(makeConst(type));
+      args.push_back(makeConst(type)); // maek smart stuff for struct types here
     }
     Expression* invoke = builder.makeCall(func->name, args, func->getResults());
     if (func->getResults().isConcrete()) {

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -3121,6 +3121,38 @@
     )
   )
 
+  ;; CHECK:      (func $ref-cast-heap-type (type $ref?|$B|_ref|$B|_=>_none) (param $null-b (ref null $B)) (param $b (ref $B))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $b)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $null-b)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $b)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $null-b)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; NOMNL:      (func $ref-cast-heap-type (type $ref?|$B|_ref|$B|_=>_none) (param $null-b (ref null $B)) (param $b (ref $B))
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (local.get $b)
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (ref.as_non_null
+  ;; NOMNL-NEXT:    (local.get $null-b)
+  ;; NOMNL-NEXT:   )
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (local.get $b)
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT:  (drop
+  ;; NOMNL-NEXT:   (local.get $null-b)
+  ;; NOMNL-NEXT:  )
+  ;; NOMNL-NEXT: )
   (func $ref-cast-heap-type (param $null-b (ref null $B)) (param $b (ref $B))
     ;; We are casting a heap type to a supertype, which always succeeds. However
     ;; we need to check for nullability.

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -3120,4 +3120,35 @@
       (ref.null nofunc)
     )
   )
+
+  (func $ref-cast-heap-type (param $null-b (ref null $B)) (param $b (ref $B))
+    ;; We are casting a heap type to a supertype, which always succeeds. However
+    ;; we need to check for nullability.
+
+    ;; Non-nullable casts. When the input is non-nullable we must succeed.
+    (drop
+      (ref.cast $A
+        (local.get $b)
+      )
+    )
+    ;; When the input can be null, we might fail if it is a null. But we can
+    ;; switch to checking only that.
+    (drop
+      (ref.cast $A
+        (local.get $null-b)
+      )
+    )
+
+    ;; Null casts. Both of these must succeed.
+    (drop
+      (ref.cast null $A
+        (local.get $b)
+      )
+    )
+    (drop
+      (ref.cast null $A
+        (local.get $null-b)
+      )
+    )
+  )
 )


### PR DESCRIPTION
We were checking the heap type, but now casts care about the nullability as
well.

If the nullability is the only problem, that is, the heap type will be fine but we
might have a null, we can at least switch a `ref.cast` (non-null) to a
`ref.as_non_null`.

I believe this might be related to recent cast/null changes. Found by the fuzzer.