### PR TITLE
Fix a crash in TypeRefining on bottom types

### DIFF
--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -400,11 +400,16 @@ struct TypeRefining : public Pass {
 
       void visitStructSet(StructSet* curr) {
         if (curr->type == Type::unreachable) {
+          // Ignore unreachable code.
+          return;
+        }
+        auto type = curr->ref->type.getHeapType();
+        if (!type.isStruct()) {
+          // Ignore a bottom type.
           return;
         }
 
-        auto fieldType =
-          curr->ref->type.getHeapType().getStruct().fields[curr->index].type;
+        auto fieldType = type.getStruct().fields[curr->index].type;
 
         if (!Type::isSubType(curr->value->type, fieldType)) {
           curr->value =

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -404,7 +404,7 @@ struct TypeRefining : public Pass {
           return;
         }
         auto type = curr->ref->type.getHeapType();
-        if (!type.isStruct()) {
+        if (type.isBottom()) {
           // Ignore a bottom type.
           return;
         }

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -1225,7 +1225,11 @@
 
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $ref|$A|_externref_=>_none (func (param (ref $A) externref)))
+  ;; CHECK-NEXT:  (type $ref|noextern|_=>_none (func (param (ref noextern))))
+
+  ;; CHECK:       (type $ref|none|_ref|noextern|_=>_none (func (param (ref none) (ref noextern))))
+
+  ;; CHECK:       (type $ref|$A|_externref_=>_none (func (param (ref $A) externref)))
 
   ;; CHECK:       (type $A (struct (field (mut (ref noextern)))))
   (type $A (struct (field (mut externref))))
@@ -1328,6 +1332,44 @@
           (local.get $extern)
         )
       )
+    )
+  )
+
+  ;; CHECK:      (func $bottom.type (type $ref|none|_ref|noextern|_=>_none) (param $ref (ref none)) (param $value (ref noextern))
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $ref)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $value)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $bottom.type (param $ref (ref none)) (param $value (ref noextern))
+    ;; The reference here is a bottom type, which we should not crash on.
+    (struct.set $A 0
+      (local.get $ref)
+      (local.get $value)
+    )
+  )
+
+  ;; CHECK:      (func $unreachable (type $ref|noextern|_=>_none) (param $value (ref noextern))
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.get $value)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $unreachable (param $value (ref noextern))
+    ;; The reference here is unreachable, which we should not crash on.
+    (struct.set $A 0
+      (unreachable)
+      (local.get $value)
     )
   )
 )


### PR DESCRIPTION
This is what I get for not fuzzing #5840 enough beforehand.