### PR TITLE
Never flip a call from unreachable to reachable during inlining

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -425,7 +425,11 @@ static Expression* doInlining(Module* module,
   // validates that way. To fix, this, if the call was unreachable then we make
   // the inlined code unreachable as well. That also maximizes DCE
   // opportunities by propagating unreachability as much as possible.
-  if (call->type == Type::unreachable && contents->type != Type::unreachable) {
+  //
+  // (Note that we don't need to do this for a return_call, which is always
+  // unreachable anyhow.)
+  if (call->type == Type::unreachable && contents->type != Type::unreachable &&
+      !call->isReturn) {
     // Make the block unreachable by adding an unreachable, and also drop the
     // previous last item if we need to.
     if (block->list.back()->type.isConcrete()) {

--- a/test/lit/passes/inlining-unreachable.wast
+++ b/test/lit/passes/inlining-unreachable.wast
@@ -16,7 +16,6 @@
   ;; CHECK:      (func $call-trap (type $none_=>_none)
   ;; CHECK-NEXT:  (block $__inlined_func$trap
   ;; CHECK-NEXT:   (unreachable)
-  ;; CHECK-NEXT:   (br $__inlined_func$trap)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-trap
@@ -59,7 +58,6 @@
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (br $__inlined_func$contents-then-trap)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-contents-then-trap

--- a/test/lit/passes/inlining_all-features.wast
+++ b/test/lit/passes/inlining_all-features.wast
@@ -142,13 +142,11 @@
  ;; CHECK:      (func $1 (type $none_=>_none)
  ;; CHECK-NEXT:  (block $__inlined_func$0
  ;; CHECK-NEXT:   (unreachable)
- ;; CHECK-NEXT:   (br $__inlined_func$0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  ;; NOMNL:      (func $1 (type $none_=>_none)
  ;; NOMNL-NEXT:  (block $__inlined_func$0
  ;; NOMNL-NEXT:   (unreachable)
- ;; NOMNL-NEXT:   (br $__inlined_func$0)
  ;; NOMNL-NEXT:  )
  ;; NOMNL-NEXT: )
  (func $1

--- a/test/lit/passes/inlining_enable-tail-call.wast
+++ b/test/lit/passes/inlining_enable-tail-call.wast
@@ -445,8 +445,11 @@
 
  ;; CHECK:      (func $0 (result i32)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (block $__inlined_func$1 (result i32)
- ;; CHECK-NEXT:    (i32.const 42)
+ ;; CHECK-NEXT:   (block $__inlined_func$1
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (i32.const 42)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -470,6 +473,7 @@
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (local.get $0)
  ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (return)
  ;; CHECK-NEXT:  )
@@ -491,11 +495,14 @@
  ;; CHECK:      (func $0 (result i32)
  ;; CHECK-NEXT:  (local $0 i32)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (block $__inlined_func$1 (result i32)
+ ;; CHECK-NEXT:   (block $__inlined_func$1
  ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (local.get $0)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -561,7 +568,6 @@
  ;; CHECK-NEXT:     (br $__inlined_func$1)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (br $__inlined_func$1)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $0
@@ -629,7 +635,6 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (br $__inlined_func$1)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (br $__inlined_func$1)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $0
@@ -689,12 +694,12 @@
  ;; CHECK-NEXT:           (i32.const 1)
  ;; CHECK-NEXT:          )
  ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (unreachable)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:        (br $__inlined_func$13)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (br $__inlined_func$13)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -719,25 +724,28 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (return
- ;; CHECK-NEXT:    (block $__inlined_func$is_odd (result i32)
+ ;; CHECK-NEXT:    (block $__inlined_func$is_odd
  ;; CHECK-NEXT:     (local.set $1
  ;; CHECK-NEXT:      (i32.sub
  ;; CHECK-NEXT:       (local.get $i)
  ;; CHECK-NEXT:       (i32.const 1)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (if (result i32)
- ;; CHECK-NEXT:      (i32.eqz
- ;; CHECK-NEXT:       (local.get $1)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (i32.const 0)
- ;; CHECK-NEXT:      (return_call $is_even
- ;; CHECK-NEXT:       (i32.sub
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (if (result i32)
+ ;; CHECK-NEXT:       (i32.eqz
  ;; CHECK-NEXT:        (local.get $1)
- ;; CHECK-NEXT:        (i32.const 1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (i32.const 0)
+ ;; CHECK-NEXT:       (return_call $is_even
+ ;; CHECK-NEXT:        (i32.sub
+ ;; CHECK-NEXT:         (local.get $1)
+ ;; CHECK-NEXT:         (i32.const 1)
+ ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/inlining_enable-tail-call.wast
+++ b/test/lit/passes/inlining_enable-tail-call.wast
@@ -445,11 +445,8 @@
 
  ;; CHECK:      (func $0 (result i32)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (block $__inlined_func$1
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (i32.const 42)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   (block $__inlined_func$1 (result i32)
+ ;; CHECK-NEXT:    (i32.const 42)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -473,7 +470,6 @@
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (local.get $0)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (return)
  ;; CHECK-NEXT:  )
@@ -495,14 +491,11 @@
  ;; CHECK:      (func $0 (result i32)
  ;; CHECK-NEXT:  (local $0 i32)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (block $__inlined_func$1
+ ;; CHECK-NEXT:   (block $__inlined_func$1 (result i32)
  ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (local.get $0)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -694,7 +687,6 @@
  ;; CHECK-NEXT:           (i32.const 1)
  ;; CHECK-NEXT:          )
  ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:         (unreachable)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:        (br $__inlined_func$13)
  ;; CHECK-NEXT:       )
@@ -724,28 +716,25 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (return
- ;; CHECK-NEXT:    (block $__inlined_func$is_odd
+ ;; CHECK-NEXT:    (block $__inlined_func$is_odd (result i32)
  ;; CHECK-NEXT:     (local.set $1
  ;; CHECK-NEXT:      (i32.sub
  ;; CHECK-NEXT:       (local.get $i)
  ;; CHECK-NEXT:       (i32.const 1)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (drop
- ;; CHECK-NEXT:      (if (result i32)
- ;; CHECK-NEXT:       (i32.eqz
+ ;; CHECK-NEXT:     (if (result i32)
+ ;; CHECK-NEXT:      (i32.eqz
+ ;; CHECK-NEXT:       (local.get $1)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (i32.const 0)
+ ;; CHECK-NEXT:      (return_call $is_even
+ ;; CHECK-NEXT:       (i32.sub
  ;; CHECK-NEXT:        (local.get $1)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (i32.const 0)
- ;; CHECK-NEXT:       (return_call $is_even
- ;; CHECK-NEXT:        (i32.sub
- ;; CHECK-NEXT:         (local.get $1)
- ;; CHECK-NEXT:         (i32.const 1)
- ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (i32.const 1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/inlining_optimize-level=3.wast
+++ b/test/lit/passes/inlining_optimize-level=3.wast
@@ -495,3 +495,68 @@
   (unreachable)
  )
 )
+
+;; We inline multiple times here, and in the sequence of those inlinings we
+;; turn the code in $B unreachable (when we inline $D), and no later inlining
+;; (of $C or $A, or even $C's inlining in $A) should turn it into anything else
+;; than an unreachable - once it is unreachable, we should keep it that way.
+;; (That avoids possible validation problems, and maximizes DCE.)
+(module
+ ;; CHECK:      (type $f32_=>_none (func (param f32)))
+
+ ;; CHECK:      (type $none_=>_none (func))
+
+ ;; CHECK:      (func $A (param $0 f32)
+ ;; CHECK-NEXT:  (local $1 f32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block (result f32)
+ ;; CHECK-NEXT:    (block $__inlined_func$C (result f32)
+ ;; CHECK-NEXT:     (local.set $1
+ ;; CHECK-NEXT:      (local.get $0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $1)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $A (param $0 f32)
+  (drop
+   (call $C
+    (local.get $0)
+   )
+  )
+ )
+ ;; CHECK:      (func $B
+ ;; CHECK-NEXT:  (local $0 f32)
+ ;; CHECK-NEXT:  (call $A
+ ;; CHECK-NEXT:   (block
+ ;; CHECK-NEXT:    (block $__inlined_func$C
+ ;; CHECK-NEXT:     (local.tee $0
+ ;; CHECK-NEXT:      (block
+ ;; CHECK-NEXT:       (block $__inlined_func$D
+ ;; CHECK-NEXT:        (unreachable)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (local.get $0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (unreachable)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $B
+  (call $A
+   (call $C
+    (call $D)
+   )
+  )
+ )
+ (func $C (param $0 f32) (result f32)
+  (local.get $0)
+ )
+ (func $D (result f32)
+  (unreachable)
+ )
+)

--- a/test/lit/passes/inlining_optimize-level=3.wast
+++ b/test/lit/passes/inlining_optimize-level=3.wast
@@ -500,7 +500,8 @@
 ;; turn the code in $B unreachable (when we inline $D), and no later inlining
 ;; (of $C or $A, or even $C's inlining in $A) should turn it into anything else
 ;; than an unreachable - once it is unreachable, we should keep it that way.
-;; (That avoids possible validation problems, and maximizes DCE.)
+;; (That avoids possible validation problems, and maximizes DCE.) To keep it
+;; unreachable we'll add an unreachable instruction after the inlined code.
 (module
  ;; CHECK:      (type $f32_=>_none (func (param f32)))
 

--- a/test/lit/passes/inlining_optimize-level=3.wast
+++ b/test/lit/passes/inlining_optimize-level=3.wast
@@ -531,16 +531,18 @@
  ;; CHECK-NEXT:  (local $0 f32)
  ;; CHECK-NEXT:  (call $A
  ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (block $__inlined_func$C
- ;; CHECK-NEXT:     (local.tee $0
- ;; CHECK-NEXT:      (block
- ;; CHECK-NEXT:       (block $__inlined_func$D
- ;; CHECK-NEXT:        (unreachable)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    (block
  ;; CHECK-NEXT:     (drop
- ;; CHECK-NEXT:      (local.get $0)
+ ;; CHECK-NEXT:      (block $__inlined_func$C (result f32)
+ ;; CHECK-NEXT:       (local.tee $0
+ ;; CHECK-NEXT:        (block
+ ;; CHECK-NEXT:         (block $__inlined_func$D
+ ;; CHECK-NEXT:          (unreachable)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (local.get $0)
+ ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/inlining_splitting.wast
+++ b/test/lit/passes/inlining_splitting.wast
@@ -231,7 +231,6 @@
   ;; CHECK-NEXT:     (br $l)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (br $__inlined_func$nondefaultable-param)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $call-nondefaultable-param


### PR DESCRIPTION
See example in the new comment. In general, we never want to go from
unreachable to reachable (refinalize doesn't even try), as it misses out on
DCE opportunities. Also it may have validation issues, which is how the
fuzzer found this.

Remove code in the same place that was redundant after the refinalize
was added in #5492. That simplifies some existing testcases slightly, by
removing an unneeded `br` we added, and now we add a new `unreachable`
at the end in other cases that need it.
