### PR TITLE
Make lattice compare function non-static

### DIFF
--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -31,7 +31,8 @@ constexpr bool has_getBottom =
 template<typename Lattice>
 constexpr bool has_compare =
   std::is_invocable_r<LatticeComparison,
-                      decltype(Lattice::compare),
+                      decltype(&Lattice::compare),
+                      Lattice,
                       const typename Lattice::Element&,
                       const typename Lattice::Element&>::value;
 template<typename Element>
@@ -110,7 +111,7 @@ public:
 
   // Compares two lattice elements and returns a result indicating the
   // left element's relation to the right element.
-  static LatticeComparison compare(const Element& left, const Element& right);
+  LatticeComparison compare(const Element& left, const Element& right);
 
   // Returns an instance of the bottom lattice element.
   Element getBottom();
@@ -168,8 +169,8 @@ public:
   }
 
   // We use implementations from FiniteIntPowersetLattice here.
-  static LatticeComparison compare(const Element& left, const Element& right) {
-    return FiniteIntPowersetLattice::compare(left, right);
+  LatticeComparison compare(const Element& left, const Element& right) {
+    return intLattice.compare(left, right);
   }
 
   Element getBottom() { return intLattice.getBottom(); }

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -320,10 +320,9 @@ TEST_F(CFGTest, FinitePowersetLatticeFunctioning) {
 
   auto element2 = element1;
   lattice.remove(&element2, "c");
-  EXPECT_EQ(FinitePowersetLattice<std::string>::compare(element1, element2),
-            LatticeComparison::GREATER);
+  EXPECT_EQ(lattice.compare(element1, element2), LatticeComparison::GREATER);
   lattice.add(&element2, "f");
-  EXPECT_EQ(FinitePowersetLattice<std::string>::compare(element1, element2),
+  EXPECT_EQ(lattice.compare(element1, element2),
             LatticeComparison::NO_RELATION);
 
   std::stringstream ss;


### PR DESCRIPTION
This changes the static asserts checking a lattice type to require a non-static `compare` function instead of a static one, since a lattice instance may have instance-specific data relevant to such a comparison. The change also changes the `compare` functions of existing lattices to be non-static.