### PR TITLE
Emit source map information for control flow structures

### DIFF
--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -251,12 +251,12 @@ void BinaryenIRWriter<SubType>::visit(Expression* curr) {
     // `curr` is not reachable, so don't emit it.
     return;
   }
+  emitDebugLocation(curr);
   // Control flow requires special handling, but most instructions can be
   // emitted directly after their children.
   if (Properties::isControlFlowStructure(curr)) {
     Visitor<BinaryenIRWriter>::visit(curr);
   } else {
-    emitDebugLocation(curr);
     emit(curr);
   }
 }

--- a/test/lit/source-map.wast
+++ b/test/lit/source-map.wast
@@ -26,8 +26,9 @@
 )
 
 ;; CHECK:  (func $foo (param $x i32) (param $y i32)
-;; CHECK-NEXT:   ;;@ src.cpp:20:1
+;; CHECK-NEXT:   ;;@ src.cpp:10:1
 ;; CHECK-NEXT:   (if
+;; CHECK-NEXT:    ;;@ src.cpp:20:1
 ;; CHECK-NEXT:    (i32.add
 ;; CHECK-NEXT:     ;;@ src.cpp:30:1
 ;; CHECK-NEXT:     (local.get $x)


### PR DESCRIPTION
With this, the sourcemap testcase outputs the exact same thing as the input.

Followup to #5504

cc @JesseCodeBones