### PR TITLE
Fix a call to make_unique without std

### DIFF
--- a/src/wasm-module-building.h
+++ b/src/wasm-module-building.h
@@ -199,7 +199,7 @@ public:
 private:
   void createWorker() {
     DEBUG_THREAD("create a worker");
-    threads.emplace_back(make_unique<std::thread>(workerMain, this));
+    threads.emplace_back(std::make_unique<std::thread>(workerMain, this));
   }
 
   void notifyWorker() {


### PR DESCRIPTION
Followup to #5613

Not sure how this builds for us, but it breaks on the J2Wasm roll on `make_unique` not being declared.