### PR TITLE
Emit the fuzzer hashMemory function after modifications

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -176,6 +176,7 @@ private:
   void prepareHangLimitSupport();
   void addHangLimitSupport();
   void addImportLoggingSupport();
+  void addHashMemorySupport();
 
   // Special expression makers
   Expression* makeHangLimitCheck();

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1969,7 +1969,7 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
     // If there is no last function, and we have others, pick between them. Also
     // pick between them with some random probability even if there is a last
     // function.
-    if (!target || (!wasm.functions.empty() && !oneIn(wasm.functions.size()))) {
+    if (!target && !wasm.functions.empty() && !oneIn(wasm.functions.size())) {
       target = pick(wasm.functions).get();
     }
     if (target) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1994,7 +1994,7 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
     // If there is no last function, and we have others, pick between them. Also
     // pick between them with some random probability even if there is a last
     // function.
-    if (!wasm.functions.empty() && (!target || !oneIn(wasm.functions.size())) {
+    if (!wasm.functions.empty() && (!target || !oneIn(wasm.functions.size()))) {
       target = pick(wasm.functions).get();
     }
     if (target) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1994,7 +1994,7 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
     // If there is no last function, and we have others, pick between them. Also
     // pick between them with some random probability even if there is a last
     // function.
-    if (!target && !wasm.functions.empty() && !oneIn(wasm.functions.size())) {
+    if (!wasm.functions.empty() && (!target || !oneIn(wasm.functions.size())) {
       target = pick(wasm.functions).get();
     }
     if (target) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3088,7 +3088,8 @@ Expression* TranslateToFuzzReader::makeMemoryFill() {
 }
 
 Type TranslateToFuzzReader::getSingleConcreteType() {
-  if (wasm.features.hasReferenceTypes() && !interestingHeapTypes.empty() && oneIn(3)) {
+  if (wasm.features.hasReferenceTypes() && !interestingHeapTypes.empty() &&
+      oneIn(3)) {
     auto heapType = pick(interestingHeapTypes);
     auto nullability = getNullability();
     return Type(heapType, nullability);
@@ -3122,7 +3123,8 @@ Type TranslateToFuzzReader::getSingleConcreteType() {
 }
 
 Type TranslateToFuzzReader::getReferenceType() {
-  if (wasm.features.hasReferenceTypes() && !interestingHeapTypes.empty() && oneIn(2)) {
+  if (wasm.features.hasReferenceTypes() && !interestingHeapTypes.empty() &&
+      oneIn(2)) {
     auto heapType = pick(interestingHeapTypes);
     auto nullability = getNullability();
     return Type(heapType, nullability);

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,33 +1,34 @@
 total
- [exports]      : 71      
- [funcs]        : 97      
+ [exports]      : 59      
+ [funcs]        : 86      
  [globals]      : 9       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 2       
- [table-data]   : 29      
+ [table-data]   : 34      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 9772    
- [vars]         : 262     
- Binary         : 728     
- Block          : 1590    
- Break          : 299     
- Call           : 459     
- CallIndirect   : 97      
- Const          : 1686    
- Drop           : 92      
- GlobalGet      : 775     
- GlobalSet      : 636     
- If             : 515     
- Load           : 166     
- LocalGet       : 671     
- LocalSet       : 502     
- Loop           : 201     
- Nop            : 111     
- RefFunc        : 29      
- Return         : 82      
- Select         : 87      
- Store          : 93      
- Unary          : 653     
- Unreachable    : 300     
+ [total]        : 9333    
+ [vars]         : 265     
+ Binary         : 675     
+ Block          : 1567    
+ Break          : 310     
+ Call           : 441     
+ CallIndirect   : 68      
+ Const          : 1667    
+ Drop           : 68      
+ GlobalGet      : 735     
+ GlobalSet      : 594     
+ If             : 514     
+ Load           : 144     
+ LocalGet       : 542     
+ LocalSet       : 431     
+ Loop           : 197     
+ Nop            : 167     
+ RefFunc        : 34      
+ Return         : 84      
+ Select         : 65      
+ Store          : 80      
+ Switch         : 2       
+ Unary          : 660     
+ Unreachable    : 288     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,40 +1,36 @@
 total
- [exports]      : 8       
- [funcs]        : 15      
+ [exports]      : 6       
+ [funcs]        : 10      
  [globals]      : 11      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 5       
+ [table-data]   : 2       
  [tables]       : 1       
- [tags]         : 1       
- [total]        : 538     
- [vars]         : 43      
- ArrayNewFixed  : 1       
- AtomicFence    : 2       
- Binary         : 67      
- Block          : 70      
- Break          : 1       
- Call           : 23      
- CallRef        : 1       
- Const          : 116     
- Drop           : 11      
- GlobalGet      : 36      
- GlobalSet      : 34      
- I31New         : 4       
- If             : 19      
- Load           : 16      
- LocalGet       : 35      
- LocalSet       : 17      
- Loop           : 2       
- MemoryInit     : 1       
- Nop            : 5       
- RefFunc        : 17      
- RefNull        : 5       
- Return         : 4       
+ [tags]         : 0       
+ [total]        : 401     
+ [vars]         : 12      
+ ArrayNewFixed  : 2       
+ Binary         : 65      
+ Block          : 46      
+ Break          : 3       
+ Call           : 10      
+ Const          : 85      
+ Drop           : 3       
+ GlobalGet      : 26      
+ GlobalSet      : 24      
+ I31New         : 2       
+ If             : 14      
+ Load           : 17      
+ LocalGet       : 39      
+ LocalSet       : 20      
+ Loop           : 3       
+ Nop            : 3       
+ RefFunc        : 5       
+ Return         : 1       
  SIMDExtract    : 1       
- Store          : 1       
- StructNew      : 5       
- TupleMake      : 9       
- Unary          : 18      
- Unreachable    : 17      
+ StructNew      : 1       
+ TupleExtract   : 1       
+ TupleMake      : 1       
+ Unary          : 17      
+ Unreachable    : 12      

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,80 +1,39 @@
 total
-<<<<<<< HEAD
- [exports]      : 6       
- [funcs]        : 10      
- [globals]      : 11      
-=======
- [exports]      : 3       
- [funcs]        : 4       
+ [exports]      : 4       
+ [funcs]        : 8       
  [globals]      : 5       
->>>>>>> origin/main
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
  [table-data]   : 2       
  [tables]       : 1       
- [tags]         : 0       
-<<<<<<< HEAD
- [total]        : 401     
- [vars]         : 12      
- ArrayNewFixed  : 2       
- Binary         : 65      
- Block          : 46      
- Break          : 3       
+ [tags]         : 1       
+ [total]        : 526     
+ [vars]         : 8       
+ Binary         : 69      
+ Block          : 74      
+ Break          : 11      
  Call           : 10      
- Const          : 85      
- Drop           : 3       
- GlobalGet      : 26      
- GlobalSet      : 24      
- I31New         : 2       
- If             : 14      
- Load           : 17      
- LocalGet       : 39      
- LocalSet       : 20      
- Loop           : 3       
- Nop            : 3       
+ Const          : 100     
+ Drop           : 1       
+ GlobalGet      : 32      
+ GlobalSet      : 33      
+ I31Get         : 1       
+ I31New         : 3       
+ If             : 23      
+ Load           : 19      
+ LocalGet       : 40      
+ LocalSet       : 23      
+ Loop           : 10      
+ Nop            : 17      
+ RefAs          : 2       
  RefFunc        : 5       
- Return         : 1       
- SIMDExtract    : 1       
- StructNew      : 1       
- TupleExtract   : 1       
- TupleMake      : 1       
- Unary          : 17      
- Unreachable    : 12      
-=======
- [total]        : 682     
- [vars]         : 3       
- AtomicCmpxchg  : 1       
- AtomicFence    : 3       
- AtomicNotify   : 2       
- Binary         : 76      
- Block          : 105     
- Break          : 15      
- Call           : 5       
- CallRef        : 3       
- Const          : 170     
- Drop           : 3       
- GlobalGet      : 42      
- GlobalSet      : 41      
- I31Get         : 2       
- I31New         : 2       
- If             : 32      
- Load           : 16      
- LocalGet       : 23      
- LocalSet       : 19      
- Loop           : 16      
- MemoryCopy     : 1       
- MemoryFill     : 2       
- MemoryInit     : 2       
- Nop            : 23      
- RefFunc        : 7       
- RefNull        : 1       
- Return         : 5       
- SIMDExtract    : 2       
- Select         : 4       
- Store          : 3       
- StructNew      : 1       
- TupleMake      : 2       
- Unary          : 33      
- Unreachable    : 20      
->>>>>>> origin/main
+ RefIsNull      : 1       
+ RefNull        : 3       
+ Return         : 2       
+ Select         : 1       
+ Store          : 1       
+ StructNew      : 2       
+ TupleMake      : 3       
+ Unary          : 23      
+ Unreachable    : 17      


### PR DESCRIPTION
Previously we emitted it early, and would then modify it in random ways
like other initial content. But this function is called frequently during
execution, so if we were unlucky and modded that function to trap then
basically all other functions would trap as well.

After fixing this, some places assert on not having any functions or types
to pick a random one from, so fix those places too.