### PR TITLE
Use SmallVector in TypeUpdating::updateParamTypes()

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -19,6 +19,7 @@
 #include "ir/local-structural-dominance.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
+#include "support/small_vector.h"
 #include "support/topological_sort.h"
 #include "wasm-type-ordering.h"
 #include "wasm-type.h"
@@ -443,7 +444,9 @@ void updateParamTypes(Function* func,
   if (!paramFixups.empty()) {
     // Write the params immediately to the fixups.
     Builder builder(wasm);
-    std::vector<Expression*> contents;
+    // Use a small vector as functions generally have a reasonable number of
+    // parameters.
+    SmallVector<Expression*, 10> contents;
     for (Index index = 0; index < func->getNumParams(); index++) {
       auto iter = paramFixups.find(index);
       if (iter != paramFixups.end()) {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -19,6 +19,7 @@
 
 #include "ir/manipulation.h"
 #include "parsing.h"
+#include "support/small_vector.h"
 #include "wasm.h"
 
 namespace wasm {
@@ -227,6 +228,13 @@ public:
     ret->name = name;
     ret->list.set(items);
     ret->finalize(type);
+    return ret;
+  }
+  template<size_t N>
+  Block* makeBlock(const SmallVector<Expression*, N>& items) {
+    auto* ret = wasm.allocator.alloc<Block>();
+    ret->list.set(items);
+    ret->finalize();
     return ret;
   }
   If* makeIf(Expression* condition,


### PR DESCRIPTION
Noticed when profiling for https://github.com/WebAssembly/binaryen/issues/5561#issuecomment-1470783261