### PR TITLE
Optimize ArrayNew zero construction

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1642,8 +1642,9 @@ public:
     }
     Literals data(num);
     if (curr->isWithDefault()) {
+      auto zero = Literal::makeZero(element.type);
       for (Index i = 0; i < num; i++) {
-        data[i] = Literal::makeZero(element.type);
+        data[i] = zero;
       }
     } else {
       auto field = curr->type.getHeapType().getArray().element;


### PR DESCRIPTION
All array elements have the same type, so we can construct a single zero
and just copy it.

This makes ArrayNew of large arrays 2x faster. I also experimented with
putting `Literal::makeZero` in a header, in hopes of inlining leading to
licm helping here, but that did not help at all unfortunately, at least not
in gcc.