### PR TITLE
Fix: remove excess optimization for sourcemap

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1343,7 +1343,6 @@ public:
   void writeDylinkSection();
   void writeLegacyDylinkSection();
 
-  void initializeDebugInfo();
   void writeSourceMapProlog();
   void writeSourceMapEpilog();
   void writeDebugLocation(const Function::DebugLocation& loc);
@@ -1404,7 +1403,6 @@ private:
   std::vector<std::pair<size_t, const Function::DebugLocation*>>
     sourceMapLocations;
   size_t sourceMapLocationsSizeAtSectionStart;
-  Function::DebugLocation lastDebugLocation;
 
   std::unique_ptr<ImportInfo> importInfo;
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -43,7 +43,6 @@ void WasmBinaryWriter::write() {
 
   writeDylinkSection();
 
-  initializeDebugInfo();
   if (sourceMap) {
     writeSourceMapProlog();
   }
@@ -1120,10 +1119,6 @@ void WasmBinaryWriter::writeSymbolMap() {
   file.close();
 }
 
-void WasmBinaryWriter::initializeDebugInfo() {
-  lastDebugLocation = {0, /* lineNumber = */ 1, 0};
-}
-
 void WasmBinaryWriter::writeSourceMapProlog() {
   *sourceMap << "{\"version\":3,\"sources\":[";
   for (size_t i = 0; i < wasm->debugInfoFileNames.size(); i++) {
@@ -1304,12 +1299,8 @@ void WasmBinaryWriter::writeDylinkSection() {
 }
 
 void WasmBinaryWriter::writeDebugLocation(const Function::DebugLocation& loc) {
-  if (loc == lastDebugLocation) {
-    return;
-  }
   auto offset = o.size();
   sourceMapLocations.emplace_back(offset, &loc);
-  lastDebugLocation = loc;
 }
 
 void WasmBinaryWriter::writeDebugLocation(Expression* curr, Function* func) {

--- a/test/fib-dbg.wasm.fromBinary
+++ b/test/fib-dbg.wasm.fromBinary
@@ -133,6 +133,7 @@
      (i32.const 0)
     )
    )
+   ;;@ fib.c:3:0
    (if
     (local.get $6)
     (block
@@ -156,6 +157,7 @@
      )
     )
    )
+   ;;@ fib.c:8:0
    (loop $label$4
     (block $label$5
      ;;@ fib.c:4:0
@@ -172,12 +174,14 @@
        (i32.const 1)
       )
      )
+     ;;@ fib.c:3:0
      (local.set $7
       (i32.eq
        (local.get $9)
        (local.get $0)
       )
      )
+     ;;@ fib.c:3:0
      (if
       (local.get $7)
       (block
@@ -201,6 +205,7 @@
        )
       )
      )
+     ;;@ fib.c:3:0
      (br $label$4)
     )
    )

--- a/test/lit/source-map-siblings-print.wast
+++ b/test/lit/source-map-siblings-print.wast
@@ -1,0 +1,81 @@
+;; RUN: wasm-opt %s -o %t.wasm -osm %t.map -g -q
+;; RUN: wasm-opt %t.wasm -ism %t.map -q -o - -S | filecheck %s
+
+(module
+  (func $foo (param $x i32) (param $y i32)
+    ;;@ src.cpp:1:1
+    (if
+      (i32.add
+        (local.get $x)
+        ;;@ src.cpp:2:1
+        (local.get $y)
+      )
+      ;;@ src.cpp:3:1
+      (return)
+    )
+    ;;@ src.cpp:1:1
+    (block
+      ;;@ src.cpp:4:1
+      (drop
+        (i32.add
+          (local.get $x)
+          ;;@ src.cpp:5:1
+          (local.get $y)
+        )
+      )
+      (drop
+        (i32.sub
+          (local.get $x)
+          (local.get $y)
+        )
+      )
+    )
+    (drop
+      (i32.mul
+        (local.get $x)
+        ;;@ src.cpp:6:1
+        (local.get $y)
+      )
+    )
+    (return)
+  )
+)
+
+;; CHECK:  (func $foo (param $x i32) (param $y i32)
+;; CHECK-NEXT:  ;;@ src.cpp:1:1
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $x)
+;; CHECK-NEXT:    ;;@ src.cpp:2:1
+;; CHECK-NEXT:    (local.get $y)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   ;;@ src.cpp:3:1
+;; CHECK-NEXT:   (return)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  ;;@ src.cpp:4:1
+;; CHECK-NEXT:  (drop
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $x)
+;; CHECK-NEXT:    ;;@ src.cpp:5:1
+;; CHECK-NEXT:    (local.get $y)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  ;;@ src.cpp:4:1
+;; CHECK-NEXT:  (drop
+;; CHECK-NEXT:   (i32.sub
+;; CHECK-NEXT:    (local.get $x)
+;; CHECK-NEXT:    (local.get $y)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  ;;@ src.cpp:1:1
+;; CHECK-NEXT:  (drop
+;; CHECK-NEXT:   (i32.mul
+;; CHECK-NEXT:    (local.get $x)
+;; CHECK-NEXT:    ;;@ src.cpp:6:1
+;; CHECK-NEXT:    (local.get $y)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  ;;@ src.cpp:1:1
+;; CHECK-NEXT:  (return)
+;; CHECK-NEXT: )
+;; CHECK-NEXT:)


### PR DESCRIPTION
Removing the excess optimization for source map generation and print.
Followup to: [5504](https://github.com/WebAssembly/binaryen/pull/5504) and [5524](https://github.com/WebAssembly/binaryen/pull/5524)