### PR TITLE
TypeRefining: Fix a bug with chains of StructGets

### DIFF
--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -268,15 +268,15 @@ struct TypeRefining : public Pass {
           auto oldType = oldInputType.getHeapType();
           auto newFieldType = parent.finalInfos[oldType][get->index].getLUB();
           if (Type::isSubType(newFieldType, get->type)) {
-            // This is the normal situation, where the new type is a refinement of
-            // the old type. Apply that type so that the type of the struct.get
-            // matches what is in the refined field. ReFinalize will later
-            // propagate this to parents.
+            // This is the normal situation, where the new type is a refinement
+            // of the old type. Apply that type so that the type of the
+            // struct.get matches what is in the refined field. ReFinalize will
+            // later propagate this to parents.
             //
             // Note that ReFinalize will also apply the type of the field itself
             // to a struct.get, so our doing it here in this pass is usually
-            // redundant. But ReFinalize also updates other types while doing so,
-            // which can cause a problem:
+            // redundant. But ReFinalize also updates other types while doing
+            // so, which can cause a problem:
             //
             //  (struct.get $A
             //    (block (result (ref null $A))
@@ -285,28 +285,28 @@ struct TypeRefining : public Pass {
             //  )
             //
             // Here ReFinalize will turn the block's result into a bottom type,
-            // which means it won't know a type for the struct.get at that point.
-            // Doing it in this pass avoids that issue, as we have all the
-            // necessary information. (ReFinalize will still get into the
+            // which means it won't know a type for the struct.get at that
+            // point. Doing it in this pass avoids that issue, as we have all
+            // the necessary information. (ReFinalize will still get into the
             // situation where it doesn't know how to update the type of the
             // struct.get, but it will just leave the existing type - it assumes
-            // no update is needed - which will be correct, since we've updated it
-            // ourselves here, before.)
+            // no update is needed - which will be correct, since we've updated
+            // it ourselves here, before.)
             get->type = newFieldType;
           } else {
             // This instruction is invalid, so it must be the result of the
             // situation described above: we ignored the read during our
-            // inference, and optimized accordingly, and so now we must remove it
-            // to keep the module validating. It doesn't matter what we emit here,
-            // since there are no struct.new or struct.sets for this type, so this
-            // code is logically unreachable.
+            // inference, and optimized accordingly, and so now we must remove
+            // it to keep the module validating. It doesn't matter what we emit
+            // here, since there are no struct.new or struct.sets for this type,
+            // so this code is logically unreachable.
             //
-            // Note that we emit an unreachable here, which changes the type, and
-            // so we should refinalize. However, we will be refinalizing later
-            // anyhow in updateTypes, so there is no need.
+            // Note that we emit an unreachable here, which changes the type,
+            // and so we should refinalize. However, we will be refinalizing
+            // later anyhow in updateTypes, so there is no need.
             Builder builder(*getModule());
             *getp = builder.makeSequence(builder.makeDrop(get->ref),
-                                                builder.makeUnreachable());
+                                         builder.makeUnreachable());
           }
         }
       }

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -277,6 +277,9 @@ struct TypeRefining : public Pass {
         for (Index i = 0; i < gets.size(); i++) {
           auto** getp = gets[i];
           auto* get = (*getp)->cast<StructGet>();
+          // Use the old ref type from where we stored those, since reading it
+          // from get->ref->type might return something that was just modified
+          // (see comment above).
           auto oldRefType = oldRefTypes[i];
           if (oldRefType == Type::unreachable || oldRefType.isNull()) {
             continue;

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -282,7 +282,8 @@ struct TypeRefining : public Pass {
             continue;
           }
 
-          auto newFieldType = parent.finalInfos[oldRefType.getHeapType()][get->index].getLUB();
+          auto newFieldType =
+            parent.finalInfos[oldRefType.getHeapType()][get->index].getLUB();
           if (Type::isSubType(newFieldType, get->type)) {
             // This is the normal situation, where the new type is a refinement
             // of the old type. Apply that type so that the type of the

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -1170,10 +1170,30 @@
 
 (module
   (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $A (struct (field (mut nullref))))
     (type $A (struct (field (mut anyref))))
+    ;; CHECK:       (type $B (struct (field (mut nullref))))
     (type $B (struct (field (mut (ref null $A)))))
   )
 
+  ;; CHECK:       (type $none_=>_none (func))
+
+  ;; CHECK:      (func $0 (type $none_=>_none)
+  ;; CHECK-NEXT:  (struct.set $A 0
+  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (struct.get $B 0
+  ;; CHECK-NEXT:       (struct.new_default $B)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $0
     (struct.set $A 0
       (struct.new $A

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -1180,18 +1180,26 @@
   ;; CHECK:       (type $none_=>_none (func))
 
   ;; CHECK:      (func $0 (type $none_=>_none)
-  ;; CHECK-NEXT:  (struct.set $A 0
-  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit)
   ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (struct.get $B 0
-  ;; CHECK-NEXT:       (struct.new_default $B)
+  ;; CHECK-NEXT:      (block
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (struct.get $B 0
+  ;; CHECK-NEXT:         (struct.new_default $B)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (unreachable)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $0

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -1167,3 +1167,30 @@
     )
   )
 )
+
+(module
+  (rec
+    (type $A (struct (field (mut anyref))))
+    (type $B (struct (field (mut (ref null $A)))))
+  )
+
+  (func $0
+    (struct.set $A 0
+      (struct.new $A
+        ;; These two struct.gets will both be refined. That of $B will be
+        ;; refined to a get of a null, at which point the get of $A could get
+        ;; confused and not know what type it is reading from (since in the IR,
+        ;; we depend on the ref for that). The pass should not error here while
+        ;; it refines both the struct type's fields to nullref, after which the
+        ;; code here will be unreachable (since we do a struct.get from a
+        ;; nullref).
+        (struct.get $A 0
+          (struct.get $B 0
+            (struct.new_default $B)
+          )
+        )
+      )
+      (ref.null none)
+    )
+  )
+)


### PR DESCRIPTION
If we have

```wat
(struct.get $A
  (struct.get $B
```

then if both types end up refined we may have a problem. If the inner one is
refined to emit `nullref` then the outer one no longer knows what type it is,
since it depends on the type of the `ref` child for that in our IR.

To avoid that, note all the types first before optimizing.

Diff without whitespace is smaller.