### PR TITLE
Fix a fuzz bug in TypeMapper

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -28,7 +28,9 @@ namespace wasm {
 
 GlobalTypeRewriter::GlobalTypeRewriter(Module& wasm) : wasm(wasm) {}
 
-void GlobalTypeRewriter::update() {
+void GlobalTypeRewriter::update() { mapTypes(rebuildTypes()); }
+
+GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes() {
   // Find the heap types that are not publicly observable. Even in a closed
   // world scenario, don't modify public types because we assume that they may
   // be reflected on or used for linking. Figure out where each private type
@@ -56,7 +58,7 @@ void GlobalTypeRewriter::update() {
   }
 
   if (typeIndices.size() == 0) {
-    return;
+    return {};
   }
   typeBuilder.grow(typeIndices.size());
 
@@ -139,7 +141,7 @@ void GlobalTypeRewriter::update() {
     }
   }
 
-  mapTypes(oldToNewTypes);
+  return oldToNewTypes;
 }
 
 void GlobalTypeRewriter::mapTypes(const TypeMap& oldToNewTypes) {

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -364,11 +364,6 @@ public:
   // not appear, it is mapped to itself.
   void mapTypes(const TypeMap& oldToNewTypes);
 
-  // Builds new types after updating their contents using the hooks below and
-  // returns a map from the old types to the modified types. Used internally in
-  // update().
-  TypeMap rebuildTypes();
-
   // Subclasses can implement these methods to modify the new set of types that
   // we map to. By default, we simply copy over the types, and these functions
   // are the hooks to apply changes through. The methods receive as input the
@@ -419,6 +414,12 @@ public:
     } rewriter(wasm, updates);
   }
 
+protected:
+  // Builds new types after updating their contents using the hooks below and
+  // returns a map from the old types to the modified types. Used internally in
+  // update().
+  TypeMap rebuildTypes();
+
 private:
   TypeBuilder typeBuilder;
 
