### PR TITLE
[Wasm GC] Remove RefIsFunc and RefIsI31

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1130,8 +1130,6 @@ enum ASTNodes {
   BrOnCastNull = 0x4a,
   BrOnCastFailNull = 0x4b,
   RefCastNop = 0x4c,
-  RefIsFunc = 0x50,
-  RefIsI31 = 0x52,
   RefAsFunc = 0x58,
   RefAsI31 = 0x5a,
   BrOnFunc = 0x60,
@@ -1745,7 +1743,6 @@ public:
   void visitDrop(Drop* curr);
   void visitRefNull(RefNull* curr);
   void visitRefIsNull(RefIsNull* curr);
-  void visitRefIs(RefTest* curr, uint8_t code);
   void visitRefFunc(RefFunc* curr);
   void visitRefEq(RefEq* curr);
   void visitTableGet(TableGet* curr);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4041,12 +4041,6 @@ BinaryConsts::ASTNodes WasmBinaryBuilder::readExpression(Expression*& curr) {
       if (maybeVisitStringSliceIter(curr, opcode)) {
         break;
       }
-      if (opcode == BinaryConsts::RefIsFunc ||
-          opcode == BinaryConsts::RefIsI31) {
-        visitRefIs((curr = allocator.alloc<RefTest>())->cast<RefTest>(),
-                   opcode);
-        break;
-      }
       if (opcode == BinaryConsts::RefAsFunc ||
           opcode == BinaryConsts::RefAsI31) {
         visitRefAsCast((curr = allocator.alloc<RefCast>())->cast<RefCast>(),
@@ -6615,22 +6609,6 @@ void WasmBinaryBuilder::visitRefNull(RefNull* curr) {
 void WasmBinaryBuilder::visitRefIsNull(RefIsNull* curr) {
   BYN_TRACE("zz node: RefIsNull\n");
   curr->value = popNonVoidExpression();
-  curr->finalize();
-}
-
-void WasmBinaryBuilder::visitRefIs(RefTest* curr, uint8_t code) {
-  BYN_TRACE("zz node: RefIs\n");
-  switch (code) {
-    case BinaryConsts::RefIsFunc:
-      curr->castType = Type(HeapType::func, NonNullable);
-      break;
-    case BinaryConsts::RefIsI31:
-      curr->castType = Type(HeapType::i31, NonNullable);
-      break;
-    default:
-      WASM_UNREACHABLE("invalid code for ref.is_*");
-  }
-  curr->ref = popNonVoidExpression();
   curr->finalize();
 }
 

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2010,20 +2010,6 @@ void BinaryInstWriter::visitCallRef(CallRef* curr) {
 
 void BinaryInstWriter::visitRefTest(RefTest* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
-  // TODO: These instructions are deprecated. Remove them.
-  if (auto type = curr->castType.getHeapType();
-      curr->castType.isNonNullable() && type.isBasic()) {
-    switch (type.getBasic()) {
-      case HeapType::func:
-        o << U32LEB(BinaryConsts::RefIsFunc);
-        return;
-      case HeapType::i31:
-        o << U32LEB(BinaryConsts::RefIsI31);
-        return;
-      default:
-        break;
-    }
-  }
   if (curr->castType.isNullable()) {
     o << U32LEB(BinaryConsts::RefTestNull);
   } else {


### PR DESCRIPTION
These are deprecated, and we can implement them using `ref.test`.

V8 has already removed the deprecated ones. After this PR, this module
successfully validates there:
```wat
(module
 (func $test (result i32)
  (ref.is_func
   (ref.null func)
  )
 )
)
```