### PR TITLE
Emit memory segment index for data segments

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -590,11 +590,20 @@ void WasmBinaryWriter::writeDataSegments() {
   o << U32LEB(wasm->dataSegments.size());
   for (auto& segment : wasm->dataSegments) {
     uint32_t flags = 0;
+    Index memoryIndex = 0;
     if (segment->isPassive) {
       flags |= BinaryConsts::IsPassive;
+    } else {
+      memoryIndex = getMemoryIndex(segment->memory);
+      if (memoryIndex) {
+        flags |= BinaryConsts::HasIndex;
+      }
     }
     o << U32LEB(flags);
     if (!segment->isPassive) {
+      if (memoryIndex) {
+        o << U32LEB(memoryIndex);
+      }
       writeExpression(segment->offset);
       o << int8_t(BinaryConsts::End);
     }

--- a/test/lit/multi-memories-basics.wast
+++ b/test/lit/multi-memories-basics.wast
@@ -11,7 +11,10 @@
   (memory $memory2 1 800)
   ;; CHECK:      (memory $memory3 1 400)
   (memory $memory3 1 400)
-  (data (memory $memory1) (i32.const 0) "a" "" "bcd")
+  ;; CHECK:      (data $data1 (memory $memory1) (i32.const 0) "abcd")
+  (data $data1 (memory $memory1) (i32.const 0) "a" "" "bcd")
+  ;; CHECK:      (data $data2 (memory $memory2) (i32.const 9) "w")
+  (data $data2 (memory $memory2) (i32.const 9) "w")
   (import "env" "memory" (memory $importedMemory 1 1))
   ;; CHECK:      (func $memory.fill
   ;; CHECK-NEXT:  (memory.fill $memory2
@@ -42,7 +45,7 @@
     )
   )
   ;; CHECK:      (func $memory.init
-  ;; CHECK-NEXT:  (memory.init $memory1 $0
+  ;; CHECK-NEXT:  (memory.init $memory1 $data1
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (i32.const 45)


### PR DESCRIPTION
Before this fix we would flip all data segments to use the first memory.

Noticed while fuzzing a wip wasm-merge (it merges modules and so often it ends up with multiple memories, so a higher chance to find issues like this).