### PR TITLE
[Outlining] Integration test for suffix_tree and stringify

### DIFF
--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -172,8 +172,15 @@ public:
     void advance();
 
   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = RepeatedSubstring;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const RepeatedSubstring*;
+    using reference = const RepeatedSubstring&;
+
     /// Return the current repeated substring.
     RepeatedSubstring& operator*() { return RS; }
+    RepeatedSubstring* operator->() { return &RS; }
 
     RepeatedSubstringIterator& operator++() {
       advance();

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -60,8 +60,7 @@ public:
     std::vector<unsigned> StartIndices;
 
     bool operator==(const RepeatedSubstring& other) const {
-      return this->Length == other.Length &&
-             this->StartIndices == other.StartIndices;
+      return Length == other.Length && StartIndices == other.StartIndices;
     }
   };
 

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -58,6 +58,11 @@ public:
 
     /// The start indices of each occurrence.
     std::vector<unsigned> StartIndices;
+
+    bool operator==(const RepeatedSubstring& other) const {
+      return this->Length == other.Length &&
+             this->StartIndices == other.StartIndices;
+    }
   };
 
 private:

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -238,9 +238,14 @@ TEST_F(StringifyTest, Substrings) {
   EXPECT_EQ(
     substrings,
     (std::vector<SuffixTree::RepeatedSubstring>{
+      // 5, 6, 7, 6 appears at idx 9 and again at 22
       SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
+      // 6, 7, 6 appears at idx 10 and again at 23
       SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{10, 23})},
+      // 10, 11, 6 appears at idx 18 and again at 27
       SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})},
+      // 11, 6 appears at idx 32, 19 and again at 28
       SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{32, 19, 28})},
+      // 7, 6 appears at idx 11 and again at 24
       SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})}}));
 }

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -235,20 +235,12 @@ TEST_F(StringifyTest, Substrings) {
              (b.Length * b.StartIndices.size());
     });
 
-  for (size_t i = 0; i < substrings.size(); i++) {
-    SuffixTree::RepeatedSubstring rs = substrings[i];
-    std::cout << rs.Length << " ";
-    for (size_t j = 0; j < rs.StartIndices.size(); j++) {
-      std::cout << rs.StartIndices[j] << ", ";
-    }
-  }
-
   EXPECT_EQ(
     substrings,
     (std::vector<SuffixTree::RepeatedSubstring>{
-      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{10, 23})},
       SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
-      SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})},
+      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{10, 23})},
       SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})},
-      SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{32, 19, 28})}}));
+      SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{32, 19, 28})},
+      SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})}}));
 }

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -226,9 +226,21 @@ TEST_F(StringifyTest, Substrings) {
   stringify.walkModule(&wasm);
 
   SuffixTree st(stringify.hashString);
-  std::vector<SuffixTree::RepeatedSubstring> substrings;
-  for (auto it = st.begin(); it != st.end(); it++) {
-    substrings.push_back(*it);
+  std::vector<SuffixTree::RepeatedSubstring> substrings(st.begin(), st.end());
+  std::sort(
+    substrings.begin(),
+    substrings.end(),
+    [](SuffixTree::RepeatedSubstring a, SuffixTree::RepeatedSubstring b) {
+      return (a.Length * a.StartIndices.size()) >
+             (b.Length * b.StartIndices.size());
+    });
+
+  for (size_t i = 0; i < substrings.size(); i++) {
+    SuffixTree::RepeatedSubstring rs = substrings[i];
+    std::cout << rs.Length << " ";
+    for (size_t j = 0; j < rs.StartIndices.size(); j++) {
+      std::cout << rs.StartIndices[j] << ", ";
+    }
   }
 
   EXPECT_EQ(

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -1,6 +1,7 @@
 #include "ir/utils.h"
 #include "passes/stringify-walker.h"
 #include "print-test.h"
+#include "support/suffix_tree.h"
 
 using namespace wasm;
 
@@ -124,8 +125,7 @@ adding unique symbol
   EXPECT_EQ(ss.str(), stringifyText);
 }
 
-TEST_F(StringifyTest, Stringify) {
-  auto moduleText = R"wasm(
+static auto dupModuleText = R"wasm(
     (module
     (func $a
       (block $block_a
@@ -161,8 +161,9 @@ TEST_F(StringifyTest, Stringify) {
    )
   )wasm";
 
+TEST_F(StringifyTest, Stringify) {
   Module wasm;
-  parseWast(wasm, moduleText);
+  parseWast(wasm, dupModuleText);
 
   HashStringifyWalker stringify = HashStringifyWalker();
   stringify.walkModule(&wasm);
@@ -215,4 +216,27 @@ TEST_F(StringifyTest, Stringify) {
               14,            // i32.const 30
               (uint32_t)-13  // separate block_f if-true
             }));
+}
+
+TEST_F(StringifyTest, Substrings) {
+  Module wasm;
+  parseWast(wasm, dupModuleText);
+
+  HashStringifyWalker stringify = HashStringifyWalker();
+  stringify.walkModule(&wasm);
+
+  SuffixTree st(stringify.hashString);
+  std::vector<SuffixTree::RepeatedSubstring> substrings;
+  for (auto it = st.begin(); it != st.end(); it++) {
+    substrings.push_back(*it);
+  }
+
+  EXPECT_EQ(
+    substrings,
+    (std::vector<SuffixTree::RepeatedSubstring>{
+      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{10, 23})},
+      SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
+      SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})},
+      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})},
+      SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{32, 19, 28})}}));
 }

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -231,8 +231,12 @@ TEST_F(StringifyTest, Substrings) {
     substrings.begin(),
     substrings.end(),
     [](SuffixTree::RepeatedSubstring a, SuffixTree::RepeatedSubstring b) {
-      return (a.Length * a.StartIndices.size()) >
-             (b.Length * b.StartIndices.size());
+      size_t aWeight = a.Length * a.StartIndices.size();
+      size_t bWeight = b.Length * b.StartIndices.size();
+      if (aWeight == bWeight) {
+        return a.StartIndices[0] < b.StartIndices[0];
+      }
+      return aWeight > bWeight;
     });
 
   EXPECT_EQ(


### PR DESCRIPTION
Adds an integration test that identifies the substrings of a stringified wasm module using the suffix_tree.