### PR TITLE
Dynamic Sized Bitvector Powerset Lattice for Static Analysis

### DIFF
--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -1,9 +1,10 @@
 #ifndef wasm_analysis_lattice_h
 #define wasm_analysis_lattice_h
 
-#include "wasm.h"
-#include <bitset>
 #include <iostream>
+#include <vector>
+
+#include "wasm.h"
 
 namespace wasm::analysis {
 
@@ -30,21 +31,34 @@ constexpr bool is_lattice =
 
 // Represents a powerset lattice element (i.e. a set) as a bitvector. A true
 // means that an element is present in the set.
-template<size_t N> struct BitsetPowersetLattice {
-  std::bitset<N> value;
+class FinitePowersetLattice {
+  std::vector<bool> bitvector;
+  size_t trues;
 
-  static BitsetPowersetLattice<N> getBottom();
-  static bool isTop(const BitsetPowersetLattice<N>& element);
-  static bool isBottom(const BitsetPowersetLattice<N>& element);
+  FinitePowersetLattice(size_t size);
+
+public:
+  void set(size_t index, bool value);
+  bool get(size_t index);
+  size_t size() { return bitvector.size(); }
+  size_t countElements() { return trues; }
+
+  using iterator = std::vector<bool>::const_iterator;
+  iterator begin() { return bitvector.cbegin(); }
+  iterator end() { return bitvector.cend(); }
+
+  static FinitePowersetLattice getBottom(size_t size);
+  bool isTop(const FinitePowersetLattice& element);
+  bool isBottom(const FinitePowersetLattice& element);
 
   // Compares two lattice elements and returns a result indicating the
   // left element's relation to the right element.
-  static LatticeComparison compare(const BitsetPowersetLattice<N>& left,
-                                   const BitsetPowersetLattice<N>& right);
+  static LatticeComparison compare(const FinitePowersetLattice& left,
+                                   const FinitePowersetLattice& right);
 
   // Calculates the LUB of this current (left) lattice element with some right
   // element. It then updates this current lattice element to the LUB in place.
-  void getLeastUpperBound(const BitsetPowersetLattice<N>& right);
+  bool getLeastUpperBound(const FinitePowersetLattice& right);
 
   // Prints out the bits in the bitvector for a lattice element.
   void print(std::ostream& os);

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -20,10 +20,10 @@ constexpr bool has_getLeastUpperBound = std::
   is_invocable_r<void, decltype(&T::getLeastUpperBound), T, const T&>::value;
 template<typename T>
 constexpr bool has_isTop =
-  std::is_invocable_r<bool, decltype(T::isTop), const T&>::value;
+  std::is_invocable_r<bool, decltype(&T::isTop), T>::value;
 template<typename T>
 constexpr bool has_isBottom =
-  std::is_invocable_r<bool, decltype(T::isBottom), const T&>::value;
+  std::is_invocable_r<bool, decltype(&T::isBottom), T>::value;
 
 template<typename T>
 constexpr bool is_lattice =
@@ -33,8 +33,13 @@ constexpr bool is_lattice =
 // means that an element is present in the set.
 class FinitePowersetLattice {
   std::vector<bool> bitvector;
+
+  // Counts the number of elements in the set (i. e. number of trues in the
+  // bitvector).
   size_t trues;
 
+  // Size of the top lattice element must be specified, as it determines the set
+  // of the bitvector.
   FinitePowersetLattice(size_t size);
 
 public:
@@ -47,9 +52,11 @@ public:
   iterator begin() { return bitvector.cbegin(); }
   iterator end() { return bitvector.cend(); }
 
+  // Returns an instance of the bottom lattice element. The size of the the top
+  // lattice element must be specified.
   static FinitePowersetLattice getBottom(size_t size);
-  bool isTop(const FinitePowersetLattice& element);
-  bool isBottom(const FinitePowersetLattice& element);
+  bool isTop();
+  bool isBottom();
 
   // Compares two lattice elements and returns a result indicating the
   // left element's relation to the right element.
@@ -58,6 +65,7 @@ public:
 
   // Calculates the LUB of this current (left) lattice element with some right
   // element. It then updates this current lattice element to the LUB in place.
+  // Returns true if the current lattice element was changed, false otherwise.
   bool getLeastUpperBound(const FinitePowersetLattice& right);
 
   // Prints out the bits in the bitvector for a lattice element.

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -82,10 +82,10 @@ public:
     bool isTop() { return count() == bitvector.size(); }
     bool isBottom() { return count() == 0; }
 
-    // Calculates the LUB of this element with some right element and sets
+    // Calculates the LUB of this element with some other element and sets
     // this element to the LUB in place. Returns true if this element before
     // this method call was different than the LUB.
-    bool makeLeastUpperBound(const Element& right);
+    bool makeLeastUpperBound(const Element& other);
 
     // Prints out the bits in the bitvector for a lattice element.
     void print(std::ostream& os);

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -32,44 +32,49 @@ constexpr bool is_lattice =
 // Represents a powerset lattice element (i.e. a set) as a bitvector. A true
 // means that an element is present in the set.
 class FinitePowersetLattice {
-  std::vector<bool> bitvector;
-
-  // Counts the number of elements in the set (i. e. number of trues in the
-  // bitvector).
-  size_t trues;
-
-  // Size of the top lattice element must be specified, as it determines the set
-  // of the bitvector.
-  FinitePowersetLattice(size_t size);
+  // The size of the set that the powerset lattice was created from. This is
+  // equivalent to the size of the Top lattice element.
+  size_t setSize;
 
 public:
-  void set(size_t index, bool value);
-  bool get(size_t index);
-  size_t size() { return bitvector.size(); }
-  size_t countElements() { return trues; }
+  FinitePowersetLattice(size_t setSize) : setSize(setSize) {}
 
-  using iterator = std::vector<bool>::const_iterator;
-  iterator begin() { return bitvector.cbegin(); }
-  iterator end() { return bitvector.cend(); }
+  class Element {
+  private:
+    std::vector<bool> bitvector;
+    size_t elementSize;
 
-  // Returns an instance of the bottom lattice element. The size of the the top
-  // lattice element must be specified.
-  static FinitePowersetLattice getBottom(size_t size);
-  bool isTop();
-  bool isBottom();
+    Element(size_t latticeSetSize)
+      : bitvector(latticeSetSize), elementSize(0) {}
+
+  public:
+    using iterator = std::vector<bool>::const_iterator;
+    iterator begin() { return bitvector.cbegin(); }
+    iterator end() { return bitvector.cend(); }
+    bool get(size_t index) { return bitvector[index]; }
+    void set(size_t index, bool value);
+    size_t size() { return elementSize; }
+    bool isTop() { return elementSize == bitvector.size(); }
+    bool isBottom() { return elementSize == 0; }
+
+    // Calculates the LUB of this element with some right element and sets
+    // this element to the LUB in place. Returns true if this element before
+    // this method call was different than the LUB.
+    bool getLeastUpperBound(const Element& right);
+
+    // Prints out the bits in the bitvector for a lattice element.
+    void print(std::ostream& os);
+
+    friend FinitePowersetLattice;
+  };
 
   // Compares two lattice elements and returns a result indicating the
   // left element's relation to the right element.
-  static LatticeComparison compare(const FinitePowersetLattice& left,
-                                   const FinitePowersetLattice& right);
+  static LatticeComparison compare(const Element& left, const Element& right);
 
-  // Calculates the LUB of this current (left) lattice element with some right
-  // element. It then updates this current lattice element to the LUB in place.
-  // Returns true if the current lattice element was changed, false otherwise.
-  bool getLeastUpperBound(const FinitePowersetLattice& right);
-
-  // Prints out the bits in the bitvector for a lattice element.
-  void print(std::ostream& os);
+  // Returns an instance of the bottom lattice element. The size of the the top
+  // lattice element must be specified.
+  Element getBottom();
 };
 
 } // namespace wasm::analysis

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -39,23 +39,19 @@ class FinitePowersetLattice {
 public:
   FinitePowersetLattice(size_t setSize) : setSize(setSize) {}
 
-  class Element {
-  private:
+  struct Element {
     std::vector<bool> bitvector;
-    size_t elementSize;
 
-    Element(size_t latticeSetSize)
-      : bitvector(latticeSetSize), elementSize(0) {}
+    size_t count();
 
-  public:
     using iterator = std::vector<bool>::const_iterator;
     iterator begin() { return bitvector.cbegin(); }
     iterator end() { return bitvector.cend(); }
     bool get(size_t index) { return bitvector[index]; }
-    void set(size_t index, bool value);
-    size_t size() { return elementSize; }
-    bool isTop() { return elementSize == bitvector.size(); }
-    bool isBottom() { return elementSize == 0; }
+    void set(size_t index, bool value) { bitvector[index] = value; }
+
+    bool isTop() { return count() == bitvector.size(); }
+    bool isBottom() { return count() == 0; }
 
     // Calculates the LUB of this element with some right element and sets
     // this element to the LUB in place. Returns true if this element before
@@ -64,6 +60,9 @@ public:
 
     // Prints out the bits in the bitvector for a lattice element.
     void print(std::ostream& os);
+
+  private:
+    Element(size_t latticeSetSize) : bitvector(latticeSetSize) {}
 
     friend FinitePowersetLattice;
   };

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -72,6 +72,19 @@ public:
     // Prints out the bits in the bitvector for a lattice element.
     void print(std::ostream& os);
 
+    Element(Element&& source) : bitvector(std::move(source.bitvector)) {}
+    Element(Element& source) : bitvector(source.bitvector) {}
+
+    Element& operator=(Element&& source) {
+      bitvector = std::move(source.bitvector);
+      return *this;
+    }
+
+    Element& operator=(const Element& source) {
+      bitvector = source.bitvector;
+      return *this;
+    }
+
   private:
     // This constructs a bottom element, given the lattice set size. Used by the
     // lattice's getBottom function.

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -29,9 +29,12 @@ template<typename T>
 constexpr bool is_lattice =
   has_compare<T>&& has_getLeastUpperBound<T>&& has_isTop<T>&& has_isBottom<T>;
 
-// Represents a powerset lattice element (i.e. a set) as a bitvector. A true
-// means that an element is present in the set.
+// Represents a powerset lattice which is constructed from a finite set which
+// can be represented by a bitvector. Set elements are represented by
+// FinitePowersetLattice::Element, which represents members present in each
+// element by bits in the bitvector.
 class FinitePowersetLattice {
+
   // The size of the set that the powerset lattice was created from. This is
   // equivalent to the size of the Top lattice element.
   size_t setSize;
@@ -39,9 +42,17 @@ class FinitePowersetLattice {
 public:
   FinitePowersetLattice(size_t setSize) : setSize(setSize) {}
 
+  // This represents an element of a powerset lattice. The element is itself a
+  // set which has set members. The bitvector tracks which possible members of
+  // the element are actually present.
   struct Element {
+    // If bitvector[i] is true, then member i is present in the lattice element,
+    // otherwise it isn't.
     std::vector<bool> bitvector;
 
+    // Counts the number of members present the element itself. For instance, if
+    // we had {true, false, true}, the count would be 2. O(N) operation which
+    // iterates through the bitvector.
     size_t count();
 
     using iterator = std::vector<bool>::const_iterator;
@@ -62,6 +73,8 @@ public:
     void print(std::ostream& os);
 
   private:
+    // This constructs a bottom element, given the lattice set size. Used by the
+    // lattice's getBottom function.
     Element(size_t latticeSetSize) : bitvector(latticeSetSize) {}
 
     friend FinitePowersetLattice;
@@ -71,10 +84,11 @@ public:
   // left element's relation to the right element.
   static LatticeComparison compare(const Element& left, const Element& right);
 
-  // Returns an instance of the bottom lattice element. The size of the the top
-  // lattice element must be specified.
+  // Returns an instance of the bottom lattice element.
   Element getBottom();
 };
+
+static_assert(has_getLeastUpperBound<FinitePowersetLattice::Element>);
 
 } // namespace wasm::analysis
 

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -88,11 +88,11 @@ inline void MonotoneCFGAnalyzer<Lattice>::fromCFG(CFG* cfg) {
     BlockState<Lattice>& currBlock = stateBlocks.at(index);
     BasicBlock::Predecessors preds = currBlock.cfgBlock->preds();
     BasicBlock::Successors succs = currBlock.cfgBlock->succs();
-    for (auto pred : preds) {
+    for (auto& pred : preds) {
       currBlock.predecessors.push_back(&stateBlocks[basicBlockToState[&pred]]);
     }
 
-    for (auto succ : succs) {
+    for (auto& succ : succs) {
       currBlock.successors.push_back(&stateBlocks[basicBlockToState[&succ]]);
     }
   }

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -48,10 +48,18 @@ template<typename Lattice> inline void BlockState<Lattice>::transfer() {
 template<typename Lattice>
 inline void BlockState<Lattice>::print(std::ostream& os) {
   os << "State Block: " << index << std::endl;
-  os << "State at beginning: ";
+  os << "Beginning State: ";
   beginningState.print(os);
-  os << std::endl << "State at end: ";
+  os << std::endl << "End State: ";
   endState.print(os);
+  os << std::endl << "Predecessors:";
+  for (auto pred : predecessors) {
+    os << " " << pred->cfgBlock->getIndex();
+  }
+  os << std::endl << "Successors:";
+  for (auto succ : successors) {
+    os << " " << succ->cfgBlock->getIndex();
+  }
   os << std::endl << "Intermediate States (reverse order): " << std::endl;
 
   currState = endState;
@@ -112,7 +120,7 @@ inline void MonotoneCFGAnalyzer<Lattice>::evaluate() {
 
     // For each expression, applies the transfer function, using the expression,
     // on the state of the expression it depends upon (here the next expression)
-    // to arrive at the expression's state. THe beginning and end states of the
+    // to arrive at the expression's state. The beginning and end states of the
     // CFG block will be updated.
     currBlockState.transfer();
 

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -14,8 +14,9 @@ template<typename Lattice>
 inline BlockState<Lattice>::BlockState(const BasicBlock* underlyingBlock,
                                        Lattice& lattice)
   : index(underlyingBlock->getIndex()), cfgBlock(underlyingBlock),
-    beginningState(lattice.getBottom()), endState(lattice.getBottom()),
-    currState(lattice.getBottom()) {}
+    beginningState(std::move(lattice.getBottom())),
+    endState(std::move(lattice.getBottom())),
+    currState(std::move(lattice.getBottom())) {}
 
 // In our current limited implementation, we just update state on gets
 // and sets of local indices.
@@ -42,7 +43,7 @@ template<typename Lattice> inline void BlockState<Lattice>::transfer() {
     BlockState::visit(*cfgIter);
     ++cfgIter;
   }
-  beginningState = currState;
+  beginningState = std::move(currState);
 }
 
 template<typename Lattice>

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -16,6 +16,7 @@ template<typename Lattice> struct MonotoneCFGAnalyzer;
 // A node which contains all the lattice states for a given CFG node.
 template<typename Lattice>
 struct BlockState : public Visitor<BlockState<Lattice>> {
+  static_assert(is_lattice<Lattice>);
   // All states are set to the bottom lattice element in this constructor.
   BlockState(const BasicBlock* underlyingBlock, Lattice& lattice);
 

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -15,14 +15,15 @@ struct MonotoneCFGAnalyzer;
 
 // A node which contains all the lattice states for a given CFG node.
 struct BlockState : public Visitor<BlockState> {
-  static_assert(is_lattice<FinitePowersetLattice>);
-  BlockState(const BasicBlock* underlyingBlock, size_t size);
+  BlockState(const BasicBlock* underlyingBlock,
+             FinitePowersetLattice::Element begin,
+             FinitePowersetLattice::Element end);
 
   void addPredecessor(BlockState* pred);
   void addSuccessor(BlockState* succ);
 
-  FinitePowersetLattice& getFirstState();
-  FinitePowersetLattice& getLastState();
+  FinitePowersetLattice::Element& getFirstState();
+  FinitePowersetLattice::Element& getLastState();
 
   // Transfer function implementation. Modifies the state for a particular
   // expression type.
@@ -42,11 +43,11 @@ private:
   Index index;
   const BasicBlock* cfgBlock;
   // State at beginning of CFG node.
-  FinitePowersetLattice beginningState;
+  FinitePowersetLattice::Element beginningState;
   // State at the end of the CFG node.
-  FinitePowersetLattice endState;
+  FinitePowersetLattice::Element endState;
   // Holds intermediate state values.
-  FinitePowersetLattice currState;
+  FinitePowersetLattice::Element currState;
   std::vector<BlockState*> predecessors;
   std::vector<BlockState*> successors;
 
@@ -64,6 +65,8 @@ struct MonotoneCFGAnalyzer {
   void print(std::ostream& os);
 
 private:
+  MonotoneCFGAnalyzer(size_t size);
+  FinitePowersetLattice lattice;
   std::vector<BlockState> stateBlocks;
 };
 

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -16,6 +16,7 @@ template<typename Lattice> struct MonotoneCFGAnalyzer;
 // A node which contains all the lattice states for a given CFG node.
 template<typename Lattice>
 struct BlockState : public Visitor<BlockState<Lattice>> {
+  // All states are set to the bottom lattice element in this constructor.
   BlockState(const BasicBlock* underlyingBlock, Lattice& lattice);
 
   typename Lattice::Element& getFirstState() { return beginningState; }
@@ -27,11 +28,10 @@ struct BlockState : public Visitor<BlockState<Lattice>> {
   void visitLocalGet(LocalGet* curr);
 
   // Executes the transfer function on all the expressions of the corresponding
-  // CFG and then propagates the state to all predecessors (which depend on the
-  // current node).
+  // CFG node.
   void transfer();
 
-  // prints out all states.
+  // Prints out all intermediate states in the block.
   void print(std::ostream& os);
 
 private:
@@ -44,14 +44,13 @@ private:
   typename Lattice::Element endState;
   // Holds intermediate state values.
   typename Lattice::Element currState;
-  std::vector<BlockState*> predecessors;
-  std::vector<BlockState*> successors;
+  std::vector<BlockState<Lattice>*> predecessors;
+  std::vector<BlockState<Lattice>*> successors;
 
   friend MonotoneCFGAnalyzer<Lattice>;
 };
 
-template<typename Lattice>
-struct MonotoneCFGAnalyzer {
+template<typename Lattice> struct MonotoneCFGAnalyzer {
   MonotoneCFGAnalyzer(Lattice lattice) : lattice(lattice) {}
 
   // Constructs a graph of BlockState objects which parallels
@@ -61,6 +60,7 @@ struct MonotoneCFGAnalyzer {
   // Runs the worklist algorithm to compute the states for the BlockList graph.
   void evaluate();
 
+  // Prints out all BlockStates in this analyzer.
   void print(std::ostream& os);
 
 private:

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -11,18 +11,18 @@
 
 namespace wasm::analysis {
 
-template<size_t N> struct MonotoneCFGAnalyzer;
+struct MonotoneCFGAnalyzer;
 
 // A node which contains all the lattice states for a given CFG node.
-template<size_t N> struct BlockState : public Visitor<BlockState<N>> {
-  static_assert(is_lattice<BitsetPowersetLattice<N>>);
-  BlockState(const BasicBlock* underlyingBlock);
+struct BlockState : public Visitor<BlockState> {
+  // static_assert(is_lattice<FinitePowersetLattice>);
+  BlockState(const BasicBlock* underlyingBlock, size_t size);
 
   void addPredecessor(BlockState* pred);
   void addSuccessor(BlockState* succ);
 
-  BitsetPowersetLattice<N>& getFirstState();
-  BitsetPowersetLattice<N>& getLastState();
+  FinitePowersetLattice& getFirstState();
+  FinitePowersetLattice& getLastState();
 
   // Transfer function implementation. Modifies the state for a particular
   // expression type.
@@ -42,23 +42,21 @@ private:
   Index index;
   const BasicBlock* cfgBlock;
   // State at beginning of CFG node.
-  BitsetPowersetLattice<N> beginningState;
+  FinitePowersetLattice beginningState;
   // State at the end of the CFG node.
-  BitsetPowersetLattice<N> endState;
+  FinitePowersetLattice endState;
   // Holds intermediate state values.
-  BitsetPowersetLattice<N> currState;
+  FinitePowersetLattice currState;
   std::vector<BlockState*> predecessors;
   std::vector<BlockState*> successors;
 
-  friend MonotoneCFGAnalyzer<N>;
+  friend MonotoneCFGAnalyzer;
 };
 
-template<size_t N> struct MonotoneCFGAnalyzer {
-  static_assert(is_lattice<BitsetPowersetLattice<N>>);
-
+struct MonotoneCFGAnalyzer {
   // Constructs a graph of BlockState objects which parallels
   // the CFG graph. Each CFG node corresponds to a BlockState node.
-  static MonotoneCFGAnalyzer<N> fromCFG(CFG* cfg);
+  static MonotoneCFGAnalyzer fromCFG(CFG* cfg, size_t size);
 
   // Runs the worklist algorithm to compute the states for the BlockList graph.
   void evaluate();
@@ -66,8 +64,7 @@ template<size_t N> struct MonotoneCFGAnalyzer {
   void print(std::ostream& os);
 
 private:
-  std::vector<BlockState<N>> stateBlocks;
-  friend BlockState<N>;
+  std::vector<BlockState> stateBlocks;
 };
 
 } // namespace wasm::analysis

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -15,7 +15,7 @@ struct MonotoneCFGAnalyzer;
 
 // A node which contains all the lattice states for a given CFG node.
 struct BlockState : public Visitor<BlockState> {
-  // static_assert(is_lattice<FinitePowersetLattice>);
+  static_assert(is_lattice<FinitePowersetLattice>);
   BlockState(const BasicBlock* underlyingBlock, size_t size);
 
   void addPredecessor(BlockState* pred);

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -17,14 +17,6 @@ FinitePowersetLattice::compare(const FinitePowersetLattice::Element& left,
   // True in right, false in left.
   bool rightNotLeft = false;
 
-  if (left.elementSize > right.elementSize) {
-    // If there are more elements in the left, some must not be in the right.
-    leftNotRight = true;
-  } else if (right.elementSize > left.elementSize) {
-    // If there are more elements in the right, some must not be in the left.
-    rightNotLeft = true;
-  }
-
   size_t size = left.bitvector.size();
 
   for (size_t i = 0; i < size; ++i) {
@@ -57,16 +49,12 @@ inline FinitePowersetLattice::Element FinitePowersetLattice::getBottom() {
   return result;
 }
 
-inline void FinitePowersetLattice::Element::set(size_t index, bool value) {
-  // The set function updates the count of true bits in the bitvector.
-  if (value != bitvector.at(index)) {
-    if (value) {
-      elementSize += 1;
-    } else {
-      elementSize -= 1;
-    }
+inline size_t FinitePowersetLattice::Element::count() {
+  size_t count = 0;
+  for (auto it : bitvector) {
+    count += it;
   }
-  bitvector.at(index) = value;
+  return count;
 }
 
 // Least upper bound is implemented as a logical OR between the bitvectors on
@@ -78,9 +66,8 @@ inline bool FinitePowersetLattice::Element::getLeastUpperBound(
 
   bool modified = false;
   for (size_t i = 0; i < bitvector.size(); ++i) {
-    if (!bitvector.at(i) && right.bitvector.at(i)) {
-      bitvector.at(i) = true;
-      elementSize++;
+    if (!bitvector[i] && right.bitvector[i]) {
+      bitvector[i] = true;
       modified = true;
     }
   }

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -20,8 +20,8 @@ FinitePowersetLattice::compare(const FinitePowersetLattice::Element& left,
   size_t size = left.bitvector.size();
 
   for (size_t i = 0; i < size; ++i) {
-    leftNotRight |= (left.bitvector[i] & !right.bitvector[i]);
-    rightNotLeft |= (right.bitvector[i] & !left.bitvector[i]);
+    leftNotRight |= (left.bitvector[i] && !right.bitvector[i]);
+    rightNotLeft |= (right.bitvector[i] && !left.bitvector[i]);
 
     // We can end early if we know neither is a subset of the other.
     if (leftNotRight && rightNotLeft) {
@@ -68,8 +68,8 @@ inline bool FinitePowersetLattice::Element::makeLeastUpperBound(
   for (size_t i = 0; i < bitvector.size(); ++i) {
     // Bit is flipped on self only if self is false and other is true when self
     // and other are OR'ed together.
-    modified |= (!bitvector[i] & other.bitvector[i]);
-    bitvector[i] = bitvector[i] | other.bitvector[i];
+    modified |= (!bitvector[i] && other.bitvector[i]);
+    bitvector[i] = bitvector[i] || other.bitvector[i];
   }
 
   return modified;

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -20,8 +20,8 @@ FinitePowersetLattice::compare(const FinitePowersetLattice::Element& left,
   size_t size = left.bitvector.size();
 
   for (size_t i = 0; i < size; ++i) {
-    leftNotRight |= (left.bitvector[i] && !right.bitvector[i]);
-    rightNotLeft |= (right.bitvector[i] && !left.bitvector[i]);
+    leftNotRight |= (left.bitvector[i] & !right.bitvector[i]);
+    rightNotLeft |= (right.bitvector[i] & !left.bitvector[i]);
 
     // We can end early if we know neither is a subset of the other.
     if (leftNotRight && rightNotLeft) {
@@ -60,16 +60,16 @@ inline size_t FinitePowersetLattice::Element::count() {
 // both sides. We return true if a bit is flipped in-place on the left so the
 // worklist algorithm will know if when to enqueue more work.
 inline bool FinitePowersetLattice::Element::makeLeastUpperBound(
-  const FinitePowersetLattice::Element& right) {
+  const FinitePowersetLattice::Element& other) {
   // Both must be from powerset lattice of the same set.
-  assert(right.bitvector.size() == bitvector.size());
+  assert(other.bitvector.size() == bitvector.size());
 
   bool modified = false;
   for (size_t i = 0; i < bitvector.size(); ++i) {
-    // Bit is flipped on left only if left is false and right is true when left
-    // and right are OR'ed together.
-    modified |= (!bitvector[i] && right.bitvector[i]);
-    bitvector[i] = bitvector[i] || right.bitvector[i];
+    // Bit is flipped on self only if self is false and other is true when self
+    // and other are OR'ed together.
+    modified |= (!bitvector[i] & other.bitvector[i]);
+    bitvector[i] = bitvector[i] | other.bitvector[i];
   }
 
   return modified;

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -18,18 +18,18 @@ inline FinitePowersetLattice FinitePowersetLattice::getBottom(size_t size) {
   return result;
 }
 
-inline bool FinitePowersetLattice::isTop(const FinitePowersetLattice& element) {
+inline bool FinitePowersetLattice::isTop() {
   // Top lattice element is the set containing all possible elements.
-  return element.trues == element.bitvector.size();
+  return trues == bitvector.size();
 }
 
-inline bool
-FinitePowersetLattice::isBottom(const FinitePowersetLattice& element) {
+inline bool FinitePowersetLattice::isBottom() {
   // Bottom lattice element is the empty set.
-  return element.trues == 0;
+  return trues == 0;
 }
 
 inline void FinitePowersetLattice::set(size_t index, bool value) {
+  // The set function updates the count of true bits in the bitvector.
   if (value != bitvector.at(index)) {
     if (value) {
       trues += 1;
@@ -47,6 +47,7 @@ inline bool FinitePowersetLattice::get(size_t index) {
 inline LatticeComparison
 FinitePowersetLattice::compare(const FinitePowersetLattice& left,
                                const FinitePowersetLattice& right) {
+  // Both must be from the powerset lattice of the same set.
   assert(left.bitvector.size() == right.bitvector.size());
 
   // True in left, false in right.
@@ -56,8 +57,10 @@ FinitePowersetLattice::compare(const FinitePowersetLattice& left,
   bool rightNotLeft = false;
 
   if (left.trues > right.trues) {
+    // If there are more elements in the left, some must not be in the right.
     leftNotRight = true;
   } else if (right.trues > left.trues) {
+    // If there are more elements in the right, some must not be in the left.
     rightNotLeft = true;
   }
 
@@ -70,6 +73,7 @@ FinitePowersetLattice::compare(const FinitePowersetLattice& left,
       rightNotLeft = true;
     }
 
+    // We can end early if we know neither is a subset of the other.
     if (leftNotRight && rightNotLeft) {
       return NO_RELATION;
     }
@@ -87,8 +91,11 @@ FinitePowersetLattice::compare(const FinitePowersetLattice& left,
   return NO_RELATION;
 }
 
+// Least upper bound is implemented as a logical OR between the bitvectors on
+// both sides.
 inline bool
 FinitePowersetLattice::getLeastUpperBound(const FinitePowersetLattice& right) {
+  // Both must be from powerset lattice of the same set.
   assert(right.bitvector.size() == bitvector.size());
 
   bool modified = false;

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -59,7 +59,7 @@ inline size_t FinitePowersetLattice::Element::count() {
 // Least upper bound is implemented as a logical OR between the bitvectors on
 // both sides. We return true if a bit is flipped in-place on the left so the
 // worklist algorithm will know if when to enqueue more work.
-inline bool FinitePowersetLattice::Element::getLeastUpperBound(
+inline bool FinitePowersetLattice::Element::makeLeastUpperBound(
   const FinitePowersetLattice::Element& right) {
   // Both must be from powerset lattice of the same set.
   assert(right.bitvector.size() == bitvector.size());

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -111,8 +111,8 @@ FinitePowersetLattice::getLeastUpperBound(const FinitePowersetLattice& right) {
 }
 
 inline void FinitePowersetLattice::print(std::ostream& os) {
-  for (auto it = bitvector.rbegin(); it != bitvector.rend(); ++it) {
-    os << *it;
+  for (auto it : bitvector) {
+    os << it;
   }
 }
 

--- a/src/analysis/sign-lattice.cpp
+++ b/src/analysis/sign-lattice.cpp
@@ -11,11 +11,9 @@ private:
   Sign value;
 
 public:
-  static bool isTop(const SignLattice& element) { return element.value == TOP; }
+  bool isTop() { return value == TOP; }
 
-  static bool isBottom(const SignLattice& element) {
-    return element.value == BOTTOM;
-  }
+  bool isBottom() { return value == BOTTOM; }
 
   static LatticeComparison compare(const SignLattice& left,
                                    const SignLattice& right) {

--- a/src/analysis/sign-lattice.cpp
+++ b/src/analysis/sign-lattice.cpp
@@ -42,6 +42,4 @@ public:
   }
 };
 
-static_assert(is_lattice<SignLattice>);
-
 } // namespace wasm::analysis

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -121,7 +121,7 @@ block
 drop
 000
 local.get $2
-100
+001
 local.set $2
 000
 i32.const 1
@@ -129,11 +129,11 @@ i32.const 1
 local.set $1
 000
 local.get $0
-001
+100
 drop
-001
+100
 local.get $0
-001
+100
 local.set $0
 000
 i32.const 1
@@ -183,15 +183,15 @@ TEST_F(CFGTest, NonlinearLiveness) {
   auto analyzerText = R"analyzer(CFG Analyzer
 State Block: 0
 State at beginning: 00
-State at end: 01
+State at end: 10
 Intermediate States (reverse order): 
-01
+10
 i32.eq
-01
+10
 i32.const 2
-01
+10
 local.get $0
-01
+10
 local.set $0
 00
 i32.const 1
@@ -206,14 +206,14 @@ local.set $1
 i32.const 4
 00
 State Block: 2
-State at beginning: 01
+State at beginning: 10
 State at end: 00
 Intermediate States (reverse order): 
 00
 drop
 00
 local.get $0
-01
+10
 State Block: 3
 State at beginning: 00
 State at end: 00

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -145,8 +145,9 @@ End
   parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
-  MonotoneCFGAnalyzer analyzer =
-    MonotoneCFGAnalyzer::fromCFG(&cfg, wasm.getFunction("bar")->getNumLocals());
+  FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
+  MonotoneCFGAnalyzer<FinitePowersetLattice> analyzer(lattice);
+  analyzer.fromCFG(&cfg);
   analyzer.evaluate();
 
   std::stringstream ss;
@@ -228,8 +229,9 @@ End
   parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
-  MonotoneCFGAnalyzer analyzer =
-    MonotoneCFGAnalyzer::fromCFG(&cfg, wasm.getFunction("bar")->getNumLocals());
+  FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
+  MonotoneCFGAnalyzer<FinitePowersetLattice> analyzer(lattice);
+  analyzer.fromCFG(&cfg);
   analyzer.evaluate();
 
   std::stringstream ss;

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -112,8 +112,10 @@ TEST_F(CFGTest, LinearLiveness) {
 
   auto analyzerText = R"analyzer(CFG Analyzer
 State Block: 0
-State at beginning: 000
-State at end: 000
+Beginning State: 000
+End State: 000
+Predecessors:
+Successors:
 Intermediate States (reverse order): 
 000
 block
@@ -183,8 +185,10 @@ TEST_F(CFGTest, NonlinearLiveness) {
 
   auto analyzerText = R"analyzer(CFG Analyzer
 State Block: 0
-State at beginning: 00
-State at end: 10
+Beginning State: 00
+End State: 10
+Predecessors:
+Successors: 1 2
 Intermediate States (reverse order): 
 10
 i32.eq
@@ -198,8 +202,10 @@ local.set $0
 i32.const 1
 00
 State Block: 1
-State at beginning: 00
-State at end: 00
+Beginning State: 00
+End State: 00
+Predecessors: 0
+Successors: 3
 Intermediate States (reverse order): 
 00
 local.set $1
@@ -207,8 +213,10 @@ local.set $1
 i32.const 4
 00
 State Block: 2
-State at beginning: 10
-State at end: 00
+Beginning State: 10
+End State: 00
+Predecessors: 0
+Successors: 3
 Intermediate States (reverse order): 
 00
 drop
@@ -216,8 +224,10 @@ drop
 local.get $0
 10
 State Block: 3
-State at beginning: 00
-State at end: 00
+Beginning State: 00
+End State: 00
+Predecessors: 2 1
+Successors:
 Intermediate States (reverse order): 
 00
 block

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -145,8 +145,8 @@ End
   parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
-  const size_t sz = 3;
-  MonotoneCFGAnalyzer<sz> analyzer = MonotoneCFGAnalyzer<sz>::fromCFG(&cfg);
+  MonotoneCFGAnalyzer analyzer =
+    MonotoneCFGAnalyzer::fromCFG(&cfg, wasm.getFunction("bar")->getNumLocals());
   analyzer.evaluate();
 
   std::stringstream ss;
@@ -228,8 +228,8 @@ End
   parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
-  const size_t sz = 2;
-  MonotoneCFGAnalyzer<sz> analyzer = MonotoneCFGAnalyzer<sz>::fromCFG(&cfg);
+  MonotoneCFGAnalyzer analyzer =
+    MonotoneCFGAnalyzer::fromCFG(&cfg, wasm.getFunction("bar")->getNumLocals());
   analyzer.evaluate();
 
   std::stringstream ss;


### PR DESCRIPTION
This change introduces a finite-height powerset lattice `FinitePowersetLattice` where each element's height is determined when constructed in runtime. This is implemented using a vector of `bool`'s. The previous finite-height powerset lattice implementation had used a `bitset`, which forced the size of each lattice element to be determined statically at compile time, which is a significant drawback, as most powerset lattice sizes are determined by the input program.

This change also modifies `BlockState` and `MonotoneCFGAnalyzer` to be templated on a generic lattice type instead of using a hardcoded lattice. It also fixes an iterator bug in `MonotoneCFGAnalyzer::fromCFG` which assigned a temporary iterator object as predecessor and successor pointers to `BlockState`'s instead of pointers to actual `BlockState` objects.