### PR TITLE
Allow opting into standard GC encodings at compile time

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -21,6 +21,25 @@
 #ifndef wasm_wasm_binary_h
 #define wasm_wasm_binary_h
 
+// Default to using the legacy encodings. Switch this when WasmGC ships.
+// Override the default with USE_STANDARD_GC_ENCODINGS or
+// USE_LEGACY_GC_ENCODINGS.
+#define STANDARD_GC_ENCODINGS 0
+
+#ifdef USE_STANDARD_GC_ENCODINGS
+#ifdef USE_LEGACY_GC_ENCODINGS
+#error                                                                         \
+  "Cannot define both USE_STANDARD_GC_ENCODINGS and USE_LEGACY_GC_ENCODINGS"
+#endif
+#undef STANDARD_GC_ENCODINGS
+#define STANDARD_GC_ENCODINGS 1
+#else
+#ifdef USE_LEGACY_GC_ENCODINGS
+#undef STANDARD_GC_ENCODINGS
+#define STANDARD_GC_ENCODINGS 0
+#endif
+#endif
+
 #include <cassert>
 #include <ostream>
 #include <type_traits>
@@ -350,70 +369,112 @@ enum SegmentFlag {
 };
 
 enum EncodedType {
-  // value_type
+  // value types
   i32 = -0x1,  // 0x7f
   i64 = -0x2,  // 0x7e
   f32 = -0x3,  // 0x7d
   f64 = -0x4,  // 0x7c
   v128 = -0x5, // 0x7b
-  i8 = -0x6,   // 0x7a
-  i16 = -0x7,  // 0x79
-  // function reference type
-  funcref = -0x10, // 0x70
-  // external (host) references
-  externref = -0x11, // 0x6f
-  // top type of references to non-function Wasm data.
-  anyref = -0x12, // 0x6e
-  // comparable reference type
-  eqref = -0x13, // 0x6d
-  // nullable typed function reference type, with parameter
-  nullable = -0x14, // 0x6c
-  // non-nullable typed function reference type, with parameter
-  nonnullable = -0x15, // 0x6b
-  // integer reference type
-  i31ref = -0x16, // 0x6a
-  // gc and string reference types
-  structref = -0x19,        // 0x67
-  arrayref = -0x1a,         // 0x66
-  stringref = -0x1c,        // 0x64
-  stringview_wtf8 = -0x1d,  // 0x63
-  stringview_wtf16 = -0x1e, // 0x62
-  stringview_iter = -0x1f,  // 0x61
-  // bottom types
+// packed types
+#if STANDARD_GC_ENCODINGS
+  i8 = -0x8,  // 0x78
+  i16 = -0x9, // 0x77
+#else
+  i8 = -0x6,  // 0x7a
+  i16 = -0x7, // 0x79
+#endif
+// reference types
+#if STANDARD_GC_ENCODINGS
+  nullfuncref = -0xd,   // 0x73
+  nullexternref = -0xe, // 0x72
+  nullref = -0xf,       // 0x71
+  i31ref = -0x14,       // 0x6c
+  structref = -0x15,    // 0x6b
+  arrayref = -0x16,     // 0x6a
+#else
   nullexternref = -0x17, // 0x69
   nullfuncref = -0x18,   // 0x68
   nullref = -0x1b,       // 0x65
+  i31ref = -0x16,        // 0x6a
+  structref = -0x19,     // 0x67
+  arrayref = -0x1a,      // 0x66
+#endif
+  funcref = -0x10,   // 0x70
+  externref = -0x11, // 0x6f
+  anyref = -0x12,    // 0x6e
+  eqref = -0x13,     // 0x6d
+#if STANDARD_GC_ENCODINGS
+#else
+#endif
+#if STANDARD_GC_ENCODINGS
+  nullable = -0x1c,    // 0x64
+  nonnullable = -0x1d, // 0x63
+#else
+  nullable = -0x14,    // 0x6c
+  nonnullable = -0x15, // 0x6b
+#endif
+// string reference types
+#if STANDARD_GC_ENCODINGS
+  stringref = -0x19,       // 0x67
+  stringview_wtf8 = -0x1a, // 0x66
+#else
+  stringref = -0x1c,       // 0x64
+  stringview_wtf8 = -0x1d, // 0x63
+#endif
+  stringview_wtf16 = -0x1e, // 0x62
+  stringview_iter = -0x1f,  // 0x61
   // type forms
-  Func = -0x20,     // 0x60
-  Struct = -0x21,   // 0x5f
-  Array = -0x22,    // 0x5e
-  Sub = -0x30,      // 0x50
+  Func = -0x20,   // 0x60
+  Struct = -0x21, // 0x5f
+  Array = -0x22,  // 0x5e
+  Sub = -0x30,    // 0x50
+#if STANDARD_GC_ENCODINGS
+  SubFinal = -0x31, // 0x4f
+#else
   SubFinal = -0x32, // 0x4e
-  // isorecursive recursion groups
+#endif
+// isorecursive recursion groups
+#if STANDARD_GC_ENCODINGS
+  Rec = -0x32, // 0x4e
+#else
   Rec = -0x31, // 0x4f
+#endif
   // block_type
-  Empty = -0x40 // 0x40
+  Empty = -0x40, // 0x40
 };
 
 enum EncodedHeapType {
-  func = -0x10,    // 0x70
-  ext = -0x11,     // 0x6f
-  any = -0x12,     // 0x6e
-  eq = -0x13,      // 0x6d
-  i31 = -0x16,     // 0x6a
-  struct_ = -0x19, // 0x67
-  array = -0x1a,   // 0x66
-  string = -0x1c,  // 0x64
-  // stringview/iter constants are identical to type, and cannot be duplicated
-  // here as that would be a compiler error, so add _heap suffixes. See
-  // https://github.com/WebAssembly/stringref/issues/12
-  stringview_wtf8_heap = -0x1d,  // 0x63
-  stringview_wtf16_heap = -0x1e, // 0x62
-  stringview_iter_heap = -0x1f,  // 0x61
-  // bottom types
+#if STANDARD_GC_ENCODINGS
+  nofunc = -0xd, // 0x73
+  noext = -0xe,  // 0x72
+  none = -0xf,   // 0x71
+#else
   noext = -0x17,  // 0x69
   nofunc = -0x18, // 0x68
   none = -0x1b,   // 0x65
+#endif
+  func = -0x10, // 0x70
+  ext = -0x11,  // 0x6f
+  any = -0x12,  // 0x6e
+  eq = -0x13,   // 0x6d
+#if STANDARD_GC_ENCODINGS
+  i31 = -0x14,     // 0x6c
+  struct_ = -0x15, // 0x6b
+  array = -0x16,   // 0x6a
+  string = -0x19,  // 0x67
+  // stringview/iter constants are identical to type, and cannot be duplicated
+  // here as that would be a compiler error, so add _heap suffixes. See
+  // https://github.com/WebAssembly/stringref/issues/12
+  stringview_wtf8_heap = -0x1a, // 0x66
+#else
+  i31 = -0x16,                  // 0x6a
+  struct_ = -0x19,              // 0x67
+  array = -0x1a,                // 0x66
+  string = -0x1c,               // 0x64
+  stringview_wtf8_heap = -0x1d, // 0x63
+#endif
+  stringview_wtf16_heap = -0x1e, // 0x62
+  stringview_iter_heap = -0x1f,  // 0x61
 };
 
 namespace CustomSections {
@@ -1072,9 +1133,17 @@ enum ASTNodes {
   RefNull = 0xd0,
   RefIsNull = 0xd1,
   RefFunc = 0xd2,
+#if STANDARD_GC_ENCODINGS
+  RefEq = 0xd3,
+  RefAsNonNull = 0xd4,
+  BrOnNull = 0xd5,
+  BrOnNonNull = 0xd6,
+#else
   RefAsNonNull = 0xd3,
   BrOnNull = 0xd4,
+  RefEq = 0xd5,
   BrOnNonNull = 0xd6,
+#endif
 
   // exception handling opcodes
 
@@ -1090,9 +1159,40 @@ enum ASTNodes {
   CallRef = 0x14,
   RetCallRef = 0x15,
 
-  // gc opcodes
-
-  RefEq = 0xd5,
+// gc opcodes
+#if STANDARD_GC_ENCODINGS
+  StructNew = 0x00,
+  StructNewDefault = 0x01,
+  StructGet = 0x02,
+  StructGetS = 0x03,
+  StructGetU = 0x04,
+  StructSet = 0x05,
+  ArrayNew = 0x06,
+  ArrayNewDefault = 0x07,
+  ArrayNewFixed = 0x08,
+  ArrayNewData = 0x09,
+  ArrayNewElem = 0x0a,
+  ArrayGet = 0x0b,
+  ArrayGetS = 0x0c,
+  ArrayGetU = 0x0d,
+  ArraySet = 0x0e,
+  ArrayLen = 0x0f,
+  ArrayFill = 0x10,
+  ArrayCopy = 0x11,
+  ArrayInitData = 0x12,
+  ArrayInitElem = 0x13,
+  RefTest = 0x14,
+  RefTestNull = 0x15,
+  RefCast = 0x16,
+  RefCastNull = 0x17,
+  BrOnCast = 0x18,
+  BrOnCastFail = 0x19,
+  ExternInternalize = 0x1a,
+  ExternExternalize = 0x1b,
+  I31New = 0x1c,
+  I31GetS = 0x1d,
+  I31GetU = 0x1e,
+#else
   StructGet = 0x03,
   StructGetS = 0x04,
   StructGetU = 0x05,
@@ -1124,6 +1224,10 @@ enum ASTNodes {
   ArrayFill = 0x0f,
   ArrayInitData = 0x54,
   ArrayInitElem = 0x55,
+#endif
+
+  // stringref opcodes
+
   StringNewUTF8 = 0x80,
   StringNewWTF16 = 0x81,
   StringConst = 0x82,

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -380,8 +380,8 @@ enum EncodedType {
   i8 = -0x8,  // 0x78
   i16 = -0x9, // 0x77
 #else
-  i8 = -0x6,  // 0x7a
-  i16 = -0x7, // 0x79
+  i8 = -0x6,                    // 0x7a
+  i16 = -0x7,                   // 0x79
 #endif
 // reference types
 #if STANDARD_GC_ENCODINGS
@@ -392,12 +392,12 @@ enum EncodedType {
   structref = -0x15,    // 0x6b
   arrayref = -0x16,     // 0x6a
 #else
-  nullexternref = -0x17, // 0x69
-  nullfuncref = -0x18,   // 0x68
-  nullref = -0x1b,       // 0x65
-  i31ref = -0x16,        // 0x6a
-  structref = -0x19,     // 0x67
-  arrayref = -0x1a,      // 0x66
+  nullexternref = -0x17,        // 0x69
+  nullfuncref = -0x18,          // 0x68
+  nullref = -0x1b,              // 0x65
+  i31ref = -0x16,               // 0x6a
+  structref = -0x19,            // 0x67
+  arrayref = -0x1a,             // 0x66
 #endif
   funcref = -0x10,   // 0x70
   externref = -0x11, // 0x6f
@@ -410,16 +410,16 @@ enum EncodedType {
   nullable = -0x1c,    // 0x64
   nonnullable = -0x1d, // 0x63
 #else
-  nullable = -0x14,    // 0x6c
-  nonnullable = -0x15, // 0x6b
+  nullable = -0x14,             // 0x6c
+  nonnullable = -0x15,          // 0x6b
 #endif
 // string reference types
 #if STANDARD_GC_ENCODINGS
   stringref = -0x19,       // 0x67
   stringview_wtf8 = -0x1a, // 0x66
 #else
-  stringref = -0x1c,       // 0x64
-  stringview_wtf8 = -0x1d, // 0x63
+  stringref = -0x1c,            // 0x64
+  stringview_wtf8 = -0x1d,      // 0x63
 #endif
   stringview_wtf16 = -0x1e, // 0x62
   stringview_iter = -0x1f,  // 0x61
@@ -431,13 +431,13 @@ enum EncodedType {
 #if STANDARD_GC_ENCODINGS
   SubFinal = -0x31, // 0x4f
 #else
-  SubFinal = -0x32, // 0x4e
+  SubFinal = -0x32,             // 0x4e
 #endif
 // isorecursive recursion groups
 #if STANDARD_GC_ENCODINGS
   Rec = -0x32, // 0x4e
 #else
-  Rec = -0x31, // 0x4f
+  Rec = -0x31,                  // 0x4f
 #endif
   // block_type
   Empty = -0x40, // 0x40
@@ -449,9 +449,9 @@ enum EncodedHeapType {
   noext = -0xe,  // 0x72
   none = -0xf,   // 0x71
 #else
-  noext = -0x17,  // 0x69
-  nofunc = -0x18, // 0x68
-  none = -0x1b,   // 0x65
+  noext = -0x17,                // 0x69
+  nofunc = -0x18,               // 0x68
+  none = -0x1b,                 // 0x65
 #endif
   func = -0x10, // 0x70
   ext = -0x11,  // 0x6f


### PR DESCRIPTION
Depending on whether preprocessor macros USE_STANDARD_GC_ENCODINGS and
USE_LEGACY_GC_ENCODINGS are defined, use the standard or legacy encodings for GC
types and instructions. Default to the latter for now. When WasmGC reaches phase
4, we will switch the default to be the standard encodings instead. After users
have time to update, we will remove the legacy encodings entirely.

Tested manually by building with USE_STANDARD_GC_ENCODINGS locally and seeing
that all the tests pass except for some tests that depend on the specific binary
encoding.