### PR TITLE
Switch fuzzer to the hybrid type system

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -43,7 +43,7 @@ assert sys.version_info.major == 3, 'requires Python 3!'
 
 # parameters
 
-TYPE_SYSTEM_FLAG = '--nominal'
+TYPE_SYSTEM_FLAG = '--hybrid'
 
 # feature options that are always passed to the tools.
 CONSTANT_FEATURE_OPTS = ['--all-features']


### PR DESCRIPTION
This is the default, and also used by J2Wasm.

Fuzzing for a day with this I found no issues.