### PR TITLE
Improve cast optimizations

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -371,7 +371,7 @@ inline Type getFallthroughType(Expression* curr,
   if (!type.isRef()) {
     // Only reference types can be improved (excepting improvements to
     // unreachable, which we leave to refinalization).
-    // TOOD: Handle tuples if that ever becomes important.
+    // TODO: Handle tuples if that ever becomes important.
     return type;
   }
   while (1) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2028,7 +2028,7 @@ struct OptimizeInstructions
       case GCTypeUtils::SuccessOnlyIfNonNull: {
         // We know the cast will succeed, or at most requires a null check, so
         // we can try to optimize it out. Find the best-typed fallthrough value
-        // to propagate.        
+        // to propagate.
         auto** refp = Properties::getMostRefinedFallthrough(
           &curr->ref, getPassOptions(), *getModule());
         auto* ref = *refp;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2094,12 +2094,15 @@ struct OptimizeInstructions
             builder.makeSequence(builder.makeDrop(curr->ref), get));
           return;
         }
-        // If we get here, then we know that the heap type of the cast value is
+        // If we get here, then we know that the heap type of the cast input is
         // more refined than the heap type of best available fallthrough
         // expression. The only way this can happen is if we were able to infer
-        // that the value has bottom heap type because it was typed with
-        // multiple, incompatible heap types. In this case, the cast succeeds
-        // only if the value is null, so we can fall through to that case.
+        // that the input has bottom heap type because it was typed with
+        // multiple, incompatible heap types in different fallthrough
+        // expressions. In this case, the cast succeeds only if the value is
+        // null, so we can fall through to that case.
+        assert(Type::isSubType(refType, ref->type));
+        assert(refType.getHeapType().isBottom());
       }
         [[fallthrough]];
       case GCTypeUtils::SuccessOnlyIfNull: {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2009,11 +2009,7 @@ struct OptimizeInstructions
     // have. We know any less specific type either cannot appear or will fail
     // the cast anyways.
     auto glb = Type::getGreatestLowerBound(curr->type, refType);
-    if (glb == Type::unreachable) {
-      // Let DCE do the rest of the work here.
-      return;
-    }
-    if (glb != curr->type) {
+    if (glb != Type::unreachable && glb != curr->type) {
       curr->type = glb;
       refinalize = true;
       // Call replaceCurrent() to make us re-optimize this node, as we may have

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2095,7 +2095,7 @@ struct OptimizeInstructions
           return;
         }
         // If we get here, then we know that the heap type of the cast input is
-        // more refined than the heap type of best available fallthrough
+        // more refined than the heap type of the best available fallthrough
         // expression. The only way this can happen is if we were able to infer
         // that the input has bottom heap type because it was typed with
         // multiple, incompatible heap types in different fallthrough

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2099,8 +2099,15 @@ struct OptimizeInstructions
         // expression. The only way this can happen is if we were able to infer
         // that the input has bottom heap type because it was typed with
         // multiple, incompatible heap types in different fallthrough
-        // expressions. In this case, the cast succeeds only if the value is
-        // null, so we can fall through to that case.
+        // expressions. For example:
+        //
+        // (ref.cast eqref
+        //   (br_on_cast_fail $l anyref i31ref
+        //     (br_on_cast_fail $l anyref structref
+        //       ...)))
+        //
+        // In this case, the cast succeeds because the value must be null, so we
+        // can fall through to handle that case.
         assert(Type::isSubType(refType, ref->type));
         assert(refType.getHeapType().isBottom());
       }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2013,6 +2013,7 @@ struct OptimizeInstructions
       // the rest, but we'd need to do more work to make sure all the local
       // state in this function is in sync which this change; it's easier to
       // just do another clean pass on this node.)
+      refinalize = true;
       replaceCurrent(curr);
       return;
     }
@@ -2030,9 +2031,6 @@ struct OptimizeInstructions
         auto** refp = Properties::getMostRefinedFallthrough(
           &curr->ref, getPassOptions(), *getModule());
         auto* ref = *refp;
-        if (curr->type != refType) {
-          refinalize = true;
-        }
         // We know ref's heap type matches, but the knowledge that the
         // nullabillity matches might come from somewhere else or we might not
         // know at all whether the nullability matches, so we might need to emit
