### PR TITLE
[NFC] Rewrite isorecursive canonicalization

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -631,6 +631,7 @@ struct TypeBuilder {
     const std::vector<HeapType>& operator*() const {
       return std::get<std::vector<HeapType>>(*this);
     }
+    const std::vector<HeapType>* operator->() const { return &*(*this); }
     const Error* getError() const { return std::get_if<Error>(this); }
   };
 


### PR DESCRIPTION
Rewrite the type canonicalization algorithm to fully canonicalize a single rec
group at a time rather than canonicalizing multiple rec groups at once in
multiple stages. The previous code was useful when it had to be shared with
equirecursive and nominal canonicalization, but was much more complicated than
necessary for just isorecursive canonicalization, which is all we support today.