### PR TITLE
Fuzzer: When nested under makeTrivial(), avoid normal make()

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -265,6 +265,10 @@ private:
   // Make something with no chance of infinite recursion.
   Expression* makeTrivial(Type type);
 
+  // We must note when we are nested in a makeTrivial() call. When we are, all
+  // operations must try to be as trivial as possible.
+  int trivialNesting = 0;
+
   // Specific expression creators
   Expression* makeBlock(Type type);
   Expression* makeLoop(Type type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1048,6 +1048,10 @@ void TranslateToFuzzReader::addInvocations(Function* func) {
 
 Expression* TranslateToFuzzReader::make(Type type) {
   auto subtype = getSubType(type);
+  if (trivialNesting) {
+    // We are nested under a makeTrivial call, so only emit something trivial.
+    return makeTrivial(type);
+  }
   // When we should stop, emit something small (but not necessarily trivial).
   if (random.finished() || nesting >= 5 * NESTING_LIMIT || // hard limit
       (nesting >= NESTING_LIMIT && !oneIn(3))) {
@@ -1212,6 +1216,16 @@ Expression* TranslateToFuzzReader::_makeunreachable() {
 }
 
 Expression* TranslateToFuzzReader::makeTrivial(Type type) {
+  struct TrivialNester {
+    TranslateToFuzzReader& parent;
+    TrivialNester(TranslateToFuzzReader& parent) : parent(parent) {
+      parent.trivialNesting++;
+    }
+    ~TrivialNester() {
+      parent.trivialNesting--;
+    }
+  } nester(*this);
+
   if (type.isConcrete()) {
     if (oneIn(2) && funcContext) {
       return makeLocalGet(type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1221,9 +1221,7 @@ Expression* TranslateToFuzzReader::makeTrivial(Type type) {
     TrivialNester(TranslateToFuzzReader& parent) : parent(parent) {
       parent.trivialNesting++;
     }
-    ~TrivialNester() {
-      parent.trivialNesting--;
-    }
+    ~TrivialNester() { parent.trivialNesting--; }
   } nester(*this);
 
   if (type.isConcrete()) {

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,44 +1,35 @@
 total
- [exports]      : 3       
- [funcs]        : 11      
+ [exports]      : 5       
+ [funcs]        : 13      
  [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 7       
+ [table-data]   : 1       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 593     
- [vars]         : 14      
- ArrayNew       : 3       
- AtomicCmpxchg  : 1       
+ [total]        : 430     
+ [vars]         : 17      
+ ArrayNew       : 5       
  AtomicFence    : 2       
- AtomicRMW      : 1       
- Binary         : 72      
- Block          : 77      
- Break          : 5       
- Call           : 14      
- CallRef        : 1       
- Const          : 130     
- Drop           : 4       
- GlobalGet      : 34      
- GlobalSet      : 34      
+ Binary         : 61      
+ Block          : 45      
+ Call           : 19      
+ Const          : 97      
+ Drop           : 3       
+ GlobalGet      : 25      
+ GlobalSet      : 24      
  I31New         : 1       
- If             : 24      
- Load           : 18      
+ If             : 13      
+ Load           : 16      
  LocalGet       : 34      
- LocalSet       : 17      
- Loop           : 7       
- Nop            : 17      
- RefAs          : 5       
- RefFunc        : 13      
- RefNull        : 12      
- Return         : 1       
- SIMDExtract    : 1       
- Store          : 1       
- StructGet      : 2       
- StructNew      : 4       
- TupleExtract   : 2       
- TupleMake      : 11      
- Unary          : 25      
- Unreachable    : 20      
+ LocalSet       : 18      
+ Nop            : 3       
+ RefAs          : 1       
+ RefFunc        : 8       
+ RefNull        : 6       
+ Return         : 5       
+ StructNew      : 8       
+ TupleMake      : 7       
+ Unary          : 14      
+ Unreachable    : 15      

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,79 +1,45 @@
 total
-<<<<<<< HEAD
- [exports]      : 5       
- [funcs]        : 13      
-=======
- [exports]      : 4       
- [funcs]        : 11      
->>>>>>> origin/main
+ [exports]      : 2       
+ [funcs]        : 10      
  [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
-<<<<<<< HEAD
- [table-data]   : 1       
+ [table-data]   : 5       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 430     
- [vars]         : 17      
+ [total]        : 500     
+ [vars]         : 9       
  ArrayNew       : 5       
+ AtomicCmpxchg  : 1       
  AtomicFence    : 2       
- Binary         : 61      
- Block          : 45      
- Call           : 19      
- Const          : 97      
- Drop           : 3       
+ AtomicNotify   : 2       
+ Binary         : 66      
+ Block          : 49      
+ Break          : 5       
+ Call           : 4       
+ Const          : 121     
+ Drop           : 1       
  GlobalGet      : 25      
  GlobalSet      : 24      
- I31New         : 1       
- If             : 13      
- Load           : 16      
- LocalGet       : 34      
- LocalSet       : 18      
- Nop            : 3       
- RefAs          : 1       
- RefFunc        : 8       
- RefNull        : 6       
- Return         : 5       
- StructNew      : 8       
- TupleMake      : 7       
- Unary          : 14      
- Unreachable    : 15      
-=======
- [table-data]   : 2       
- [tables]       : 1       
- [tags]         : 2       
- [total]        : 521     
- [vars]         : 21      
- ArrayLen       : 1       
- ArrayNew       : 6       
- ArrayNewFixed  : 1       
- ArraySet       : 1       
- Binary         : 66      
- Block          : 58      
- Break          : 3       
- Call           : 7       
- Const          : 117     
- Drop           : 4       
- GlobalGet      : 32      
- GlobalSet      : 32      
  I31New         : 2       
- If             : 19      
+ If             : 16      
  Load           : 17      
- LocalGet       : 41      
- LocalSet       : 23      
- Loop           : 6       
- Nop            : 3       
- RefAs          : 4       
- RefEq          : 1       
+ LocalGet       : 40      
+ LocalSet       : 28      
+ Loop           : 3       
+ Nop            : 9       
+ RefAs          : 2       
+ RefEq          : 2       
  RefFunc        : 10      
  RefNull        : 8       
- Return         : 1       
- Select         : 1       
- StructNew      : 5       
+ RefTest        : 1       
+ Return         : 2       
+ SIMDExtract    : 2       
+ Select         : 4       
+ StructNew      : 8       
  StructSet      : 1       
  TupleExtract   : 1       
- TupleMake      : 9       
- Unary          : 22      
- Unreachable    : 19      
->>>>>>> origin/main
+ TupleMake      : 8       
+ Unary          : 16      
+ Unreachable    : 15      


### PR DESCRIPTION
Without this, in certain complex operations we could end up calling a nested
`make()` operation that included nontrivial things, which could cause problems.
The specific problem I encountered was in `fixAfterChanges()` we tried to fix up
a duplicate label, but calling `makeTrivial()` emitted something very large that
happened to include a new block with a new label nested under a `struct.get`,
and that block's label conflicted with a label we'd already processed.