### PR TITLE
Do not prompt user on fuzz_opt.py --auto-initial-contents

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -274,14 +274,6 @@ def init_important_initial_contents():
         print('  ' + test)
     print()
 
-    # We prompt the user only when there is no seed given. This fuzz_opt.py is
-    # often used with seed in a script called from wasm-reduce, in which case we
-    # should not pause for a user input.
-    if given_seed is None:
-        ret = input('Do you want to proceed with these initial contents? (Y/n) ').lower()
-        if ret != 'y' and ret != '':
-            sys.exit(1)
-
     initial_contents = FIXED_IMPORTANT_INITIAL_CONTENTS + recent_contents
     global IMPORTANT_INITIAL_CONTENTS
     IMPORTANT_INITIAL_CONTENTS = [os.path.join(shared.get_test_dir('.'), t) for t in initial_contents]


### PR DESCRIPTION
Remove the prompt for user confirmation when using the --auto-initial-contents
option with the fuzzer. It is not actionable, and it prevents me from going off
and doing something else when I build and start the fuzzer in the same command.