### PR TITLE
Only update functions in optimizeAfterInlining()

### DIFF
--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -37,7 +37,7 @@ inline void optimizeAfterInlining(const std::unordered_set<Function*>& funcs,
   // save the full list of functions on the side
   std::vector<std::unique_ptr<Function>> all;
   all.swap(module->functions);
-  module->updateMaps();
+  module->updateFunctionsMap();
   for (auto& func : funcs) {
     module->addFunction(func);
   }

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -53,7 +53,7 @@ inline void optimizeAfterInlining(const std::unordered_set<Function*>& funcs,
     func.release();
   }
   all.swap(module->functions);
-  module->updateMaps();
+  module->updateFunctionsMap();
 }
 
 struct FunctionRefReplacer

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2239,6 +2239,7 @@ public:
   void removeGlobals(std::function<bool(Global*)> pred);
   void removeTags(std::function<bool(Tag*)> pred);
 
+  void updateFunctionsMap();
   void updateDataSegmentsMap();
   void updateMaps();
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1583,6 +1583,7 @@ void Module::updateDataSegmentsMap() {
 }
 
 void Module::updateMaps() {
+  updateFunctionsMap();
   exportsMap.clear();
   for (auto& curr : exports) {
     exportsMap[curr->name] = curr.get();

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1568,6 +1568,13 @@ void Module::removeTags(std::function<bool(Tag*)> pred) {
   removeModuleElements(tags, tagsMap, pred);
 }
 
+void Module::updateFunctionsMap() {
+  functionsMap.clear();
+  for (auto& curr : functions) {
+    functionsMap[curr->name] = curr.get();
+  }
+}
+
 void Module::updateDataSegmentsMap() {
   dataSegmentsMap.clear();
   for (auto& curr : dataSegments) {
@@ -1576,10 +1583,6 @@ void Module::updateDataSegmentsMap() {
 }
 
 void Module::updateMaps() {
-  functionsMap.clear();
-  for (auto& curr : functions) {
-    functionsMap[curr->name] = curr.get();
-  }
   exportsMap.clear();
   for (auto& curr : exports) {
     exportsMap[curr->name] = curr.get();


### PR DESCRIPTION
This saves the work of freeing and allocating for all the other maps. This is a
code path that is used by several passes so it showed up in profiling for
#5561 