### PR TITLE
Disable the memory64 feature in Memory64Lowering.cpp

### DIFF
--- a/src/passes/Memory64Lowering.cpp
+++ b/src/passes/Memory64Lowering.cpp
@@ -159,6 +159,14 @@ struct Memory64Lowering : public WalkerPass<PostWalker<Memory64Lowering>> {
       }
     }
   }
+
+  void run(Module* module) override {
+    if (!module->features.has(FeatureSet::Memory64)) {
+      return;
+    }
+    super::run(module);
+    module->features.disable(FeatureSet::Memory64);
+  }
 };
 
 Pass* createMemory64LoweringPass() { return new Memory64Lowering(); }

--- a/src/passes/SignExtLowering.cpp
+++ b/src/passes/SignExtLowering.cpp
@@ -68,6 +68,14 @@ struct SignExtLowering : public WalkerPass<PostWalker<SignExtLowering>> {
       }
     }
   }
+
+  void run(Module* module) override {
+    if (!module->features.has(FeatureSet::SignExt)) {
+      return;
+    }
+    super::run(module);
+    module->features.disable(FeatureSet::SignExt);
+  }
 };
 
 Pass* createSignExtLoweringPass() { return new SignExtLowering(); }

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -408,7 +408,8 @@ void PassRegistry::registerPasses() {
                "apply more specific subtypes to signature types where possible",
                createSignatureRefiningPass);
   registerPass("signext-lowering",
-               "lower sign-ext operations to wasm mvp",
+               "lower sign-ext operations to wasm mvp and disable the sign "
+               "extension feature",
                createSignExtLoweringPass);
   registerPass("simplify-globals",
                "miscellaneous globals-related optimizations",

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -399,7 +399,8 @@
 ;; CHECK-NEXT:                                                 signature types where possible
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --signext-lowering                            lower sign-ext operations to
-;; CHECK-NEXT:                                                 wasm mvp
+;; CHECK-NEXT:                                                 wasm mvp and disable the sign
+;; CHECK-NEXT:                                                 extension feature
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --simplify-globals                            miscellaneous globals-related
 ;; CHECK-NEXT:                                                 optimizations

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -358,7 +358,8 @@
 ;; CHECK-NEXT:                                                 signature types where possible
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --signext-lowering                            lower sign-ext operations to
-;; CHECK-NEXT:                                                 wasm mvp
+;; CHECK-NEXT:                                                 wasm mvp and disable the sign
+;; CHECK-NEXT:                                                 extension feature
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --simplify-globals                            miscellaneous globals-related
 ;; CHECK-NEXT:                                                 optimizations

--- a/test/lit/passes/memory64-lowering-features.wast
+++ b/test/lit/passes/memory64-lowering-features.wast
@@ -1,6 +1,6 @@
 ;; RUN: wasm-opt %s --enable-memory64 --print-features --print --memory64-lowering --print-features | filecheck %s
 
-;; Check that the --signext-lowering pass disables the signext feature.
+;; Check that the --memory64-lowering pass disables the signext feature.
 
 ;; CHECK: --enable-memory64
 ;; CHECK: (module

--- a/test/lit/passes/memory64-lowering-features.wast
+++ b/test/lit/passes/memory64-lowering-features.wast
@@ -1,0 +1,9 @@
+;; RUN: wasm-opt %s --enable-memory64 --print-features --print --memory64-lowering --print-features | filecheck %s
+
+;; Check that the --signext-lowering pass disables the signext feature.
+
+;; CHECK: --enable-memory64
+;; CHECK: (module
+;; CHECK-NOT: --enable-memory64
+
+(module)

--- a/test/lit/passes/signext-lowering-features.wast
+++ b/test/lit/passes/signext-lowering-features.wast
@@ -1,0 +1,9 @@
+;; RUN: wasm-opt %s --enable-sign-ext --print-features --print --signext-lowering --print-features | filecheck %s
+
+;; Check that the --signext-lowering pass disables the signext feature.
+
+;; CHECK: --enable-sign-ext
+;; CHECK: (module
+;; CHECK-NOT: --enable-sign-ext
+
+(module)


### PR DESCRIPTION
For consistency with other feature lowering passes, disable memory64 in addition
to lowering its use away. Although no other passes would introduce new uses of
memory64 at the moment, this makes the lowering pass more robust against a
future where memory64 might accidentally be reintroduced after being lowered away.