### PR TITLE
End the current basic block on a Call

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -297,9 +297,10 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   static void doEndCall(SubType* self, Expression** currp) {
     doEndThrowingInst(self, currp);
     // Create a new basic block and link to it. We do this even if there are no
-    // other edges leaving this call (if a throw would go entirely outside of
-    // the function), because we want to preserve the property that a basic
-    // block ends with an instruction that might branch.
+    // other edges leaving this call (no catch bodies we can reach if we throw),
+    // because we want to preserve the property that a basic block ends with an
+    // instruction that might branch, and the call might branch out of the
+    // entire function if it throws.
     auto* last = self->currBasicBlock;
     self->link(last, self->startBasicBlock());
   }

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -297,10 +297,10 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   static void doEndCall(SubType* self, Expression** currp) {
     doEndThrowingInst(self, currp);
     // Create a new basic block and link to it. We do this even if there are no
-    // other edges leaving this call (no catch bodies we can reach if we throw),
-    // because we want to preserve the property that a basic block ends with an
-    // instruction that might branch, and the call might branch out of the
-    // entire function if it throws.
+    // other edges leaving this call (no catch bodies in this function that we
+    // can reach if we throw), because we want to preserve the property that a
+    // basic block ends with an instruction that might branch, and the call
+    // might branch out of the entire function if it throws.
     auto* last = self->currBasicBlock;
     self->link(last, self->startBasicBlock());
   }

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -397,7 +397,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
       case Expression::Id::CallIndirectId:
       case Expression::Id::CallRefId: {
         auto* module = self->getModule();
-        if (module && module->features.hasExceptionHandling()) {
+        if (!module || module->features.hasExceptionHandling()) {
           // This call might throw, so run the code to handle that.
           self->pushTask(SubType::doEndCall, currp);
         }

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -297,6 +297,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   static void doEndCall(SubType* self, Expression** currp) {
     auto* module = self->getModule();
     if (module && !module->features.hasExceptionHandling()) {
+      // EH is disabled, so there cannot be a branch here due to a throw.
       return;
     }
 

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -296,11 +296,12 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
 
   static void doEndCall(SubType* self, Expression** currp) {
     doEndThrowingInst(self, currp);
-    if (!self->throwingInstsStack.empty()) {
-      // exception not thrown. link to the continuation BB
-      auto* last = self->currBasicBlock;
-      self->link(last, self->startBasicBlock());
-    }
+    // Create a new basic block and link to it. We do this even if there are no
+    // other edges leaving this call (if a throw would go entirely outside of
+    // the function), because we want to preserve the property that a basic
+    // block ends with an instruction that might branch.
+    auto* last = self->currBasicBlock;
+    self->link(last, self->startBasicBlock());
   }
 
   static void doStartTry(SubType* self, Expression** currp) {

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -295,6 +295,11 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   }
 
   static void doEndCall(SubType* self, Expression** currp) {
+    auto* module = self->getModule();
+    if (module && !module->features.hasExceptionHandling()) {
+      return;
+    }
+
     doEndThrowingInst(self, currp);
     // Create a new basic block and link to it. We do this even if there are no
     // other edges leaving this call (no catch bodies in this function that we

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -41,9 +41,11 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
 
   Flower(LocalGraph::GetSetses& getSetses,
          LocalGraph::Locations& locations,
-         Function* func)
+         Function* func,
+         Module* module)
     : getSetses(getSetses), locations(locations) {
     setFunction(func);
+    setModule(module);
     // create the CFG by walking the IR
     CFGWalker<Flower, Visitor<Flower>, Info>::doWalkFunction(func);
     // flow gets across blocks
@@ -227,8 +229,8 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
 
 // LocalGraph implementation
 
-LocalGraph::LocalGraph(Function* func) : func(func) {
-  LocalGraphInternal::Flower flower(getSetses, locations, func);
+LocalGraph::LocalGraph(Function* func, Module* module) : func(func) {
+  LocalGraphInternal::Flower flower(getSetses, locations, func, module);
 
 #ifdef LOCAL_GRAPH_DEBUG
   std::cout << "LocalGraph::dump\n";

--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -33,8 +33,12 @@ namespace wasm {
 struct LocalGraph {
   // main API
 
-  // the constructor computes getSetses, the sets affecting each get
-  LocalGraph(Function* func);
+  // The constructor computes getSetses, the sets affecting each get.
+  //
+  // If a module is passed in, it is used to find which features are needed in
+  // the computation (for example, if exception handling is disabled, then we
+  // can generate a simpler CFG, as calls cannot throw).
+  LocalGraph(Function* func, Module* module = nullptr);
 
   // The local.sets relevant for an index or a get. The most common case is to
   // have a single set; after that, to be a phi of 2 items, so we use a small

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1177,7 +1177,7 @@ struct InfoCollector
     assert(handledPops == totalPops);
 
     // Handle local.get/sets: each set must write to the proper gets.
-    LocalGraph localGraph(func);
+    LocalGraph localGraph(func, getModule());
 
     for (auto& [get, setsForGet] : localGraph.getSetses) {
       auto index = get->index;

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -184,8 +184,8 @@ struct Heap2LocalOptimizer {
   Heap2LocalOptimizer(Function* func,
                       Module* module,
                       const PassOptions& passOptions)
-    : func(func), module(module), passOptions(passOptions), localGraph(func),
-      parents(func->body), branchTargets(func->body) {
+    : func(func), module(module), passOptions(passOptions),
+      localGraph(func, module), parents(func->body), branchTargets(func->body) {
     // We need to track what each set influences, to see where its value can
     // flow to.
     localGraph.computeSetInfluences();

--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -60,7 +60,7 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
     //
     // TODO: Optimize this, as LocalGraph computes more than we need, and on
     //       more locals than we need.
-    LocalGraph localGraph(func);
+    LocalGraph localGraph(func, getModule());
 
     // For each local index, compute all the the sets and gets.
     std::vector<std::vector<LocalSet*>> setsForLocal(numLocals);

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -49,7 +49,7 @@ struct LoopInvariantCodeMotion
 
   void doWalkFunction(Function* func) {
     // Compute all local dependencies first.
-    LocalGraph localGraphInstance(func);
+    LocalGraph localGraphInstance(func, getModule());
     localGraph = &localGraphInstance;
     // Traverse the function.
     super::doWalkFunction(func);

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -107,7 +107,7 @@ struct MergeLocals
     }
     // compute all dependencies
     auto* func = getFunction();
-    LocalGraph preGraph(func);
+    LocalGraph preGraph(func, getModule());
     preGraph.computeInfluences();
     // optimize each copy
     std::unordered_map<LocalSet*, LocalSet*> optimizedToCopy,
@@ -193,7 +193,7 @@ struct MergeLocals
       // if one does not work, we need to undo all its siblings (don't extend
       // the live range unless we are definitely removing a conflict, same
       // logic as before).
-      LocalGraph postGraph(func);
+      LocalGraph postGraph(func, getModule());
       postGraph.computeSetInfluences();
       for (auto& [copy, trivial] : optimizedToCopy) {
         auto& trivialInfluences = preGraph.setInfluences[trivial];

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -296,7 +296,7 @@ struct OptimizeAddedConstants
       helperIndexes.clear();
       propagatable.clear();
       if (propagate) {
-        localGraph = std::make_unique<LocalGraph>(func);
+        localGraph = std::make_unique<LocalGraph>(func, getModule());
         localGraph->computeSetInfluences();
         localGraph->computeSSAIndexes();
         findPropagatable();

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -370,7 +370,7 @@ private:
     // compute other sets as locals (since some of the gets they read may be
     // constant).
     // compute all dependencies
-    LocalGraph localGraph(func);
+    LocalGraph localGraph(func, getModule());
     localGraph.computeInfluences();
     // prepare the work list. we add things here that might change to a constant
     // initially, that means everything

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -89,7 +89,7 @@ struct SSAify : public Pass {
   void runOnFunction(Module* module_, Function* func_) override {
     module = module_;
     func = func_;
-    LocalGraph graph(func);
+    LocalGraph graph(func, module);
     graph.computeSetInfluences();
     graph.computeSSAIndexes();
     // create new local indexes, one for each set

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -85,6 +85,51 @@ TEST_F(CFGTest, Print) {
   EXPECT_EQ(ss.str(), cfgText);
 }
 
+TEST_F(CFGTest, CallBlock) {
+  // Verify that a call instruction ends the current basic block. Even if the
+  // call has no control flow edges inside the function (no catches it can
+  // reach), we still end a basic block with the call, so that we preserve the
+  // property of basic blocks ending in possibly-control-flow-transferring
+  // instructions.
+  auto moduleText = R"wasm(
+    (module
+      (func $foo
+        (drop
+          (i32.const 0)
+        )
+        (call $bar)
+        (drop
+          (i32.const 1)
+        )
+      )
+      (func $bar)
+    )
+  )wasm";
+
+  auto cfgText = R"cfg(;; preds: [], succs: [1]
+0:
+  0: i32.const 0
+  1: drop
+  2: call $bar
+
+;; preds: [0], succs: []
+1:
+  3: i32.const 1
+  4: drop
+  5: block
+)cfg";
+
+  Module wasm;
+  parseWast(wasm, moduleText);
+
+  CFG cfg = CFG::fromFunction(wasm.getFunction("foo"));
+
+  std::stringstream ss;
+  cfg.print(ss);
+
+  EXPECT_EQ(ss.str(), cfgText);
+}
+
 TEST_F(CFGTest, LinearLiveness) {
   auto moduleText = R"wasm(
     (module


### PR DESCRIPTION
Before this PR, if a call had no paths to a catch in the same function then we skipped
creating a new basic block right after it. As a result, we could have a call in the middle
of a basic block.

That is ok, but I think it might be good to have the property that basic blocks end in
possibly-control-flow-transferring instructions. That is, anything that might branch -
even if just out of the whole function - ends a basic block, which is what this PR changes. 

This change makes a future PR simpler, as it wants to depend on that assumption.

I added a test in the analysis CFG file as that seems simplest: we can print out the
CFG there to verify what we want.
