### PR TITLE
Fix issues with ref.cast_nop

### DIFF
--- a/src/wasm-delegations-fields.def
+++ b/src/wasm-delegations-fields.def
@@ -620,6 +620,7 @@ switch (DELEGATE_ID) {
   }
   case Expression::Id::RefCastId: {
     DELEGATE_START(RefCast);
+    DELEGATE_FIELD_INT(RefCast, safety);
     DELEGATE_FIELD_CHILD(RefCast, ref);
     DELEGATE_END(RefCast);
     break;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6935,8 +6935,7 @@ void WasmBinaryBuilder::visitRefAsCast(RefCast* curr, uint32_t code) {
 bool WasmBinaryBuilder::maybeVisitRefCast(Expression*& out, uint32_t code) {
   if (code == BinaryConsts::RefCastStatic || code == BinaryConsts::RefCast ||
       code == BinaryConsts::RefCastNull || code == BinaryConsts::RefCastNop) {
-    bool legacy =
-      code == BinaryConsts::RefCastStatic;
+    bool legacy = code == BinaryConsts::RefCastStatic;
     auto heapType = legacy ? getIndexedHeapType() : getHeapType();
     auto* ref = popNonVoidExpression();
     Nullability nullability;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6936,7 +6936,7 @@ bool WasmBinaryBuilder::maybeVisitRefCast(Expression*& out, uint32_t code) {
   if (code == BinaryConsts::RefCastStatic || code == BinaryConsts::RefCast ||
       code == BinaryConsts::RefCastNull || code == BinaryConsts::RefCastNop) {
     bool legacy =
-      code == BinaryConsts::RefCastStatic || code == BinaryConsts::RefCastNop;
+      code == BinaryConsts::RefCastStatic;
     auto heapType = legacy ? getIndexedHeapType() : getHeapType();
     auto* ref = popNonVoidExpression();
     Nullability nullability;

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2036,7 +2036,7 @@ void BinaryInstWriter::visitRefCast(RefCast* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   if (curr->safety == RefCast::Unsafe) {
     o << U32LEB(BinaryConsts::RefCastNop);
-    parent.writeIndexedHeapType(curr->type.getHeapType());
+    parent.writeHeapType(curr->type.getHeapType());
   } else {
     // TODO: These instructions are deprecated. Remove them.
     if (auto type = curr->type.getHeapType();

--- a/test/lit/ref-cast-nop.wast
+++ b/test/lit/ref-cast-nop.wast
@@ -15,4 +15,15 @@
    (local.get $x)
   )
  )
+
+ ;; CHECK:      (func $ref.cast_nop.null (type $ref|any|_=>_ref|none|) (param $x (ref any)) (result (ref none))
+ ;; CHECK-NEXT:  (ref.cast_nop none
+ ;; CHECK-NEXT:   (local.get $x)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $ref.cast_nop.null (param $x (ref any)) (result (ref none))
+  (ref.cast_nop none
+   (local.get $x)
+  )
+ )
 )


### PR DESCRIPTION
It did not have proper annotation for the safety field, and also
it could not handle basic heap types.

If we don't want to fix the latter in this way, we would need to
have optimization passes check `safety`, since the reason I noticed
this is that CastRefining will turn casts to cast to null, which then
errors for the `_nop` variant.

Is this even still needed, I wonder?