### PR TITLE
[NFC] Improve debug printing for type canonicalization

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2490,13 +2490,14 @@ struct CanonicalizationState {
 
 #if TRACE_CANONICALIZATION
   void dump() {
+    IndexedTypeNameGenerator print(results);
     std::cerr << "Results:\n";
     for (size_t i = 0; i < results.size(); ++i) {
-      std::cerr << i << ": " << results[i] << "\n";
+      std::cerr << i << ": " << print(results[i]) << "\n";
     }
     std::cerr << "NewInfos:\n";
     for (size_t i = 0; i < newInfos.size(); ++i) {
-      std::cerr << asHeapType(newInfos[i]) << "\n";
+      std::cerr << print(asHeapType(newInfos[i])) << "\n";
     }
     std::cerr << '\n';
   }


### PR DESCRIPTION
Use an `IndexedTypeNameGenerator` to give types stable names for the entire
`dump` method rather than generating fresh type names every time a single type
is printed. This makes it possible to understand the relationships between the
types in the debug output.