### PR TITLE
[Wasm GC] Stop printing deprecated cast etc. instructions

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2092,20 +2092,6 @@ struct PrintExpressionContents
     printHeapType(o, curr->target->type.getHeapType(), wasm);
   }
   void visitRefTest(RefTest* curr) {
-    // TODO: These instructions are deprecated. Remove them.
-    if (auto type = curr->castType.getHeapType();
-        curr->castType.isNonNullable() && type.isBasic()) {
-      switch (type.getBasic()) {
-        case HeapType::func:
-          printMedium(o, "ref.is_func");
-          return;
-        case HeapType::i31:
-          printMedium(o, "ref.is_i31");
-          return;
-        default:
-          break;
-      }
-    }
     printMedium(o, "ref.test ");
     if (curr->castType.isNullable()) {
       printMedium(o, "null ");
@@ -2119,20 +2105,6 @@ struct PrintExpressionContents
     if (curr->safety == RefCast::Unsafe) {
       printMedium(o, "ref.cast_nop ");
     } else {
-      // TODO: These instructions are deprecated. Remove them.
-      if (auto type = curr->type.getHeapType();
-          type.isBasic() && curr->type.isNonNullable()) {
-        switch (type.getBasic()) {
-          case HeapType::func:
-            printMedium(o, "ref.as_func");
-            return;
-          case HeapType::i31:
-            printMedium(o, "ref.as_i31");
-            return;
-          default:
-            break;
-        }
-      }
       if (curr->type.isNullable()) {
         printMedium(o, "ref.cast null ");
       } else {
@@ -2153,22 +2125,6 @@ struct PrintExpressionContents
         printName(curr->name, o);
         return;
       case BrOnCast:
-        // TODO: These instructions are deprecated, so stop emitting them.
-        if (auto type = curr->castType.getHeapType();
-            type.isBasic() && curr->castType.isNonNullable()) {
-          switch (type.getBasic()) {
-            case HeapType::func:
-              printMedium(o, "br_on_func ");
-              printName(curr->name, o);
-              return;
-            case HeapType::i31:
-              printMedium(o, "br_on_i31 ");
-              printName(curr->name, o);
-              return;
-            default:
-              break;
-          }
-        }
         printMedium(o, "br_on_cast ");
         printName(curr->name, o);
         o << ' ';
@@ -2177,22 +2133,6 @@ struct PrintExpressionContents
         printType(o, curr->castType, wasm);
         return;
       case BrOnCastFail:
-        // TODO: These instructions are deprecated, so stop emitting them.
-        if (auto type = curr->castType.getHeapType();
-            type.isBasic() && curr->castType.isNonNullable()) {
-          switch (type.getBasic()) {
-            case HeapType::func:
-              printMedium(o, "br_on_non_func ");
-              printName(curr->name, o);
-              return;
-            case HeapType::i31:
-              printMedium(o, "br_on_non_i31 ");
-              printName(curr->name, o);
-              return;
-            default:
-              break;
-          }
-        }
         printMedium(o, "br_on_cast_fail ");
         printName(curr->name, o);
         o << ' ';

--- a/test/heap-types.wast.from-wast
+++ b/test/heap-types.wast.from-wast
@@ -184,7 +184,7 @@
    (unreachable)
   )
   (if
-   (ref.is_i31
+   (ref.test i31
     (local.get $x)
    )
    (unreachable)
@@ -197,12 +197,12 @@
    )
   )
   (drop
-   (ref.as_func
+   (ref.cast func
     (local.get $f)
    )
   )
   (drop
-   (ref.as_i31
+   (ref.cast i31
     (local.get $x)
    )
   )
@@ -222,7 +222,7 @@
   (drop
    (block $i31 (result i31ref)
     (local.set $y
-     (br_on_i31 $i31
+     (br_on_cast $i31 anyref (ref i31)
       (local.get $x)
      )
     )
@@ -240,7 +240,7 @@
   (drop
    (block $non-i31 (result anyref)
     (local.set $temp-i31
-     (br_on_non_i31 $non-i31
+     (br_on_cast_fail $non-i31 anyref (ref i31)
       (local.get $x)
      )
     )

--- a/test/heap-types.wast.fromBinary
+++ b/test/heap-types.wast.fromBinary
@@ -182,7 +182,7 @@
    (unreachable)
   )
   (if
-   (ref.is_i31
+   (ref.test i31
     (local.get $x)
    )
    (unreachable)
@@ -195,12 +195,12 @@
    )
   )
   (drop
-   (ref.as_func
+   (ref.cast func
     (local.get $f)
    )
   )
   (drop
-   (ref.as_i31
+   (ref.cast i31
     (local.get $x)
    )
   )
@@ -220,7 +220,7 @@
   (drop
    (block $label$2 (result i31ref)
     (local.set $y
-     (br_on_i31 $label$2
+     (br_on_cast $label$2 anyref (ref i31)
       (local.get $x)
      )
     )
@@ -238,7 +238,7 @@
   (drop
    (block $label$4 (result anyref)
     (local.set $temp-i31
-     (br_on_non_i31 $label$4
+     (br_on_cast_fail $label$4 anyref (ref i31)
       (local.get $x)
      )
     )

--- a/test/heap-types.wast.fromBinary.noDebugInfo
+++ b/test/heap-types.wast.fromBinary.noDebugInfo
@@ -182,7 +182,7 @@
    (unreachable)
   )
   (if
-   (ref.is_i31
+   (ref.test i31
     (local.get $0)
    )
    (unreachable)
@@ -195,12 +195,12 @@
    )
   )
   (drop
-   (ref.as_func
+   (ref.cast func
     (local.get $1)
    )
   )
   (drop
-   (ref.as_i31
+   (ref.cast i31
     (local.get $0)
    )
   )
@@ -220,7 +220,7 @@
   (drop
    (block $label$2 (result i31ref)
     (local.set $1
-     (br_on_i31 $label$2
+     (br_on_cast $label$2 anyref (ref i31)
       (local.get $0)
      )
     )
@@ -238,7 +238,7 @@
   (drop
    (block $label$4 (result anyref)
     (local.set $4
-     (br_on_non_i31 $label$4
+     (br_on_cast_fail $label$4 anyref (ref i31)
       (local.get $0)
      )
     )

--- a/test/lit/passes/abstract-type-refining.wast
+++ b/test/lit/passes/abstract-type-refining.wast
@@ -218,7 +218,7 @@
   ;; YESTNH-NEXT:   )
   ;; YESTNH-NEXT:  )
   ;; YESTNH-NEXT:  (drop
-  ;; YESTNH-NEXT:   (ref.as_i31
+  ;; YESTNH-NEXT:   (ref.cast i31
   ;; YESTNH-NEXT:    (local.get $x)
   ;; YESTNH-NEXT:   )
   ;; YESTNH-NEXT:  )
@@ -230,7 +230,7 @@
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (ref.as_i31
+  ;; NO_TNH-NEXT:   (ref.cast i31
   ;; NO_TNH-NEXT:    (local.get $x)
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -223,7 +223,7 @@
  ;; CHECK-NEXT:  (local $0 i31ref)
  ;; CHECK-NEXT:  (i32.add
  ;; CHECK-NEXT:   (unreachable)
- ;; CHECK-NEXT:   (ref.is_i31
+ ;; CHECK-NEXT:   (ref.test i31
  ;; CHECK-NEXT:    (ref.cast null i31
  ;; CHECK-NEXT:     (block (result i31ref)
  ;; CHECK-NEXT:      (i31.new

--- a/test/lit/passes/code-pushing-gc.wast
+++ b/test/lit/passes/code-pushing-gc.wast
@@ -7,7 +7,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block $out (result (ref func))
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (br_on_func $out
+  ;; CHECK-NEXT:     (br_on_cast $out (ref $none_=>_none) (ref func)
   ;; CHECK-NEXT:      (ref.func $br_on)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -48,7 +48,7 @@
   ;; CHECK-NEXT:     (ref.func $br_on_no)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (br_on_func $out
+  ;; CHECK-NEXT:     (br_on_cast $out (ref $none_=>_none) (ref func)
   ;; CHECK-NEXT:      (ref.func $br_on_no)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/merge-blocks.wast
+++ b/test/lit/passes/merge-blocks.wast
@@ -20,7 +20,7 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block $label$1 (result i31ref)
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (br_on_i31 $label$1
+ ;; CHECK-NEXT:     (br_on_cast $label$1 nullref (ref i31)
  ;; CHECK-NEXT:      (ref.null none)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -269,7 +269,7 @@
 
   ;; CHECK:      (func $unneeded_unreachability (type $void)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.is_func
+  ;; CHECK-NEXT:   (ref.test func
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -586,7 +586,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result (ref $struct))
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.as_i31
+  ;; CHECK-NEXT:     (ref.cast i31
   ;; CHECK-NEXT:      (local.get $x)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/vacuum-gc.wast
+++ b/test/lit/passes/vacuum-gc.wast
@@ -18,7 +18,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.as_i31
+  ;; CHECK-NEXT:   (ref.cast i31
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/vacuum-tnh.wast
+++ b/test/lit/passes/vacuum-tnh.wast
@@ -33,7 +33,7 @@
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (ref.as_i31
+  ;; NO_TNH-NEXT:   (ref.cast i31
   ;; NO_TNH-NEXT:    (local.get $y)
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )


### PR DESCRIPTION
Stop printing `ref.as_i31`, `br_on_func`, etc. because they have been removed
from the spec and are no longer supported by V8. #5614 already made this change
for the binary format. Like that PR, leave reading unmodified in case someone is
still using these instructions (even though they are useless). They will be
fully removed in a future PR as we finalize things ahead of standardizing
WasmGC.