### PR TITLE
[analysis] Add a new iterable CFG utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ add_subdirectory(src/emscripten-optimizer)
 add_subdirectory(src/passes)
 add_subdirectory(src/support)
 add_subdirectory(src/wasm)
+add_subdirectory(src/analysis)
 
 if(BUILD_TOOLS)
   # Build binaryen tools
@@ -383,7 +384,8 @@ set(binaryen_objs
     $<TARGET_OBJECTS:emscripten-optimizer>
     $<TARGET_OBJECTS:ir>
     $<TARGET_OBJECTS:cfg>
-    $<TARGET_OBJECTS:support>)
+    $<TARGET_OBJECTS:support>
+    $<TARGET_OBJECTS:analysis>)
 
 if(BUILD_LLVM_DWARF)
   SET(binaryen_objs ${binaryen_objs} $<TARGET_OBJECTS:llvm_dwarf>)
@@ -430,7 +432,7 @@ if(EMSCRIPTEN)
   # binaryen.js WebAssembly variant
   add_executable(binaryen_wasm
                  ${binaryen_emscripten_SOURCES})
-  target_link_libraries(binaryen_wasm wasm asmjs emscripten-optimizer passes ir cfg support wasm)
+  target_link_libraries(binaryen_wasm wasm asmjs emscripten-optimizer passes ir cfg support analysis wasm)
   target_link_libraries(binaryen_wasm "-sFILESYSTEM")
   target_link_libraries(binaryen_wasm "-sEXPORT_NAME=Binaryen")
   target_link_libraries(binaryen_wasm "-sNODERAWFS=0")
@@ -451,7 +453,7 @@ if(EMSCRIPTEN)
   # binaryen.js JavaScript variant
   add_executable(binaryen_js
                  ${binaryen_emscripten_SOURCES})
-  target_link_libraries(binaryen_js wasm asmjs emscripten-optimizer passes ir cfg support wasm)
+  target_link_libraries(binaryen_js wasm asmjs emscripten-optimizer passes ir cfg support analysis wasm)
   target_link_libraries(binaryen_js "-sWASM=0")
   target_link_libraries(binaryen_js "-sWASM_ASYNC_COMPILATION=0")
   if(${CMAKE_CXX_COMPILER_VERSION} STREQUAL "6.0.1")

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB analysis_HEADERS *.h)
+set(analysis_SOURCES
+  cfg.cpp
+  ${analysis_HEADERS}
+)
+add_library(analysis OBJECT ${analysis_SOURCES})

--- a/src/analysis/cfg-impl.h
+++ b/src/analysis/cfg-impl.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace wasm::analysis {
+
+struct BasicBlock::Predecessors {
+  struct iterator;
+  iterator begin() const;
+  iterator end() const;
+
+  bool operator==(const Predecessors& other) const {
+    return cfg == other.cfg && index == other.index;
+  }
+  bool operator!=(const Predecessors& other) const { return !(*this == other); }
+
+private:
+  const CFG* cfg;
+  size_t index;
+
+  Predecessors(const CFG* cfg, size_t index) : cfg(cfg), index(index) {}
+  friend BasicBlock;
+};
+
+struct BasicBlock::Successors {
+  struct iterator;
+  iterator begin() const;
+  iterator end() const;
+
+  bool operator==(const Successors& other) const {
+    return cfg == other.cfg && index == other.index;
+  }
+
+private:
+  const CFG* cfg;
+  size_t index;
+  Successors(const CFG* cfg, size_t index) : cfg(cfg), index(index) {}
+  friend BasicBlock;
+};
+
+struct CFG::iterator : ParentIndexIterator<const CFG*, iterator> {
+  using value_type = BasicBlock;
+  using pointer = BasicBlock*;
+  using reference = BasicBlock&;
+  BasicBlock operator*() const { return BasicBlock(parent, index); }
+  iterator(const CFG* cfg, size_t index)
+    : ParentIndexIterator<const CFG*, iterator>{cfg, index} {}
+};
+
+struct BasicBlock::Predecessors::iterator
+  : ParentIndexIterator<Predecessors, iterator> {
+  using value_type = BasicBlock;
+  using pointer = BasicBlock*;
+  using reference = BasicBlock&;
+  BasicBlock operator*() {
+    return BasicBlock(parent.cfg, parent.cfg->preds[parent.index][index]);
+  }
+};
+
+struct BasicBlock::Successors::iterator
+  : ParentIndexIterator<Successors, iterator> {
+  using value_type = BasicBlock;
+  using pointer = BasicBlock*;
+  using reference = BasicBlock&;
+  BasicBlock operator*() {
+    return BasicBlock(parent.cfg, parent.cfg->succs[parent.index][index]);
+  }
+};
+
+inline CFG::iterator CFG::begin() const { return iterator(this, 0); }
+
+inline CFG::iterator CFG::end() const { return iterator(this, blocks.size()); }
+
+inline size_t CFG::size() const { return blocks.size(); }
+
+inline BasicBlock::iterator BasicBlock::begin() const {
+  return cfg->blocks[index].cbegin();
+}
+
+inline BasicBlock::iterator BasicBlock::end() const {
+  return cfg->blocks[index].cend();
+}
+
+inline size_t BasicBlock::size() const { return cfg->blocks[index].size(); }
+
+inline BasicBlock::Predecessors::iterator
+BasicBlock::Predecessors::begin() const {
+  return iterator{*this, 0};
+}
+
+inline BasicBlock::Predecessors::iterator
+BasicBlock::Predecessors::end() const {
+  return iterator{*this, cfg->preds[index].size()};
+}
+
+inline BasicBlock::Successors::iterator BasicBlock::Successors::begin() const {
+  return iterator{*this, 0};
+}
+
+inline BasicBlock::Successors::iterator BasicBlock::Successors::end() const {
+  return iterator{*this, cfg->succs[index].size()};
+}
+
+inline BasicBlock::Predecessors BasicBlock::preds() const {
+  return Predecessors{cfg, index};
+}
+
+inline BasicBlock::Successors BasicBlock::succs() const {
+  return Successors{cfg, index};
+}
+
+inline bool BasicBlock::operator==(const BasicBlock& other) const {
+  return cfg == other.cfg && index == other.index;
+}
+
+inline bool BasicBlock::operator!=(const BasicBlock& other) const {
+  return !(*this == other);
+}
+
+} // namespace wasm::analysis

