### PR TITLE
Validate tag param types

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3683,11 +3683,16 @@ static void validateTags(Module& module, ValidationInfo& info) {
         curr->name,
         "Multivalue tag type requires multivalue [--enable-multivalue]");
     }
+    FeatureSet features;
     for (const auto& param : curr->sig.params) {
+      features |= param.getFeatures();
       info.shouldBeTrue(param.isConcrete(),
                         curr->name,
                         "Values in a tag should have concrete types");
     }
+    info.shouldBeTrue(features <= module.features,
+                 curr->name,
+                 "all param types in tags should be allowed");
   }
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3691,8 +3691,8 @@ static void validateTags(Module& module, ValidationInfo& info) {
                         "Values in a tag should have concrete types");
     }
     info.shouldBeTrue(features <= module.features,
-                 curr->name,
-                 "all param types in tags should be allowed");
+                      curr->name,
+                      "all param types in tags should be allowed");
   }
 }
 


### PR DESCRIPTION
We already validated function params, but were missing tags.

Without this the fuzzer can get confused if a type is only used in a tag.