### PR TITLE
Disable inline CodeCov annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     project:
       default:
         informational: true
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
While useful these annotations in the GitHub code review UI, are also extremely
intrusive and make reading code under review harder.