--- a/src/analysis/cfg.cpp
+++ b/src/analysis/cfg.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <unordered_map>
+
+#include "analysis/cfg.h"
+#include "cfg/cfg-traversal.h"
+#include "wasm-stack.h"
+
+namespace wasm::analysis {
+
+CFG CFG::fromFunction(Function* func) {
+  struct CFGBuilder : CFGWalker<CFGBuilder,
+                                UnifiedExpressionVisitor<CFGBuilder>,
+                                std::vector<Expression*>> {
+    void visitExpression(Expression* curr) {
+      if (currBasicBlock) {
+        currBasicBlock->contents.push_back(curr);
+      }
+    }
+  };
+
+  CFGBuilder builder;
+  builder.walkFunction(func);
+
+  std::unordered_map<CFGBuilder::BasicBlock*, size_t> blockIndices;
+  for (size_t i = 0; i < builder.basicBlocks.size(); ++i) {
+    blockIndices[builder.basicBlocks[i].get()] = i;
+  }
+
+  CFG cfg;
+  for (auto& block : builder.basicBlocks) {
+    cfg.blocks.emplace_back(std::move(block->contents));
+
+    std::vector<size_t> preds;
+    for (auto* pred : block->in) {
+      preds.push_back(blockIndices.at(pred));
+    }
+    cfg.preds.emplace_back(std::move(preds));
+
+    std::vector<size_t> succs;
+    for (auto* succ : block->out) {
+      succs.push_back(blockIndices.at(succ));
+    }
+    cfg.succs.emplace_back(std::move(succs));
+  }
+
+  return cfg;
+}
+
+void CFG::print(std::ostream& os, Module* wasm) {
+  size_t start = 0;
+  for (auto block : *this) {
+    if (block != *begin()) {
+      os << '\n';
+    }
+    block.print(os, wasm, start);
+    start += block.size();
+  }
+}
+
+void BasicBlock::print(std::ostream& os, Module* wasm, size_t start) {
+  os << ";; preds: [";
+  for (auto pred : preds()) {
+    if (pred != *preds().begin()) {
+      os << ", ";
+    }
+    os << pred.index;
+  }
+  os << "], succs: [";
+
+  for (auto succ : succs()) {
+    if (succ != *succs().begin()) {
+      os << ", ";
+    }
+    os << succ.index;
+  }
+  os << "]\n";
+
+  os << index << ":\n";
+  size_t instIndex = start;
+  for (auto* inst : *this) {
+    os << "  " << instIndex++ << ": " << ShallowExpression{inst, wasm} << '\n';
+  }
+}
+
+} // namespace wasm::analysis

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_analysis_cfg_h
+#define wasm_analysis_cfg_h
+
+#include <iostream>
+#include <vector>
+
+#include "wasm.h"
+
+namespace wasm::analysis {
+
+struct BasicBlock;
+
+struct CFG {
+  // Iterate through basic blocks.
+  struct iterator;
+  iterator begin() const;
+  iterator end() const;
+  size_t size() const;
+
+  static CFG fromFunction(Function* func);
+
+  void print(std::ostream& os, Module* wasm = nullptr);
+
+private:
+  std::vector<std::vector<Expression*>> blocks;
+  std::vector<std::vector<size_t>> succs;
+  std::vector<std::vector<size_t>> preds;
+  friend BasicBlock;
+};
+
+struct BasicBlock {
+  using iterator = std::vector<Expression*>::const_iterator;
+
+  // Iterate through instructions.
+  iterator begin() const;
+  iterator end() const;
+  size_t size() const;
+
+  // Iterables for predecessor and successor blocks.
+  struct Predecessors;
+  struct Successors;
+  Predecessors preds() const;
+  Successors succs() const;
+
+  bool operator==(const BasicBlock& other) const;
+  bool operator!=(const BasicBlock& other) const;
+
+  void print(std::ostream& os, Module* wasm = nullptr, size_t start = 0);
+
+private:
+  const CFG* cfg;
+  size_t index;
+
+  BasicBlock(const CFG* cfg, size_t index) : cfg(cfg), index(index) {}
+  friend CFG;
+};
+
+} // namespace wasm::analysis
+
+#include "cfg-impl.h"
+
+#endif // wasm_analysis_cfg_h

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3776,6 +3776,17 @@ std::ostream& operator<<(std::ostream& o, wasm::ModuleExpression pair) {
   return wasm::printExpression(pair.second, o, false, false, &pair.first);
 }
 
