### PR TITLE
Fallback to direct inline if the outline will be inlined.

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -588,8 +588,7 @@ struct FunctionSplitter {
       // return), and we would not even attempt to do splitting.
       assert(body->is<Block>());
 
-      auto outlinedFunctionSize =
-        info.size - Measurer::measure(iff);
+      auto outlinedFunctionSize = info.size - Measurer::measure(iff);
       // If outlined function will be worth normal inline, skip the intermediate
       // state and inline fully.
       if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
@@ -676,8 +675,8 @@ struct FunctionSplitter {
     }
     // Success, this matches the pattern.
 
-    // If the outlined function will be worth inlining normally, skip the intermediate
-    // state and inline fully.
+    // If the outlined function will be worth inlining normally, skip the
+    // intermediate state and inline fully.
     if (numIfs == 1) {
       auto outlinedFunctionSize = Measurer::measure(iff->ifTrue);
       if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
@@ -754,8 +753,7 @@ private:
     // loop or calls even though this section may not have.
     // This is a conservative estimate, that is, it will return true only when
     // it should, but might return false when a more precise analysis would
-    return true. And it is a practical
-    // estimation to avoid extra future work.
+    // return true. And it is a practical estimation to avoid extra future work.
     info = origin;
     info.size = sizeEstimate;
     return info.worthFullInlining(options);

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -588,8 +588,8 @@ struct FunctionSplitter {
       // return), and we would not even attempt to do splitting.
       assert(body->is<Block>());
 
-      Index outlinedFunctionSize =
-        info.size - Measurer::measure(iff->condition) - /* if itself */ 1;
+      auto outlinedFunctionSize =
+        info.size - Measurer::measure(iff);
       // If outlined function will be worth normal inline, skip the intermediate
       // state and inline fully.
       if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
@@ -676,10 +676,10 @@ struct FunctionSplitter {
     }
     // Success, this matches the pattern.
 
-    // If outlined function will be worth normal inline, skip the intermediate
+    // If the outlined function will be worth inlining normally, skip the intermediate
     // state and inline fully.
     if (numIfs == 1) {
-      Index outlinedFunctionSize = Measurer::measure(iff->ifTrue);
+      auto outlinedFunctionSize = Measurer::measure(iff->ifTrue);
       if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
         return InliningMode::Full;
       }
@@ -749,9 +749,12 @@ private:
 
   bool outlinedFunctionWorthInlining(FunctionInfo& origin, Index sizeEstimate) {
     FunctionInfo info;
+    // Start with a copy of the origin's info, and apply the size estimate.
     // This is not accurate, for example the origin function may have
     // loop or calls even though this section may not have.
-    // However since this is more conservative and it is a practical
+    // This is a conservative estimate, that is, it will return true only when
+    // it should, but might return false when a more precise analysis would
+    return true. And it is a practical
     // estimation to avoid extra future work.
     info = origin;
     info.size = sizeEstimate;

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -552,6 +552,11 @@ struct FunctionSplitter {
   // into account (like limitations on which functions can be inlined into in
   // each iteration, the number of iterations, etc.). Therefore this function
   // may only find out if we *can* split, but not actually do any splitting.
+  //
+  // Note that to avoid wasteful work, this function may return "Full' inlining
+  // mode instead of a split inining. That is; if it detects that a partial
+  // inlining will trigger a follow up full inline of the splitted function
+  // it will instead return "InliningMode::Full" directly.
   InliningMode getSplitDrivenInliningMode(Function* func, FunctionInfo& info) {
     auto* body = func->body;
 
@@ -590,7 +595,7 @@ struct FunctionSplitter {
 
       auto outlinedFunctionSize = info.size - Measurer::measure(iff);
       // If outlined function will be worth normal inline, skip the intermediate
-      // state and inline fully.
+      // state and inline fully now.
       if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
         return InliningMode::Full;
       }
@@ -676,7 +681,7 @@ struct FunctionSplitter {
     // Success, this matches the pattern.
 
     // If the outlined function will be worth inlining normally, skip the
-    // intermediate state and inline fully.
+    // intermediate state and inline fully now.
     if (numIfs == 1) {
       auto outlinedFunctionSize = Measurer::measure(iff->ifTrue);
       if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -552,7 +552,7 @@ struct FunctionSplitter {
   // into account (like limitations on which functions can be inlined into in
   // each iteration, the number of iterations, etc.). Therefore this function
   // may only find out if we *can* split, but not actually do any splitting.
-  InliningMode getSplitInliningMode(Function* func) {
+  InliningMode getSplitDrivenInliningMode(Function* func, FunctionInfo& info) {
     auto* body = func->body;
 
     // If the body is a block, and we have breaks to that block, then we cannot
@@ -587,6 +587,14 @@ struct FunctionSplitter {
       // would be easily inlineable (just an if with a simple condition and a
       // return), and we would not even attempt to do splitting.
       assert(body->is<Block>());
+
+      Index outlinedFunctionSize =
+        info.size - Measurer::measure(iff->condition) - /* if itself */ 1;
+      // If outlined function will be worth normal inline, skip the intermediate
+      // state and inline fully.
+      if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
+        return InliningMode::Full;
+      }
 
       return InliningMode::SplitPatternA;
     }
@@ -666,8 +674,17 @@ struct FunctionSplitter {
         assert(iff->ifTrue->type == Type::unreachable);
       }
     }
-
     // Success, this matches the pattern.
+
+    // If outlined function will be worth normal inline, skip the intermediate
+    // state and inline fully.
+    if (numIfs == 1) {
+      Index outlinedFunctionSize = Measurer::measure(iff->ifTrue);
+      if (outlinedFunctionWorthInlining(info, outlinedFunctionSize)) {
+        return InliningMode::Full;
+      }
+    }
+
     return InliningMode::SplitPatternB;
   }
 
@@ -729,6 +746,17 @@ private:
   // inlining code can remove functions as it goes, but we can rely on names
   // staying constant.
   std::unordered_map<Name, Split> splits;
+
+  bool outlinedFunctionWorthInlining(FunctionInfo& origin, Index sizeEstimate) {
+    FunctionInfo info;
+    // This is not accurate, for example the origin function may have
+    // loop or calls even though this section may not have.
+    // However since this is more conservative and it is a practical
+    // estimation to avoid extra future work.
+    info = origin;
+    info.size = sizeEstimate;
+    return info.worthFullInlining(options);
+  }
 
   Function* doSplit(Function* func, InliningMode inliningMode) {
     Builder builder(*module);
@@ -1084,8 +1112,8 @@ struct Inlining : public Pass {
     // Otherwise, check if we can at least inline part of it, if we are
     // interested in such things.
     if (functionSplitter) {
-      info.inliningMode =
-        functionSplitter->getSplitInliningMode(module->getFunction(name));
+      info.inliningMode = functionSplitter->getSplitDrivenInliningMode(
+        module->getFunction(name), info);
       return info.inliningMode;
     }
 


### PR DESCRIPTION
This workarounds the extra work around the edge case where;
 - Function is too big to full-inline
 - It is a candidate for partial inline
 - Outlined version becomes eligible for full-inline.

In such a case, binaryen would introduce a temporary state with partial inlined functions and later on inline them. J2CL hit this scenario for String literal which resulted in significant regressions in compilation time.

This patch updates partial inlining analysis to identify the edge case and direct to full-inling when that happens.

It probably worths adding new tests but unfortunately I'm not familiar enough with Binaryen to add such tests.