### PR TITLE
[Outlining] LLVM Suffix Tree

### DIFF
--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -10,6 +10,8 @@ set(support_SOURCES
   istring.cpp
   path.cpp
   safe_integer.cpp
+  suffix_tree.cpp
+  suffix_tree_node.cpp
   threads.cpp
   utilities.cpp
   ${support_HEADERS}

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -10,10 +10,19 @@ set(support_SOURCES
   istring.cpp
   path.cpp
   safe_integer.cpp
-  suffix_tree.cpp
-  suffix_tree_node.cpp
   threads.cpp
   utilities.cpp
   ${support_HEADERS}
 )
+
+#[[ The below condition is intended for removal once the suffix_tree and suffix_tree_node source files no longer depend on LLVM code in the third_party folder ]]
+if(EMSCRIPTEN)
 add_library(support OBJECT ${support_SOURCES})
+else()
+set(support_with_suffix_tree_SOURCES
+  suffix_tree.cpp
+  suffix_tree_node.cpp
+  ${support_SOURCES}
+)
+add_library(support OBJECT ${support_with_suffix_tree_SOURCES})
+endif()

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -15,14 +15,16 @@ set(support_SOURCES
   ${support_HEADERS}
 )
 
-#[[ The below condition is intended for removal once the suffix_tree and suffix_tree_node source files no longer depend on LLVM code in the third_party folder ]]
+# The below condition is intended for removal once the suffix_tree and
+# suffix_tree_node source files no longer depend on LLVM code in the
+# third_party folder
 if(EMSCRIPTEN)
-add_library(support OBJECT ${support_SOURCES})
+  add_library(support OBJECT ${support_SOURCES})
 else()
-set(support_with_suffix_tree_SOURCES
-  suffix_tree.cpp
-  suffix_tree_node.cpp
-  ${support_SOURCES}
-)
-add_library(support OBJECT ${support_with_suffix_tree_SOURCES})
+  set(support_with_suffix_tree_SOURCES
+    suffix_tree.cpp
+    suffix_tree_node.cpp
+    ${support_SOURCES}
+  )
+  add_library(support OBJECT ${support_with_suffix_tree_SOURCES})
 endif()

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -71,7 +71,8 @@ SuffixTreeNode* SuffixTree::insertLeaf(SuffixTreeInternalNode& Parent,
                                        unsigned StartIdx,
                                        unsigned Edge) {
   assert(StartIdx <= LeafEndIdx && "String can't start after it ends!");
-  auto* N = new SuffixTreeLeafNode(StartIdx, &LeafEndIdx);
+  auto* N = new (LeafNodeAllocator.Allocate())
+    SuffixTreeLeafNode(StartIdx, &LeafEndIdx);
   Parent.Children[Edge] = N;
   return N;
 }
@@ -84,7 +85,8 @@ SuffixTree::insertInternalNode(SuffixTreeInternalNode* Parent,
   assert(StartIdx <= EndIdx && "String can't start after it ends!");
   assert(!(!Parent && StartIdx != SuffixTreeNode::EmptyIdx) &&
          "Non-root internal nodes must have parents!");
-  auto* N = new SuffixTreeInternalNode(StartIdx, EndIdx, Root);
+  auto* N = new (InternalNodeAllocator.Allocate())
+    SuffixTreeInternalNode(StartIdx, EndIdx, Root);
   if (Parent)
     Parent->Children[Edge] = N;
   return N;

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -1,20 +1,5 @@
-// TODO: figure out license and proper attribution
-
-/*
- * Copyright 2023 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// This file began as an import from LLVM, and so it has the same license as
+// LLVM, copied below together with the code.
 
 //===- llvm/Support/SuffixTree.cpp - Implement Suffix Tree ------*- C++ -*-===//
 //

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -13,6 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// clang-format off
+
 #include "support/suffix_tree.h"
 #include "support/suffix_tree_node.h"
 #include "third_party/llvm-project/include/llvm/Support/Casting.h"

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-
 #include "support/suffix_tree.h"
 #include "support/suffix_tree_node.h"
 #include "llvm/Support/Casting.h"
@@ -26,9 +24,11 @@ namespace wasm {
 /// \returns the number of elements in the substring associated with \p N.
 static size_t numElementsInSubstring(const SuffixTreeNode* N) {
   assert(N && "Got a null node?");
-  if (auto* Internal = dyn_cast<SuffixTreeInternalNode>(N))
-    if (Internal->isRoot())
+  if (auto* Internal = dyn_cast<SuffixTreeInternalNode>(N)) {
+    if (Internal->isRoot()) {
       return 0;
+    }
+  }
   return N->getEndIdx() - N->getStartIdx() + 1;
 }
 
@@ -74,8 +74,9 @@ SuffixTree::insertInternalNode(SuffixTreeInternalNode* Parent,
          "Non-root internal nodes must have parents!");
   auto* N = new (InternalNodeAllocator.Allocate())
     SuffixTreeInternalNode(StartIdx, EndIdx, Root);
-  if (Parent)
+  if (Parent) {
     Parent->Children[Edge] = N;
+  }
   return N;
 }
 
@@ -102,16 +103,18 @@ void SuffixTree::setSuffixIndices() {
     ToVisit.pop_back();
     // Length of the current node from the root down to here.
     CurrNode->setConcatLen(CurrNodeLen);
-    if (auto* InternalNode = dyn_cast<SuffixTreeInternalNode>(CurrNode))
+    if (auto* InternalNode = dyn_cast<SuffixTreeInternalNode>(CurrNode)) {
       for (auto& ChildPair : InternalNode->Children) {
         assert(ChildPair.second && "Node had a null child!");
         ToVisit.push_back(
           {ChildPair.second,
            CurrNodeLen + numElementsInSubstring(ChildPair.second)});
       }
+    }
     // No children, so we are at the end of the string.
-    if (auto* LeafNode = dyn_cast<SuffixTreeLeafNode>(CurrNode))
+    if (auto* LeafNode = dyn_cast<SuffixTreeLeafNode>(CurrNode)) {
       LeafNode->setSuffixIdx(Str.size() - CurrNodeLen);
+    }
   }
 }
 
@@ -211,8 +214,9 @@ unsigned SuffixTree::extend(unsigned EndIdx, unsigned SuffixesToAdd) {
       SplitNode->Children[Str[NextNode->getStartIdx()]] = NextNode;
 
       // SplitNode is an internal node, update the suffix link.
-      if (NeedsLink)
+      if (NeedsLink) {
         NeedsLink->setLink(SplitNode);
+      }
 
       NeedsLink = SplitNode;
     }
@@ -265,8 +269,9 @@ void SuffixTree::RepeatedSubstringIterator::advance() {
         continue;
       }
 
-      if (Length < MinLength)
+      if (Length < MinLength) {
         continue;
+      }
 
       // Have an occurrence of a potentially repeated string. Save it.
       auto* Leaf = cast<SuffixTreeLeafNode>(ChildPair.second);
@@ -275,12 +280,14 @@ void SuffixTree::RepeatedSubstringIterator::advance() {
 
     // The root never represents a repeated substring. If we're looking at
     // that, then skip it.
-    if (Curr->isRoot())
+    if (Curr->isRoot()) {
       continue;
+    }
 
     // Do we have any repeated substrings?
-    if (RepeatedSubstringStarts.size() < 2)
+    if (RepeatedSubstringStarts.size() < 2) {
       continue;
+    }
 
     // Yes. Update the state to reflect this, and then bail out.
     N = Curr;

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -17,7 +17,7 @@
 
 #include "support/suffix_tree.h"
 #include "support/suffix_tree_node.h"
-#include "third_party/llvm-project/include/llvm/Support/Casting.h"
+#include "llvm/Support/Casting.h"
 
 using namespace llvm;
 

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -1,0 +1,308 @@
+// TODO: figure out license and proper attribution
+
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===- llvm/Support/SuffixTree.cpp - Implement Suffix Tree ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the Suffix Tree class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/suffix_tree.h"
+#include "support/suffix_tree_node.h"
+#include "third_party/llvm-project/include/llvm/Support/Casting.h"
+
+using namespace llvm;
+
+namespace wasm {
+
+/// \returns the number of elements in the substring associated with \p N.
+static size_t numElementsInSubstring(const SuffixTreeNode* N) {
+  assert(N && "Got a null node?");
+  if (auto* Internal = dyn_cast<SuffixTreeInternalNode>(N))
+    if (Internal->isRoot())
+      return 0;
+  return N->getEndIdx() - N->getStartIdx() + 1;
+}
+
+SuffixTree::SuffixTree(const std::vector<unsigned>& Str) : Str(Str) {
+  Root = insertRoot();
+  Active.Node = Root;
+
+  // Keep track of the number of suffixes we have to add of the current
+  // prefix.
+  unsigned SuffixesToAdd = 0;
+
+  // Construct the suffix tree iteratively on each prefix of the string.
+  // PfxEndIdx is the end index of the current prefix.
+  // End is one past the last element in the string.
+  for (unsigned PfxEndIdx = 0, End = Str.size(); PfxEndIdx < End; PfxEndIdx++) {
+    SuffixesToAdd++;
+    LeafEndIdx = PfxEndIdx; // Extend each of the leaves.
+    SuffixesToAdd = extend(PfxEndIdx, SuffixesToAdd);
+  }
+
+  // Set the suffix indices of each leaf.
+  assert(Root && "Root node can't be nullptr!");
+  setSuffixIndices();
+}
+
+SuffixTreeNode* SuffixTree::insertLeaf(SuffixTreeInternalNode& Parent,
+                                       unsigned StartIdx,
+                                       unsigned Edge) {
+  assert(StartIdx <= LeafEndIdx && "String can't start after it ends!");
+  auto* N = new SuffixTreeLeafNode(StartIdx, &LeafEndIdx);
+  Parent.Children[Edge] = N;
+  return N;
+}
+
+SuffixTreeInternalNode*
+SuffixTree::insertInternalNode(SuffixTreeInternalNode* Parent,
+                               unsigned StartIdx,
+                               unsigned EndIdx,
+                               unsigned Edge) {
+  assert(StartIdx <= EndIdx && "String can't start after it ends!");
+  assert(!(!Parent && StartIdx != SuffixTreeNode::EmptyIdx) &&
+         "Non-root internal nodes must have parents!");
+  auto* N = new SuffixTreeInternalNode(StartIdx, EndIdx, Root);
+  if (Parent)
+    Parent->Children[Edge] = N;
+  return N;
+}
+
+SuffixTreeInternalNode* SuffixTree::insertRoot() {
+  return insertInternalNode(/*Parent = */ nullptr,
+                            SuffixTreeNode::EmptyIdx,
+                            SuffixTreeNode::EmptyIdx,
+                            /*Edge = */ 0);
+}
+
+void SuffixTree::setSuffixIndices() {
+  // List of nodes we need to visit along with the current length of the
+  // string.
+  std::vector<std::pair<SuffixTreeNode*, unsigned>> ToVisit;
+
+  // Current node being visited.
+  SuffixTreeNode* CurrNode = Root;
+
+  // Sum of the lengths of the nodes down the path to the current one.
+  unsigned CurrNodeLen = 0;
+  ToVisit.push_back({CurrNode, CurrNodeLen});
+  while (!ToVisit.empty()) {
+    std::tie(CurrNode, CurrNodeLen) = ToVisit.back();
+    ToVisit.pop_back();
+    // Length of the current node from the root down to here.
+    CurrNode->setConcatLen(CurrNodeLen);
+    if (auto* InternalNode = dyn_cast<SuffixTreeInternalNode>(CurrNode))
+      for (auto& ChildPair : InternalNode->Children) {
+        assert(ChildPair.second && "Node had a null child!");
+        ToVisit.push_back(
+          {ChildPair.second,
+           CurrNodeLen + numElementsInSubstring(ChildPair.second)});
+      }
+    // No children, so we are at the end of the string.
+    if (auto* LeafNode = dyn_cast<SuffixTreeLeafNode>(CurrNode))
+      LeafNode->setSuffixIdx(Str.size() - CurrNodeLen);
+  }
+}
+
+unsigned SuffixTree::extend(unsigned EndIdx, unsigned SuffixesToAdd) {
+  SuffixTreeInternalNode* NeedsLink = nullptr;
+
+  while (SuffixesToAdd > 0) {
+
+    // Are we waiting to add anything other than just the last character?
+    if (Active.Len == 0) {
+      // If not, then say the active index is the end index.
+      Active.Idx = EndIdx;
+    }
+
+    assert(Active.Idx <= EndIdx && "Start index can't be after end index!");
+
+    // The first character in the current substring we're looking at.
+    unsigned FirstChar = Str[Active.Idx];
+
+    // Have we inserted anything starting with FirstChar at the current node?
+    if (Active.Node->Children.count(FirstChar) == 0) {
+      // If not, then we can just insert a leaf and move to the next step.
+      insertLeaf(*Active.Node, EndIdx, FirstChar);
+
+      // The active node is an internal node, and we visited it, so it must
+      // need a link if it doesn't have one.
+      if (NeedsLink) {
+        NeedsLink->setLink(Active.Node);
+        NeedsLink = nullptr;
+      }
+    } else {
+      // There's a match with FirstChar, so look for the point in the tree to
+      // insert a new node.
+      SuffixTreeNode* NextNode = Active.Node->Children[FirstChar];
+
+      unsigned SubstringLen = numElementsInSubstring(NextNode);
+
+      // Is the current suffix we're trying to insert longer than the size of
+      // the child we want to move to?
+      if (Active.Len >= SubstringLen) {
+        // If yes, then consume the characters we've seen and move to the next
+        // node.
+        // TODO: Enable the below assert
+        // assert(isa<SuffixTreeInternalNode>(NextNode) &&
+        //       "Expected an internal node?");
+        Active.Idx += SubstringLen;
+        Active.Len -= SubstringLen;
+        Active.Node = cast<SuffixTreeInternalNode>(NextNode);
+        continue;
+      }
+
+      // Otherwise, the suffix we're trying to insert must be contained in the
+      // next node we want to move to.
+      unsigned LastChar = Str[EndIdx];
+
+      // Is the string we're trying to insert a substring of the next node?
+      if (Str[NextNode->getStartIdx() + Active.Len] == LastChar) {
+        // If yes, then we're done for this step. Remember our insertion point
+        // and move to the next end index. At this point, we have an implicit
+        // suffix tree.
+        if (NeedsLink && !Active.Node->isRoot()) {
+          NeedsLink->setLink(Active.Node);
+          NeedsLink = nullptr;
+        }
+
+        Active.Len++;
+        break;
+      }
+
+      // The string we're trying to insert isn't a substring of the next node,
+      // but matches up to a point. Split the node.
+      //
+      // For example, say we ended our search at a node n and we're trying to
+      // insert ABD. Then we'll create a new node s for AB, reduce n to just
+      // representing C, and insert a new leaf node l to represent d. This
+      // allows us to ensure that if n was a leaf, it remains a leaf.
+      //
+      //   | ABC  ---split--->  | AB
+      //   n                    s
+      //                     C / \ D
+      //                      n   l
+
+      // The node s from the diagram
+      SuffixTreeInternalNode* SplitNode =
+        insertInternalNode(Active.Node,
+                           NextNode->getStartIdx(),
+                           NextNode->getStartIdx() + Active.Len - 1,
+                           FirstChar);
+
+      // Insert the new node representing the new substring into the tree as
+      // a child of the split node. This is the node l from the diagram.
+      insertLeaf(*SplitNode, EndIdx, LastChar);
+
+      // Make the old node a child of the split node and update its start
+      // index. This is the node n from the diagram.
+      NextNode->incrementStartIdx(Active.Len);
+      SplitNode->Children[Str[NextNode->getStartIdx()]] = NextNode;
+
+      // SplitNode is an internal node, update the suffix link.
+      if (NeedsLink)
+        NeedsLink->setLink(SplitNode);
+
+      NeedsLink = SplitNode;
+    }
+
+    // We've added something new to the tree, so there's one less suffix to
+    // add.
+    SuffixesToAdd--;
+
+    if (Active.Node->isRoot()) {
+      if (Active.Len > 0) {
+        Active.Len--;
+        Active.Idx = EndIdx - SuffixesToAdd + 1;
+      }
+    } else {
+      // Start the next phase at the next smallest suffix.
+      Active.Node = Active.Node->getLink();
+    }
+  }
+
+  return SuffixesToAdd;
+}
+
+void SuffixTree::RepeatedSubstringIterator::advance() {
+  // Clear the current state. If we're at the end of the range, then this
+  // is the state we want to be in.
+  RS = RepeatedSubstring();
+  N = nullptr;
+
+  // Each leaf node represents a repeat of a string.
+  std::vector<unsigned> RepeatedSubstringStarts;
+
+  // Continue visiting nodes until we find one which repeats more than once.
+  while (!InternalNodesToVisit.empty()) {
+    RepeatedSubstringStarts.clear();
+    auto* Curr = InternalNodesToVisit.back();
+    InternalNodesToVisit.pop_back();
+
+    // Keep track of the length of the string associated with the node. If
+    // it's too short, we'll quit.
+    unsigned Length = Curr->getConcatLen();
+
+    // Iterate over each child, saving internal nodes for visiting, and
+    // leaf nodes in LeafChildren. Internal nodes represent individual
+    // strings, which may repeat.
+    for (auto& ChildPair : Curr->Children) {
+      // Save all of this node's children for processing.
+      if (auto* InternalChild =
+            dyn_cast<SuffixTreeInternalNode>(ChildPair.second)) {
+        InternalNodesToVisit.push_back(InternalChild);
+        continue;
+      }
+
+      if (Length < MinLength)
+        continue;
+
+      // Have an occurrence of a potentially repeated string. Save it.
+      auto* Leaf = cast<SuffixTreeLeafNode>(ChildPair.second);
+      RepeatedSubstringStarts.push_back(Leaf->getSuffixIdx());
+    }
+
+    // The root never represents a repeated substring. If we're looking at
+    // that, then skip it.
+    if (Curr->isRoot())
+      continue;
+
+    // Do we have any repeated substrings?
+    if (RepeatedSubstringStarts.size() < 2)
+      continue;
+
+    // Yes. Update the state to reflect this, and then bail out.
+    N = Curr;
+    RS.Length = Length;
+    for (unsigned StartIdx : RepeatedSubstringStarts)
+      RS.StartIndices.push_back(StartIdx);
+    break;
+  }
+  // At this point, either NewRS is an empty RepeatedSubstring, or it was
+  // set in the above loop. Similarly, N is either nullptr, or the node
+  // associated with NewRS.
+}
+
+} // namespace wasm