+std::ostream& operator<<(std::ostream& o, wasm::ShallowExpression expression) {
+  if (expression.module) {
+    wasm::PrintExpressionContents printer(expression.module, nullptr, o);
+    printer.visit(expression.expr);
+  } else {
+    wasm::PrintExpressionContents printer(nullptr, o);
+    printer.visit(expression.expr);
+  }
+  return o;
+}
+
 std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst) {
   return wasm::printStackInst(&inst, o);
 }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2308,7 +2308,15 @@ public:
   void clearDebugInfo();
 };
 
+// Utility for printing an expression with named types.
 using ModuleExpression = std::pair<Module&, Expression*>;
+
+// Utility for printing only the top level of an expression. Named types will be
+// used if `module` is non-null.
+struct ShallowExpression {
+  Expression* expr;
+  Module* module = nullptr;
+};
 
 } // namespace wasm
 
@@ -2322,6 +2330,7 @@ template<> struct hash<wasm::Address> {
 std::ostream& operator<<(std::ostream& o, wasm::Module& module);
 std::ostream& operator<<(std::ostream& o, wasm::Expression& expression);
 std::ostream& operator<<(std::ostream& o, wasm::ModuleExpression pair);
+std::ostream& operator<<(std::ostream& o, wasm::ShallowExpression expression);
 std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst);
 std::ostream& operator<<(std::ostream& o, wasm::StackIR& ir);
 

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(../../third_party/googletest/googletest/include)
 include_directories(../../src/wasm)
 
 set(unittest_SOURCES
+  cfg.cpp
   dfa_minimization.cpp
   possible-contents.cpp
   type-builder.cpp

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -1,0 +1,84 @@
+#include "analysis/cfg.h"
+#include "support/colors.h"
+#include "wasm-s-parser.h"
+#include "wasm.h"
+#include "gtest/gtest.h"
+
+using namespace wasm;
+using namespace wasm::analysis;
+
+TEST(CFGTest, Print) {
+  auto moduleText = R"wasm(
+    (module
+      (func $foo
+        (drop
+          (i32.const 0)
+        )
+        (drop
+          (if (result i32)
+            (i32.const 1)
+            (block
+              (loop $loop
+                (br_if $loop
+                  (i32.const 2)
+                )
+              )
+              (i32.const 3)
+            )
+            (return
+              (i32.const 4)
+            )
+          )
+        )
+      )
+    )
+  )wasm";
+
+  auto cfgText = R"cfg(;; preds: [], succs: [1, 5]
+0:
+  0: i32.const 0
+  1: drop
+  2: i32.const 1
+
+;; preds: [0], succs: [2]
+1:
+
+;; preds: [1, 2], succs: [3, 2]
+2:
+  3: i32.const 2
+  4: br_if $loop
+
+;; preds: [2], succs: [4]
+3:
+  5: loop $loop
+
+;; preds: [3], succs: [6]
+4:
+  6: i32.const 3
+  7: block
+
+;; preds: [0], succs: []
+5:
+  8: i32.const 4
+  9: return
+
+;; preds: [4], succs: []
+6:
+  10: drop
+  11: block
+)cfg";
+
+  Module wasm;
+  SExpressionParser parser(moduleText);
+  SExpressionWasmBuilder builder(wasm, *(*parser.root)[0], IRProfile::Normal);
+
+  CFG cfg = CFG::fromFunction(wasm.getFunction("foo"));
+
+  bool colors = Colors::isEnabled();
+  Colors::setEnabled(false);
+  std::stringstream ss;
+  cfg.print(ss);
+  Colors::setEnabled(colors);
+
+  EXPECT_EQ(ss.str(), cfgText);
+}


### PR DESCRIPTION
Add a new "analysis" source directory that will contain the source for a new
static program analysis framework. To start the framework, add a CFG utility
that provides convenient iterators for iterating through the basic blocks of the
CFG as well as the predecessors, successors, and contents of each block.

The new CFGs are constructed using the existing CFGWalker, but they are
different in that the new utility is meant to provide a usable representation of
a CFG whereas CFGWalker is meant to allow collecting arbitrary information about
each basic block in a CFG.

For testing and debugging purposes, add `print` methods to CFGs and basic
blocks. This requires exposing the ability to print expression contents
excluding children, which was something we previously did only for StackIR.

Also add a new gtest file with a test for constructing and printing a CFG. The
test reveals some strange properties of the current CFG construction, including
empty blocks and strange placement of `loop` instructions, but fixing these
problems is left as future work.