### PR TITLE
SignatureRefining: Skip types with supertypes for now

### DIFF
--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -147,6 +147,12 @@ struct SignatureRefining : public Pass {
     for (auto& [type, info] : allInfo) {
       if (!subTypes.getStrictSubTypes(type).empty()) {
         info.canModify = false;
+      } else if (type.getSuperType()) {
+        // Also avoid modifying types with supertypes, as we do not handle
+        // contravariance here. That is, when we refine parameters we look for
+        // a more refined type, but the type must be *less* refined than the
+        // param type for the parent (or equal) TODO
+        info.canModify = false;
       }
     }
 

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -780,3 +780,33 @@
     (ref.func $func)
   )
 )
+
+;; Until we handle contravariance, do not try to optimize a type that has a
+;; supertype. In this example, refining the child's anyref to nullref would
+;; cause an error.
+(module
+  ;; CHECK:      (type $parent (func (param anyref)))
+  (type $parent (func (param anyref)))
+  ;; CHECK:      (type $child (func_subtype (param anyref) $parent))
+  (type $child (func_subtype (param anyref) $parent))
+
+  ;; CHECK:      (type $none_=>_none (func))
+
+  ;; CHECK:      (func $func (type $child) (param $0 anyref)
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $func (type $child) (param anyref)
+    (unreachable)
+  )
+
+  ;; CHECK:      (func $caller (type $none_=>_none)
+  ;; CHECK-NEXT:  (call $func
+  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $caller
+    (call $func
+      (ref.null eq)
+    )
+  )
+)


### PR DESCRIPTION
We'd need to handle contravariance to optimize them.
