### PR TITLE
add explicit include for <cstdint>

### DIFF
--- a/src/wat-lexer.h
+++ b/src/wat-lexer.h
@@ -15,6 +15,7 @@
  */
 
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <iterator>
 #include <optional>


### PR DESCRIPTION
This fixes the following error when compiling with GCC 13:
```
In file included from /builddir/build/BUILD/binaryen-version_111/test/gtest/wat-lexer.cpp:19:
/builddir/build/BUILD/binaryen-version_111/src/wat-lexer.h:62:3: error: 'uint64_t' does not name a type
   62 |   uint64_t n;
      |   ^~~~~~~~
/builddir/build/BUILD/binaryen-version_111/src/wat-lexer.h:24:1: note: 'uint64_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   23 | #include <variant>
  +++ |+#include <cstdint>
...
```
This is required before #5456 can be reproduced.