### PR TITLE
[NFC] Remove redundant code from EffectAnalyzer

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -264,11 +264,6 @@ public:
         return true;
       }
     }
-    // We are ok to reorder implicit traps, but not conditionalize them.
-    if ((trap && other.transfersControlFlow()) ||
-        (other.trap && transfersControlFlow())) {
-      return true;
-    }
     // Note that the above includes disallowing the reordering of a trap with an
     // exception (as an exception can transfer control flow inside the current
     // function, so transfersControlFlow would be true) - while we allow the


### PR DESCRIPTION
This PR removes a check for

```cpp
transfersControlFlow() && other.trap
```

which is already checked higher up in the code, here:

```cpp
transfersControlFlow() && other.hasSideEffects()
```

https://github.com/WebAssembly/binaryen/blob/7b093e8d0cfe09471aed4eb40c093f0603f11efb/src/ir/effects.h#L223-L224

That last code handles the first code because trapping is part
of `hasSideEffects()`.