### PR TITLE
[Wasm GC] Automatically make RefCast heap types more precise

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -947,7 +947,17 @@ void RefCast::finalize() {
     type = Type::unreachable;
     return;
   }
-  // Do not unnecessarily lose non-nullability information.
+
+  // Do not unnecessarily lose heap type information. We could leave this for
+  // optimizations, but doing it here as part of finalization/refinalization
+  // ensures that type information flows through in an optimal manner and can be
+  // used as soon as possible.
+  if (Type::isSubType(ref->type, type)) {
+    type = Type(ref->type.getHeapType(), type.getNullability());
+  }
+
+  // Do not unnecessarily lose non-nullability information, as above for heap
+  // types.
   if (ref->type.isNonNullable() && type.isNullable()) {
     type = Type(type.getHeapType(), NonNullable);
   }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -956,8 +956,13 @@ void RefCast::finalize() {
     type = Type(type.getHeapType(), NonNullable);
   }
 
-  // Do not unnecessarily lose heap type info, as above for nullability.
-  if (HeapType::isSubType(ref->type.getHeapType(), type.getHeapType())) {
+  // Do not unnecessarily lose heap type info, as above for nullability. Note
+  // that we must check if the ref has a heap type, as we reach this before
+  // validation, which will error if the ref does not in fact have a heap type.
+  // (This is a downside of propagating type information here, as opposed to
+  // leaving it for an optimization pass.)
+  if (ref->type.isRef() &&
+      HeapType::isSubType(ref->type.getHeapType(), type.getHeapType())) {
     type = Type(ref->type.getHeapType(), type.getNullability());
   }
 }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -956,7 +956,7 @@ void RefCast::finalize() {
     type = Type(type.getHeapType(), NonNullable);
   }
 
-  // Do not unnecessarily lose heap type infor, as above for nullability.
+  // Do not unnecessarily lose heap type info, as above for nullability.
   if (HeapType::isSubType(ref->type.getHeapType(), type.getHeapType())) {
     type = Type(ref->type.getHeapType(), type.getNullability());
   }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -957,7 +957,7 @@ void RefCast::finalize() {
   }
 
   // Do not unnecessarily lose heap type infor, as above for nullability.
-  if (Type::isSubType(ref->type, type)) {
+  if (HeapType::isSubType(ref->type.getHeapType(), type.getHeapType())) {
     type = Type(ref->type.getHeapType(), type.getNullability());
   }
 }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -948,18 +948,17 @@ void RefCast::finalize() {
     return;
   }
 
-  // Do not unnecessarily lose heap type information. We could leave this for
+  // Do not unnecessarily lose non-nullability info. We could leave this for
   // optimizations, but doing it here as part of finalization/refinalization
   // ensures that type information flows through in an optimal manner and can be
   // used as soon as possible.
