### PR TITLE
Remove BinaryenIRToBinaryWriter::visit

### DIFF
--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -411,10 +411,6 @@ public:
     : BinaryenIRWriter<BinaryenIRToBinaryWriter>(func), parent(parent),
       writer(parent, o, func, sourceMap, DWARF), sourceMap(sourceMap) {}
 
-  void visit(Expression* curr) {
-    BinaryenIRWriter<BinaryenIRToBinaryWriter>::visit(curr);
-  }
-
   void emit(Expression* curr) { writer.visit(curr); }
   void emitHeader() {
     if (func->prologLocation.size()) {


### PR DESCRIPTION
This is not used. We use the parent's `visit` method instead: https://github.com/WebAssembly/binaryen/blob/585af93ec6a22feb8954bc118f0bff997d1fc165/src/wasm-stack.h#L233-L262