### PR TITLE
ConstantFieldPropagation: Track copied values properly

### DIFF
--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -228,23 +228,6 @@ struct ConstantFieldPropagation : public Pass {
     BoolStructValuesMap combinedCopyInfos;
     functionCopyInfos.combineInto(combinedCopyInfos);
 
-std::cout << "new " << combinedNewInfos.size() << '\n';
-for (auto& [k, v] : combinedNewInfos) {
-  std::cout << "  " << k << ": ";
-  for (auto x : v) x.dump(std::cout);
-  std::cout << '\n';
-}
-
-std::cout << "set " << combinedSetInfos.size() << '\n';
-for (auto& [k, v] : combinedSetInfos) {
-  std::cout << "  " << k << ": ";
-  for (auto x : v) x.dump(std::cout);
-  std::cout << '\n';
-}
-
-// copied fields need to be treated like sets and not like news in the prop - prop bot hwayz
-// PCV scanner can return copied fields. a copied field can just copy the new into into the sets before the sets are propagated.
-
     // Handle subtyping. |combinedInfo| so far contains data that represents
     // each struct.new and struct.set's operation on the struct type used in
     // that instruction. That is, if we do a struct.set to type T, the value was

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -54,18 +54,13 @@ struct Bool {
   Bool() {}
   Bool(bool value) : value(value) {}
 
-  operator bool() const {
-    return value;
-  }
+  operator bool() const { return value; }
 
-  void combine(bool other) {
-    value = value || other;
-  }
+  void combine(bool other) { value = value || other; }
 };
 
 using BoolStructValuesMap = StructUtils::StructValuesMap<Bool>;
-using BoolFunctionStructValuesMap =
-  StructUtils::FunctionStructValuesMap<Bool>;
+using BoolFunctionStructValuesMap = StructUtils::FunctionStructValuesMap<Bool>;
 
 // Optimize struct gets based on what we've learned about writes.
 //
@@ -161,18 +156,16 @@ private:
 struct PCVScanner
   : public StructUtils::StructScanner<PossibleConstantValues, PCVScanner> {
   std::unique_ptr<Pass> create() override {
-    return std::make_unique<PCVScanner>(functionNewInfos, functionSetGetInfos, functionCopyInfos);
+    return std::make_unique<PCVScanner>(
+      functionNewInfos, functionSetGetInfos, functionCopyInfos);
   }
 
-  PCVScanner(PCVFunctionStructValuesMap&
-               functionNewInfos,
-             PCVFunctionStructValuesMap&
-               functionSetInfos,
-             BoolFunctionStructValuesMap&
-               functionCopyInfos
-                              )
+  PCVScanner(PCVFunctionStructValuesMap& functionNewInfos,
+             PCVFunctionStructValuesMap& functionSetInfos,
+             BoolFunctionStructValuesMap& functionCopyInfos)
     : StructUtils::StructScanner<PossibleConstantValues, PCVScanner>(
-        functionNewInfos, functionSetInfos), functionCopyInfos(functionCopyInfos) {}
+        functionNewInfos, functionSetInfos),
+      functionCopyInfos(functionCopyInfos) {}
 
   void noteExpression(Expression* expr,
                       HeapType type,

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2270,7 +2270,7 @@
       ;; and not $B, so it looks like a perfect copy of $A->$A.
       (select (result (ref null $A))
         (ref.null $A)
-          (local.tee $B
+        (local.tee $B
           (struct.new $B
             (i32.const 20)
           )
@@ -2286,7 +2286,7 @@
     ;; This should not turn into 20, since just based on values flowing to
     ;; fields we cannot infer that (the value will be 10, but CFP cannot infer
     ;; that either - that would require tracking references through locals
-    // etc.).
+    ;; etc.).
     (struct.get $B 0
       (local.get $B)
     )

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2222,3 +2222,71 @@
     )
   )
 )
+
+(module
+  (rec
+   ;; CHECK:      (rec
+   ;; CHECK-NEXT:  (type $A (struct (field (mut i32))))
+   (type $A (struct (field (mut i32))))
+   ;; CHECK:       (type $B (struct_subtype (field (mut i32)) $A))
+   (type $B (struct_subtype (field (mut i32)) $A))
+  )
+
+  ;; CHECK:      (type $i32_=>_i32 (func (param i32) (result i32)))
+
+  ;; CHECK:      (func $test (type $i32_=>_i32) (param $0 i32) (result i32)
+  ;; CHECK-NEXT:  (local $A (ref $A))
+  ;; CHECK-NEXT:  (local $B (ref $B))
+  ;; CHECK-NEXT:  (struct.set $A 0
+  ;; CHECK-NEXT:   (select (result (ref null $A))
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:    (local.tee $B
+  ;; CHECK-NEXT:     (struct.new $B
+  ;; CHECK-NEXT:      (i32.const 20)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (struct.get $A 0
+  ;; CHECK-NEXT:    (struct.new $A
+  ;; CHECK-NEXT:     (i32.const 10)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.get $B 0
+  ;; CHECK-NEXT:   (local.get $B)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $0 i32) (result i32)
+    (local $A (ref $A))
+    (local $B (ref $B))
+    ;; This set is part of a copy, as th value is a struct.get. The copy is on
+    ;; $A, but the reference we operate on is an instance of $B, actually. So
+    ;; the value read at the end is in fact 10. That is, this test verifies
+    ;; that we track the copied value even though the copy is on $A but it
+    ;; affects $B.
+    (struct.set $A 0
+      ;; This select is used to keep the type that reaches the struct.set $A,
+      ;; and not $B, so it looks like a perfect copy of $A->$A.
+      (select (result (ref null $A))
+        (ref.null $A)
+          (local.tee $B
+          (struct.new $B
+            (i32.const 20)
+          )
+        )
+        (i32.const 0)
+      )
+      (struct.get $A 0
+        (struct.new $A
+          (i32.const 10)
+        )
+      )
+    )
+    ;; This should not turn into 20 (or 10), since just based on values flowing
+    ;; to fields we cannot infer that.
+    (struct.get $B 0
+      (local.get $B)
+    )
+  )
+)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2260,7 +2260,7 @@
   (func $test (param $0 i32) (result i32)
     (local $A (ref $A))
     (local $B (ref $B))
-    ;; This set is part of a copy, as th value is a struct.get. The copy is on
+    ;; This set is part of a copy, as the value is a struct.get. The copy is on
     ;; $A, but the reference we operate on is an instance of $B, actually. So
     ;; the value read at the end is in fact 10. That is, this test verifies
     ;; that we track the copied value even though the copy is on $A but it
@@ -2283,8 +2283,10 @@
         )
       )
     )
-    ;; This should not turn into 20 (or 10), since just based on values flowing
-    ;; to fields we cannot infer that.
+    ;; This should not turn into 20, since just based on values flowing to
+    ;; fields we cannot infer that (the value will be 10, but CFP cannot infer
+    ;; that either - that would require tracking references through locals
+    // etc.).
     (struct.get $B 0
       (local.get $B)
     )


### PR DESCRIPTION
The logic ignored copied values, which was fine for `struct.get` operations but
not for `struct.new`. See the example in the comment and the testcase.