### PR TITLE
Fix DeadArgumentElimination return value opts on nesting+recursion

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -335,8 +335,7 @@ private:
     // Remove any return values.
     struct ReturnUpdater : public PostWalker<ReturnUpdater> {
       Module* module;
-      Function* func;
-      ReturnUpdater(Function* func, Module* module) : module(module), func(func) {
+      ReturnUpdater(Function* func, Module* module) : module(module) {
         walk(func->body);
       }
       void visitReturn(Return* curr) {

--- a/test/lit/passes/dae_all-features.wast
+++ b/test/lit/passes/dae_all-features.wast
@@ -658,3 +658,36 @@
   )
  )
 )
+
+(module
+ ;; CHECK:      (type $i32_=>_none (func (param i32)))
+
+ ;; CHECK:      (func $0 (type $i32_=>_none) (param $0 i32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (call $0
+ ;; CHECK-NEXT:    (block
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (i32.const 1)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (return)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return)
+ ;; CHECK-NEXT: )
+ (func $0 (param $0 i32) (result i32)
+  ;; The result of this function can be removed, which makes us modify the
+  ;; returns (we should not return a value any more). The returns here are
+  ;; nested in each other, and one is a recursive call to this function itself,
+  ;; which makes this a corner case we might emit invalid code for.
+  (return
+   (drop
+    (call $0
+     (return
+      (i32.const 1)
+     )
+    )
+   )
+  )
+ )
+)

--- a/test/lit/passes/dae_all-features.wast
+++ b/test/lit/passes/dae_all-features.wast
@@ -677,9 +677,10 @@
  ;; CHECK-NEXT: )
  (func $0 (param $0 i32) (result i32)
   ;; The result of this function can be removed, which makes us modify the
-  ;; returns (we should not return a value any more). The returns here are
-  ;; nested in each other, and one is a recursive call to this function itself,
-  ;; which makes this a corner case we might emit invalid code for.
+  ;; returns (we should not return a value any more) and also the calls (the
+  ;; calls must be dropped). The returns here are nested in each other, and one
+  ;; is a recursive call to this function itself, which makes this a corner case
+  ;; we might emit invalid code for.
   (return
    (drop
     (call $0


### PR DESCRIPTION
The testcase here has a recursive call that is also nested in itself, something
like
```wat
(return
  (call $me
    (return
      ..
```
This found a bug in our return value removal logic. When we remove a return
value we both modify call sites (to add drops) and modify returns
(to remove their values). One of those uses pointers into the IR which the other
invalidated, so the order of the two matters. This PR just reorders that code to
fix the bug.