### PR TITLE
Enable auto_initial_contents by default in fuzz_opt.py

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -254,7 +254,8 @@ def init_important_initial_contents():
             return False
 
     if not is_git_repo() and shared.options.auto_initial_contents:
-        print('Warning: The current directory is not a git repository, so you cannot use "--auto-initial-contents". Using the manually selected contents.\n')
+        print('Warning: The current directory is not a git repository, ' +
+              'so not automatically selecting initial contents.')
         shared.options.auto_initial_contents = False
 
     print('- Perenially-important initial contents:')
@@ -1764,8 +1765,8 @@ on valid wasm files.)
                 shutil.copyfile('a.wasm', original_wasm)
                 # write out a useful reduce.sh
                 auto_init = ''
-                if shared.options.auto_initial_contents:
-                    auto_init = '--auto-initial-contents'
+                if not shared.options.auto_initial_contents:
+                    auto_init = '--no-auto-initial-contents'
                 with open('reduce.sh', 'w') as reduce_sh:
                     reduce_sh.write('''\
 # check the input is even a valid wasm file

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -96,8 +96,8 @@ def parse_args(args):
     # TODO Allow each script to inherit the default set of options and add its
     # own custom options on top of that
     parser.add_argument(
-        '--auto-initial-contents', dest='auto_initial_contents',
-        action='store_true', default=False,
+        '--no-auto-initial-contents', dest='auto_initial_contents',
+        action='store_false', default=True,
         help='Select important initial contents automaticaly in fuzzer. '
              'Default: disabled.')
 


### PR DESCRIPTION
This setting is useful enough that there is basically no reason not to use it.
Turn it on by default to save some typing when running the fuzzer.