### PR TITLE
Fuzzer: Emit nulls with low probability in makeConstCompoundRef

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -138,8 +138,19 @@ private:
 
   FunctionCreationContext* funcContext = nullptr;
 
+public:
   int nesting = 0;
 
+  struct AutoNester {
+    TranslateToFuzzReader& parent;
+
+    AutoNester(TranslateToFuzzReader& parent) : parent(parent) {
+      parent.nesting++;
+    }
+    ~AutoNester() { parent.nesting--; }
+  };
+
+private:
   // Generating random data is common enough that it's worth having helpers that
   // forward to `random`.
   int8_t get() { return random.get(); }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2022,7 +2022,8 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
     Expression* ret = builder.makeRefNull(HeapType::nofunc);
     if (!type.isNullable()) {
       assert(funcContext);
-      std::cout << "1nonnull in " << funcContext->func->name << " of " << ret->type << '\n';
+      std::cout << "1nonnull in " << funcContext->func->name << " of "
+                << ret->type << '\n';
       ret = builder.makeRefAs(RefAsNonNull, ret);
     }
     return ret;
@@ -2076,7 +2077,6 @@ Expression* TranslateToFuzzReader::makeConstBasicRef(Type type) {
       // similar.
       if (!type.isNullable()) {
         assert(funcContext);
-      std::cout << "2nonnull in " << funcContext->func->name << " of NULL for exttttt\n";
         return builder.makeRefAs(RefAsNonNull, null);
       }
       return null;
@@ -2161,7 +2161,6 @@ Expression* TranslateToFuzzReader::makeConstBasicRef(Type type) {
       auto null = builder.makeRefNull(heapType);
       if (!type.isNullable()) {
         assert(funcContext);
-      std::cout << "3nonnull in " << funcContext->func->name << " of NULL, for " <<type << "\n";// << ret->type << '\n';
         return builder.makeRefAs(RefAsNonNull, null);
       }
       return null;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2022,8 +2022,6 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
     Expression* ret = builder.makeRefNull(HeapType::nofunc);
     if (!type.isNullable()) {
       assert(funcContext);
-      std::cout << "1nonnull in " << funcContext->func->name << " of "
-                << ret->type << '\n';
       ret = builder.makeRefAs(RefAsNonNull, ret);
     }
     return ret;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2173,8 +2173,7 @@ Expression* TranslateToFuzzReader::makeConstCompoundRef(Type type) {
   assert(!heapType.isBasic());
   assert(wasm.features.hasReferenceTypes());
 
-  // Prefer not to emit a null, in general, as we can trap from them. But if we
-  // fail to do anything else will we emit a null at the end.
+  // Prefer not to emit a null, in general, as we can trap from them.
   if (type.isNullable() && oneIn(10)) {
     return builder.makeRefNull(heapType);
   }

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,39 +1,43 @@
 total
- [exports]      : 4       
- [funcs]        : 8       
+ [exports]      : 6       
+ [funcs]        : 13      
  [globals]      : 5       
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 2       
+ [table-data]   : 3       
  [tables]       : 1       
  [tags]         : 1       
- [total]        : 526     
- [vars]         : 8       
- Binary         : 69      
- Block          : 74      
- Break          : 11      
- Call           : 10      
- Const          : 100     
- Drop           : 1       
- GlobalGet      : 32      
- GlobalSet      : 33      
- I31Get         : 1       
- I31New         : 3       
- If             : 23      
- Load           : 19      
- LocalGet       : 40      
- LocalSet       : 23      
- Loop           : 10      
- Nop            : 17      
- RefAs          : 2       
- RefFunc        : 5       
- RefIsNull      : 1       
- RefNull        : 3       
- Return         : 2       
- Select         : 1       
- Store          : 1       
- StructNew      : 2       
- TupleMake      : 3       
- Unary          : 23      
- Unreachable    : 17      
+ [total]        : 558     
+ [vars]         : 36      
+ ArrayNew       : 7       
+ ArrayNewFixed  : 3       
+ AtomicCmpxchg  : 1       
+ AtomicNotify   : 1       
+ Binary         : 70      
+ Block          : 73      
+ Break          : 2       
+ Call           : 21      
+ CallRef        : 1       
+ Const          : 120     
+ Drop           : 9       
+ GlobalGet      : 34      
+ GlobalSet      : 34      
+ I31New         : 1       
+ If             : 22      
+ Load           : 18      
+ LocalGet       : 38      
+ LocalSet       : 19      
+ Loop           : 5       
+ Nop            : 5       
+ RefAs          : 1       
+ RefFunc        : 8       
+ RefNull        : 4       
+ Return         : 5       
+ SIMDExtract    : 1       
+ Select         : 2       
+ StructNew      : 6       
+ TupleExtract   : 3       
+ TupleMake      : 6       
+ Unary          : 20      
+ Unreachable    : 18      


### PR DESCRIPTION
In particular, the removed code path here that did a RefAsNonNull of a null
was causing a lot of code to just trap.