### PR TITLE
[Wasm GC] Handle an unreachable br_on_cast_fail in DCE

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1014,7 +1014,10 @@ Type BrOn::getSentType() {
         return castType;
       }
     case BrOnCastFail:
-      // The same as the result type of br_on_cast.
+      // The same as the result type of br_on_cast (if reachable).
+      if (ref->type == Type::unreachable) {
+        return Type::unreachable;
+      }
       if (castType.isNullable()) {
         return Type(ref->type.getHeapType(), NonNullable);
       } else {

--- a/test/lit/passes/dce_all-features.wast
+++ b/test/lit/passes/dce_all-features.wast
@@ -1398,10 +1398,10 @@
 (module
   ;; CHECK:      (type $none_=>_ref|any| (func (result (ref any))))
 
-  ;; CHECK:      (func $foo (type $none_=>_ref|any|) (result (ref any))
+  ;; CHECK:      (func $br_on_non_null (type $none_=>_ref|any|) (result (ref any))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
-  (func $foo (result (ref any))
+  (func $br_on_non_null (result (ref any))
     (block $label$1 (result (ref any))
       ;; this break has an unreachable input, and so it does not have a heap type
       ;; there, and no heap type to send on the branch. this tests we do not hit
@@ -1410,6 +1410,19 @@
         (block (result anyref)
           (unreachable)
         )
+      )
+      (unreachable)
+    )
+  )
+
+  ;; CHECK:      (func $br_on_cast_fail (type $none_=>_ref|any|) (result (ref any))
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $br_on_cast_fail (result (ref any))
+    (block $label$1 (result (ref none))
+      ;; Similar to the above, but using br_on_cast_fail.
+      (br_on_cast_fail $label$1 null struct
+        (unreachable)
       )
       (unreachable)
     )


### PR DESCRIPTION
Without this we hit an assertion on unreachable not being a heap type.