### PR TITLE
[NFC] Simplify the HeapTypeStore

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -119,9 +119,6 @@ struct HeapTypeInfo {
   constexpr bool isStruct() const { return kind == StructKind; }
   constexpr bool isArray() const { return kind == ArrayKind; }
   constexpr bool isData() const { return isStruct() || isArray(); }
-
-  bool operator==(const HeapTypeInfo& other) const;
-  bool operator!=(const HeapTypeInfo& other) const { return !(*this == other); }
 };
 
 // Helper for coinductively checking whether a pair of Types or HeapTypes are in
@@ -588,10 +585,6 @@ HeapTypeInfo::~HeapTypeInfo() {
       return;
   }
   WASM_UNREACHABLE("unexpected kind");
-}
-
-bool HeapTypeInfo::operator==(const HeapTypeInfo& other) const {
-  return this == &other;
 }
 
 struct TypeStore {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -386,11 +386,6 @@ public:
   size_t operator()(const wasm::TypeInfo& info) const;
 };
 
-template<> class hash<wasm::HeapTypeInfo> {
-public:
-  size_t operator()(const wasm::HeapTypeInfo& info) const;
-};
-
 template<typename T> class hash<reference_wrapper<const T>> {
 public:
   size_t operator()(const reference_wrapper<const T>& ref) const {
@@ -2795,11 +2790,6 @@ size_t hash<wasm::TypeInfo>::operator()(const wasm::TypeInfo& info) const {
       return digest;
   }
   WASM_UNREACHABLE("unexpected kind");
-}
-
-size_t
-hash<wasm::HeapTypeInfo>::operator()(const wasm::HeapTypeInfo& info) const {
-  return wasm::hash(uintptr_t(&info));
 }
 
 } // namespace std


### PR DESCRIPTION
Now that we support only isorecursive typing, which canonicalizes heap types by
the rec group rather than individually, we no longer need a canonicalizing store
for heap types. Simplify the `Store` implementation, which was previously
generic over both `HeapType`s and `Type`s, to instead work only for `Type`s.
Replace `globalHeapTypeStore` with a simple vector to keep canonicalized
`HeapTypeInfo`s alive. Also simplify global canonicalization to not replace heap
type uses, since that is already done separately as part of isorecursive rec
group canonicalization.

This simplification does require adding new information to
`CanonicalizationState`, but further work will simplify that away as well.