### PR TITLE
[Strings] Start some basic fuzzing support for strings

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2110,6 +2110,7 @@ Expression* TranslateToFuzzReader::makeConstBasicRef(Type type) {
       return builder.makeArrayInit(trivialArray, {});
     }
     case HeapType::string:
+      return builder.makeStringConst(std::to_string(upTo(1024)));
     case HeapType::stringview_wtf8:
     case HeapType::stringview_wtf16:
     case HeapType::stringview_iter:
@@ -3218,6 +3219,7 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
       case HeapType::array:
         return pick(HeapType::array, HeapType::none);
       case HeapType::string:
+        return HeapType::string;
       case HeapType::stringview_wtf8:
       case HeapType::stringview_wtf16:
       case HeapType::stringview_iter:


### PR DESCRIPTION
This is necessary to avoid fuzzer breakage after #5497 as it added a test with
strings. We could also ignore that file, like we do for other string files, but this
was not much work so just implement it.