### PR TITLE
Add a "mayNotReturn" effect

### DIFF
--- a/test/lit/passes/vacuum-tnh.wast
+++ b/test/lit/passes/vacuum-tnh.wast
@@ -186,7 +186,14 @@
   )
 
   ;; YESTNH:      (func $drop-loop (type $none_=>_none)
-  ;; YESTNH-NEXT:  (nop)
+  ;; YESTNH-NEXT:  (drop
+  ;; YESTNH-NEXT:   (loop $loop (result i32)
+  ;; YESTNH-NEXT:    (br_if $loop
+  ;; YESTNH-NEXT:     (i32.const 1)
+  ;; YESTNH-NEXT:    )
+  ;; YESTNH-NEXT:    (i32.const 10)
+  ;; YESTNH-NEXT:   )
+  ;; YESTNH-NEXT:  )
   ;; YESTNH-NEXT: )
   ;; NO_TNH:      (func $drop-loop (type $none_=>_none)
   ;; NO_TNH-NEXT:  (drop
@@ -199,8 +206,8 @@
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT: )
   (func $drop-loop
-    ;; A loop has effects, since it might infinite loop (and hit a timeout trap
-    ;; eventually), so we do not vacuum it out unless we are ignoring traps.
+    ;; A loop has the effect of potentially being infinite. Even in TNH mode we
+    ;; do not optimize out such loops.
     (drop
       (loop $loop (result i32)
         (br_if $loop

--- a/test/wasm2js/br_table_to_loop.2asm.js.opt
+++ b/test/wasm2js/br_table_to_loop.2asm.js.opt
@@ -1,6 +1,4 @@
 
-function wasm2js_trap() { throw new Error('abort'); }
-
 function asmFunc(imports) {
  var Math_imul = Math.imul;
  var Math_fround = Math.fround;
@@ -13,7 +11,7 @@ function asmFunc(imports) {
  var Math_trunc = Math.trunc;
  var Math_sqrt = Math.sqrt;
  function $0() {
-  wasm2js_trap();
+  while (1) continue;
  }
  
  function $1() {


### PR DESCRIPTION
This changes loops from having the effect "may trap (timeout)" to having
"may not return." The only noticeable difference is in TrapsNeverHappen mode,
which ignores the former but not the latter. So after this PR, in TNH mode we do
not optimize away an infinite loop that seems to have no other side effects. We
may also use this for other things in the future, like continuations/stack switching.

There are upsides and downsides to allowing the optimizer to remove infinite
loops (the C and C++ communities have had interesting discussions on that topic
over the years...) but it seems safer to not optimize them out for now, to let the
most code work properly. If a need comes up to optimize such code, we can look
at various options then (like a flag to ignore infinite loops).

As suggested by @tlively in #5228, which this may unblock.