### PR TITLE
Add a Max Bits Analysis

### DIFF
--- a/src/analysis/bits-bounds-lattice.h
+++ b/src/analysis/bits-bounds-lattice.h
@@ -1,0 +1,144 @@
+#ifndef wasm_analysis_bits_bounds_lattice_h
+#define wasm_analysis_bits_bounds_lattice_h
+
+#include <optional>
+
+#include "lattice.h"
+#include "wasm.h"
+
+namespace wasm::analysis {
+
+struct MaxBitsLattice {
+  enum LatticeState { BOTTOM, REGULAR_VALUE, TOP };
+
+  struct Element {
+    Index upperBound = 0;
+    std::optional<Literal> constVal;
+    LatticeState state = BOTTOM;
+
+    bool isTop() const { return state == TOP; }
+
+    bool isBottom() const { return state == BOTTOM; }
+
+    void setUpperBound(Index upperBound) {
+      if (state != TOP) {
+        state = REGULAR_VALUE;
+        this->upperBound = upperBound;
+        constVal.reset();
+      }
+    }
+
+    void setUpperBound(Index upperBound, Literal constVal) {
+      if (state != TOP) {
+        state = REGULAR_VALUE;
+        this->upperBound = upperBound;
+        this->constVal = constVal;
+      }
+    }
+
+    void setTop() {
+      state = TOP;
+      upperBound = UINT32_MAX;
+      constVal.reset();
+    }
+
+    bool makeLeastUpperBound(const Element& other) {
+      if (other.isBottom() || isTop()) {
+        return false;
+      } else if (other.isTop()) {
+        setTop();
+        return true;
+      } else if (isBottom()) {
+        if (other.constVal.has_value()) {
+          setUpperBound(other.upperBound, other.constVal.value());
+        } else {
+          setUpperBound(other.upperBound);
+        }
+        return true;
+      }
+
+      if (upperBound < other.upperBound) {
+        if (other.constVal.has_value()) {
+          setUpperBound(other.upperBound, other.constVal.value());
+        } else {
+          setUpperBound(other.upperBound);
+        }
+        return true;
+      } else if (upperBound == other.upperBound && other.constVal.has_value()) {
+        if (constVal.has_value()) {
+          constVal.reset();
+        } else {
+          constVal = other.constVal.value();
+        }
+        return true;
+      }
+
+      return false;
+    }
+
+    void print(std::ostream& os) {
+      if (state == TOP) {
+        os << "TOP";
+      } else if (state == BOTTOM) {
+        os << "BOTTOM";
+      } else {
+        os << upperBound;
+        if (constVal.has_value()) {
+          os << " " << constVal.value();
+        }
+      }
+    }
+
+    friend MaxBitsLattice;
+  };
+
+  LatticeComparison compare(const Element& left, const Element& right) {
+    if (left.isTop()) {
+      if (right.isTop()) {
+        return LatticeComparison::EQUAL;
+      } else {
+        return LatticeComparison::GREATER;
+      }
+    } else if (right.isTop()) {
+      return LatticeComparison::LESS;
+    } else if (left.isBottom()) {
+      if (right.isBottom()) {
+        return LatticeComparison::EQUAL;
+      } else {
+        return LatticeComparison::LESS;
+      }
+    } else if (right.isBottom()) {
+      return LatticeComparison::GREATER;
+    }
+
+    if (left.upperBound > right.upperBound) {
+      return LatticeComparison::GREATER;
+    } else if (left.upperBound < right.upperBound) {
+      return LatticeComparison::LESS;
+    } else {
+      if (left.constVal.has_value()) {
+        if (right.constVal.has_value()) {
+          if (left.constVal.value() == right.constVal.value()) {
+            return LatticeComparison::EQUAL;
+          } else {
+            return LatticeComparison::NO_RELATION;
+          }
+        } else {
+          return LatticeComparison::LESS;
+        }
+      } else {
+        if (right.constVal.has_value()) {
+          return LatticeComparison::GREATER;
+        } else {
+          return LatticeComparison::EQUAL;
+        }
+      }
+    }
+  }
+
+  Element getBottom() { return Element{}; }
+};
+
+} // namespace wasm::analysis
+
+#endif // wasm_analysis_bits_bounds_lattice_h

