### PR TITLE
fix: debug info print with depth

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -170,6 +170,8 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
 
   std::vector<HeapType> heapTypes;
 
+  unsigned lastPrintIndent = 0;
+
   // Print type names by saved name or index if we have a module, or otherwise
   // by generating minimalist names. TODO: Handle conflicts between
   // user-provided names and the fallback indexed names.
@@ -2375,10 +2377,11 @@ std::ostream& PrintSExpression::printPrefixedTypes(const char* prefix,
 
 void PrintSExpression::printDebugLocation(
   const Function::DebugLocation& location) {
-  if (lastPrintedLocation == location) {
+  if (lastPrintedLocation == location && indent > lastPrintIndent) {
     return;
   }
   lastPrintedLocation = location;
+  lastPrintIndent = indent;
   auto fileName = currModule->debugInfoFileNames[location.fileIndex];
   o << ";;@ " << fileName << ":" << location.lineNumber << ":"
     << location.columnNumber << '\n';

--- a/test/fib-dbg.wasm.fromBinary
+++ b/test/fib-dbg.wasm.fromBinary
@@ -133,6 +133,7 @@
      (i32.const 0)
     )
    )
+   ;;@ fib.c:3:0
    (if
     (local.get $6)
     (block
@@ -156,6 +157,7 @@
      )
     )
    )
+   ;;@ fib.c:8:0
    (loop $label$4
     (block $label$5
      ;;@ fib.c:4:0
@@ -172,12 +174,14 @@
        (i32.const 1)
       )
      )
+     ;;@ fib.c:3:0
      (local.set $7
       (i32.eq
        (local.get $9)
        (local.get $0)
       )
      )
+     ;;@ fib.c:3:0
      (if
       (local.get $7)
       (block
@@ -201,6 +205,7 @@
        )
       )
      )
+     ;;@ fib.c:3:0
      (br $label$4)
     )
    )


### PR DESCRIPTION
Split from https://github.com/WebAssembly/binaryen/pull/5547.
Focus on debug info print optimization.