### PR TITLE
Fix printing of types for imported functions

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2846,7 +2846,7 @@ void PrintSExpression::visitImportedFunction(Function* curr) {
   lastPrintedLocation = {0, 0, 0};
   o << '(';
   emitImportHeader(curr);
-  handleSignature(curr->getSig(), curr->name);
+  handleSignature(curr->type, curr->name);
   o << ')';
   o << maybeNewLine;
 }

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -398,7 +398,7 @@
 
   ;; As above, but now an import also uses this signature, which prevents us
   ;; from changing anything.
-  ;; CHECK:      (import "out" "func" (func $import (type $func.0) (param i32)))
+  ;; CHECK:      (import "out" "func" (func $import (type $sig) (param i32)))
   (import "out" "func" (func $import (type $sig) (param i32)))
 
   (memory 1 1)

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -918,7 +918,7 @@
 
  ;; CHECK:      (type $8 (func (param funcref) (result (ref $C))))
 
- ;; CHECK:      (import "binaryen-intrinsics" "call.without.effects" (func $no.side.effects (type $func.0) (param funcref) (result (ref null $A))))
+ ;; CHECK:      (import "binaryen-intrinsics" "call.without.effects" (func $no.side.effects (type $6) (param funcref) (result (ref null $A))))
  (import "binaryen-intrinsics" "call.without.effects" (func $no.side.effects
    (param funcref)
    (result (ref null $A))

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -168,7 +168,7 @@
 
  ;; CHECK:      (import "mod" "" (global $gimport$1 (ref null $many)))
 
- ;; CHECK:      (import "mod" "f5" (func $fimport$1 (type $func.0)))
+ ;; CHECK:      (import "mod" "f5" (func $fimport$1 (type $void)))
 
  ;; CHECK:      (global $2 (mut i32) (i32.const 0))
 


### PR DESCRIPTION
Previously, the printer incorrectly reconstructed imported functions' types from
their signatures instead of printing their types directly. This could cause the
printer to print uses of types that were never defined and did not exist in the
module. Fix the bug by printing imported functions' heap types directly.