### PR TITLE
Fuzzer: Handle HostLimitException during instance creation

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -673,7 +673,7 @@ class FuzzExec(TestCaseHandler):
     frequency = 1
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):
-        run_vm([in_bin('wasm-opt'), before_wasm] + opts + ['--fuzz-exec'])
+        run([in_bin('wasm-opt'), before_wasm] + opts + ['--fuzz-exec'])
 
 
 class CompareVMs(TestCaseHandler):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -673,7 +673,7 @@ class FuzzExec(TestCaseHandler):
     frequency = 1
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):
-        run([in_bin('wasm-opt'), before_wasm] + opts + ['--fuzz-exec'])
+        run_vm([in_bin('wasm-opt'), before_wasm] + opts + ['--fuzz-exec'])
 
 
 class CompareVMs(TestCaseHandler):

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -132,6 +132,8 @@ struct ExecutionResults {
       }
     } catch (const TrapException&) {
       // may throw in instance creation (init of offsets)
+    } catch (const HostLimitException&) {
+      // may throw in instance creation (e.g. array.new of huge size)
     }
   }
 
@@ -220,6 +222,9 @@ struct ExecutionResults {
       return run(func, wasm, instance);
     } catch (const TrapException&) {
       // may throw in instance creation (init of offsets)
+      return {};
+    } catch (const HostLimitException&) {
+      // may throw in instance creation (e.g. array.new of huge size)
       return {};
     }
   }


### PR DESCRIPTION
We handle this like the existing handling of TrapException: we skip running
this module (since we can't even instantiate it, so there is nothing to run).