### PR TITLE
Move casts which are immediate children of local.gets to earlier local.gets

### DIFF
--- a/src/passes/OptimizeCasts.cpp
+++ b/src/passes/OptimizeCasts.cpp
@@ -89,9 +89,9 @@
 //    (ref.cast .. (local.get $ref))
 //  )
 //
-// TODO: 1. Move casts earlier in a basic block as well, at least in
-//          traps-never-happen mode where we can assume they never fail, and
-//          perhaps in other situations too.
+// TODO: 1. Check if casts whose fallthroughs, but not immediate falthroughs 
+//          are local.gets can be moved earlier, and also see if we can move
+//          multiple casts to the same local.get.
 // TODO: 2. Look past individual basic blocks? This may be worth considering
 //          given the pattern of a cast appearing in an if condition that is
 //          then used in an if arm, for example, where simple dominance shows

--- a/src/passes/OptimizeCasts.cpp
+++ b/src/passes/OptimizeCasts.cpp
@@ -89,7 +89,7 @@
 //    (ref.cast .. (local.get $ref))
 //  )
 //
-// TODO: 1. Check if casts whose fallthroughs, but not immediate falthroughs 
+// TODO: 1. Check if casts whose fallthroughs, but not immediate fallthroughs
 //          are local.gets can be moved earlier, and also see if we can move
 //          multiple casts to the same local.get.
 // TODO: 2. Look past individual basic blocks? This may be worth considering

--- a/src/passes/OptimizeCasts.cpp
+++ b/src/passes/OptimizeCasts.cpp
@@ -176,7 +176,7 @@ struct EarlyCastFinder
       currRefAsMove(func->getNumLocals()), testRefCast(options, *module),
       testRefAs(options, *module) {
 
-    // TODO: generalize this when we handle more than RefAsNonNull
+    // TODO: generalize this when we handle more than RefAsNonNull.
     RefCast dummyRefCast(module->allocator);
     RefAs dummyRefAs(module->allocator);
     dummyRefAs.op = RefAsNonNull;
@@ -273,8 +273,8 @@ struct EarlyCastFinder
     }
 
     // As we only move RefAsNonNull RefAs casts right now, we should
-    // ignore a LocalGet if the type is already non-nullable, and
-    // adding an extra ref.as_non_null has no effect
+    // ignore a LocalGet if the type is already non-nullable, as
+    // adding an extra ref.as_non_null has no effect.
     if (!currRefAsMove[curr->index].target && curr->type.isNullable()) {
       currRefAsMove[curr->index].target = curr;
     }