--- a/src/analysis/bits-bounds-transfer-function.h
+++ b/src/analysis/bits-bounds-transfer-function.h
@@ -1,0 +1,367 @@
+#ifndef wasm_analysis_bits_bounds_transfer_function_h
+#define wasm_analysis_bits_bounds_transfer_function_H
+
+#include <unordered_map>
+
+#include "bits-bounds-lattice.h"
+#include "ir/bits.h"
+#include "ir/stack-utils.h"
+#include "stack-lattice.h"
+#include "visitor-transfer-function.h"
+
+namespace wasm::analysis {
+
+class MaxBitsTransferFunction
+  : public VisitorTransferFunc<MaxBitsTransferFunction,
+                               StackLattice<MaxBitsLattice>,
+                               AnalysisDirection::Forward> {
+  MaxBitsLattice& bitsLattice;
+
+public:
+  std::unordered_map<Expression*, Index> exprMaxBounds;
+
+  MaxBitsTransferFunction(MaxBitsLattice& bitsLattice)
+    : bitsLattice(bitsLattice) {}
+
+  void visitConst(Const* curr) {
+    MaxBitsLattice::Element currElement = bitsLattice.getBottom();
+
+    bool addInformation = true;
+    switch (curr->type.getBasic()) {
+      case Type::i32:
+        currElement.setUpperBound(
+          32 - curr->value.countLeadingZeroes().geti32(), curr->value);
+        break;
+      case Type::i64:
+        currElement.setUpperBound(
+          64 - curr->value.countLeadingZeroes().geti64(), curr->value);
+        break;
+      default: {
+        addInformation = false;
+      }
+    }
+
+    if (collectingResults && addInformation) {
+      exprMaxBounds[curr] = currElement.upperBound;
+    }
+
+    currState->push(std::move(currElement));
+  }
+
+  void visitBinary(Binary* curr) {
+    MaxBitsLattice::Element right = currState->pop();
+    MaxBitsLattice::Element left = currState->pop();
+
+    MaxBitsLattice::Element currElement = bitsLattice.getBottom();
+
+    bool addInformation = true;
+    switch (curr->op) {
+      case RotLInt32:
+      case RotRInt32:
+      case SubInt32: {
+        currElement.setUpperBound(32);
+        break;
+      }
+      case AddInt32: {
+        currElement.setUpperBound(
+          std::min(Index(32), std::max(left.upperBound, right.upperBound) + 1));
+        break;
+      }
+      case MulInt32: {
+        currElement.setUpperBound(
+          std::min(Index(32), left.upperBound + right.upperBound));
+        break;
+      }
+      case DivSInt32: {
+        int32_t maxBitsLeft = left.upperBound;
+        int32_t maxBitsRight = right.upperBound;
+        if (maxBitsLeft == 32 || maxBitsRight == 32) {
+          currElement.setUpperBound(32);
+        } else {
+          currElement.setUpperBound(
+            std::max(0, maxBitsLeft - maxBitsRight + 1));
+        }
+        break;
+      }
+      case DivUInt32: {
+        int32_t maxBitsLeft = left.upperBound;
+        int32_t maxBitsRight = right.upperBound;
+        currElement.setUpperBound(std::max(0, maxBitsLeft - maxBitsRight + 1));
+        break;
+      }
+      case RemSInt32: {
+        if (right.constVal.has_value()) {
+          if (left.upperBound == 32) {
+            currElement.setUpperBound(32);
+          } else {
+            auto bitsRight =
+              Index(wasm::Bits::ceilLog2(right.constVal.value().geti32()));
+            currElement.setUpperBound(std::min(left.upperBound, bitsRight));
+          }
+        } else {
+          currElement.setUpperBound(32);
+        }
+        break;
+      }
+      case RemUInt32: {
+        if (right.constVal.has_value()) {
+          auto bitsRight =
+            Index(wasm::Bits::ceilLog2(right.constVal.value().geti32()));
+          currElement.setUpperBound(std::min(left.upperBound, bitsRight));
+        } else {
+          currElement.setUpperBound(32);
+        }
+        break;
+      }
+      case AndInt32: {
+        currElement.setUpperBound(std::min(left.upperBound, right.upperBound));
+        break;
+      }
+      case OrInt32:
+      case XorInt32: {
+        currElement.setUpperBound(std::max(left.upperBound, right.upperBound));
+        break;
+      }
+      case ShlInt32: {
+        if (right.constVal.has_value()) {
+          currElement.setUpperBound(std::min(
+            Index(32),
+            left.upperBound + Bits::getEffectiveShifts(
+                                right.constVal.value().geti32(), Type::i32)));
+        }
+        break;
+      }
+      case ShrUInt32: {
+        if (right.constVal.has_value()) {
+          auto shifts = std::min(Index(Bits::getEffectiveShifts(
+                                   right.constVal.value().geti32(), Type::i32)),
+                                 left.upperBound);
+          currElement.setUpperBound(
+            std::max(Index(0), left.upperBound - shifts));
+        } else {
+          currElement.setUpperBound(32);
+        }
+        break;
+      }
+      case ShrSInt32: {
+        if (right.constVal.has_value()) {
+          if (left.upperBound == 32) {
+            currElement.setUpperBound(32);
+          } else {
+            auto shifts =
+              std::min(Index(Bits::getEffectiveShifts(
+                         right.constVal.value().geti32(), Type::i32)),
+                       left.upperBound);
+            currElement.setUpperBound(
+              std::max(Index(0), left.upperBound - shifts));
+          }
+        } else {
+          currElement.setUpperBound(32);
+        }
+        break;
+      }
+      case RotLInt64:
+      case RotRInt64:
+      case SubInt64: {
+        currElement.setUpperBound(64);
+        break;
+      }
+      case AddInt64: {
+        currElement.setUpperBound(
+          std::min(Index(64), std::max(left.upperBound, right.upperBound)));
+        break;
+      }
+      case MulInt64: {
+        currElement.setUpperBound(
+          std::min(Index(64), left.upperBound + right.upperBound));
+        break;
+      }
+      case DivSInt64: {
+        int32_t maxBitsLeft = left.upperBound;
+        int32_t maxBitsRight = right.upperBound;
+        if (maxBitsLeft == 64 || maxBitsRight == 64) {
+          currElement.setUpperBound(64);
+        } else {
+          currElement.setUpperBound(
+            std::max(0, maxBitsLeft - maxBitsRight + 1));
+        }
+        break;
+      }
+      case DivUInt64: {
+        int32_t maxBitsLeft = left.upperBound;
+        int32_t maxBitsRight = right.upperBound;
+        currElement.setUpperBound(std::max(0, maxBitsLeft - maxBitsRight + 1));
+        break;
+      }
+      case RemSInt64: {
+        if (right.constVal.has_value()) {
+          if (left.upperBound == 64) {
+            currElement.setUpperBound(64);
+          } else {
+            auto bitsRight =
+              Index(wasm::Bits::ceilLog2(right.constVal.value().geti64()));
+            currElement.setUpperBound(std::min(left.upperBound, bitsRight));
+          }
+        } else {
+          currElement.setUpperBound(64);
+        }
+        break;
+      }
+      case RemUInt64: {
+        if (right.constVal.has_value()) {
+          auto bitsRight =
+            Index(wasm::Bits::ceilLog2(right.constVal.value().geti64()));
+          currElement.setUpperBound(std::min(left.upperBound, bitsRight));
+        } else {
+          currElement.setUpperBound(64);
+        }
+        break;
+      }
+      case AndInt64: {
+        currElement.setUpperBound(std::min(left.upperBound, right.upperBound));
+        break;
+      }
+      case OrInt64:
+      case XorInt64: {
+        currElement.setUpperBound(std::max(left.upperBound, right.upperBound));
+        break;
+      }
+      case ShlInt64: {
+        if (right.constVal.has_value()) {
+          currElement.setUpperBound(
+            std::min(Index(64),
+                     Bits::getEffectiveShifts(right.constVal.value().geti64(),
+                                              Type::i64) +
+                       left.upperBound));
+        } else {
+          currElement.setUpperBound(64);
+        }
+        break;
+      }
+      case ShrUInt64: {
+        if (right.constVal.has_value()) {
+          auto shifts = std::min(Index(Bits::getEffectiveShifts(
+                                   right.constVal.value().geti64(), Type::i64)),
+                                 left.upperBound);
+          currElement.setUpperBound(
+            std::max(Index(0), left.upperBound - shifts));
+        } else {
+          currElement.setUpperBound(64);
+        }
+        break;
+      }
+      case ShrSInt64: {
+        if (right.constVal.has_value()) {
+          if (left.upperBound == 64) {
+            currElement.setUpperBound(64);
+          } else {
+            auto shifts =
+              std::min(Index(Bits::getEffectiveShifts(
+                         right.constVal.value().geti64(), Type::i64)),
+                       left.upperBound);
+            currElement.setUpperBound(
+              std::max(Index(0), left.upperBound - shifts));
+          }
+        } else {
+          currElement.setUpperBound(64);
+        }
+        break;
+      }
+      default: {
+        addInformation = false;
+      }
+    }
+
+    if (collectingResults && addInformation) {
+      exprMaxBounds[curr] = currElement.upperBound;
+    }
+
+    currState->push(std::move(currElement));
+  }
+
+  void visitUnary(Unary* curr) {
+    MaxBitsLattice::Element unaryVal = currState->pop();
+    MaxBitsLattice::Element currElement = bitsLattice.getBottom();
+
+    bool addInformation = true;
+    switch (curr->op) {
+      case ClzInt32:
+      case CtzInt32:
+      case PopcntInt32: {
+        currElement.setUpperBound(6);
+        break;
+      }
+      case ClzInt64:
+      case CtzInt64:
+      case PopcntInt64: {
+        currElement.setUpperBound(7);
+        break;
+      }
+      case WrapInt64:
+      case ExtendUInt32: {
+        currElement.setUpperBound(unaryVal.upperBound);
+        break;
+      }
+      case ExtendS8Int32: {
+        currElement.setUpperBound(
+          unaryVal.upperBound >= 8 ? Index(32) : unaryVal.upperBound);
+        break;
+      }
+      case ExtendS16Int32: {
+        currElement.setUpperBound(
+          unaryVal.upperBound >= 16 ? Index(32) : unaryVal.upperBound);
+        break;
+      }
+      case ExtendS8Int64: {
+        currElement.setUpperBound(
+          unaryVal.upperBound >= 8 ? Index(64) : unaryVal.upperBound);
+        break;
+      }
+      case ExtendS16Int64: {
+        currElement.setUpperBound(
+          unaryVal.upperBound >= 16 ? Index(64) : unaryVal.upperBound);
+        break;
+      }
+      case ExtendS32Int64:
+      case ExtendSInt32: {
+        currElement.setUpperBound(
+          unaryVal.upperBound >= 32 ? Index(64) : unaryVal.upperBound);
+        break;
+      }
+      default: {
+        addInformation = false;
+      }
+    }
+
+    if (collectingResults && addInformation) {
+      exprMaxBounds[curr] = currElement.upperBound;
+    }
+
+    currState->push(std::move(currElement));
+  }
+
+  void visitLocalSet(LocalSet* curr) {
+    MaxBitsLattice::Element val = currState->pop();
+
+    if (collectingResults && !val.isTop()) {
+      exprMaxBounds[curr] = val.upperBound;
+    }
+  }
+
+  void visitExpression(Expression* curr) {
+    StackSignature exprSignature(curr);
+    for (size_t i = 0; i < exprSignature.params.size(); ++i) {
+      MaxBitsLattice::Element currElement = bitsLattice.getBottom();
+      currElement.setTop();
+      currState->push(std::move(currElement));
+    }
+
+    for (size_t i = 0; i < exprSignature.results.size(); ++i) {
+      currState->pop();
+    }
+  }
+};
+
+} // namespace wasm::analysis
+
+#endif // wasm_analysis_bits_bounds_transfer_function_H

