### PR TITLE
[NFC] Avoid using ControlFlowWalker in CFGWalker

### DIFF
--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -220,8 +220,7 @@ struct CFGWalker : public PostWalker<SubType, VisitorType> {
     auto branchTargets = BranchUtils::getUniqueTargets(curr);
     // Add branches to the targets.
     for (auto target : branchTargets) {
-      self->branches[target].push_back(
-        self->currBasicBlock);
+      self->branches[target].push_back(self->currBasicBlock);
     }
     if (curr->type != Type::unreachable) {
       auto* last = self->currBasicBlock;

--- a/src/cfg/cfg-traversal.h
+++ b/src/cfg/cfg-traversal.h
@@ -37,7 +37,7 @@
 namespace wasm {
 
 template<typename SubType, typename VisitorType, typename Contents>
-struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
+struct CFGWalker : public PostWalker<SubType, VisitorType> {
 
   // public interface
 
@@ -87,7 +87,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
   // analysis on the CFG once it is constructed).
   BasicBlock* currBasicBlock;
   // a block or loop => its branches
-  std::map<Expression*, std::vector<BasicBlock*>> branches;
+  std::map<Name, std::vector<BasicBlock*>> branches;
   // stack of the last blocks of if conditions + the last blocks of if true
   // bodies
   std::vector<BasicBlock*> ifStack;
@@ -142,7 +142,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     if (!curr->name.is()) {
       return;
     }
-    auto iter = self->branches.find(curr);
+    auto iter = self->branches.find(curr->name);
     if (iter == self->branches.end()) {
       return;
     }
@@ -158,7 +158,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     for (auto* origin : origins) {
       self->link(origin, self->currBasicBlock);
     }
-    self->branches.erase(curr);
+    self->branches.erase(curr->name);
   }
 
   static void doStartIfTrue(SubType* self, Expression** currp) {
@@ -206,11 +206,11 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     // branches to the top of the loop
     if (curr->name.is()) {
       auto* loopStart = self->loopStack.back();
-      auto& origins = self->branches[curr];
+      auto& origins = self->branches[curr->name];
       for (auto* origin : origins) {
         self->link(origin, loopStart);
       }
-      self->branches.erase(curr);
+      self->branches.erase(curr->name);
     }
     self->loopStack.pop_back();
   }
@@ -220,7 +220,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
     auto branchTargets = BranchUtils::getUniqueTargets(curr);
     // Add branches to the targets.
     for (auto target : branchTargets) {
-      self->branches[self->findBreakTarget(target)].push_back(
+      self->branches[target].push_back(
         self->currBasicBlock);
     }
     if (curr->type != Type::unreachable) {
@@ -424,7 +424,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
       }
     }
 
-    ControlFlowWalker<SubType, VisitorType>::scan(self, currp);
+    PostWalker<SubType, VisitorType>::scan(self, currp);
 
     switch (curr->_id) {
       case Expression::Id::LoopId: {
@@ -441,7 +441,7 @@ struct CFGWalker : public ControlFlowWalker<SubType, VisitorType> {
 
     startBasicBlock();
     entry = currBasicBlock;
-    ControlFlowWalker<SubType, VisitorType>::doWalkFunction(func);
+    PostWalker<SubType, VisitorType>::doWalkFunction(func);
     exit = currBasicBlock;
 
     assert(branches.size() == 0);


### PR DESCRIPTION
ControlFlowWalker builds a stack of control flow items and allows finding
the target of a branch using it. But the only use CFGWalker made of that was
to map a block or a loop to its branches. We can just use the name of the block
or loop in the map, and avoid the extra overhead.

`perf stat` confirms fewer instructions and branches with this change, but
the difference in runtime is too small to measure.