### PR TITLE
[NFC] Assert that module maps are the right size

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1591,6 +1591,7 @@ void Module::updateFunctionsMap() {
   for (auto& curr : functions) {
     functionsMap[curr->name] = curr.get();
   }
+  assert(functionsMap.size() == functions.size());
 }
 
 void Module::updateDataSegmentsMap() {
@@ -1598,6 +1599,7 @@ void Module::updateDataSegmentsMap() {
   for (auto& curr : dataSegments) {
     dataSegmentsMap[curr->name] = curr.get();
   }
+  assert(dataSegmentsMap.size() == dataSegments.size());
 }
 
 void Module::updateMaps() {
@@ -1606,27 +1608,33 @@ void Module::updateMaps() {
   for (auto& curr : exports) {
     exportsMap[curr->name] = curr.get();
   }
+  assert(exportsMap.size() == exports.size());
   tablesMap.clear();
   for (auto& curr : tables) {
     tablesMap[curr->name] = curr.get();
   }
+  assert(tablesMap.size() == tables.size());
   elementSegmentsMap.clear();
   for (auto& curr : elementSegments) {
     elementSegmentsMap[curr->name] = curr.get();
   }
+  assert(elementSegmentsMap.size() == elementSegments.size());
   memoriesMap.clear();
   for (auto& curr : memories) {
     memoriesMap[curr->name] = curr.get();
   }
+  assert(memoriesMap.size() == memories.size());
   updateDataSegmentsMap();
   globalsMap.clear();
   for (auto& curr : globals) {
     globalsMap[curr->name] = curr.get();
   }
+  assert(globalsMap.size() == globals.size());
   tagsMap.clear();
   for (auto& curr : tags) {
     tagsMap[curr->name] = curr.get();
   }
+  assert(tagsMap.size() == tags.size());
 }
 
 void Module::clearDebugInfo() { debugInfoFileNames.clear(); }


### PR DESCRIPTION
If the names are not unique then the map would be smaller than
the vector it is built from. I am investigating a bug where that
happens, that these asserts would have helped with.