### PR TITLE
remote unnecessary echo PATH in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
       run: |
         sudo pip3 install -r requirements-dev.txt
         sudo apt-get install clang-format clang-tidy
-    - name: update path
-      run:  echo "PATH=$PATH:/usr/lib/llvm-8/bin" >> $GITHUB_ENV
     - run: flake8
     - run: ./scripts/clang-format-diff.sh
     - name: clang-tidy


### PR DESCRIPTION
The runner ubuntu-latest is Ubuntu 22, which no longer use llvm-8, so this PATH can be remoted.

This llvm-8 here is misleading. Some developers spend a lot of time to compile llvm-8 from source, because llvm-8 is not available in new Ubuntu apt. But actually CI is not using llvm-8.