### PR TITLE
Fix a typo in Flat IR validation logic

### DIFF
--- a/src/ir/flat.h
+++ b/src/ir/flat.h
@@ -122,7 +122,7 @@ inline void verifyFlatness(Module* module) {
       return std::make_unique<VerifyFlatness>();
     }
 
-    void doVisitFunction(Function* func) { verifyFlatness(func); }
+    void visitFunction(Function* func) { verifyFlatness(func); }
   };
 
   PassRunner runner(module);


### PR DESCRIPTION
`doVisitFunction` does not exist, and we don't have static checking of that
sadly. Could `overrides` work here..?