### PR TITLE
Fuzzer: Ignore testcases that V8 OOMs on

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -616,6 +616,9 @@ def run_vm(cmd):
             # note that this text is a little too broad, but the problem is rare
             # enough that it's unlikely to hide an unrelated issue
             'found br_if of type',
+            # this text is emitted from V8 when it runs out of memory during a
+            # GC allocation.
+            'out of memory',
             # all host limitations are arbitrary and may differ between VMs and
             # also be affected by optimizations, so ignore them.
             # this is the prefix that the binaryen interpreter emits. For V8,


### PR DESCRIPTION
We already ignore OOMs in the interpreter. This adds the syntax for V8, which
I saw an error on now (on an `array.new` of a massive size).