### PR TITLE
Move closed world flag to tool options

### DIFF
--- a/src/tools/optimization-options.h
+++ b/src/tools/optimization-options.h
@@ -270,18 +270,6 @@ struct OptimizationOptions : public ToolOptions {
         OptimizationOptionsCategory,
         Options::Arguments::Zero,
         [this](Options*, const std::string&) { passOptions.fastMath = true; })
-      .add(
-        "--closed-world",
-        "-cw",
-        "Assume code outside of the module does not inspect or interact with "
-        "GC and function references, even if they are passed out. The outside "
-        "may hold on to them and pass them back in, but not inspect their "
-        "contents or call them.",
-        OptimizationOptionsCategory,
-        Options::Arguments::Zero,
-        [this](Options*, const std::string&) {
-          passOptions.closedWorld = true;
-        })
       .add("--zero-filled-memory",
            "-uim",
            "Assume that an imported memory will be zero-initialized",

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -156,7 +156,19 @@ struct ToolOptions : public Options {
            Options::Arguments::Zero,
            [](Options* o, const std::string& argument) {
              setTypeSystem(TypeSystem::Isorecursive);
-           });
+           })
+      .add(
+        "--closed-world",
+        "-cw",
+        "Assume code outside of the module does not inspect or interact with "
+        "GC and function references, even if they are passed out. The outside "
+        "may hold on to them and pass them back in, but not inspect their "
+        "contents or call them.",
+        ToolOptionsCategory,
+        Options::Arguments::Zero,
+        [this](Options*, const std::string&) {
+          passOptions.closedWorld = true;
+        });
   }
 
   ToolOptions& addFeature(FeatureSet::Feature feature,

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -126,6 +126,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -130,6 +130,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -119,6 +119,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -166,6 +166,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -167,6 +167,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -564,15 +564,6 @@
 ;; CHECK-NEXT:                                                 corner cases of NaNs and
 ;; CHECK-NEXT:                                                 rounding
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --closed-world,-cw                            Assume code outside of the
-;; CHECK-NEXT:                                                 module does not inspect or
-;; CHECK-NEXT:                                                 interact with GC and function
-;; CHECK-NEXT:                                                 references, even if they are
-;; CHECK-NEXT:                                                 passed out. The outside may hold
-;; CHECK-NEXT:                                                 on to them and pass them back
-;; CHECK-NEXT:                                                 in, but not inspect their
-;; CHECK-NEXT:                                                 contents or call them.
-;; CHECK-NEXT:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory
 ;; CHECK-NEXT:                                                 will be zero-initialized
 ;; CHECK-NEXT:
@@ -686,6 +677,15 @@
 ;; CHECK-NEXT:   --hybrid                                      Force all GC type definitions to
 ;; CHECK-NEXT:                                                 be parsed using the isorecursive
 ;; CHECK-NEXT:                                                 hybrid type system.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                            Assume code outside of the
+;; CHECK-NEXT:                                                 module does not inspect or
+;; CHECK-NEXT:                                                 interact with GC and function
+;; CHECK-NEXT:                                                 references, even if they are
+;; CHECK-NEXT:                                                 passed out. The outside may hold
+;; CHECK-NEXT:                                                 on to them and pass them back
+;; CHECK-NEXT:                                                 in, but not inspect their
+;; CHECK-NEXT:                                                 contents or call them.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -155,6 +155,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -235,6 +235,13 @@
 ;; CHECK-NEXT:                                        parsed using the isorecursive hybrid type
 ;; CHECK-NEXT:                                        system.
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                   Assume code outside of the module does
+;; CHECK-NEXT:                                        not inspect or interact with GC and
+;; CHECK-NEXT:                                        function references, even if they are
+;; CHECK-NEXT:                                        passed out. The outside may hold on to
+;; CHECK-NEXT:                                        them and pass them back in, but not
+;; CHECK-NEXT:                                        inspect their contents or call them.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -523,15 +523,6 @@
 ;; CHECK-NEXT:                                                 corner cases of NaNs and
 ;; CHECK-NEXT:                                                 rounding
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --closed-world,-cw                            Assume code outside of the
-;; CHECK-NEXT:                                                 module does not inspect or
-;; CHECK-NEXT:                                                 interact with GC and function
-;; CHECK-NEXT:                                                 references, even if they are
-;; CHECK-NEXT:                                                 passed out. The outside may hold
-;; CHECK-NEXT:                                                 on to them and pass them back
-;; CHECK-NEXT:                                                 in, but not inspect their
-;; CHECK-NEXT:                                                 contents or call them.
-;; CHECK-NEXT:
 ;; CHECK-NEXT:   --zero-filled-memory,-uim                     Assume that an imported memory
 ;; CHECK-NEXT:                                                 will be zero-initialized
 ;; CHECK-NEXT:
@@ -645,6 +636,15 @@
 ;; CHECK-NEXT:   --hybrid                                      Force all GC type definitions to
 ;; CHECK-NEXT:                                                 be parsed using the isorecursive
 ;; CHECK-NEXT:                                                 hybrid type system.
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --closed-world,-cw                            Assume code outside of the
+;; CHECK-NEXT:                                                 module does not inspect or
+;; CHECK-NEXT:                                                 interact with GC and function
+;; CHECK-NEXT:                                                 references, even if they are
+;; CHECK-NEXT:                                                 passed out. The outside may hold
+;; CHECK-NEXT:                                                 on to them and pass them back
+;; CHECK-NEXT:                                                 in, but not inspect their
+;; CHECK-NEXT:                                                 contents or call them.
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:


### PR DESCRIPTION
This allows tools like wasm-reduce to be told to operate in closed-world mode. That
lets them validate in the more strict way of that mode.