--- a/src/analysis/visitor-transfer-function.h
+++ b/src/analysis/visitor-transfer-function.h
@@ -15,7 +15,7 @@ enum class AnalysisDirection { Forward, Backward };
 // analysis. Forward analysis is chosen by default unless the template parameter
 // Backward is true.
 template<typename SubType, typename Lattice, AnalysisDirection Direction>
-struct VisitorTransferFunc : public Visitor<SubType> {
+struct VisitorTransferFunc : public UnifiedExpressionVisitor<SubType> {
 protected:
   typename Lattice::Element* currState = nullptr;
 

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -1,5 +1,7 @@
 #include <iostream>
 
+#include "analysis/bits-bounds-lattice.h"
+#include "analysis/bits-bounds-transfer-function.h"
 #include "analysis/cfg.h"
 #include "analysis/lattice.h"
 #include "analysis/liveness-transfer-function.h"
@@ -676,4 +678,37 @@ TEST_F(CFGTest, StackLatticeFunctioning) {
 
   EXPECT_EQ(stackLattice.compare(thirdStack, expectedStack),
             LatticeComparison::EQUAL);
+}
+
+TEST_F(CFGTest, MaxBitsAnalysis) {
+  auto moduleText = R"wasm(
+    (module
+      (func $bar (param $x (i32))
+        (local.set $x (i32.mul (i32.const 1234) (i32.const 432)))
+        (local.set $x (i32.add (i32.const 64) (i32.const 32)))
+        (local.set $x (i32.xor (i32.const 123) (i32.const 47)))
+      )
+    )
+  )wasm";
+
+  Module wasm;
+  parseWast(wasm, moduleText);
+
+  Function* func = wasm.getFunction("bar");
+  CFG cfg = CFG::fromFunction(func);
+
+  MaxBitsLattice maxBitsLattice;
+  StackLattice<MaxBitsLattice> lattice(maxBitsLattice);
+
+  MaxBitsTransferFunction transferFunction(maxBitsLattice);
+  MonotoneCFGAnalyzer<StackLattice<MaxBitsLattice>, MaxBitsTransferFunction>
+    analyzer(lattice, transferFunction, cfg);
+  analyzer.evaluateAndCollectResults();
+
+  for (auto cfgBlock = cfg.begin(); cfgBlock != cfg.end(); ++cfgBlock) {
+    for (auto expr = cfgBlock->begin(); expr != cfgBlock->end(); ++expr) {
+      std::cout << ShallowExpression{*expr} << " "
+                << transferFunction.exprMaxBounds[*expr] << std::endl;
+    }
+  }
 }


### PR DESCRIPTION
This change introduces a prototype max bits analysis for values in the wasm value stack using the abstract interpretation static analysis framework. The implementation mirrors the existing `getMaxBits` function in `bits.h` but does not cover local indices and other values outside of the wasm value stack.