--- a/src/support/suffix_tree.cpp
+++ b/src/support/suffix_tree.cpp
@@ -292,8 +292,9 @@ void SuffixTree::RepeatedSubstringIterator::advance() {
     // Yes. Update the state to reflect this, and then bail out.
     N = Curr;
     RS.Length = Length;
-    for (unsigned StartIdx : RepeatedSubstringStarts)
+    for (unsigned StartIdx : RepeatedSubstringStarts) {
       RS.StartIndices.push_back(StartIdx);
+    }
     break;
   }
   // At this point, either NewRS is an empty RepeatedSubstring, or it was

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -1,20 +1,5 @@
-// TODO: figure out license and proper attribution
-
-/*
- * Copyright 2023 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// This file began as an import from LLVM, and so it has the same license as
+// LLVM, copied below together with the code.
 
 //===- llvm/ADT/SuffixTree.h - Tree for substrings --------------*- C++ -*-===//
 //

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -37,7 +37,7 @@
 #ifndef wasm_support_suffix_tree_h
 #define wasm_support_suffix_tree_h
 
-#include "third_party/llvm-project/include/llvm/Support/Allocator.h"
+#include "llvm/Support/Allocator.h"
 #include <cassert>
 #include <cstddef>
 #include <vector>

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -32,6 +32,8 @@
 // https://www.cs.helsinki.fi/u/ukkonen/SuffixT1withFigs.pdf
 //===----------------------------------------------------------------------===//
 
+// clang-format off
+
 #ifndef wasm_support_suffix_tree_h
 #define wasm_support_suffix_tree_h
 

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -50,11 +50,14 @@
 #ifndef wasm_support_suffix_tree_h
 #define wasm_support_suffix_tree_h
 
+#include "third_party/llvm-project/include/llvm/Support/Allocator.h"
 #include <cassert>
 #include <cstddef>
 #include <vector>
 
 #include "support/suffix_tree_node.h"
+
+using namespace llvm;
 
 namespace wasm {
 class SuffixTree {
@@ -74,9 +77,9 @@ public:
 
 private:
   /// Maintains internal nodes in the tree.
-  // SpecificBumpPtrAllocator<SuffixTreeInternalNode> InternalNodeAllocator;
+  SpecificBumpPtrAllocator<SuffixTreeInternalNode> InternalNodeAllocator;
   /// Maintains leaf nodes in the tree.
-  // SpecificBumpPtrAllocator<SuffixTreeLeafNode> LeafNodeAllocator;
+  SpecificBumpPtrAllocator<SuffixTreeLeafNode> LeafNodeAllocator;
 
   /// The root of the suffix tree.
   ///

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -32,8 +32,6 @@
 // https://www.cs.helsinki.fi/u/ukkonen/SuffixT1withFigs.pdf
 //===----------------------------------------------------------------------===//
 
-// clang-format off
-
 #ifndef wasm_support_suffix_tree_h
 #define wasm_support_suffix_tree_h
 
@@ -193,8 +191,9 @@ public:
 
     RepeatedSubstringIterator(SuffixTreeInternalNode* N) : N(N) {
       // Do we have a non-null node?
-      if (!N)
+      if (!N) {
         return;
+      }
       // Yes. At the first step, we need to visit all of N's children.
       // Note: This means that we visit N last.
       InternalNodesToVisit.push_back(N);

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -1,0 +1,221 @@
+// TODO: figure out license and proper attribution
+
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===- llvm/ADT/SuffixTree.h - Tree for substrings --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// A data structure for fast substring queries.
+//
+// Suffix trees represent the suffixes of their input strings in their leaves.
+// A suffix tree is a type of compressed trie structure where each node
+// represents an entire substring rather than a single character. Each leaf
+// of the tree is a suffix.
+//
+// A suffix tree can be seen as a type of state machine where each state is a
+// substring of the full string. The tree is structured so that, for a string
+// of length N, there are exactly N leaves in the tree. This structure allows
+// us to quickly find repeated substrings of the input string.
+//
+// In this implementation, a "string" is a vector of unsigned integers.
+// These integers may result from hashing some data type. A suffix tree can
+// contain 1 or many strings, which can then be queried as one large string.
+//
+// The suffix tree is implemented using Ukkonen's algorithm for linear-time
+// suffix tree construction. Ukkonen's algorithm is explained in more detail
+// in the paper by Esko Ukkonen "On-line construction of suffix trees. The
+// paper is available at
+//
+// https://www.cs.helsinki.fi/u/ukkonen/SuffixT1withFigs.pdf
+//===----------------------------------------------------------------------===//
+
+#ifndef wasm_support_suffix_tree_h
+#define wasm_support_suffix_tree_h
+
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+#include "support/suffix_tree_node.h"
+
+namespace wasm {
+class SuffixTree {
+public:
+  /// Each element is an integer representing an instruction in the module.
+  std::vector<unsigned> Str;
+
+  /// A repeated substring in the tree.
+  struct RepeatedSubstring {
+    /// The length of the string.
+    unsigned Length;
+
+    /// The start indices of each occurrence.
+    std::vector<unsigned> StartIndices;
+  };
+
+private:
+  /// Maintains internal nodes in the tree.
+  // SpecificBumpPtrAllocator<SuffixTreeInternalNode> InternalNodeAllocator;
+  /// Maintains leaf nodes in the tree.
+  // SpecificBumpPtrAllocator<SuffixTreeLeafNode> LeafNodeAllocator;
+
+  /// The root of the suffix tree.
+  ///
+  /// The root represents the empty string. It is maintained by the
+  /// \p NodeAllocator like every other node in the tree.
+  SuffixTreeInternalNode* Root = nullptr;
+
+  /// The end index of each leaf in the tree.
+  unsigned LeafEndIdx = SuffixTreeNode::EmptyIdx;
+
+  /// Helper struct which keeps track of the next insertion point in
+  /// Ukkonen's algorithm.
+  struct ActiveState {
+    /// The next node to insert at.
+    SuffixTreeInternalNode* Node = nullptr;
+
+    /// The index of the first character in the substring currently being added.
+    unsigned Idx = SuffixTreeNode::EmptyIdx;
+
+    /// The length of the substring we have to add at the current step.
+    unsigned Len = 0;
+  };
+
+  /// The point the next insertion will take place at in the
+  /// construction algorithm.
+  ActiveState Active;
+
+  /// Allocate a leaf node and add it to the tree.
+  ///
+  /// \param Parent The parent of this node.
+  /// \param StartIdx The start index of this node's associated string.
+  /// \param Edge The label on the edge leaving \p Parent to this node.
+  ///
+  /// \returns A pointer to the allocated leaf node.
+  SuffixTreeNode*
+  insertLeaf(SuffixTreeInternalNode& Parent, unsigned StartIdx, unsigned Edge);
+
+  /// Allocate an internal node and add it to the tree.
+  ///
+  /// \param Parent The parent of this node. Only null when allocating the root.
+  /// \param StartIdx The start index of this node's associated string.
+  /// \param EndIdx The end index of this node's associated string.
+  /// \param Edge The label on the edge leaving \p Parent to this node.
+  ///
+  /// \returns A pointer to the allocated internal node.
+  SuffixTreeInternalNode* insertInternalNode(SuffixTreeInternalNode* Parent,
+                                             unsigned StartIdx,
+                                             unsigned EndIdx,
+                                             unsigned Edge);
+
+  /// Allocate the root node and add it to the tree.
+  ///
+  /// \returns A pointer to the root.
+  SuffixTreeInternalNode* insertRoot();
+
+  /// Set the suffix indices of the leaves to the start indices of their
+  /// respective suffixes.
+  void setSuffixIndices();
+
+  /// Construct the suffix tree for the prefix of the input ending at
+  /// \p EndIdx.
+  ///
+  /// Used to construct the full suffix tree iteratively. At the end of each
+  /// step, the constructed suffix tree is either a valid suffix tree, or a
+  /// suffix tree with implicit suffixes. At the end of the final step, the
+  /// suffix tree is a valid tree.
+  ///
+  /// \param EndIdx The end index of the current prefix in the main string.
+  /// \param SuffixesToAdd The number of suffixes that must be added
+  /// to complete the suffix tree at the current phase.
+  ///
+  /// \returns The number of suffixes that have not been added at the end of
+  /// this step.
+  unsigned extend(unsigned EndIdx, unsigned SuffixesToAdd);
+
+public:
+  /// Construct a suffix tree from a sequence of unsigned integers.
+  ///
+  /// \param Str The string to construct the suffix tree for.
+  SuffixTree(const std::vector<unsigned>& Str);
+
+  /// Iterator for finding all repeated substrings in the suffix tree.
+  struct RepeatedSubstringIterator {
+  private:
+    /// The current node we're visiting.
+    SuffixTreeNode* N = nullptr;
+
+    /// The repeated substring associated with this node.
+    RepeatedSubstring RS;
+
+    /// The nodes left to visit.
+    std::vector<SuffixTreeInternalNode*> InternalNodesToVisit;
+
+    /// The minimum length of a repeated substring to find.
+    /// Since we're outlining, we want at least two instructions in the range.
+    /// FIXME: This may not be true for targets like X86 which support many
+    /// instruction lengths.
+    const unsigned MinLength = 2;
+
+    /// Move the iterator to the next repeated substring.
+    void advance();
+
+  public:
+    /// Return the current repeated substring.
+    RepeatedSubstring& operator*() { return RS; }
+
+    RepeatedSubstringIterator& operator++() {
+      advance();
+      return *this;
+    }
+
+    RepeatedSubstringIterator operator++(int I) {
+      RepeatedSubstringIterator It(*this);
+      advance();
+      return It;
+    }
+
+    bool operator==(const RepeatedSubstringIterator& Other) const {
+      return N == Other.N;
+    }
+    bool operator!=(const RepeatedSubstringIterator& Other) const {
+      return !(*this == Other);
+    }
+
+    RepeatedSubstringIterator(SuffixTreeInternalNode* N) : N(N) {
+      // Do we have a non-null node?
+      if (!N)
+        return;
+      // Yes. At the first step, we need to visit all of N's children.
+      // Note: This means that we visit N last.
+      InternalNodesToVisit.push_back(N);
+      advance();
+    }
+  };
+
+  typedef RepeatedSubstringIterator iterator;
+  iterator begin() { return iterator(Root); }
+  iterator end() { return iterator(nullptr); }
+};
+
+} // namespace wasm
+
+#endif // wasm_support_suffix_tree_h

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -60,6 +60,7 @@ namespace wasm {
 class SuffixTree {
 public:
   /// Each element is an integer representing an instruction in the module.
+  // TODO: This was an ArrayRef originally
   std::vector<unsigned> Str;
 
   /// A repeated substring in the tree.

--- a/src/support/suffix_tree_node.cpp
+++ b/src/support/suffix_tree_node.cpp
@@ -1,0 +1,58 @@
+// TODO: figure out license and proper attribution
+
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===- llvm/ADT/SuffixTreeNode.cpp - Nodes for SuffixTrees --------*- C++
+//-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines nodes for use within a SuffixTree.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/SuffixTreeNode.h"
+
+using namespace llvm;
+
+unsigned SuffixTreeNode::getStartIdx() const { return StartIdx; }
+void SuffixTreeNode::incrementStartIdx(unsigned Inc) { StartIdx += Inc; }
+void SuffixTreeNode::setConcatLen(unsigned Len) { ConcatLen = Len; }
+unsigned SuffixTreeNode::getConcatLen() const { return ConcatLen; }
+
+bool SuffixTreeInternalNode::isRoot() const {
+  return getStartIdx() == EmptyIdx;
+}
+unsigned SuffixTreeInternalNode::getEndIdx() const { return EndIdx; }
+void SuffixTreeInternalNode::setLink(SuffixTreeInternalNode* L) {
+  assert(L && "Cannot set a null link?");
+  Link = L;
+}
+SuffixTreeInternalNode* SuffixTreeInternalNode::getLink() const { return Link; }
+
+unsigned SuffixTreeLeafNode::getEndIdx() const {
+  assert(EndIdx && "EndIdx is empty?");
+  return *EndIdx;
+}
+
+unsigned SuffixTreeLeafNode::getSuffixIdx() const { return SuffixIdx; }
+void SuffixTreeLeafNode::setSuffixIdx(unsigned Idx) { SuffixIdx = Idx; }

--- a/src/support/suffix_tree_node.cpp
+++ b/src/support/suffix_tree_node.cpp
@@ -1,20 +1,5 @@
-// TODO: figure out license and proper attribution
-
-/*
- * Copyright 2023 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// This file began as an import from LLVM, and so it has the same license as
+// LLVM, copied below together with the code.
 
 //===- llvm/ADT/SuffixTreeNode.cpp - Nodes for SuffixTrees --------*- C++
 //-*-===//

--- a/src/support/suffix_tree_node.cpp
+++ b/src/support/suffix_tree_node.cpp
@@ -29,10 +29,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/SuffixTreeNode.h"
+#include "support/suffix_tree_node.h"
+#include <cassert>
 
-using namespace llvm;
+namespace wasm {
 
 unsigned SuffixTreeNode::getStartIdx() const { return StartIdx; }
 void SuffixTreeNode::incrementStartIdx(unsigned Inc) { StartIdx += Inc; }
@@ -56,3 +56,5 @@ unsigned SuffixTreeLeafNode::getEndIdx() const {
 
 unsigned SuffixTreeLeafNode::getSuffixIdx() const { return SuffixIdx; }
 void SuffixTreeLeafNode::setSuffixIdx(unsigned Idx) { SuffixIdx = Idx; }
+
+} // namespace wasm

--- a/src/support/suffix_tree_node.h
+++ b/src/support/suffix_tree_node.h
@@ -44,6 +44,8 @@
 #ifndef wasm_support_suffix_tree_node_h
 #define wasm_support_suffix_tree_node_h
 
+#include <unordered_map>
+
 namespace wasm {
 
 /// A node in a suffix tree which represents a substring or suffix.
@@ -141,7 +143,7 @@ public:
   /// A child existing on an unsigned integer implies that from the mapping
   /// represented by the current node, there is a way to reach another
   /// mapping by tacking that character on the end of the current string.
-  DenseMap<unsigned, SuffixTreeNode*> Children;
+  std::unordered_map<unsigned, SuffixTreeNode*> Children;
 
   SuffixTreeInternalNode(unsigned StartIdx,
                          unsigned EndIdx,

--- a/src/support/suffix_tree_node.h
+++ b/src/support/suffix_tree_node.h
@@ -1,0 +1,190 @@
+// TODO: figure out license and proper attribution
+
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===- llvm/ADT/SuffixTreeNode.h - Nodes for SuffixTrees --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines nodes for use within a SuffixTree.
+//
+// Each node has either no children or at least two children, with the root
+// being a exception in the empty tree.
+//
+// Children are represented as a map between unsigned integers and nodes. If
+// a node N has a child M on unsigned integer k, then the mapping represented
+// by N is a proper prefix of the mapping represented by M. Note that this,
+// although similar to a trie is somewhat different: each node stores a full
+// substring of the full mapping rather than a single character state.
+//
+// Each internal node contains a pointer to the internal node representing
+// the same string, but with the first character chopped off. This is stored
+// in \p Link. Each leaf node stores the start index of its respective
+// suffix in \p SuffixIdx.
+//===----------------------------------------------------------------------===//
+
+#ifndef wasm_support_suffix_tree_node_h
+#define wasm_support_suffix_tree_node_h
+
+namespace wasm {
+
+/// A node in a suffix tree which represents a substring or suffix.
+struct SuffixTreeNode {
+public:
+  /// Represents an undefined index in the suffix tree.
+  static const unsigned EmptyIdx = -1;
+  enum class NodeKind { ST_Leaf, ST_Internal };
+
+private:
+  const NodeKind Kind;
+
+  /// The start index of this node's substring in the main string.
+  unsigned StartIdx = EmptyIdx;
+
+  /// The length of the string formed by concatenating the edge labels from
+  /// the root to this node.
+  unsigned ConcatLen = 0;
+
+public:
+  // LLVM RTTI boilerplate.
+  NodeKind getKind() const { return Kind; }
+
+  /// \return the start index of this node's substring in the entire string.
+  unsigned getStartIdx() const;
+
+  /// \returns the end index of this node.
+  virtual unsigned getEndIdx() const = 0;
+
+  /// Advance this node's StartIdx by \p Inc.
+  void incrementStartIdx(unsigned Inc);
+
+  /// Set the length of the string from the root to this node to \p Len.
+  void setConcatLen(unsigned Len);
+
+  /// \returns the length of the string from the root to this node.
+  unsigned getConcatLen() const;
+
+  SuffixTreeNode(NodeKind Kind, unsigned StartIdx)
+    : Kind(Kind), StartIdx(StartIdx) {}
+  virtual ~SuffixTreeNode() = default;
+};
+
+// A node with two or more children, or the root.
+struct SuffixTreeInternalNode : SuffixTreeNode {
+private:
+  /// The end index of this node's substring in the main string.
+  ///
+  /// Every leaf node must have its \p EndIdx incremented at the end of every
+  /// step in the construction algorithm. To avoid having to update O(N)
+  /// nodes individually at the end of every step, the end index is stored
+  /// as a pointer.
+  unsigned EndIdx = EmptyIdx;
+
+  /// A pointer to the internal node representing the same sequence with the
+  /// first character chopped off.
+  ///
+  /// This acts as a shortcut in Ukkonen's algorithm. One of the things that
+  /// Ukkonen's algorithm does to achieve linear-time construction is
+  /// keep track of which node the next insert should be at. This makes each
+  /// insert O(1), and there are a total of O(N) inserts. The suffix link
+  /// helps with inserting children of internal nodes.
+  ///
+  /// Say we add a child to an internal node with associated mapping S. The
+  /// next insertion must be at the node representing S - its first character.
+  /// This is given by the way that we iteratively build the tree in Ukkonen's
+  /// algorithm. The main idea is to look at the suffixes of each prefix in the
+  /// string, starting with the longest suffix of the prefix, and ending with
+  /// the shortest. Therefore, if we keep pointers between such nodes, we can
+  /// move to the next insertion point in O(1) time. If we don't, then we'd
+  /// have to query from the root, which takes O(N) time. This would make the
+  /// construction algorithm O(N^2) rather than O(N).
+  SuffixTreeInternalNode* Link = nullptr;
+
+public:
+  // LLVM RTTI boilerplate.
+  static bool classof(const SuffixTreeNode* N) {
+    return N->getKind() == NodeKind::ST_Internal;
+  }
+
+  /// \returns true if this node is the root of its owning \p SuffixTree.
+  bool isRoot() const;
+
+  /// \returns the end index of this node's substring in the entire string.
+  unsigned getEndIdx() const override;
+
+  /// Sets \p Link to \p L. Assumes \p L is not null.
+  void setLink(SuffixTreeInternalNode* L);
+
+  /// \returns the pointer to the Link node.
+  SuffixTreeInternalNode* getLink() const;
+
+  /// The children of this node.
+  ///
+  /// A child existing on an unsigned integer implies that from the mapping
+  /// represented by the current node, there is a way to reach another
+  /// mapping by tacking that character on the end of the current string.
+  DenseMap<unsigned, SuffixTreeNode*> Children;
+
+  SuffixTreeInternalNode(unsigned StartIdx,
+                         unsigned EndIdx,
+                         SuffixTreeInternalNode* Link)
+    : SuffixTreeNode(NodeKind::ST_Internal, StartIdx), EndIdx(EndIdx),
+      Link(Link) {}
+
+  virtual ~SuffixTreeInternalNode() = default;
+};
+
+// A node representing a suffix.
+struct SuffixTreeLeafNode : SuffixTreeNode {
+private:
+  /// The start index of the suffix represented by this leaf.
+  unsigned SuffixIdx = EmptyIdx;
+
+  /// The end index of this node's substring in the main string.
+  ///
+  /// Every leaf node must have its \p EndIdx incremented at the end of every
+  /// step in the construction algorithm. To avoid having to update O(N)
+  /// nodes individually at the end of every step, the end index is stored
+  /// as a pointer.
+  unsigned* EndIdx = nullptr;
+
+public:
+  // LLVM RTTI boilerplate.
+  static bool classof(const SuffixTreeNode* N) {
+    return N->getKind() == NodeKind::ST_Leaf;
+  }
+
+  /// \returns the end index of this node's substring in the entire string.
+  unsigned getEndIdx() const override;
+
+  /// \returns the start index of the suffix represented by this leaf.
+  unsigned getSuffixIdx() const;
+
+  /// Sets the start index of the suffix represented by this leaf to \p Idx.
+  void setSuffixIdx(unsigned Idx);
+  SuffixTreeLeafNode(unsigned StartIdx, unsigned* EndIdx)
+    : SuffixTreeNode(NodeKind::ST_Leaf, StartIdx), EndIdx(EndIdx) {}
+
+  virtual ~SuffixTreeLeafNode() = default;
+};
+} // namespace wasm
+
+#endif // wasm_support_suffix_tree_node_h

--- a/src/support/suffix_tree_node.h
+++ b/src/support/suffix_tree_node.h
@@ -1,20 +1,5 @@
-// TODO: figure out license and proper attribution
-
-/*
- * Copyright 2023 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// This file began as an import from LLVM, and so it has the same license as
+// LLVM, copied below together with the code.
 
 //===- llvm/ADT/SuffixTreeNode.h - Nodes for SuffixTrees --------*- C++ -*-===//
 //

--- a/src/support/suffix_tree_node.h
+++ b/src/support/suffix_tree_node.h
@@ -26,6 +26,8 @@
 // suffix in \p SuffixIdx.
 //===----------------------------------------------------------------------===//
 
+// clang-format off
+
 #ifndef wasm_support_suffix_tree_node_h
 #define wasm_support_suffix_tree_node_h
 

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -6,9 +6,15 @@ set(unittest_SOURCES
   dfa_minimization.cpp
   possible-contents.cpp
   stringify.cpp
+  suffix_tree.cpp
   type-builder.cpp
   wat-lexer.cpp
 )
+
+# suffix_tree.cpp includes LLVM header using std::iterator (deprecated in C++17)
+if (NOT MSVC)
+  set_source_files_properties(suffix_tree.cpp PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+endif()
 
 binaryen_add_executable(binaryen-unittests "${unittest_SOURCES}")
 target_link_libraries(binaryen-unittests gtest gtest_main)

--- a/test/gtest/suffix_tree.cpp
+++ b/test/gtest/suffix_tree.cpp
@@ -1,20 +1,5 @@
-// TODO: figure out license and proper attribution
-
-/*
- * Copyright 2023 WebAssembly Community Group participants
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// This file began as an import from LLVM, and so it has the same license as
+// LLVM, copied below together with the code.
 
 //===- unittests/Support/SuffixTreeTest.cpp - suffix tree tests -----------===//
 //

--- a/test/gtest/suffix_tree.cpp
+++ b/test/gtest/suffix_tree.cpp
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// clang-format off
+
 #include "support/suffix_tree.h"
 #include "third_party/llvm-project/include/llvm/ADT/STLExtras.h"
 #include "third_party/llvm-project/include/llvm/ADT/iterator_range.h"

--- a/test/gtest/suffix_tree.cpp
+++ b/test/gtest/suffix_tree.cpp
@@ -12,8 +12,8 @@
 // clang-format off
 
 #include "support/suffix_tree.h"
-#include "third_party/llvm-project/include/llvm/ADT/STLExtras.h"
-#include "third_party/llvm-project/include/llvm/ADT/iterator_range.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/iterator_range.h"
 #include "gtest/gtest.h"
 #include <vector>
 

--- a/test/gtest/suffix_tree.cpp
+++ b/test/gtest/suffix_tree.cpp
@@ -1,0 +1,163 @@
+// TODO: figure out license and proper attribution
+
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//===- unittests/Support/SuffixTreeTest.cpp - suffix tree tests -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/suffix_tree.h"
+#include "third_party/llvm-project/include/llvm/ADT/STLExtras.h"
+#include "third_party/llvm-project/include/llvm/ADT/iterator_range.h"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace llvm;
+
+namespace wasm {
+
+// Each example vector has a unique element at the end to represent the end of
+// the string
+
+// Tests that The SuffixTree finds a simple repetition of the substring {1, 2}
+// {1, 2} twice in the provided string.
+TEST(SuffixTreeTest, TestSingleRepetition) {
+  std::vector<unsigned> SimpleRepetitionData = {1, 2, 1, 2, 3};
+  SuffixTree ST(SimpleRepetitionData);
+  std::vector<SuffixTree::RepeatedSubstring> SubStrings;
+  for (auto It = ST.begin(); It != ST.end(); It++)
+    SubStrings.push_back(*It);
+  ASSERT_EQ(SubStrings.size(), 1u);
+  EXPECT_EQ(SubStrings[0].Length, 2u);
+  EXPECT_EQ(SubStrings[0].StartIndices.size(), 2u);
+  for (unsigned StartIdx : SubStrings[0].StartIndices) {
+    EXPECT_EQ(SimpleRepetitionData[StartIdx], 1u);
+    EXPECT_EQ(SimpleRepetitionData[StartIdx + 1], 2u);
+  }
+}
+
+// Tests that the SuffixTree is able to find the substrings {1, 2, 3} at
+// at indices 0 and 3 as well as the substrings {2, 3} at indices 1 and 4.
+// This test also serves as a flag for improvements to the suffix tree.
+//
+// FIXME: Right now, the longest repeated substring from a specific index is
+// returned, this could be improved to return the longest repeated substring, as
+// well as those that are smaller.
+TEST(SuffixTreeTest, TestLongerRepetition) {
+  std::vector<unsigned> RepeatedRepetitionData = {1, 2, 3, 1, 2, 3, 4};
+  SuffixTree ST(RepeatedRepetitionData);
+  std::vector<SuffixTree::RepeatedSubstring> SubStrings;
+  for (auto It = ST.begin(); It != ST.end(); It++)
+    SubStrings.push_back(*It);
+  EXPECT_EQ(SubStrings.size(), 2u);
+  unsigned Len;
+  for (SuffixTree::RepeatedSubstring& RS : SubStrings) {
+    Len = RS.Length;
+    bool IsExpectedLen = (Len == 3u || Len == 2u);
+    bool IsExpectedIndex;
+    ASSERT_TRUE(IsExpectedLen);
+
+    if (Len == 3u) {
+      for (unsigned StartIdx : RS.StartIndices) {
+        IsExpectedIndex = (StartIdx == 0u || StartIdx == 3u);
+        EXPECT_TRUE(IsExpectedIndex);
+        EXPECT_EQ(RepeatedRepetitionData[StartIdx], 1u);
+        EXPECT_EQ(RepeatedRepetitionData[StartIdx + 1], 2u);
+        EXPECT_EQ(RepeatedRepetitionData[StartIdx + 2], 3u);
+      }
+    } else {
+      for (unsigned StartIdx : RS.StartIndices) {
+        IsExpectedIndex = (StartIdx == 1u || StartIdx == 4u);
+        EXPECT_TRUE(IsExpectedIndex);
+        EXPECT_EQ(RepeatedRepetitionData[StartIdx], 2u);
+        EXPECT_EQ(RepeatedRepetitionData[StartIdx + 1], 3u);
+      }
+    }
+  }
+}
+
+// Tests that the SuffixTree is able to find substring {1, 1, 1, 1, 1} at
+// indices 0 and 1.
+//
+// FIXME: Add support for detecting {1, 1} and {1, 1, 1}
+TEST(SuffixTreeTest, TestSingleCharacterRepeat) {
+  std::vector<unsigned> RepeatedRepetitionData = {1, 1, 1, 1, 1, 1, 2};
+  std::vector<unsigned>::iterator RRDIt, RRDIt2;
+  SuffixTree ST(RepeatedRepetitionData);
+  std::vector<SuffixTree::RepeatedSubstring> SubStrings;
+  for (auto It = ST.begin(); It != ST.end(); It++)
+    SubStrings.push_back(*It);
+  EXPECT_EQ(SubStrings.size(), 1u);
+  for (SuffixTree::RepeatedSubstring& RS : SubStrings) {
+    EXPECT_EQ(RS.StartIndices.size(),
+              RepeatedRepetitionData.size() - RS.Length);
+    for (unsigned StartIdx : SubStrings[0].StartIndices) {
+      RRDIt = RRDIt2 = RepeatedRepetitionData.begin();
+      std::advance(RRDIt, StartIdx);
+      std::advance(RRDIt2, StartIdx + SubStrings[0].Length);
+      ASSERT_TRUE(
+        all_of(make_range<std::vector<unsigned>::iterator>(RRDIt, RRDIt2),
+               [](unsigned Elt) { return Elt == 1; }));
+    }
+  }
+}
+
+// The suffix tree cannot currently find repeated substrings in strings of the
+// form {1, 2, 3, 1, 2, 3}, because the two {1, 2, 3}s are adjacent ("tandem
+// repeats")
+//
+// FIXME: Teach the SuffixTree to recognize these cases.
+TEST(SuffixTreeTest, TestTandemRepeat) {
+  std::vector<unsigned> RepeatedRepetitionData = {1, 2, 3, 1, 2, 3};
+  SuffixTree ST(RepeatedRepetitionData);
+  std::vector<SuffixTree::RepeatedSubstring> SubStrings;
+  for (auto It = ST.begin(); It != ST.end(); It++)
+    SubStrings.push_back(*It);
+  EXPECT_EQ(SubStrings.size(), 0u);
+}
+
+// Tests that the SuffixTree does not erroneously include values that are not
+// in repeated substrings.  That is, only finds {1, 1} at indices 0 and 3 and
+// does not include 2 and 3.
+TEST(SuffixTreeTest, TestExclusion) {
+  std::vector<unsigned> RepeatedRepetitionData = {1, 1, 2, 1, 1, 3};
+  std::vector<unsigned>::iterator RRDIt, RRDIt2;
+  SuffixTree ST(RepeatedRepetitionData);
+  std::vector<SuffixTree::RepeatedSubstring> SubStrings;
+  for (auto It = ST.begin(); It != ST.end(); It++)
+    SubStrings.push_back(*It);
+  EXPECT_EQ(SubStrings.size(), 1u);
+  bool IsExpectedIndex;
+  for (SuffixTree::RepeatedSubstring& RS : SubStrings) {
+    for (unsigned StartIdx : RS.StartIndices) {
+      IsExpectedIndex = (StartIdx == 0u || StartIdx == 3u);
+      EXPECT_TRUE(IsExpectedIndex);
+      RRDIt = RRDIt2 = RepeatedRepetitionData.begin();
+      std::advance(RRDIt, StartIdx);
+      std::advance(RRDIt2, StartIdx + RS.Length);
+      EXPECT_TRUE(
+        all_of(make_range<std::vector<unsigned>::iterator>(RRDIt, RRDIt2),
+               [](unsigned Elt) { return Elt == 1; }));
+    }
+  }
+}
+
+} // namespace wasm


### PR DESCRIPTION
This PR adds LLVM's suffix tree data structure to Binaryen. This suffix tree is implemented using Ukkonen's algorithm for linear-time suffix tree construction, and is intended for fast substring queries.

Note: All of the .h and .cpp files included are from LLVM. These files were copied directly instead of imported into our existing LLVM integration (in third_party/) to avoid bumping the commit hash and avoid the potential for complications with upstream changes. 