### PR TITLE
Prepare to release Version 116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,13 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+v116
+----
+
  - "I31New" changed to "RefI31" everywhere it appears in the C API and similarly
    "i31.new" has been replaced with "ref.i31" in the JS API and in printed
-   output.
+   output (#5930, #3931).
+ - The standard WasmGC opcodes are now on by default (#5873).
 
 v115
 ----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.10.2)
 # to reduce this for compatability with emsdk.
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
 
-project(binaryen LANGUAGES C CXX VERSION 115)
+project(binaryen LANGUAGES C CXX VERSION 116)
 include(GNUInstallDirs)
 
 # The C++ standard whose features are required to build Binaryen.


### PR DESCRIPTION
The important included change is the switch to default GC opcodes.