### PR TITLE
Fix visitBlock and add visitBlockStart in IRBuilder

### DIFF
--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -45,15 +45,13 @@ public:
   [[nodiscard]] Result<Expression*> build();
 
   // Call visit() on an existing Expression with its non-child fields
-  // initialized to initialize the child fields and refinalize it. The specific
-  // visitors are internal implementation details.
+  // initialized to initialize the child fields and refinalize it.
   [[nodiscard]] Result<> visit(Expression*);
-  [[nodiscard]] Result<> visitExpression(Expression*);
-  [[nodiscard]] Result<> visitBlock(Block*);
-  [[nodiscard]] Result<> visitReturn(Return*);
-  [[nodiscard]] Result<> visitStructNew(StructNew*);
-  [[nodiscard]] Result<> visitArrayNew(ArrayNew*);
 
+  // Handle the boundaries of control flow structures. Users may choose to use
+  // the corresponding `makeXYZ` function below instead of `visitXYZStart`, but
+  // either way must call `visitEnd` and friends at the appropriate times.
+  [[nodiscard]] Result<> visitBlockStart(Block* block);
   [[nodiscard]] Result<> visitEnd();
 
   // Alternatively, call makeXYZ to have the IRBuilder allocate the nodes. This
@@ -170,6 +168,13 @@ public:
   // [[nodiscard]] Result<> makeStringSliceIter();
 
   void setFunction(Function* func) { this->func = func; }
+
+  // Private functions that must be public for technical reasons.
+  [[nodiscard]] Result<> visitExpression(Expression*);
+  [[nodiscard]] Result<> visitBlock(Block*);
+  [[nodiscard]] Result<> visitReturn(Return*);
+  [[nodiscard]] Result<> visitStructNew(StructNew*);
+  [[nodiscard]] Result<> visitArrayNew(ArrayNew*);
 
 private:
   Module& wasm;

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -233,7 +233,7 @@ Result<> IRBuilder::visitExpression(Expression* curr) {
 }
 
 Result<> IRBuilder::visitBlock(Block* curr) {
-  scopeStack.push_back({{}, curr});
+  // No children; pushing and finalizing will be handled by `visit`.
   return Ok{};
 }
 
@@ -278,6 +278,11 @@ Result<> IRBuilder::visitArrayNew(ArrayNew* curr) {
     CHECK_ERR(init);
     curr->init = *init;
   }
+  return Ok{};
+}
+
+Result<> IRBuilder::visitBlockStart(Block* curr) {
+  scopeStack.push_back({{}, curr});
   return Ok{};
 }
 
@@ -347,7 +352,7 @@ Result<> IRBuilder::makeBlock(Name label, Type type) {
   auto* block = wasm.allocator.alloc<Block>();
   block->name = label;
   block->type = type;
-  scopeStack.push_back({{}, block});
+  CHECK_ERR(visitBlockStart(block));
   return Ok{};
 }
 


### PR DESCRIPTION
Visiting a block should push it onto the stack just like visiting any other
expression, but we previously had a `visitBlock` that introduced a new scope
instead. Fix `visitBlock` to behave as expected and introduce a new
`visitBlockStart` method to introduce a new scope.

Unfortunately this cannot be fully tested yet because the wat parser uses the
`makeXYZ` API intead of the `visit` API, but at least I updated `makeBlock` to
call `visitBlockStart`, so that is tested.