### PR TITLE
[GUFA] Refine global types during flow

### DIFF
--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -800,6 +800,11 @@ TEST_F(PossibleContentsTest, TestStructCones) {
                      PossibleContents::fullConeType(signature),
                      PossibleContents::fullConeType(signature));
 
+  // A global can be filtered to have a non-nullable type.
+  auto nonNullFuncRef = Type(HeapType::func, NonNullable);
+  assertIntersection(
+    funcGlobal, PossibleContents::fullConeType(nonNullFuncRef), nonNullFuncGlobal);
+
   // Incompatible hierarchies have no intersection.
   assertIntersection(
     literalNullA, PossibleContents::fullConeType(funcref), none);

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -803,12 +803,12 @@ TEST_F(PossibleContentsTest, TestStructCones) {
 
   // Filter a global's nullability only.
   auto nonNullFuncRef = Type(HeapType::func, NonNullable);
-  assertIntersection(
-    funcGlobal, PossibleContents::fullConeType(nonNullFuncRef), nonNullFuncGlobal);
+  assertIntersection(funcGlobal,
+                     PossibleContents::fullConeType(nonNullFuncRef),
+                     nonNullFuncGlobal);
 
   // Incompatible global and cone types have no intersection.
-  assertIntersection(
-    funcGlobal, PossibleContents::fullConeType(nullE), none);
+  assertIntersection(funcGlobal, PossibleContents::fullConeType(nullE), none);
 
   // Incompatible hierarchies have no intersection.
   assertIntersection(

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -787,23 +787,28 @@ TEST_F(PossibleContentsTest, TestStructCones) {
                      PossibleContents::fullConeType(nnD),
                      none);
 
-  // Globals stay as globals if their type is in the cone. Otherwise, they lose
-  // the global info and we compute a normal cone intersection on them. The
-  // same for literals.
+  // Globals stay as globals, but their type might get refined.
   assertIntersection(
     funcGlobal, PossibleContents::fullConeType(funcref), funcGlobal);
 
+  // No global filtering.
   auto signature = Type(Signature(Type::none, Type::none), Nullable);
   assertIntersection(
     nonNullFunc, PossibleContents::fullConeType(signature), nonNullFunc);
+
+  // Filter a global to a more specific type.
   assertIntersection(funcGlobal,
                      PossibleContents::fullConeType(signature),
-                     PossibleContents::fullConeType(signature));
+                     PossibleContents::global("funcGlobal", signature));
 
-  // A global can be filtered to have a non-nullable type.
+  // Filter a global's nullability only.
   auto nonNullFuncRef = Type(HeapType::func, NonNullable);
   assertIntersection(
     funcGlobal, PossibleContents::fullConeType(nonNullFuncRef), nonNullFuncGlobal);
+
+  // Incompatible global and cone types have no intersection.
+  assertIntersection(
+    funcGlobal, PossibleContents::fullConeType(nullE), none);
 
   // Incompatible hierarchies have no intersection.
   assertIntersection(


### PR DESCRIPTION
Previously `(ref.as_non_null (global.get ..))` would return the global with no changes,
and if the global was nullable then the type didn't match the output, which hit an
assertion (where GUFA checks that the contents match the declared type in the wasm).

To fix this, refine global types, that is, the type we track on GlobalInfo may be more
refined than the global itself. In the above example, if the global is nullable then
the GlobalInfo would point to that global but have a non-nullable type.

In fact the code was already prepared for this, and few changes were needed.