### PR TITLE
Make the Transfer Function a Generic, Interchangeable Type for the Monotone Analyzer

### DIFF
--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -69,6 +69,10 @@ struct CFG {
   iterator end() const { return blocks.cend(); }
   size_t size() const { return blocks.size(); }
 
+  using reverse_iterator = std::vector<BasicBlock>::const_reverse_iterator;
+  reverse_iterator rbegin() const { return blocks.rbegin(); }
+  reverse_iterator rend() const { return blocks.rend(); }
+
   static CFG fromFunction(Function* func);
 
   void print(std::ostream& os, Module* wasm = nullptr) const;

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -22,8 +22,8 @@ public:
   }
 
   // Executes the transfer function on all the expressions of the corresponding
-  // CFG node, starting with the node's input state. Returns the final output
-  // state of the node.
+  // CFG node, starting with the node's input state, and changes the input state
+  // to the final output state of the node in place.
   void transfer(const BasicBlock* cfgBlock,
                 FinitePowersetLattice::Element& inputState) {
     // If the block is empty, we propagate the state by inputState =

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -10,8 +10,7 @@ class LivenessTransferFunction : public Visitor<LivenessTransferFunction> {
   FinitePowersetLattice::Element* currState;
 
 public:
-  LivenessTransferFunction(FinitePowersetLattice& lattice)
-    : currState(nullptr) {}
+  LivenessTransferFunction() : currState(nullptr) {}
 
   // Transfer function implementation. Modifies the state for a particular
   // expression type. In our current limited implementation, we just update
@@ -34,7 +33,7 @@ public:
   transfer(const BasicBlock* cfgBlock,
            FinitePowersetLattice::Element& inputState) {
     // If the block is empty, we propagate the state by inputState =
-    // outputSTate.
+    // outputState.
 
     FinitePowersetLattice::Element outputState = inputState;
     currState = &outputState;

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -1,0 +1,89 @@
+#ifndef wasm_analysis_liveness_transfer_function_h
+#define wasm_analysis_liveness_transfer_function_h
+
+#include "lattice.h"
+#include "monotone-analyzer.h"
+
+namespace wasm::analysis {
+
+class LivenessTransferFunction : public Visitor<LivenessTransferFunction> {
+  FinitePowersetLattice::Element currState;
+
+public:
+  LivenessTransferFunction(FinitePowersetLattice& lattice)
+    : currState(lattice.getBottom()) {}
+
+  // Transfer function implementation. Modifies the state for a particular
+  // expression type. In our current limited implementation, we just update
+  // state on gets and sets of local indices.
+  void visitLocalSet(LocalSet* curr) { currState.set(curr->index, false); }
+  void visitLocalGet(LocalGet* curr) { currState.set(curr->index, true); }
+
+  // Executes the transfer function on all the expressions of the corresponding
+  // CFG node.
+  void transfer(BlockState<FinitePowersetLattice>& currBlock) {
+    // If the block is empty, we propagate the state by endState = currState,
+    // then currState = beginningState.
+
+    // Compute transfer function for all expressions in the CFG block.
+    auto cfgIter = currBlock.getCFGBlock()->rbegin();
+    currState = currBlock.getLastState();
+
+    while (cfgIter != currBlock.getCFGBlock()->rend()) {
+      // Run transfer function.
+      LivenessTransferFunction::visit(*cfgIter);
+      ++cfgIter;
+    }
+
+    currBlock.getFirstState() = std::move(currState);
+  }
+
+  void enqueueWorklist(
+    const std::vector<BlockState<FinitePowersetLattice>>& stateBlocks,
+    std::queue<Index>& worklist) {
+    for (auto it = stateBlocks.rbegin(); it != stateBlocks.rend(); ++it) {
+      worklist.push((*it).getCFGBlock()->getIndex());
+    }
+  }
+
+  using iterator =
+    std::vector<BlockState<FinitePowersetLattice>*>::const_iterator;
+  iterator depsBegin(BlockState<FinitePowersetLattice>& currBlock) {
+    return currBlock.predecessorsBegin();
+  }
+  iterator depsEnd(BlockState<FinitePowersetLattice>& currBlock) {
+    return currBlock.predecessorsEnd();
+  }
+
+  FinitePowersetLattice::Element&
+  getInputState(BlockState<FinitePowersetLattice>* currBlock) {
+    return currBlock->getLastState();
+  }
+  FinitePowersetLattice::Element&
+  getOutputState(BlockState<FinitePowersetLattice>* currBlock) {
+    return currBlock->getFirstState();
+  }
+
+  void print(std::ostream& os, BlockState<FinitePowersetLattice>& currBlock) {
+    os << "Intermediate States (reverse order): " << std::endl;
+    currState = currBlock.getLastState();
+    currState.print(os);
+    os << std::endl;
+    auto cfgIter = currBlock.getCFGBlock()->rbegin();
+
+    // Since we don't store the intermediate states in the BlockState, we need
+    // to re-run the transfer function on all the CFG node expressions to
+    // reconstruct the intermediate states here.
+    while (cfgIter != currBlock.getCFGBlock()->rend()) {
+      os << ShallowExpression{*cfgIter} << std::endl;
+      LivenessTransferFunction::visit(*cfgIter);
+      currState.print(os);
+      os << std::endl;
+      ++cfgIter;
+    }
+  }
+};
+
+} // namespace wasm::analysis
+
+#endif // wasm_analysis_liveness_transfer_function_h

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -38,6 +38,12 @@ public:
     currBlock.getFirstState() = std::move(currState);
   }
 
+  // Enqueues the worklist before the worklist algorithm is run. For
+  // liveness analysis, we are doing a backward analysis, so we want
+  // to enqueue the worklist backward so that later CFG blocks are
+  // run before earlier CFG blocks. This improves performance by
+  // reducing the number of state propagations needed, since we are
+  // naturally following the backward flow at the beginning.
   void enqueueWorklist(
     const std::vector<BlockState<FinitePowersetLattice>>& stateBlocks,
     std::queue<Index>& worklist) {
@@ -46,6 +52,7 @@ public:
     }
   }
 
+  // Predecessors depend on use for information.
   using iterator =
     std::vector<BlockState<FinitePowersetLattice>*>::const_iterator;
   iterator depsBegin(BlockState<FinitePowersetLattice>& currBlock) {
@@ -55,6 +62,8 @@ public:
     return currBlock.predecessorsEnd();
   }
 
+  // We start at the last state and end at the first state in a
+  // backward analysis.
   FinitePowersetLattice::Element&
   getInputState(BlockState<FinitePowersetLattice>* currBlock) {
     return currBlock->getLastState();
@@ -64,6 +73,9 @@ public:
     return currBlock->getFirstState();
   }
 
+  // Prints the intermediate states of each BlockState currBlock by applying
+  // the transfer function on each expression of the CFG block. This data is
+  // not stored in the BlockState itself.
   void print(std::ostream& os, BlockState<FinitePowersetLattice>& currBlock) {
     os << "Intermediate States (reverse order): " << std::endl;
     currState = currBlock.getLastState();

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -47,14 +47,14 @@ public:
   // run before earlier CFG blocks. This improves performance by
   // reducing the number of state propagations needed, since we are
   // naturally following the backward flow at the beginning.
-  void enqueueWorklist(CFG* cfg, std::queue<Index>& worklist) {
-    for (auto it = cfg->rbegin(); it != cfg->rend(); ++it) {
-      worklist.push((*it).getIndex());
+  void enqueueWorklist(CFG& cfg, std::queue<const BasicBlock*>& worklist) {
+    for (auto it = cfg.rbegin(); it != cfg.rend(); ++it) {
+      worklist.push(&(*it));
     }
   }
 
   // Predecessors depend on current basic block for information.
-  _indirect_ptr_vec<BasicBlock> getDependents(const BasicBlock* currBlock) {
+  BasicBlock::Predecessors getDependents(const BasicBlock* currBlock) {
     return currBlock->preds();
   }
 

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -13,41 +13,13 @@ namespace wasm::analysis {
 template<typename Lattice>
 inline BlockState<Lattice>::BlockState(const BasicBlock* underlyingBlock,
                                        Lattice& lattice)
-  : index(underlyingBlock->getIndex()), cfgBlock(underlyingBlock),
-    beginningState(lattice.getBottom()), endState(lattice.getBottom()),
-    currState(lattice.getBottom()) {}
+  : cfgBlock(underlyingBlock),
+    beginningState(lattice.getBottom()),
+    endState(lattice.getBottom()) {}
 
-// In our current limited implementation, we just update state on gets
-// and sets of local indices.
-template<typename Lattice>
-inline void BlockState<Lattice>::visitLocalSet(LocalSet* curr) {
-  currState.set(curr->index, false);
-}
-
-template<typename Lattice>
-inline void BlockState<Lattice>::visitLocalGet(LocalGet* curr) {
-  currState.set(curr->index, true);
-}
-
-template<typename Lattice> inline void BlockState<Lattice>::transfer() {
-  // If the block is empty, we propagate the state by endState = currState, then
-  // currState = beginningState.
-
-  // Compute transfer function for all expressions in the CFG block.
-  auto cfgIter = cfgBlock->rbegin();
-  currState = endState;
-
-  while (cfgIter != cfgBlock->rend()) {
-    // Run transfer function.
-    BlockState::visit(*cfgIter);
-    ++cfgIter;
-  }
-  beginningState = std::move(currState);
-}
-
-template<typename Lattice>
-inline void BlockState<Lattice>::print(std::ostream& os) {
-  os << "State Block: " << index << std::endl;
+// Prints out inforamtion about a CFG node's state, but not intermediate states.
+template<typename Lattice> inline void BlockState<Lattice>::print(std::ostream& os) {
+  os << "CFG Block: " << cfgBlock->getIndex() << std::endl;
   os << "Beginning State: ";
   beginningState.print(os);
   os << std::endl << "End State: ";
@@ -60,27 +32,68 @@ inline void BlockState<Lattice>::print(std::ostream& os) {
   for (auto succ : successors) {
     os << " " << succ->cfgBlock->getIndex();
   }
-  os << std::endl << "Intermediate States (reverse order): " << std::endl;
+  os << std::endl;
+}
 
-  currState = endState;
+template<typename Lattice> LivenessTransferFunction<Lattice>::LivenessTransferFunction(Lattice& lattice) : currState(lattice.getBottom()) {}
+
+// In our current limited implementation, we just update state on gets
+// and sets of local indices.
+template<typename Lattice>
+inline void LivenessTransferFunction<Lattice>::visitLocalSet(LocalSet* curr) {
+  currState.set(curr->index, false);
+}
+
+template<typename Lattice>
+inline void LivenessTransferFunction<Lattice>::visitLocalGet(LocalGet* curr) {
+  currState.set(curr->index, true);
+}
+
+template<typename Lattice> inline void LivenessTransferFunction<Lattice>::transfer(BlockState<Lattice>& currBlock) {
+  // If the block is empty, we propagate the state by endState = currState, then
+  // currState = beginningState.
+
+  // Compute transfer function for all expressions in the CFG block.
+  auto cfgIter = currBlock.getCFGBlock()->rbegin();
+  currState = currBlock.getLastState();
+
+  while (cfgIter != currBlock.getCFGBlock()->rend()) {
+    // Run transfer function.
+    LivenessTransferFunction<Lattice>::visit(*cfgIter);
+    ++cfgIter;
+  }
+
+  currBlock.getFirstState() = std::move(currState);
+}
+  
+template<typename Lattice> inline void LivenessTransferFunction<Lattice>::enqueueWorklist(const std::vector<BlockState<Lattice>>& stateBlocks, std::queue<Index>& worklist)   {
+  for (auto it = stateBlocks.rbegin(); it != stateBlocks.rend(); ++it) {
+    worklist.push((*it).getCFGBlock()->getIndex());
+  }
+}
+
+template<typename Lattice>
+inline void LivenessTransferFunction<Lattice>::print(std::ostream& os, BlockState<Lattice>& currBlock) {
+  os << "Intermediate States (reverse order): " << std::endl;
+  currState = currBlock.getLastState();
   currState.print(os);
   os << std::endl;
-  auto cfgIter = cfgBlock->rbegin();
+  auto cfgIter = currBlock.getCFGBlock()->rbegin();
 
   // Since we don't store the intermediate states in the BlockState, we need to
   // re-run the transfer function on all the CFG node expressions to reconstruct
   // the intermediate states here.
-  while (cfgIter != cfgBlock->rend()) {
+  while (cfgIter != currBlock.getCFGBlock()->rend()) {
     os << ShallowExpression{*cfgIter} << std::endl;
-    BlockState::visit(*cfgIter);
+    LivenessTransferFunction<Lattice>::visit(*cfgIter);
     currState.print(os);
     os << std::endl;
     ++cfgIter;
   }
 }
 
-template<typename Lattice>
-inline void MonotoneCFGAnalyzer<Lattice>::fromCFG(CFG* cfg) {
+template<typename Lattice, template<typename> typename TransferFunction>
+inline void MonotoneCFGAnalyzer<Lattice, TransferFunction>::fromCFG(CFG* cfg) {
   // Construct BlockStates for each BasicBlock and map each BasicBlock to each
   // BlockState's index in stateBlocks.
   std::unordered_map<const BasicBlock*, size_t> basicBlockToState;
@@ -94,25 +107,22 @@ inline void MonotoneCFGAnalyzer<Lattice>::fromCFG(CFG* cfg) {
   // according to the BasicBlock's predecessors and successors.
   for (index = 0; index < stateBlocks.size(); ++index) {
     BlockState<Lattice>& currBlock = stateBlocks.at(index);
-    BasicBlock::Predecessors preds = currBlock.cfgBlock->preds();
-    BasicBlock::Successors succs = currBlock.cfgBlock->succs();
+    BasicBlock::Predecessors preds = currBlock.getCFGBlock()->preds();
+    BasicBlock::Successors succs = currBlock.getCFGBlock()->succs();
     for (auto& pred : preds) {
-      currBlock.predecessors.push_back(&stateBlocks[basicBlockToState[&pred]]);
+      currBlock.addPredecessor(&stateBlocks[basicBlockToState[&pred]]);
     }
 
     for (auto& succ : succs) {
-      currBlock.successors.push_back(&stateBlocks[basicBlockToState[&succ]]);
+      currBlock.addSuccessor(&stateBlocks[basicBlockToState[&succ]]);
     }
   }
 }
 
-template<typename Lattice>
-inline void MonotoneCFGAnalyzer<Lattice>::evaluate() {
+template<typename Lattice, template<typename> typename TransferFunction>
+inline void MonotoneCFGAnalyzer<Lattice, TransferFunction>::evaluate() {
   std::queue<Index> worklist;
-
-  for (auto it = stateBlocks.rbegin(); it != stateBlocks.rend(); ++it) {
-    worklist.push(it->index);
-  }
+  transferFunction.enqueueWorklist(stateBlocks, worklist);
 
   while (!worklist.empty()) {
     BlockState<Lattice>& currBlockState = stateBlocks[worklist.front()];
@@ -122,23 +132,24 @@ inline void MonotoneCFGAnalyzer<Lattice>::evaluate() {
     // on the state of the expression it depends upon (here the next expression)
     // to arrive at the expression's state. The beginning and end states of the
     // CFG block will be updated.
-    currBlockState.transfer();
+    transferFunction.transfer(currBlockState);
 
-    // Propagate state to dependents
-    for (size_t j = 0; j < currBlockState.predecessors.size(); ++j) {
-      if (currBlockState.predecessors[j]->getLastState().makeLeastUpperBound(
-            currBlockState.getFirstState())) {
-        worklist.push(currBlockState.predecessors[j]->index);
+    // Propagate state to dependents.
+    for (auto dep = transferFunction.depsBegin(currBlockState); dep != transferFunction.depsEnd(currBlockState); ++dep) {
+      if (transferFunction.getInputState(*dep).makeLeastUpperBound(
+            transferFunction.getOutputState(&currBlockState))) {
+        worklist.push((*dep)->getCFGBlock()->getIndex());
       }
     }
   }
 }
 
-template<typename Lattice>
-inline void MonotoneCFGAnalyzer<Lattice>::print(std::ostream& os) {
+template<typename Lattice, template<typename> typename TransferFunction>
+inline void MonotoneCFGAnalyzer<Lattice, TransferFunction>::print(std::ostream& os) {
   os << "CFG Analyzer" << std::endl;
   for (auto state : stateBlocks) {
     state.print(os);
+    transferFunction.print(os, state);
   }
   os << "End" << std::endl;
 }

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -74,8 +74,8 @@ inline void MonotoneCFGAnalyzer<Lattice, TransferFunction>::evaluate() {
     // on the state of the expression it depends upon (here the next expression)
     // to arrive at the expression's state. The beginning and end states of the
     // CFG block will be updated.
-    typename Lattice::Element outputState = transferFunction.transfer(
-      currBlockState.getCFGBlock(), currBlockState.getInputState());
+    typename Lattice::Element outputState = currBlockState.getInputState();
+    transferFunction.transfer(currBlockState.getCFGBlock(), outputState);
 
     // Propagate state to dependents of currBlockState.
     for (auto dep = transferFunction.depsBegin(currBlockState);

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -34,7 +34,7 @@ inline void BlockState<Lattice>::print(std::ostream& os) {
 
 template<typename Lattice, typename TransferFunction>
 inline MonotoneCFGAnalyzer<Lattice, TransferFunction>::MonotoneCFGAnalyzer(
-  Lattice lattice, TransferFunction transferFunction, CFG& cfg)
+  Lattice& lattice, TransferFunction& transferFunction, CFG& cfg)
   : lattice(lattice), transferFunction(transferFunction), cfg(cfg) {
 
   // Construct BlockStates for each BasicBlock.

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -49,46 +49,6 @@ public:
   void print(std::ostream& os);
 };
 
-class LivenessTransferFunction : public Visitor<LivenessTransferFunction> {
-  FinitePowersetLattice::Element currState;
-
-public:
-  LivenessTransferFunction(FinitePowersetLattice& lattice);
-
-  // Transfer function implementation. Modifies the state for a particular
-  // expression type.
-  void visitLocalSet(LocalSet* curr);
-  void visitLocalGet(LocalGet* curr);
-
-  // Executes the transfer function on all the expressions of the corresponding
-  // CFG node.
-  void transfer(BlockState<FinitePowersetLattice>& currBlock);
-
-  void enqueueWorklist(
-    const std::vector<BlockState<FinitePowersetLattice>>& stateBlocks,
-    std::queue<Index>& worklist);
-
-  using iterator =
-    std::vector<BlockState<FinitePowersetLattice>*>::const_iterator;
-  iterator depsBegin(BlockState<FinitePowersetLattice>& currBlock) {
-    return currBlock.predecessorsBegin();
-  }
-  iterator depsEnd(BlockState<FinitePowersetLattice>& currBlock) {
-    return currBlock.predecessorsEnd();
-  }
-
-  FinitePowersetLattice::Element&
-  getInputState(BlockState<FinitePowersetLattice>* currBlock) {
-    return currBlock->getLastState();
-  }
-  FinitePowersetLattice::Element&
-  getOutputState(BlockState<FinitePowersetLattice>* currBlock) {
-    return currBlock->getFirstState();
-  }
-
-  void print(std::ostream& os, BlockState<FinitePowersetLattice>& currBlock);
-};
-
 template<typename Lattice, typename TransferFunction>
 struct MonotoneCFGAnalyzer {
   static_assert(is_lattice<Lattice>);

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -12,7 +12,7 @@
 namespace wasm::analysis {
 
 // A node which contains all the lattice states for a given CFG node.
-template<typename Lattice> class BlockState {
+template<typename Lattice> struct BlockState {
   static_assert(is_lattice<Lattice>);
 
   // CFG node corresponding to this state block.
@@ -21,27 +21,8 @@ template<typename Lattice> class BlockState {
   // state for backward analysis, or the beginning state for forward analysis.
   typename Lattice::Element inputState;
 
-  std::vector<BlockState<Lattice>*> predecessors;
-  std::vector<BlockState<Lattice>*> successors;
-
-public:
   // All states are set to the bottom lattice element in this constructor.
   BlockState(const BasicBlock* underlyingBlock, Lattice& lattice);
-
-  // Accessors.
-  typename Lattice::Element& getInputState() { return inputState; }
-  const BasicBlock* getCFGBlock() const { return cfgBlock; }
-
-  // Methods to manipulate predecessors and successors.
-  using iterator = typename std::vector<BlockState<Lattice>*>::const_iterator;
-  iterator predecessorsBegin() { return predecessors.cbegin(); };
-  iterator successorsBegin() { return successors.cbegin(); }
-  iterator predecessorsEnd() { return predecessors.cend(); }
-  iterator successorsEnd() { return successors.cend(); }
-  void addPredecessor(BlockState<Lattice>* pred) {
-    predecessors.push_back(pred);
-  }
-  void addSuccessor(BlockState<Lattice>* succ) { successors.push_back(succ); }
 
   // Prints out BlockState information, but not any intermediate states.
   void print(std::ostream& os);
@@ -60,28 +41,20 @@ constexpr bool has_enqueueWorklist =
   std::is_invocable_r<void,
                       decltype(&TransferFunction::enqueueWorklist),
                       TransferFunction,
-                      const std::vector<BlockState<Lattice>>&,
+                      CFG*,
                       std::queue<Index>&>::value;
 
-template<typename TransferFunction, typename Lattice>
-constexpr bool has_depsBegin = std::is_invocable_r<
-  typename std::vector<BlockState<Lattice>*>::const_iterator,
-  decltype(&TransferFunction::depsBegin),
-  TransferFunction,
-  BlockState<Lattice>&>::value;
-
-template<typename TransferFunction, typename Lattice>
-constexpr bool has_depsEnd = std::is_invocable_r<
-  typename std::vector<BlockState<Lattice>*>::const_iterator,
-  decltype(&TransferFunction::depsEnd),
-  TransferFunction,
-  BlockState<Lattice>&>::value;
+template<typename TransferFunction>
+constexpr bool has_getDependents =
+  std::is_invocable_r<_indirect_ptr_vec<BasicBlock>,
+                      decltype(&TransferFunction::getDependents),
+                      TransferFunction,
+                      const BasicBlock*>::value;
 
 template<typename TransferFunction, typename Lattice>
 constexpr bool is_TransferFunction = has_transfer<TransferFunction, Lattice>&&
   has_enqueueWorklist<TransferFunction, Lattice>&&
-    has_depsBegin<TransferFunction, Lattice>&&
-      has_depsEnd<TransferFunction, Lattice>;
+    has_getDependents<TransferFunction>;
 
 // A transfer function using a lattice <Lattice> is required to have the
 // following methods:
@@ -101,25 +74,20 @@ constexpr bool is_TransferFunction = has_transfer<TransferFunction, Lattice>&&
 // void enqueueWorklist(const std::vector<BlockState<Lattice>>& stateBlocks,
 // std::queue<index>& value);
 
-// Loads CFG nodes in some order into the worklist. Custom specifying the order
-// in which worklist nodes are loaded for each analysis brings performance
-// savings. For example, when doing a backward analysis, loading the CFG blocks
-// in reverse order will lead to less state propagations, and therefore better
-// performance. The opposite is true for a forward analysis.
+// Loads the indices of CFG BasicBlocks in some order into the worklist. Custom
+// specifying the order in which worklist nodes are loaded for each analysis
+// brings performance savings. For example, when doing a backward analysis,
+// loading the CFG BasicBlocks in reverse order will lead to less state
+// propagations, and therefore better performance. The opposite is true for a
+// forward analysis.
 
 // std::vector<BlockState<Lattice>*>::const_iterator
 // depsBegin(BlockState<Lattice>& currBlock);
 
-// Returns a begin iterator to the blocks which depend on currBlock for
+// Returns an iterable to the CFG BasicBlocks which depend on currBlock for
 // information (e.g. predecessors in a backward analysis). Used to select
 // which blocks to propagate to after applying the transfer function to
 // a block.
-
-// std::vector<BlockState<Lattice>*>::const_iterator
-// depsEnd(BlockState<Lattice>& currBlock);
-
-// Returns an end iterator to the blocks which depend on currBlock for
-// information. Used for propagating states, like depsBegin.
 
 template<typename Lattice, typename TransferFunction>
 struct MonotoneCFGAnalyzer {
@@ -143,6 +111,7 @@ private:
   Lattice lattice;
   TransferFunction transferFunction;
   std::vector<BlockState<Lattice>> stateBlocks;
+  CFG* cfg = nullptr;
 };
 
 } // namespace wasm::analysis

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -49,7 +49,7 @@ public:
 
 template<typename TransferFunction, typename Lattice>
 constexpr bool has_transfer =
-  std::is_invocable_r<typename Lattice::Element,
+  std::is_invocable_r<void,
                       decltype(&TransferFunction::transfer),
                       TransferFunction,
                       const BasicBlock*,
@@ -90,12 +90,12 @@ constexpr bool is_TransferFunction = has_transfer<TransferFunction, Lattice>&&
 // inputState);
 
 // This function takes in a pointer to a CFG BasicBlock and the input state
-// associated with it and generates the output state for the basic block by
-// applying the analysis transfer function to each expression in the CFG
-// BasicBlock. Starting with the input state, the transfer function is used to
-// derive new intermediate states based on each expression until we reach the
-// output state, which is returned. This outuput state will be propagated to
-// dependents of the CFG BasicBlock by the worklist algorithm in
+// associated with it and modifies the input state in-place into the ouptut
+// state for the basic block by applying the analysis transfer function to each
+// expression in the CFG BasicBlock. Starting with the input state, the transfer
+// function is used to change the state to new intermediate states based on each
+// expression until we reach the output state. The outuput state will be
+// propagated to dependents of the CFG BasicBlock by the worklist algorithm in
 // MonotoneCFGAnalyzer.
 
 // void enqueueWorklist(const std::vector<BlockState<Lattice>>& stateBlocks,

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -15,7 +15,7 @@ namespace wasm::analysis {
 template<typename Lattice> class BlockState {
   static_assert(is_lattice<Lattice>);
 
-  // CFG node corresponding to this state block
+  // CFG node corresponding to this state block.
   const BasicBlock* cfgBlock;
   // State at beginning of CFG node.
   typename Lattice::Element beginningState;
@@ -45,7 +45,7 @@ public:
   }
   void addSuccessor(BlockState<Lattice>* succ) { successors.push_back(succ); }
 
-  // Prints out the beginning and end states.
+  // Prints out BlockState information, but not any intermediate states.
   void print(std::ostream& os);
 };
 
@@ -99,6 +99,52 @@ constexpr bool is_TransferFunction = has_transfer<TransferFunction, Lattice>&&
       has_depsEnd<TransferFunction, Lattice>&&
         has_getInputState<TransferFunction, Lattice>&&
           has_getOutputState<TransferFunction, Lattice>;
+
+// A transfer function using a lattice <Lattice> is required to have the
+// following methods:
+
+// void transfer(BlockState<Lattice>& currBlock);
+
+// This function updates the output state of currBlock in-place. To do this, it
+// starts at the input state of currBlock and applies the analysis transfer
+// function to each expression in the CFG block associated with currBlock to
+// derive the intermediate states associated with each expression until we
+// produce the output state.
+
+// void enqueueWorklist(const std::vector<BlockState<Lattice>>& stateBlocks,
+// std::queue<index>& value);
+
+// Loads CFG nodes in some order into the worklist. Custom specifying the order
+// in which worklist nodes are loaded for each analysis brings performance
+// savings. For example, when doing a backward analysis, loading the CFG blocks
+// in reverse order will lead to less state propagations, and therefore better
+// performance. The opposite is true for a forward analysis.
+
+// std::vector<BlockState<Lattice>*>::const_iterator
+// depsBegin(BlockState<Lattice>& currBlock);
+
+// Returns a begin iterator to the blocks which depend on currBlock for
+// information (e.g. predecessors in a backward analysis). Used for propagating
+// states.
+
+// std::vector<BlockState<Lattice>*>::const_iterator
+// depsEnd(BlockState<Lattice>& currBlock);
+
+// Returns an end iterator to the blocks which depend on currBlock for
+// information. Used for propagating states.
+
+// Lattice::Element& getInputState(BlockState<Lattice>* currBlock);
+
+// Returns a reference to the state at which the static analysis flow for
+// currBlock starts. For instance for backward analysis, we start at the end
+// state of currBlock. States from other blocks are propagated to currBlock via
+// this input state.
+
+// Lattice::Element& getOutputState(BlockState<Lattice>* currBlock);
+
+// Returns a reference to the state at which the static analysis flow for
+// currBlock (e.g. the start state in a backward analysis). This state may be
+// propagated to other blocks.
 
 template<typename Lattice, typename TransferFunction>
 struct MonotoneCFGAnalyzer {

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -11,18 +11,50 @@
 
 namespace wasm::analysis {
 
-template<typename Lattice> struct MonotoneCFGAnalyzer;
-
 // A node which contains all the lattice states for a given CFG node.
 template<typename Lattice>
-struct BlockState : public Visitor<BlockState<Lattice>> {
+class BlockState {
   static_assert(is_lattice<Lattice>);
+
+  // CFG node corresponding to this state block
+  const BasicBlock* cfgBlock;
+  // State at beginning of CFG node.
+  typename Lattice::Element beginningState;
+  // State at the end of the CFG node.
+  typename Lattice::Element endState;
+
+  std::vector<BlockState<Lattice>*> predecessors;
+  std::vector<BlockState<Lattice>*> successors;
+
+  public:
   // All states are set to the bottom lattice element in this constructor.
   BlockState(const BasicBlock* underlyingBlock, Lattice& lattice);
 
+  // Accessors.
   typename Lattice::Element& getFirstState() { return beginningState; }
   typename Lattice::Element& getLastState() { return endState; }
+  const BasicBlock* getCFGBlock() const { return cfgBlock; }
 
+  // Methods to manipulate predecessors and successors.
+  using iterator = typename std::vector<BlockState<Lattice>*>::const_iterator;
+  iterator predecessorsBegin() { return predecessors.cbegin(); };
+  iterator successorsBegin() { return successors.cbegin(); }
+  iterator predecessorsEnd() { return predecessors.cend(); }
+  iterator successorsEnd() { return successors.cend(); }
+  void addPredecessor(BlockState<Lattice>* pred) { predecessors.push_back(pred); }
+  void addSuccessor(BlockState<Lattice>* succ) { successors.push_back(succ); }
+
+  // Prints out the beginning and end states.
+  void print(std::ostream& os);
+};
+
+template<typename Lattice>
+class LivenessTransferFunction : public Visitor<LivenessTransferFunction<Lattice>> {
+  typename Lattice::Element currState;  
+
+  public:
+  LivenessTransferFunction(Lattice& lattice); 
+  
   // Transfer function implementation. Modifies the state for a particular
   // expression type.
   void visitLocalSet(LocalSet* curr);
@@ -30,29 +62,25 @@ struct BlockState : public Visitor<BlockState<Lattice>> {
 
   // Executes the transfer function on all the expressions of the corresponding
   // CFG node.
-  void transfer();
+  void transfer(BlockState<Lattice>& currBlock);
+  
+  void enqueueWorklist(const std::vector<BlockState<Lattice>>& stateBlocks, std::queue<Index>& worklist);
 
-  // Prints out all intermediate states in the block.
-  void print(std::ostream& os);
+  using iterator = typename std::vector<BlockState<Lattice>*>::const_iterator;
+  iterator depsBegin(BlockState<Lattice>& currBlock) { return currBlock.predecessorsBegin(); }
+  iterator depsEnd(BlockState<Lattice>& currBlock) { return currBlock.predecessorsEnd(); }
 
-private:
-  // The index of the block is same as the CFG index.
-  Index index;
-  const BasicBlock* cfgBlock;
-  // State at beginning of CFG node.
-  typename Lattice::Element beginningState;
-  // State at the end of the CFG node.
-  typename Lattice::Element endState;
-  // Holds intermediate state values.
-  typename Lattice::Element currState;
-  std::vector<BlockState<Lattice>*> predecessors;
-  std::vector<BlockState<Lattice>*> successors;
+  typename Lattice::Element& getInputState(BlockState<Lattice>* currBlock) { return currBlock->getLastState(); }
+  typename Lattice::Element& getOutputState(BlockState<Lattice>* currBlock) { return currBlock->getFirstState(); }
 
-  friend MonotoneCFGAnalyzer<Lattice>;
+  void print(std::ostream& os, BlockState<Lattice>& currBlock);
 };
 
-template<typename Lattice> struct MonotoneCFGAnalyzer {
-  MonotoneCFGAnalyzer(Lattice lattice) : lattice(lattice) {}
+template<typename Lattice, template<typename> typename TransferFunction>
+struct MonotoneCFGAnalyzer {
+  static_assert(is_lattice<Lattice>);
+  
+  MonotoneCFGAnalyzer(Lattice lattice, TransferFunction<Lattice> transferFunction) : lattice(lattice), transferFunction(transferFunction) {}
 
   // Constructs a graph of BlockState objects which parallels
   // the CFG graph. Each CFG node corresponds to a BlockState node.
@@ -66,6 +94,7 @@ template<typename Lattice> struct MonotoneCFGAnalyzer {
 
 private:
   Lattice lattice;
+  TransferFunction<Lattice> transferFunction;
   std::vector<BlockState<Lattice>> stateBlocks;
 };
 

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -151,8 +151,7 @@ End
   LivenessTransferFunction transferFunction;
 
   MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
-    lattice, transferFunction);
-  analyzer.fromCFG(&cfg);
+    lattice, transferFunction, cfg);
   analyzer.evaluate();
 
   std::stringstream ss;
@@ -242,8 +241,7 @@ End
   LivenessTransferFunction transferFunction;
 
   MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
-    lattice, transferFunction);
-  analyzer.fromCFG(&cfg);
+    lattice, transferFunction, cfg);
   analyzer.evaluate();
 
   std::stringstream ss;

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -148,9 +148,10 @@ End
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  LivenessTransferFunction<FinitePowersetLattice> transferFunction(lattice);
-  
-  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(lattice, transferFunction);
+  LivenessTransferFunction transferFunction(lattice);
+
+  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
+    lattice, transferFunction);
   analyzer.fromCFG(&cfg);
   analyzer.evaluate();
 
@@ -242,9 +243,10 @@ End
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  LivenessTransferFunction<FinitePowersetLattice> transferFunction(lattice);
-  
-  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(lattice, transferFunction);
+  LivenessTransferFunction transferFunction(lattice);
+
+  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
+    lattice, transferFunction);
   analyzer.fromCFG(&cfg);
   analyzer.evaluate();
 

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -2,6 +2,7 @@
 
 #include "analysis/cfg.h"
 #include "analysis/lattice.h"
+#include "analysis/liveness-transfer-function.h"
 #include "analysis/monotone-analyzer.h"
 #include "print-test.h"
 #include "wasm.h"

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -148,7 +148,7 @@ End
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  LivenessTransferFunction transferFunction(lattice);
+  LivenessTransferFunction transferFunction;
 
   MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
     lattice, transferFunction);
@@ -239,7 +239,7 @@ End
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  LivenessTransferFunction transferFunction(lattice);
+  LivenessTransferFunction transferFunction;
 
   MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
     lattice, transferFunction);

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -111,7 +111,7 @@ TEST_F(CFGTest, LinearLiveness) {
   )wasm";
 
   auto analyzerText = R"analyzer(CFG Analyzer
-State Block: 0
+CFG Block: 0
 Beginning State: 000
 End State: 000
 Predecessors:
@@ -148,7 +148,9 @@ End
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  MonotoneCFGAnalyzer<FinitePowersetLattice> analyzer(lattice);
+  LivenessTransferFunction<FinitePowersetLattice> transferFunction(lattice);
+  
+  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(lattice, transferFunction);
   analyzer.fromCFG(&cfg);
   analyzer.evaluate();
 
@@ -184,7 +186,7 @@ TEST_F(CFGTest, NonlinearLiveness) {
   )wasm";
 
   auto analyzerText = R"analyzer(CFG Analyzer
-State Block: 0
+CFG Block: 0
 Beginning State: 00
 End State: 10
 Predecessors:
@@ -201,7 +203,7 @@ local.set $0
 00
 i32.const 1
 00
-State Block: 1
+CFG Block: 1
 Beginning State: 00
 End State: 00
 Predecessors: 0
@@ -212,7 +214,7 @@ local.set $1
 00
 i32.const 4
 00
-State Block: 2
+CFG Block: 2
 Beginning State: 10
 End State: 00
 Predecessors: 0
@@ -223,7 +225,7 @@ drop
 00
 local.get $0
 10
-State Block: 3
+CFG Block: 3
 Beginning State: 00
 End State: 00
 Predecessors: 2 1
@@ -240,7 +242,9 @@ End
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  MonotoneCFGAnalyzer<FinitePowersetLattice> analyzer(lattice);
+  LivenessTransferFunction<FinitePowersetLattice> transferFunction(lattice);
+  
+  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(lattice, transferFunction);
   analyzer.fromCFG(&cfg);
   analyzer.evaluate();
 

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -113,8 +113,7 @@ TEST_F(CFGTest, LinearLiveness) {
 
   auto analyzerText = R"analyzer(CFG Analyzer
 CFG Block: 0
-Beginning State: 000
-End State: 000
+Input State: 000
 Predecessors:
 Successors:
 Intermediate States (reverse order): 
@@ -189,8 +188,7 @@ TEST_F(CFGTest, NonlinearLiveness) {
 
   auto analyzerText = R"analyzer(CFG Analyzer
 CFG Block: 0
-Beginning State: 00
-End State: 10
+Input State: 10
 Predecessors:
 Successors: 1 2
 Intermediate States (reverse order): 
@@ -206,8 +204,7 @@ local.set $0
 i32.const 1
 00
 CFG Block: 1
-Beginning State: 00
-End State: 00
+Input State: 00
 Predecessors: 0
 Successors: 3
 Intermediate States (reverse order): 
@@ -217,8 +214,7 @@ local.set $1
 i32.const 4
 00
 CFG Block: 2
-Beginning State: 10
-End State: 00
+Input State: 00
 Predecessors: 0
 Successors: 3
 Intermediate States (reverse order): 
@@ -228,8 +224,7 @@ drop
 local.get $0
 10
 CFG Block: 3
-Beginning State: 00
-End State: 00
+Input State: 00
 Predecessors: 2 1
 Successors:
 Intermediate States (reverse order): 


### PR DESCRIPTION
This change makes the transfer function an object separate from the monotone analyzer. The transfer function class type is a generic template of the monotone analyzer, and an instance of the transfer function is instantiated and then passed into the monotone analyzer via its constructor.

This change introduces `LivenessTransferFunction` as a transfer function for liveness analysis as an example.