### PR TITLE
Fix ambiguous operators under C++20

### DIFF
--- a/src/support/parent_index_iterator.h
+++ b/src/support/parent_index_iterator.h
@@ -49,10 +49,12 @@ template<typename Parent, typename Iterator> struct ParentIndexIterator {
 
   Iterator& self() { return *static_cast<Iterator*>(this); }
 
-  bool operator==(const Iterator& other) const {
+  bool operator==(const ParentIndexIterator& other) const {
     return index == other.index && parent == other.parent;
   }
-  bool operator!=(const Iterator& other) const { return !(*this == other); }
+  bool operator!=(const ParentIndexIterator& other) const {
+    return !(*this == other);
+  }
   Iterator& operator++() {
     ++index;
     return self();


### PR DESCRIPTION
When resolving `operator!=`, C++20 also considers `operator==` implementations
when the types on `operator!=` do not match exactly. This caused the modified
code to have no most-specific overload to choose, resulting in an error. This is
actually a bug in the language that is being fixed, but there exist compilers
without the fix applied.

Work around the problem by updating the types in the declaration of `operator==`
and `operator!=` to be more exact.

This is a copy of #5029 with formatting fixes.