### PR TITLE
Add a gtest fixture for tests checking printed output

### DIFF
--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -1,13 +1,14 @@
 #include "analysis/cfg.h"
-#include "support/colors.h"
-#include "wasm-s-parser.h"
+#include "print-test.h"
 #include "wasm.h"
 #include "gtest/gtest.h"
 
 using namespace wasm;
 using namespace wasm::analysis;
 
-TEST(CFGTest, Print) {
+using CFGTest = PrintTest;
+
+TEST_F(CFGTest, Print) {
   auto moduleText = R"wasm(
     (module
       (func $foo
@@ -69,16 +70,12 @@ TEST(CFGTest, Print) {
 )cfg";
 
   Module wasm;
-  SExpressionParser parser(moduleText);
-  SExpressionWasmBuilder builder(wasm, *(*parser.root)[0], IRProfile::Normal);
+  parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("foo"));
 
-  bool colors = Colors::isEnabled();
-  Colors::setEnabled(false);
   std::stringstream ss;
   cfg.print(ss);
-  Colors::setEnabled(colors);
 
   EXPECT_EQ(ss.str(), cfgText);
 }

--- a/test/gtest/print-test.h
+++ b/test/gtest/print-test.h
@@ -1,0 +1,28 @@
+#include <iostream>
+
+#include "support/colors.h"
+#include "wasm-s-parser.h"
+#include "wasm.h"
+#include "gtest/gtest.h"
+
+#ifndef wasm_test_gtest_print_test_h
+#define wasm_test_gtest_print_test_h
+
+// Helper test fixture for parsing wast and checking some printed output.
+class PrintTest : public ::testing::Test {
+  bool colors = Colors::isEnabled();
+
+public:
+  PrintTest() { Colors::setEnabled(false); }
+
+protected:
+  void TearDown() override { Colors::setEnabled(colors); }
+
+  void parseWast(wasm::Module& wasm, const std::string& wast) {
+    wasm::SExpressionParser parser(wast.c_str());
+    wasm::SExpressionWasmBuilder builder(
+      wasm, *(*parser.root)[0], wasm::IRProfile::Normal);
+  }
+};
+
+#endif


### PR DESCRIPTION
Such tests all have to handle disabling and re-enabling color output for printed
wast and have to handle parsing input wast, so add a test fixture that makes
these tasks easier.