### PR TITLE
Add CodeCov to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,3 +304,35 @@ jobs:
         cmake -S . -B out -G "MSYS Makefiles"
     - name: build
       run: cmake --build out
+
+  # Duplicates build-asan.  Please keep in sync
+  build-gcov:
+    name: coverage
+    runs-on: ubuntu-latest
+    env:
+      COMPILER_FLAGS: "-fprofile-arcs -ftest-coverage"
+      CC: "gcc"
+      CXX: "g++"
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: install ninja
+      run: sudo apt-get install ninja-build
+    - name: install Python dev dependencies
+      run: pip3 install -r requirements-dev.txt
+    - name: cmake
+      run: |
+        mkdir -p out
+        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS"
+    - name: build
+      run: cmake --build out
+    - name: test
+      run: python check.py --binaryen-bin=out/bin lit
+    - name: upload coverage
+      uses: codecov/codecov-action@v3
+      with:
+        gcov: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
     - name: cmake
       run: |
         mkdir -p out
-        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS"
+        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_C_FLAGS="$COMPILER_FLAGS" -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS -DCMAKE_BUILD_TYPE=Debug"
     - name: build
       run: cmake --build out
     - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,9 @@ jobs:
     - name: build
       run: cmake --build out
     - name: test
-      run: python check.py --binaryen-bin=out/bin lit
+      run: |
+        python check.py --binaryen-bin=out/bin lit
+        python check.py --binaryen-bin=out/bin gtest
     - name: upload coverage
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Add a CI step to build with gcov instrumentation and run the lit test suite to
gather profiles, then upload those profiles to codecov.io to generate a code
coverage report for each PR. The goal is not necessarily to achieve 100% code
coverage, but rather to help find important missing test cases and dead code.