@@ -441,24 +442,24 @@ public:
   void map() {
     // Update the internals of types (struct fields, signatures, etc.) to
     // refer to the merged types.
-    auto oldToNewTypes = rebuildTypes();
+    auto newMapping = rebuildTypes();
 
     // Compose the user-provided mapping from old types to other old types with
-    // the new mapping from old types to new types. `oldToNewtypes` will become
+    // the new mapping from old types to new types. `newMapping` will become
     // a copy of `mapping` except that the destination types will be the newly
     // built types.
     for (auto& [src, dest] : mapping) {
-      if (auto it = oldToNewTypes.find(dest); it != oldToNewTypes.end()) {
-        oldToNewTypes[src] = it->second;
+      if (auto it = newMapping.find(dest); it != newMapping.end()) {
+        newMapping[src] = it->second;
       } else {
         // This mapping was to a type that was not rebuilt, perhaps because it
         // is a basic type. Just use this mapping unmodified.
-        oldToNewTypes[src] = dest;
+        newMapping[src] = dest;
       }
     }
 
     // Map the types of expressions (curr->type, etc.) to the correct new types.
-    mapTypes(oldToNewTypes);
+    mapTypes(newMapping);
   }
 
   Type getNewType(Type type) {

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -366,7 +366,7 @@ public:
 
   // Builds new types after updating their contents using the hooks below and
   // returns a map from the old types to the modified types. Used internally in
-  // update()`.
+  // update().
   TypeMap rebuildTypes();
 
   // Subclasses can implement these methods to modify the new set of types that
@@ -443,18 +443,21 @@ public:
     // refer to the merged types.
     auto oldToNewTypes = rebuildTypes();
 
-    // Compose the given mapping from old types to old types with the new
-    // mapping from old types to new types.
+    // Compose the user-provided mapping from old types to other old types with
+    // the new mapping from old types to new types. `oldToNewtypes` will become
+    // a copy of `mapping` except that the destination types will be the newly
+    // built types.
     for (auto& [src, dest] : mapping) {
       if (auto it = oldToNewTypes.find(dest); it != oldToNewTypes.end()) {
         oldToNewTypes[src] = it->second;
       } else {
+        // This mapping was to a type that was not rebuilt, perhaps because it
+        // is a basic type. Just use this mapping unmodified.
         oldToNewTypes[src] = dest;
       }
     }
 
-    // Map the types of expressions (curr->type, etc.) to their merged
-    // types.
+    // Map the types of expressions (curr->type, etc.) to the correct new types.
     mapTypes(oldToNewTypes);
   }
 

--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -41,7 +41,6 @@
 #include "pass.h"
 #include "support/dfa_minimization.h"
 #include "support/small_set.h"
-#include "support/topological_sort.h"
 #include "wasm-builder.h"
 #include "wasm-type-ordering.h"
 #include "wasm.h"
@@ -246,8 +245,9 @@ bool TypeMerging::merge(MergeKind kind) {
   Partitions partitions;
 
 #if TYPE_MERGING_DEBUG
+  auto printedPrivateTypes = ModuleUtils::getPrivateHeapTypes(*module);
   using Fallback = IndexedTypeNameGenerator<DefaultTypeNameGenerator>;
-  Fallback printPrivate(ModuleUtils::getPrivateHeapTypes(*module), "private.");
+  Fallback printPrivate(printedPrivateTypes, "private.");
   ModuleTypeNameGenerator<Fallback> print(*module, printPrivate);
   auto dumpPartitions = [&]() {
     size_t i = 0;
@@ -342,7 +342,16 @@ bool TypeMerging::merge(MergeKind kind) {
   }
 
 #if TYPE_MERGING_DEBUG
-  std::cerr << "Initial partitions:\n";
+  std::cerr << "Initial partitions (";
+  switch (kind) {
+    case Supertypes:
+      std::cerr << "supertypes";
+      break;
+    case Siblings:
+      std::cerr << "siblings";
+      break;
+  }
+  std::cerr << "):\n";
   dumpPartitions();
 #endif
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -655,6 +655,8 @@ struct TypeBuilder {
   };
 
   Entry operator[](size_t i) { return Entry{*this, i}; }
+
+  void dump();
 };
 
 std::ostream& operator<<(std::ostream&, Type);

--- a/test/lit/passes/type-merging.wast
+++ b/test/lit/passes/type-merging.wast
@@ -921,7 +921,7 @@
 ;; Regression test for a bug where we updated module types before building the
 ;; new types, causing the set of private types to change unexpectedly and
 ;; leading to a failure to build new types.
-:: TODO: Store a heap type on control flow structures to avoid creating
+;; TODO: Store a heap type on control flow structures to avoid creating
 ;; standalone function types for them.
 ;; TODO: Investigate why the rec group contains two of the same type below.
 (module

--- a/test/lit/passes/type-merging.wast
+++ b/test/lit/passes/type-merging.wast
@@ -918,12 +918,12 @@
   )
 )
 
-;; Regression test for bug where we updated module types before building the new
-;; types, causing the set of private types to change unexpectedly and leading to
-;; a failure to build new types.
+;; Regression test for a bug where we updated module types before building the
+;; new types, causing the set of private types to change unexpectedly and
+;; leading to a failure to build new types.
 :: TODO: Store a heap type on control flow structures to avoid creating
 ;; standalone function types for them.
-;; TODO: Investigate why the rec group contains two of the same type below
+;; TODO: Investigate why the rec group contains two of the same type below.
 (module
  (rec
   (type $A (func (result (ref any) (ref $C))))

--- a/test/lit/passes/type-merging.wast
+++ b/test/lit/passes/type-merging.wast
@@ -918,6 +918,41 @@
   )
 )
 
+;; Regression test for bug where we updated module types before building the new
+;; types, causing the set of private types to change unexpectedly and leading to
+;; a failure to build new types.
+:: TODO: Store a heap type on control flow structures to avoid creating
+;; standalone function types for them.
+;; TODO: Investigate why the rec group contains two of the same type below
+(module
+ (rec
+  (type $A (func (result (ref any) (ref $C))))
+  ;; CHECK:      (rec
+  ;; CHECK-NEXT:  (type $B (func))
+  (type $B (func))
+  (type $C (sub $B (func)))
+  ;; CHECK:       (type $none_=>_ref|any|_ref|$B| (func (result (ref any) (ref $B))))
+
+  ;; CHECK:       (type $none_=>_ref|any|_ref|$B| (func (result (ref any) (ref $B))))
+
+  ;; CHECK:       (type $D (sub final $none_=>_ref|any|_ref|$B| (func (result (ref any) (ref $B)))))
+  (type $D (sub final $A (func (result (ref any) (ref $C)))))
+ )
+
+ ;; CHECK:      (type $none_=>_ref|any|_ref|$B| (func (result (ref any) (ref $B))))
+
+ ;; CHECK:      (func $test (type $D) (result (ref any) (ref $B))
+ ;; CHECK-NEXT:  (block $l (result (ref any) (ref $B))
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $test (type $D) (result (ref any) (ref $C))
+  (block $l (result (ref any) (ref $C))
+   (unreachable)
+  )
+ )
+)
+
 ;; Check that a ref.test inhibits merging (ref.cast is already checked above).
 (module
   ;; CHECK:      (rec


### PR DESCRIPTION
TypeMapper is a utility used to globally rewrite types, mapping some eliminated
source types into destination types they should be replaced with. This was
previously done by first rewriting all the types in the IR according to the
given mapping, then rewriting the type definitions and updating all the types in
the IR again. Not only was doing the rewriting twice inefficient, it also
introduced a subtle bug where the set of private types eligible to be rewritten
could be inconsistent because updating types in the IR could change the types of
control flow structures. The fuzzer found a case where this inconsistency caused
the type rebuilding to fail.

Fix the bug by first building the new types with the mapping applied and only
then rewriting the IR a single time.

Fixes #5845.