### PR TITLE
[NFC] Fix the use of "strict" in subtypes.h

### DIFF
--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -275,7 +275,7 @@ private:
       if (toSubTypes) {
         // Propagate shared fields to the subtypes.
         auto numFields = type.getStruct().fields.size();
-        for (auto subType : subTypes.getStrictSubTypes(type)) {
+        for (auto subType : subTypes.getImmediateSubTypes(type)) {
           auto& subInfos = combinedInfos[subType];
           for (Index i = 0; i < numFields; i++) {
             if (subInfos[i].combine(infos[i])) {

--- a/src/passes/AbstractTypeRefining.cpp
+++ b/src/passes/AbstractTypeRefining.cpp
@@ -113,7 +113,7 @@ struct AbstractTypeRefining : public Pass {
     createdTypesOrSubTypes = createdTypes;
     for (auto type : subTypes.getSubTypesFirstSort()) {
       // If any of our subtypes are created, so are we.
-      for (auto subType : subTypes.getStrictSubTypes(type)) {
+      for (auto subType : subTypes.getImmediateSubTypes(type)) {
         if (createdTypesOrSubTypes.count(subType)) {
           createdTypesOrSubTypes.insert(type);
           break;
@@ -159,7 +159,7 @@ struct AbstractTypeRefining : public Pass {
       }
 
       std::optional<HeapType> refinedType;
-      auto& typeSubTypes = subTypes.getStrictSubTypes(type);
+      auto& typeSubTypes = subTypes.getImmediateSubTypes(type);
       if (typeSubTypes.size() == 1) {
         // There is only a single possibility, so we can definitely use that
         /// one.

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -350,7 +350,7 @@ struct Analyzer {
 
     // Call all the functions of that signature, and subtypes. We can then
     // forget about them, as those signatures will be marked as called.
-    for (auto subType : subTypes->getAllSubTypes(type)) {
+    for (auto subType : subTypes->getSubTypes(type)) {
       auto iter = uncalledRefFuncMap.find(subType);
       if (iter != uncalledRefFuncMap.end()) {
         // We must not have a type in both calledSignatures and

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -181,7 +181,7 @@ struct SignaturePruning : public Pass {
         continue;
       }
 
-      if (!subTypes.getStrictSubTypes(type).empty()) {
+      if (!subTypes.getImmediateSubTypes(type).empty()) {
         continue;
       }
       if (auto super = type.getSuperType()) {

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -145,7 +145,7 @@ struct SignatureRefining : public Pass {
     // TypeRefining, and perhaps we can unify this pass with that. TODO
     SubTypes subTypes(*module);
     for (auto& [type, info] : allInfo) {
-      if (!subTypes.getStrictSubTypes(type).empty()) {
+      if (!subTypes.getImmediateSubTypes(type).empty()) {
         info.canModify = false;
       } else if (type.getSuperType()) {
         // Also avoid modifying types with supertypes, as we do not handle

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -216,7 +216,7 @@ struct TypeRefining : public Pass {
         }
       }
 
-      for (auto subType : subTypes.getStrictSubTypes(type)) {
+      for (auto subType : subTypes.getImmediateSubTypes(type)) {
         work.push(subType);
       }
     }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -279,7 +279,7 @@ void TranslateToFuzzReader::setupHeapTypes() {
   // now, rather than lazily later.
   SubTypes subTypes(interestingHeapTypes);
   for (auto type : interestingHeapTypes) {
-    for (auto subType : subTypes.getStrictSubTypes(type)) {
+    for (auto subType : subTypes.getImmediateSubTypes(type)) {
       interestingHeapSubTypes[type].push_back(subType);
     }
     // Basic types must be handled directly, since subTypes doesn't look at

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -226,8 +226,7 @@ void WasmBinaryWriter::writeTypes() {
     return;
   }
   // Count the number of recursion groups, which is the number of elements in
-  // the type section. With nominal typing there is always one group and with
-  // equirecursive typing there is one group per type.
+  // the type section.
   size_t numGroups = 0;
   {
     std::optional<RecGroup> lastGroup;

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -853,13 +853,13 @@ TEST_F(TypeTest, TestSubTypes) {
     {Type(built[0], Nullable), Type(built[1], Nullable)},
     wasmBuilder.makeNop()));
   SubTypes subTypes(wasm);
-  auto subTypes0 = subTypes.getStrictSubTypes(built[0]);
+  auto subTypes0 = subTypes.getImmediateSubTypes(built[0]);
   EXPECT_TRUE(subTypes0.size() == 1 && subTypes0[0] == built[1]);
-  auto subTypes0Inclusive = subTypes.getAllSubTypes(built[0]);
+  auto subTypes0Inclusive = subTypes.getSubTypes(built[0]);
   EXPECT_TRUE(subTypes0Inclusive.size() == 2 &&
               subTypes0Inclusive[0] == built[1] &&
               subTypes0Inclusive[1] == built[0]);
-  auto subTypes1 = subTypes.getStrictSubTypes(built[1]);
+  auto subTypes1 = subTypes.getImmediateSubTypes(built[1]);
   EXPECT_EQ(subTypes1.size(), 0u);
 }
 


### PR DESCRIPTION
Previously we incorrectly used "strict" to mean the immediate subtypes of a
type, when in fact a strict subtype of a type is any subtype excluding the type
itself. Rename the incorrect `getStrictSubTypes` to `getImmediateSubTypes`,
rename the redundant `getAllStrictSubTypes` to `getStrictSubTypes`, and rename
the redundant `getAllSubTypes` to `getSubTypes`. Fixing the capitalization of
"SubType" to "Subtype" is left as future work.