### PR TITLE
[NFC] Refactor some old fuzzer code

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -909,9 +909,7 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
       }
     }
 
-    void replace() {
-      replaceCurrent(parent.makeTrivial(getCurrent()->type));
-    }
+    void replace() { replaceCurrent(parent.makeTrivial(getCurrent()->type)); }
 
     bool hasBreakTarget(Name name) {
       if (controlFlowStack.empty()) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -902,16 +902,16 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
       });
     }
 
-    bool replaceIfInvalid(Name target) {
+    void replaceIfInvalid(Name target) {
       if (!hasBreakTarget(target)) {
         // There is no valid parent, replace with something trivially safe.
         replace();
-        return true;
       }
-      return false;
     }
 
-    void replace() { replaceCurrent(parent.makeTrivial(getCurrent()->type)); }
+    void replace() {
+      replaceCurrent(parent.makeTrivial(getCurrent()->type));
+    }
 
     bool hasBreakTarget(Name name) {
       if (controlFlowStack.empty()) {
@@ -920,17 +920,14 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
       Index i = controlFlowStack.size() - 1;
       while (1) {
         auto* curr = controlFlowStack[i];
-        if (auto* block = curr->dynCast<Block>()) {
-          if (name == block->name) {
-            return true;
+        bool has = false;
+        BranchUtils::operateOnScopeNameDefs(curr, [&](Name& def) {
+          if (def == name) {
+            has = true;
           }
-        } else if (auto* loop = curr->dynCast<Loop>()) {
-          if (name == loop->name) {
-            return true;
-          }
-        } else {
-          // an if or a try, ignorable
-          assert(curr->is<If>() || curr->is<Try>());
+        });
+        if (has) {
+          return true;
         }
         if (i == 0) {
           return false;


### PR DESCRIPTION
A return value was unused, and we have `BranchUtils::operateOnScopeNameDefs` now
which can replace old manual code.