### PR TITLE
[binaryen.js] Avoid use of the global buffer var which emcc has removed

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2597,7 +2597,7 @@ function wrapModule(module, self = {}) {
         const ptr = _malloc(size);
         Module['_BinaryenCopyMemorySegmentData'](module, id, ptr);
         const res = new Uint8Array(size);
-        res.set(new Uint8Array(buffer, ptr, size));
+        res.set(HEAP8.subarray(ptr, ptr + size));
         _free(ptr);
         return res.buffer;
       })(),


### PR DESCRIPTION
Error on CI that this should fix:

https://github.com/WebAssembly/binaryen/actions/runs/3894806501/jobs/6649299612

I am a little unclear as to why the error began on CI here... the emcc tot build has not been updated in a while as the roller is stalled (at least 6 days it seems). But this error began just over the last 24 hours somehow..? Anyhow, this fix is necessary given the change to remove this var.