### PR TITLE
avoid incomplete type in a vector

### DIFF
--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -30,23 +30,7 @@
 
 namespace wasm::analysis {
 
-struct BasicBlock;
-
-struct CFG {
-  // Iterate through basic blocks.
-  using iterator = std::vector<BasicBlock>::const_iterator;
-  iterator begin() const { return blocks.cbegin(); }
-  iterator end() const { return blocks.cend(); }
-  size_t size() const { return blocks.size(); }
-
-  static CFG fromFunction(Function* func);
-
-  void print(std::ostream& os, Module* wasm = nullptr) const;
-
-private:
-  std::vector<BasicBlock> blocks;
-  friend BasicBlock;
-};
+struct CFG;
 
 struct BasicBlock {
   using iterator = std::vector<Expression*>::const_iterator;
@@ -70,6 +54,22 @@ private:
   std::vector<BasicBlock*> predecessors;
   std::vector<BasicBlock*> successors;
   friend CFG;
+};
+
+struct CFG {
+  // Iterate through basic blocks.
+  using iterator = std::vector<BasicBlock>::const_iterator;
+  iterator begin() const { return blocks.cbegin(); }
+  iterator end() const { return blocks.cend(); }
+  size_t size() const { return blocks.size(); }
+
+  static CFG fromFunction(Function* func);
+
+  void print(std::ostream& os, Module* wasm = nullptr) const;
+
+private:
+  std::vector<BasicBlock> blocks;
+  friend BasicBlock;
 };
 
 } // namespace wasm::analysis


### PR DESCRIPTION
Swap the order of struct declarations to avoid using an incomplete type in a vector.

In C++20, using std::vector with an incomplete type often becomes a build failure due to increased usage of constexpr for vector members.