### PR TITLE
Fuzzer: Emit more variations of If

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1363,8 +1363,31 @@ Expression* TranslateToFuzzReader::buildIf(const struct ThreeArgs& args,
 Expression* TranslateToFuzzReader::makeIf(Type type) {
   auto* condition = makeCondition();
   funcContext->hangStack.push_back(nullptr);
-  auto* ret =
-    buildIf({condition, makeMaybeBlock(type), makeMaybeBlock(type)}, type);
+
+  Expression* ret;
+  if (type == Type::none && oneIn(2)) {
+    // Just an ifTrue arm.
+    ret = buildIf({condition, makeMaybeBlock(type), nullptr}, type);
+  } else {
+    // Also an ifFalse arm.
+
+    // Some of the time make one arm unreachable (but not both, as then the if
+    // as a whole would be unreachable).
+    auto trueType = type;
+    auto falseType = type;
+    switch (upTo(20)) {
+      case 0:
+        trueType = Type::unreachable;
+        break;
+      case 1:
+        falseType = Type::unreachable;
+        break;
+      default:
+    }
+    ret =
+        buildIf({condition, makeMaybeBlock(trueType), makeMaybeBlock(falseType)}, type);
+  }
+
   funcContext->hangStack.pop_back();
   return ret;
 }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1383,8 +1383,8 @@ Expression* TranslateToFuzzReader::makeIf(Type type) {
         falseType = Type::unreachable;
         break;
     }
-    ret =
-        buildIf({condition, makeMaybeBlock(trueType), makeMaybeBlock(falseType)}, type);
+    ret = buildIf(
+      {condition, makeMaybeBlock(trueType), makeMaybeBlock(falseType)}, type);
   }
 
   funcContext->hangStack.pop_back();

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1382,7 +1382,6 @@ Expression* TranslateToFuzzReader::makeIf(Type type) {
       case 1:
         falseType = Type::unreachable;
         break;
-      default:
     }
     ret =
         buildIf({condition, makeMaybeBlock(trueType), makeMaybeBlock(falseType)}, type);

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,33 +1,34 @@
 total
- [exports]      : 20      
- [funcs]        : 23      
+ [exports]      : 42      
+ [funcs]        : 62      
  [globals]      : 9       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 2       
- [table-data]   : 5       
+ [table-data]   : 18      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3867    
- [vars]         : 64      
- Binary         : 296     
- Block          : 626     
- Break          : 124     
- Call           : 155     
- CallIndirect   : 17      
- Const          : 625     
- Drop           : 28      
- GlobalGet      : 292     
- GlobalSet      : 223     
- If             : 210     
- Load           : 77      
- LocalGet       : 339     
- LocalSet       : 228     
- Loop           : 85      
- Nop            : 50      
- RefFunc        : 5       
- Return         : 55      
- Select         : 22      
- Store          : 28      
- Unary          : 275     
- Unreachable    : 107     
+ [total]        : 8712    
+ [vars]         : 175     
+ Binary         : 633     
+ Block          : 1393    
+ Break          : 282     
+ Call           : 282     
+ CallIndirect   : 77      
+ Const          : 1517    
+ Drop           : 76      
+ GlobalGet      : 675     
+ GlobalSet      : 528     
+ If             : 472     
+ Load           : 157     
+ LocalGet       : 631     
+ LocalSet       : 475     
+ Loop           : 192     
+ Nop            : 155     
+ RefFunc        : 18      
+ Return         : 116     
+ Select         : 91      
+ Store          : 66      
+ Switch         : 6       
+ Unary          : 609     
+ Unreachable    : 261     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,40 +1,47 @@
 total
- [exports]      : 3       
- [funcs]        : 6       
+ [exports]      : 7       
+ [funcs]        : 12      
  [globals]      : 1       
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 0       
+ [table-data]   : 3       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 463     
- [vars]         : 19      
- ArrayCopy      : 1       
- ArrayLen       : 6       
- ArrayNew       : 8       
- ArraySet       : 1       
- AtomicFence    : 1       
- Binary         : 79      
- Block          : 49      
- Break          : 5       
- Call           : 7       
- CallRef        : 2       
- Const          : 96      
- Drop           : 2       
- GlobalGet      : 20      
- GlobalSet      : 20      
- If             : 17      
- Load           : 18      
- LocalGet       : 44      
- LocalSet       : 34      
- Loop           : 6       
- Nop            : 6       
- RefAs          : 3       
- RefFunc        : 2       
- RefNull        : 3       
- Return         : 4       
+ [total]        : 575     
+ [vars]         : 17      
+ ArrayLen       : 1       
+ ArrayNew       : 4       
+ ArrayNewFixed  : 1       
+ AtomicCmpxchg  : 1       
+ Binary         : 75      
+ Block          : 68      
+ Break          : 6       
+ Call           : 15      
+ CallRef        : 1       
+ Const          : 148     
+ Drop           : 4       
+ GlobalGet      : 28      
+ GlobalSet      : 28      
+ I31Get         : 1       
+ I31New         : 3       
+ If             : 24      
+ Load           : 20      
+ LocalGet       : 33      
+ LocalSet       : 22      
+ Loop           : 4       
+ MemoryFill     : 2       
+ Nop            : 7       
+ RefFunc        : 6       
+ RefIsNull      : 1       
+ RefNull        : 7       
+ RefTest        : 1       
+ Return         : 7       
+ SIMDExtract    : 1       
+ Select         : 2       
  Store          : 2       
- StructNew      : 1       
- Unary          : 14      
- Unreachable    : 12      
+ StructNew      : 7       
+ StructSet      : 1       
+ TupleMake      : 3       
+ Unary          : 24      
+ Unreachable    : 17      


### PR DESCRIPTION
Before we always created if-elses. Now we also create an If with one arm some of
the time, when we can.

Also, sometimes make one if arm unreachable, if we have two arms.