### PR TITLE
TrapsNeverHappen fuzzing: Handle a trap vs a host limitation

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1135,6 +1135,14 @@ class TrapsNeverHappen(TestCaseHandler):
             print(f'ignoring code due to trap (from "{call_line}"), lines to compare goes {lines_pre} => {lines_post} ')
 
             # also remove the relevant lines from after.
+            if call_line not in after:
+                # the normal run hit a trap, and the tnh run hit a host
+                # limitation that forces us to ignore this run. for example,
+                # after running tnh we may end up doing an unbounded number of
+                # allocations, if that is what the program normally does (and
+                # the normal run only avoided that by trapping).
+                assert IGNORE in after
+                return
             after_index = after.index(call_line)
             after = after[:after_index]
 


### PR DESCRIPTION
If the program tries to allocate an infinite number of objects, but is
prevented from doing that by a null pointer trap, then after we run
with trapsNeverHappen the trap may fail to occur, and we'll hit the
host limitation on allocations. As a result, we'd be comparing one
run with a trap and one run that is meant to be ignored (as we ignore
runs with host limitations), and before this PR we'd error as we would
expect to find the normal output and not the "ignore this host
limitation" marker.