### PR TITLE
Generalize Finite Powerset Lattice to Any Given Type

### DIFF
--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -150,6 +150,7 @@ public:
   static LatticeComparison compare(const Element& left, const Element& right) {
     return FiniteIntPowersetLattice::compare(left, right);
   }
+
   Element getBottom() { return intLattice.getBottom(); }
 };
 

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -42,8 +42,8 @@ constexpr bool is_lattice = has_getBottom<Lattice>&& has_compare<Lattice>&&
 
 // Represents a powerset lattice constructed from a finite set of consecutive
 // integers from 0 to n which can be represented by a bitvector. Set elements
-// are represented by FinitePowersetLattice::Element, which represents members
-// present in each element by bits in the bitvector.
+// are represented by FiniteIntPowersetLattice::Element, which represents
+// members present in each element by bits in the bitvector.
 class FiniteIntPowersetLattice {
   // The size of the set that the powerset lattice was created from. This is
   // equivalent to the size of the Top lattice element.

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -7,29 +7,25 @@
 namespace wasm::analysis {
 
 class LivenessTransferFunction : public Visitor<LivenessTransferFunction> {
-  FinitePowersetLattice<Index>::Element* currState = nullptr;
-  FinitePowersetLattice<Index>& lattice;
+  FiniteIntPowersetLattice::Element* currState = nullptr;
 
 public:
-  LivenessTransferFunction(FinitePowersetLattice<Index>& lattice)
-    : lattice(lattice) {}
-
   // Transfer function implementation. A local becomes live before a get
   // and becomes dead before a set.
   void visitLocalSet(LocalSet* curr) {
     assert(currState);
-    lattice.remove(currState, curr->index);
+    currState->set(curr->index, false);
   }
   void visitLocalGet(LocalGet* curr) {
     assert(currState);
-    lattice.add(currState, curr->index);
+    currState->set(curr->index, true);
   }
 
   // Executes the transfer function on all the expressions of the corresponding
   // CFG node, starting with the node's input state, and changes the input state
   // to the final output state of the node in place.
   void transfer(const BasicBlock* cfgBlock,
-                FinitePowersetLattice<Index>::Element& inputState) {
+                FiniteIntPowersetLattice::Element& inputState) {
     // If the block is empty, we propagate the state by inputState =
     // outputState.
 
@@ -69,7 +65,7 @@ public:
   // in place to produce the intermediate states.
   void print(std::ostream& os,
              const BasicBlock* cfgBlock,
-             FinitePowersetLattice<Index>::Element& inputState) {
+             FiniteIntPowersetLattice::Element& inputState) {
     os << "Intermediate States (reverse order): " << std::endl;
     currState = &inputState;
     currState->print(os);

--- a/src/analysis/liveness-transfer-function.h
+++ b/src/analysis/liveness-transfer-function.h
@@ -7,25 +7,29 @@
 namespace wasm::analysis {
 
 class LivenessTransferFunction : public Visitor<LivenessTransferFunction> {
-  FinitePowersetLattice::Element* currState = nullptr;
+  FinitePowersetLattice<Index>::Element* currState = nullptr;
+  FinitePowersetLattice<Index>& lattice;
 
 public:
+  LivenessTransferFunction(FinitePowersetLattice<Index>& lattice)
+    : lattice(lattice) {}
+
   // Transfer function implementation. A local becomes live before a get
   // and becomes dead before a set.
   void visitLocalSet(LocalSet* curr) {
     assert(currState);
-    currState->set(curr->index, false);
+    lattice.remove(currState, curr->index);
   }
   void visitLocalGet(LocalGet* curr) {
     assert(currState);
-    currState->set(curr->index, true);
+    lattice.add(currState, curr->index);
   }
 
   // Executes the transfer function on all the expressions of the corresponding
   // CFG node, starting with the node's input state, and changes the input state
   // to the final output state of the node in place.
   void transfer(const BasicBlock* cfgBlock,
-                FinitePowersetLattice::Element& inputState) {
+                FinitePowersetLattice<Index>::Element& inputState) {
     // If the block is empty, we propagate the state by inputState =
     // outputState.
 
@@ -65,7 +69,7 @@ public:
   // in place to produce the intermediate states.
   void print(std::ostream& os,
              const BasicBlock* cfgBlock,
-             FinitePowersetLattice::Element& inputState) {
+             FinitePowersetLattice<Index>::Element& inputState) {
     os << "Intermediate States (reverse order): " << std::endl;
     currState = &inputState;
     currState->print(os);

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -5,9 +5,10 @@
 
 namespace wasm::analysis {
 
-inline LatticeComparison
-FinitePowersetLattice::compare(const FinitePowersetLattice::Element& left,
-                               const FinitePowersetLattice::Element& right) {
+template<typename Type>
+inline LatticeComparison FinitePowersetLattice<Type>::compare(
+  const FinitePowersetLattice<Type>::Element& left,
+  const FinitePowersetLattice<Type>::Element& right) {
   // Both must be from the powerset lattice of the same set.
   assert(left.bitvector.size() == right.bitvector.size());
 
@@ -41,14 +42,17 @@ FinitePowersetLattice::compare(const FinitePowersetLattice::Element& left,
   return NO_RELATION;
 }
 
-inline FinitePowersetLattice::Element FinitePowersetLattice::getBottom() {
-  FinitePowersetLattice::Element result(setSize);
+template<typename Type>
+inline typename FinitePowersetLattice<Type>::Element
+FinitePowersetLattice<Type>::getBottom() {
+  typename FinitePowersetLattice<Type>::Element result(setSize);
   return result;
 }
 
 // We count the number of element members present in the element by counting the
 // trues in the bitvector.
-inline size_t FinitePowersetLattice::Element::count() {
+template<typename Type>
+inline size_t FinitePowersetLattice<Type>::Element::count() {
   size_t count = 0;
   for (auto it : bitvector) {
     count += it;
@@ -59,8 +63,9 @@ inline size_t FinitePowersetLattice::Element::count() {
 // Least upper bound is implemented as a logical OR between the bitvectors on
 // both sides. We return true if a bit is flipped in-place on the left so the
 // worklist algorithm will know if when to enqueue more work.
-inline bool FinitePowersetLattice::Element::makeLeastUpperBound(
-  const FinitePowersetLattice::Element& other) {
+template<typename Type>
+inline bool FinitePowersetLattice<Type>::Element::makeLeastUpperBound(
+  const FinitePowersetLattice<Type>::Element& other) {
   // Both must be from powerset lattice of the same set.
   assert(other.bitvector.size() == bitvector.size());
 
@@ -75,7 +80,8 @@ inline bool FinitePowersetLattice::Element::makeLeastUpperBound(
   return modified;
 }
 
-inline void FinitePowersetLattice::Element::print(std::ostream& os) {
+template<typename Type>
+inline void FinitePowersetLattice<Type>::Element::print(std::ostream& os) {
   // Element member 0 is on the left, element member N is on the right.
   for (auto it : bitvector) {
     os << it;

--- a/src/analysis/powerset-lattice-impl.h
+++ b/src/analysis/powerset-lattice-impl.h
@@ -5,10 +5,9 @@
 
 namespace wasm::analysis {
 
-template<typename Type>
-inline LatticeComparison FinitePowersetLattice<Type>::compare(
-  const FinitePowersetLattice<Type>::Element& left,
-  const FinitePowersetLattice<Type>::Element& right) {
+inline LatticeComparison FiniteIntPowersetLattice::compare(
+  const FiniteIntPowersetLattice::Element& left,
+  const FiniteIntPowersetLattice::Element& right) {
   // Both must be from the powerset lattice of the same set.
   assert(left.bitvector.size() == right.bitvector.size());
 
@@ -42,17 +41,14 @@ inline LatticeComparison FinitePowersetLattice<Type>::compare(
   return NO_RELATION;
 }
 
-template<typename Type>
-inline typename FinitePowersetLattice<Type>::Element
-FinitePowersetLattice<Type>::getBottom() {
-  typename FinitePowersetLattice<Type>::Element result(setSize);
+inline FiniteIntPowersetLattice::Element FiniteIntPowersetLattice::getBottom() {
+  FiniteIntPowersetLattice::Element result(setSize);
   return result;
 }
 
 // We count the number of element members present in the element by counting the
 // trues in the bitvector.
-template<typename Type>
-inline size_t FinitePowersetLattice<Type>::Element::count() {
+inline size_t FiniteIntPowersetLattice::Element::count() {
   size_t count = 0;
   for (auto it : bitvector) {
     count += it;
@@ -63,9 +59,8 @@ inline size_t FinitePowersetLattice<Type>::Element::count() {
 // Least upper bound is implemented as a logical OR between the bitvectors on
 // both sides. We return true if a bit is flipped in-place on the left so the
 // worklist algorithm will know if when to enqueue more work.
-template<typename Type>
-inline bool FinitePowersetLattice<Type>::Element::makeLeastUpperBound(
-  const FinitePowersetLattice<Type>::Element& other) {
+inline bool FiniteIntPowersetLattice::Element::makeLeastUpperBound(
+  const FiniteIntPowersetLattice::Element& other) {
   // Both must be from powerset lattice of the same set.
   assert(other.bitvector.size() == bitvector.size());
 
@@ -80,8 +75,7 @@ inline bool FinitePowersetLattice<Type>::Element::makeLeastUpperBound(
   return modified;
 }
 
-template<typename Type>
-inline void FinitePowersetLattice<Type>::Element::print(std::ostream& os) {
+inline void FiniteIntPowersetLattice::Element::print(std::ostream& os) {
   // Element member 0 is on the left, element member N is on the right.
   for (auto it : bitvector) {
     os << it;

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -253,3 +253,42 @@ End
 
   EXPECT_EQ(ss.str(), analyzerText);
 }
+
+TEST_F(CFGTest, FinitePowersetLatticeFunctioning) {
+
+  std::vector<std::string> initialSet = {"a", "b", "c", "d", "e", "f"};
+  FinitePowersetLattice<std::string> lattice(std::move(initialSet));
+
+  FinitePowersetLattice<std::string>::Element element1 = lattice.getBottom();
+
+  EXPECT_EQ(element1.isBottom(), true);
+
+  lattice.add(&element1, "c");
+  lattice.add(&element1, "d");
+  lattice.add(&element1, "a");
+
+  EXPECT_EQ(element1.isBottom(), false);
+  EXPECT_EQ(element1.isTop(), false);
+
+  FinitePowersetLattice<std::string>::Element element2 = element1;
+  lattice.remove(&element2, "c");
+  EXPECT_EQ(FinitePowersetLattice<std::string>::compare(element1, element2),
+            LatticeComparison::GREATER);
+  lattice.add(&element2, "f");
+  EXPECT_EQ(FinitePowersetLattice<std::string>::compare(element1, element2),
+            LatticeComparison::NO_RELATION);
+
+  std::stringstream ss;
+  element1.print(ss);
+  ss << std::endl;
+  element2.print(ss);
+  ss << std::endl;
+  element2.makeLeastUpperBound(element1);
+  element2.print(ss);
+
+  auto resultText = R"result(101100
+100101
+101101)result";
+
+  EXPECT_EQ(ss.str(), resultText);
+}

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -259,18 +259,19 @@ TEST_F(CFGTest, FinitePowersetLatticeFunctioning) {
   std::vector<std::string> initialSet = {"a", "b", "c", "d", "e", "f"};
   FinitePowersetLattice<std::string> lattice(std::move(initialSet));
 
-  FinitePowersetLattice<std::string>::Element element1 = lattice.getBottom();
+  auto element1 = lattice.getBottom();
 
-  EXPECT_EQ(element1.isBottom(), true);
+  EXPECT_TRUE(element1.isBottom());
+  EXPECT_FALSE(element1.isTop());
 
   lattice.add(&element1, "c");
   lattice.add(&element1, "d");
   lattice.add(&element1, "a");
 
-  EXPECT_EQ(element1.isBottom(), false);
-  EXPECT_EQ(element1.isTop(), false);
+  EXPECT_FALSE(element1.isBottom());
+  EXPECT_FALSE(element1.isTop());
 
-  FinitePowersetLattice<std::string>::Element element2 = element1;
+  auto element2 = element1;
   lattice.remove(&element2, "c");
   EXPECT_EQ(FinitePowersetLattice<std::string>::compare(element1, element2),
             LatticeComparison::GREATER);
@@ -280,15 +281,12 @@ TEST_F(CFGTest, FinitePowersetLatticeFunctioning) {
 
   std::stringstream ss;
   element1.print(ss);
-  ss << std::endl;
+  EXPECT_EQ(ss.str(), "101100");
+  ss.str(std::string());
   element2.print(ss);
-  ss << std::endl;
+  EXPECT_EQ(ss.str(), "100101");
+  ss.str(std::string());
   element2.makeLeastUpperBound(element1);
   element2.print(ss);
-
-  auto resultText = R"result(101100
-100101
-101101)result";
-
-  EXPECT_EQ(ss.str(), resultText);
+  EXPECT_EQ(ss.str(), "101101");
 }

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -147,11 +147,19 @@ End
   parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
-  FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  LivenessTransferFunction transferFunction;
+  size_t numLocals = wasm.getFunction("bar")->getNumLocals();
 
-  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
-    lattice, transferFunction, cfg);
+  std::vector<Index> localIndices(numLocals);
+
+  for (Index i = 0; i < numLocals; ++i) {
+    localIndices[i] = i;
+  }
+
+  FinitePowersetLattice<Index> lattice(std::move(localIndices));
+  LivenessTransferFunction transferFunction(lattice);
+
+  MonotoneCFGAnalyzer<FinitePowersetLattice<Index>, LivenessTransferFunction>
+    analyzer(lattice, transferFunction, cfg);
   analyzer.evaluate();
 
   std::stringstream ss;
@@ -237,11 +245,19 @@ End
   parseWast(wasm, moduleText);
 
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
-  FinitePowersetLattice lattice(wasm.getFunction("bar")->getNumLocals());
-  LivenessTransferFunction transferFunction;
+  size_t numLocals = wasm.getFunction("bar")->getNumLocals();
 
-  MonotoneCFGAnalyzer<FinitePowersetLattice, LivenessTransferFunction> analyzer(
-    lattice, transferFunction, cfg);
+  std::vector<Index> localIndices(numLocals);
+
+  for (Index i = 0; i < numLocals; ++i) {
+    localIndices[i] = i;
+  }
+
+  FinitePowersetLattice<Index> lattice(std::move(localIndices));
+  LivenessTransferFunction transferFunction(lattice);
+
+  MonotoneCFGAnalyzer<FinitePowersetLattice<Index>, LivenessTransferFunction>
+    analyzer(lattice, transferFunction, cfg);
   analyzer.evaluate();
 
   std::stringstream ss;

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -149,16 +149,10 @@ End
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   size_t numLocals = wasm.getFunction("bar")->getNumLocals();
 
-  std::vector<Index> localIndices(numLocals);
+  FiniteIntPowersetLattice lattice(numLocals);
+  LivenessTransferFunction transferFunction;
 
-  for (Index i = 0; i < numLocals; ++i) {
-    localIndices[i] = i;
-  }
-
-  FinitePowersetLattice<Index> lattice(std::move(localIndices));
-  LivenessTransferFunction transferFunction(lattice);
-
-  MonotoneCFGAnalyzer<FinitePowersetLattice<Index>, LivenessTransferFunction>
+  MonotoneCFGAnalyzer<FiniteIntPowersetLattice, LivenessTransferFunction>
     analyzer(lattice, transferFunction, cfg);
   analyzer.evaluate();
 
@@ -247,16 +241,10 @@ End
   CFG cfg = CFG::fromFunction(wasm.getFunction("bar"));
   size_t numLocals = wasm.getFunction("bar")->getNumLocals();
 
-  std::vector<Index> localIndices(numLocals);
+  FiniteIntPowersetLattice lattice(numLocals);
+  LivenessTransferFunction transferFunction;
 
-  for (Index i = 0; i < numLocals; ++i) {
-    localIndices[i] = i;
-  }
-
-  FinitePowersetLattice<Index> lattice(std::move(localIndices));
-  LivenessTransferFunction transferFunction(lattice);
-
-  MonotoneCFGAnalyzer<FinitePowersetLattice<Index>, LivenessTransferFunction>
+  MonotoneCFGAnalyzer<FiniteIntPowersetLattice, LivenessTransferFunction>
     analyzer(lattice, transferFunction, cfg);
   analyzer.evaluate();
 


### PR DESCRIPTION
This change enables the `FinitePowersetLattice` to be directly used to represent powerset lattices constructed from a set of arbitrary type members. The `FinitePowersetLattice` is made to map members to bitvector indices. During construction, an ordered vector of members of some templated type `Type` is passed in, and this ordering is used to determine the mapping of `Type` members to bitvector indices. Instead of having users directly manipulate the bitvector for each lattice element, methods `add` and `remove` are introduced to add or remove a lattice element member of `Type`.