### PR TITLE
Do not optimize tuple locals in StackIR local2stack

### DIFF
--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -194,6 +194,9 @@ private:
       // This is something we should handle, look into it.
       if (inst->type.isConcrete()) {
         bool optimized = false;
+        // Do not optimize multivalue locals, since those will be better
+        // optimized when they are visited in the binary writer and this
+        // optimization would intefere with that one.
         if (auto* get = inst->origin->dynCast<LocalGet>();
             get && inst->type.isSingle()) {
           // This is a potential optimization opportunity! See if we

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -194,7 +194,8 @@ private:
       // This is something we should handle, look into it.
       if (inst->type.isConcrete()) {
         bool optimized = false;
-        if (auto* get = inst->origin->dynCast<LocalGet>()) {
+        if (auto* get = inst->origin->dynCast<LocalGet>();
+            get && inst->type.isSingle()) {
           // This is a potential optimization opportunity! See if we
           // can reach the set.
           if (values.size() > 0) {

--- a/test/lit/passes/optimize-stack-ir.wast
+++ b/test/lit/passes/optimize-stack-ir.wast
@@ -1398,4 +1398,33 @@
       )
     )
   )
+
+  ;; CHECK:      (func $tuple-local2stack (type $FUNCSIG$v)
+  ;; CHECK-NEXT:  (local $pair (f32 i32))
+  ;; CHECK-NEXT:  (local $f32 f32)
+  ;; CHECK-NEXT:  f32.const 0
+  ;; CHECK-NEXT:  i32.const 0
+  ;; CHECK-NEXT:  tuple.make
+  ;; CHECK-NEXT:  local.set $pair
+  ;; CHECK-NEXT:  local.get $pair
+  ;; CHECK-NEXT:  tuple.extract 0
+  ;; CHECK-NEXT:  local.set $f32
+  ;; CHECK-NEXT: )
+  (func $tuple-local2stack
+    (local $pair (f32 i32))
+    (local $f32 f32)
+    ;; We should not optimize out this get-set pair in Stack IR since we can do
+    ;; better in the binary writer.
+    (local.set $pair
+      (tuple.make
+        (f32.const 0)
+        (i32.const 0)
+      )
+    )
+    (local.set $f32
+      (tuple.extract 0
+        (local.get $pair)
+      )
+    )
+  )
 )


### PR DESCRIPTION
This Stack IR optimization is not compatible with a much more powerful
optimization we plan to do for tuples in the binary writer.