### PR TITLE
Note function signature param/result features for validation

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -405,6 +405,8 @@ public:
   // Returns true if left is a subtype of right. Subtype includes itself.
   static bool isSubType(HeapType left, HeapType right);
 
+  std::vector<Type> getTypeChildren() const;
+
   // Return the ordered HeapType children, looking through child Types.
   std::vector<HeapType> getHeapTypeChildren() const;
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1046,8 +1046,16 @@ FeatureSet Type::getFeatures() const {
       // yet, so we apply the more refined types), so we don't add that in any
       // case here.
       FeatureSet feats = FeatureSet::ReferenceTypes;
-      if (heapType.getSignature().results.isTuple()) {
+      auto sig = heapType.getSignature();
+      if (sig.results.isTuple()) {
         feats |= FeatureSet::Multivalue;
+      }
+      // Also add features needed for the params and results.
+      for (auto t : sig.params) {
+        feats |= t.getFeatures();
+      }
+      for (auto t : sig.results) {
+        feats |= t.getFeatures();
       }
       return feats;
     }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1017,7 +1017,7 @@ FeatureSet Type::getFeatures() const {
 
         void noteChild(HeapType* heapType) {
           if (heapType->isBasic()) {
-            switch (heapType.getBasic()) {
+            switch (heapType->getBasic()) {
               case HeapType::ext:
               case HeapType::func:
                 feats |= FeatureSet::ReferenceTypes;
@@ -1065,7 +1065,8 @@ FeatureSet Type::getFeatures() const {
       };
 
       ReferenceFeatureCollector collector;
-      collector.walkRoot(t.getHeapType());
+      auto heapType = t.getHeapType();
+      collector.walkRoot(&heapType);
       return collector.feats;
     }
     TODO_SINGLE_COMPOUND(t);
@@ -1075,22 +1076,17 @@ FeatureSet Type::getFeatures() const {
       default:
         return FeatureSet::MVP;
     }
+  };
 
-    if (type.isTuple()) {
-      FeatureSet feats = FeatureSet::Multivalue;
-      for (const auto& t : type) {
-        feats |= getSingleFeatures(t);
-      }
-      return feats;
+  if (isTuple()) {
+    FeatureSet feats = FeatureSet::Multivalue;
+    for (const auto& t : *this) {
+      feats |= getSingleFeatures(t);
     }
-    return getSingleFeatures(type);
+    return feats;
   }
-
-  const Tuple&
-  Type::getTuple() const {
-    assert(isTuple());
-    return getTypeInfo(*this)->tuple;
-  }
+  return getSingleFeatures(type);
+}
 
 HeapType Type::getHeapType() const {
   if (isBasic()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1085,7 +1085,12 @@ FeatureSet Type::getFeatures() const {
     }
     return feats;
   }
-  return getSingleFeatures(type);
+  return getSingleFeatures(*this);
+}
+
+const Tuple& Type::getTuple() const {
+  assert(isTuple());
+  return getTypeInfo(*this)->tuple;
 }
 
 HeapType Type::getHeapType() const {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1009,85 +1009,91 @@ FeatureSet Type::getFeatures() const {
   // Types may recurse, so we need to avoid infinite recursing when finding all
   // used features. Use a small set as the common case is to have little or no
   // recursion at all.
-  SmallUnorderedSet<Type, 10> seen;
+  SmallUnorderedSet<Type, 2> seen;
 
-  auto getSingleFeatures = [&](Type t) -> FeatureSet {
-    if (seen.count(t)) {
-      // We've already seen this, so the features will already be accounted for.
-      return FeatureSet::None;
-    }
-    seen.insert(t);
+  std::function<FeatureSet(Type)> getFeaturesInternal =
+    [&](Type t) -> FeatureSet {
+    auto getSingleFeatures = [&](Type t) -> FeatureSet {
+      if (seen.count(t)) {
+        // We've already seen this, so the features will already be accounted
+        // for.
+        return FeatureSet::None;
+      }
+      seen.insert(t);
 
-    if (t.isRef()) {
-      // A reference type implies we need that feature. Some also require more,
-      // such as GC or exceptions.
-      auto heapType = t.getHeapType();
-      if (heapType.isBasic()) {
-        switch (heapType.getBasic()) {
-          case HeapType::ext:
-          case HeapType::func:
-            return FeatureSet::ReferenceTypes;
-          case HeapType::any:
-          case HeapType::eq:
-          case HeapType::i31:
-          case HeapType::struct_:
-          case HeapType::array:
-            return FeatureSet::ReferenceTypes | FeatureSet::GC;
-          case HeapType::string:
-          case HeapType::stringview_wtf8:
-          case HeapType::stringview_wtf16:
-          case HeapType::stringview_iter:
-            return FeatureSet::ReferenceTypes | FeatureSet::Strings;
-          case HeapType::none:
-          case HeapType::noext:
-          case HeapType::nofunc:
-            // Technically introduced in GC, but used internally as part of
-            // ref.null with just reference types.
-            return FeatureSet::ReferenceTypes;
+      if (t.isRef()) {
+        // A reference type implies we need that feature. Some also require
+        // more, such as GC or exceptions.
+        auto heapType = t.getHeapType();
+        if (heapType.isBasic()) {
+          switch (heapType.getBasic()) {
+            case HeapType::ext:
+            case HeapType::func:
+              return FeatureSet::ReferenceTypes;
+            case HeapType::any:
+            case HeapType::eq:
+            case HeapType::i31:
+            case HeapType::struct_:
+            case HeapType::array:
+              return FeatureSet::ReferenceTypes | FeatureSet::GC;
+            case HeapType::string:
+            case HeapType::stringview_wtf8:
+            case HeapType::stringview_wtf16:
+            case HeapType::stringview_iter:
+              return FeatureSet::ReferenceTypes | FeatureSet::Strings;
+            case HeapType::none:
+            case HeapType::noext:
+            case HeapType::nofunc:
+              // Technically introduced in GC, but used internally as part of
+              // ref.null with just reference types.
+              return FeatureSet::ReferenceTypes;
+          }
         }
+        if (heapType.isStruct() || heapType.isArray() ||
+            heapType.getRecGroup().size() > 1 || heapType.getSuperType()) {
+          return FeatureSet::ReferenceTypes | FeatureSet::GC;
+        }
+        // Otherwise, this is a function reference, which requires reference
+        // types and possibly also multivalue (if it has multiple returns).
+        // Note: Technically typed function references also require GC, however,
+        // we use these types internally regardless of the presence of GC (in
+        // particular, since during load of the wasm we don't know the features
+        // yet, so we apply the more refined types), so we don't add that in any
+        // case here.
+        FeatureSet feats = FeatureSet::ReferenceTypes;
+        auto sig = heapType.getSignature();
+        if (sig.results.isTuple()) {
+          feats |= FeatureSet::Multivalue;
+        }
+        // Also add features needed for the params and results.
+        for (auto t : sig.params) {
+          feats |= getFeaturesInternal(t);
+        }
+        for (auto t : sig.results) {
+          feats |= getFeaturesInternal(t);
+        }
+        return feats;
       }
-      if (heapType.isStruct() || heapType.isArray() ||
-          heapType.getRecGroup().size() > 1 || heapType.getSuperType()) {
-        return FeatureSet::ReferenceTypes | FeatureSet::GC;
+      TODO_SINGLE_COMPOUND(t);
+      switch (t.getBasic()) {
+        case Type::v128:
+          return FeatureSet::SIMD;
+        default:
+          return FeatureSet::MVP;
       }
-      // Otherwise, this is a function reference, which requires reference types
-      // and possibly also multivalue (if it has multiple returns).
-      // Note: Technically typed function references also require GC, however,
-      // we use these types internally regardless of the presence of GC (in
-      // particular, since during load of the wasm we don't know the features
-      // yet, so we apply the more refined types), so we don't add that in any
-      // case here.
-      FeatureSet feats = FeatureSet::ReferenceTypes;
-      auto sig = heapType.getSignature();
-      if (sig.results.isTuple()) {
-        feats |= FeatureSet::Multivalue;
-      }
-      // Also add features needed for the params and results.
-      for (auto t : sig.params) {
-        feats |= t.getFeatures();
-      }
-      for (auto t : sig.results) {
-        feats |= t.getFeatures();
+    };
+
+    if (isTuple()) {
+      FeatureSet feats = FeatureSet::Multivalue;
+      for (const auto& t : *this) {
+        feats |= getSingleFeatures(t);
       }
       return feats;
     }
-    TODO_SINGLE_COMPOUND(t);
-    switch (t.getBasic()) {
-      case Type::v128:
-        return FeatureSet::SIMD;
-      default:
-        return FeatureSet::MVP;
-    }
+    return getSingleFeatures(*this);
   };
 
-  if (isTuple()) {
-    FeatureSet feats = FeatureSet::Multivalue;
-    for (const auto& t : *this) {
-      feats |= getSingleFeatures(t);
-    }
-    return feats;
-  }
-  return getSingleFeatures(*this);
+  return getFeaturesInternal(*this);
 }
 
 const Tuple& Type::getTuple() const {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1012,7 +1012,7 @@ FeatureSet Type::getFeatures() const {
   SmallUnorderedSet<Type, 2> seen;
 
   std::function<FeatureSet(Type)> getFeaturesInternal =
-    [&](Type t) -> FeatureSet {
+    [&](Type type) -> FeatureSet {
     auto getSingleFeatures = [&](Type t) -> FeatureSet {
       if (seen.count(t)) {
         // We've already seen this, so the features will already be accounted
@@ -1083,14 +1083,14 @@ FeatureSet Type::getFeatures() const {
       }
     };
 
-    if (isTuple()) {
+    if (type.isTuple()) {
       FeatureSet feats = FeatureSet::Multivalue;
-      for (const auto& t : *this) {
+      for (const auto& t : type) {
         feats |= getSingleFeatures(t);
       }
       return feats;
     }
-    return getSingleFeatures(*this);
+    return getSingleFeatures(type);
   };
 
   return getFeaturesInternal(*this);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -27,7 +27,6 @@
 #include "compiler-support.h"
 #include "support/hash.h"
 #include "support/insert_ordered.h"
-#include "support/small_set.h"
 #include "wasm-features.h"
 #include "wasm-type-printing.h"
 #include "wasm-type.h"

--- a/test/lit/validation/ref-func-simd.wast
+++ b/test/lit/validation/ref-func-simd.wast
@@ -1,0 +1,16 @@
+;; A function type that uses a SIMD type requires the SIMD feature.
+;; RUN: not wasm-opt --enable-reference-types %s 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+  (type $simd-user (func (param v128)))
+
+  (global $g (ref null $simd-user) (ref.null func))
+)
+
+;; But it passes with the feature enabled.
+;; RUN: wasm-opt --enable-reference-types --enable-simd %s
+
+
+

--- a/test/lit/validation/ref-func-simd.wast
+++ b/test/lit/validation/ref-func-simd.wast
@@ -11,6 +11,3 @@
 
 ;; But it passes with the feature enabled.
 ;; RUN: wasm-opt --enable-reference-types --enable-simd %s
-
-
-

--- a/test/lit/validation/ref-gc-simd.wast
+++ b/test/lit/validation/ref-gc-simd.wast
@@ -1,0 +1,13 @@
+;; A gc type that uses a SIMD type requires the SIMD feature.
+;; RUN: not wasm-opt --enable-reference-types --enable-gc %s 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+  (type $simd-user (struct (field v128)))
+
+  (global $g (ref null $simd-user) (ref.null $simd-user))
+)
+
+;; But it passes with the feature enabled.
+;; RUN: wasm-opt --enable-reference-types --enable-gc --enable-simd %s


### PR DESCRIPTION
As with #5535, this was not noticed because it can only happen on very
small modules where the param/result type appears nowhere else but
in a function signature, but my wip fuzzer branch now finds it.