### PR TITLE
Fix a bug optimizing out br_on_cast

### DIFF
--- a/src/ir/gc-type-utils.h
+++ b/src/ir/gc-type-utils.h
@@ -62,10 +62,10 @@ inline EvaluationResult evaluateKindCheck(Expression* curr) {
           return flip ? Failure : Success;
         }
         // If the cast type is unrelated to the type we have and it's not
-        // possible for the cast succeed anyway because the value is null, then
-        // the cast will certainly fail. TODO: This is essentially the same as
-        // `canBeCastTo` in OptimizeInstructions. Find a way to deduplicate this
-        // logic.
+        // possible for the cast to succeed anyway because the value is null,
+        // then the cast will certainly fail. TODO: This is essentially the same
+        // as `canBeCastTo` in OptimizeInstructions. Find a way to deduplicate
+        // this logic.
         if (!Type::isSubType(br->castType, br->ref->type) &&
             (br->castType.isNonNullable() || br->ref->type.isNonNullable())) {
           return flip ? Success : Failure;

--- a/src/ir/gc-type-utils.h
+++ b/src/ir/gc-type-utils.h
@@ -61,9 +61,13 @@ inline EvaluationResult evaluateKindCheck(Expression* curr) {
         if (Type::isSubType(br->ref->type, br->castType)) {
           return flip ? Failure : Success;
         }
-        // If the cast type is unrelated to the type we have, the cast will
-        // certainly fail.
-        if (!Type::isSubType(br->castType, br->ref->type)) {
+        // If the cast type is unrelated to the type we have and it's not
+        // possible for the cast succeed anyway because the value is null, then
+        // the cast will certainly fail. TODO: This is essentially the same as
+        // `canBeCastTo` in OptimizeInstructions. Find a way to deduplicate this
+        // logic.
+        if (!Type::isSubType(br->castType, br->ref->type) &&
+            (br->castType.isNonNullable() || br->ref->type.isNonNullable())) {
           return flip ? Success : Failure;
         }
         return Unknown;

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -228,13 +228,13 @@
   (block $block (result anyref)
    (drop
     ;; This cast can be computed at compile time: it will definitely fail, so we
-    ;; can remove it.
+    ;; can replace it with an unconditional br.
     (br_on_cast_fail $block $struct
      (struct.new $struct2)
     )
    )
    (drop
-    ;; We can still remove it even if the cast allows nulls.
+    ;; We can still replace it even if the cast allows nulls.
     (br_on_cast_fail $block null $struct
      (struct.new $struct2)
     )


### PR DESCRIPTION
We were considering casts between unrelated types as unconditionally failing,
but in the case where the unrelated types are nullable, the cast could still
succeed if the value is null.

This bug was introduced in #5397.