@@ -2115,6 +2113,7 @@ struct OptimizeInstructions
         // is not already a null type.
         if (curr->type != nullType) {
           curr->type = nullType;
+          refinalize = true;
           replaceCurrent(curr);
           return;
         }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2026,8 +2026,9 @@ struct OptimizeInstructions
         break;
       case GCTypeUtils::Success:
       case GCTypeUtils::SuccessOnlyIfNonNull: {
-        // We know the cast will succeed, so we can try to optimize it out. Find
-        // the best-typed fallthrough value to propagate.
+        // We know the cast will succeed, or at most requires a null check, so
+        // we can try to optimize it out. Find the best-typed fallthrough value
+        // to propagate.        
         auto** refp = Properties::getMostRefinedFallthrough(
           &curr->ref, getPassOptions(), *getModule());
         auto* ref = *refp;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2115,15 +2115,9 @@ struct OptimizeInstructions
             curr->type));
           return;
         }
-
-        // Without trapsNeverHappen we can at least refine the type here if it
-        // is not already a null type.
-        if (curr->type != nullType) {
-          curr->type = nullType;
-          refinalize = true;
-          replaceCurrent(curr);
-          return;
-        }
+        // Otherwise, we should have already refined the cast type to cast
+        // directly to null.
+        assert(curr->type == nullType);
         break;
       }
       case GCTypeUtils::Unreachable:

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2173,6 +2173,13 @@ struct OptimizeInstructions
     // we are given, but at fallthrough values as well.
     Type refType =
       Properties::getFallthroughType(curr->ref, getPassOptions(), *getModule());
+
+    // Improve the cast type as much as we can without changing the results.
+    auto glb = Type::getGreatestLowerBound(curr->castType, refType);
+    if (glb != Type::unreachable && glb != curr->castType) {
+      curr->castType = glb;
+    }
+
     switch (GCTypeUtils::evaluateCastCheck(refType, curr->castType)) {
       case GCTypeUtils::Unknown:
         break;

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -264,6 +264,8 @@ public:
     return lub;
   }
 
+  static Type getGreatestLowerBound(Type a, Type b);
+
   // Helper allowing the value of `print(...)` to be sent to an ostream. Stores
   // a `TypeID` because `Type` is incomplete at this point and using a reference
   // makes it less convenient to use.

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1035,6 +1035,31 @@ Type Type::getLeastUpperBound(Type a, Type b) {
   WASM_UNREACHABLE("unexpected type");
 }
 
