### PR TITLE
[Wasm GC] Stop emitting deprecated cast etc. instructions

### DIFF
--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2024,20 +2024,6 @@ void BinaryInstWriter::visitRefCast(RefCast* curr) {
     o << U32LEB(BinaryConsts::RefCastNop);
     parent.writeHeapType(curr->type.getHeapType());
   } else {
-    // TODO: These instructions are deprecated. Remove them.
-    if (auto type = curr->type.getHeapType();
-        type.isBasic() && curr->type.isNonNullable()) {
-      switch (type.getBasic()) {
-        case HeapType::func:
-          o << U32LEB(BinaryConsts::RefAsFunc);
-          return;
-        case HeapType::i31:
-          o << U32LEB(BinaryConsts::RefAsI31);
-          return;
-        default:
-          break;
-      }
-    }
     if (curr->type.isNullable()) {
       o << U32LEB(BinaryConsts::RefCastNull);
     } else {
@@ -2059,22 +2045,6 @@ void BinaryInstWriter::visitBrOn(BrOn* curr) {
       return;
     case BrOnCast:
       o << int8_t(BinaryConsts::GCPrefix);
-      // TODO: These instructions are deprecated, so stop emitting them.
-      if (auto type = curr->castType.getHeapType();
-          type.isBasic() && curr->castType.isNonNullable()) {
-        switch (type.getBasic()) {
-          case HeapType::func:
-            o << U32LEB(BinaryConsts::BrOnFunc);
-            o << U32LEB(getBreakIndex(curr->name));
-            return;
-          case HeapType::i31:
-            o << U32LEB(BinaryConsts::BrOnI31);
-            o << U32LEB(getBreakIndex(curr->name));
-            return;
-          default:
-            break;
-        }
-      }
       if (curr->castType.isNullable()) {
         o << U32LEB(BinaryConsts::BrOnCastNull);
       } else {
@@ -2085,22 +2055,6 @@ void BinaryInstWriter::visitBrOn(BrOn* curr) {
       return;
     case BrOnCastFail:
       o << int8_t(BinaryConsts::GCPrefix);
-      // TODO: These instructions are deprecated, so stop emitting them.
-      if (auto type = curr->castType.getHeapType();
-          type.isBasic() && curr->castType.isNonNullable()) {
-        switch (type.getBasic()) {
-          case HeapType::func:
-            o << U32LEB(BinaryConsts::BrOnNonFunc);
-            o << U32LEB(getBreakIndex(curr->name));
-            return;
-          case HeapType::i31:
-            o << U32LEB(BinaryConsts::BrOnNonI31);
-            o << U32LEB(getBreakIndex(curr->name));
-            return;
-          default:
-            break;
-        }
-      }
       if (curr->castType.isNullable()) {
         o << U32LEB(BinaryConsts::BrOnCastFailNull);
       } else {


### PR DESCRIPTION
This is necessary to start fuzzing RefCast etc., as otherwise the fuzzer
errors on V8 which has already removed support for the deprecated
ones apparently.

Do not remove read support for them yet, as perhaps some users
still need that.