### PR TITLE
Skip function references when detecting uninhabitable types

### DIFF
--- a/src/tools/wasm-fuzz-types.cpp
+++ b/src/tools/wasm-fuzz-types.cpp
@@ -502,9 +502,14 @@ static std::optional<HeapType>
 findUninhabitable(HeapType type,
                   std::unordered_set<HeapType>& visited,
                   std::unordered_set<HeapType>& visiting) {
-  if (type.isBasic() || visited.count(type)) {
+  if (type.isBasic()) {
     return std::nullopt;
-  } else if (type.isBasic()) {
+  }
+  if (type.isSignature()) {
+    // Function types are always inhabitable.
+    return std::nullopt;
+  }
+  if (visited.count(type)) {
     return std::nullopt;
   }
 
@@ -522,15 +527,6 @@ findUninhabitable(HeapType type,
     if (auto t = findUninhabitable(
           type, type.getArray().element.type, visited, visiting)) {
       return t;
-    }
-  } else if (type.isSignature()) {
-    auto sig = type.getSignature();
-    for (auto types : {sig.params, sig.results}) {
-      for (auto child : types) {
-        if (auto t = findUninhabitable(type, child, visited, visiting)) {
-          return t;
-        }
-      }
     }
   } else {
     WASM_UNREACHABLE("unexpected type kind");


### PR DESCRIPTION
Function references are always inhabitable because functions can be created with
any function type, even types that refer to uninhabitable types. Take advantage
of this by skipping function references when finding non-nullable reference
cycles that cause uninhabitability.