### PR TITLE
[Wasm GC] Handle packed fields in GUFA and CFP

### DIFF
--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -448,18 +448,6 @@ inline Index getMinBits(Expression* curr) {
   return 0;
 }
 
-inline Index getBits(Field::PackedType packed) {
-  switch (packed) {
-    case Field::PackedType::i8:
-      return 8;
-    case Field::PackedType::i16:
-      return 16;
-    case Field::PackedType::not_packed:
-      return 32;
-  }
-  WASM_UNREACHABLE("invalid packing");
-}
-
 } // namespace wasm::Bits
 
 #endif // wasm_ir_bits_h

--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -448,6 +448,18 @@ inline Index getMinBits(Expression* curr) {
   return 0;
 }
 
+inline Index getBits(Field::PackedType packed) {
+  switch (packed) {
+    case Field::PackedType::i8:
+      return 8;
+    case Field::PackedType::i16:
+      return 16;
+    case Field::PackedType::not_packed:
+      return 32;
+  }
+  WASM_UNREACHABLE("invalid packing");
+}
+
 } // namespace wasm::Bits
 
 #endif // wasm_ir_bits_h

--- a/src/ir/gc-type-utils.h
+++ b/src/ir/gc-type-utils.h
@@ -127,10 +127,6 @@ inline std::optional<Field> getField(Type type, Index index = 0) {
   return {};
 }
 
-inline std::optional<Field> getField(Expression* ref, Index index = 0) {
-  return getField(ref->type, index);
-}
-
 } // namespace wasm::GCTypeUtils
 
 #endif // wasm_ir_gc_type_utils_h

--- a/src/ir/gc-type-utils.h
+++ b/src/ir/gc-type-utils.h
@@ -105,6 +105,28 @@ inline EvaluationResult evaluateCastCheck(Type refType, Type castType) {
   return Unknown;
 }
 
+// Given a reference and a field index, return the field for it, if one exists.
+// One may not exist if the reference is unreachable, or a bottom type.
+//
+// The index is optional as it does not matter for an array.
+//
+// TODO: use in more places
+inline std::optional<Field> getField(Type type, Index index = 0) {
+  if (type.isRef()) {
+    auto heapType = type.getHeapType();
+    if (heapType.isStruct()) {
+      return heapType.getStruct().fields[index];
+    } else if (heapType.isArray()) {
+      return heapType.getArray().element;
+    }
+  }
+  return {};
+}
+
+inline std::optional<Field> getField(Expression* ref, Index index = 0) {
+  return getField(ref->type, index);
+}
+
 } // namespace wasm::GCTypeUtils
 
 #endif // wasm_ir_gc_type_utils_h

--- a/src/ir/gc-type-utils.h
+++ b/src/ir/gc-type-utils.h
@@ -111,14 +111,18 @@ inline EvaluationResult evaluateCastCheck(Type refType, Type castType) {
 // The index is optional as it does not matter for an array.
 //
 // TODO: use in more places
+inline std::optional<Field> getField(HeapType type, Index index = 0) {
+  if (type.isStruct()) {
+    return type.getStruct().fields[index];
+  } else if (type.isArray()) {
+    return type.getArray().element;
+  }
+  return {};
+}
+
 inline std::optional<Field> getField(Type type, Index index = 0) {
   if (type.isRef()) {
-    auto heapType = type.getHeapType();
-    if (heapType.isStruct()) {
-      return heapType.getStruct().fields[index];
-    } else if (heapType.isArray()) {
-      return heapType.getArray().element;
-    }
+    return getField(type.getHeapType(), index);
   }
   return {};
 }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1720,7 +1720,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
     filterGlobalContents(contents, *globalLoc);
     filtered = true;
   } else if (auto* dataLoc = std::get_if<DataLocation>(&location)) {
-    filterDataContents(contents, dataLoc);
+    filterDataContents(contents, *dataLoc);
     filtered = true;
   }
 
