### PR TITLE
Fix finalization of call_ref to handle refined target types

### DIFF
--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1503,7 +1503,6 @@ public:
   bool isReturn = false;
 
   void finalize();
-  void finalize(Type type_);
 };
 
 class RefTest : public SpecificExpression<Expression::RefTestId> {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6936,7 +6936,10 @@ void WasmBinaryReader::visitCallRef(CallRef* curr) {
   for (size_t i = 0; i < num; i++) {
     curr->operands[num - i - 1] = popNonVoidExpression();
   }
-  curr->finalize(sig.results);
+  // If the target has bottom type, we won't be able to infer the correct type
+  // from it, so set the type manually to be safe.
+  curr->type = sig.results;
+  curr->finalize();
 }
 
 bool WasmBinaryReader::maybeVisitI31New(Expression*& out, uint32_t code) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2822,6 +2822,13 @@ Expression* SExpressionWasmBuilder::makeCallRef(Element& s, bool isReturn) {
       s.line,
       s.col);
   }
+  if (!Type::isSubType(target->type, Type(sigType, Nullable))) {
+    throw ParseException(
+      std::string(isReturn ? "return_call_ref" : "call_ref") +
+        " target should match expected type",
+      s.line,
+      s.col);
+  }
   return Builder(wasm).makeCallRef(
     target, operands, sigType.getSignature().results, isReturn);
 }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -920,7 +920,9 @@ void I31Get::finalize() {
 }
 
 void CallRef::finalize() {
-  handleUnreachableOperands(this);
+  if (handleUnreachableOperands(this)) {
+    return;
+  }
   if (isReturn) {
     type = Type::unreachable;
     return;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -937,7 +937,6 @@ void CallRef::finalize() {
   type = target->type.getHeapType().getSignature().results;
 }
 
-
 void RefTest::finalize() {
   if (ref->type == Type::unreachable) {
     type = Type::unreachable;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -923,16 +923,20 @@ void CallRef::finalize() {
   handleUnreachableOperands(this);
   if (isReturn) {
     type = Type::unreachable;
+    return;
   }
   if (target->type == Type::unreachable) {
     type = Type::unreachable;
+    return;
   }
+  assert(target->type.isRef());
+  if (target->type.getHeapType().isBottom()) {
+    return;
+  }
+  assert(target->type.getHeapType().isSignature());
+  type = target->type.getHeapType().getSignature().results;
 }
 
-void CallRef::finalize(Type type_) {
-  type = type_;
-  finalize();
-}
 
 void RefTest::finalize() {
   if (ref->type == Type::unreachable) {

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -234,7 +234,7 @@
     )
   )
 
-  ;; CHECK:      (func $multiple-iterations-refinalize-call-ref (type $i32_=>_none) (param $i i32)
+  ;; CHECK:      (func $multiple-iterations-refinalize-call-ref (type $none_=>_none)
   ;; CHECK-NEXT:  (local $f (ref $ret-i31))
   ;; CHECK-NEXT:  (local $x i31ref)
   ;; CHECK-NEXT:  (local.set $f
@@ -246,7 +246,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $multiple-iterations-refinalize-call-ref (param $i i32)
+  (func $multiple-iterations-refinalize-call-ref
     (local $f (ref null $ret-any))
     (local $x (anyref))
     (local.set $f
@@ -255,6 +255,37 @@
     (local.set $x
       ;; After $f is refined to hold $ret-i31 and the call_ref is refinalized,
       ;; we will be able to refine $x to i31.
+      (call_ref $ret-any
+        (local.get $f)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $multiple-iterations-refinalize-call-ref-bottom (type $none_=>_none)
+  ;; CHECK-NEXT:  (local $f nullfuncref)
+  ;; CHECK-NEXT:  (local $x anyref)
+  ;; CHECK-NEXT:  (local.set $f
+  ;; CHECK-NEXT:   (ref.null nofunc)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $f)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $multiple-iterations-refinalize-call-ref-bottom
+    (local $f (ref null $ret-any))
+    (local $x (anyref))
+    ;; Same as above, but now we refine $f to nullfuncref. Check that we don't crash.
+    (local.set $f
+      (ref.null nofunc)
+    )
+    (local.set $x
+      ;; We can no longer refine $x because there is no result type we can use
+      ;; after refining $f.
       (call_ref $ret-any
         (local.get $f)
       )


### PR DESCRIPTION
Previously CallRef::finalize() would never update the type of the CallRef, even
if the type of the call target had been refined to give a more precise result
type. Besides unnecessarily losing type information, this could also lead to
validation errors, since the validator checks that the type of CallRef matches
the result type of the target signature.

Fix the bug by updating CallRef's type based on its target signature in
CallRef::finalize() and add a test that depends on this refinalization.