### PR TITLE
Fuzzer: CompareVMs: Do not compare when hitting a host limitation

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -839,7 +839,10 @@ class CompareVMs(TestCaseHandler):
                 # NaNs can differ from wasm VMs
                 return not NANS
 
-        self.vms = [BinaryenInterpreter(),
+        # the binaryen interpreter is specifically useful for various things
+        self.bynterpreter = BinaryenInterpreter()
+
+        self.vms = [bynterpreter,
                     D8(),
                     D8Liftoff(),
                     D8TurboFan(),
@@ -858,14 +861,7 @@ class CompareVMs(TestCaseHandler):
         # testcase, or for some other reason we need to ignore this, then stop
         # (otherwise, a host limitation on say allocations may be hit in the
         # 'before' but not in the 'after' as allocations may remove it).
-        #
-        # the binaryen interpreter is the first one we run, so just read that
-        # already-computed data to avoid extra work (but assert it is the
-        # right one so we never reorder and break this; we are best at
-        # recognizing host limitations in the binaryen interpreter, and would
-        # need more work for others)
-        assert(self.vms[0].name == 'binaryen interpreter')
-        if before[0] == IGNORE:
+        if before[self.bynterpreter] == IGNORE:
             # the ignoring should have been noted during run_vms()
             assert(ignored_vm_runs > ignored_before)
             return

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -849,6 +849,9 @@ class CompareVMs(TestCaseHandler):
                     ]
 
     def handle_pair(self, input, before_wasm, after_wasm, opts):
+        global ignored_vm_runs
+        ignored_before = ignored_vm_runs
+
         before = self.run_vms(before_wasm)
 
         # if the binaryen interpreter hit a host limitation on the original
@@ -863,6 +866,8 @@ class CompareVMs(TestCaseHandler):
         # need more work for others)
         assert(self.vms[0].name == 'binaryen interpreter')
         if before[0] == IGNORE:
+            # the ignoring should have been noted during run_vms()
+            assert(ignored_vm_runs > ignored_before)
             return
 
         after = self.run_vms(after_wasm)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -860,7 +860,7 @@ class CompareVMs(TestCaseHandler):
         # if the binaryen interpreter hit a host limitation on the original
         # testcase, or for some other reason we need to ignore this, then stop
         # (otherwise, a host limitation on say allocations may be hit in the
-        # 'before' but not in the 'after' as allocations may remove it).
+        # 'before' but not in the 'after' as optimizations may remove it).
         if before[self.bynterpreter] == IGNORE:
             # the ignoring should have been noted during run_vms()
             assert(ignored_vm_runs > ignored_before)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -842,7 +842,7 @@ class CompareVMs(TestCaseHandler):
         # the binaryen interpreter is specifically useful for various things
         self.bynterpreter = BinaryenInterpreter()
 
-        self.vms = [bynterpreter,
+        self.vms = [self.bynterpreter,
                     D8(),
                     D8Liftoff(),
                     D8TurboFan(),


### PR DESCRIPTION
For example, we might hit an allocation limit in the wasm, but the
optimized wasm might optimize that allocation out. So we need to
ignore comparisons in such cases, as we cannot expect the output
to be identical. We already do similar things for FuzzExec and
#5560 adds it for TrapsNeverHappen; this adds it to CompareVMs.