### PR TITLE
[wasm2js] Fix atomic notify to take an unsigned count

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -2135,8 +2135,9 @@ Ref Wasm2JSBuilder::processFunctionBody(Module* m,
       ValueBuilder::appendToCall(
         call,
         ValueBuilder::makePtrShift(makePointer(curr->ptr, curr->offset), 2));
-      ValueBuilder::appendToCall(call,
-                                 visit(curr->notifyCount, EXPRESSION_RESULT));
+      ValueBuilder::appendToCall(
+        call,
+        makeSigning(visit(curr->notifyCount, EXPRESSION_RESULT), JS_UNSIGNED));
       return call;
     }
 

--- a/test/wasm2js/atomics_32.2asm.js
+++ b/test/wasm2js/atomics_32.2asm.js
@@ -123,8 +123,8 @@ function asmFunc(imports) {
   wasm2js_atomic_wait_i32(4 | 0, 8 | 0, 16 | 0, -1 | 0, i64toi32_i32$0 | 0) | 0;
   wasm2js_memory_init(0, 512, 0, 4);
   wasm2js_memory_init(1, 1024, 4, 2);
-  Atomics.notify(HEAP32, 4 >> 2, 2);
-  Atomics.notify(HEAP32, (4 + 20 | 0) >> 2, 2);
+  Atomics.notify(HEAP32, 4 >> 2, 2 >>> 0);
+  Atomics.notify(HEAP32, (4 + 20 | 0) >> 2, -1 >>> 0);
   Atomics.add(HEAP32, 8 >> 2, 12);
   Atomics.sub(HEAP32, 8 >> 2, 12);
   Atomics.and(HEAP32, 8 >> 2, 12);

--- a/test/wasm2js/atomics_32.2asm.js.opt
+++ b/test/wasm2js/atomics_32.2asm.js.opt
@@ -122,7 +122,7 @@ function asmFunc(imports) {
   wasm2js_memory_init(0, 512, 0, 4);
   wasm2js_memory_init(1, 1024, 4, 2);
   Atomics.notify(HEAP32, 1, 2);
-  Atomics.notify(HEAP32, 4 + 20 >> 2, 2);
+  Atomics.notify(HEAP32, 4 + 20 >> 2, 4294967295);
   Atomics.add(HEAP32, 2, 12);
   Atomics.sub(HEAP32, 2, 12);
   Atomics.and(HEAP32, 2, 12);

--- a/test/wasm2js/atomics_32.wast
+++ b/test/wasm2js/atomics_32.wast
@@ -16,7 +16,7 @@
     (memory.init 0 (i32.const 512) (i32.const 0) (i32.const 4))
     (memory.init 1 (i32.const 1024) (i32.const 4) (i32.const 2))
     (local.set $x (memory.atomic.notify (i32.const 4) (i32.const 2)))
-    (local.set $x (memory.atomic.notify offset=20 (i32.const 4) (i32.const 2)))
+    (local.set $x (memory.atomic.notify offset=20 (i32.const 4) (i32.const -1)))
     (local.set $x (i32.atomic.rmw.add (i32.const 8) (i32.const 12)))
     (local.set $x (i32.atomic.rmw.sub (i32.const 8) (i32.const 12)))
     (local.set $x (i32.atomic.rmw.and (i32.const 8) (i32.const 12)))


### PR DESCRIPTION
Without this fix, the common idiom of using `INT_MAX` in C source to mean an
unlimited number of waiters should be woken up actually compiled down to an
argument of -1 in JS, causing zero waiters to be woken.