### PR TITLE
[Wasm GC] Fix SignatureRefining on a call_ref to a bottom type

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -37,14 +37,21 @@ struct SubTypes {
   SubTypes(Module& wasm) : SubTypes(ModuleUtils::collectHeapTypes(wasm)) {}
 
   const std::vector<HeapType>& getStrictSubTypes(HeapType type) const {
+    // When we return an empty result, use a canonical constant empty vec to
+    // avoid allocation.
+    static const std::vector<HeapType> empty;
+
+    if (type.isBottom()) {
+      // Bottom types have no subtypes.
+      return empty;
+    }
+
     assert(!type.isBasic());
     if (auto iter = typeSubTypes.find(type); iter != typeSubTypes.end()) {
       return iter->second;
     }
 
-    // No entry exists. Return a canonical constant empty vec, to avoid
-    // allocation.
-    static const std::vector<HeapType> empty;
+    // No entry exists.
     return empty;
   }
 

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -810,3 +810,14 @@
     )
   )
 )
+
+(module
+  (type $F (func))
+
+  (func $func
+    ;; We should not error on a call_ref to a bottom type.
+    (call_ref $F
+      (ref.null nofunc)
+    )
+  )
+)

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -812,8 +812,17 @@
 )
 
 (module
+  ;; CHECK:      (type $F (func))
   (type $F (func))
 
+  ;; CHECK:      (func $func (type $F)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (ref.null nofunc)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $func
     ;; We should not error on a call_ref to a bottom type.
     (call_ref $F


### PR DESCRIPTION
Before this PR we hit the assert on the type not being basic.

We could also look into fixing the caller to skip bottom types, but as
bottom types trivially have no subtypes, it is more future-facing to
simply handle it.