### PR TITLE
[Wasm GC] Fix detection of externalize/internalize as constant

### DIFF
--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -36,6 +36,8 @@ bool isGenerative(Expression* curr, FeatureSet features) {
   return scanner.generative;
 }
 
+// Checks an expression in a shallow manner (i.e., does not check children) as
+// to whether it is valid in a wasm constant expression.
 static bool isValidInConstantExpression(Module& wasm, Expression* expr) {
   if (isSingleConstantExpression(expr) || expr->is<StructNew>() ||
       expr->is<ArrayNew>() || expr->is<ArrayNewFixed>() || expr->is<I31New>() ||
@@ -45,7 +47,7 @@ static bool isValidInConstantExpression(Module& wasm, Expression* expr) {
 
   if (auto* refAs = expr->dynCast<RefAs>()) {
     if (refAs->op == ExternExternalize || refAs->op == ExternInternalize) {
-      return isValidInConstantExpression(wasm, refAs->value);
+      return true;
     }
   }
 

--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -43,6 +43,13 @@ static bool isValidInConstantExpression(Module& wasm, Expression* expr) {
     return true;
   }
 
+  if (auto* refAs = expr->dynCast<RefAs>()) {
+    if (refAs->op == ExternExternalize ||
+        refAs->op == ExternInternalize) {
+      return isValidInConstantExpression(wasm, refAs->value);
+    }
+  }
+
   if (auto* get = expr->dynCast<GlobalGet>()) {
     auto* g = wasm.getGlobalOrNull(get->name);
     // This is called from the validator, so we have to handle non-existent

--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -44,8 +44,7 @@ static bool isValidInConstantExpression(Module& wasm, Expression* expr) {
   }
 
   if (auto* refAs = expr->dynCast<RefAs>()) {
-    if (refAs->op == ExternExternalize ||
-        refAs->op == ExternInternalize) {
+    if (refAs->op == ExternExternalize || refAs->op == ExternInternalize) {
       return isValidInConstantExpression(wasm, refAs->value);
     }
   }

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -83,8 +83,7 @@ inline bool isNamedControlFlow(Expression* curr) {
 // isValidInConstantExpression or find better names(#4845)
 inline bool isSingleConstantExpression(const Expression* curr) {
   if (auto* refAs = curr->dynCast<RefAs>()) {
-    if (refAs->op == ExternExternalize ||
-        refAs->op == ExternInternalize) {
+    if (refAs->op == ExternExternalize || refAs->op == ExternInternalize) {
       return isSingleConstantExpression(refAs->value);
     }
   }

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -82,10 +82,14 @@ inline bool isNamedControlFlow(Expression* curr) {
 // runtime will be equal as well. TODO: combine this with
 // isValidInConstantExpression or find better names(#4845)
 inline bool isSingleConstantExpression(const Expression* curr) {
+  if (auto* refAs = curr->dynCast<RefAs>()) {
+    if (refAs->op == ExternExternalize ||
+        refAs->op == ExternInternalize) {
+      return isSingleConstantExpression(refAs->value);
+    }
+  }
   return curr->is<Const>() || curr->is<RefNull>() || curr->is<RefFunc>() ||
-         curr->is<StringConst>() ||
-         (curr->is<RefAs>() && (curr->cast<RefAs>()->op == ExternExternalize ||
-                                curr->cast<RefAs>()->op == ExternInternalize));
+         curr->is<StringConst>();
 }
 
 inline bool isConstantExpression(const Expression* curr) {
@@ -120,6 +124,12 @@ inline Literal getLiteral(const Expression* curr) {
     }
   } else if (auto* s = curr->dynCast<StringConst>()) {
     return Literal(s->string.toString());
+  } else if (auto* r = curr->dynCast<RefAs>()) {
+    if (r->op == ExternExternalize) {
+      return getLiteral(r->value).externalize();
+    } else if (r->op == ExternInternalize) {
+      return getLiteral(r->value).internalize();
+    }
   }
   WASM_UNREACHABLE("non-constant expression");
 }


### PR DESCRIPTION
Both `isValidInConstantExpression` and `isSingleConstantExpression` must look
recursively at the internals of a RefAs that externalizes and internalizes, or else
we might do something like externalize a `local.get`, which is not constant.

`getLiteral` must handle externalize/internalize as well, and return a properly-
modified literal.

Without these fixes the testcase hits different internal assertions, and we either
fail to recognize something is constant or not, or think that it is but fail to
produce a literal for it.