### PR TITLE
SimplifyLocals: Refinalize after removing redundant tees

### DIFF
--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -1025,6 +1025,7 @@ struct SimplifyLocals
             if (removeEquivalentSets) {
               if (curr->isTee()) {
                 this->replaceCurrent(curr->value);
+                refinalize = true;
               } else {
                 this->replaceCurrent(Builder(*module).makeDrop(curr->value));
               }

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -1024,8 +1024,10 @@ struct SimplifyLocals
             // This is an unnecessary copy!
             if (removeEquivalentSets) {
               if (curr->isTee()) {
+                if (curr->value->type != curr->type) {
+                  refinalize = true;
+                }
                 this->replaceCurrent(curr->value);
-                refinalize = true;
               } else {
                 this->replaceCurrent(Builder(*module).makeDrop(curr->value));
               }

--- a/test/lit/passes/simplify-locals-gc.wast
+++ b/test/lit/passes/simplify-locals-gc.wast
@@ -517,4 +517,28 @@
       )
     )
   )
+
+  ;; CHECK:      (func $redundant-tee-finalize (type $anyref_=>_none) (param $x anyref)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (ref.cast any
+  ;; CHECK-NEXT:    (ref.cast any
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $redundant-tee-finalize (param $x anyref)
+    ;; The tee in the middle will be removed, as it copies a local to itself.
+    ;; After doing so, the outer cast should become non-nullable as we
+    ;; refinalize.
+    (drop
+      (ref.cast null any
+        (local.tee $x
+          (ref.cast any
+            (local.get $x)
+          )
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
A minor old bug that the fuzzer found just now. Removing a tee in the middle
can place a more refined type in a location, which requires updating parents.