### PR TITLE
Disable sign extension in SignExtLowering.cpp

### DIFF
--- a/src/passes/SignExtLowering.cpp
+++ b/src/passes/SignExtLowering.cpp
@@ -68,6 +68,14 @@ struct SignExtLowering : public WalkerPass<PostWalker<SignExtLowering>> {
       }
     }
   }
+
+  void run(Module* module) override {
+    if (!module->features.has(FeatureSet::SignExt)) {
+      return;
+    }
+    super::run(module);
+    module->features.disable(FeatureSet::SignExt);
+  }
 };
 
 Pass* createSignExtLoweringPass() { return new SignExtLowering(); }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -408,7 +408,8 @@ void PassRegistry::registerPasses() {
                "apply more specific subtypes to signature types where possible",
                createSignatureRefiningPass);
   registerPass("signext-lowering",
-               "lower sign-ext operations to wasm mvp",
+               "lower sign-ext operations to wasm mvp and disable the sign "
+               "extension feature",
                createSignExtLoweringPass);
   registerPass("simplify-globals",
                "miscellaneous globals-related optimizations",

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -399,7 +399,8 @@
 ;; CHECK-NEXT:                                                 signature types where possible
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --signext-lowering                            lower sign-ext operations to
-;; CHECK-NEXT:                                                 wasm mvp
+;; CHECK-NEXT:                                                 wasm mvp and disable the sign
+;; CHECK-NEXT:                                                 extension feature
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --simplify-globals                            miscellaneous globals-related
 ;; CHECK-NEXT:                                                 optimizations

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -358,7 +358,8 @@
 ;; CHECK-NEXT:                                                 signature types where possible
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --signext-lowering                            lower sign-ext operations to
-;; CHECK-NEXT:                                                 wasm mvp
+;; CHECK-NEXT:                                                 wasm mvp and disable the sign
+;; CHECK-NEXT:                                                 extension feature
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --simplify-globals                            miscellaneous globals-related
 ;; CHECK-NEXT:                                                 optimizations

--- a/test/lit/passes/signext-lowering-features.wast
+++ b/test/lit/passes/signext-lowering-features.wast
@@ -1,0 +1,9 @@
+;; RUN: wasm-opt %s --enable-sign-ext --print-features --print --signext-lowering --print-features | filecheck %s
+
+;; Check that the --signext-lowering pass disables the signext feature.
+
+;; CHECK: --enable-sign-ext
+;; CHECK: (module
+;; CHECK-NOT: --enable-sign-ext
+
+(module)


### PR DESCRIPTION
The sign extension lowering pass would previously lower away the sign extension
instructions, but it wouldn't disable the sign extension feature, so follow-on
passes such as optimize-instructions could reintroduce sign extension
instructions.

Fix the pass to disable the sign extension feature to prevent sign extension
instructions from being reintroduced later.