### PR TITLE
[NFC] Source maps: Simplify the code and add comments

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1540,7 +1540,7 @@ class WasmBinaryReader {
   // and there is nothing left to read.
   size_t nextDebugPos;
 
-  // The debug location (file:line:col) corresponding to |nextDebugOffset|. That
+  // The debug location (file:line:col) corresponding to |nextDebugPos|. That
   // is, this is the next 3 fields in a source map entry that we have read, but
   // not used yet.
   //

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1531,25 +1531,29 @@ class WasmBinaryReader {
   std::istream* sourceMap;
 
   // The binary position that the next debug location refers to. That is, this
-  // is the first item in a source map entry that we have read, but have not
-  // used yet (we use it when we read the expression at this debug location).
+  // is the first item in a source map entry that we have read (the "column", in
+  // source map terms, which for wasm means the offset in the binary). We have
+  // read this entry, but have not used it yet (we use it when we read the
+  // expression at this binary offset).
   //
-  // This is set to 0 if we reach the end of the source and there is nothing
-  // left to read.
+  // This is set to 0 as an invalid value if we reach the end of the source map
+  // and there is nothing left to read.
   size_t nextDebugPos;
 
-  // The debug location (file:line:col) corresponding to |nextDebugOffset|. If
-  // that location has no debug info, then this contains the info from the
-  // previous one (because in a source map, these fields are relative to their
-  // last appearance (we "skip" over a place without debug info).
+  // The debug location (file:line:col) corresponding to |nextDebugOffset|. That
+  // is, this is the next 3 fields in a source map entry that we have read, but
+  // not used yet.
+  //
+  // If that location has no debug info (it lacks those 3 fields), then this
+  // contains the info from the previous one, because in a source map, these
+  // fields are relative to their last appearance, so we cannot forget them (we
+  // can't just do something like std::optional<DebugLocation> or such); for
+  // example, if we have line number 100, then no debug info, and then line
+  // number 500, then when we get to 500 we will see "+400" which is relative to
+  // the last existing line number (we "skip" over a place without debug info).
   Function::DebugLocation nextDebugLocation;
 
-  // Whether debug info is present on |nextDebugOffset|. As mentioned there, we
-  // need to track this boolean alongside |nextDebugLocation| - that is, we
-  // can't just do something like std::optional<DebugLocation> or such - as we
-  // still need to track the previous values anyhow (e.g. if we have line number
-  // 100, then no debug info, and then line number 500, then when we get to 500
-  // we will see "+400" which is relative to the last existing line number).
+  // Whether debug info is present on |nextDebugOffset| (see comment there).
   bool nextDebugLocationHasDebugInfo;
 
   // Settings.

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1526,34 +1526,44 @@ class WasmBinaryReader {
   MixedArena& allocator;
   const std::vector<char>& input;
 
+  // Source map debugging support.
+
   std::istream* sourceMap;
 
-  struct NextDebugLocation {
-    uint32_t availablePos;
-    uint32_t previousPos;
-    Function::DebugLocation next;
-  } nextDebugLocation;
+  // The binary position that the next debug location refers to. That is, this
+  // is the first item in a source map entry that we have read, but have not
+  // used yet (we use it when we read the expression at this debug location).
+  //
+  // This is set to 0 if we reach the end of the source and there is nothing
+  // left to read.
+  size_t nextDebugPos;
 
-  // Whether debug info is present next or not in the next debug location. A
-  // debug location can contain debug info (file:line:col) or it might not. We
+  // The debug location (file:line:col) corresponding to |nextDebugOffset|. If
+  // that location has no debug info, then this contains the info from the
+  // previous one (because in a source map, these fields are relative to their
+  // last appearance (we "skip" over a place without debug info).
+  Function::DebugLocation nextDebugLocation;
+
+  // Whether debug info is present on |nextDebugOffset|. As mentioned there, we
   // need to track this boolean alongside |nextDebugLocation| - that is, we
   // can't just do something like std::optional<DebugLocation> or such - as we
-  // still need to track the values in |next|, as later positions are relative
-  // to them. That is, if we have line number 100, then no debug info, and then
-  // line number 500, then when we get to 500 we will see "+400" which is
-  // relative to the last existing line number (we "skip" over the place without
-  // debug info).
+  // still need to track the previous values anyhow (e.g. if we have line number
+  // 100, then no debug info, and then line number 500, then when we get to 500
+  // we will see "+400" which is relative to the last existing line number).
   bool nextDebugLocationHasDebugInfo;
+
+  // Settings.
 
   bool debugInfo = true;
   bool DWARF = false;
   bool skipFunctionBodies = false;
 
+  // Internal state.
+
   size_t pos = 0;
   Index startIndex = -1;
   std::set<Function::DebugLocation> debugLocation;
   size_t codeSectionLocation;
-
   std::set<BinaryConsts::Section> seenSections;
 
   // All types defined in the type section

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1553,7 +1553,7 @@ class WasmBinaryReader {
   // the last existing line number (we "skip" over a place without debug info).
   Function::DebugLocation nextDebugLocation;
 
-  // Whether debug info is present on |nextDebugOffset| (see comment there).
+  // Whether debug info is present on |nextDebugPos| (see comment there).
   bool nextDebugLocationHasDebugInfo;
 
   // Settings.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1638,8 +1638,8 @@ void WasmBinaryWriter::writeField(const Field& field) {
 WasmBinaryReader::WasmBinaryReader(Module& wasm,
                                    FeatureSet features,
                                    const std::vector<char>& input)
-  : wasm(wasm), allocator(wasm.allocator), input(input),
-    sourceMap(nullptr), nextDebugPos(0), nextDebugLocation{0, 0, 0},
+  : wasm(wasm), allocator(wasm.allocator), input(input), sourceMap(nullptr),
+    nextDebugPos(0), nextDebugLocation{0, 0, 0},
     nextDebugLocationHasDebugInfo(false), debugLocation() {
   wasm.features = features;
 }
@@ -2827,8 +2827,7 @@ void WasmBinaryReader::readNextDebugLocation() {
     return;
   }
 
-  while (nextDebugPos &&
-         nextDebugPos <= pos) {
+  while (nextDebugPos && nextDebugPos <= pos) {
     debugLocation.clear();
     // use debugLocation only for function expressions
     if (currFunction) {
@@ -2866,8 +2865,7 @@ void WasmBinaryReader::readNextDebugLocation() {
     int32_t lineNumberDelta = readBase64VLQ(*sourceMap);
     uint32_t lineNumber = nextDebugLocation.lineNumber + lineNumberDelta;
     int32_t columnNumberDelta = readBase64VLQ(*sourceMap);
-    uint32_t columnNumber =
-      nextDebugLocation.columnNumber + columnNumberDelta;
+    uint32_t columnNumber = nextDebugLocation.columnNumber + columnNumberDelta;
 
     nextDebugLocation = {fileIndex, lineNumber, columnNumber};
     nextDebugLocationHasDebugInfo = true;


### PR DESCRIPTION
Almost entirely trivial, except for this part:

```diff
-  if (nextDebugLocation.availablePos == 0 &&
-      nextDebugLocation.previousPos <= pos) {
+  if (nextDebugLocation.availablePos == 0) {
      return;
```

I believe removing the extra check has no effect. Removing it does not change
anything in the test suite, and logically, if we set `availablePos` to 0 then we
definitely want to return here - we set it to 0 to indicate there is nothing left
to read, which is what the code after it does.

As a result, we can remove the `previousPos` field entirely.

cc @JesseCodeBones - am I missing something about `previousPos`? Do you have
an example maybe that shows it is needed?