+Type Type::getGreatestLowerBound(Type a, Type b) {
+  if (a == b) {
+    return a;
+  }
+  if (!a.isRef() || !b.isRef()) {
+    return Type::unreachable;
+  }
+  auto heapA = a.getHeapType();
+  auto heapB = b.getHeapType();
+  if (heapA.getBottom() != heapB.getBottom()) {
+    return Type::unreachable;
+  }
+  auto nullability =
+    (a.isNonNullable() || b.isNonNullable()) ? NonNullable : Nullable;
+  HeapType heapType;
+  if (HeapType::isSubType(heapA, heapB)) {
+    heapType = heapA;
+  } else if (HeapType::isSubType(heapB, heapA)) {
+    heapType = heapB;
+  } else {
+    heapType = heapA.getBottom();
+  }
+  return Type(heapType, nullability);
+}
+
 size_t Type::size() const {
   if (isTuple()) {
     return getTypeInfo(*this)->tuple.size();

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -158,13 +158,16 @@
  )
 
  ;; CHECK:      (func $fallthrough-bad-type (type $none_=>_i32) (result i32)
- ;; CHECK-NEXT:  (call_ref $none_=>_i32
- ;; CHECK-NEXT:   (block (result (ref $none_=>_i32))
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (ref.func $return-nothing)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (block
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (ref.func $return-nothing)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $fallthrough-bad-type (result i32)

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -39,7 +39,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $other))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $child)
   ;; CHECK-NEXT:    )
@@ -60,7 +60,7 @@
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block (result (ref $other))
+  ;; TNH-NEXT:   (block
   ;; TNH-NEXT:    (drop
   ;; TNH-NEXT:     (local.get $child)
   ;; TNH-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -641,15 +641,17 @@
   )
 
   ;; TNH:      (func $cast-if-null (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
-  ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block
-  ;; TNH-NEXT:    (drop
-  ;; TNH-NEXT:     (i32.const 1)
+  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; TNH-NEXT:   (drop
+  ;; TNH-NEXT:    (block
+  ;; TNH-NEXT:     (drop
+  ;; TNH-NEXT:      (i32.const 1)
+  ;; TNH-NEXT:     )
+  ;; TNH-NEXT:     (unreachable)
   ;; TNH-NEXT:    )
-  ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
+  ;; TNH-NEXT:   (unreachable)
   ;; TNH-NEXT:  )
-  ;; TNH-NEXT:  (unreachable)
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $cast-if-null (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
   ;; NO_TNH-NEXT:  (drop
@@ -675,15 +677,17 @@
   )
 
   ;; TNH:      (func $cast-if-null-flip (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
-  ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block
-  ;; TNH-NEXT:    (drop
-  ;; TNH-NEXT:     (i32.const 1)
+  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; TNH-NEXT:   (drop
+  ;; TNH-NEXT:    (block
+  ;; TNH-NEXT:     (drop
+  ;; TNH-NEXT:      (i32.const 1)
+  ;; TNH-NEXT:     )
+  ;; TNH-NEXT:     (unreachable)
   ;; TNH-NEXT:    )
-  ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
+  ;; TNH-NEXT:   (unreachable)
   ;; TNH-NEXT:  )
-  ;; TNH-NEXT:  (unreachable)
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $cast-if-null-flip (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
   ;; NO_TNH-NEXT:  (drop
@@ -932,29 +936,23 @@
 
   ;; TNH:      (func $if.null.child.but.no.flow (type $void)
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block (result (ref nofunc))
-  ;; TNH-NEXT:    (drop
-  ;; TNH-NEXT:     (if (result (ref nofunc))
-  ;; TNH-NEXT:      (i32.const 1)
-  ;; TNH-NEXT:      (return)
-  ;; TNH-NEXT:      (unreachable)
-  ;; TNH-NEXT:     )
+  ;; TNH-NEXT:   (ref.cast nofunc
+  ;; TNH-NEXT:    (if (result (ref nofunc))
+  ;; TNH-NEXT:     (i32.const 1)
+  ;; TNH-NEXT:     (return)
+  ;; TNH-NEXT:     (unreachable)
   ;; TNH-NEXT:    )
-  ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $if.null.child.but.no.flow (type $void)
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (block (result (ref nofunc))
-  ;; NO_TNH-NEXT:    (drop
-  ;; NO_TNH-NEXT:     (if (result (ref nofunc))
-  ;; NO_TNH-NEXT:      (i32.const 1)
-  ;; NO_TNH-NEXT:      (return)
-  ;; NO_TNH-NEXT:      (unreachable)
-  ;; NO_TNH-NEXT:     )
+  ;; NO_TNH-NEXT:   (ref.cast nofunc
+  ;; NO_TNH-NEXT:    (if (result (ref nofunc))
+  ;; NO_TNH-NEXT:     (i32.const 1)
+  ;; NO_TNH-NEXT:     (return)
+  ;; NO_TNH-NEXT:     (unreachable)
   ;; NO_TNH-NEXT:    )
-  ;; NO_TNH-NEXT:    (unreachable)
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT: )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -641,17 +641,15 @@
   )
 
   ;; TNH:      (func $cast-if-null (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
-  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
-  ;; TNH-NEXT:   (drop
-  ;; TNH-NEXT:    (block
-  ;; TNH-NEXT:     (drop
-  ;; TNH-NEXT:      (i32.const 1)
-  ;; TNH-NEXT:     )
-  ;; TNH-NEXT:     (unreachable)
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (block
+  ;; TNH-NEXT:    (drop
+  ;; TNH-NEXT:     (i32.const 1)
   ;; TNH-NEXT:    )
+  ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
-  ;; TNH-NEXT:   (unreachable)
   ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (unreachable)
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $cast-if-null (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
   ;; NO_TNH-NEXT:  (drop
@@ -677,17 +675,15 @@
   )
 
   ;; TNH:      (func $cast-if-null-flip (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
-  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
-  ;; TNH-NEXT:   (drop
-  ;; TNH-NEXT:    (block
-  ;; TNH-NEXT:     (drop
-  ;; TNH-NEXT:      (i32.const 1)
-  ;; TNH-NEXT:     )
-  ;; TNH-NEXT:     (unreachable)
+  ;; TNH-NEXT:  (drop
+  ;; TNH-NEXT:   (block
+  ;; TNH-NEXT:    (drop
+  ;; TNH-NEXT:     (i32.const 1)
   ;; TNH-NEXT:    )
+  ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
-  ;; TNH-NEXT:   (unreachable)
   ;; TNH-NEXT:  )
+  ;; TNH-NEXT:  (unreachable)
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $cast-if-null-flip (type $ref|none|_=>_ref|$struct|) (param $x (ref none)) (result (ref $struct))
   ;; NO_TNH-NEXT:  (drop
@@ -936,23 +932,29 @@
 
   ;; TNH:      (func $if.null.child.but.no.flow (type $void)
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (ref.cast nofunc
-  ;; TNH-NEXT:    (if (result (ref nofunc))
-  ;; TNH-NEXT:     (i32.const 1)
-  ;; TNH-NEXT:     (return)
-  ;; TNH-NEXT:     (unreachable)
+  ;; TNH-NEXT:   (block (result (ref nofunc))
+  ;; TNH-NEXT:    (drop
+  ;; TNH-NEXT:     (if (result (ref nofunc))
+  ;; TNH-NEXT:      (i32.const 1)
+  ;; TNH-NEXT:      (return)
+  ;; TNH-NEXT:      (unreachable)
+  ;; TNH-NEXT:     )
   ;; TNH-NEXT:    )
+  ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $if.null.child.but.no.flow (type $void)
   ;; NO_TNH-NEXT:  (drop
-  ;; NO_TNH-NEXT:   (ref.cast nofunc
-  ;; NO_TNH-NEXT:    (if (result (ref nofunc))
-  ;; NO_TNH-NEXT:     (i32.const 1)
-  ;; NO_TNH-NEXT:     (return)
-  ;; NO_TNH-NEXT:     (unreachable)
+  ;; NO_TNH-NEXT:   (block (result (ref nofunc))
+  ;; NO_TNH-NEXT:    (drop
+  ;; NO_TNH-NEXT:     (if (result (ref nofunc))
+  ;; NO_TNH-NEXT:      (i32.const 1)
+  ;; NO_TNH-NEXT:      (return)
+  ;; NO_TNH-NEXT:      (unreachable)
+  ;; NO_TNH-NEXT:     )
   ;; NO_TNH-NEXT:    )
+  ;; NO_TNH-NEXT:    (unreachable)
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:  )
   ;; NO_TNH-NEXT: )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2842,13 +2842,14 @@
 
   ;; CHECK:      (func $non-null-bottom-ref (type $none_=>_ref|func|) (result (ref func))
   ;; CHECK-NEXT:  (local $0 funcref)
-  ;; CHECK-NEXT:  (ref.cast func
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $0
   ;; CHECK-NEXT:    (loop (result (ref nofunc))
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $non-null-bottom-ref (result (ref func))
     (local $0 (ref null func))

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -2414,7 +2414,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $compatible-cast-fallthrough-null-check (param $eqref eqref) (result (ref i31))
-    ;; Similar to above, but now the cast only succeeds if the value is non-null.
+    ;; Similar to above, but now we no longer know whether the value going into
+    ;; the cast is null or not.
     (ref.cast i31
       (local.tee $eqref
         (block (result eqref)

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -1318,6 +1318,27 @@
     )
   )
 
+  ;; CHECK:      (func $improvable-test-separate-fallthrough (type $eqref_=>_i32) (param $eqref eqref) (result i32)
+  ;; CHECK-NEXT:  (ref.test i31
+  ;; CHECK-NEXT:   (block (result eqref)
+  ;; CHECK-NEXT:    (ref.as_non_null
+  ;; CHECK-NEXT:     (local.get $eqref)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $improvable-test-separate-fallthrough (param $eqref eqref) (result i32)
+    ;; There is no need to admit null here, but we don't know whether we have an i31.
+    (ref.test null i31
+      (block (result eqref)
+        ;; Prove that the value is non-nullable
+        (ref.as_non_null
+          (local.get $eqref)
+        )
+      )
+    )
+  )
+
   ;; CHECK:      (func $incompatible-test-separate-fallthrough (type $eqref_=>_i32) (param $eqref eqref) (result i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $eqref

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -584,7 +584,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast i31
   ;; CHECK-NEXT:      (local.get $x)
@@ -1088,7 +1088,7 @@
 
   ;; CHECK:      (func $incompatible-cast-of-non-null (type $ref|$struct|_=>_none) (param $struct (ref $struct))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $array))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $struct)
   ;; CHECK-NEXT:    )
@@ -1888,9 +1888,9 @@
 
   ;; CHECK:      (func $ref-cast-static-fallthrough-remaining-impossible (type $ref|eq|_=>_none) (param $x (ref eq))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $array))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result (ref eq))
+  ;; CHECK-NEXT:     (block (result (ref $struct))
   ;; CHECK-NEXT:      (call $ref-cast-static-fallthrough-remaining-impossible
   ;; CHECK-NEXT:       (local.get $x)
   ;; CHECK-NEXT:      )
@@ -2575,12 +2575,12 @@
   )
 
   ;; CHECK:      (func $incompatible-cast-heap-types-nonnullable (type $anyref_=>_anyref) (param $anyref anyref) (result anyref)
-  ;; CHECK-NEXT:  (block $outer (result anyref)
-  ;; CHECK-NEXT:   (block (result (ref struct))
+  ;; CHECK-NEXT:  (block $outer (result (ref any))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (br_on_cast_fail $outer anyref i31ref
-  ;; CHECK-NEXT:       (block (result anyref)
+  ;; CHECK-NEXT:     (block (result i31ref)
+  ;; CHECK-NEXT:      (br_on_cast_fail $outer structref i31ref
+  ;; CHECK-NEXT:       (block (result structref)
   ;; CHECK-NEXT:        (br_on_cast_fail $outer anyref structref
   ;; CHECK-NEXT:         (local.get $anyref)
   ;; CHECK-NEXT:        )
@@ -2842,14 +2842,13 @@
 
   ;; CHECK:      (func $non-null-bottom-ref (type $none_=>_ref|func|) (result (ref func))
   ;; CHECK-NEXT:  (local $0 funcref)
-  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:  (ref.cast func
   ;; CHECK-NEXT:   (local.tee $0
   ;; CHECK-NEXT:    (loop (result (ref nofunc))
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $non-null-bottom-ref (result (ref func))
     (local $0 (ref null func))

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -1842,7 +1842,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast $array
   ;; CHECK-NEXT:      (local.get $x)
@@ -1852,7 +1852,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast $array
   ;; CHECK-NEXT:      (local.get $x)
@@ -1862,7 +1862,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast $array
   ;; CHECK-NEXT:      (local.get $x)
@@ -2174,7 +2174,7 @@
 
   ;; CHECK:      (func $ref-cast-heap-type-incompatible (type $ref?|$B|_ref|$B|_=>_none) (param $null-b (ref null $B)) (param $b (ref $B))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $b)
   ;; CHECK-NEXT:    )
@@ -2182,7 +2182,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $null-b)
   ;; CHECK-NEXT:    )
@@ -2190,7 +2190,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $struct))
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $b)
   ;; CHECK-NEXT:    )
@@ -2275,7 +2275,7 @@
   ;; CHECK-NEXT:  (local $1 i31ref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $eqref
-  ;; CHECK-NEXT:    (block (result i31ref)
+  ;; CHECK-NEXT:    (block (result eqref)
   ;; CHECK-NEXT:     (local.tee $1
   ;; CHECK-NEXT:      (ref.cast null i31
   ;; CHECK-NEXT:       (local.get $eqref)
@@ -2418,9 +2418,9 @@
   ;; CHECK:      (func $incompatible-cast-separate-fallthrough (type $eqref_=>_structref) (param $eqref eqref) (result structref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $eqref
-  ;; CHECK-NEXT:    (block (result eqref)
+  ;; CHECK-NEXT:    (block (result (ref i31))
   ;; CHECK-NEXT:     (ref.as_non_null
-  ;; CHECK-NEXT:      (block (result eqref)
+  ;; CHECK-NEXT:      (block (result i31ref)
   ;; CHECK-NEXT:       (ref.cast null i31
   ;; CHECK-NEXT:        (local.get $eqref)
   ;; CHECK-NEXT:       )


### PR DESCRIPTION
Simplify the optimization of ref.cast and ref.test in OptimizeInstructions by
moving the loop that examines fallthrough values one at a time out to a shared
function in properties.h. Also simplify ref.cast optimization by analyzing the
cast result in just one place.

In addition to simplifying the code, also make the cast optimizations more
powerful by analyzing the nullability and heap type of the cast value
independently, resulting in a potentially more precise analysis of the cast
behavior. Also improve optimization power by considering fallthrough values when
optimizing the SuccessOnlyIfNonNull case.