### PR TITLE
[Wasm GC] Improve GC operation coverage by using locals more

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -302,6 +302,7 @@ private:
   Expression* makeLoad(Type type);
   Expression* makeNonAtomicStore(Type type);
   Expression* makeStore(Type type);
+
   // Makes a small change to a constant value.
   Literal tweak(Literal value);
   Literal makeLiteral(Type type);
@@ -317,6 +318,11 @@ private:
   // compound ones.
   Expression* makeBasicRef(Type type);
   Expression* makeCompoundRef(Type type);
+
+  // Similar to makeBasic/CompoundRef, but indicates that this value will be
+  // used in a place that will trap on null. For example, the reference of a
+  // struct.get or array.set would use this.
+  Expression* makeTrappingRefUse(HeapType type);
 
   Expression* buildUnary(const UnaryArgs& args);
   Expression* makeUnary(Type type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2371,6 +2371,40 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
   }
 }
 
+Expression* TranslateToFuzzReader::makeTrappingRefUse(HeapType type) {
+  auto percent = upTo(100);
+  // Only give a low probability to emit a nullable reference.
+  if (percent < 5) {
+    return make(Type(type, Nullable));
+  }
+  // Otherwise, usually emit a non-nullable one.
+  auto nonNull = Type(type, NonNullable);
+  if (percent < 70 || !funcContext) {
+    return make(nonNull);
+  }
+  // With significant probability, try to use an existing value. it is better to
+  // have patterns like this:
+  //
+  //  (local.set $ref (struct.new $..
+  //  (struct.get (local.get $ref))
+  //
+  // Rather than constantly operating on new data each time:
+  //
+  //  (local.set $ref (struct.new $..
+  //  (struct.get (struct.new $..
+  //
+  // By using local values more, we get more coverage of interesting sequences
+  // of reads and writes to the same objects.
+  auto& typeLocals = funcContext->typeLocals[nonNull];
+  if (!typeLocals.empty()) {
+    return builder.makeLocalGet(pick(typeLocals), nonNull);
+  }
+  // Add a new local and tee it, so later operations can use it.
+  auto index = builder.addVar(funcContext->func, nonNull);
+  funcContext->typeLocals[nonNull].push_back(index);
+  return builder.makeLocalTee(index, make(nonNull), nonNull);
+}
+
 Expression* TranslateToFuzzReader::buildUnary(const UnaryArgs& args) {
   return builder.makeUnary(args.a, args.b);
 }
@@ -3272,12 +3306,7 @@ Expression* TranslateToFuzzReader::makeStructGet(Type type) {
   auto& structFields = typeStructFields[type];
   assert(!structFields.empty());
   auto [structType, fieldIndex] = pick(structFields);
-  // TODO: also nullable ones? that would increase the risk of traps
-  // TODO: Ensure a good chance to use a local.get or tee here, as we want to
-  //       test the same reference having multiple sets/gets on it, and not
-  //       gets/sets of struct.news everywhere. Also in struct.set, array.get,
-  //       array.set.
-  auto* ref = make(Type(structType, NonNullable));
+  auto* ref = makeTrappingRefUse(structType);
   // TODO: fuzz signed and unsigned
   return builder.makeStructGet(fieldIndex, ref, type);
 }
@@ -3289,8 +3318,7 @@ Expression* TranslateToFuzzReader::makeStructSet(Type type) {
   }
   auto [structType, fieldIndex] = pick(mutableStructFields);
   auto fieldType = structType.getStruct().fields[fieldIndex].type;
-  // TODO: also nullable ones? that would increase the risk of traps
-  auto* ref = make(Type(structType, NonNullable));
+  auto* ref = makeTrappingRefUse(structType);
   auto* value = make(fieldType);
   return builder.makeStructSet(fieldIndex, ref, value);
 }
