### PR TITLE
[Wasm GC] Always refinalize in SignatureRefining

### DIFF
--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -156,8 +156,6 @@ struct SignatureRefining : public Pass {
       }
     }
 
-    bool refinedResults = false;
-
     // Compute optimal LUBs.
     std::unordered_set<HeapType> seen;
     for (auto& func : module->functions) {
@@ -225,8 +223,6 @@ struct SignatureRefining : public Pass {
       newSignatures[type] = Signature(newParams, newResults);
 
       if (newResults != func->getResults()) {
-        refinedResults = true;
-
         // Update the types of calls using the signature.
         for (auto* call : info.calls) {
           if (call->type != Type::unreachable) {
@@ -288,11 +284,8 @@ struct SignatureRefining : public Pass {
     // Rewrite the types.
     GlobalTypeRewriter::updateSignatures(newSignatures, *module);
 
-    if (refinedResults) {
-      // After return types change we need to propagate.
-      // TODO: we could do this only in relevant functions perhaps
-      ReFinalize().run(getPassRunner(), module);
-    }
+    // TODO: we could do this only in relevant functions perhaps
+    ReFinalize().run(getPassRunner(), module);
   }
 };
 

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -850,3 +850,21 @@
     )
   )
 )
+
+(module
+ (type $[i8] (array i8))
+
+ (func $0
+  (call $1
+   (array.new_fixed $[i8])
+  )
+ )
+
+ (func $1 (param $2 anyref)
+  (drop
+   (ref.cast null struct
+    (local.get $2)
+   )
+  )
+ )
+) ;; TODO

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -852,14 +852,32 @@
 )
 
 (module
+ ;; CHECK:      (rec
+ ;; CHECK-NEXT:  (type $ref|$[i8]|_=>_none (func (param (ref $[i8]))))
+
+ ;; CHECK:       (type $[i8] (array i8))
  (type $[i8] (array i8))
 
+ ;; CHECK:       (type $none_=>_none (func))
+
+ ;; CHECK:      (func $0 (type $none_=>_none)
+ ;; CHECK-NEXT:  (call $1
+ ;; CHECK-NEXT:   (array.new_fixed $[i8])
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
  (func $0
   (call $1
    (array.new_fixed $[i8])
   )
  )
 
+ ;; CHECK:      (func $1 (type $ref|$[i8]|_=>_none) (param $2 (ref $[i8]))
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (ref.cast struct
+ ;; CHECK-NEXT:    (local.get $2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
  (func $1 (param $2 anyref)
   (drop
    (ref.cast null struct

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -879,6 +879,8 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $1 (param $2 anyref)
+  ;; The param will become non-nullable after we refine. We must refinalize
+  ;; after doing so, so the cast becomes non-nullable as well.
   (drop
    (ref.cast null struct
     (local.get $2)


### PR DESCRIPTION
We used to refine only for result changes, but param changes can
also lead to opportunities.