### PR TITLE
Use more than a single wasm page in Asyncify fuzzing

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -45,7 +45,9 @@ var Asyncify = {
   sleeps: 0,
   maxDepth: 0,
   DATA_ADDR: 4,
-  DATA_MAX: 65536,
+  // The fuzzer emits memories of size 16 (pages). Allow us to use almost all of
+  // that (we start from offset 4, so we can't use them all).
+  DATA_MAX: 15 * 65536,
   savedMemory: null,
   instrumentImports: function(imports) {
     var ret = {};


### PR DESCRIPTION
I saw a testcase fail on the internal assertion of the buffer being too small.
Enlarge it to use as much of the memory we have anyhow to reduce that
risk (we can use 15 pages instead of 1, without changing anything else).