### PR TITLE
RemoveUnusedModuleElements: Support function subtyping

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -292,7 +292,7 @@ struct Analyzer {
     return worked;
   }
 
-  std::unique_ptr<SubTypes> subTypes;
+  std::optional<SubTypes> subTypes;
 
   void useCallRefType(HeapType type) {
     if (!subTypes) {

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -296,7 +296,7 @@ struct Analyzer {
 
   void useCallRefType(HeapType type) {
     if (!subTypes) {
-      subTypes = std::move(SubTypes(*module));
+      subTypes = SubTypes(*module);
     }
 
     // Call all the functions of that signature, and subtypes. We can then

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -295,6 +295,12 @@ struct Analyzer {
   std::optional<SubTypes> subTypes;
 
   void useCallRefType(HeapType type) {
+    if (type.isBasic()) {
+      // Nothing to do for something like a bottom type; attempts to call such a
+      // type will trap at runtime.
+      return;
+    }
+
     if (!subTypes) {
       subTypes = SubTypes(*module);
     }

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -296,7 +296,7 @@ struct Analyzer {
 
   void useCallRefType(HeapType type) {
     if (!subTypes) {
-      subTypes = std::make_unique<SubTypes>(*module);
+      subTypes = std::move(SubTypes(*module));
     }
 
     // Call all the functions of that signature, and subtypes. We can then

--- a/test/lit/passes/remove-unused-module-elements-refs.wast
+++ b/test/lit/passes/remove-unused-module-elements-refs.wast
@@ -7,9 +7,13 @@
 ;; if no calls exist to the right type, the function is not reached.
 
 (module
+  (type $A-super (func))
+
   ;; CHECK:      (type $A (func))
   ;; OPEN_WORLD:      (type $A (func))
-  (type $A (func))
+  (type $A (func_subtype $A-super))
+
+  (type $A-sub (func_subtype $A))
 
   ;; CHECK:      (type $B (func))
   ;; OPEN_WORLD:      (type $B (func))
@@ -92,6 +96,15 @@
   (func $target-A-noref (type $A)
     ;; This function is not reachable. We have a CallRef of the right type, but
     ;; no RefFunc.
+  )
+
+  (func $target-A-subtype (type $A-sub)
+    ;; This function is reachable because we have a CallRef of a supertype ($A).
+  )
+
+  (func $target-A-supertype (type $A-super)
+    ;; This function is not reachable. We have a CallRef of a subtype ($A), but
+    ;; that is not enough.
   )
 
   ;; CHECK:      (func $target-B (type $B)


### PR DESCRIPTION
When we see a `call_ref` or `call_indirect` of a heap type, we might be calling a
subtype of that type.