### PR TITLE
C API: Add BinaryenAddFunction2 which takes a heap type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Current Trunk
 
 - Add a pass to reorder functions by name, which can be useful for debugging
   (e.g. comparisons after optimizations), `--reorder-functions-by-name`.
+- C API: Add BinaryenAddFunction2() which is like BinaryenAddFunction but takes
+  a heap type. The old function is kept for backwards compatibilty and as a
+  convenience.
 
 v114
 ----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ Current Trunk
 
 - Add a pass to reorder functions by name, which can be useful for debugging
   (e.g. comparisons after optimizations), `--reorder-functions-by-name`.
-- C API: Add BinaryenAddFunction2() which is like BinaryenAddFunction but takes
-  a heap type. The old function is kept for backwards compatibilty and as a
-  convenience.
+- C API: Add BinaryenAddFunctionWithHeapType() which is like BinaryenAddFunction
+  but takes a heap type. The old function is kept for backwards compatibility
+  and as a convenience.
 
 v114
 ----

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4943,12 +4943,13 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module,
   HeapType type = Signature(Type(params), Type(results));
   return addFunctionInternal(module, name, type, varTypes, numVarTypes, body);
 }
-BinaryenFunctionRef BinaryenAddFunction2(BinaryenModuleRef module,
-                                         const char* name,
-                                         BinaryenHeapType type,
-                                         BinaryenType* varTypes,
-                                         BinaryenIndex numVarTypes,
-                                         BinaryenExpressionRef body) {
+BinaryenFunctionRef
+BinaryenAddFunctionWithHeapType(BinaryenModuleRef module,
+                                const char* name,
+                                BinaryenHeapType type,
+                                BinaryenType* varTypes,
+                                BinaryenIndex numVarTypes,
+                                BinaryenExpressionRef body) {
   return addFunctionInternal(
     module, name, HeapType(type), varTypes, numVarTypes, body);
 }

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4910,11 +4910,11 @@ void BinaryenStringSliceIterSetNum(BinaryenExpressionRef expr,
 // Functions
 
 static BinaryenFunctionRef addFunctionInternal(BinaryenModuleRef module,
-                                         const char* name,
-                                         HeapType type,
-                                         BinaryenType* varTypes,
-                                         BinaryenIndex numVarTypes,
-                                         BinaryenExpressionRef body) {
+                                               const char* name,
+                                               HeapType type,
+                                               BinaryenType* varTypes,
+                                               BinaryenIndex numVarTypes,
+                                               BinaryenExpressionRef body) {
   auto* ret = new Function;
   ret->setExplicitName(name);
   ret->type = type;
@@ -4949,7 +4949,8 @@ BinaryenFunctionRef BinaryenAddFunction2(BinaryenModuleRef module,
                                          BinaryenType* varTypes,
                                          BinaryenIndex numVarTypes,
                                          BinaryenExpressionRef body) {
-  return addFunctionInternal(module, name, HeapType(type), varTypes, numVarTypes, body);
+  return addFunctionInternal(
+    module, name, HeapType(type), varTypes, numVarTypes, body);
 }
 BinaryenFunctionRef BinaryenGetFunction(BinaryenModuleRef module,
                                         const char* name) {

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4909,17 +4909,15 @@ void BinaryenStringSliceIterSetNum(BinaryenExpressionRef expr,
 
 // Functions
 
-BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module,
-                                        const char* name,
-                                        BinaryenType params,
-                                        BinaryenType results,
-                                        BinaryenType* varTypes,
-                                        BinaryenIndex numVarTypes,
-                                        BinaryenExpressionRef body) {
+static BinaryenFunctionRef addFunctionInternal(BinaryenModuleRef module,
+                                         const char* name,
+                                         HeapType type,
+                                         BinaryenType* varTypes,
+                                         BinaryenIndex numVarTypes,
+                                         BinaryenExpressionRef body) {
   auto* ret = new Function;
   ret->setExplicitName(name);
-  // TODO: Take a HeapType rather than params and results.
-  ret->type = Signature(Type(params), Type(results));
+  ret->type = type;
   for (BinaryenIndex i = 0; i < numVarTypes; i++) {
     ret->vars.push_back(Type(varTypes[i]));
   }
@@ -4933,6 +4931,25 @@ BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module,
   }
 
   return ret;
+}
+
+BinaryenFunctionRef BinaryenAddFunction(BinaryenModuleRef module,
+                                        const char* name,
+                                        BinaryenType params,
+                                        BinaryenType results,
+                                        BinaryenType* varTypes,
+                                        BinaryenIndex numVarTypes,
+                                        BinaryenExpressionRef body) {
+  HeapType type = Signature(Type(params), Type(results));
+  return addFunctionInternal(module, name, type, varTypes, numVarTypes, body);
+}
+BinaryenFunctionRef BinaryenAddFunction2(BinaryenModuleRef module,
+                                         const char* name,
+                                         BinaryenHeapType type,
+                                         BinaryenType* varTypes,
+                                         BinaryenIndex numVarTypes,
+                                         BinaryenExpressionRef body) {
+  return addFunctionInternal(module, name, HeapType(type), varTypes, numVarTypes, body);
 }
 BinaryenFunctionRef BinaryenGetFunction(BinaryenModuleRef module,
                                         const char* name) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2723,6 +2723,15 @@ BinaryenAddFunction(BinaryenModuleRef module,
                     BinaryenType* varTypes,
                     BinaryenIndex numVarTypes,
                     BinaryenExpressionRef body);
+// As BinaryenAddFunction, but takes a HeapType rather than params and results.
+// This lets you set the specific type of the function.
+BINARYEN_API BinaryenFunctionRef
+BinaryenAddFunction2(BinaryenModuleRef module,
+                     const char* name,
+                     BinaryenHeapType type,
+                     BinaryenType* varTypes,
+                     BinaryenIndex numVarTypes,
+                     BinaryenExpressionRef body);
 // Gets a function reference by name. Returns NULL if the function does not
 // exist.
 BINARYEN_API BinaryenFunctionRef BinaryenGetFunction(BinaryenModuleRef module,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2726,12 +2726,12 @@ BinaryenAddFunction(BinaryenModuleRef module,
 // As BinaryenAddFunction, but takes a HeapType rather than params and results.
 // This lets you set the specific type of the function.
 BINARYEN_API BinaryenFunctionRef
-BinaryenAddFunction2(BinaryenModuleRef module,
-                     const char* name,
-                     BinaryenHeapType type,
-                     BinaryenType* varTypes,
-                     BinaryenIndex numVarTypes,
-                     BinaryenExpressionRef body);
+BinaryenAddFunctionWithHeapType(BinaryenModuleRef module,
+                                const char* name,
+                                BinaryenHeapType type,
+                                BinaryenType* varTypes,
+                                BinaryenIndex numVarTypes,
+                                BinaryenExpressionRef body);
 // Gets a function reference by name. Returns NULL if the function does not
 // exist.
 BINARYEN_API BinaryenFunctionRef BinaryenGetFunction(BinaryenModuleRef module,

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -2309,6 +2309,13 @@ void test_typebuilder() {
                         varTypes,
                         4,
                         BinaryenNop(module));
+    // Also test adding a function using the HeapType-using API.
+    BinaryenAddFunction2(module,
+                         "test2",
+                         signatureHeapType,
+                         NULL,
+                         0,
+                         BinaryenUnreachable(module));
   }
   bool didValidate = BinaryenModuleValidate(module);
   assert(didValidate);

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -2310,12 +2310,8 @@ void test_typebuilder() {
                         4,
                         BinaryenNop(module));
     // Also test adding a function using the HeapType-using API.
-    BinaryenAddFunction2(module,
-                         "test2",
-                         signatureHeapType,
-                         NULL,
-                         0,
-                         BinaryenUnreachable(module));
+    BinaryenAddFunction2(
+      module, "test2", signatureHeapType, NULL, 0, BinaryenUnreachable(module));
   }
   bool didValidate = BinaryenModuleValidate(module);
   assert(didValidate);

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -2310,7 +2310,7 @@ void test_typebuilder() {
                         4,
                         BinaryenNop(module));
     // Also test adding a function using the HeapType-using API.
-    BinaryenAddFunction2(
+    BinaryenAddFunctionWithHeapType(
       module, "test2", signatureHeapType, NULL, 0, BinaryenUnreachable(module));
   }
   bool didValidate = BinaryenModuleValidate(module);

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -3167,8 +3167,8 @@ TypeBuilderErrorReasonForwardChildReference: 3
 module with recursive GC types:
 (module
  (type $SomeArray (array (mut (ref null $SomeArray))))
- (type $SomeStruct (struct (field $SomeField (mut (ref null $SomeStruct)))))
  (type $SomeSignature (func (param (ref null $SomeSignature) (ref null $SomeArray)) (result (ref null $SomeSignature))))
+ (type $SomeStruct (struct (field $SomeField (mut (ref null $SomeStruct)))))
  (type $none_=>_none (func))
  (type $SomeSubStruct (sub $SomeStruct (struct (field $SomeField (mut (ref null $SomeStruct))) (field $SomePackedField i8))))
  (func $test (type $none_=>_none)
@@ -3177,5 +3177,8 @@ module with recursive GC types:
   (local $2 (ref null $SomeSignature))
   (local $3 (ref null $SomeSubStruct))
   (nop)
+ )
+ (func $test2 (type $SomeSignature) (param $0 (ref null $SomeSignature)) (param $1 (ref null $SomeArray)) (result (ref null $SomeSignature))
+  (unreachable)
  )
 )


### PR DESCRIPTION
This is necessary for WasmGC producers using the C API, so that they can set the
heap type of functions. Otherwise the heap type is set structurally using params
and results in the old API.

The old API is kept for backwards compatibility and convenience (for the structural
case, which is all code before WasmGC basically).

Fixes #5826