### PR TITLE
EffectAnalyzer: Do not clear break targets before walk()/visit()

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -53,14 +53,12 @@ public:
 
   // Walk an expression and all its children.
   void walk(Expression* ast) {
-    pre();
     InternalAnalyzer(*this).walk(ast);
     post();
   }
 
   // Visit an expression, without any children.
   void visit(Expression* ast) {
-    pre();
     InternalAnalyzer(*this).visit(ast);
     post();
   }
@@ -1024,11 +1022,6 @@ public:
   }
 
 private:
-  void pre() {
-    breakTargets.clear();
-    delegateTargets.clear();
-  }
-
   void post() {
     assert(tryDepth == 0);
 

--- a/test/example/cpp-unit.cpp
+++ b/test/example/cpp-unit.cpp
@@ -637,6 +637,19 @@ void test_effects() {
     assert_equal(effects.readsMutableStruct, false);
     assert_equal(effects.writesStruct, false);
   }
+
+  {
+    EffectAnalyzer effects(options, module);
+
+    // If we break, then we transfer control flow.
+    effects.breakTargets.insert("block");
+    assert_equal(effects.transfersControlFlow(), true);
+
+    // Repeated walks accumulate effects, that is, old effects are not
+    // removed.
+    effects.walk(&nop);
+    assert_equal(effects.transfersControlFlow(), true);
+  }
 }
 
 void test_field() {


### PR DESCRIPTION
I honestly can't think of why we did that clearing... seems odd. Maybe I'm
forgetting something? Overall, in general we depend on repeated calls to
walk/visit accumulating effects; if we want to clear stuff then we create a
new EffectAnalyzer. So I think this PR is a correct change.

Removing that fixes the attached testcase. Also added a unit test. The fuzzer
seems happy as well after several thousand iterations.