### PR TITLE
Fix MemoryPacking handling of array.init_data

### DIFF
--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -278,8 +278,8 @@ bool MemoryPacking::canSplit(const std::unique_ptr<DataSegment>& segment,
           return false;
         }
       }
-    } else if (referrer->is<ArrayNewSeg>()) {
-      // TODO: Split segments referenced by array.new_data instructions.
+    } else if (referrer->is<ArrayNewSeg>() || referrer->is<ArrayInit>()) {
+      // TODO: Split segments referenced by GC instructions.
       return false;
     }
   }
@@ -479,8 +479,10 @@ void MemoryPacking::getSegmentReferrers(Module* module,
           referrers[curr->segment].push_back(curr);
         }
       }
-      void doWalkFunction(Function* func) {
-        super::doWalkFunction(func);
+      void visitArrayInit(ArrayInit* curr) {
+        if (curr->op == InitData) {
+          referrers[curr->segment].push_back(curr);
+        }
       }
     } collector(referrers);
     collector.walkFunctionInModule(func, module);

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -588,7 +588,7 @@ void MemoryPacking::createSplitSegments(
                                          segment->memory,
                                          segment->isPassive,
                                          offset,
-                                         &segment->data[range.start],
+                                         segment->data.data() + range.start,
                                          range.end - range.start);
     curr->hasExplicitName = hasExplicitName;
     packed.push_back(std::move(curr));

--- a/test/lit/passes/memory-packing_all-features.wast
+++ b/test/lit/passes/memory-packing_all-features.wast
@@ -2389,3 +2389,31 @@
   )
  )
 )
+(module
+ ;; CHECK:      (type $array (array (mut i32)))
+ (type $array (array (mut i32)))
+ ;; CHECK:      (type $ref|$array|_i32_i32_i32_=>_none (func (param (ref $array) i32 i32 i32)))
+
+ ;; CHECK:      (memory $0 (shared 16 17))
+ (memory $0 (shared 16 17))
+ ;; CHECK:      (data $0 "")
+ (data $0 "")
+ ;; CHECK:      (func $0 (type $ref|$array|_i32_i32_i32_=>_none) (param $0 (ref $array)) (param $1 i32) (param $2 i32) (param $3 i32)
+ ;; CHECK-NEXT:  (array.init_data $array $0
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $0 (param $0 (ref $array)) (param $1 i32) (param $2 i32) (param $3 i32)
+  ;; test that we do not improperly optimize out segments referred to by
+  ;; array.init_data instructions.
+  (array.init_data $array $0
+   (local.get $0)
+   (i32.const 0)
+   (i32.const 0)
+   (i32.const 0)
+  )
+ )
+)


### PR DESCRIPTION
Do not optimize out or split segments that are referred to array.init_data
instructions. Fixes a bug where segments could get optimized out, producing
invalid modules. Doing the work to actually split segments used by
array.init_data is left for the future.