### PR TITLE
[Wasm GC] Fix CoalesceLocals i31 local removal

### DIFF
--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1295,7 +1295,12 @@ public:
       return ExpressionManipulator::refNull(curr, curr->type);
     }
     if (curr->type.isRef() && curr->type.getHeapType() == HeapType::i31) {
-      return makeI31New(makeConst(0));
+      Expression* ret = makeI31New(makeConst(0));
+      if (curr->type.isNullable()) {
+        // To keep the type identical, wrap it in a block that adds nullability.
+        ret = makeBlock({ret}, curr->type);
+      }
+      return ret;
     }
     if (!curr->type.isBasic()) {
       // We can't do any better, keep the original.

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -216,4 +216,21 @@
    )
   )
  )
+
+ (func $replace-i31-local (result i32)
+  (local $local i31ref)
+  (i32.add
+   (unreachable)
+   (ref.test i31
+    (ref.cast null i31
+     ;; This local.get is in unreachable code, and coalesce-locals will remove
+     ;; it in order to avoid using the local index at all. While doing so it
+     ;; must emit something of the exact same type so validation still works
+     ;; (we can't turn this into a non-nullable reference, in particular - that
+     ;; would hit a validation error as the cast outside of us is nullable).
+     (local.get $local)
+    )
+   )
+  )
+ )
 )

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -155,8 +155,10 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (i31.new
- ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   (block (result i31ref)
+ ;; CHECK-NEXT:    (i31.new
+ ;; CHECK-NEXT:     (i32.const 0)
+ ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -217,6 +219,21 @@
   )
  )
 
+ ;; CHECK:      (func $replace-i31-local (type $none_=>_i32) (result i32)
+ ;; CHECK-NEXT:  (local $0 i31ref)
+ ;; CHECK-NEXT:  (i32.add
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:   (ref.is_i31
+ ;; CHECK-NEXT:    (ref.cast null i31
+ ;; CHECK-NEXT:     (block (result i31ref)
+ ;; CHECK-NEXT:      (i31.new
+ ;; CHECK-NEXT:       (i32.const 0)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
  (func $replace-i31-local (result i32)
   (local $local i31ref)
   (i32.add


### PR DESCRIPTION
When removing a `local.get` we must replace it with something of the
identical type, and not make it non-nullable.