### PR TITLE
Preserve imports when copying module items

### DIFF
--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -66,6 +66,8 @@ inline Tag* copyTag(Tag* tag, Module& out) {
   auto* ret = new Tag();
   ret->name = tag->name;
   ret->sig = tag->sig;
+  ret->module = tag->module;
+  ret->base = tag->base;
   out.addTag(ret);
   return ret;
 }
@@ -113,6 +115,8 @@ inline Memory* copyMemory(const Memory* memory, Module& out) {
   ret->max = memory->max;
   ret->shared = memory->shared;
   ret->indexType = memory->indexType;
+  ret->module = memory->module;
+  ret->base = memory->base;
 
   return out.addMemory(std::move(ret));
 }

--- a/test/lit/merge/fusing.wat
+++ b/test/lit/merge/fusing.wat
@@ -32,11 +32,7 @@
 
   ;; CHECK:      (memory $second.mem 2)
 
-  ;; CHECK:      (memory $other.mem_2 1)
-
   ;; CHECK:      (tag $exn (param))
-
-  ;; CHECK:      (tag $exn_1 (param))
 
   ;; CHECK:      (export "foo" (func $first.foo))
 
@@ -119,11 +115,11 @@
 ;; CHECK-NEXT: )
 
 ;; CHECK:      (func $keepalive2 (type $none_=>_i32) (result i32)
-;; CHECK-NEXT:  (i32.load $other.mem_2
+;; CHECK-NEXT:  (i32.load $first.mem
 ;; CHECK-NEXT:   (i32.const 10)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
 ;; CHECK:      (func $keepalive3 (type $none_=>_none)
-;; CHECK-NEXT:  (throw $exn_1)
+;; CHECK-NEXT:  (throw $exn)
 ;; CHECK-NEXT: )

--- a/test/lit/merge/fusing.wat
+++ b/test/lit/merge/fusing.wat
@@ -7,6 +7,9 @@
 ;; We test functions and memories here, and not every possible entity in a
 ;; comprehensive way, since they all go through the same code path. (But we test
 ;; two to at least verify we differentiate them.)
+;;
+;; We also test importing memories and tags from another file than the
+;; first one, which was initially broken.
 
 (module
   ;; The first two imports here will be resolved to direct calls into the
@@ -25,7 +28,15 @@
   ;; CHECK:      (import "third" "missing" (func $other.missing (type $none_=>_none)))
   (import "third" "missing" (func $other.missing))
 
+  ;; CHECK:      (memory $first.mem 2)
+
   ;; CHECK:      (memory $second.mem 2)
+
+  ;; CHECK:      (memory $other.mem_2 1)
+
+  ;; CHECK:      (tag $exn (param))
+
+  ;; CHECK:      (tag $exn_1 (param))
 
   ;; CHECK:      (export "foo" (func $first.foo))
 
@@ -33,11 +44,19 @@
 
   ;; CHECK:      (export "keepalive" (func $keepalive))
 
-  ;; CHECK:      (export "mem" (memory $second.mem))
+  ;; CHECK:      (export "mem" (memory $first.mem))
 
-  ;; CHECK:      (export "foo_4" (func $second.foo))
+  ;; CHECK:      (export "exn" (tag $exn))
 
-  ;; CHECK:      (export "bar_5" (func $bar_6))
+  ;; CHECK:      (export "mem_5" (memory $second.mem))
+
+  ;; CHECK:      (export "foo_6" (func $second.foo))
+
+  ;; CHECK:      (export "bar_7" (func $bar_6))
+
+  ;; CHECK:      (export "keepalive2" (func $keepalive2))
+
+  ;; CHECK:      (export "keepalive3" (func $keepalive3))
 
   ;; CHECK:      (func $first.foo (type $none_=>_none)
   ;; CHECK-NEXT:  (drop
@@ -68,7 +87,7 @@
   )
 
   ;; CHECK:      (func $keepalive (type $none_=>_i32) (result i32)
-  ;; CHECK-NEXT:  (i32.load
+  ;; CHECK-NEXT:  (i32.load $second.mem
   ;; CHECK-NEXT:   (i32.const 10)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -78,6 +97,12 @@
       (i32.const 10)
     )
   )
+
+  (memory $first.mem 2)
+
+  (export "mem" (memory $first.mem))
+
+  (tag $exn (export "exn"))
 )
 ;; CHECK:      (func $second.foo (type $none_=>_none)
 ;; CHECK-NEXT:  (call $first.foo)
@@ -91,4 +116,14 @@
 ;; CHECK-NEXT:  (drop
 ;; CHECK-NEXT:   (i32.const 4)
 ;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $keepalive2 (type $none_=>_i32) (result i32)
+;; CHECK-NEXT:  (i32.load $other.mem_2
+;; CHECK-NEXT:   (i32.const 10)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $keepalive3 (type $none_=>_none)
+;; CHECK-NEXT:  (throw $exn_1)
 ;; CHECK-NEXT: )

--- a/test/lit/merge/fusing.wat.second
+++ b/test/lit/merge/fusing.wat.second
@@ -25,4 +25,16 @@
       (i32.const 4)
     )
   )
+
+  (import "first" "mem" (memory $other.mem 1))
+
+  (func $keepalive2 (export "keepalive2") (result i32)
+    ;; Load from the memory imported from the second module.
+    (i32.load $other.mem
+      (i32.const 10)
+    )
+  )
+
+  (import "first" "exn" (tag $exn))
+  (func $keepalive3 (export "keepalive3") (throw $exn))
 )

--- a/test/lit/merge/memory_data.wat
+++ b/test/lit/merge/memory_data.wat
@@ -14,9 +14,13 @@
   ;; CHECK:      (memory $bar 10)
   (memory $bar 10)
 
+  (memory $shared 10)
+
   ;; CHECK:      (memory $other 100)
 
-  ;; CHECK:      (memory $bar_2 1000)
+  ;; CHECK:      (memory $bar_3 1000)
+
+  ;; CHECK:      (memory $imported 10000)
 
   ;; CHECK:      (data $a (i32.const 0) "a")
   (data $a (memory $foo) (i32.const 0) "a")
@@ -26,14 +30,17 @@
 
   ;; CHECK:      (data $a_2 (memory $other) (i32.const 0) "a2")
 
-  ;; CHECK:      (data $b_2 (memory $bar_2) (i32.const 0) "b2")
+  ;; CHECK:      (data $b_2 (memory $bar_3) (i32.const 0) "b2")
 
   ;; CHECK:      (export "keepalive" (memory $foo))
   (export "keepalive" (memory $foo))
 
   ;; CHECK:      (export "keepalive1" (memory $bar))
   (export "keepalive1" (memory $bar))
+
 )
 ;; CHECK:      (export "keepalive_2" (memory $other))
 
-;; CHECK:      (export "keepalive1_3" (memory $bar_2))
+;; CHECK:      (export "keepalive1_3" (memory $bar_3))
+
+;; CHECK:      (export "keepalive2" (memory $imported))

--- a/test/lit/merge/memory_data.wat
+++ b/test/lit/merge/memory_data.wat
@@ -8,6 +8,8 @@
 ;; such name changes.
 
 (module
+  ;; CHECK:      (import "import" "mem" (memory $imported 10000))
+
   ;; CHECK:      (memory $foo 1)
   (memory $foo 1)
 
@@ -19,8 +21,6 @@
   ;; CHECK:      (memory $other 100)
 
   ;; CHECK:      (memory $bar_3 1000)
-
-  ;; CHECK:      (memory $imported 10000)
 
   ;; CHECK:      (data $a (i32.const 0) "a")
   (data $a (memory $foo) (i32.const 0) "a")

--- a/test/lit/merge/memory_data.wat.second
+++ b/test/lit/merge/memory_data.wat.second
@@ -3,6 +3,9 @@
 
   (memory $bar 1000)
 
+  ;; Test that the import remains
+  (import "import" "mem" (memory $imported 10000))
+
   (data $a (memory $other) (i32.const 0) "a2")
 
   (data $b (memory $bar) (i32.const 0) "b2")
@@ -10,4 +13,6 @@
   (export "keepalive" (memory $other))
 
   (export "keepalive1" (memory $bar))
+
+  (export "keepalive2" (memory $imported))
 )

--- a/test/lit/merge/renamings.wat
+++ b/test/lit/merge/renamings.wat
@@ -11,6 +11,8 @@
   ;; will be renamed.
   ;; CHECK:      (type $none_=>_none (func))
 
+  ;; CHECK:      (type $f64_=>_none (func (param f64)))
+
   ;; CHECK:      (type $ref|$array|_=>_none (func (param (ref $array))))
 
   ;; CHECK:      (type $i32_=>_none (func (param i32)))
@@ -18,8 +20,6 @@
   ;; CHECK:      (type $i64_=>_none (func (param i64)))
 
   ;; CHECK:      (type $f32_=>_none (func (param f32)))
-
-  ;; CHECK:      (type $f64_=>_none (func (param f64)))
 
   ;; CHECK:      (global $foo i32 (i32.const 1))
   (global $foo i32 (i32.const 1))
@@ -89,6 +89,8 @@
 
   ;; This export has a conflict in second.wat, and so second.wat's $foo
   ;; will be renamed.
+  ;; CHECK:      (tag $imported (param f64))
+
   ;; CHECK:      (tag $foo_2 (param f32))
 
   ;; CHECK:      (tag $other (param f64))
@@ -107,6 +109,8 @@
   ;; CHECK:      (export "other" (func $other))
 
   ;; CHECK:      (export "keepalive_5" (func $uses.second))
+
+  ;; CHECK:      (export "keepalive.tag" (tag $imported))
 
   ;; CHECK:      (export "other-b" (func $other))
 

--- a/test/lit/merge/renamings.wat
+++ b/test/lit/merge/renamings.wat
@@ -21,6 +21,8 @@
 
   ;; CHECK:      (type $f32_=>_none (func (param f32)))
 
+  ;; CHECK:      (import "elsewhere" "some.tag" (tag $imported (param f64)))
+
   ;; CHECK:      (global $foo i32 (i32.const 1))
   (global $foo i32 (i32.const 1))
 
@@ -89,8 +91,6 @@
 
   ;; This export has a conflict in second.wat, and so second.wat's $foo
   ;; will be renamed.
-  ;; CHECK:      (tag $imported (param f64))
-
   ;; CHECK:      (tag $foo_2 (param f32))
 
   ;; CHECK:      (tag $other (param f64))

--- a/test/lit/merge/renamings.wat.second
+++ b/test/lit/merge/renamings.wat.second
@@ -5,6 +5,9 @@
 
   (tag $other (param f64))
 
+  ;; Test that the import remains
+  (import "elsewhere" "some.tag" (tag $imported (param f64)))
+
   (memory $foo 50 60)
 
   (memory $other 70 80)
@@ -30,6 +33,8 @@
   (export "other" (func $other))
 
   (export "keepalive" (func $uses.second))
+
+  (export "keepalive.tag" (tag $imported))
 
   ;; Also test having a different name for the export as for the internal
   ;; thing it refers to, to test we don't assume they are identical.


### PR DESCRIPTION
The import information of tags and memories were not preserved.

As a consequence, `wasm-merge` were not merging exported and imported tags.
For instance, consider this file `export.wat`:
```
(module
   (tag $exn (export "exn")))
```
and this file `import.wat`:
```
(module
  (import "env" "exn" (tag $exn))
  (func $f (export "f") (throw $exn))
)
```
Then, the command `wasm-merge --enable-exception-handling /tmp/export.wat env /tmp/import.wat exec -S -o -` outputs the following:
```
(module
 (type $none_=>_none (func))
 (tag $exn (param))
 (tag $exn_1 (param))
 (export "exn" (tag $exn))
 (export "f" (func $f))
 (func $f
  (throw $exn_1)
 )
)
```
With this PR, I get the expected result:
```
(module
 (type $none_=>_none (func))
 (tag $exn (param))
 (export "exn" (tag $exn))
 (export "f" (func $f))
 (func $f
  (throw $exn)
 )
)
```