### PR TITLE
Static Analysis: Add an API to get the block index of an expression

### DIFF
--- a/src/analysis/cfg.cpp
+++ b/src/analysis/cfg.cpp
@@ -78,6 +78,14 @@ void CFG::print(std::ostream& os, Module* wasm) const {
   }
 }
 
+void CFG::computeExpressionBlockIndexes() {
+  for (auto& block : *this) {
+    for (auto* expr : block) {
+      expressionBlockIndexMap[expr] = block.getIndex();
+    }
+  }
+}
+
 void BasicBlock::print(std::ostream& os, Module* wasm, size_t start) const {
   os << ";; preds: [";
   for (auto& pred : preds()) {

--- a/src/analysis/cfg.cpp
+++ b/src/analysis/cfg.cpp
@@ -78,14 +78,6 @@ void CFG::print(std::ostream& os, Module* wasm) const {
   }
 }
 
-void CFG::computeExpressionBlockIndexes() {
-  for (auto& block : *this) {
-    for (auto* expr : block) {
-      expressionBlockIndexMap[expr] = block.getIndex();
-    }
-  }
-}
-
 void BasicBlock::print(std::ostream& os, Module* wasm, size_t start) const {
   os << ";; preds: [";
   for (auto& pred : preds()) {
@@ -108,6 +100,14 @@ void BasicBlock::print(std::ostream& os, Module* wasm, size_t start) const {
   size_t instIndex = start;
   for (auto* inst : *this) {
     os << "  " << instIndex++ << ": " << ShallowExpression{inst, wasm} << '\n';
+  }
+}
+
+CFGBlockIndexes::CFGBlockIndexes(const CFG& cfg) {
+  for (auto& block : cfg) {
+    for (auto* expr : block) {
+      expressionBlockIndexMap[expr] = block.getIndex();
+    }
   }
 }
 

--- a/src/analysis/cfg.cpp
+++ b/src/analysis/cfg.cpp
@@ -106,7 +106,7 @@ void BasicBlock::print(std::ostream& os, Module* wasm, size_t start) const {
 CFGBlockIndexes::CFGBlockIndexes(const CFG& cfg) {
   for (auto& block : cfg) {
     for (auto* expr : block) {
-      expressionBlockIndexMap[expr] = block.getIndex();
+      map[expr] = block.getIndex();
     }
   }
 }

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -89,7 +89,7 @@ struct CFGBlockIndexes {
   CFGBlockIndexes(const CFG& cfg);
 
   // Gets the index of the basic block in which the instruction resides.
-  Index get(Expression* expr) {
+  Index get(Expression* expr) const {
     auto iter = map.find(expr);
     if (iter == map.end()) {
       // There is no entry for this, which can be the case for control flow

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <vector>
 
-#include "ir/properties.h"
 #include "wasm.h"
 
 namespace wasm::analysis {
@@ -88,8 +87,7 @@ struct CFG {
     auto iter = expressionBlockIndexMap.find(expr);
     if (iter == expressionBlockIndexMap.end()) {
       // There is no entry for this, which can be the case for control flow
-      // structures.
-      assert(Properties::isControlFlowStructure(expr));
+      // structures, or for unreachable code.
       return InvalidBlock;
     }
     return iter->second;

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -77,11 +77,18 @@ struct CFG {
 
   void print(std::ostream& os, Module* wasm = nullptr) const;
 
-  // This must be done before getBlockIndex is called on an expression.
-  void computeExpressionBlockIndexes();
+private:
+  std::vector<BasicBlock> blocks;
+
+  friend BasicBlock;
+};
+
+// A helper class that computes block indexes for a CFG and allows querying of
+// them.
+struct CFGBlockIndexes {
+  CFGBlockIndexes(const CFG& cfg);
 
   // Gets the index of the basic block in which the instruction resides.
-  // computeExpressionBlockIndexes() must be called first to populate the map.
   Index getBlockIndex(Expression* expr) {
     auto iter = expressionBlockIndexMap.find(expr);
     if (iter == expressionBlockIndexMap.end()) {
@@ -95,11 +102,7 @@ struct CFG {
   enum { InvalidBlock = Index(-1) };
 
 private:
-  std::vector<BasicBlock> blocks;
-
   std::unordered_map<Expression*, Index> expressionBlockIndexMap;
-
-  friend BasicBlock;
 };
 
 } // namespace wasm::analysis

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -83,7 +83,7 @@ struct CFG {
   void computeExpressionBlockIndexes();
 
   // Gets the index of the basic block in which the instruction resides.
-  // getBlockIndex() must be called first to populate the map.
+  // computeExpressionBlockIndexes() must be called first to populate the map.
   Index getBlockIndex(Expression* expr) {
     auto iter = expressionBlockIndexMap.find(expr);
     if (iter == expressionBlockIndexMap.end()) {

--- a/src/analysis/cfg.h
+++ b/src/analysis/cfg.h
@@ -89,9 +89,9 @@ struct CFGBlockIndexes {
   CFGBlockIndexes(const CFG& cfg);
 
   // Gets the index of the basic block in which the instruction resides.
-  Index getBlockIndex(Expression* expr) {
-    auto iter = expressionBlockIndexMap.find(expr);
-    if (iter == expressionBlockIndexMap.end()) {
+  Index get(Expression* expr) {
+    auto iter = map.find(expr);
+    if (iter == map.end()) {
       // There is no entry for this, which can be the case for control flow
       // structures, or for unreachable code.
       return InvalidBlock;
@@ -102,7 +102,7 @@ struct CFGBlockIndexes {
   enum { InvalidBlock = Index(-1) };
 
 private:
-  std::unordered_map<Expression*, Index> expressionBlockIndexMap;
+  std::unordered_map<Expression*, Index> map;
 };
 
 } // namespace wasm::analysis

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -330,4 +330,3 @@ TEST_F(CFGTest, BlockIndexes) {
   EXPECT_EQ(cfg.getBlockIndex(block->list[0]), Index(1));
   EXPECT_EQ(cfg.getBlockIndex(block->list[1]), Index(1));
 }
-

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -317,20 +317,20 @@ TEST_F(CFGTest, BlockIndexes) {
 
   auto* func = wasm.getFunction("foo");
   CFG cfg = CFG::fromFunction(func);
-  cfg.computeExpressionBlockIndexes();
+  CFGBlockIndexes indexes(cfg);
 
   // The body of the function is an if. An if is a control flow structure and so
   // it has no basic block (it can contain multiple ones).
   auto* iff = func->body->cast<If>();
-  EXPECT_EQ(cfg.getBlockIndex(iff), CFG::InvalidBlock);
+  EXPECT_EQ(indexes.get(iff), indexes.InvalidBlock);
 
   // The constant 1 is in the entry block.
-  EXPECT_EQ(cfg.getBlockIndex(iff->condition), Index(0));
+  EXPECT_EQ(indexes.get(iff->condition), Index(0));
 
   // The dropped constants 2 and three are in another block, together.
   auto* block = iff->ifTrue->cast<Block>();
-  EXPECT_EQ(cfg.getBlockIndex(block->list[0]), Index(1));
-  EXPECT_EQ(cfg.getBlockIndex(block->list[1]), Index(1));
+  EXPECT_EQ(indexes.get(block->list[0]), Index(1));
+  EXPECT_EQ(indexes.get(block->list[1]), Index(1));
 }
 
 TEST_F(CFGTest, LinearReachingDefinitions) {


### PR DESCRIPTION
I'd like to use this in the reverse-direction analysis for TrapsNeverHappen: I need to know
which expressions are in the same basic block.