### PR TITLE
Function types with multiple results require multivalue

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1039,7 +1039,7 @@ FeatureSet Type::getFeatures() const {
         return FeatureSet::ReferenceTypes | FeatureSet::GC;
       }
       // Otherwise, this is a function reference, which requires reference types
-      // and possible also multivalue (if it has multiple returns).
+      // and possibly also multivalue (if it has multiple returns).
       // Note: Technically typed function references also require GC, however,
       // we use these types internally regardless of the presence of GC (in
       // particular, since during load of the wasm we don't know the features

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1038,13 +1038,18 @@ FeatureSet Type::getFeatures() const {
           heapType.getRecGroup().size() > 1 || heapType.getSuperType()) {
         return FeatureSet::ReferenceTypes | FeatureSet::GC;
       }
+      // Otherwise, this is a function reference, which requires reference types
+      // and possible also multivalue (if it has multiple returns).
       // Note: Technically typed function references also require GC, however,
       // we use these types internally regardless of the presence of GC (in
       // particular, since during load of the wasm we don't know the features
       // yet, so we apply the more refined types), so we don't add that in any
       // case here.
-      assert(heapType.isSignature());
-      return FeatureSet::ReferenceTypes;
+      FeatureSet feats = FeatureSet::ReferenceTypes;
+      if (heapType.getSignature().results.isTuple()) {
+        feats |= FeatureSet::Multivalue;
+      }
+      return feats;
     }
     TODO_SINGLE_COMPOUND(t);
     switch (t.getBasic()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1045,7 +1045,7 @@ FeatureSet Type::getFeatures() const {
       // particular, since during load of the wasm we don't know the features
       // yet, so we apply the more refined types), so we don't add that in any
       // case here.
-      FeatureSet feats = FeatureSet::ReferenceTypes;
+      auto feats = FeatureSet::ReferenceTypes;
       if (heapType.getSignature().results.isTuple()) {
         feats |= FeatureSet::Multivalue;
       }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1045,7 +1045,7 @@ FeatureSet Type::getFeatures() const {
       // particular, since during load of the wasm we don't know the features
       // yet, so we apply the more refined types), so we don't add that in any
       // case here.
-      auto feats = FeatureSet::ReferenceTypes;
+      FeatureSet feats = FeatureSet::ReferenceTypes;
       if (heapType.getSignature().results.isTuple()) {
         feats |= FeatureSet::Multivalue;
       }

--- a/test/lit/validation/ref-func-multivalue.wast
+++ b/test/lit/validation/ref-func-multivalue.wast
@@ -1,0 +1,19 @@
+;; A local ref of a function type with multiple results requires multivalue.
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+  (type $T (func (param i32 i32) (result i32 i32 i32)))
+
+  (func $foo
+    (local $t (ref null $T))
+  )
+)
+
+;; Still fails with just reference types or multivalue.
+;; RUN: not wasm-opt --enable-reference-types %s 2>&1 | filecheck %s
+;; RUN: not wasm-opt --enable-multivalue %s 2>&1 | filecheck %s
+
+;; But it passes with both.
+;; RUN: wasm-opt --enable-reference-types --enable-multivalue %s


### PR DESCRIPTION
This was not noticed before because normally if there is a function type
with multiple results then there is also a function with that property. But
it is possible to make small testcases without such a function, and one might
be imported etc., so we do need to validate this.