@@ -3323,8 +3351,7 @@ Expression* TranslateToFuzzReader::makeArrayGet(Type type) {
   auto& arrays = typeArrays[type];
   assert(!arrays.empty());
   auto arrayType = pick(arrays);
-  // TODO: also nullable ones? that would increase the risk of traps
-  auto* ref = make(Type(arrayType, NonNullable));
+  auto* ref = makeTrappingRefUse(arrayType);
   auto* index = make(Type::i32);
   // Only rarely emit a plain get which might trap. See related logic in
   // ::makePointer().
@@ -3350,8 +3377,7 @@ Expression* TranslateToFuzzReader::makeArraySet(Type type) {
   auto arrayType = pick(mutableArrays);
   auto elementType = arrayType.getArray().element.type;
   auto* index = make(Type::i32);
-  // TODO: also nullable ones? that would increase the risk of traps
-  auto* ref = make(Type(arrayType, NonNullable));
+  auto* ref = makeTrappingRefUse(arrayType);
   auto* value = make(elementType);
   // Only rarely emit a plain get which might trap. See related logic in
   // ::makePointer().
@@ -3371,9 +3397,7 @@ Expression* TranslateToFuzzReader::makeArraySet(Type type) {
 Expression* TranslateToFuzzReader::makeI31Get(Type type) {
   assert(type == Type::i32);
   assert(wasm.features.hasReferenceTypes() && wasm.features.hasGC());
-  // TODO: Maybe this should be nullable?
-  // https://github.com/WebAssembly/gc/issues/312
-  auto* i31 = make(Type(HeapType::i31, NonNullable));
+  auto* i31 = makeTrappingRefUse(HeapType::i31);
   return builder.makeI31Get(i31, bool(oneIn(2)));
 }
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1055,14 +1055,17 @@ void TranslateToFuzzReader::addInvocations(Function* func) {
 }
 
 Expression* TranslateToFuzzReader::make(Type type) {
+std::cout << "a1\n";
   auto subtype = getSubType(type);
   if (trivialNesting) {
     // We are nested under a makeTrivial call, so only emit something trivial.
     return makeTrivial(type);
   }
+std::cout << "a2\n";
   // When we should stop, emit something small (but not necessarily trivial).
   if (random.finished() || nesting >= 5 * NESTING_LIMIT || // hard limit
       (nesting >= NESTING_LIMIT && !oneIn(3))) {
+std::cout << "a3\n";
     if (type.isConcrete()) {
       if (oneIn(2)) {
         return makeConst(subtype);
@@ -1079,9 +1082,11 @@ Expression* TranslateToFuzzReader::make(Type type) {
     assert(type == Type::unreachable);
     return makeTrivial(type);
   }
+std::cout << "a4\n";
   nesting++;
   Expression* ret = nullptr;
   if (type.isConcrete()) {
+std::cout << "a5\n";
     ret = _makeConcrete(subtype);
   } else if (type == Type::none) {
     ret = _makenone();
@@ -1226,6 +1231,7 @@ Expression* TranslateToFuzzReader::_makeunreachable() {
 }
 
 Expression* TranslateToFuzzReader::makeTrivial(Type type) {
+std::cout << "makeTrivial\n";
   struct TrivialNester {
     TranslateToFuzzReader& parent;
     TrivialNester(TranslateToFuzzReader& parent) : parent(parent) {
@@ -2165,15 +2171,19 @@ Expression* TranslateToFuzzReader::makeRefFuncConst(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeConst(Type type) {
+std::cout << "makeConst " << type << "\n";
   if (type.isRef()) {
+std::cout << "  mc1\n";
     assert(wasm.features.hasReferenceTypes());
     // With a low chance, just emit a null if that is valid.
     if (type.isNullable() && oneIn(8)) {
       return builder.makeRefNull(type.getHeapType());
     }
+std::cout << "  mc2\n";
     if (type.getHeapType().isBasic()) {
       return makeBasicRef(type);
     } else {
+std::cout << "  mc3\n";
       return makeCompoundRef(type);
     }
   } else if (type.isTuple()) {
@@ -2313,8 +2323,10 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
   // inhabitable.)
   const auto LIMIT = NESTING_LIMIT + 1;
   AutoNester nester(*this);
+std::cout << "mCC1\n";
   if (type.isNullable() &&
       (random.finished() || nesting >= LIMIT || oneIn(LIMIT - nesting + 1))) {
+std::cout << "mCC2\n";
     return builder.makeRefNull(heapType);
   }
 
@@ -2323,8 +2335,17 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
   // least avoids infinite recursion here, and we emit a valid (but not that
   // useful) wasm.
   if (type.isNonNullable() && (random.finished() || nesting >= LIMIT)) {
+std::cout << "mCC3\n";
+    // If we have a function context then we can at least emit a local.get,
+    // perhaps, which is less bad. Note that we need to check typeLocals
+    // manually here to avoid infinite recursion (as makeLocalGet will fall back
+    // to us, if there is no local).
+    if (funcContext && !funcContext->typeLocals[type].empty()) {
+      return makeLocalGet(type);
+    }
     return builder.makeRefAs(RefAsNonNull, builder.makeRefNull(heapType));
   }
+std::cout << "mCC4\n";
 
   // When we make children, they must be trivial if we are not in a function
   // context.
@@ -2373,13 +2394,16 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
 
 Expression* TranslateToFuzzReader::makeTrappingRefUse(HeapType type) {
   auto percent = upTo(100);
+std::cout << "waka mTRU " << percent << '\n';
   // Only give a low probability to emit a nullable reference.
   if (percent < 5) {
+std::cout << "maek1 " << *make(Type(type, Nullable)) << '\n';
     return make(Type(type, Nullable));
   }
   // Otherwise, usually emit a non-nullable one.
   auto nonNull = Type(type, NonNullable);
   if (percent < 70 || !funcContext) {
+std::cout << "maek2 " << *make(nonNull) << '\n';
     return make(nonNull);
   }
   // With significant probability, try to use an existing value. it is better to
@@ -2397,12 +2421,18 @@ Expression* TranslateToFuzzReader::makeTrappingRefUse(HeapType type) {
   // of reads and writes to the same objects.
   auto& typeLocals = funcContext->typeLocals[nonNull];
   if (!typeLocals.empty()) {
+std::cout << "maek3 " << *builder.makeLocalGet(pick(typeLocals), nonNull) << '\n';
     return builder.makeLocalGet(pick(typeLocals), nonNull);
   }
   // Add a new local and tee it, so later operations can use it.
   auto index = builder.addVar(funcContext->func, nonNull);
+  // Note we must create the child ref here before adding the local to
+  // typeLocals (or else we might end up using it prematurely).
+std::cout << "maek4pre\n";// " << *tee << " for " << nonNull << " : " << type << '\n';
+  auto* tee = builder.makeLocalTee(index, make(nonNull), nonNull);
   funcContext->typeLocals[nonNull].push_back(index);
-  return builder.makeLocalTee(index, make(nonNull), nonNull);
+std::cout << "maek4 " << *tee << " for " << nonNull << " : " << type << '\n';
+  return tee;
 }
 
 Expression* TranslateToFuzzReader::buildUnary(const UnaryArgs& args) {

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,45 +1,36 @@
 total
  [exports]      : 2       
- [funcs]        : 10      
+ [funcs]        : 7       
  [globals]      : 16      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 5       
+ [table-data]   : 1       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 500     
- [vars]         : 9       
- ArrayNew       : 5       
- AtomicCmpxchg  : 1       
- AtomicFence    : 2       
- AtomicNotify   : 2       
- Binary         : 66      
- Block          : 49      
- Break          : 5       
- Call           : 4       
- Const          : 121     
- Drop           : 1       
- GlobalGet      : 25      
- GlobalSet      : 24      
- I31New         : 2       
- If             : 16      
- Load           : 17      
+ [total]        : 350     
+ [vars]         : 10      
+ ArrayLen       : 1       
+ ArrayNew       : 2       
+ ArraySet       : 1       
+ Binary         : 61      
+ Block          : 27      
+ Const          : 87      
+ GlobalGet      : 16      
+ GlobalSet      : 16      
+ I31New         : 1       
+ If             : 11      
+ Load           : 18      
  LocalGet       : 40      
- LocalSet       : 28      
- Loop           : 3       
- Nop            : 9       
- RefAs          : 2       
- RefEq          : 2       
- RefFunc        : 10      
- RefNull        : 8       
- RefTest        : 1       
- Return         : 2       
- SIMDExtract    : 2       
- Select         : 4       
- StructNew      : 8       
- StructSet      : 1       
- TupleExtract   : 1       
- TupleMake      : 8       
- Unary          : 16      
- Unreachable    : 15      
+ LocalSet       : 21      
+ Loop           : 2       
+ Nop            : 1       
+ RefFunc        : 6       
+ RefIsNull      : 1       
+ RefNull        : 4       
+ Return         : 4       
+ Store          : 1       
+ StructNew      : 2       
+ TupleMake      : 7       
+ Unary          : 9       
+ Unreachable    : 11      


### PR DESCRIPTION
When we emit e.g. a `struct.get`'s reference, this PR makes us prefer a non-nullable
value, and even to reuse an existing local if possible. By doing that we reduce
the risk of a trap, and also by using locals we end up testing operations on the
same data, like this:
```js
x = new A();
x.a = ..
foo(x.a)
```
In contrast, without this PR each of those `x.` uses might be `new A()`.