### PR TITLE
Fuzzer: Only use RefAs in a function context

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1974,7 +1974,8 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
   // but only rarely if the type is non-nullable (because in that case we'd need
   // to add a ref.as_non_null to validate, and the code will trap when we get
   // here).
-  if ((type.isNullable() && oneIn(2)) || (type.isNonNullable() && oneIn(16))) {
+  if ((type.isNullable() && oneIn(2)) ||
+      (type.isNonNullable() && oneIn(16) && funcContext)) {
     Expression* ret = builder.makeRefNull(HeapType::nofunc);
     if (!type.isNullable()) {
       ret = builder.makeRefAs(RefAsNonNull, ret);
@@ -2155,6 +2156,7 @@ Expression* TranslateToFuzzReader::makeConstCompoundRef(Type type) {
         })) {
       // There is a nondefaultable field, which we must create.
       for (auto& field : fields) {
+        // TODO: when in a function context, we don't need to be trivial.
         values.push_back(makeTrivial(field.type));
       }
     }
@@ -2163,6 +2165,7 @@ Expression* TranslateToFuzzReader::makeConstCompoundRef(Type type) {
     auto element = heapType.getArray().element;
     Expression* init = nullptr;
     if (!element.type.isDefaultable()) {
+      // TODO: when in a function context, we don't need to be trivial.
       init = makeTrivial(element.type);
     }
     return builder.makeArrayNew(type.getHeapType(), makeConst(Type::i32), init);


### PR DESCRIPTION
Line 1980/1981 below is where we use a RefAs. We need to avoid getting
there if we are not in a function.