### PR TITLE
Configure CodeCov to be informational only

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
Add a codecov.yml file configuring CodeCov to be in informational mode, meaning
that it will never report a failure.