### PR TITLE
Avoid off_t in small_vector.h

### DIFF
--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -185,7 +185,7 @@ public:
       return Iterator(*this) += off;
     }
 
-    off_t operator-(const Iterator& other) const { return index - other.index; }
+    difference_type operator-(const Iterator& other) const { return index - other.index; }
 
     bool operator==(const Iterator& other) const {
       return parent == other.parent && index == other.index;

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -185,7 +185,9 @@ public:
       return Iterator(*this) += off;
     }
 
-    difference_type operator-(const Iterator& other) const { return index - other.index; }
+    difference_type operator-(const Iterator& other) const {
+      return index - other.index;
+    }
 
     bool operator==(const Iterator& other) const {
       return parent == other.parent && index == other.index;


### PR DESCRIPTION
Fix #5928 , on FreeBSD `off_t` is not defined in the headers we include, apparently.