### PR TITLE
Further improve ref.cast during finalization

### DIFF
--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -824,7 +824,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast $D
-  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -841,7 +843,9 @@
     )
     (drop
       (ref.cast $D
-        (local.get $x)
+        (block (result anyref)
+          (local.get $x)
+        )
       )
     )
   )

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -160,7 +160,7 @@
  ;; CHECK:      (func $fallthrough-bad-type (type $none_=>_i32) (result i32)
  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
  ;; CHECK-NEXT:   (drop
- ;; CHECK-NEXT:    (block
+ ;; CHECK-NEXT:    (block (result (ref nofunc))
  ;; CHECK-NEXT:     (drop
  ;; CHECK-NEXT:      (ref.func $return-nothing)
  ;; CHECK-NEXT:     )

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -39,7 +39,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $child)
   ;; CHECK-NEXT:    )
@@ -60,7 +60,7 @@
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block
+  ;; TNH-NEXT:   (block (result (ref none))
   ;; TNH-NEXT:    (drop
   ;; TNH-NEXT:     (local.get $child)
   ;; TNH-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -584,7 +584,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast i31
   ;; CHECK-NEXT:      (local.get $x)
@@ -1088,7 +1088,7 @@
 
   ;; CHECK:      (func $incompatible-cast-of-non-null (type $ref|$struct|_=>_none) (param $struct (ref $struct))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $struct)
   ;; CHECK-NEXT:    )
@@ -1988,7 +1988,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast $array
   ;; CHECK-NEXT:      (local.get $x)
@@ -1998,7 +1998,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast $array
   ;; CHECK-NEXT:      (local.get $x)
@@ -2008,7 +2008,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.cast $array
   ;; CHECK-NEXT:      (local.get $x)
@@ -2320,7 +2320,7 @@
 
   ;; CHECK:      (func $ref-cast-heap-type-incompatible (type $ref?|$B|_ref|$B|_=>_none) (param $null-b (ref null $B)) (param $b (ref $B))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $b)
   ;; CHECK-NEXT:    )
@@ -2328,7 +2328,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $null-b)
   ;; CHECK-NEXT:    )
@@ -2336,7 +2336,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block (result (ref none))
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $b)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -810,7 +810,7 @@
 
  ;; CHECK:      (func $odd-cast-and-get-non-null (type $ref|$func-return-i32|_=>_none) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (ref.cast $func-return-i32
+ ;; CHECK-NEXT:   (ref.cast nofunc
  ;; CHECK-NEXT:    (ref.func $receive-f64)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -873,7 +873,7 @@
 
  ;; CHECK:      (func $1 (type $ref|$[i8]|_=>_none) (param $2 (ref $[i8]))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (ref.cast struct
+ ;; CHECK-NEXT:   (ref.cast none
  ;; CHECK-NEXT:    (local.get $2)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )


### PR DESCRIPTION
We previously improved the nullability and heap type of the ref.cast target type
in RefCast::finalize() based on what we knew about its input type. Simplify the
code and make this improvement more powerful by using the greatest lower bound
of the original cast target and input type.