### PR TITLE
[Strings] Fix non-nullable string emitting in the binary format

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1401,9 +1401,15 @@ void WasmBinaryWriter::writeType(Type type) {
         o << S32LEB(BinaryConsts::EncodedType::funcref);
         return;
       }
-      assert(Type::isSubType(type, Type(HeapType::ext, Nullable)));
-      o << S32LEB(BinaryConsts::EncodedType::externref);
-      return;
+      if (Type::isSubType(type, Type(HeapType::ext, Nullable))) {
+        o << S32LEB(BinaryConsts::EncodedType::externref);
+        return;
+      }
+      if (Type::isSubType(type, Type(HeapType::string, Nullable))) {
+        o << S32LEB(BinaryConsts::EncodedType::stringref);
+        return;
+      }
+      WASM_UNREACHABLE("bad type without GC");
     }
     auto heapType = type.getHeapType();
     if (heapType.isBasic() && type.isNullable()) {

--- a/test/lit/downgrade-reftypes.wast
+++ b/test/lit/downgrade-reftypes.wast
@@ -33,6 +33,13 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block $label$4 (result stringref)
+  ;; CHECK-NEXT:    (br $label$4
+  ;; CHECK-NEXT:     (string.const "hello world")
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $foo (type $f)
     (drop
@@ -54,6 +61,13 @@
       (block $l3 (result nullexternref)
         (br $l3
           (ref.null noextern)
+        )
+      )
+    )
+    (drop
+      (block $l4 (result (ref string))
+        (br $l4
+          (string.const "hello world")
         )
       )
     )


### PR DESCRIPTION
Related to #5737 which did something similar for other types.

Found by the fuzzer.