### PR TITLE
[Wasm GC] Fuzz struct.set and array.set

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -334,7 +334,9 @@ private:
   Expression* makeRefTest(Type type);
   Expression* makeRefCast(Type type);
   Expression* makeStructGet(Type type);
+  Expression* makeStructSet(Type type);
   Expression* makeArrayGet(Type type);
+  Expression* makeArraySet(Type type);
   Expression* makeI31Get(Type type);
   Expression* makeMemoryInit();
   Expression* makeDataDrop();

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -124,6 +124,12 @@ private:
   // Type => list of array types that have that type.
   std::unordered_map<Type, std::vector<HeapType>> typeArrays;
 
+  // All struct fields that are mutable.
+  std::vector<StructField> mutableStructFields;
+
+  // All arrays that are mutable.
+  std::vector<HeapType> mutableArrays;
+
   Index numAddedFunctions = 0;
 
   // RAII helper for managing the state used to create a single function.

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3280,11 +3280,7 @@ Expression* TranslateToFuzzReader::makeStructSet(Type type) {
     return makeTrivial(type);
   }
   auto [structType, fieldIndex] = pick(mutableStructFields);
-  auto& fields = structType.getStruct().fields;
-  if (fields.empty()) {
-    return makeTrivial(type);
-  }
-  auto fieldType = fields[fieldIndex].type;
+  auto fieldType = structType.getStruct().fields[fieldIndex].type;
   // TODO: also nullable ones? that would increase the risk of traps
   auto* ref = make(Type(structType, NonNullable));
   auto* value = make(fieldType);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3262,12 +3262,12 @@ Expression* TranslateToFuzzReader::makeStructSet(Type type) {
   assert(type == Type::none);
   auto structTypes = interestingHeapSubTypes[HeapType::struct_];
   if (structTypes.empty()) {
-    return makeTrivial(type::none);
+    return makeTrivial(type);
   }
   auto structType = pick(structTypes);
   auto& fields = structType.getStruct().fields;
   if (fields.empty()) {
-    return makeTrivial(type::none);
+    return makeTrivial(type);
   }
   auto fieldIndex = upTo(fields.size());
   auto fieldType = fields[fieldIndex].type;
@@ -3309,16 +3309,16 @@ Expression* TranslateToFuzzReader::makeArrayGet(Type type) {
 
 Expression* TranslateToFuzzReader::makeArraySet(Type type) {
   assert(type == Type::none);
-  auto arrayTypes = interestingHeapSubTypes[HeapType::array_];
+  auto arrayTypes = interestingHeapSubTypes[HeapType::array];
   if (arrayTypes.empty()) {
-    return makeTrivial(type::none);
+    return makeTrivial(type);
   }
   auto arrayType = pick(arrayTypes);
   auto elementType = arrayType.getArray().element.type;
   auto* index = make(Type::i32);
   // TODO: also nullable ones? that would increase the risk of traps
   auto* ref = make(Type(arrayType, NonNullable));
-  auto* value = make(fieldType);
+  auto* value = make(elementType);
   // Only rarely emit a plain get which might trap. See related logic in
   // ::makePointer().
   if (allowOOB && oneIn(10)) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3265,6 +3265,10 @@ Expression* TranslateToFuzzReader::makeStructGet(Type type) {
   assert(!structFields.empty());
   auto [structType, fieldIndex] = pick(structFields);
   // TODO: also nullable ones? that would increase the risk of traps
+  // TODO: Ensure a good chance to use a local.get or tee here, as we want to
+  //       test the same reference having multiple sets/gets on it, and not
+  //       gets/sets of struct.news everywhere. Also in struct.set, array.get,
+  //       array.set.
   auto* ref = make(Type(structType, NonNullable));
   // TODO: fuzz signed and unsigned
   return builder.makeStructGet(fieldIndex, ref, type);

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,44 +1,43 @@
 total
- [exports]      : 3       
+ [exports]      : 4       
  [funcs]        : 11      
  [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 7       
+ [table-data]   : 2       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 593     
- [vars]         : 14      
- ArrayNew       : 3       
- AtomicCmpxchg  : 1       
- AtomicFence    : 2       
- AtomicRMW      : 1       
- Binary         : 72      
- Block          : 77      
- Break          : 5       
- Call           : 14      
- CallRef        : 1       
- Const          : 130     
+ [total]        : 521     
+ [vars]         : 21      
+ ArrayLen       : 1       
+ ArrayNew       : 6       
+ ArrayNewFixed  : 1       
+ ArraySet       : 1       
+ Binary         : 66      
+ Block          : 58      
+ Break          : 3       
+ Call           : 7       
+ Const          : 117     
  Drop           : 4       
- GlobalGet      : 34      
- GlobalSet      : 34      
- I31New         : 1       
- If             : 24      
- Load           : 18      
- LocalGet       : 34      
- LocalSet       : 17      
- Loop           : 7       
- Nop            : 17      
- RefAs          : 5       
- RefFunc        : 13      
- RefNull        : 12      
+ GlobalGet      : 32      
+ GlobalSet      : 32      
+ I31New         : 2       
+ If             : 19      
+ Load           : 17      
+ LocalGet       : 41      
+ LocalSet       : 23      
+ Loop           : 6       
+ Nop            : 3       
+ RefAs          : 4       
+ RefEq          : 1       
+ RefFunc        : 10      
+ RefNull        : 8       
  Return         : 1       
- SIMDExtract    : 1       
- Store          : 1       
- StructGet      : 2       
- StructNew      : 4       
- TupleExtract   : 2       
- TupleMake      : 11      
- Unary          : 25      
- Unreachable    : 20      
+ Select         : 1       
+ StructNew      : 5       
+ StructSet      : 1       
+ TupleExtract   : 1       
+ TupleMake      : 9       
+ Unary          : 22      
+ Unreachable    : 19      


### PR DESCRIPTION
Example output of the `array.set` length check:
```wat
          (if
           (i32.lt_u
            (local.tee $8
             (select
              (i32.const -65536)
              (ref.is_null
               (array.new_fixed $[i8])
              )
              (local.get $4)
             )
            )
            (array.len
             (local.tee $14
              (array.new $[mut:ref?|{i32_mut:ref|i31|_mut:i16_mut:f32}|]
               (ref.null none)
               (i32.const 88)
              )
             )
            )
           )
           (array.set $[mut:ref?|{i32_mut:ref|i31|_mut:i16_mut:f32}|]
            (local.get $14)
            (local.get $8)
            (ref.null none)
           )
          )
```
Locals `$14, $8` store the ref and the index, which are each used twice.