-  if (Type::isSubType(ref->type, type)) {
-    type = Type(ref->type.getHeapType(), type.getNullability());
-  }
-
-  // Do not unnecessarily lose non-nullability information, as above for heap
-  // types.
   if (ref->type.isNonNullable() && type.isNullable()) {
     type = Type(type.getHeapType(), NonNullable);
+  }
+
+  // Do not unnecessarily lose heap type infor, as above for nullability.
+  if (Type::isSubType(ref->type, type)) {
+    type = Type(ref->type.getHeapType(), type.getNullability());
   }
 }
 

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -371,7 +371,7 @@
    )
   )
   (drop
-   (ref.cast null $struct.B
+   (ref.cast null none
     (ref.null none)
    )
   )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -324,7 +324,7 @@
    )
   )
   (drop
-   (ref.cast null $struct.B
+   (ref.cast null none
     (ref.null none)
    )
   )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -324,7 +324,7 @@
    )
   )
   (drop
-   (ref.cast null ${i8_mut:i16_ref|{i32_f32_f64}|_mut:ref|{i32_f32_f64}|}
+   (ref.cast null none
     (ref.null none)
    )
   )

--- a/test/lit/binary/legacy-static-casts.test
+++ b/test/lit/binary/legacy-static-casts.test
@@ -15,12 +15,12 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (ref.cast null ${}
+;; CHECK-NEXT:   (ref.cast null none
 ;; CHECK-NEXT:    (ref.null none)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (ref.cast_nop ${}
+;; CHECK-NEXT:   (ref.cast_nop none
 ;; CHECK-NEXT:    (ref.null none)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )

--- a/test/lit/cast-to-basic.wast
+++ b/test/lit/cast-to-basic.wast
@@ -16,19 +16,17 @@
     )
   )
 
-  ;; CHECK:      (func $cast (type $none_=>_none)
+  ;; CHECK:      (func $cast (type $structref_=>_none) (param $x structref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null none
-  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   (ref.cast null struct
+  ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $cast
-    ;; Note that this will not round-trip precisely because Binaryen IR will
-    ;; apply the more refined type to the cast automatically (in finalize).
+  (func $cast (param $x (ref null struct))
     (drop
       (ref.cast null struct
-        (ref.null none)
+        (local.get $x)
       )
     )
   )

--- a/test/lit/cast-to-basic.wast
+++ b/test/lit/cast-to-basic.wast
@@ -18,12 +18,14 @@
 
   ;; CHECK:      (func $cast (type $none_=>_none)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null struct
+  ;; CHECK-NEXT:   (ref.cast null none
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $cast
+    ;; Note that this will not round-trip precisely because Binaryen IR will
+    ;; apply the more refined type to the cast automatically (in finalize).
     (drop
       (ref.cast null struct
         (ref.null none)

--- a/test/lit/heap-types.wast
+++ b/test/lit/heap-types.wast
@@ -26,17 +26,18 @@
 )
 
 (module
-  ;; CHECK:      (type $struct.A (struct (field i32)))
   (type $struct.A (struct i32))
   (type $struct.B (struct i32))
   ;; CHECK:      (func $test (type $none_=>_none)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $struct.A
+  ;; CHECK-NEXT:   (ref.cast null none
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $test
+    ;; Note that this will not round-trip precisely because Binaryen IR will
+    ;; apply the more refined type to the cast automatically (in finalize).
     (drop
       (ref.cast null $struct.B (ref.null $struct.A))
     )

--- a/test/lit/legacy-static-casts.wast
+++ b/test/lit/legacy-static-casts.wast
@@ -17,12 +17,12 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast null $struct
+  ;; CHECK-NEXT:   (ref.cast null none
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast_nop $struct
+  ;; CHECK-NEXT:   (ref.cast_nop none
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -1101,7 +1101,7 @@
   ;; CHECK-NEXT:      (br $block1
   ;; CHECK-NEXT:       (block (result nullref)
   ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (ref.cast null $child
+  ;; CHECK-NEXT:         (ref.cast null none
   ;; CHECK-NEXT:          (ref.null none)
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
@@ -2452,10 +2452,10 @@
   (type $substruct (struct_subtype (field i32) (field i32) $struct))
   ;; CHECK:      (type $none_=>_none (func))
 
-  ;; CHECK:      (type $i32_=>_none (func (param i32)))
-
   ;; CHECK:      (type $subsubstruct (struct_subtype (field i32) (field i32) (field i32) $substruct))
   (type $subsubstruct (struct_subtype (field i32) (field i32) (field i32) $substruct))
+
+  ;; CHECK:      (type $i32_=>_none (func (param i32)))
 
   ;; CHECK:      (type $other (struct ))
   (type $other (struct_subtype data))
@@ -2494,7 +2494,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast $substruct
+  ;; CHECK-NEXT:   (ref.cast $subsubstruct
   ;; CHECK-NEXT:    (struct.new $subsubstruct
   ;; CHECK-NEXT:     (i32.const 3)
   ;; CHECK-NEXT:     (i32.const 4)
@@ -2539,7 +2539,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result nullref)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.cast null $struct
+  ;; CHECK-NEXT:     (ref.cast null none
   ;; CHECK-NEXT:      (block (result nullref)
   ;; CHECK-NEXT:       (drop
   ;; CHECK-NEXT:        (call $import)

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -2039,17 +2039,19 @@
     )
   )
   ;; CHECK:      (func $set (type $none_=>_none)
-  ;; CHECK-NEXT:  (struct.set $A 0
-  ;; CHECK-NEXT:   (ref.cast $A
+  ;; CHECK-NEXT:  (struct.set $C 0
+  ;; CHECK-NEXT:   (ref.cast $C
   ;; CHECK-NEXT:    (call $create-C)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.const 20)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $set
-    ;; Set of $A, but the reference is actually a $C. We add a cast to make sure
-    ;; the type is $A, which should not confuse us: this set does alias the data
-    ;; in $C, which means we cannot optimize in the function $get below.
+    ;; Set of $A, but the reference is actually a $C. We add a cast to try to
+    ;; make sure the type is $A, which should not confuse us: this set does
+    ;; alias the data in $C, which means we cannot optimize in the function $get
+    ;; below. (Note that finalize will turn the cast into a cast of $C
+    ;; automatically; that is not part of GUFA.)
     (struct.set $A 0
       (ref.cast $A
         (call $create-C)

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -218,7 +218,7 @@
   ;; CHECK-NEXT:   (local.get $1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.cast $A
+  ;; CHECK-NEXT:   (ref.cast $B
   ;; CHECK-NEXT:    (local.get $1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -39,7 +39,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref $other))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $child)
   ;; CHECK-NEXT:    )
@@ -60,7 +60,7 @@
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block
+  ;; TNH-NEXT:   (block (result (ref $other))
   ;; TNH-NEXT:    (drop
   ;; TNH-NEXT:     (local.get $child)
   ;; TNH-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -904,7 +904,7 @@
 
   ;; TNH:      (func $if.null.child.but.no.flow (type $void)
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block (result (ref func))
+  ;; TNH-NEXT:   (block (result (ref nofunc))
   ;; TNH-NEXT:    (drop
   ;; TNH-NEXT:     (if (result (ref nofunc))
   ;; TNH-NEXT:      (i32.const 1)
@@ -918,7 +918,7 @@
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $if.null.child.but.no.flow (type $void)
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (block (result (ref func))
+  ;; NO_TNH-NEXT:   (block (result (ref nofunc))
   ;; NO_TNH-NEXT:    (drop
   ;; NO_TNH-NEXT:     (if (result (ref nofunc))
   ;; NO_TNH-NEXT:      (i32.const 1)

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -338,7 +338,7 @@
  ;; CHECK-NEXT:   (if (result anyref)
  ;; CHECK-NEXT:    (local.get $x)
  ;; CHECK-NEXT:    (ref.null none)
- ;; CHECK-NEXT:    (ref.cast null $struct
+ ;; CHECK-NEXT:    (ref.cast null none
  ;; CHECK-NEXT:     (ref.null none)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )


### PR DESCRIPTION
We already did this for nullablilty, and so for the same reasons we should do it
for heap types as well. Also, I realized that doing so  would solve #5703, which
is the new test added for TypeRefining here.

The fuzz bug solved here is that our analysis of struct gets/sets will skip
copy operations - a read from a field that is written into it. And we skip
fallthrough values while doing so, since it doesn't matter if the read goes
through an if arm or a cast. An if would automatically get a more precise
type during refinalize, so this PR does the same for a cast basically.

Fixes #5703