@@ -1956,10 +1956,10 @@ void Flower::filterGlobalContents(PossibleContents& contents,
 
 void Flower::filterDataContents(PossibleContents& contents,
                                 const DataLocation& dataLoc) {
-  auto type = dataLoc->type;
+  auto type = dataLoc.type;
   Field field;
   if (type.isStruct()) {
-    field = type.getStruct().fields[dataLoc->index];
+    field = type.getStruct().fields[dataLoc.index];
   } else {
     field = type.getArray().element;
   }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1408,7 +1408,8 @@ private:
                                 bool& worthSendingMore);
   void filterGlobalContents(PossibleContents& contents,
                             const GlobalLocation& globalLoc);
-  void filterDataContents(PossibleContents& contents, const DataLoc& dataLoc);
+  void filterDataContents(PossibleContents& contents,
+                          const DataLocation& dataLoc);
 
   // Reads from GC data: a struct.get or array.get. This is given the type of
   // the read operation, the field that is read on that type, the known contents
@@ -1954,7 +1955,7 @@ void Flower::filterGlobalContents(PossibleContents& contents,
 }
 
 void Flower::filterDataContents(PossibleContents& contents,
-                                const DataLoc& dataLoc) {
+                                const DataLocation& dataLoc) {
   auto type = dataLoc->type;
   Field field;
   if (type.isStruct()) {

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -19,8 +19,8 @@
 
 #include "ir/bits.h"
 #include "ir/branch-utils.h"
-#include "ir/gc-type-utils.h"
 #include "ir/eh-utils.h"
+#include "ir/gc-type-utils.h"
 #include "ir/local-graph.h"
 #include "ir/module-utils.h"
 #include "ir/possible-contents.h"
@@ -1963,8 +1963,7 @@ void Flower::filterDataContents(PossibleContents& contents,
     // We must handle packed fields carefully.
     if (contents.isLiteral()) {
       // This is a constant. We can truncate it and use that value.
-      auto mask =
-        Literal(int32_t(Bits::lowBitMask(field->getByteSize() * 8)));
+      auto mask = Literal(int32_t(Bits::lowBitMask(field->getByteSize() * 8)));
       contents = PossibleContents::literal(contents.getLiteral().and_(mask));
     } else {
       // This is not a constant. We can't even handle a global here, as we'd

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1408,8 +1408,7 @@ private:
                                 bool& worthSendingMore);
   void filterGlobalContents(PossibleContents& contents,
                             const GlobalLocation& globalLoc);
-  void filterDataContents(PossibleContents& contents,
-                          const DataLoc& dataLoc);
+  void filterDataContents(PossibleContents& contents, const DataLoc& dataLoc);
 
   // Reads from GC data: a struct.get or array.get. This is given the type of
   // the read operation, the field that is read on that type, the known contents

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1957,7 +1957,6 @@ void Flower::filterGlobalContents(PossibleContents& contents,
 
 void Flower::filterDataContents(PossibleContents& contents,
                                 const DataLocation& dataLoc) {
-  auto type = dataLoc.type;
   auto field = GCTypeUtils::getField(dataLoc.type, dataLoc.index);
   assert(field);
   if (field->isPacked()) {

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -110,7 +110,8 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
       // We cannot just pass through a value that is packed, as the input gets
       // truncated.
       auto mask = Bits::lowBitMask(Bits::getBits(field.packedType));
-      value = builder.makeBinary(AndInt32, value, builder.makeConst(int32_t(mask)));
+      value =
+        builder.makeBinary(AndInt32, value, builder.makeConst(int32_t(mask)));
     }
     replaceCurrent(builder.makeSequence(
       builder.makeDrop(builder.makeRefAs(RefAsNonNull, curr->ref)), value));

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -27,6 +27,7 @@
 //        wasm GC programs we need to check for type escaping.
 //
 
+#include "ir/bits.h"
 #include "ir/module-utils.h"
 #include "ir/possible-constant.h"
 #include "ir/struct-utils.h"

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2135,3 +2135,64 @@
     )
   )
 )
+
+;; Test we handle packed fields properly.
+(module
+ ;; CHECK:      (type $none_=>_none (func))
+
+ ;; CHECK:      (type $A_8 (struct (field i8)))
+ (type $A_8 (struct (field i8)))
+ ;; CHECK:      (type $A_16 (struct (field i16)))
+ (type $A_16 (struct (field i16)))
+
+ ;; CHECK:      (func $test (type $none_=>_none)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block (result i32)
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (ref.as_non_null
+ ;; CHECK-NEXT:      (struct.new $A_8
+ ;; CHECK-NEXT:       (i32.const 305419896)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (i32.and
+ ;; CHECK-NEXT:     (i32.const 305419896)
+ ;; CHECK-NEXT:     (i32.const 255)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block (result i32)
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (ref.as_non_null
+ ;; CHECK-NEXT:      (struct.new $A_16
+ ;; CHECK-NEXT:       (i32.const 305419896)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (i32.and
+ ;; CHECK-NEXT:     (i32.const 305419896)
+ ;; CHECK-NEXT:     (i32.const 65535)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $test
+  ;; We can infer values here, but must add proper masks, as the inputs get
+  ;; truncated during packing.
+  (drop
+   (struct.get_u $A_8 0
+    (struct.new $A_8
+     (i32.const 0x12345678)
+    )
+   )
+  )
+  (drop
+   (struct.get_u $A_16 0
+    (struct.new $A_16
+     (i32.const 0x12345678)
+    )
+   )
+  )
+ )
+)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2138,61 +2138,61 @@
 
 ;; Test we handle packed fields properly.
 (module
- ;; CHECK:      (type $none_=>_none (func))
+  ;; CHECK:      (type $none_=>_none (func))
 
- ;; CHECK:      (type $A_8 (struct (field i8)))
- (type $A_8 (struct (field i8)))
- ;; CHECK:      (type $A_16 (struct (field i16)))
- (type $A_16 (struct (field i16)))
+  ;; CHECK:      (type $A_8 (struct (field i8)))
+  (type $A_8 (struct (field i8)))
+  ;; CHECK:      (type $A_16 (struct (field i16)))
+  (type $A_16 (struct (field i16)))
 
- ;; CHECK:      (func $test (type $none_=>_none)
- ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (ref.as_non_null
- ;; CHECK-NEXT:      (struct.new $A_8
- ;; CHECK-NEXT:       (i32.const 305419896)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (i32.and
- ;; CHECK-NEXT:     (i32.const 305419896)
- ;; CHECK-NEXT:     (i32.const 255)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (ref.as_non_null
- ;; CHECK-NEXT:      (struct.new $A_16
- ;; CHECK-NEXT:       (i32.const 305419896)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (i32.and
- ;; CHECK-NEXT:     (i32.const 305419896)
- ;; CHECK-NEXT:     (i32.const 65535)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT: )
- (func $test
-  ;; We can infer values here, but must add proper masks, as the inputs get
-  ;; truncated during packing.
-  (drop
-   (struct.get_u $A_8 0
-    (struct.new $A_8
-     (i32.const 0x12345678)
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (struct.new $A_8
+  ;; CHECK-NEXT:       (i32.const 305419896)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.and
+  ;; CHECK-NEXT:     (i32.const 305419896)
+  ;; CHECK-NEXT:     (i32.const 255)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (struct.new $A_16
+  ;; CHECK-NEXT:       (i32.const 305419896)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.and
+  ;; CHECK-NEXT:     (i32.const 305419896)
+  ;; CHECK-NEXT:     (i32.const 65535)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    ;; We can infer values here, but must add proper masks, as the inputs get
+    ;; truncated during packing.
+    (drop
+      (struct.get_u $A_8 0
+        (struct.new $A_8
+          (i32.const 0x12345678)
+        )
+      )
     )
-   )
-  )
-  (drop
-   (struct.get_u $A_16 0
-    (struct.new $A_16
-     (i32.const 0x12345678)
+    (drop
+      (struct.get_u $A_16 0
+        (struct.new $A_16
+          (i32.const 0x12345678)
+        )
+      )
     )
-   )
   )
- )
 )

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2144,6 +2144,11 @@
   (type $A_8 (struct (field i8)))
   ;; CHECK:      (type $A_16 (struct (field i16)))
   (type $A_16 (struct (field i16)))
+  ;; CHECK:      (type $B_16 (struct (field i16)))
+  (type $B_16 (struct (field i16)))
+
+  ;; CHECK:      (import "a" "b" (global $g i32))
+  (import "a" "b" (global $g i32))
 
   ;; CHECK:      (func $test (type $none_=>_none)
   ;; CHECK-NEXT:  (drop
@@ -2176,6 +2181,21 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (struct.new $B_16
+  ;; CHECK-NEXT:       (global.get $g)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.and
+  ;; CHECK-NEXT:     (global.get $g)
+  ;; CHECK-NEXT:     (i32.const 65535)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $test
     ;; We can infer values here, but must add proper masks, as the inputs get
@@ -2191,6 +2211,15 @@
       (struct.get_u $A_16 0
         (struct.new $A_16
           (i32.const 0x12345678)
+        )
+      )
+    )
+    ;; Also test reading a value from an imported global, which is an unknown
+    ;; value at compile time, but which we know must be masked as well.
+    (drop
+      (struct.get_u $B_16 0
+        (struct.new $B_16
+          (global.get $g)
         )
       )
     )

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -2665,3 +2665,28 @@
     )
   )
 )
+
+;; Test we handle packed fields properly.
+(module
+  (type $A_8 (struct (field i8)))
+  (type $A_16 (struct (field i16)))
+
+  (func $test
+    ;; We can infer values here, but must add proper masks, as the inputs get
+    ;; truncated during packing.
+    (drop
+      (struct.get_u $A_8 0
+        (struct.new $A_8
+          (i32.const 0x12345678)
+        )
+      )
+    )
+    (drop
+      (struct.get_u $A_16 0
+        (struct.new $A_16
+          (i32.const 0x12345678)
+        )
+      )
+    )
+  )
+)

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -2670,6 +2670,7 @@
 (module
   (type $A_8 (struct (field i8)))
   (type $A_16 (struct (field i16)))
+  ;; CHECK:      (type $B_16 (struct (field i16)))
   (type $B_16 (struct (field i16)))
 
   ;; CHECK:      (type $none_=>_none (func))
@@ -2679,13 +2680,17 @@
 
   ;; CHECK:      (func $test (type $none_=>_none)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 305419896)
+  ;; CHECK-NEXT:   (i32.const 120)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 305419896)
+  ;; CHECK-NEXT:   (i32.const 22136)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (global.get $g)
+  ;; CHECK-NEXT:   (struct.get_u $B_16 0
+  ;; CHECK-NEXT:    (struct.new $B_16
+  ;; CHECK-NEXT:     (global.get $g)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $test

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -2670,7 +2670,24 @@
 (module
   (type $A_8 (struct (field i8)))
   (type $A_16 (struct (field i16)))
+  (type $B_16 (struct (field i16)))
 
+  ;; CHECK:      (type $none_=>_none (func))
+
+  ;; CHECK:      (import "a" "b" (global $g i32))
+  (import "a" "b" (global $g i32))
+
+  ;; CHECK:      (func $test (type $none_=>_none)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 305419896)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 305419896)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (global.get $g)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $test
     ;; We can infer values here, but must add proper masks, as the inputs get
     ;; truncated during packing.
@@ -2685,6 +2702,15 @@
       (struct.get_u $A_16 0
         (struct.new $A_16
           (i32.const 0x12345678)
+        )
+      )
+    )
+    ;; Also test reading a value from an imported global, which is an unknown
+    ;; value at compile time, but which we know must be masked as well.
+    (drop
+      (struct.get_u $B_16 0
+        (struct.new $B_16
+          (global.get $g)
         )
       )
     )

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -2694,8 +2694,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $test
-    ;; We can infer values here, but must add proper masks, as the inputs get
-    ;; truncated during packing.
+    ;; We can infer values here, but must mask them.
     (drop
       (struct.get_u $A_8 0
         (struct.new $A_8
@@ -2711,7 +2710,8 @@
       )
     )
     ;; Also test reading a value from an imported global, which is an unknown
-    ;; value at compile time, but which we know must be masked as well.
+    ;; value at compile time, but which we know must be masked as well. Atm
+    ;; GUFA does not handle this, unlike CFP (see TODO in filterDataContents).
     (drop
       (struct.get_u $B_16 0
         (struct.new $B_16


### PR DESCRIPTION
The same bug was present in both: We ignored packing, so writing a larger
value than fits in the field would lead to us propagating that original value.