### PR TITLE
Add missing #include needed for GCC 13

### DIFF
--- a/src/wat-lexer.h
+++ b/src/wat-lexer.h
@@ -15,6 +15,7 @@
  */
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <iterator>
 #include <optional>


### PR DESCRIPTION
Fixes errors like `error: 'uint32_t' does not name a type`.