### PR TITLE
Do not treat `atomic.fence` as using a memory

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -138,7 +138,6 @@ struct ReferenceFinder : public PostWalker<ReferenceFinder> {
   void visitAtomicRMW(AtomicRMW* curr) { usesMemory = true; }
   void visitAtomicWait(AtomicWait* curr) { usesMemory = true; }
   void visitAtomicNotify(AtomicNotify* curr) { usesMemory = true; }
-  void visitAtomicFence(AtomicFence* curr) { usesMemory = true; }
   void visitMemoryInit(MemoryInit* curr) { usesMemory = true; }
   void visitDataDrop(DataDrop* curr) {
     // TODO: Replace this with a use of a data segment (#5224).

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1172,8 +1172,6 @@ void FunctionValidator::visitAtomicNotify(AtomicNotify* curr) {
 }
 
 void FunctionValidator::visitAtomicFence(AtomicFence* curr) {
-  shouldBeFalse(
-    getModule()->memories.empty(), curr, "Memory operations require a memory");
   shouldBeTrue(getModule()->features.hasAtomics(),
                curr,
                "Atomic operations require threads [--enable-threads]");

--- a/test/lit/passes/remove-unused-module-elements_all-features.wast
+++ b/test/lit/passes/remove-unused-module-elements_all-features.wast
@@ -351,6 +351,19 @@
     (memory.atomic.notify (i32.const 0) (i32.const 0))
   )
 )
+(module ;; atomic.fence does not use a memory, so should not keep the memory alive.
+  (memory $0 (shared 1 1))
+  ;; CHECK:      (type $none_=>_none (func))
+
+  ;; CHECK:      (export "fake-user" (func $user))
+  (export "fake-user" $user)
+  ;; CHECK:      (func $user (type $none_=>_none)
+  ;; CHECK-NEXT:  (atomic.fence)
+  ;; CHECK-NEXT: )
+  (func $user
+    (atomic.fence)
+  )
+)
 (module ;; more use checks
   ;; CHECK:      (type $none_=>_i32 (func (result i32)))
 

--- a/test/wasm2js/atomic_fence.2asm.js
+++ b/test/wasm2js/atomic_fence.2asm.js
@@ -1,14 +1,5 @@
 
 function asmFunc(imports) {
- var buffer = new ArrayBuffer(1507328);
- var HEAP8 = new Int8Array(buffer);
- var HEAP16 = new Int16Array(buffer);
- var HEAP32 = new Int32Array(buffer);
- var HEAPU8 = new Uint8Array(buffer);
- var HEAPU16 = new Uint16Array(buffer);
- var HEAPU32 = new Uint32Array(buffer);
- var HEAPF32 = new Float32Array(buffer);
- var HEAPF64 = new Float64Array(buffer);
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
  var Math_abs = Math.abs;
@@ -21,31 +12,6 @@ function asmFunc(imports) {
  var Math_sqrt = Math.sqrt;
  function $0() {
   
- }
- 
- function __wasm_memory_size() {
-  return buffer.byteLength / 65536 | 0;
- }
- 
- function __wasm_memory_grow(pagesToAdd) {
-  pagesToAdd = pagesToAdd | 0;
-  var oldPages = __wasm_memory_size() | 0;
-  var newPages = oldPages + pagesToAdd | 0;
-  if ((oldPages < newPages) && (newPages < 65536)) {
-   var newBuffer = new ArrayBuffer(Math_imul(newPages, 65536));
-   var newHEAP8 = new Int8Array(newBuffer);
-   newHEAP8.set(HEAP8);
-   HEAP8 = new Int8Array(newBuffer);
-   HEAP16 = new Int16Array(newBuffer);
-   HEAP32 = new Int32Array(newBuffer);
-   HEAPU8 = new Uint8Array(newBuffer);
-   HEAPU16 = new Uint16Array(newBuffer);
-   HEAPU32 = new Uint32Array(newBuffer);
-   HEAPF32 = new Float32Array(newBuffer);
-   HEAPF64 = new Float64Array(newBuffer);
-   buffer = newBuffer;
-  }
-  return oldPages;
  }
  
  return {


### PR DESCRIPTION
Update RemoveUnusedModuleElements so that it no longer keeps the memory alive
due to an `atomic.fence` instruction and update validation to allow modules to
use `atomic.fence` without a memory.