### PR TITLE
[Wasm GC] OptimizeInstructions: Don't turn ref.test into unreachable immediately

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2169,8 +2169,13 @@ struct OptimizeInstructions
           {builder.makeDrop(curr->ref), builder.makeConst(int32_t(1))}));
         break;
       case GCTypeUtils::Unreachable:
-        replaceCurrent(builder.makeSequence(builder.makeDrop(curr->ref),
-                                            builder.makeUnreachable()));
+        // Make sure to emit a block with the same type as us, to avoid other
+        // code in this pass needing to handle unexpected unreachable code
+        // (which is only properly propagated at the end of this pass when we
+        // refinalize).
+        replaceCurrent(builder.makeBlock({builder.makeDrop(curr->ref),
+                                          builder.makeUnreachable()},
+                                          Type::i32));
         break;
       case GCTypeUtils::Failure:
         replaceCurrent(builder.makeSequence(builder.makeDrop(curr->ref),

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2173,9 +2173,8 @@ struct OptimizeInstructions
         // code in this pass needing to handle unexpected unreachable code
         // (which is only properly propagated at the end of this pass when we
         // refinalize).
-        replaceCurrent(builder.makeBlock({builder.makeDrop(curr->ref),
-                                          builder.makeUnreachable()},
-                                          Type::i32));
+        replaceCurrent(builder.makeBlock(
+          {builder.makeDrop(curr->ref), builder.makeUnreachable()}, Type::i32));
         break;
       case GCTypeUtils::Failure:
         replaceCurrent(builder.makeSequence(builder.makeDrop(curr->ref),

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2438,7 +2438,7 @@
     ;; The cast will become unreachable, and then the test as well. We should
     ;; not error in the subsequent optimizeAddedConstants function that will be
     ;; called on the adds. The risk here is that that code does not expect an
-    ;; unreachable to appear inside a non-unreachable add, which can happen if
+    ;; unreachable to appear inside a non-unreachable add, which can happen as
     ;; we delay updating types til the end of the pass. To avoid that, the
     ;; ref.test should not change its type, but only replace itself with a block
     ;; containing an unreachable (but declared as the old type; leaving

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2392,7 +2392,7 @@
   ;; CHECK:      (func $non-null-bottom-ref-test-notee (type $none_=>_i32) (result i32)
   ;; CHECK-NEXT:  (local $0 funcref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (loop
+  ;; CHECK-NEXT:   (loop (result (ref nofunc))
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -2420,6 +2420,39 @@
     ;; This cast cannot succeed, so return 0.
     (ref.test nofunc
       (ref.func $non-null-bottom-cast)
+    )
+  )
+
+  ;; CHECK:      (func $ref.test-then-optimizeAddedConstants (type $none_=>_i32) (result i32)
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (unreachable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 3)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $ref.test-then-optimizeAddedConstants (result i32)
+    ;; The cast will become unreachable, and then the test as well. We should
+    ;; not error in the subsequent optimizeAddedConstants function that will be
+    ;; called on the adds. The risk here is that that code does not expect an
+    ;; unreachable to appear inside a non-unreachable add, which can happen if
+    ;; we delay updating types til the end of the pass. To avoid that, the
+    ;; ref.test should not change its type, but only replace itself with a block
+    ;; containing an unreachable (but declared as the old type; leaving
+    ;; optimizing it further for other passes).
+    (i32.add
+      (i32.const 1)
+      (i32.add
+        (i32.const 2)
+        (ref.test func
+          (ref.cast func
+            (ref.null nofunc)
+          )
+        )
+      )
     )
   )
 )


### PR DESCRIPTION
Emit an unreachable, but guarded by a block as we do in other cases in this pass, to avoid
having unreachable code that is not fully propagated during the pass (as we only do a full
refinalize at the end). See existing comments starting with
"`Make sure to emit a block with the same type as us`" in the pass.

This is mostly not a problem with other casts, but `ref.test` returns an `i32` which we have
lots of code that tries to optimize.