### PR TITLE
[Wasm GC] SignaturePruning should not prune fields from a type with subtypes

### DIFF
--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -150,7 +150,7 @@ struct SignaturePruning : public Pass {
       }
     }
 
-    // Types with subtypes cannot be pruned (for a function type B to be a
+    // Types with subtypes cannot be pruned: for a function type B to be a
     // subtype of A, we need them to have the same number of parameters, as B's
     // parameters must be a subtype of A's, and tuple types are only subtypes if
     // their sizes match.

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -150,9 +150,9 @@ struct SignaturePruning : public Pass {
       }
     }
 
-    // Types with subtypes cannot be pruned as we must preserve contravariance
-    // of parameters. Likewise, we must preserve covariance of results, so in
-    // practice a type with either a supertype or a subtype cannot be modified.
+    // A type must have the same number of parameters and results as its
+    // supertypes and subtypes, so we only attempt to modify types without
+    // supertypes or subtypes.
     // TODO We could handle "cycles" where we remove fields from a group of
     //      types with subtyping relations at once.
     SubTypes subTypes(*module);

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -849,3 +849,41 @@
     )
   )
 )
+
+;; Due to function subtyping, we cannot prune fields from $func.B without also
+;; pruning them in $func.A, if they have a subtyping relationship. Atm we do not
+;; prune such "cycles" so we do not optimize here. TODO
+(module
+  ;; CHECK:      (type $array.A (array (ref $struct.A)))
+
+  ;; CHECK:      (type $array.B (array_subtype (ref $struct.B) $array.A))
+
+  ;; CHECK:      (type $func.A (func (param (ref $array.B)) (result (ref $array.A))))
+
+  ;; CHECK:      (type $func.B (func_subtype (param (ref $array.A)) (result (ref $array.B)) $func.A))
+
+  ;; CHECK:      (type $struct.A (struct (field i32)))
+  (type $struct.A (struct (field i32)))
+  ;; CHECK:      (type $struct.B (struct_subtype (field i32) (field i64) $struct.A))
+  (type $struct.B (struct_subtype (field i32) (field i64) $struct.A))
+
+  (type $array.A (array (ref $struct.A)))
+  (type $array.B (array_subtype (ref $struct.B) $array.A))
+
+  (type $func.A (func (param (ref $array.B)) (result (ref $array.A))))
+  (type $func.B (func_subtype (param (ref $array.A)) (result (ref $array.B)) $func.A))
+
+  ;; CHECK:      (func $func.A (type $func.A) (param $0 (ref $array.B)) (result (ref $array.A))
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $func.A (type $func.A) (param $0 (ref $array.B)) (result (ref $array.A))
+    (unreachable)
+  )
+
+  ;; CHECK:      (func $func.B (type $func.B) (param $0 (ref $array.A)) (result (ref $array.B))
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $func.B (type $func.B) (param $0 (ref $array.A)) (result (ref $array.B))
+    (unreachable)
+  )
+)

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -851,8 +851,9 @@
 )
 
 ;; Due to function subtyping, we cannot prune fields from $func.B without also
-;; pruning them in $func.A, if they have a subtyping relationship. Atm we do not
-;; prune such "cycles" so we do not optimize here. TODO
+;; pruning them in $func.A, and vice versa, if they have a subtyping
+;; relationship. Atm we do not prune such "cycles" so we do not optimize here.
+;; TODO
 (module
   ;; CHECK:      (type $array.A (array (ref $struct.A)))
 


### PR DESCRIPTION
For subtyping to not break, we must leave the number of fields equal in both
super and subtype, for each such pair.

Found by the fuzzer.