### PR TITLE
[wasm-metadce] Consider ref.func as introducing a dependency + fix rooting of segment offsets

### DIFF
--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -209,7 +209,9 @@ struct MetaDCEGraph {
           // it's an import.
           dceName = parent->importIdToDCENode[parent->getGlobalImportId(name)];
         }
-        if (!parentDceName.isNull()) {
+        if (parentDceName.isNull()) {
+          parent->roots.insert(dceName);
+        } else {
           parent->nodes[parentDceName].reaches.push_back(dceName);
         }
       }

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -195,6 +195,17 @@ struct MetaDCEGraph {
 
       void visitGlobalGet(GlobalGet* curr) { handleGlobal(curr->name); }
       void visitGlobalSet(GlobalSet* curr) { handleGlobal(curr->name); }
+      void visitRefFunc(RefFunc* curr) {
+        Name dceName;
+        if (!getModule()->getFunction(curr->func)->imported()) {
+          dceName = parent->functionToDCENode[curr->func];
+        } else {
+          dceName =
+            parent->importIdToDCENode[parent->getFunctionImportId(curr->func)];
+        }
+        assert(!parentDceName.isNull());
+        parent->nodes[parentDceName].reaches.push_back(dceName);
+      }
 
     private:
       MetaDCEGraph* parent;
@@ -250,18 +261,8 @@ struct MetaDCEGraph {
         return std::make_unique<Scanner>(parent);
       }
 
-      void visitCall(Call* curr) {
-        if (!getModule()->getFunction(curr->target)->imported()) {
-          parent->nodes[parent->functionToDCENode[getFunction()->name]]
-            .reaches.push_back(parent->functionToDCENode[curr->target]);
-        } else {
-          assert(parent->functionToDCENode.count(getFunction()->name) > 0);
-          parent->nodes[parent->functionToDCENode[getFunction()->name]]
-            .reaches.push_back(
-              parent
-                ->importIdToDCENode[parent->getFunctionImportId(curr->target)]);
-        }
-      }
+      void visitCall(Call* curr) { handleFunction(curr->target); }
+      void visitRefFunc(RefFunc* curr) { handleFunction(curr->func); }
       void visitGlobalGet(GlobalGet* curr) { handleGlobal(curr->name); }
       void visitGlobalSet(GlobalSet* curr) { handleGlobal(curr->name); }
       void visitThrow(Throw* curr) { handleTag(curr->tag); }
@@ -273,6 +274,18 @@ struct MetaDCEGraph {
 
     private:
       MetaDCEGraph* parent;
+
+      void handleFunction(Name name) {
+        if (!getModule()->getFunction(name)->imported()) {
+          parent->nodes[parent->functionToDCENode[getFunction()->name]]
+            .reaches.push_back(parent->functionToDCENode[name]);
+        } else {
+          assert(parent->functionToDCENode.count(getFunction()->name) > 0);
+          parent->nodes[parent->functionToDCENode[getFunction()->name]]
+            .reaches.push_back(
+              parent->importIdToDCENode[parent->getFunctionImportId(name)]);
+        }
+      }
 
       void handleGlobal(Name name) {
         if (!getFunction()) {

--- a/test/metadce/ref-func.wast
+++ b/test/metadce/ref-func.wast
@@ -1,0 +1,11 @@
+(module
+ (import "env" "f1" (func $f1))
+ (import "env" "f2" (func $f2))
+
+ (export "g" (global $g))
+ (export "f" (func $f))
+
+ (global $g funcref (ref.func $f1))
+
+ (func $f (result funcref) (ref.func $f2))
+)

--- a/test/metadce/ref-func.wast.dced
+++ b/test/metadce/ref-func.wast.dced
@@ -1,0 +1,13 @@
+(module
+ (type $none_=>_none (func))
+ (type $none_=>_funcref (func (result funcref)))
+ (import "env" "f2" (func $f2 (type $none_=>_none)))
+ (import "env" "f1" (func $f1 (type $none_=>_none)))
+ (global $g funcref (ref.func $f1))
+ (elem declare func $f2)
+ (export "g" (global $g))
+ (export "f" (func $f))
+ (func $f (type $none_=>_funcref) (result funcref)
+  (ref.func $f2)
+ )
+)

--- a/test/metadce/ref-func.wast.dced.stdout
+++ b/test/metadce/ref-func.wast.dced.stdout
@@ -1,0 +1,2 @@
+unused: f1
+unused: f2

--- a/test/metadce/ref-func.wast.dced.stdout
+++ b/test/metadce/ref-func.wast.dced.stdout
@@ -1,2 +1,0 @@
-unused: f1
-unused: f2

--- a/test/metadce/ref-func.wast.graph.txt
+++ b/test/metadce/ref-func.wast.graph.txt
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "root",
+    "reaches": ["f", "g"],
+    "root": true
+  },
+  {
+    "name": "f",
+    "export": "f"
+  },
+  {
+    "name": "g",
+    "export": "g"
+  },
+  {
+    "name": "f1",
+    "import": ["env", "f1"]
+  },
+  {
+    "name": "f2",
+    "import": ["env", "f2"]
+  },
+]

--- a/test/metadce/segments.wast
+++ b/test/metadce/segments.wast
@@ -1,0 +1,14 @@
+(module
+ (import "env" "g1" (global $g1 i32))
+ (import "env" "g2" (global $g2 i32))
+
+ (table $tbl funcref)
+ (elem (offset (global.get $g1)) funcref (ref.func $f))
+
+ (memory 3)
+ (data (offset (global.get $g2)) "xxx")
+
+ (export "f" (func $f))
+ (func $f (param i32)
+  (call_indirect (param i32) (local.get 0) (i32.load8_u (i32.const 0))))
+)

--- a/test/metadce/segments.wast.dced
+++ b/test/metadce/segments.wast.dced
@@ -1,0 +1,18 @@
+(module
+ (type $i32_=>_none (func (param i32)))
+ (import "env" "g1" (global $g1 i32))
+ (import "env" "g2" (global $g2 i32))
+ (memory $0 3)
+ (data $0 (global.get $g2) "xxx")
+ (table $tbl 0 funcref)
+ (elem $0 (global.get $g1) $f)
+ (export "f" (func $f))
+ (func $f (type $i32_=>_none) (param $0 i32)
+  (call_indirect $tbl (type $i32_=>_none)
+   (local.get $0)
+   (i32.load8_u
+    (i32.const 0)
+   )
+  )
+ )
+)

--- a/test/metadce/segments.wast.dced.stdout
+++ b/test/metadce/segments.wast.dced.stdout
@@ -1,2 +1,0 @@
-unused: g1
-unused: g2

--- a/test/metadce/segments.wast.dced.stdout
+++ b/test/metadce/segments.wast.dced.stdout
@@ -1,0 +1,2 @@
+unused: g1
+unused: g2

--- a/test/metadce/segments.wast.graph.txt
+++ b/test/metadce/segments.wast.graph.txt
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "root",
+    "reaches": ["f"],
+    "root": true
+  },
+  {
+    "name": "f",
+    "export": "f"
+  },
+  {
+    "name": "g1",
+    "import": ["env", "g1"]
+  },
+  {
+    "name": "g2",
+    "import": ["env", "g2"]
+  },
+]


### PR DESCRIPTION
`wasm-metadce` could wrongly consider some functions as unused since it did not take `ref.func` into consideration.