### PR TITLE
[NFC] Simplify `Tuple` by making it an alias of `TypeList`

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -162,7 +162,7 @@ void GlobalTypeRewriter::mapTypes(const TypeMap& oldToNewTypes) {
       }
       if (type.isTuple()) {
         auto tuple = type.getTuple();
-        for (auto& t : tuple.types) {
+        for (auto& t : tuple) {
           t = getNew(t);
         }
         return Type(tuple);
@@ -284,7 +284,7 @@ Type GlobalTypeRewriter::getTempType(Type type) {
   if (type.isTuple()) {
     auto& tuple = type.getTuple();
     auto newTuple = tuple;
-    for (auto& t : newTuple.types) {
+    for (auto& t : newTuple) {
       t = getTempType(t);
     }
     return typeBuilder.getTempTupleType(newTuple);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -254,7 +254,7 @@ void TypeNamePrinter::print(HeapType type) {
 
 void TypeNamePrinter::print(const Tuple& tuple) {
   auto sep = "";
-  for (auto type : tuple.types) {
+  for (auto type : tuple) {
     os << sep;
     sep = "_";
     print(type);

--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -587,11 +587,11 @@ size_t shapeHash(Type a) {
 }
 
 bool shapeEq(const Tuple& a, const Tuple& b) {
-  if (a.types.size() != b.types.size()) {
+  if (a.size() != b.size()) {
     return false;
   }
-  for (size_t i = 0; i < a.types.size(); ++i) {
-    if (!shapeEq(a.types[i], b.types[i])) {
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (!shapeEq(a[i], b[i])) {
       return false;
     }
   }
@@ -599,8 +599,8 @@ bool shapeEq(const Tuple& a, const Tuple& b) {
 }
 
 size_t shapeHash(const Tuple& a) {
-  auto digest = hash(a.types.size());
-  for (auto type : a.types) {
+  auto digest = hash(a.size());
+  for (auto type : a) {
     hash_combine(digest, shapeHash(type));
   }
   return digest;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -51,11 +51,13 @@ void destroyAllTypesForTestingPurposesOnly();
 class Type;
 class HeapType;
 class RecGroup;
-struct Tuple;
 struct Signature;
 struct Field;
 struct Struct;
 struct Array;
+
+using TypeList = std::vector<Type>;
+using Tuple = TypeList;
 
 enum Nullability { NonNullable, Nullable };
 enum Mutability { Immutable, Mutable };
@@ -453,31 +455,6 @@ public:
   HeapType operator[](size_t i) const { return *Iterator{{this, i}}; }
 };
 
-using TypeList = std::vector<Type>;
-
-// Passed by reference rather than by value because it can own an unbounded
-// amount of data.
-struct Tuple {
-  TypeList types;
-  Tuple() : types() {}
-  Tuple(std::initializer_list<Type> types) : types(types) { validate(); }
-  Tuple(const TypeList& types) : types(types) { validate(); }
-  Tuple(TypeList&& types) : types(std::move(types)) { validate(); }
-
-  bool operator==(const Tuple& other) const { return types == other.types; }
-  bool operator!=(const Tuple& other) const { return !(*this == other); }
-  std::string toString() const;
-
-private:
-  void validate() {
-#ifndef NDEBUG
-    for (auto type : types) {
-      assert(type.isSingle());
-    }
-#endif
-  }
-};
-
 struct Signature {
   Type params;
   Type results;
@@ -691,10 +668,6 @@ namespace std {
 template<> class hash<wasm::Type> {
 public:
   size_t operator()(const wasm::Type&) const;
-};
-template<> class hash<wasm::Tuple> {
-public:
-  size_t operator()(const wasm::Tuple&) const;
 };
 template<> class hash<wasm::Signature> {
 public:

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -687,6 +687,14 @@ struct RecGroupStore {
 
 static RecGroupStore globalRecGroupStore;
 
+void validateTuple(const Tuple& tuple) {
+#ifndef NDEBUG
+  for (auto type : tuple) {
+    assert(type.isSingle());
+  }
+#endif
+}
+
 } // anonymous namespace
 
 void destroyAllTypesForTestingPurposesOnly() {
@@ -698,6 +706,7 @@ void destroyAllTypesForTestingPurposesOnly() {
 Type::Type(std::initializer_list<Type> types) : Type(Tuple(types)) {}
 
 Type::Type(const Tuple& tuple) {
+  validateTuple(tuple);
 #ifndef NDEBUG
   for (auto type : tuple) {
     assert(!isTemp(type) && "Leaking temporary type!");

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -522,11 +522,11 @@ TypeInfo::~TypeInfo() {
 
 std::optional<Type> TypeInfo::getCanonical() const {
   if (isTuple()) {
-    if (tuple.types.size() == 0) {
+    if (tuple.size() == 0) {
       return Type::none;
     }
-    if (tuple.types.size() == 1) {
-      return tuple.types[0];
+    if (tuple.size() == 1) {
+      return tuple[0];
     }
   }
   return {};
@@ -699,7 +699,7 @@ Type::Type(std::initializer_list<Type> types) : Type(Tuple(types)) {}
 
 Type::Type(const Tuple& tuple) {
 #ifndef NDEBUG
-  for (auto type : tuple.types) {
+  for (auto type : tuple) {
     assert(!isTemp(type) && "Leaking temporary type!");
   }
 #endif
@@ -708,7 +708,7 @@ Type::Type(const Tuple& tuple) {
 
 Type::Type(Tuple&& tuple) {
 #ifndef NDEBUG
-  for (auto type : tuple.types) {
+  for (auto type : tuple) {
     assert(!isTemp(type) && "Leaking temporary type!");
   }
 #endif
@@ -1030,7 +1030,7 @@ Type Type::getLeastUpperBound(Type a, Type b) {
 
 size_t Type::size() const {
   if (isTuple()) {
-    return getTypeInfo(*this)->tuple.types.size();
+    return getTypeInfo(*this)->tuple.size();
   } else {
     // TODO: unreachable is special and expands to {unreachable} currently.
     // see also: https://github.com/WebAssembly/binaryen/issues/3062
@@ -1040,7 +1040,7 @@ size_t Type::size() const {
 
 const Type& Type::Iterator::operator*() const {
   if (parent->isTuple()) {
-    return getTypeInfo(*parent)->tuple.types[index];
+    return getTypeInfo(*parent)->tuple[index];
   } else {
     // TODO: see comment in Type::size()
     assert(index == 0 && parent->id != Type::none && "Index out of bounds");
@@ -1427,7 +1427,6 @@ template<typename T> static std::string genericToString(const T& t) {
 }
 std::string Type::toString() const { return genericToString(*this); }
 std::string HeapType::toString() const { return genericToString(*this); }
-std::string Tuple::toString() const { return genericToString(*this); }
 std::string Signature::toString() const { return genericToString(*this); }
 std::string Struct::toString() const { return genericToString(*this); }
 std::string Array::toString() const { return genericToString(*this); }
@@ -1560,11 +1559,11 @@ bool SubTyper::isSubType(HeapType a, HeapType b) {
 }
 
 bool SubTyper::isSubType(const Tuple& a, const Tuple& b) {
-  if (a.types.size() != b.types.size()) {
+  if (a.size() != b.size()) {
     return false;
   }
-  for (size_t i = 0; i < a.types.size(); ++i) {
-    if (!isSubType(a.types[i], b.types[i])) {
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (!isSubType(a[i], b[i])) {
       return false;
     }
   }
@@ -1745,7 +1744,7 @@ std::ostream& TypePrinter::print(HeapType type) {
 std::ostream& TypePrinter::print(const Tuple& tuple) {
   os << '(';
   auto sep = "";
-  for (Type type : tuple.types) {
+  for (Type type : tuple) {
     os << sep;
     sep = " ";
     print(type);
@@ -1924,8 +1923,8 @@ size_t RecGroupHasher::hash(const HeapTypeInfo& info) const {
 }
 
 size_t RecGroupHasher::hash(const Tuple& tuple) const {
-  size_t digest = wasm::hash(tuple.types.size());
-  for (auto type : tuple.types) {
+  size_t digest = wasm::hash(tuple.size());
+  for (auto type : tuple) {
     hash_combine(digest, hash(type));
   }
   return digest;
@@ -2045,11 +2044,10 @@ bool RecGroupEquator::eq(const HeapTypeInfo& a, const HeapTypeInfo& b) const {
 }
 
 bool RecGroupEquator::eq(const Tuple& a, const Tuple& b) const {
-  return std::equal(a.types.begin(),
-                    a.types.end(),
-                    b.types.begin(),
-                    b.types.end(),
-                    [&](const Type& x, const Type& y) { return eq(x, y); });
+  return std::equal(
+    a.begin(), a.end(), b.begin(), b.end(), [&](const Type& x, const Type& y) {
+      return eq(x, y);
+    });
 }
 
 bool RecGroupEquator::eq(const Field& a, const Field& b) const {
@@ -2123,7 +2121,7 @@ template<typename Self> void TypeGraphWalkerBase<Self>::scanType(Type* type) {
   auto* info = getTypeInfo(*type);
   switch (info->kind) {
     case TypeInfo::TupleKind: {
-      auto& types = info->tuple.types;
+      auto& types = info->tuple;
       for (auto it = types.rbegin(); it != types.rend(); ++it) {
         taskList.push_back(Task::scan(&*it));
       }
@@ -2247,7 +2245,7 @@ HeapType TypeBuilder::getTempHeapType(size_t i) {
 
 Type TypeBuilder::getTempTupleType(const Tuple& tuple) {
   Type ret = impl->typeStore.insert(tuple);
-  if (tuple.types.size() > 1) {
+  if (tuple.size() > 1) {
     return markTemp(ret);
   } else {
     // No new tuple was created, so the result might not be temporary.
@@ -2508,7 +2506,7 @@ TypeBuilder::BuildResult TypeBuilder::build() {
 
 namespace std {
 
-template<> class hash<wasm::TypeList> {
+template<> class hash<wasm::Tuple> {
 public:
   size_t operator()(const wasm::TypeList& types) const {
     auto digest = wasm::hash(types.size());
@@ -2532,10 +2530,6 @@ public:
 
 size_t hash<wasm::Type>::operator()(const wasm::Type& type) const {
   return wasm::hash(type.getID());
-}
-
-size_t hash<wasm::Tuple>::operator()(const wasm::Tuple& tuple) const {
-  return wasm::hash(tuple.types);
 }
 
 size_t hash<wasm::Signature>::operator()(const wasm::Signature& sig) const {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3357,7 +3357,7 @@ static void validateImports(Module& module, ValidationInfo& info) {
     if (Intrinsics(module).isCallWithoutEffects(curr)) {
       auto lastParam = curr->getParams();
       if (lastParam.isTuple()) {
-        lastParam = lastParam.getTuple().types.back();
+        lastParam = lastParam.getTuple().back();
       }
       info.shouldBeTrue(lastParam.isFunction(),
                         curr->name,

--- a/test/example/typeinfo.cpp
+++ b/test/example/typeinfo.cpp
@@ -79,7 +79,7 @@ void test_compound() {
            Type(otherArray, NonNullable).getID());
   }
   {
-    Tuple singleTuple({Type::i32});
+    Tuple singleTuple = {Type::i32};
     assert(Type(singleTuple).getID() == Type::i32);
 
     Tuple tuple({Type::i32, Type::f64});


### PR DESCRIPTION
Rather than wrap a `TypeList`, make `Tuple` an alias of `TypeList`. This means
removing `Tuple::toString`, but that had no callers and was of limited use for
debugging anyway. In return, the use of tuples becomes much less verbose.

In the future, it may make sense to remove one of `Tuple` and `TypeList`.