### PR TITLE
Ensure a deterministic order in the type names section

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -265,7 +265,8 @@ void TranslateToFuzzReader::setupHeapTypes() {
         interestingHeapTypes.push_back(type);
         if (oneIn(2)) {
           // Add a name for this type.
-          wasm.typeNames[type].name = "generated_type$" + std::to_string(interestingHeapTypes.size());
+          wasm.typeNames[type].name =
+            "generated_type$" + std::to_string(interestingHeapTypes.size());
         }
       }
     }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -263,6 +263,10 @@ void TranslateToFuzzReader::setupHeapTypes() {
       // non-nullable bottom heap type).
       if (!type.isBottom() && !type.isBasic()) {
         interestingHeapTypes.push_back(type);
+        if (oneIn(2)) {
+          // Add a name for this type.
+          wasm.typeNames[type].name = "generated_type$" + std::to_string(interestingHeapTypes.size());
+        }
       }
     }
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -896,7 +896,7 @@ void WasmBinaryWriter::writeNames() {
   // type names
   {
     std::vector<HeapType> namedTypes;
-    for (auto& [type, _] : indexedTypes.indices) {
+    for (auto type : indexedTypes.types) {
       if (wasm->typeNames.count(type) && wasm->typeNames[type].name.is()) {
         namedTypes.push_back(type);
       }

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,41 +1,47 @@
 total
- [exports]      : 9       
- [funcs]        : 18      
- [globals]      : 5       
+ [exports]      : 6       
+ [funcs]        : 10      
+ [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 4       
+ [table-data]   : 2       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 579     
- [vars]         : 19      
- ArrayNew       : 5       
- ArrayNewFixed  : 8       
- Binary         : 71      
- Block          : 74      
- Break          : 2       
- Call           : 18      
- CallRef        : 2       
- Const          : 121     
- DataDrop       : 1       
- Drop           : 5       
- GlobalGet      : 34      
- GlobalSet      : 34      
- I31Get         : 2       
+ [total]        : 682     
+ [vars]         : 9       
+ ArrayNew       : 4       
+ ArrayNewFixed  : 5       
+ AtomicCmpxchg  : 1       
+ AtomicNotify   : 1       
+ Binary         : 78      
+ Block          : 88      
+ Break          : 11      
+ Call           : 28      
+ Const          : 145     
+ Drop           : 8       
+ GlobalGet      : 35      
+ GlobalSet      : 35      
+ I31Get         : 1       
  I31New         : 4       
- If             : 21      
- Load           : 19      
- LocalGet       : 46      
- LocalSet       : 22      
- Loop           : 2       
- Nop            : 9       
+ If             : 30      
+ Load           : 18      
+ LocalGet       : 44      
+ LocalSet       : 24      
+ Loop           : 10      
+ MemoryFill     : 2       
+ MemoryInit     : 1       
+ Nop            : 14      
+ RefAs          : 1       
  RefEq          : 1       
- RefFunc        : 16      
- RefNull        : 4       
- Return         : 6       
- Store          : 1       
+ RefFunc        : 10      
+ RefNull        : 8       
+ RefTest        : 2       
+ Return         : 4       
+ Select         : 1       
+ Store          : 3       
  StructNew      : 5       
- TupleMake      : 5       
- Unary          : 20      
- Unreachable    : 21      
+ TupleExtract   : 1       
+ TupleMake      : 8       
+ Unary          : 32      
+ Unreachable    : 19      


### PR DESCRIPTION
Before this PR we iterated over an unordered set. Replace that with an
iteration on a vector. (Also, the value in the set was not even used, so
this should even be faster.)

Add random names in the fuzzer to types, the lack of which is I believe
the reason this was not detected before.