### PR TITLE
StackIR: Remove nops

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1527,6 +1527,8 @@ opt_choices = [
     ("--optimize-instructions",),
     ("--optimize-stack-ir",),
     ("--generate-stack-ir", "--optimize-stack-ir",),
+    # the full lifecycle of stack IR: generate, optimize, and write (and read)
+    ("--generate-stack-ir", "--optimize-stack-ir", "--roundtrip"),
     ("--pick-load-signs",),
     ("--precompute",),
     ("--precompute-propagate",),

--- a/test/lit/passes/roundtrip-gc.wast
+++ b/test/lit/passes/roundtrip-gc.wast
@@ -12,7 +12,7 @@
  ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (struct.new_default $\7bi32\7d)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:    (call $other)
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (i32.const 1)
@@ -21,20 +21,24 @@
  (func $test
   (call $help
    (struct.new_default ${i32})
-   ;; Stack IR optimizations can remove this block, leaving a nop in an odd
+   ;; Stack IR optimizations can remove this block, leaving a call in an odd
    ;; "stacky" location. On load, we will use a local to work around that. It
    ;; is fine for the local to be non-nullable since the get is later in that
    ;; same block.
    (block $block (result i32)
-    (nop)
+    (call $other)
     (i32.const 1)
    )
   )
  )
  ;; CHECK:      (func $help (type $ref|$\7bi32\7d|_i32_=>_none) (param $3 (ref $\7bi32\7d)) (param $4 i32)
- ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $help (param $3 (ref ${i32})) (param $4 i32)
   (nop)
+ )
+
+ ;; CHECK:      (func $other (type $none_=>_none)
+ ;; CHECK-NEXT: )
+ (func $other
  )
 )

--- a/test/lit/passes/stack-ir-eh.wast
+++ b/test/lit/passes/stack-ir-eh.wast
@@ -23,10 +23,8 @@
   ;; CHECK-NEXT:   delegate $l00
   ;; CHECK-NEXT:   unreachable
   ;; CHECK-NEXT:  catch_all
-  ;; CHECK-NEXT:   nop
   ;; CHECK-NEXT:  end
   ;; CHECK-NEXT:  try $l01
-  ;; CHECK-NEXT:   nop
   ;; CHECK-NEXT:  delegate 0
   ;; CHECK-NEXT: )
   (func $eh

--- a/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_optimize-level=3.txt
+++ b/test/passes/generate-stack-ir_optimize-stack-ir_print-stack-ir_optimize-level=3.txt
@@ -158,7 +158,6 @@
     i32.const 2
     br $topmost
    end
-   nop
    block $switch-default$7
     block $switch-case$6
      block $switch-case$5
@@ -173,7 +172,6 @@
     i32.const 51
     br $topmost
    end
-   nop
    block $label$break$Lout
     block $switch-default$16
      block $switch-case$15
@@ -201,7 +199,6 @@
      end
      unreachable
     end
-    nop
    end
    i32.const 0
   end
@@ -297,10 +294,8 @@
   drop
  )
  (func $z
-  nop
  )
  (func $w
-  nop
  )
  (func $block_and_after (result i32)
   block $waka
@@ -381,7 +376,6 @@
  )
  (func $unreachable-loop (result i32)
   loop $loop-in
-   nop
    i32.const 1
    return
   end
@@ -396,7 +390,6 @@
  )
  (func $unreachable-loop-toplevel (result i32)
   loop $loop-in
-   nop
    i32.const 1
    return
   end
@@ -415,7 +408,6 @@
  (func $unreachable-if-arm
   i32.const 1
   if
-   nop
   else
    unreachable
   end
@@ -591,7 +583,6 @@
   call $local-to-stack-multi-4
   i32.const 0
   if
-   nop
   end
   drop
   i32.const 2

--- a/test/reduce/memory_table.wast.txt
+++ b/test/reduce/memory_table.wast.txt
@@ -6,7 +6,6 @@
  (export "f2" (func $1))
  (export "f4" (func $2))
  (func $0
-  (nop)
  )
  (func $1 (result i32)
   (i32.store


### PR DESCRIPTION
No `nop` instruction is necessary in wasm, so in StackIR we can simply
remove them all.

(Unless I'm forgetting something..?)

Fixes #5745