### PR TITLE
[NFC] Move ModuleUtils copying and renaming logic from header to cpp

### DIFF
--- a/src/ir/lubs.cpp
+++ b/src/ir/lubs.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "ir/find_all.h"
 #include "ir/lubs.h"
+#include "ir/find_all.h"
 #include "ir/utils.h"
 #include "wasm-type.h"
 #include "wasm.h"

--- a/src/ir/lubs.cpp
+++ b/src/ir/lubs.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "ir/find_all.h"
 #include "ir/lubs.h"
 #include "ir/utils.h"
 #include "wasm-type.h"

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -15,11 +15,219 @@
  */
 
 #include "module-utils.h"
+#include "ir/manipulation.h"
+#include "ir/properties.h"
 #include "ir/intrinsics.h"
 #include "support/insert_ordered.h"
 #include "support/topological_sort.h"
 
 namespace wasm::ModuleUtils {
+
+// Copies a function into a module. If newName is provided it is used as the
+// name of the function (otherwise the original name is copied).
+Function*
+copyFunction(Function* func, Module& out, Name newName) {
+  auto ret = std::make_unique<Function>();
+  ret->name = newName.is() ? newName : func->name;
+  ret->type = func->type;
+  ret->vars = func->vars;
+  ret->localNames = func->localNames;
+  ret->localIndices = func->localIndices;
+  ret->debugLocations = func->debugLocations;
+  ret->body = ExpressionManipulator::copy(func->body, out);
+  ret->module = func->module;
+  ret->base = func->base;
+  // TODO: copy Stack IR
+  assert(!func->stackIR);
+  return out.addFunction(std::move(ret));
+}
+
+Global* copyGlobal(Global* global, Module& out) {
+  auto* ret = new Global();
+  ret->name = global->name;
+  ret->type = global->type;
+  ret->mutable_ = global->mutable_;
+  ret->module = global->module;
+  ret->base = global->base;
+  if (global->imported()) {
+    ret->init = nullptr;
+  } else {
+    ret->init = ExpressionManipulator::copy(global->init, out);
+  }
+  out.addGlobal(ret);
+  return ret;
+}
+
+Tag* copyTag(Tag* tag, Module& out) {
+  auto* ret = new Tag();
+  ret->name = tag->name;
+  ret->sig = tag->sig;
+  ret->module = tag->module;
+  ret->base = tag->base;
+  out.addTag(ret);
+  return ret;
+}
+
+ElementSegment* copyElementSegment(const ElementSegment* segment,
+                                          Module& out) {
+  auto copy = [&](std::unique_ptr<ElementSegment>&& ret) {
+    ret->name = segment->name;
+    ret->hasExplicitName = segment->hasExplicitName;
+    ret->type = segment->type;
+    ret->data.reserve(segment->data.size());
+    for (auto* item : segment->data) {
+      ret->data.push_back(ExpressionManipulator::copy(item, out));
+    }
+
+    return out.addElementSegment(std::move(ret));
+  };
+
+  if (segment->table.isNull()) {
+    return copy(std::make_unique<ElementSegment>());
+  } else {
+    auto offset = ExpressionManipulator::copy(segment->offset, out);
+    return copy(std::make_unique<ElementSegment>(segment->table, offset));
+  }
+}
+
+Table* copyTable(const Table* table, Module& out) {
+  auto ret = std::make_unique<Table>();
+  ret->name = table->name;
+  ret->hasExplicitName = table->hasExplicitName;
+  ret->type = table->type;
+  ret->module = table->module;
+  ret->base = table->base;
+
+  ret->initial = table->initial;
+  ret->max = table->max;
+
+  return out.addTable(std::move(ret));
+}
+
+Memory* copyMemory(const Memory* memory, Module& out) {
+  auto ret = Builder::makeMemory(memory->name);
+  ret->hasExplicitName = memory->hasExplicitName;
+  ret->initial = memory->initial;
+  ret->max = memory->max;
+  ret->shared = memory->shared;
+  ret->indexType = memory->indexType;
+  ret->module = memory->module;
+  ret->base = memory->base;
+
+  return out.addMemory(std::move(ret));
+}
+
+DataSegment* copyDataSegment(const DataSegment* segment, Module& out) {
+  auto ret = Builder::makeDataSegment();
+  ret->name = segment->name;
+  ret->hasExplicitName = segment->hasExplicitName;
+  ret->memory = segment->memory;
+  ret->isPassive = segment->isPassive;
+  if (!segment->isPassive) {
+    auto offset = ExpressionManipulator::copy(segment->offset, out);
+    ret->offset = offset;
+  }
+  ret->data = segment->data;
+
+  return out.addDataSegment(std::move(ret));
+}
+
+// Copies named toplevel module items (things of kind ModuleItemKind). See
+// copyModule() for something that also copies exports, the start function, etc.
+void copyModuleItems(const Module& in, Module& out) {
+  for (auto& curr : in.functions) {
+    copyFunction(curr.get(), out);
+  }
+  for (auto& curr : in.globals) {
+    copyGlobal(curr.get(), out);
+  }
+  for (auto& curr : in.tags) {
+    copyTag(curr.get(), out);
+  }
+  for (auto& curr : in.elementSegments) {
+    copyElementSegment(curr.get(), out);
+  }
+  for (auto& curr : in.tables) {
+    copyTable(curr.get(), out);
+  }
+  for (auto& curr : in.memories) {
+    copyMemory(curr.get(), out);
+  }
+  for (auto& curr : in.dataSegments) {
+    copyDataSegment(curr.get(), out);
+  }
+}
+
+void copyModule(const Module& in, Module& out) {
+  // we use names throughout, not raw pointers, so simple copying is fine
+  // for everything *but* expressions
+  for (auto& curr : in.exports) {
+    out.addExport(std::make_unique<Export>(*curr));
+  }
+  copyModuleItems(in, out);
+  out.start = in.start;
+  out.customSections = in.customSections;
+  out.debugInfoFileNames = in.debugInfoFileNames;
+  out.features = in.features;
+  out.typeNames = in.typeNames;
+}
+
+void clearModule(Module& wasm) {
+  wasm.~Module();
+  new (&wasm) Module;
+}
+
+// Renaming
+
+// Rename functions along with all their uses.
+// Note that for this to work the functions themselves don't necessarily need
+// to exist.  For example, it is possible to remove a given function and then
+// call this to redirect all of its uses.
+template<typename T> void renameFunctions(Module& wasm, T& map) {
+  // Update the function itself.
+  for (auto& [oldName, newName] : map) {
+    if (Function* func = wasm.getFunctionOrNull(oldName)) {
+      assert(!wasm.getFunctionOrNull(newName) || func->name == newName);
+      func->name = newName;
+    }
+  }
+  wasm.updateMaps();
+
+  // Update all references to it.
+  struct Updater : public WalkerPass<PostWalker<Updater>> {
+    bool isFunctionParallel() override { return true; }
+
+    T& map;
+
+    void maybeUpdate(Name& name) {
+      if (auto iter = map.find(name); iter != map.end()) {
+        name = iter->second;
+      }
+    }
+
+    Updater(T& map) : map(map) {}
+
+    std::unique_ptr<Pass> create() override {
+      return std::make_unique<Updater>(map);
+    }
+
+    void visitCall(Call* curr) { maybeUpdate(curr->target); }
+
+    void visitRefFunc(RefFunc* curr) { maybeUpdate(curr->func); }
+  };
+
+  Updater updater(map);
+  updater.maybeUpdate(wasm.start);
+  PassRunner runner(&wasm);
+  updater.run(&runner, &wasm);
+  updater.runOnModuleCode(&runner, &wasm);
+}
+
+void renameFunction(Module& wasm, Name oldName, Name newName) {
+  std::map<Name, Name> map;
+  map[oldName] = newName;
+  renameFunctions(wasm, map);
+}
 
 namespace {
 

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "module-utils.h"
+#include "ir/intrinsics.h"
 #include "ir/manipulation.h"
 #include "ir/properties.h"
-#include "ir/intrinsics.h"
 #include "support/insert_ordered.h"
 #include "support/topological_sort.h"
 
@@ -25,8 +25,7 @@ namespace wasm::ModuleUtils {
 
 // Copies a function into a module. If newName is provided it is used as the
 // name of the function (otherwise the original name is copied).
-Function*
-copyFunction(Function* func, Module& out, Name newName) {
+Function* copyFunction(Function* func, Module& out, Name newName) {
   auto ret = std::make_unique<Function>();
   ret->name = newName.is() ? newName : func->name;
   ret->type = func->type;
@@ -68,8 +67,7 @@ Tag* copyTag(Tag* tag, Module& out) {
   return ret;
 }
 
-ElementSegment* copyElementSegment(const ElementSegment* segment,
-                                          Module& out) {
+ElementSegment* copyElementSegment(const ElementSegment* segment, Module& out) {
   auto copy = [&](std::unique_ptr<ElementSegment>&& ret) {
     ret->name = segment->name;
     ret->hasExplicitName = segment->hasExplicitName;

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -17,10 +17,6 @@
 #ifndef wasm_ir_module_h
 #define wasm_ir_module_h
 
-#include "ir/element-utils.h"
-#include "ir/find_all.h"
-#include "ir/manipulation.h"
-#include "ir/properties.h"
 #include "pass.h"
 #include "support/unique_deferring_queue.h"
 #include "wasm.h"
@@ -29,157 +25,29 @@ namespace wasm::ModuleUtils {
 
 // Copies a function into a module. If newName is provided it is used as the
 // name of the function (otherwise the original name is copied).
-inline Function*
-copyFunction(Function* func, Module& out, Name newName = Name()) {
-  auto ret = std::make_unique<Function>();
-  ret->name = newName.is() ? newName : func->name;
-  ret->type = func->type;
-  ret->vars = func->vars;
-  ret->localNames = func->localNames;
-  ret->localIndices = func->localIndices;
-  ret->debugLocations = func->debugLocations;
-  ret->body = ExpressionManipulator::copy(func->body, out);
-  ret->module = func->module;
-  ret->base = func->base;
-  // TODO: copy Stack IR
-  assert(!func->stackIR);
-  return out.addFunction(std::move(ret));
-}
+Function*
+copyFunction(Function* func, Module& out, Name newName = Name());
 
-inline Global* copyGlobal(Global* global, Module& out) {
-  auto* ret = new Global();
-  ret->name = global->name;
-  ret->type = global->type;
-  ret->mutable_ = global->mutable_;
-  ret->module = global->module;
-  ret->base = global->base;
-  if (global->imported()) {
-    ret->init = nullptr;
-  } else {
-    ret->init = ExpressionManipulator::copy(global->init, out);
-  }
-  out.addGlobal(ret);
-  return ret;
-}
+Global* copyGlobal(Global* global, Module& out);
 
-inline Tag* copyTag(Tag* tag, Module& out) {
-  auto* ret = new Tag();
-  ret->name = tag->name;
-  ret->sig = tag->sig;
-  ret->module = tag->module;
-  ret->base = tag->base;
-  out.addTag(ret);
-  return ret;
-}
+Tag* copyTag(Tag* tag, Module& out);
 
-inline ElementSegment* copyElementSegment(const ElementSegment* segment,
-                                          Module& out) {
-  auto copy = [&](std::unique_ptr<ElementSegment>&& ret) {
-    ret->name = segment->name;
-    ret->hasExplicitName = segment->hasExplicitName;
-    ret->type = segment->type;
-    ret->data.reserve(segment->data.size());
-    for (auto* item : segment->data) {
-      ret->data.push_back(ExpressionManipulator::copy(item, out));
-    }
+ElementSegment* copyElementSegment(const ElementSegment* segment,
+                                          Module& out);
 
-    return out.addElementSegment(std::move(ret));
-  };
+Table* copyTable(const Table* table, Module& out);
 
-  if (segment->table.isNull()) {
-    return copy(std::make_unique<ElementSegment>());
-  } else {
-    auto offset = ExpressionManipulator::copy(segment->offset, out);
-    return copy(std::make_unique<ElementSegment>(segment->table, offset));
-  }
-}
+Memory* copyMemory(const Memory* memory, Module& out);
 
-inline Table* copyTable(const Table* table, Module& out) {
-  auto ret = std::make_unique<Table>();
-  ret->name = table->name;
-  ret->hasExplicitName = table->hasExplicitName;
-  ret->type = table->type;
-  ret->module = table->module;
-  ret->base = table->base;
-
-  ret->initial = table->initial;
-  ret->max = table->max;
-
-  return out.addTable(std::move(ret));
-}
-
-inline Memory* copyMemory(const Memory* memory, Module& out) {
-  auto ret = Builder::makeMemory(memory->name);
-  ret->hasExplicitName = memory->hasExplicitName;
-  ret->initial = memory->initial;
-  ret->max = memory->max;
-  ret->shared = memory->shared;
-  ret->indexType = memory->indexType;
-  ret->module = memory->module;
-  ret->base = memory->base;
-
-  return out.addMemory(std::move(ret));
-}
-
-inline DataSegment* copyDataSegment(const DataSegment* segment, Module& out) {
-  auto ret = Builder::makeDataSegment();
-  ret->name = segment->name;
-  ret->hasExplicitName = segment->hasExplicitName;
-  ret->memory = segment->memory;
-  ret->isPassive = segment->isPassive;
-  if (!segment->isPassive) {
-    auto offset = ExpressionManipulator::copy(segment->offset, out);
-    ret->offset = offset;
-  }
-  ret->data = segment->data;
-
-  return out.addDataSegment(std::move(ret));
-}
+DataSegment* copyDataSegment(const DataSegment* segment, Module& out);
 
 // Copies named toplevel module items (things of kind ModuleItemKind). See
 // copyModule() for something that also copies exports, the start function, etc.
-inline void copyModuleItems(const Module& in, Module& out) {
-  for (auto& curr : in.functions) {
-    copyFunction(curr.get(), out);
-  }
-  for (auto& curr : in.globals) {
-    copyGlobal(curr.get(), out);
-  }
-  for (auto& curr : in.tags) {
-    copyTag(curr.get(), out);
-  }
-  for (auto& curr : in.elementSegments) {
-    copyElementSegment(curr.get(), out);
-  }
-  for (auto& curr : in.tables) {
-    copyTable(curr.get(), out);
-  }
-  for (auto& curr : in.memories) {
-    copyMemory(curr.get(), out);
-  }
-  for (auto& curr : in.dataSegments) {
-    copyDataSegment(curr.get(), out);
-  }
-}
+void copyModuleItems(const Module& in, Module& out);
 
-inline void copyModule(const Module& in, Module& out) {
-  // we use names throughout, not raw pointers, so simple copying is fine
-  // for everything *but* expressions
-  for (auto& curr : in.exports) {
-    out.addExport(std::make_unique<Export>(*curr));
-  }
-  copyModuleItems(in, out);
-  out.start = in.start;
-  out.customSections = in.customSections;
-  out.debugInfoFileNames = in.debugInfoFileNames;
-  out.features = in.features;
-  out.typeNames = in.typeNames;
-}
+void copyModule(const Module& in, Module& out);
 
-inline void clearModule(Module& wasm) {
-  wasm.~Module();
-  new (&wasm) Module;
-}
+void clearModule(Module& wasm);
 
 // Renaming
 
@@ -187,51 +55,9 @@ inline void clearModule(Module& wasm) {
 // Note that for this to work the functions themselves don't necessarily need
 // to exist.  For example, it is possible to remove a given function and then
 // call this to redirect all of its uses.
-template<typename T> inline void renameFunctions(Module& wasm, T& map) {
-  // Update the function itself.
-  for (auto& [oldName, newName] : map) {
-    if (Function* func = wasm.getFunctionOrNull(oldName)) {
-      assert(!wasm.getFunctionOrNull(newName) || func->name == newName);
-      func->name = newName;
-    }
-  }
-  wasm.updateMaps();
+template<typename T> void renameFunctions(Module& wasm, T& map);
 
-  // Update all references to it.
-  struct Updater : public WalkerPass<PostWalker<Updater>> {
-    bool isFunctionParallel() override { return true; }
-
-    T& map;
-
-    void maybeUpdate(Name& name) {
-      if (auto iter = map.find(name); iter != map.end()) {
-        name = iter->second;
-      }
-    }
-
-    Updater(T& map) : map(map) {}
-
-    std::unique_ptr<Pass> create() override {
-      return std::make_unique<Updater>(map);
-    }
-
-    void visitCall(Call* curr) { maybeUpdate(curr->target); }
-
-    void visitRefFunc(RefFunc* curr) { maybeUpdate(curr->func); }
-  };
-
-  Updater updater(map);
-  updater.maybeUpdate(wasm.start);
-  PassRunner runner(&wasm);
-  updater.run(&runner, &wasm);
-  updater.runOnModuleCode(&runner, &wasm);
-}
-
-inline void renameFunction(Module& wasm, Name oldName, Name newName) {
-  std::map<Name, Name> map;
-  map[oldName] = newName;
-  renameFunctions(wasm, map);
-}
+void renameFunction(Module& wasm, Name oldName, Name newName);
 
 // Convenient iteration over imported/non-imported module elements
 

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -25,15 +25,13 @@ namespace wasm::ModuleUtils {
 
 // Copies a function into a module. If newName is provided it is used as the
 // name of the function (otherwise the original name is copied).
-Function*
-copyFunction(Function* func, Module& out, Name newName = Name());
+Function* copyFunction(Function* func, Module& out, Name newName = Name());
 
 Global* copyGlobal(Global* global, Module& out);
 
 Tag* copyTag(Tag* tag, Module& out);
 
-ElementSegment* copyElementSegment(const ElementSegment* segment,
-                                          Module& out);
+ElementSegment* copyElementSegment(const ElementSegment* segment, Module& out);
 
 Table* copyTable(const Table* table, Module& out);
 

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -17,6 +17,7 @@
 #ifndef wasm_ir_struct_utils_h
 #define wasm_ir_struct_utils_h
 
+#include "ir/properties.h"
 #include "ir/subtypes.h"
 #include "wasm.h"
 

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -33,8 +33,8 @@
 #include <unordered_map>
 
 #include "call-utils.h"
-#include "ir/find_all.h"
 #include "ir/drop.h"
+#include "ir/find_all.h"
 #include "ir/table-utils.h"
 #include "ir/utils.h"
 #include "pass.h"

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -33,6 +33,7 @@
 #include <unordered_map>
 
 #include "call-utils.h"
+#include "ir/find_all.h"
 #include "ir/drop.h"
 #include "ir/table-utils.h"
 #include "ir/utils.h"

--- a/src/passes/GlobalEffects.cpp
+++ b/src/passes/GlobalEffects.cpp
@@ -19,6 +19,7 @@
 // PassOptions structure; see more details there.
 //
 
+#include "ir/effects.h"
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "wasm.h"

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -50,6 +50,7 @@
 
 #include "ir/find_all.h"
 #include "ir/module-utils.h"
+#include "ir/properties.h"
 #include "ir/subtypes.h"
 #include "pass.h"
 #include "wasm-builder.h"

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -35,6 +35,7 @@
 #include "ir/drop.h"
 #include "ir/eh-utils.h"
 #include "ir/element-utils.h"
+#include "ir/find_all.h"
 #include "ir/literal-utils.h"
 #include "ir/module-utils.h"
 #include "ir/names.h"

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -40,6 +40,7 @@
 // the same semantics as v8, which is to bounds check all Atomic instructions
 // the same way and trap for out-of-bounds.
 
+#include "ir/abstract.h"
 #include "ir/module-utils.h"
 #include "ir/names.h"
 #include "wasm-builder.h"

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -96,6 +96,7 @@
 #include "ir/names.h"
 #include "support/colors.h"
 #include "support/file.h"
+#include "wasm-builder.h"
 #include "wasm-io.h"
 #include "wasm-validator.h"
 #include "wasm.h"

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -18,6 +18,7 @@
 #include "ir/module-utils.h"
 #include "ir/names.h"
 #include "support/name.h"
+#include "wasm-builder.h"
 #include "wasm-type.h"
 
 namespace wasm {

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -1,5 +1,6 @@
 #include "ir/subtypes.h"
 #include "type-test.h"
+#include "wasm-builder.h"
 #include "wasm-type-printing.h"
 #include "wasm-type.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
None of that code is speed-sensitive, or at least doesn't need to be inlined to be
fast. Move it to cpp for faster compile times.

This caused a cascade of necessary header fixes (i.e. after removing unneeded
header inclusions in `module-utils.h`, files that improperly depended on that
stopped working and needed an added include).