### PR TITLE
[CMake] Enable EMSCRIPTEN_ENABLE_WASM_EH by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,14 +40,14 @@ option(BUILD_TOOLS "Build tools" ON)
 # Turn this off to install only tools and not static/dynamic libs
 option(INSTALL_LIBS "Install libraries" ON)
 
+# Turn this on to use the Wasm EH feature instead of emscripten EH in the wasm/BinaryenJS builds
+option(EMSCRIPTEN_ENABLE_WASM_EH "Enable Wasm EH feature in emscripten build" ON)
+
 # Turn this on to build only the subset of tools needed for emscripten
 option(BUILD_EMSCRIPTEN_TOOLS_ONLY "Build only tools needed by emscripten" OFF)
 
 # Turn this on to build binaryen.js as ES5, with additional compatibility configuration for js_of_ocaml.
 option(JS_OF_OCAML "Build binaryen.js for js_of_ocaml" OFF)
-
-# Turn this on to use the Wasm EH feature instead of emscripten EH in the wasm/BinaryenJS builds
-option(EMSCRIPTEN_ENABLE_WASM_EH "Enable Wasm EH feature in emscripten build" OFF)
 
 # For git users, attempt to generate a more useful version string
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)


### PR DESCRIPTION
I propose enable EMSCRIPTEN_ENABLE_WASM_EH to ON state. Due to it already cover Node LTS requirements: https://github.com/WebAssembly/binaryen/pull/5454#issuecomment-1414465879