### PR TITLE
CtorEval Fuzzer: Generalize export regex

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1263,7 +1263,7 @@ class CtorEval(TestCaseHandler):
 
         # get the list of exports, so we can tell ctor-eval what to eval.
         wat = run([in_bin('wasm-dis'), wasm] + FEATURE_OPTS)
-        p = re.compile(r'^ [(]export "([^"]+)" [(]func')
+        p = re.compile(r'^ [(]export "(.*[^\\]?)" [(]func')
         exports = []
         for line in wat.splitlines():
             m = p.match(line)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1263,7 +1263,7 @@ class CtorEval(TestCaseHandler):
 
         # get the list of exports, so we can tell ctor-eval what to eval.
         wat = run([in_bin('wasm-dis'), wasm] + FEATURE_OPTS)
-        p = re.compile(r'^ [(]export "([\d\w$+-_:.]+)" [(]func')
+        p = re.compile(r'^ [(]export "([^"]+)" [(]func')
         exports = []
         for line in wat.splitlines():
             m = p.match(line)


### PR DESCRIPTION
Just look for export names as "" with some non-" in the middle.

That should handle everything but escaping of " in an export name (which I don't know
if we can handle in a regex?).

Missing from the old regex: spaces, parens, and probably more. Spaces and parens
are used in the test suite, which is how this was noticed by the fuzzer.