@@ -283,7 +283,7 @@ struct EarlyCastFinder
   void visitRefAs(RefAs* curr) {
     visitExpression(curr);
 
-    // TODO: support more than RefAsNonNull
+    // TODO: support more than RefAsNonNull.
     if (curr->op != RefAsNonNull) {
       return;
     }

--- a/src/passes/OptimizeCasts.cpp
+++ b/src/passes/OptimizeCasts.cpp
@@ -336,7 +336,7 @@ struct EarlyCastFinder
     auto* fallthrough = Properties::getFallthrough(curr, options, *getModule());
     if (auto* get = fallthrough->dynCast<LocalGet>()) {
       auto& bestMove = currRefCastMove[get->index];
-      // Do not move a cast if it's type is not related to the target
+      // Do not move a cast if its type is not related to the target
       // local.get's type (i.e. not in a subtyping relationship). Otherwise
       // a type error will occur. Also, if the target local.get's type is
       // already more refined than this current cast, there is no point in

--- a/src/passes/OptimizeCasts.cpp
+++ b/src/passes/OptimizeCasts.cpp
@@ -272,7 +272,10 @@ struct EarlyCastFinder
       currRefCastMove[curr->index].target = curr;
     }
 
-    if (!currRefAsMove[curr->index].target) {
+    // As we only move RefAsNonNull RefAs casts right now, we should
+    // ignore a LocalGet if the type is already non-nullable, and
+    // adding an extra ref.as_non_null has no effect
+    if (!currRefAsMove[curr->index].target && curr->type.isNullable()) {
       currRefAsMove[curr->index].target = curr;
     }
   }

--- a/src/passes/OptimizeCasts.cpp
+++ b/src/passes/OptimizeCasts.cpp
@@ -336,7 +336,13 @@ struct EarlyCastFinder
     auto* fallthrough = Properties::getFallthrough(curr, options, *getModule());
     if (auto* get = fallthrough->dynCast<LocalGet>()) {
       auto& bestMove = currRefCastMove[get->index];
-      if (bestMove.target) {
+      // Do not move a cast if it's type is not related to the target
+      // local.get's type (i.e. not in a subtyping relationship). Otherwise
+      // a type error will occur. Also, if the target local.get's type is
+      // already more refined than this current cast, there is no point in
+      // moving it.
+      if (bestMove.target && bestMove.target->type != curr->type &&
+          Type::isSubType(curr->type, bestMove.target->type)) {
         if (!bestMove.bestCast) {
           // If there isn't any other cast to move, the current cast is the
           // best.

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -8,16 +8,21 @@
   ;; CHECK:      (type $B (struct_subtype  $A))
   (type $B (struct_subtype $A))
 
+  ;; CHECK:      (global $a (mut i32) (i32.const 10))
+  (global $a (mut i32) (i32.const 10))
+
   ;; CHECK:      (func $ref.as (type $ref?|$A|_=>_none) (param $x (ref null $A))
   ;; CHECK-NEXT:  (local $1 (ref $A))
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $x)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $1
   ;; CHECK-NEXT:    (ref.as_non_null
   ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -30,8 +35,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $ref.as (param $x (ref null $A))
-    ;; After the first ref.as, we can use the cast value in later gets, which is
-    ;; more refined.
+    ;; Formerly, after the first ref.as, we can use the cast value in later gets,
+    ;;  which is more refined. However, the ref.as is moved up to the first
+    ;; local.get.
     (drop
       (local.get $x)
     )
@@ -54,7 +60,9 @@
 
   ;; CHECK:      (func $ref.as-no (type $ref|$A|_=>_none) (param $x (ref $A))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
@@ -71,8 +79,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $ref.as-no (param $x (ref $A))
-    ;; As above, but the param is now non-nullable anyhow, so we should do
-    ;; nothing.
+    ;; As above, but the param is now non-nullable anyhow, so we should not
+    ;; tee a new local variable.
     (drop
       (local.get $x)
     )
@@ -170,8 +178,14 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $a
+  ;; CHECK-NEXT:   (i32.const 30)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $a
+  ;; CHECK-NEXT:   (i32.const 30)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $2
@@ -179,6 +193,9 @@
   ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $a
+  ;; CHECK-NEXT:   (i32.const 30)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $2)
@@ -190,14 +207,23 @@
         (local.get $x)
       )
     )
+    (global.set $a
+      (i32.const 30)
+    )
     ;; Here we should use $A.
     (drop
       (local.get $x)
+    )
+    (global.set $a
+      (i32.const 30)
     )
     (drop
       (ref.cast $B
         (local.get $x)
       )
+    )
+    (global.set $a
+      (i32.const 30)
     )
     ;; Here we should use $B, which is even better.
     (drop
@@ -384,6 +410,194 @@
     )
     (drop
       (local.get $b)
+    )
+  )
+
+  ;; CHECK:      (func $testMoveCast (type $ref|struct|_=>_none) (param $x (ref struct))
+  ;; CHECK-NEXT:  (local $1 (ref $B))
+  ;; CHECK-NEXT:  (local $2 (ref $A))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $B
+  ;; CHECK-NEXT:    (local.tee $1
+  ;; CHECK-NEXT:     (ref.cast $B
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $B
+  ;; CHECK-NEXT:    (local.get $1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (call $get)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (call $get)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.tee $2
+  ;; CHECK-NEXT:    (ref.cast $A
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (ref.cast $A
+  ;; CHECK-NEXT:     (local.get $2)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $testMoveCast (param $x (ref struct))
+    (drop
+      (ref.cast $A
+        (local.get $x)
+      )
+    )
+    (drop
+      (local.get $x)
+    )
+    (drop
+      (ref.cast $B
+        (local.get $x)
+      )
+    )
+    ;; Casts cannot be moved past local sets.
+    (local.set $x
+      (call $get)
+    )
+    (drop
+      (local.get $x)
+    )
+    (drop
+      ;; This will be moved above as the first RefAs.
+      (ref.as_non_null
+        (local.get $x)
+      )
+    )
+    (local.set $x
+      (call $get)
+    )
+    (drop
+      (local.get $x)
+    )
+    (drop
+      ;; This will not be moved, as the RefCast has precedence.
+      (ref.as_non_null
+        (local.get $x)
+      )
+    )
+    (drop
+      (ref.as_non_null
+        ;; Only the RefCast will be moved since we only move
+        ;; immediate parents of local gets right now.
+        (ref.cast $A
+          (local.get $x)
+        )
+      )
+    )
+  )
+
+  ;; CHECK:      (func $testMoveCastSideEffects (type $ref|struct|_ref|struct|_=>_none) (param $x (ref struct)) (param $y (ref struct))
+  ;; CHECK-NEXT:  (local $2 (ref $A))
+  ;; CHECK-NEXT:  (local $3 (ref $B))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $a
+  ;; CHECK-NEXT:   (i32.const 30)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.tee $2
+  ;; CHECK-NEXT:    (ref.cast $A
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.tee $3
+  ;; CHECK-NEXT:    (ref.cast $B
+  ;; CHECK-NEXT:     (local.get $y)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $A
+  ;; CHECK-NEXT:    (local.get $2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (local.get $3)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $B
+  ;; CHECK-NEXT:    (local.get $3)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $a
+  ;; CHECK-NEXT:   (i32.const 30)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $B
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $testMoveCastSideEffects (param $x (ref struct)) (param $y (ref struct))
+    (drop
+      (local.get $x)
+    )
+    ;; Cannot move past global set due to trap possibility.
+    (global.set $a
+      (i32.const 30)
+    )
+    (drop
+      (local.get $x)
+    )
+    (drop
+      (local.get $y)
+    )
+    (drop
+      (ref.cast $A
+        (local.get $x)
+      )
+    )
+    (local.set $x
+      (local.get $y)
+    )
+    (drop
+      (ref.cast $B
+        (local.get $y)
+      )
+    )
+    (global.set $a
+      (i32.const 30)
+    )
+    (drop
+      (ref.cast $B
+        (local.get $x)
+      )
     )
   )
 

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -60,9 +60,7 @@
 
   ;; CHECK:      (func $ref.as-no (type $ref|$A|_=>_none) (param $x (ref $A))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
@@ -79,8 +77,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $ref.as-no (param $x (ref $A))
-    ;; As above, but the param is now non-nullable anyhow, so we should not
-    ;; tee a new local variable.
+    ;; As above, but the param is now non-nullable anyhow, so we should do
+    ;; nothing.
     (drop
       (local.get $x)
     )
@@ -437,9 +435,7 @@
   ;; CHECK-NEXT:   (call $get)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.as_non_null
@@ -450,11 +446,9 @@
   ;; CHECK-NEXT:   (call $get)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (local.tee $2
-  ;; CHECK-NEXT:     (ref.cast $A
-  ;; CHECK-NEXT:      (local.get $x)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (local.tee $2
+  ;; CHECK-NEXT:    (ref.cast $A
+  ;; CHECK-NEXT:     (local.get $x)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -450,9 +450,11 @@
   ;; CHECK-NEXT:   (call $get)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.tee $2
-  ;; CHECK-NEXT:    (ref.cast $A
-  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.tee $2
+  ;; CHECK-NEXT:     (ref.cast $A
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -462,10 +464,8 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_non_null
-  ;; CHECK-NEXT:    (ref.cast $A
-  ;; CHECK-NEXT:     (local.get $2)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (ref.cast $A
+  ;; CHECK-NEXT:    (local.get $2)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -503,18 +503,13 @@
       (local.get $x)
     )
     (drop
-      ;; This will not be moved, as the RefCast has precedence.
       (ref.as_non_null
         (local.get $x)
       )
     )
     (drop
-      (ref.as_non_null
-        ;; Only the RefCast will be moved since we only move
-        ;; immediate parents of local gets right now.
-        (ref.cast $A
-          (local.get $x)
-        )
+      (ref.cast null $A
+        (local.get $x)
       )
     )
   )
@@ -560,7 +555,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast $B
-  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -596,7 +593,9 @@
     )
     (drop
       (ref.cast $B
-        (local.get $x)
+        (ref.as_non_null
+          (local.get $x)
+        )
       )
     )
   )

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -600,6 +600,74 @@
     )
   )
 
+  ;; CHECK:      (func $testRefAsAndRefCast (type $structref_=>_none) (param $x structref)
+  ;; CHECK-NEXT:  (local $1 (ref $A))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.tee $1
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (ref.cast null $A
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (ref.cast $A
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $a
+  ;; CHECK-NEXT:   (i32.const 30)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (ref.cast $A
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $A
+  ;; CHECK-NEXT:    (local.get $1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $testRefAsAndRefCast (param $x (ref null struct))
+    (drop
+      (local.get $x)
+    )
+    (drop
+      (ref.as_non_null
+        (ref.cast null $A
+          (local.get $x)
+        )
+      )
+    )
+    (global.set $a
+      (i32.const 30)
+    )
+    (drop
+      (local.get $x)
+    )
+    (drop
+      (ref.cast null $A
+        (local.get $x)
+      )
+    )
+    (drop
+      (ref.as_non_null
+        (local.get $x)
+      )
+    )
+  )
+
   ;; CHECK:      (func $get (type $none_=>_ref|struct|) (result (ref struct))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -1144,8 +1144,7 @@
   (func $move-identical-repeated-casts (param $x (ref struct))
     ;; This tests the case where there are two casts with equal type which can
     ;; be moved to an earlier local.get. Only one of the casts will be duplicated
-    ;; to the earlier local.get; which one is not visible in this test, but should
-    ;; be the earlier.
+    ;; to the earliest local.get (which one is not visible to the test).
     (drop
       (local.get $x)
     )

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -663,6 +663,31 @@
     )
   )
 
+  ;; CHECK:      (func $move-over-tee (type $structref_structref_=>_none) (param $x structref) (param $y structref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast $A
+  ;; CHECK-NEXT:    (local.tee $x
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $move-over-tee (param $x (ref null struct)) (param $y (ref null struct))
+    (drop
+      (local.get $x)
+    )
+    (drop
+      (ref.cast $A
+        (local.tee $x
+          (local.get $x)
+        )
+      )
+    )
+  )
+
   ;; CHECK:      (func $get (type $none_=>_ref|struct|) (result (ref struct))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )


### PR DESCRIPTION
In the `OptimizeCasts` pass, it is useful to move more refined casts as early as possible without causing side-effects. This will allow such casts to potentially trap earlier, and will allow the `OptimizeCasts` pass to use more refined casts earlier. This change allows a more refined cast to be duplicated at an earlier `local.get` expression. The later instance of the cast will then be eliminated in a later optimization pass.

For example, if we have the following instructions:
```
(drop
  (local.get $x)
)
(drop
  (ref.cast $A
    (local.get $x)
)
(drop
  (ref.cast $B
    (local.get $x)
  )
)
```
Where `$B` is a sublcass of `$A`, we can convert this to:
```
(drop
  (ref.cast $B
    (local.get $x)
  )
)
(drop
  (ref.cast $A
    (local.get $x)
)
(drop
  (ref.cast $B
    (local.get $x)
  )
)
```
Currently this change only moves casts whose immediate value (i.e. child) is a `local.get`. Furthermore, the change current allows only one cast to be moved up to an earlier `local.get` location. `RefCast`s are given precedence. 

This is implemented as a separate walker traversal before the existing `OptimizeCast` pass. `EffectAnalyzers` are used to analyze the expressions between a cast an a `local.get` we want to move to for side effects if we move the cast up. 