### PR TITLE
[Wasm GC] Parse (sub $super _) for array, func, and struct

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -52,8 +52,7 @@ namespace wasm {
 static Name STRUCT("struct"), FIELD("field"), ARRAY("array"),
   FUNC_SUBTYPE("func_subtype"), STRUCT_SUBTYPE("struct_subtype"),
   ARRAY_SUBTYPE("array_subtype"), EXTENDS("extends"), REC("rec"), I8("i8"),
-  I16("i16"), DECLARE("declare"), ITEM("item"), OFFSET("offset"),
-  SUB("sub");
+  I16("i16"), DECLARE("declare"), ITEM("item"), OFFSET("offset"), SUB("sub");
 
 static Address getAddress(const Element* s) {
   return std::stoll(s->toString());
@@ -905,12 +904,12 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
         throw ParseException("invalid 'sub' form", kind.line, kind.col);
       }
       super = def[1];
-      Element &subtype = *def[2];
+      Element& subtype = *def[2];
       if (!subtype.isList() || subtype.size() < 1) {
-        throw ParseException("invalid subtype definition", subtype.line,
-                             subtype.col);
+        throw ParseException(
+          "invalid subtype definition", subtype.line, subtype.col);
       }
-      Element &subtypeKind = *subtype[0];
+      Element& subtypeKind = *subtype[0];
       if (subtypeKind == FUNC) {
         builder[index] = parseSignatureDef(subtype, 0);
       } else if (subtypeKind == STRUCT) {
@@ -918,8 +917,8 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
       } else if (subtypeKind == ARRAY) {
         builder[index] = parseArrayDef(subtype);
       } else {
-        throw ParseException("unknown subtype kind", subtypeKind.line,
-                             subtypeKind.col);
+        throw ParseException(
+          "unknown subtype kind", subtypeKind.line, subtypeKind.col);
       }
     } else {
       if (kind == FUNC) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -902,7 +902,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
     Element* super = nullptr;
     if (kind == SUB) {
       if (def.size() != 3) {
-        throw ParseException("invalid `sub' form", kind.line, kind.col);
+        throw ParseException("invalid 'sub' form", kind.line, kind.col);
       }
       super = def[1];
       Element &subtype = *def[2];

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -926,7 +926,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
       } else if (kind == FUNC_SUBTYPE) {
         builder[index] = parseSignatureDef(def, 1);
         super = def[def.size() - 1];
-        if (super->str() == FUNC) {
+        if (!super->dollared() && super->str() == FUNC) {
           // OK; no supertype
           super = nullptr;
         }
@@ -935,7 +935,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
       } else if (kind == STRUCT_SUBTYPE) {
         builder[index] = parseStructDef(def, index, 1);
         super = def[def.size() - 1];
-        if (super->str() == DATA) {
+        if (!super->dollared() && super->str() == DATA) {
           // OK; no supertype
           super = nullptr;
         }
@@ -944,7 +944,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
       } else if (kind == ARRAY_SUBTYPE) {
         builder[index] = parseArrayDef(def);
         super = def[def.size() - 1];
-        if (super->str() == DATA) {
+        if (!super->dollared() && super->str() == DATA) {
           // OK; no supertype
           super = nullptr;
         }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -52,7 +52,8 @@ namespace wasm {
 static Name STRUCT("struct"), FIELD("field"), ARRAY("array"),
   FUNC_SUBTYPE("func_subtype"), STRUCT_SUBTYPE("struct_subtype"),
   ARRAY_SUBTYPE("array_subtype"), EXTENDS("extends"), REC("rec"), I8("i8"),
-  I16("i16"), DECLARE("declare"), ITEM("item"), OFFSET("offset");
+  I16("i16"), DECLARE("declare"), ITEM("item"), OFFSET("offset"),
+  SUB("sub");
 
 static Address getAddress(const Element* s) {
   return std::stoll(s->toString());
@@ -898,30 +899,62 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
   forEachType([&](Element& elem, size_t) {
     Element& def = elem[1]->dollared() ? *elem[2] : *elem[1];
     Element& kind = *def[0];
-    bool hasSupertype =
-      kind == FUNC_SUBTYPE || kind == STRUCT_SUBTYPE || kind == ARRAY_SUBTYPE;
-    if (kind == FUNC || kind == FUNC_SUBTYPE) {
-      builder[index] = parseSignatureDef(def, hasSupertype);
-    } else if (kind == STRUCT || kind == STRUCT_SUBTYPE) {
-      builder[index] = parseStructDef(def, index, hasSupertype);
-    } else if (kind == ARRAY || kind == ARRAY_SUBTYPE) {
-      builder[index] = parseArrayDef(def);
-    } else {
-      throw ParseException("unknown heaptype kind", kind.line, kind.col);
-    }
     Element* super = nullptr;
-    if (hasSupertype) {
-      super = def[def.size() - 1];
-      if (super->dollared()) {
-        // OK
-      } else if (kind == FUNC_SUBTYPE && super->str() == FUNC) {
-        // OK; no supertype
-        super = nullptr;
-      } else if ((kind == STRUCT_SUBTYPE || kind == ARRAY_SUBTYPE) &&
-                 super->str() == DATA) {
-        // OK; no supertype
-        super = nullptr;
+    if (kind == SUB) {
+      if (def.size() != 3) {
+        throw ParseException("invalid `sub' form", kind.line, kind.col);
+      }
+      super = def[1];
+      Element &subtype = *def[2];
+      if (!subtype.isList() || subtype.size() < 1) {
+        throw ParseException("invalid subtype definition", subtype.line,
+                             subtype.col);
+      }
+      Element &subtypeKind = *subtype[0];
+      if (subtypeKind == FUNC) {
+        builder[index] = parseSignatureDef(subtype, 0);
+      } else if (subtypeKind == STRUCT) {
+        builder[index] = parseStructDef(subtype, index, 0);
+      } else if (subtypeKind == ARRAY) {
+        builder[index] = parseArrayDef(subtype);
       } else {
+        throw ParseException("unknown subtype kind", subtypeKind.line,
+                             subtypeKind.col);
+      }
+    } else {
+      if (kind == FUNC) {
+        builder[index] = parseSignatureDef(def, 0);
+      } else if (kind == FUNC_SUBTYPE) {
+        builder[index] = parseSignatureDef(def, 1);
+        super = def[def.size() - 1];
+        if (super->str() == FUNC) {
+          // OK; no supertype
+          super = nullptr;
+        }
+      } else if (kind == STRUCT) {
+        builder[index] = parseStructDef(def, index, 0);
+      } else if (kind == STRUCT_SUBTYPE) {
+        builder[index] = parseStructDef(def, index, 1);
+        super = def[def.size() - 1];
+        if (super->str() == DATA) {
+          // OK; no supertype
+          super = nullptr;
+        }
+      } else if (kind == ARRAY) {
+        builder[index] = parseArrayDef(def);
+      } else if (kind == ARRAY_SUBTYPE) {
+        builder[index] = parseArrayDef(def);
+        super = def[def.size() - 1];
+        if (super->str() == DATA) {
+          // OK; no supertype
+          super = nullptr;
+        }
+      } else {
+        throw ParseException("unknown heaptype kind", kind.line, kind.col);
+      }
+    }
+    if (super) {
+      if (!super->dollared()) {
         throw ParseException("unknown supertype", super->line, super->col);
       }
     } else if (elementStartsWith(elem[elem.size() - 1], EXTENDS)) {

--- a/test/lit/isorecursive-good.wast
+++ b/test/lit/isorecursive-good.wast
@@ -16,7 +16,7 @@
     (type $super-struct (struct i32))
     ;; HYBRID:       (type $sub-struct (struct_subtype (field i32) (field i64) $super-struct))
     ;; NOMINAL:      (type $sub-struct (struct_subtype (field i32) (field i64) $super-struct))
-    (type $sub-struct (struct_subtype i32 i64 $super-struct))
+    (type $sub-struct (sub $super-struct (struct i32 i64)))
   )
 
   (rec
@@ -24,7 +24,7 @@
     ;; HYBRID-NEXT:  (type $super-array (array (ref $super-struct)))
     (type $super-array (array (ref $super-struct)))
     ;; HYBRID:       (type $sub-array (array_subtype (ref $sub-struct) $super-array))
-    (type $sub-array (array_subtype (ref $sub-struct) $super-array))
+    (type $sub-array (sub $super-array (array (ref $sub-struct))))
   )
 
   (rec
@@ -34,7 +34,7 @@
     (type $super-func (func (param (ref $sub-array)) (result (ref $super-array))))
     ;; HYBRID:       (type $sub-func (func_subtype (param (ref $super-array)) (result (ref $sub-array)) $super-func))
     ;; NOMINAL:      (type $sub-func (func_subtype (param (ref $super-array)) (result (ref $sub-array)) $super-func))
-    (type $sub-func (func_subtype (param (ref $super-array)) (result (ref $sub-array)) $super-func))
+    (type $sub-func (sub $super-func (func (param (ref $super-array)) (result (ref $sub-array)))))
   )
 
   ;; HYBRID:      (func $make-super-struct (type $none_=>_ref|$super-struct|) (result (ref $super-struct))

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -121,6 +121,9 @@
  ;; CHECK:      (type $s8 (struct (field i32) (field i64) (field $z f32) (field f64) (field (mut i32))))
  (type $s8 (struct i32 (field) i64 (field $z f32) (field f64 (mut i32))))
 
+ ;; CHECK:      (type $s9 (struct_subtype (field i32) $s2))
+ (type $s9) (sub $s2 (struct i64))
+
  ;; CHECK:      (type $a0 (array i32))
  (type $a0 (array i32))
  (type $a1 (array (field i64)))

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -121,9 +121,6 @@
  ;; CHECK:      (type $s8 (struct (field i32) (field i64) (field $z f32) (field f64) (field (mut i32))))
  (type $s8 (struct i32 (field) i64 (field $z f32) (field f64 (mut i32))))
 
- ;; CHECK:      (type $s9 (struct_subtype (field i32) $s2))
- (type $s9) (sub $s2 (struct i64))
-
  ;; CHECK:      (type $a0 (array i32))
  (type $a0 (array i32))
  (type $a1 (array (field i64)))


### PR DESCRIPTION
The pretty-printer will still serialize these using the old func_subtype, array_subtype, and struct_subtype syntax, though.