### PR TITLE
Fuzzer: Limit array sizes

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2213,16 +2213,7 @@ Expression* TranslateToFuzzReader::makeConstCompoundRef(Type type) {
       // TODO: when in a function context, we don't need to be trivial.
       init = makeTrivial(element.type);
     }
-    Expression* count;
-    if (oneIn(100)) {
-      // With low probability pick a totally random count. This can easily be a
-      // super-high number that immediately causes a host limit error on running
-      // out of memory.
-      count = makeConst(Type::i32);
-    } else {
-      // Otherwise, most of the time pick a reasonable/realistic number.
-      count = builder.makeConst(int32_t(upTo(100)));
-    }
+    auto* count = builder.makeConst(int32_t(upTo(MAX_ARRAY_SIZE)));
     return builder.makeArrayNew(type.getHeapType(), count, init);
   } else {
     WASM_UNREACHABLE("bad user-defined ref type");

--- a/src/tools/fuzzing/parameters.h
+++ b/src/tools/fuzzing/parameters.h
@@ -38,7 +38,7 @@ constexpr int MAX_TUPLE_SIZE = 6;
 // The maximum number of struct fields.
 static const int MAX_STRUCT_SIZE = 6;
 
-// The maximum number of arrays.
+// The maximum number of elements in an array.
 static const int MAX_ARRAY_SIZE = 100;
 
 // The number of nontrivial heap types to generate.

--- a/src/tools/fuzzing/parameters.h
+++ b/src/tools/fuzzing/parameters.h
@@ -38,6 +38,9 @@ constexpr int MAX_TUPLE_SIZE = 6;
 // The maximum number of struct fields.
 static const int MAX_STRUCT_SIZE = 6;
 
+// The maximum number of arrays.
+static const int MAX_ARRAY_SIZE = 100;
+
 // The number of nontrivial heap types to generate.
 constexpr int MIN_HEAPTYPES = 4;
 constexpr int MAX_HEAPTYPES = 20;

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,41 +1,43 @@
 total
- [exports]      : 8       
- [funcs]        : 16      
+ [exports]      : 7       
+ [funcs]        : 10      
  [globals]      : 5       
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 3       
+ [table-data]   : 1       
  [tables]       : 1       
  [tags]         : 1       
- [total]        : 653     
- [vars]         : 36      
- ArrayNew       : 8       
- ArrayNewFixed  : 4       
- Binary         : 76      
- Block          : 90      
- Break          : 3       
- Call           : 25      
+ [total]        : 849     
+ [vars]         : 6       
+ ArrayNew       : 2       
+ ArrayNewFixed  : 5       
+ Binary         : 97      
+ Block          : 127     
+ Break          : 15      
+ Call           : 13      
  CallRef        : 3       
- Const          : 134     
- Drop           : 11      
- GlobalGet      : 40      
- GlobalSet      : 40      
- I31New         : 1       
- If             : 26      
- Load           : 19      
- LocalGet       : 43      
- LocalSet       : 21      
- Loop           : 6       
- Nop            : 11      
- RefFunc        : 13      
- RefNull        : 4       
- Return         : 3       
+ Const          : 186     
+ DataDrop       : 1       
+ Drop           : 6       
+ GlobalGet      : 58      
+ GlobalSet      : 58      
+ I31New         : 2       
+ If             : 38      
+ Load           : 23      
+ LocalGet       : 38      
+ LocalSet       : 23      
+ Loop           : 20      
+ Nop            : 18      
+ RefEq          : 1       
+ RefFunc        : 7       
+ RefNull        : 2       
+ Return         : 1       
  SIMDExtract    : 1       
- Select         : 4       
- Store          : 2       
- StructNew      : 9       
- TupleExtract   : 2       
- TupleMake      : 5       
- Unary          : 27      
- Unreachable    : 22      
+ Select         : 3       
+ Store          : 8       
+ StructNew      : 6       
+ TupleExtract   : 3       
+ TupleMake      : 6       
+ Unary          : 48      
+ Unreachable    : 30      


### PR DESCRIPTION
Even with a 1% chance of a huge array, there is a second problem aside from
hitting an allocation failure, which is DoS - building such a huge array of
Literals takes noticeable time in the fuzzer. Instead, just limit array max sizes,
which is consistent with what we do for struct sizes etc.