### PR TITLE
Fuzzer: Improve mutate()

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -802,12 +802,14 @@ void TranslateToFuzzReader::mutate(Function* func) {
   // average. To achieve that, we raise r/100, which is in the range [0, 1], to
   // the 9th power, giving us a number also in the range [0, 1] with a mean of
   //   \integral_0^1 t^9 dx = 0.1 * t^10 |_0^1 = 0.1
+  // As a result, we get a value in the range of 0-100%. We'll adjust 0% to 1%
+  // so we avoid doing nothing at all, and note that 100% is ok since we can't
+  // replace everything anyhow (see below).
   double t = r;
   t = t / 100;
   t = t * t * t * t * t * t * t * t * t;
   Index percentChance = t * 100;
   if (percentChance == 0) {
-    // Give at least a 1% chance, or else we'll be doing nothing here.
     percentChance = 1;
   }
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -805,7 +805,7 @@ void TranslateToFuzzReader::mutate(Function* func) {
   double t = r;
   t = t / 100;
   t = t * t * t * t * t * t * t * t * t;
-  int percentChance = t * 100;
+  Index percentChance = t * 100;
   if (percentChance == 0) {
     // Give at least a 1% chance, or else we'll be doing nothing here.
     percentChance = 1;
@@ -814,13 +814,13 @@ void TranslateToFuzzReader::mutate(Function* func) {
   struct Modder : public PostWalker<Modder, UnifiedExpressionVisitor<Modder>> {
     Module& wasm;
     TranslateToFuzzReader& parent;
-    int percentChance;
+    Index percentChance;
 
     // Whether to replace with unreachable. This can lead to less code getting
     // executed, so we don't want to do it all the time even in a big function.
     bool allowUnreachable;
 
-    Modder(Module& wasm, TranslateToFuzzReader& parent, int percentChance)
+    Modder(Module& wasm, TranslateToFuzzReader& parent, Index percentChance)
       : wasm(wasm), parent(parent), percentChance(percentChance) {
       // If the parent allows it then sometimes replace with an unreachable, and
       // sometimes not. Even if we allow it, only do it in certain functions

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -833,7 +833,7 @@ void TranslateToFuzzReader::mutate(Function* func) {
     void visitExpression(Expression* curr) {
       if (parent.upTo(100) < percentChance &&
           parent.canBeArbitrarilyReplaced(curr)) {
-        if (allowUnreachable && parent.oneIn(10)) {
+        if (allowUnreachable && parent.oneIn(20)) {
           replaceCurrent(parent.make(Type::unreachable));
           return;
         }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -823,9 +823,11 @@ void TranslateToFuzzReader::mutate(Function* func) {
         // TODO: more minor tweaks to immediates, like making a load atomic or
         // not, changing an offset, etc.
         // Perform a general replacement. (This is not always valid due to
-        // nesting of labels, but we'll fix that up later.)
-        // TODO: pick a subtype of the current type
-        replaceCurrent(parent.make(curr->type));
+        // nesting of labels, but we'll fix that up later.) We both pick a
+        // possible subtype here, and then pick something of that type, so that
+        // we should give a possibility for any valid replacement here to
+        // appear.
+        replaceCurrent(parent.make(parent.getSubType(curr->type)));
       }
     }
   };

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,33 +1,33 @@
 total
- [exports]      : 37      
- [funcs]        : 53      
+ [exports]      : 11      
+ [funcs]        : 12      
  [globals]      : 9       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 2       
- [table-data]   : 11      
+ [table-data]   : 1       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3757    
- [vars]         : 140     
- Binary         : 290     
- Block          : 638     
- Break          : 92      
- Call           : 200     
- CallIndirect   : 22      
- Const          : 707     
- Drop           : 45      
- GlobalGet      : 300     
- GlobalSet      : 253     
- If             : 198     
- Load           : 57      
- LocalGet       : 176     
- LocalSet       : 149     
- Loop           : 69      
- Nop            : 81      
- RefFunc        : 11      
- Return         : 49      
- Select         : 27      
- Store          : 30      
- Unary          : 240     
- Unreachable    : 123     
+ [total]        : 3243    
+ [vars]         : 39      
+ Binary         : 249     
+ Block          : 516     
+ Break          : 130     
+ Call           : 76      
+ CallIndirect   : 3       
+ Const          : 541     
+ Drop           : 20      
+ GlobalGet      : 241     
+ GlobalSet      : 183     
+ If             : 171     
+ Load           : 58      
+ LocalGet       : 289     
+ LocalSet       : 240     
+ Loop           : 77      
+ Nop            : 52      
+ RefFunc        : 1       
+ Return         : 20      
+ Select         : 28      
+ Store          : 29      
+ Unary          : 231     
+ Unreachable    : 88      

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,33 +1,33 @@
 total
- [exports]      : 11      
- [funcs]        : 12      
+ [exports]      : 20      
+ [funcs]        : 23      
  [globals]      : 9       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 2       
- [table-data]   : 1       
+ [table-data]   : 5       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3243    
- [vars]         : 39      
- Binary         : 249     
- Block          : 516     
- Break          : 130     
- Call           : 76      
- CallIndirect   : 3       
- Const          : 541     
- Drop           : 20      
- GlobalGet      : 241     
- GlobalSet      : 183     
- If             : 171     
- Load           : 58      
- LocalGet       : 289     
- LocalSet       : 240     
- Loop           : 77      
- Nop            : 52      
- RefFunc        : 1       
- Return         : 20      
- Select         : 28      
- Store          : 29      
- Unary          : 231     
- Unreachable    : 88      
+ [total]        : 3867    
+ [vars]         : 64      
+ Binary         : 296     
+ Block          : 626     
+ Break          : 124     
+ Call           : 155     
+ CallIndirect   : 17      
+ Const          : 625     
+ Drop           : 28      
+ GlobalGet      : 292     
+ GlobalSet      : 223     
+ If             : 210     
+ Load           : 77      
+ LocalGet       : 339     
+ LocalSet       : 228     
+ Loop           : 85      
+ Nop            : 50      
+ RefFunc        : 5       
+ Return         : 55      
+ Select         : 22      
+ Store          : 28      
+ Unary          : 275     
+ Unreachable    : 107     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,43 +1,43 @@
 total
  [exports]      : 5       
- [funcs]        : 18      
+ [funcs]        : 13      
  [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 4       
+ [table-data]   : 3       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 746     
- [vars]         : 33      
- ArrayNew       : 7       
- AtomicFence    : 1       
- AtomicRMW      : 1       
- Binary         : 84      
- Block          : 91      
- Break          : 3       
- Call           : 32      
- CallIndirect   : 1       
- CallRef        : 2       
- Const          : 153     
- Drop           : 11      
- GlobalGet      : 48      
- GlobalSet      : 46      
- I31New         : 1       
- If             : 29      
- Load           : 25      
- LocalGet       : 48      
- LocalSet       : 30      
- Loop           : 7       
- Nop            : 5       
- RefFunc        : 18      
- RefIsNull      : 3       
+ [total]        : 642     
+ [vars]         : 16      
+ ArrayNew       : 2       
+ ArrayNewFixed  : 1       
+ AtomicNotify   : 1       
+ Binary         : 75      
+ Block          : 77      
+ Break          : 13      
+ Call           : 26      
+ Const          : 138     
+ Drop           : 5       
+ GlobalGet      : 33      
+ GlobalSet      : 33      
+ I31New         : 2       
+ If             : 26      
+ Load           : 21      
+ LocalGet       : 45      
+ LocalSet       : 25      
+ Loop           : 5       
+ Nop            : 8       
+ RefAs          : 5       
+ RefEq          : 1       
+ RefFunc        : 11      
+ RefIsNull      : 1       
  RefNull        : 14      
- Return         : 6       
- SIMDExtract    : 2       
- Select         : 4       
- StructNew      : 3       
- TupleExtract   : 1       
- TupleMake      : 12      
- Unary          : 32      
- Unreachable    : 26      
+ RefTest        : 1       
+ Return         : 5       
+ Store          : 2       
+ StructNew      : 4       
+ TupleExtract   : 2       
+ TupleMake      : 11      
+ Unary          : 29      
+ Unreachable    : 20      

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,43 +1,42 @@
 total
- [exports]      : 5       
+ [exports]      : 4       
  [funcs]        : 13      
  [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 3       
+ [table-data]   : 4       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 642     
- [vars]         : 16      
- ArrayNew       : 2       
- ArrayNewFixed  : 1       
+ [total]        : 592     
+ [vars]         : 27      
+ ArrayNew       : 1       
  AtomicNotify   : 1       
- Binary         : 75      
- Block          : 77      
- Break          : 13      
- Call           : 26      
- Const          : 138     
- Drop           : 5       
+ Binary         : 71      
+ Block          : 72      
+ Break          : 10      
+ Call           : 20      
+ Const          : 129     
+ Drop           : 4       
  GlobalGet      : 33      
  GlobalSet      : 33      
- I31New         : 2       
- If             : 26      
- Load           : 21      
- LocalGet       : 45      
+ I31New         : 1       
+ If             : 24      
+ Load           : 19      
+ LocalGet       : 44      
  LocalSet       : 25      
- Loop           : 5       
- Nop            : 8       
- RefAs          : 5       
+ Loop           : 4       
+ Nop            : 7       
+ RefAs          : 3       
  RefEq          : 1       
- RefFunc        : 11      
+ RefFunc        : 10      
  RefIsNull      : 1       
- RefNull        : 14      
+ RefNull        : 10      
  RefTest        : 1       
- Return         : 5       
+ Return         : 4       
  Store          : 2       
  StructNew      : 4       
  TupleExtract   : 2       
  TupleMake      : 11      
- Unary          : 29      
+ Unary          : 25      
  Unreachable    : 20      


### PR DESCRIPTION
1. Pick a subtype when mutating.
2. Don't use a fixed 10% chance to mutate, but pick a mutation rate in each function.