### PR TITLE
[NFC] Templatize `makeBlock` so it can be used with any iterable

### DIFF
--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -253,8 +253,9 @@ public:
     if (allocatedElements < size) {
       static_cast<SubType*>(this)->allocate(size);
     }
-    for (size_t i = 0; i < size; i++) {
-      data[i] = list[i];
+    size_t i = 0;
+    for (auto elem : list) {
+      data[i++] = elem;
     }
     usedElements = size;
   }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -167,7 +167,6 @@ public:
   }
 
   // IR nodes
-
   Nop* makeNop() { return wasm.allocator.alloc<Nop>(); }
   Block* makeBlock(Expression* first = nullptr) {
     auto* ret = wasm.allocator.alloc<Block>();
@@ -183,52 +182,47 @@ public:
     ret->finalize();
     return ret;
   }
-  Block* makeBlock(const std::vector<Expression*>& items) {
+
+  template<typename T>
+  using bool_if_not_expr_t =
+    std::enable_if_t<std::negation_v<std::is_convertible<T, Expression*>>,
+                     bool>;
+
+  template<typename T, bool_if_not_expr_t<T> = true>
+  Block* makeBlock(const T& items) {
     auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
     ret->finalize();
     return ret;
   }
-  Block* makeBlock(const std::vector<Expression*>& items, Type type) {
+
+  template<typename T, bool_if_not_expr_t<T> = true>
+  Block* makeBlock(const T& items, Type type) {
     auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
     ret->finalize(type);
     return ret;
+  }
+
+  template<typename T, bool_if_not_expr_t<T> = true>
+  Block* makeBlock(Name name, const T& items, Type type) {
+    auto* ret = wasm.allocator.alloc<Block>();
+    ret->name = name;
+    ret->list.set(items);
+    ret->finalize(type);
+    return ret;
+  }
+  Block* makeBlock(std::initializer_list<Expression*>&& items) {
+    return makeBlock(items);
+  }
+  Block* makeBlock(std::initializer_list<Expression*>&& items, Type type) {
+    return makeBlock(items, type);
   }
   Block*
-  makeBlock(Name name, const std::vector<Expression*>& items, Type type) {
-    auto* ret = wasm.allocator.alloc<Block>();
-    ret->name = name;
-    ret->list.set(items);
-    ret->finalize(type);
-    return ret;
+  makeBlock(Name name, std::initializer_list<Expression*>&& items, Type type) {
+    return makeBlock(name, items, type);
   }
-  Block* makeBlock(const ExpressionList& items) {
-    auto* ret = wasm.allocator.alloc<Block>();
-    ret->list.set(items);
-    ret->finalize();
-    return ret;
-  }
-  Block* makeBlock(const ExpressionList& items, Type type) {
-    auto* ret = wasm.allocator.alloc<Block>();
-    ret->list.set(items);
-    ret->finalize(type);
-    return ret;
-  }
-  Block* makeBlock(Name name, const ExpressionList& items) {
-    auto* ret = wasm.allocator.alloc<Block>();
-    ret->name = name;
-    ret->list.set(items);
-    ret->finalize();
-    return ret;
-  }
-  Block* makeBlock(Name name, const ExpressionList& items, Type type) {
-    auto* ret = wasm.allocator.alloc<Block>();
-    ret->name = name;
-    ret->list.set(items);
-    ret->finalize(type);
-    return ret;
-  }
+
   If* makeIf(Expression* condition,
              Expression* ifTrue,
              Expression* ifFalse = nullptr) {


### PR DESCRIPTION
Replace the different overloads we previously had for different kinds of
containers with generic templates. We still need dedicated overloads for
`std::initializer_list` because it is never inferred in a template context,
though. Also, since `std::initializer_list` does not allow subscripting, update
the arena vector implementation to use iterators instead now that initializer
lists can be passed down to that layer without being reified as vectors.