### PR TITLE
Factor supertype-first type sort into separate header

### DIFF
--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -41,6 +41,7 @@
 #include "pass.h"
 #include "support/small_set.h"
 #include "wasm-builder.h"
+#include "wasm-type-ordering.h"
 #include "wasm.h"
 
 namespace wasm {

--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -41,7 +41,6 @@
 #include "pass.h"
 #include "support/small_set.h"
 #include "wasm-builder.h"
-#include "wasm-type-ordering.h"
 #include "wasm.h"
 
 namespace wasm {

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -44,7 +44,7 @@ struct SupertypesFirst : TopologicalSort<HeapType, SupertypesFirst<T>> {
     // Types that are not supertypes of others are the roots.
     for (auto [type, isSuper] : typeSet) {
       if (!isSuper) {
-        this->template push(type);
+        this->push(type);
       }
     }
   }

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -26,7 +26,7 @@
 namespace wasm::HeapTypeOrdering {
 
 // Given a collection of types, iterate through it such that each type in the
-// collection is visited only after its immediate children in the collection are
+// collection is visited only after its immediate supertype in the collection is
 // visited.
 template<typename T>
 struct SupertypesFirst : TopologicalSort<HeapType, SupertypesFirst<T>> {

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -36,9 +36,14 @@ struct SupertypesFirst : TopologicalSort<HeapType, SupertypesFirst<T>> {
 
   SupertypesFirst(const T& types) {
     for (auto type : types) {
-      typeSet.insert({type, false});
+      typeSet[type] = false;
+    }
+    // Find the supertypes that are in the collection.
+    for (auto [type, _] : typeSet) {
       if (auto super = type.getSuperType()) {
-        typeSet[*super] = true;
+        if (auto it = typeSet.find(*super); it != typeSet.end()) {
+          it->second = true;
+        }
       }
     }
     // Types that are not supertypes of others are the roots.

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_wasm_type_ordering_h
+#define wasm_wasm_type_ordering_h
+
+#include <unordered_set>
+
+#include "support/topological_sort.h"
+#include "wasm-type.h"
+
+namespace wasm::HeapTypeOrdering {
+
+struct SupertypesFirst : TopologicalSort<HeapType, SupertypesFirst> {
+  SupertypesFirst(const std::vector<HeapType>& types) {
+    std::unordered_set<HeapType> supertypes;
+    for (auto type : types) {
+      if (auto super = type.getSuperType()) {
+        supertypes.insert(*super);
+      }
+    }
+    // Types that are not supertypes of others are the roots.
+    for (auto type : types) {
+      if (!supertypes.count(type)) {
+        push(type);
+      }
+    }
+  }
+
+  void pushPredecessors(HeapType type) {
+    if (auto super = type.getSuperType()) {
+      push(*super);
+    }
+  }
+};
+
+} // namespace wasm::HeapTypeOrdering
+
+#endif // wasm_wasm_type_ordering_h


### PR DESCRIPTION
type-updating.cpp implemented a topological sorts on heap types that would visit
supertypes first. Since this same sort will be used by TypeMerging.cpp in #5432,
factor it out into a shared utility in a new wasm-type-ordering.h header.

At the same time, fix a bug in which the sort would visit types not in the input
collection. Concretely, this bug would cause public supertypes of private types
to be visited when only private types should have been visited. This
functionality change will be tested in #5432.

In principle the subtype-first sort used in subtypes.h could also be moved to
this header, but that is not yet duplicated in the code base and is more
efficient because it depends on implementation details of its current context,
so do not move it for now.