### PR TITLE
[NFC] Remove our bespoke `make_unique` implementation

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5025,7 +5025,7 @@ void BinaryenAddFunctionImport(BinaryenModuleRef module,
                                BinaryenType results) {
   auto* func = ((Module*)module)->getFunctionOrNull(internalName);
   if (func == nullptr) {
-    auto func = make_unique<Function>();
+    auto func = std::make_unique<Function>();
     func->name = internalName;
     func->module = externalModuleName;
     func->base = externalBaseName;
@@ -5044,7 +5044,7 @@ void BinaryenAddTableImport(BinaryenModuleRef module,
                             const char* externalBaseName) {
   auto* table = ((Module*)module)->getTableOrNull(internalName);
   if (table == nullptr) {
-    auto table = make_unique<Table>();
+    auto table = std::make_unique<Table>();
     table->name = internalName;
     table->module = externalModuleName;
     table->base = externalBaseName;
@@ -5062,7 +5062,7 @@ void BinaryenAddMemoryImport(BinaryenModuleRef module,
                              uint8_t shared) {
   auto* memory = ((Module*)module)->getMemoryOrNull(internalName);
   if (memory == nullptr) {
-    auto memory = make_unique<Memory>();
+    auto memory = std::make_unique<Memory>();
     memory->name = internalName;
     memory->module = externalModuleName;
     memory->base = externalBaseName;
@@ -5082,7 +5082,7 @@ void BinaryenAddGlobalImport(BinaryenModuleRef module,
                              bool mutable_) {
   auto* glob = ((Module*)module)->getGlobalOrNull(internalName);
   if (glob == nullptr) {
-    auto glob = make_unique<Global>();
+    auto glob = std::make_unique<Global>();
     glob->name = internalName;
     glob->module = externalModuleName;
     glob->base = externalBaseName;
@@ -5103,7 +5103,7 @@ void BinaryenAddTagImport(BinaryenModuleRef module,
                           BinaryenType results) {
   auto* tag = ((Module*)module)->getGlobalOrNull(internalName);
   if (tag == nullptr) {
-    auto tag = make_unique<Tag>();
+    auto tag = std::make_unique<Tag>();
     tag->name = internalName;
     tag->module = externalModuleName;
     tag->base = externalBaseName;
@@ -5319,7 +5319,7 @@ void BinaryenSetMemory(BinaryenModuleRef module,
   memory->shared = shared;
   memory->indexType = memory64 ? Type::i64 : Type::i32;
   if (exportName) {
-    auto memoryExport = make_unique<Export>();
+    auto memoryExport = std::make_unique<Export>();
     memoryExport->name = exportName;
     memoryExport->value = memory->name;
     memoryExport->kind = ExternalKind::Memory;

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -112,7 +112,7 @@ Branch::Branch(std::vector<wasm::Index>&& ValuesInit,
                wasm::Expression* CodeInit)
   : Condition(nullptr), Code(CodeInit) {
   if (ValuesInit.size() > 0) {
-    SwitchValues = wasm::make_unique<std::vector<wasm::Index>>(ValuesInit);
+    SwitchValues = std::make_unique<std::vector<wasm::Index>>(ValuesInit);
   }
   // otherwise, it is the default
 }

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -917,7 +917,7 @@ struct AsyncifyFlow : public Pass {
     module = module_;
     func = func_;
     builder =
-      make_unique<AsyncifyBuilder>(*module, pointerType, asyncifyMemory);
+      std::make_unique<AsyncifyBuilder>(*module, pointerType, asyncifyMemory);
     // If the function cannot change our state, we have nothing to do -
     // we will never unwind or rewind the stack here.
     if (!analyzer->needsInstrumentation(func)) {
@@ -1243,7 +1243,7 @@ struct AsyncifyAssertInNonInstrumented : public Pass {
     if (!analyzer->needsInstrumentation(func)) {
       module = module_;
       builder =
-        make_unique<AsyncifyBuilder>(*module, pointerType, asyncifyMemory);
+        std::make_unique<AsyncifyBuilder>(*module, pointerType, asyncifyMemory);
       addAssertsInNonInstrumented(func);
     }
   }
@@ -1396,8 +1396,8 @@ struct AsyncifyLocals : public WalkerPass<PostWalker<AsyncifyLocals>> {
     auto unwindIndex = builder->addVar(func, Type::i32);
     rewindIndex = builder->addVar(func, Type::i32);
     // Rewrite the function body.
-    builder =
-      make_unique<AsyncifyBuilder>(*getModule(), pointerType, asyncifyMemory);
+    builder = std::make_unique<AsyncifyBuilder>(
+      *getModule(), pointerType, asyncifyMemory);
     walk(func->body);
     // After the normal function body, emit a barrier before the postamble.
     Expression* barrier;
@@ -1719,7 +1719,7 @@ struct Asyncify : public Pass {
         runner.add("merge-blocks");
       }
       runner.add(
-        make_unique<AsyncifyFlow>(&analyzer, pointerType, asyncifyMemory));
+        std::make_unique<AsyncifyFlow>(&analyzer, pointerType, asyncifyMemory));
       runner.setIsNested(true);
       runner.setValidateGlobally(false);
       runner.run();
@@ -1728,7 +1728,7 @@ struct Asyncify : public Pass {
       // Add asserts in non-instrumented code. Note we do not use an
       // instrumented pass runner here as we do want to run on all functions.
       PassRunner runner(module);
-      runner.add(make_unique<AsyncifyAssertInNonInstrumented>(
+      runner.add(std::make_unique<AsyncifyAssertInNonInstrumented>(
         &analyzer, pointerType, asyncifyMemory));
       runner.setIsNested(true);
       runner.setValidateGlobally(false);
@@ -1744,8 +1744,8 @@ struct Asyncify : public Pass {
       if (optimize) {
         runner.addDefaultFunctionOptimizationPasses();
       }
-      runner.add(
-        make_unique<AsyncifyLocals>(&analyzer, pointerType, asyncifyMemory));
+      runner.add(std::make_unique<AsyncifyLocals>(
+        &analyzer, pointerType, asyncifyMemory));
       if (optimize) {
         runner.addDefaultFunctionOptimizationPasses();
       }

--- a/src/passes/I64ToI32Lowering.cpp
+++ b/src/passes/I64ToI32Lowering.cpp
@@ -105,7 +105,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
 
   void doWalkModule(Module* module) {
     if (!builder) {
-      builder = make_unique<Builder>(*module);
+      builder = std::make_unique<Builder>(*module);
     }
     // add new globals for high bits
     for (size_t i = 0, globals = module->globals.size(); i < globals; ++i) {
@@ -154,7 +154,7 @@ struct I64ToI32Lowering : public WalkerPass<PostWalker<I64ToI32Lowering>> {
     Flat::verifyFlatness(func);
     // create builder here if this is first entry to module for this object
     if (!builder) {
-      builder = make_unique<Builder>(*getModule());
+      builder = std::make_unique<Builder>(*getModule());
     }
     indexMap.clear();
     highBitVars.clear();

--- a/src/passes/JSPI.cpp
+++ b/src/passes/JSPI.cpp
@@ -227,12 +227,12 @@ private:
                             Name suspender,
                             bool wasmSplit) {
     Builder builder(*module);
-    auto wrapperIm = make_unique<Function>();
+    auto wrapperIm = std::make_unique<Function>();
     wrapperIm->name = Names::getValidFunctionName(
       *module, std::string("import$") + im->name.toString());
     wrapperIm->module = im->module;
     wrapperIm->base = im->base;
-    auto stub = make_unique<Function>();
+    auto stub = std::make_unique<Function>();
     stub->name = Name(im->name.str);
     stub->type = im->type;
 

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -287,11 +287,11 @@ private:
   // JS import
   Name makeLegalStubForCalledImport(Function* im, Module* module) {
     Builder builder(*module);
-    auto legalIm = make_unique<Function>();
+    auto legalIm = std::make_unique<Function>();
     legalIm->name = Name(std::string("legalimport$") + im->name.toString());
     legalIm->module = im->module;
     legalIm->base = im->base;
-    auto stub = make_unique<Function>();
+    auto stub = std::make_unique<Function>();
     stub->name = Name(std::string("legalfunc$") + im->name.toString());
     stub->type = im->type;
 

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -296,7 +296,7 @@ struct OptimizeAddedConstants
       helperIndexes.clear();
       propagatable.clear();
       if (propagate) {
-        localGraph = make_unique<LocalGraph>(func);
+        localGraph = std::make_unique<LocalGraph>(func);
         localGraph->computeSetInfluences();
         localGraph->computeSSAIndexes();
         findPropagatable();

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -299,8 +299,8 @@ struct ReReloop final : public Pass {
     // since control flow is flattened, this is pretty simple
     // first, traverse the function body. note how we don't need to traverse
     // into expressions, as we know they contain no control flow
-    builder = make_unique<Builder>(*module);
-    relooper = make_unique<CFG::Relooper>(module);
+    builder = std::make_unique<Builder>(*module);
+    relooper = std::make_unique<CFG::Relooper>(module);
     auto* entry = startCFGBlock();
     stack.push_back(TaskPtr(new TriageTask(*this, function->body)));
     // main loop

--- a/src/passes/RemoveNonJSOps.cpp
+++ b/src/passes/RemoveNonJSOps.cpp
@@ -67,7 +67,7 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
     // Discover all of the intrinsics that we need to inject, lowering all
     // operations to intrinsic calls while we're at it.
     if (!builder) {
-      builder = make_unique<Builder>(*module);
+      builder = std::make_unique<Builder>(*module);
     }
     PostWalker<RemoveNonJSOpsPass>::doWalkModule(module);
 
@@ -129,7 +129,7 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
     // Add missing globals
     for (auto& [name, type] : neededImportedGlobals) {
       if (!getModule()->getGlobalOrNull(name)) {
-        auto global = make_unique<Global>();
+        auto global = std::make_unique<Global>();
         global->name = name;
         global->type = type;
         global->mutable_ = false;
@@ -157,7 +157,7 @@ struct RemoveNonJSOpsPass : public WalkerPass<PostWalker<RemoveNonJSOpsPass>> {
 
   void doWalkFunction(Function* func) {
     if (!builder) {
-      builder = make_unique<Builder>(*getModule());
+      builder = std::make_unique<Builder>(*getModule());
     }
     PostWalker<RemoveNonJSOpsPass>::doWalkFunction(func);
   }

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -40,7 +40,7 @@ struct GenerateStackIR : public WalkerPass<PostWalker<GenerateStackIR>> {
   void doWalkFunction(Function* func) {
     StackIRGenerator stackIRGen(*getModule(), func);
     stackIRGen.write();
-    func->stackIR = make_unique<StackIR>();
+    func->stackIR = std::make_unique<StackIR>();
     func->stackIR->swap(stackIRGen.getStackIR());
   }
 };

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -321,7 +321,8 @@ public:
   void visitModule(Module* curr) { trappingFunctions->addToModule(); }
 
   void doWalkModule(Module* module) {
-    trappingFunctions = make_unique<TrappingFunctionContainer>(mode, *module);
+    trappingFunctions =
+      std::make_unique<TrappingFunctionContainer>(mode, *module);
     super::doWalkModule(module);
   }
 

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -49,7 +49,7 @@ namespace wasm {
 
 Thread::Thread(ThreadPool* parent) : parent(parent) {
   assert(!parent->isRunning());
-  thread = make_unique<std::thread>(mainLoop, this);
+  thread = std::make_unique<std::thread>(mainLoop, this);
 }
 
 Thread::~Thread() {
@@ -124,7 +124,7 @@ void ThreadPool::initialize(size_t num) {
   resetThreadsAreReady();
   for (size_t i = 0; i < num; i++) {
     try {
-      threads.emplace_back(make_unique<Thread>(this));
+      threads.emplace_back(std::make_unique<Thread>(this));
     } catch (std::system_error&) {
       // failed to create a thread - don't use multithreading, as if num cores
       // == 1
@@ -156,7 +156,7 @@ ThreadPool* ThreadPool::get() {
   std::lock_guard<std::mutex> poolLock(creationMutex);
   if (!pool) {
     DEBUG_POOL("::get() creating\n");
-    std::unique_ptr<ThreadPool> temp = make_unique<ThreadPool>();
+    std::unique_ptr<ThreadPool> temp = std::make_unique<ThreadPool>();
     temp->initialize(getNumCores());
     // assign it to the global location now that it is all ready
     pool.swap(temp);

--- a/src/support/utilities.h
+++ b/src/support/utilities.h
@@ -56,11 +56,6 @@ inline size_t alignAddr(size_t address, size_t alignment) {
   return ((address + alignment - 1) & ~(alignment - 1));
 }
 
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
 // For fatal errors which could arise from input (i.e. not assertion failures)
 class Fatal {
 private:

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -352,7 +352,7 @@ struct Reducer
   }
 
   void loadWorking() {
-    module = make_unique<Module>();
+    module = std::make_unique<Module>();
     ModuleReader reader;
     try {
       reader.read(working, *module);
@@ -371,7 +371,7 @@ struct Reducer
     // Apply features the user passed on the commandline.
     toolOptions.applyFeatures(*module);
 
-    builder = make_unique<Builder>(*module);
+    builder = std::make_unique<Builder>(*module);
     setModule(module.get());
   }
 

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -981,14 +981,14 @@ int main(int argc, const char* argv[]) {
       if (options.debug) {
         std::cerr << "s-parsing..." << std::endl;
       }
-      sexprParser = make_unique<SExpressionParser>(input.data());
+      sexprParser = std::make_unique<SExpressionParser>(input.data());
       root = sexprParser->root;
 
       if (options.debug) {
         std::cerr << "w-parsing..." << std::endl;
       }
-      sexprBuilder =
-        make_unique<SExpressionWasmBuilder>(wasm, *(*root)[0], options.profile);
+      sexprBuilder = std::make_unique<SExpressionWasmBuilder>(
+        wasm, *(*root)[0], options.profile);
     }
   } catch (ParseException& p) {
     p.dump(std::cerr);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -35,7 +35,7 @@ void WasmBinaryWriter::prepare() {
   // Collect function types and their frequencies. Collect information in each
   // function in parallel, then merge.
   indexedTypes = ModuleUtils::getOptimizedIndexedHeapTypes(*wasm);
-  importInfo = wasm::make_unique<ImportInfo>(*wasm);
+  importInfo = std::make_unique<ImportInfo>(*wasm);
 }
 
 void WasmBinaryWriter::write() {
@@ -3628,7 +3628,7 @@ void WasmBinaryBuilder::readFeatures(size_t payloadLen) {
 }
 
 void WasmBinaryBuilder::readDylink(size_t payloadLen) {
-  wasm.dylinkSection = make_unique<DylinkSection>();
+  wasm.dylinkSection = std::make_unique<DylinkSection>();
 
   auto sectionPos = pos;
 
@@ -3653,7 +3653,7 @@ void WasmBinaryBuilder::readDylink0(size_t payloadLen) {
   auto sectionPos = pos;
   uint32_t lastType = 0;
 
-  wasm.dylinkSection = make_unique<DylinkSection>();
+  wasm.dylinkSection = std::make_unique<DylinkSection>();
   while (pos < sectionPos + payloadLen) {
     auto oldPos = pos;
     auto dylinkType = getU32LEB();

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -68,7 +68,7 @@ void ModuleReader::readBinaryData(std::vector<char>& input,
   parser.setDWARF(DWARF);
   parser.setSkipFunctionBodies(skipFunctionBodies);
   if (sourceMapFilename.size()) {
-    sourceMapStream = make_unique<std::ifstream>();
+    sourceMapStream = std::make_unique<std::ifstream>();
     sourceMapStream->open(sourceMapFilename);
     parser.setDebugLocations(sourceMapStream.get());
   }
@@ -156,7 +156,7 @@ void ModuleWriter::writeBinary(Module& wasm, Output& output) {
   }
   std::unique_ptr<std::ofstream> sourceMapStream;
   if (sourceMapFilename.size()) {
-    sourceMapStream = make_unique<std::ofstream>();
+    sourceMapStream = std::make_unique<std::ofstream>();
     sourceMapStream->open(sourceMapFilename);
     writer.setSourceMap(sourceMapStream.get(), sourceMapUrl);
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1038,7 +1038,7 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     }
   }
   if (exportName.is()) {
-    auto ex = make_unique<Export>();
+    auto ex = std::make_unique<Export>();
     ex->name = exportName;
     ex->value = name;
     ex->kind = ExternalKind::Function;
@@ -1071,7 +1071,7 @@ void SExpressionWasmBuilder::parseFunction(Element& s, bool preParseImport) {
     if (!preParseImport) {
       throw ParseException("!preParseImport in func", s.line, s.col);
     }
-    auto im = make_unique<Function>();
+    auto im = std::make_unique<Function>();
     im->setName(name, hasExplicitName);
     im->module = importModule;
     im->base = importBase;
@@ -3236,7 +3236,7 @@ Index SExpressionWasmBuilder::parseMemoryLimits(
 }
 
 void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
-  auto memory = make_unique<Memory>();
+  auto memory = std::make_unique<Memory>();
   memory->shared = false;
   Index i = 1;
   if (s[i]->dollared()) {
@@ -3251,7 +3251,7 @@ void SExpressionWasmBuilder::parseMemory(Element& s, bool preParseImport) {
   if (s[i]->isList()) {
     auto& inner = *s[i];
     if (elementStartsWith(inner, EXPORT)) {
-      auto ex = make_unique<Export>();
+      auto ex = std::make_unique<Export>();
       ex->name = inner[1]->str();
       ex->value = memory->name;
       ex->kind = ExternalKind::Memory;
@@ -3388,7 +3388,7 @@ void SExpressionWasmBuilder::parseInnerData(Element& s,
 }
 
 void SExpressionWasmBuilder::parseExport(Element& s) {
-  std::unique_ptr<Export> ex = make_unique<Export>();
+  std::unique_ptr<Export> ex = std::make_unique<Export>();
   ex->name = s[1]->str();
   if (s[2]->isList()) {
     auto& inner = *s[2];
@@ -3484,7 +3484,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
   Element& inner = newStyle ? *s[3] : s;
   Index j = newStyle ? newStyleInner : i;
   if (kind == ExternalKind::Function) {
-    auto func = make_unique<Function>();
+    auto func = std::make_unique<Function>();
 
     j = parseTypeUse(inner, j, func->type);
     func->setName(name, hasExplicitName);
@@ -3499,7 +3499,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     global->module = module;
     global->base = base;
   } else if (kind == ExternalKind::Table) {
-    auto table = make_unique<Table>();
+    auto table = std::make_unique<Table>();
     table->setName(name, hasExplicitName);
     table->module = module;
     table->base = base;
@@ -3523,7 +3523,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
     j++; // funcref
     // ends with the table element type
   } else if (kind == ExternalKind::Memory) {
-    auto memory = make_unique<Memory>();
+    auto memory = std::make_unique<Memory>();
     memory->setName(name, hasExplicitName);
     memory->module = module;
     memory->base = base;
@@ -3543,7 +3543,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
 
     wasm.addMemory(std::move(memory));
   } else if (kind == ExternalKind::Tag) {
-    auto tag = make_unique<Tag>();
+    auto tag = std::make_unique<Tag>();
     HeapType tagType;
     j = parseTypeUse(inner, j, tagType);
     tag->sig = tagType.getSignature();
@@ -3559,7 +3559,7 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
 }
 
 void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
-  std::unique_ptr<Global> global = make_unique<Global>();
+  std::unique_ptr<Global> global = std::make_unique<Global>();
   size_t i = 1;
   if (s[i]->dollared()) {
     global->setExplicitName(s[i++]->str());
@@ -3576,7 +3576,7 @@ void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
   while (i < s.size() && s[i]->isList()) {
     auto& inner = *s[i++];
     if (elementStartsWith(inner, EXPORT)) {
-      auto ex = make_unique<Export>();
+      auto ex = std::make_unique<Export>();
       ex->name = inner[1]->str();
       ex->value = global->name;
       ex->kind = ExternalKind::Global;
@@ -3607,7 +3607,7 @@ void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
     if (!preParseImport) {
       throw ParseException("!preParseImport in global", s.line, s.col);
     }
-    auto im = make_unique<Global>();
+    auto im = std::make_unique<Global>();
     im->name = global->name;
     im->module = importModule;
     im->base = importBase;
@@ -3636,7 +3636,7 @@ void SExpressionWasmBuilder::parseGlobal(Element& s, bool preParseImport) {
 }
 
 void SExpressionWasmBuilder::parseTable(Element& s, bool preParseImport) {
-  std::unique_ptr<Table> table = make_unique<Table>();
+  std::unique_ptr<Table> table = std::make_unique<Table>();
   Index i = 1;
   if (s[i]->dollared()) {
     table->setExplicitName(s[i++]->str());
@@ -3649,7 +3649,7 @@ void SExpressionWasmBuilder::parseTable(Element& s, bool preParseImport) {
   if (s[i]->isList()) {
     auto& inner = *s[i];
     if (elementStartsWith(inner, EXPORT)) {
-      auto ex = make_unique<Export>();
+      auto ex = std::make_unique<Export>();
       ex->name = inner[1]->str();
       ex->value = table->name;
       ex->kind = ExternalKind::Table;
@@ -3859,7 +3859,7 @@ HeapType SExpressionWasmBuilder::parseHeapType(Element& s) {
 }
 
 void SExpressionWasmBuilder::parseTag(Element& s, bool preParseImport) {
-  auto tag = make_unique<Tag>();
+  auto tag = std::make_unique<Tag>();
   size_t i = 1;
 
   // Parse name
@@ -3910,7 +3910,7 @@ void SExpressionWasmBuilder::parseTag(Element& s, bool preParseImport) {
       throw ParseException(
         "invalid export name", exportElem[1]->line, exportElem[1]->col);
     }
-    auto ex = make_unique<Export>();
+    auto ex = std::make_unique<Export>();
     ex->name = exportElem[1]->str();
     if (wasm.getExportOrNull(ex->name)) {
       throw ParseException(

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -80,7 +80,7 @@ struct ValidationInfo {
     if (iter != outputs.end()) {
       return *(iter->second.get());
     }
-    auto& ret = outputs[func] = make_unique<std::ostringstream>();
+    auto& ret = outputs[func] = std::make_unique<std::ostringstream>();
     return *ret.get();
   }
 

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -341,7 +341,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
   // First, do the lowering to a JS-friendly subset.
   {
     PassRunner runner(wasm, options);
-    runner.add(make_unique<AutoDrop>());
+    runner.add(std::make_unique<AutoDrop>());
     // TODO: only legalize if necessary - emscripten would already do so, and
     //       likely other toolchains. but spec test suite needs that.
     runner.add("legalize-js-interface");


### PR DESCRIPTION
This code predates our adoption of C++14 and can now be removed in favor of
`std::make_unique`, which should be more efficient.