### PR TITLE
[NFC][Parser] Simplify instruction handling

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -735,9 +735,8 @@ def instruction_parser(new_parser=False):
             expr = expr.replace("(s", "(ctx, pos")
             printer.print_line("if (op == \"{inst}\"sv) {{".format(inst=inst))
             with printer.indent():
-                printer.print_line("auto ret = {expr};".format(expr=expr))
-                printer.print_line("CHECK_ERR(ret);")
-                printer.print_line("return *ret;")
+                printer.print_line("CHECK_ERR({expr});".format(expr=expr))
+                printer.print_line("return Ok{};")
             printer.print_line("}")
         else:
             printer.print_line("if (op == \"{inst}\"sv) {{ return {expr}; }}"

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3599,41 +3599,36 @@ switch (buf[0]) {
         switch (buf[6]) {
           case 'c':
             if (op == "array.copy"sv) {
-              auto ret = makeArrayCopy(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeArrayCopy(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'f':
             if (op == "array.fill"sv) {
-              auto ret = makeArrayFill(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeArrayFill(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'g': {
             switch (buf[9]) {
               case '\0':
                 if (op == "array.get"sv) {
-                  auto ret = makeArrayGet(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeArrayGet(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case '_': {
                 switch (buf[10]) {
                   case 's':
                     if (op == "array.get_s"sv) {
-                      auto ret = makeArrayGet(ctx, pos, true);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeArrayGet(ctx, pos, true));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "array.get_u"sv) {
-                      auto ret = makeArrayGet(ctx, pos, false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeArrayGet(ctx, pos, false));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -3646,16 +3641,14 @@ switch (buf[0]) {
             switch (buf[11]) {
               case 'd':
                 if (op == "array.init_data"sv) {
-                  auto ret = makeArrayInitData(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeArrayInitData(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'e':
                 if (op == "array.init_elem"sv) {
-                  auto ret = makeArrayInitElem(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeArrayInitElem(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -3663,18 +3656,16 @@ switch (buf[0]) {
           }
           case 'l':
             if (op == "array.len"sv) {
-              auto ret = makeArrayLen(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeArrayLen(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'n': {
             switch (buf[9]) {
               case '\0':
                 if (op == "array.new"sv) {
-                  auto ret = makeArrayNew(ctx, pos, false);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeArrayNew(ctx, pos, false));
+                  return Ok{};
                 }
                 goto parse_error;
               case '_': {
@@ -3683,16 +3674,14 @@ switch (buf[0]) {
                     switch (buf[11]) {
                       case 'a':
                         if (op == "array.new_data"sv) {
-                          auto ret = makeArrayNewData(ctx, pos);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeArrayNewData(ctx, pos));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'e':
                         if (op == "array.new_default"sv) {
-                          auto ret = makeArrayNew(ctx, pos, true);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeArrayNew(ctx, pos, true));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -3700,16 +3689,14 @@ switch (buf[0]) {
                   }
                   case 'e':
                     if (op == "array.new_elem"sv) {
-                      auto ret = makeArrayNewElem(ctx, pos);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeArrayNewElem(ctx, pos));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'f':
                     if (op == "array.new_fixed"sv) {
-                      auto ret = makeArrayNewFixed(ctx, pos);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeArrayNewFixed(ctx, pos));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -3720,9 +3707,8 @@ switch (buf[0]) {
           }
           case 's':
             if (op == "array.set"sv) {
-              auto ret = makeArraySet(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeArraySet(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -3730,9 +3716,8 @@ switch (buf[0]) {
       }
       case 't':
         if (op == "atomic.fence"sv) {
-          auto ret = makeAtomicFence(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeAtomicFence(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -3742,27 +3727,24 @@ switch (buf[0]) {
     switch (buf[1]) {
       case 'l':
         if (op == "block"sv) {
-          auto ret = makeBlock(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeBlock(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'r': {
         switch (buf[2]) {
           case '\0':
             if (op == "br"sv) {
-              auto ret = makeBreak(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeBreak(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case '_': {
             switch (buf[3]) {
               case 'i':
                 if (op == "br_if"sv) {
-                  auto ret = makeBreak(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBreak(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'o': {
@@ -3771,16 +3753,14 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case '\0':
                         if (op == "br_on_cast"sv) {
-                          auto ret = makeBrOnCast(ctx, pos);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBrOnCast(ctx, pos));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '_':
                         if (op == "br_on_cast_fail"sv) {
-                          auto ret = makeBrOnCast(ctx, pos, true);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBrOnCast(ctx, pos, true));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -3790,16 +3770,14 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'o':
                         if (op == "br_on_non_null"sv) {
-                          auto ret = makeBrOnNull(ctx, pos, true);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBrOnNull(ctx, pos, true));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "br_on_null"sv) {
-                          auto ret = makeBrOnNull(ctx, pos);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBrOnNull(ctx, pos));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -3810,9 +3788,8 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "br_table"sv) {
-                  auto ret = makeBreakTable(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBreakTable(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -3828,25 +3805,22 @@ switch (buf[0]) {
     switch (buf[4]) {
       case '\0':
         if (op == "call"sv) {
-          auto ret = makeCall(ctx, pos, /*isReturn=*/false);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeCall(ctx, pos, /*isReturn=*/false));
+          return Ok{};
         }
         goto parse_error;
       case '_': {
         switch (buf[5]) {
           case 'i':
             if (op == "call_indirect"sv) {
-              auto ret = makeCallIndirect(ctx, pos, /*isReturn=*/false);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeCallIndirect(ctx, pos, /*isReturn=*/false));
+              return Ok{};
             }
             goto parse_error;
           case 'r':
             if (op == "call_ref"sv) {
-              auto ret = makeCallRef(ctx, pos, /*isReturn=*/false);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeCallRef(ctx, pos, /*isReturn=*/false));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -3859,16 +3833,14 @@ switch (buf[0]) {
     switch (buf[1]) {
       case 'a':
         if (op == "data.drop"sv) {
-          auto ret = makeDataDrop(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeDataDrop(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'r':
         if (op == "drop"sv) {
-          auto ret = makeDrop(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeDrop(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -3878,16 +3850,14 @@ switch (buf[0]) {
     switch (buf[7]) {
       case 'e':
         if (op == "extern.externalize"sv) {
-          auto ret = makeRefAs(ctx, pos, ExternExternalize);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeRefAs(ctx, pos, ExternExternalize));
+          return Ok{};
         }
         goto parse_error;
       case 'i':
         if (op == "extern.internalize"sv) {
-          auto ret = makeRefAs(ctx, pos, ExternInternalize);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeRefAs(ctx, pos, ExternInternalize));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -3903,16 +3873,14 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'b':
                     if (op == "f32.abs"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::AbsFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f32.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -3922,9 +3890,8 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.ceil"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::CeilFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o': {
@@ -3933,9 +3900,8 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "f32.const"sv) {
-                              auto ret = makeConst(ctx, pos, Type::f32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeConst(ctx, pos, Type::f32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'v': {
@@ -3944,16 +3910,14 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f32.convert_i32_s"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertSInt32ToFloat32);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt32ToFloat32));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f32.convert_i32_u"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertUInt32ToFloat32);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt32ToFloat32));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -3963,16 +3927,14 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f32.convert_i64_s"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertSInt64ToFloat32);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt64ToFloat32));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f32.convert_i64_u"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertUInt64ToFloat32);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt64ToFloat32));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -3986,9 +3948,8 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "f32.copysign"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::CopySignFloat32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::CopySignFloat32));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -4001,16 +3962,14 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.demote_f64"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::DemoteFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::DemoteFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32.div"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::DivFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4018,32 +3977,28 @@ switch (buf[0]) {
               }
               case 'e':
                 if (op == "f32.eq"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::EqFloat32);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqFloat32));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'f':
                 if (op == "f32.floor"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::FloorFloat32);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorFloat32));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'g': {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.ge"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32.gt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4053,23 +4008,20 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.le"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "f32.load"sv) {
-                      auto ret = makeLoad(ctx, pos, Type::f32, /*signed=*/false, 4, /*isAtomic=*/false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeLoad(ctx, pos, Type::f32, /*signed=*/false, 4, /*isAtomic=*/false));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32.lt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4079,23 +4031,20 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'a':
                     if (op == "f32.max"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32.min"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32.mul"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MulFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4105,23 +4054,20 @@ switch (buf[0]) {
                 switch (buf[6]) {
                   case '\0':
                     if (op == "f32.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f32.nearest"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NearestFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f32.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4129,32 +4075,28 @@ switch (buf[0]) {
               }
               case 'r':
                 if (op == "f32.reinterpret_i32"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::ReinterpretInt32);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretInt32));
+                  return Ok{};
                 }
                 goto parse_error;
               case 's': {
                 switch (buf[5]) {
                   case 'q':
                     if (op == "f32.sqrt"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SqrtFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32.store"sv) {
-                      auto ret = makeStore(ctx, pos, Type::f32, 4, /*isAtomic=*/false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStore(ctx, pos, Type::f32, 4, /*isAtomic=*/false));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubFloat32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubFloat32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4162,9 +4104,8 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f32.trunc"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncFloat32);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncFloat32));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -4176,16 +4117,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'b':
                     if (op == "f32x4.abs"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::AbsVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f32x4.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4195,25 +4134,22 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.ceil"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::CeilVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o': {
                     switch (buf[20]) {
                       case 's':
                         if (op == "f32x4.convert_i32x4_s"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ConvertSVecI32x4ToVecF32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSVecI32x4ToVecF32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "f32x4.convert_i32x4_u"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ConvertUVecI32x4ToVecF32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUVecI32x4ToVecF32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -4226,16 +4162,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.demote_f64x2_zero"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::DemoteZeroVecF64x2ToVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::DemoteZeroVecF64x2ToVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32x4.div"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::DivVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4245,16 +4179,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'q':
                     if (op == "f32x4.eq"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::EqVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'x':
                     if (op == "f32x4.extract_lane"sv) {
-                      auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecF32x4, 4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecF32x4, 4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4262,25 +4194,22 @@ switch (buf[0]) {
               }
               case 'f':
                 if (op == "f32x4.floor"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::FloorVecF32x4);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorVecF32x4));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'g': {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.ge"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32x4.gt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4290,16 +4219,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.le"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32x4.lt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4309,23 +4236,20 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'a':
                     if (op == "f32x4.max"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32x4.min"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32x4.mul"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MulVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4335,23 +4259,20 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "f32x4.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f32x4.nearest"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NearestVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f32x4.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4361,16 +4282,14 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 'a':
                     if (op == "f32x4.pmax"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::PMaxVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMaxVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32x4.pmin"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::PMinVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMinVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4384,16 +4303,14 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case 'a':
                             if (op == "f32x4.relaxed_fma"sv) {
-                              auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmaVecF32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmaVecF32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "f32x4.relaxed_fms"sv) {
-                              auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmsVecF32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmsVecF32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -4403,16 +4320,14 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case 'a':
                             if (op == "f32x4.relaxed_max"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RelaxedMaxVecF32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMaxVecF32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'i':
                             if (op == "f32x4.relaxed_min"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RelaxedMinVecF32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMinVecF32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -4423,9 +4338,8 @@ switch (buf[0]) {
                   }
                   case 'p':
                     if (op == "f32x4.replace_lane"sv) {
-                      auto ret = makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecF32x4, 4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecF32x4, 4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4435,23 +4349,20 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'p':
                     if (op == "f32x4.splat"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SplatVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'q':
                     if (op == "f32x4.sqrt"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SqrtVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32x4.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubVecF32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecF32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4459,9 +4370,8 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f32x4.trunc"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncVecF32x4);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncVecF32x4));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -4478,16 +4388,14 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'b':
                     if (op == "f64.abs"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::AbsFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f64.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4497,9 +4405,8 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f64.ceil"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::CeilFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o': {
@@ -4508,9 +4415,8 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "f64.const"sv) {
-                              auto ret = makeConst(ctx, pos, Type::f64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeConst(ctx, pos, Type::f64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'v': {
@@ -4519,16 +4425,14 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f64.convert_i32_s"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertSInt32ToFloat64);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt32ToFloat64));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f64.convert_i32_u"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertUInt32ToFloat64);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt32ToFloat64));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -4538,16 +4442,14 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f64.convert_i64_s"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertSInt64ToFloat64);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt64ToFloat64));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f64.convert_i64_u"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ConvertUInt64ToFloat64);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt64ToFloat64));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -4561,9 +4463,8 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "f64.copysign"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::CopySignFloat64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::CopySignFloat64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -4574,39 +4475,34 @@ switch (buf[0]) {
               }
               case 'd':
                 if (op == "f64.div"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::DivFloat64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivFloat64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'e':
                 if (op == "f64.eq"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::EqFloat64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqFloat64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'f':
                 if (op == "f64.floor"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::FloorFloat64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorFloat64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'g': {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f64.ge"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64.gt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4616,23 +4512,20 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f64.le"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "f64.load"sv) {
-                      auto ret = makeLoad(ctx, pos, Type::f64, /*signed=*/false, 8, /*isAtomic=*/false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeLoad(ctx, pos, Type::f64, /*signed=*/false, 8, /*isAtomic=*/false));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64.lt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4642,23 +4535,20 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'a':
                     if (op == "f64.max"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f64.min"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64.mul"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MulFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4668,23 +4558,20 @@ switch (buf[0]) {
                 switch (buf[6]) {
                   case '\0':
                     if (op == "f64.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f64.nearest"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NearestFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f64.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4692,39 +4579,34 @@ switch (buf[0]) {
               }
               case 'p':
                 if (op == "f64.promote_f32"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::PromoteFloat32);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PromoteFloat32));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'r':
                 if (op == "f64.reinterpret_i64"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::ReinterpretInt64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretInt64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 's': {
                 switch (buf[5]) {
                   case 'q':
                     if (op == "f64.sqrt"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SqrtFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64.store"sv) {
-                      auto ret = makeStore(ctx, pos, Type::f64, 8, /*isAtomic=*/false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStore(ctx, pos, Type::f64, 8, /*isAtomic=*/false));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubFloat64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubFloat64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4732,9 +4614,8 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f64.trunc"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncFloat64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncFloat64));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -4746,16 +4627,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'b':
                     if (op == "f64x2.abs"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::AbsVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f64x2.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4765,25 +4644,22 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f64x2.ceil"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::CeilVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o': {
                     switch (buf[24]) {
                       case 's':
                         if (op == "f64x2.convert_low_i32x4_s"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ConvertLowSVecI32x4ToVecF64x2);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertLowSVecI32x4ToVecF64x2));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "f64x2.convert_low_i32x4_u"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ConvertLowUVecI32x4ToVecF64x2);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertLowUVecI32x4ToVecF64x2));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -4794,25 +4670,22 @@ switch (buf[0]) {
               }
               case 'd':
                 if (op == "f64x2.div"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::DivVecF64x2);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivVecF64x2));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'e': {
                 switch (buf[7]) {
                   case 'q':
                     if (op == "f64x2.eq"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::EqVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'x':
                     if (op == "f64x2.extract_lane"sv) {
-                      auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecF64x2, 2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecF64x2, 2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4820,25 +4693,22 @@ switch (buf[0]) {
               }
               case 'f':
                 if (op == "f64x2.floor"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::FloorVecF64x2);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorVecF64x2));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'g': {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f64x2.ge"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64x2.gt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4848,16 +4718,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f64x2.le"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64x2.lt"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4867,23 +4735,20 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'a':
                     if (op == "f64x2.max"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f64x2.min"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64x2.mul"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MulVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4893,23 +4758,20 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "f64x2.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f64x2.nearest"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NearestVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f64x2.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4921,16 +4783,14 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case 'a':
                         if (op == "f64x2.pmax"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::PMaxVecF64x2);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMaxVecF64x2));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'i':
                         if (op == "f64x2.pmin"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::PMinVecF64x2);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMinVecF64x2));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -4938,9 +4798,8 @@ switch (buf[0]) {
                   }
                   case 'r':
                     if (op == "f64x2.promote_low_f32x4"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::PromoteLowVecF32x4ToVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PromoteLowVecF32x4ToVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -4954,16 +4813,14 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case 'a':
                             if (op == "f64x2.relaxed_fma"sv) {
-                              auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmaVecF64x2);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmaVecF64x2));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "f64x2.relaxed_fms"sv) {
-                              auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmsVecF64x2);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmsVecF64x2));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -4973,16 +4830,14 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case 'a':
                             if (op == "f64x2.relaxed_max"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RelaxedMaxVecF64x2);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMaxVecF64x2));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'i':
                             if (op == "f64x2.relaxed_min"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RelaxedMinVecF64x2);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMinVecF64x2));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -4993,9 +4848,8 @@ switch (buf[0]) {
                   }
                   case 'p':
                     if (op == "f64x2.replace_lane"sv) {
-                      auto ret = makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecF64x2, 2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecF64x2, 2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5005,23 +4859,20 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'p':
                     if (op == "f64x2.splat"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SplatVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'q':
                     if (op == "f64x2.sqrt"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SqrtVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64x2.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubVecF64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecF64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5029,9 +4880,8 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f64x2.trunc"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncVecF64x2);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncVecF64x2));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -5047,16 +4897,14 @@ switch (buf[0]) {
     switch (buf[7]) {
       case 'g':
         if (op == "global.get"sv) {
-          auto ret = makeGlobalGet(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeGlobalGet(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 's':
         if (op == "global.set"sv) {
-          auto ret = makeGlobalSet(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeGlobalSet(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -5070,34 +4918,30 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'b':
                 if (op == "i16x8.abs"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::AbsVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'd': {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i16x8.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_': {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i16x8.add_sat_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AddSatSVecI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatSVecI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.add_sat_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AddSatUVecI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatUVecI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5108,16 +4952,14 @@ switch (buf[0]) {
               }
               case 'l':
                 if (op == "i16x8.all_true"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::AllTrueVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'v':
                 if (op == "i16x8.avgr_u"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::AvgrUVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AvgrUVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -5125,25 +4967,22 @@ switch (buf[0]) {
           }
           case 'b':
             if (op == "i16x8.bitmask"sv) {
-              auto ret = makeUnary(ctx, pos, UnaryOp::BitmaskVecI16x8);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI16x8));
+              return Ok{};
             }
             goto parse_error;
           case 'd':
             if (op == "i16x8.dot_i8x16_i7x16_s"sv) {
-              auto ret = makeBinary(ctx, pos, BinaryOp::DotI8x16I7x16SToVecI16x8);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DotI8x16I7x16SToVecI16x8));
+              return Ok{};
             }
             goto parse_error;
           case 'e': {
             switch (buf[7]) {
               case 'q':
                 if (op == "i16x8.eq"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::EqVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'x': {
@@ -5152,16 +4991,14 @@ switch (buf[0]) {
                     switch (buf[28]) {
                       case 's':
                         if (op == "i16x8.extadd_pairwise_i8x16_s"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseSVecI8x16ToI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseSVecI8x16ToI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.extadd_pairwise_i8x16_u"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseUVecI8x16ToI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseUVecI8x16ToI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5173,16 +5010,14 @@ switch (buf[0]) {
                         switch (buf[24]) {
                           case 's':
                             if (op == "i16x8.extend_high_i8x16_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI8x16ToVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI8x16ToVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extend_high_i8x16_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI8x16ToVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI8x16ToVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5192,16 +5027,14 @@ switch (buf[0]) {
                         switch (buf[23]) {
                           case 's':
                             if (op == "i16x8.extend_low_i8x16_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI8x16ToVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI8x16ToVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extend_low_i8x16_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI8x16ToVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI8x16ToVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5216,16 +5049,14 @@ switch (buf[0]) {
                         switch (buf[24]) {
                           case 's':
                             if (op == "i16x8.extmul_high_i8x16_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extmul_high_i8x16_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5235,16 +5066,14 @@ switch (buf[0]) {
                         switch (buf[23]) {
                           case 's':
                             if (op == "i16x8.extmul_low_i8x16_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extmul_low_i8x16_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI16x8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI16x8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5257,16 +5086,14 @@ switch (buf[0]) {
                     switch (buf[19]) {
                       case 's':
                         if (op == "i16x8.extract_lane_s"sv) {
-                          auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneSVecI16x8, 8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneSVecI16x8, 8));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.extract_lane_u"sv) {
-                          auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneUVecI16x8, 8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneUVecI16x8, 8));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5284,16 +5111,14 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.ge_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeSVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.ge_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeUVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5303,16 +5128,14 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.gt_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtSVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.gt_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtUVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5325,25 +5148,22 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'a':
                 if (op == "i16x8.laneselect"sv) {
-                  auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'e': {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.le_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeSVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.le_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeUVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5353,16 +5173,14 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.lt_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtSVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.lt_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtUVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5377,16 +5195,14 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i16x8.max_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxSVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxSVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.max_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxUVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxUVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5396,16 +5212,14 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i16x8.min_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinSVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinSVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.min_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinUVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinUVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5413,9 +5227,8 @@ switch (buf[0]) {
               }
               case 'u':
                 if (op == "i16x8.mul"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::MulVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -5427,16 +5240,14 @@ switch (buf[0]) {
                 switch (buf[19]) {
                   case 's':
                     if (op == "i16x8.narrow_i32x4_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NarrowSVecI32x4ToVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowSVecI32x4ToVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.narrow_i32x4_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NarrowUVecI32x4ToVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowUVecI32x4ToVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5446,16 +5257,14 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "i16x8.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "i16x8.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5466,25 +5275,22 @@ switch (buf[0]) {
           }
           case 'q':
             if (op == "i16x8.q15mulr_sat_s"sv) {
-              auto ret = makeBinary(ctx, pos, BinaryOp::Q15MulrSatSVecI16x8);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::Q15MulrSatSVecI16x8));
+              return Ok{};
             }
             goto parse_error;
           case 'r': {
             switch (buf[8]) {
               case 'l':
                 if (op == "i16x8.relaxed_q15mulr_s"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::RelaxedQ15MulrSVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedQ15MulrSVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'p':
                 if (op == "i16x8.replace_lane"sv) {
-                  auto ret = makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI16x8, 8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI16x8, 8));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -5496,25 +5302,22 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 'l':
                     if (op == "i16x8.shl"sv) {
-                      auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'r': {
                     switch (buf[10]) {
                       case 's':
                         if (op == "i16x8.shr_s"sv) {
-                          auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.shr_u"sv) {
-                          auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5525,34 +5328,30 @@ switch (buf[0]) {
               }
               case 'p':
                 if (op == "i16x8.splat"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::SplatVecI16x8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI16x8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'u': {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i16x8.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubVecI16x8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI16x8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_': {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i16x8.sub_sat_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::SubSatSVecI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatSVecI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.sub_sat_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::SubSatUVecI16x8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatUVecI16x8));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5575,16 +5374,14 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 's':
                     if (op == "i31.get_s"sv) {
-                      auto ret = makeI31Get(ctx, pos, true);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeI31Get(ctx, pos, true));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i31.get_u"sv) {
-                      auto ret = makeI31Get(ctx, pos, false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeI31Get(ctx, pos, false));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -5592,9 +5389,8 @@ switch (buf[0]) {
               }
               case 'n':
                 if (op == "i31.new"sv) {
-                  auto ret = makeRefI31(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeRefI31(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -5608,16 +5404,14 @@ switch (buf[0]) {
                     switch (buf[5]) {
                       case 'd':
                         if (op == "i32.add"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AddInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'n':
                         if (op == "i32.and"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AndInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 't': {
@@ -5626,23 +5420,20 @@ switch (buf[0]) {
                             switch (buf[15]) {
                               case '\0':
                                 if (op == "i32.atomic.load"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/false, 4, /*isAtomic=*/true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 4, /*isAtomic=*/true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '1':
                                 if (op == "i32.atomic.load16_u"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/false, 2, /*isAtomic=*/true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 2, /*isAtomic=*/true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '8':
                                 if (op == "i32.atomic.load8_u"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/false, 1, /*isAtomic=*/true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 1, /*isAtomic=*/true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -5656,16 +5447,14 @@ switch (buf[0]) {
                                     switch (buf[16]) {
                                       case 'd':
                                         if (op == "i32.atomic.rmw.add"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 4);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 4));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       case 'n':
                                         if (op == "i32.atomic.rmw.and"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 4);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 4));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       default: goto parse_error;
@@ -5673,39 +5462,34 @@ switch (buf[0]) {
                                   }
                                   case 'c':
                                     if (op == "i32.atomic.rmw.cmpxchg"sv) {
-                                      auto ret = makeAtomicCmpxchg(ctx, pos, Type::i32, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i32, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i32.atomic.rmw.or"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 's':
                                     if (op == "i32.atomic.rmw.sub"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'x': {
                                     switch (buf[16]) {
                                       case 'c':
                                         if (op == "i32.atomic.rmw.xchg"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 4);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 4));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       case 'o':
                                         if (op == "i32.atomic.rmw.xor"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 4);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 4));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       default: goto parse_error;
@@ -5720,16 +5504,14 @@ switch (buf[0]) {
                                     switch (buf[18]) {
                                       case 'd':
                                         if (op == "i32.atomic.rmw16.add_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 2);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 2));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       case 'n':
                                         if (op == "i32.atomic.rmw16.and_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 2);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 2));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       default: goto parse_error;
@@ -5737,39 +5519,34 @@ switch (buf[0]) {
                                   }
                                   case 'c':
                                     if (op == "i32.atomic.rmw16.cmpxchg_u"sv) {
-                                      auto ret = makeAtomicCmpxchg(ctx, pos, Type::i32, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i32, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i32.atomic.rmw16.or_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 's':
                                     if (op == "i32.atomic.rmw16.sub_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'x': {
                                     switch (buf[18]) {
                                       case 'c':
                                         if (op == "i32.atomic.rmw16.xchg_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 2);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 2));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       case 'o':
                                         if (op == "i32.atomic.rmw16.xor_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 2);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 2));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       default: goto parse_error;
@@ -5784,16 +5561,14 @@ switch (buf[0]) {
                                     switch (buf[17]) {
                                       case 'd':
                                         if (op == "i32.atomic.rmw8.add_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 1);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 1));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       case 'n':
                                         if (op == "i32.atomic.rmw8.and_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 1);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 1));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       default: goto parse_error;
@@ -5801,39 +5576,34 @@ switch (buf[0]) {
                                   }
                                   case 'c':
                                     if (op == "i32.atomic.rmw8.cmpxchg_u"sv) {
-                                      auto ret = makeAtomicCmpxchg(ctx, pos, Type::i32, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i32, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i32.atomic.rmw8.or_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 's':
                                     if (op == "i32.atomic.rmw8.sub_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'x': {
                                     switch (buf[17]) {
                                       case 'c':
                                         if (op == "i32.atomic.rmw8.xchg_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 1);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 1));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       case 'o':
                                         if (op == "i32.atomic.rmw8.xor_u"sv) {
-                                          auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 1);
-                                          CHECK_ERR(ret);
-                                          return *ret;
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 1));
+                                          return Ok{};
                                         }
                                         goto parse_error;
                                       default: goto parse_error;
@@ -5849,23 +5619,20 @@ switch (buf[0]) {
                             switch (buf[16]) {
                               case '\0':
                                 if (op == "i32.atomic.store"sv) {
-                                  auto ret = makeStore(ctx, pos, Type::i32, 4, /*isAtomic=*/true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStore(ctx, pos, Type::i32, 4, /*isAtomic=*/true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '1':
                                 if (op == "i32.atomic.store16"sv) {
-                                  auto ret = makeStore(ctx, pos, Type::i32, 2, /*isAtomic=*/true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStore(ctx, pos, Type::i32, 2, /*isAtomic=*/true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '8':
                                 if (op == "i32.atomic.store8"sv) {
-                                  auto ret = makeStore(ctx, pos, Type::i32, 1, /*isAtomic=*/true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStore(ctx, pos, Type::i32, 1, /*isAtomic=*/true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -5881,23 +5648,20 @@ switch (buf[0]) {
                     switch (buf[5]) {
                       case 'l':
                         if (op == "i32.clz"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ClzInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ClzInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'o':
                         if (op == "i32.const"sv) {
-                          auto ret = makeConst(ctx, pos, Type::i32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeConst(ctx, pos, Type::i32));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 't':
                         if (op == "i32.ctz"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::CtzInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CtzInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5907,16 +5671,14 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case 's':
                         if (op == "i32.div_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::DivSInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivSInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i32.div_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::DivUInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivUInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -5928,16 +5690,14 @@ switch (buf[0]) {
                         switch (buf[6]) {
                           case '\0':
                             if (op == "i32.eq"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::EqInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'z':
                             if (op == "i32.eqz"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::EqZInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::EqZInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5947,16 +5707,14 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case '1':
                             if (op == "i32.extend16_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendS16Int32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS16Int32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i32.extend8_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendS8Int32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS8Int32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5971,16 +5729,14 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.ge_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GeSInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.ge_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GeUInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -5990,16 +5746,14 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.gt_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GtSInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.gt_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GtUInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6014,16 +5768,14 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.le_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LeSInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.le_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LeUInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6033,25 +5785,22 @@ switch (buf[0]) {
                         switch (buf[8]) {
                           case '\0':
                             if (op == "i32.load"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/false, 4, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 4, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '1': {
                             switch (buf[11]) {
                               case 's':
                                 if (op == "i32.load16_s"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/true, 2, /*isAtomic=*/false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/true, 2, /*isAtomic=*/false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.load16_u"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/false, 2, /*isAtomic=*/false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 2, /*isAtomic=*/false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6061,16 +5810,14 @@ switch (buf[0]) {
                             switch (buf[10]) {
                               case 's':
                                 if (op == "i32.load8_s"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/true, 1, /*isAtomic=*/false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/true, 1, /*isAtomic=*/false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.load8_u"sv) {
-                                  auto ret = makeLoad(ctx, pos, Type::i32, /*signed=*/false, 1, /*isAtomic=*/false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 1, /*isAtomic=*/false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6083,16 +5830,14 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.lt_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LtSInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.lt_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LtUInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6103,30 +5848,26 @@ switch (buf[0]) {
                   }
                   case 'm':
                     if (op == "i32.mul"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MulInt32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulInt32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'n':
                     if (op == "i32.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeInt32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeInt32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "i32.or"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::OrInt32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::OrInt32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'p':
                     if (op == "i32.popcnt"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::PopcntInt32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PopcntInt32));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'r': {
@@ -6135,25 +5876,22 @@ switch (buf[0]) {
                         switch (buf[6]) {
                           case 'i':
                             if (op == "i32.reinterpret_f32"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ReinterpretFloat32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretFloat32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'm': {
                             switch (buf[8]) {
                               case 's':
                                 if (op == "i32.rem_s"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::RemSInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemSInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.rem_u"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::RemUInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemUInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6166,16 +5904,14 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 'l':
                             if (op == "i32.rotl"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RotLInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotLInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'r':
                             if (op == "i32.rotr"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RotRInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotRInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6190,25 +5926,22 @@ switch (buf[0]) {
                         switch (buf[6]) {
                           case 'l':
                             if (op == "i32.shl"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ShlInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShlInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'r': {
                             switch (buf[8]) {
                               case 's':
                                 if (op == "i32.shr_s"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::ShrSInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrSInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.shr_u"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::ShrUInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrUInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6221,23 +5954,20 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case '\0':
                             if (op == "i32.store"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i32, 4, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i32, 4, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '1':
                             if (op == "i32.store16"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i32, 2, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i32, 2, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i32.store8"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i32, 1, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i32, 1, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6245,9 +5975,8 @@ switch (buf[0]) {
                       }
                       case 'u':
                         if (op == "i32.sub"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::SubInt32);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubInt32));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6261,16 +5990,14 @@ switch (buf[0]) {
                             switch (buf[14]) {
                               case 's':
                                 if (op == "i32.trunc_f32_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncSFloat32ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat32ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_f32_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncUFloat32ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat32ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6280,16 +6007,14 @@ switch (buf[0]) {
                             switch (buf[14]) {
                               case 's':
                                 if (op == "i32.trunc_f64_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncSFloat64ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat64ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_f64_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncUFloat64ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat64ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6304,16 +6029,14 @@ switch (buf[0]) {
                             switch (buf[18]) {
                               case 's':
                                 if (op == "i32.trunc_sat_f32_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatSFloat32ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat32ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_sat_f32_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatUFloat32ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat32ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6323,16 +6046,14 @@ switch (buf[0]) {
                             switch (buf[18]) {
                               case 's':
                                 if (op == "i32.trunc_sat_f64_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatSFloat64ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat64ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_sat_f64_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatUFloat64ToInt32);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat64ToInt32));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6346,16 +6067,14 @@ switch (buf[0]) {
                   }
                   case 'w':
                     if (op == "i32.wrap_i64"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::WrapInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::WrapInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'x':
                     if (op == "i32.xor"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::XorInt32);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::XorInt32));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -6367,23 +6086,20 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'b':
                         if (op == "i32x4.abs"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::AbsVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'd':
                         if (op == "i32x4.add"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AddVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'l':
                         if (op == "i32x4.all_true"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::AllTrueVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6391,25 +6107,22 @@ switch (buf[0]) {
                   }
                   case 'b':
                     if (op == "i32x4.bitmask"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::BitmaskVecI32x4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI32x4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'd': {
                     switch (buf[11]) {
                       case '1':
                         if (op == "i32x4.dot_i16x8_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::DotSVecI16x8ToVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DotSVecI16x8ToVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '8':
                         if (op == "i32x4.dot_i8x16_i7x16_add_s"sv) {
-                          auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::DotI8x16I7x16AddSToVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::DotI8x16I7x16AddSToVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6419,9 +6132,8 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'q':
                         if (op == "i32x4.eq"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::EqVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'x': {
@@ -6430,16 +6142,14 @@ switch (buf[0]) {
                             switch (buf[28]) {
                               case 's':
                                 if (op == "i32x4.extadd_pairwise_i16x8_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseSVecI16x8ToI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseSVecI16x8ToI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.extadd_pairwise_i16x8_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseUVecI16x8ToI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseUVecI16x8ToI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6451,16 +6161,14 @@ switch (buf[0]) {
                                 switch (buf[24]) {
                                   case 's':
                                     if (op == "i32x4.extend_high_i16x8_s"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI16x8ToVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI16x8ToVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extend_high_i16x8_u"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI16x8ToVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI16x8ToVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -6470,16 +6178,14 @@ switch (buf[0]) {
                                 switch (buf[23]) {
                                   case 's':
                                     if (op == "i32x4.extend_low_i16x8_s"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI16x8ToVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI16x8ToVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extend_low_i16x8_u"sv) {
-                                      auto ret = makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI16x8ToVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI16x8ToVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -6494,16 +6200,14 @@ switch (buf[0]) {
                                 switch (buf[24]) {
                                   case 's':
                                     if (op == "i32x4.extmul_high_i16x8_s"sv) {
-                                      auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extmul_high_i16x8_u"sv) {
-                                      auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -6513,16 +6217,14 @@ switch (buf[0]) {
                                 switch (buf[23]) {
                                   case 's':
                                     if (op == "i32x4.extmul_low_i16x8_s"sv) {
-                                      auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extmul_low_i16x8_u"sv) {
-                                      auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI32x4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI32x4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -6533,9 +6235,8 @@ switch (buf[0]) {
                           }
                           case 'r':
                             if (op == "i32x4.extract_lane"sv) {
-                              auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecI32x4, 4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecI32x4, 4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6550,16 +6251,14 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.ge_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GeSVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.ge_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GeUVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6569,16 +6268,14 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.gt_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GtSVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.gt_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::GtUVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6591,25 +6288,22 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'a':
                         if (op == "i32x4.laneselect"sv) {
-                          auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'e': {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.le_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LeSVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.le_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LeUVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6619,16 +6313,14 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.lt_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LtSVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.lt_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::LtUVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6643,16 +6335,14 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i32x4.max_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::MaxSVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxSVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.max_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::MaxUVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxUVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6662,16 +6352,14 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i32x4.min_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::MinSVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinSVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.min_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::MinUVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinUVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6679,9 +6367,8 @@ switch (buf[0]) {
                       }
                       case 'u':
                         if (op == "i32x4.mul"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::MulVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6691,16 +6378,14 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case '\0':
                         if (op == "i32x4.ne"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::NeVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'g':
                         if (op == "i32x4.neg"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::NegVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6714,16 +6399,14 @@ switch (buf[0]) {
                             switch (buf[26]) {
                               case 's':
                                 if (op == "i32x4.relaxed_trunc_f32x4_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::RelaxedTruncSVecF32x4ToVecI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncSVecF32x4ToVecI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.relaxed_trunc_f32x4_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::RelaxedTruncUVecF32x4ToVecI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncUVecF32x4ToVecI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6733,16 +6416,14 @@ switch (buf[0]) {
                             switch (buf[26]) {
                               case 's':
                                 if (op == "i32x4.relaxed_trunc_f64x2_s_zero"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::RelaxedTruncZeroSVecF64x2ToVecI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncZeroSVecF64x2ToVecI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.relaxed_trunc_f64x2_u_zero"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::RelaxedTruncZeroUVecF64x2ToVecI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncZeroUVecF64x2ToVecI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6753,9 +6434,8 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "i32x4.replace_lane"sv) {
-                          auto ret = makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI32x4, 4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI32x4, 4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6767,25 +6447,22 @@ switch (buf[0]) {
                         switch (buf[8]) {
                           case 'l':
                             if (op == "i32x4.shl"sv) {
-                              auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'r': {
                             switch (buf[10]) {
                               case 's':
                                 if (op == "i32x4.shr_s"sv) {
-                                  auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.shr_u"sv) {
-                                  auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI32x4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI32x4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -6796,16 +6473,14 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "i32x4.splat"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::SplatVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i32x4.sub"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::SubVecI32x4);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI32x4));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -6817,16 +6492,14 @@ switch (buf[0]) {
                         switch (buf[22]) {
                           case 's':
                             if (op == "i32x4.trunc_sat_f32x4_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatSVecF32x4ToVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSVecF32x4ToVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.trunc_sat_f32x4_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatUVecF32x4ToVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUVecF32x4ToVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6836,16 +6509,14 @@ switch (buf[0]) {
                         switch (buf[22]) {
                           case 's':
                             if (op == "i32x4.trunc_sat_f64x2_s_zero"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatZeroSVecF64x2ToVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatZeroSVecF64x2ToVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.trunc_sat_f64x2_u_zero"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatZeroUVecF64x2ToVecI32x4);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatZeroUVecF64x2ToVecI32x4));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6871,16 +6542,14 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'd':
                     if (op == "i64.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'n':
                     if (op == "i64.and"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AndInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't': {
@@ -6889,30 +6558,26 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case '\0':
                             if (op == "i64.atomic.load"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 8, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 8, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '1':
                             if (op == "i64.atomic.load16_u"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 2, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 2, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '3':
                             if (op == "i64.atomic.load32_u"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 4, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 4, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i64.atomic.load8_u"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 1, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 1, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -6926,16 +6591,14 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw.add"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 8);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 8));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw.and"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 8);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 8));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -6943,39 +6606,34 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw.cmpxchg"sv) {
-                                  auto ret = makeAtomicCmpxchg(ctx, pos, Type::i64, 8);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 8));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw.or"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 8);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 8));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw.sub"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 8);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 8));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'x': {
                                 switch (buf[16]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw.xchg"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 8);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 8));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw.xor"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 8);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 8));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -6990,16 +6648,14 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw16.add_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw16.and_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -7007,39 +6663,34 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw16.cmpxchg_u"sv) {
-                                  auto ret = makeAtomicCmpxchg(ctx, pos, Type::i64, 2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw16.or_u"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw16.sub_u"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'x': {
                                 switch (buf[18]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw16.xchg_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw16.xor_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 2);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 2));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -7054,16 +6705,14 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw32.add_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw32.and_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -7071,39 +6720,34 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw32.cmpxchg_u"sv) {
-                                  auto ret = makeAtomicCmpxchg(ctx, pos, Type::i64, 4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw32.or_u"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw32.sub_u"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 4);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 4));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'x': {
                                 switch (buf[18]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw32.xchg_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw32.xor_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 4);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 4));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -7118,16 +6762,14 @@ switch (buf[0]) {
                                 switch (buf[17]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw8.add_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw8.and_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -7135,39 +6777,34 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw8.cmpxchg_u"sv) {
-                                  auto ret = makeAtomicCmpxchg(ctx, pos, Type::i64, 1);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 1));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw8.or_u"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 1);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 1));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw8.sub_u"sv) {
-                                  auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 1);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 1));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'x': {
                                 switch (buf[17]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw8.xchg_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw8.xor_u"sv) {
-                                      auto ret = makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 1);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 1));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -7183,30 +6820,26 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case '\0':
                             if (op == "i64.atomic.store"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i64, 8, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 8, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '1':
                             if (op == "i64.atomic.store16"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i64, 2, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 2, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '3':
                             if (op == "i64.atomic.store32"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i64, 4, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 4, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i64.atomic.store8"sv) {
-                              auto ret = makeStore(ctx, pos, Type::i64, 1, /*isAtomic=*/true);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 1, /*isAtomic=*/true));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7222,23 +6855,20 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'l':
                     if (op == "i64.clz"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::ClzInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ClzInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "i64.const"sv) {
-                      auto ret = makeConst(ctx, pos, Type::i64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeConst(ctx, pos, Type::i64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "i64.ctz"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::CtzInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CtzInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7248,16 +6878,14 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 's':
                     if (op == "i64.div_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::DivSInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivSInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i64.div_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::DivUInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivUInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7269,16 +6897,14 @@ switch (buf[0]) {
                     switch (buf[6]) {
                       case '\0':
                         if (op == "i64.eq"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::EqInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'z':
                         if (op == "i64.eqz"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::EqZInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::EqZInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7288,39 +6914,34 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case '1':
                         if (op == "i64.extend16_s"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ExtendS16Int64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS16Int64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '3':
                         if (op == "i64.extend32_s"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ExtendS32Int64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS32Int64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '8':
                         if (op == "i64.extend8_s"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ExtendS8Int64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS8Int64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '_': {
                         switch (buf[15]) {
                           case 's':
                             if (op == "i64.extend_i32_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendSInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendSInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.extend_i32_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::ExtendUInt32);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendUInt32));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7338,16 +6959,14 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.ge_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::GeSInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.ge_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::GeUInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7357,16 +6976,14 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.gt_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::GtSInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.gt_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::GtUInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7381,16 +6998,14 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.le_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::LeSInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.le_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::LeUInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7400,25 +7015,22 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case '\0':
                         if (op == "i64.load"sv) {
-                          auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 8, /*isAtomic=*/false);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 8, /*isAtomic=*/false));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '1': {
                         switch (buf[11]) {
                           case 's':
                             if (op == "i64.load16_s"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/true, 2, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/true, 2, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.load16_u"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 2, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 2, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7428,16 +7040,14 @@ switch (buf[0]) {
                         switch (buf[11]) {
                           case 's':
                             if (op == "i64.load32_s"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/true, 4, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/true, 4, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.load32_u"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 4, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 4, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7447,16 +7057,14 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i64.load8_s"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/true, 1, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/true, 1, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.load8_u"sv) {
-                              auto ret = makeLoad(ctx, pos, Type::i64, /*signed=*/false, 1, /*isAtomic=*/false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 1, /*isAtomic=*/false));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7469,16 +7077,14 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.lt_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::LtSInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.lt_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::LtUInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7489,30 +7095,26 @@ switch (buf[0]) {
               }
               case 'm':
                 if (op == "i64.mul"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::MulInt64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulInt64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'n':
                 if (op == "i64.ne"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::NeInt64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeInt64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'o':
                 if (op == "i64.or"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::OrInt64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::OrInt64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'p':
                 if (op == "i64.popcnt"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::PopcntInt64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PopcntInt64));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'r': {
@@ -7521,25 +7123,22 @@ switch (buf[0]) {
                     switch (buf[6]) {
                       case 'i':
                         if (op == "i64.reinterpret_f64"sv) {
-                          auto ret = makeUnary(ctx, pos, UnaryOp::ReinterpretFloat64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretFloat64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'm': {
                         switch (buf[8]) {
                           case 's':
                             if (op == "i64.rem_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RemSInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemSInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.rem_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::RemUInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemUInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7552,16 +7151,14 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'l':
                         if (op == "i64.rotl"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::RotLInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotLInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "i64.rotr"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::RotRInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotRInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7576,25 +7173,22 @@ switch (buf[0]) {
                     switch (buf[6]) {
                       case 'l':
                         if (op == "i64.shl"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::ShlInt64);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShlInt64));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'r': {
                         switch (buf[8]) {
                           case 's':
                             if (op == "i64.shr_s"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ShrSInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrSInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.shr_u"sv) {
-                              auto ret = makeBinary(ctx, pos, BinaryOp::ShrUInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrUInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7607,30 +7201,26 @@ switch (buf[0]) {
                     switch (buf[9]) {
                       case '\0':
                         if (op == "i64.store"sv) {
-                          auto ret = makeStore(ctx, pos, Type::i64, 8, /*isAtomic=*/false);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 8, /*isAtomic=*/false));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '1':
                         if (op == "i64.store16"sv) {
-                          auto ret = makeStore(ctx, pos, Type::i64, 2, /*isAtomic=*/false);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 2, /*isAtomic=*/false));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '3':
                         if (op == "i64.store32"sv) {
-                          auto ret = makeStore(ctx, pos, Type::i64, 4, /*isAtomic=*/false);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 4, /*isAtomic=*/false));
+                          return Ok{};
                         }
                         goto parse_error;
                       case '8':
                         if (op == "i64.store8"sv) {
-                          auto ret = makeStore(ctx, pos, Type::i64, 1, /*isAtomic=*/false);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 1, /*isAtomic=*/false));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7638,9 +7228,8 @@ switch (buf[0]) {
                   }
                   case 'u':
                     if (op == "i64.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubInt64);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubInt64));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7654,16 +7243,14 @@ switch (buf[0]) {
                         switch (buf[14]) {
                           case 's':
                             if (op == "i64.trunc_f32_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSFloat32ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat32ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_f32_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncUFloat32ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat32ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7673,16 +7260,14 @@ switch (buf[0]) {
                         switch (buf[14]) {
                           case 's':
                             if (op == "i64.trunc_f64_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSFloat64ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat64ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_f64_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncUFloat64ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat64ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7697,16 +7282,14 @@ switch (buf[0]) {
                         switch (buf[18]) {
                           case 's':
                             if (op == "i64.trunc_sat_f32_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatSFloat32ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat32ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_sat_f32_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatUFloat32ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat32ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7716,16 +7299,14 @@ switch (buf[0]) {
                         switch (buf[18]) {
                           case 's':
                             if (op == "i64.trunc_sat_f64_s"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatSFloat64ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat64ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_sat_f64_u"sv) {
-                              auto ret = makeUnary(ctx, pos, UnaryOp::TruncSatUFloat64ToInt64);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat64ToInt64));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -7739,9 +7320,8 @@ switch (buf[0]) {
               }
               case 'x':
                 if (op == "i64.xor"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::XorInt64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::XorInt64));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -7753,23 +7333,20 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'b':
                     if (op == "i64x2.abs"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::AbsVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "i64x2.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'l':
                     if (op == "i64x2.all_true"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::AllTrueVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7777,18 +7354,16 @@ switch (buf[0]) {
               }
               case 'b':
                 if (op == "i64x2.bitmask"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::BitmaskVecI64x2);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI64x2));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'e': {
                 switch (buf[7]) {
                   case 'q':
                     if (op == "i64x2.eq"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::EqVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'x': {
@@ -7799,16 +7374,14 @@ switch (buf[0]) {
                             switch (buf[24]) {
                               case 's':
                                 if (op == "i64x2.extend_high_i32x4_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI32x4ToVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI32x4ToVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extend_high_i32x4_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI32x4ToVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI32x4ToVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -7818,16 +7391,14 @@ switch (buf[0]) {
                             switch (buf[23]) {
                               case 's':
                                 if (op == "i64x2.extend_low_i32x4_s"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI32x4ToVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI32x4ToVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extend_low_i32x4_u"sv) {
-                                  auto ret = makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI32x4ToVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI32x4ToVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -7842,16 +7413,14 @@ switch (buf[0]) {
                             switch (buf[24]) {
                               case 's':
                                 if (op == "i64x2.extmul_high_i32x4_s"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extmul_high_i32x4_u"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -7861,16 +7430,14 @@ switch (buf[0]) {
                             switch (buf[23]) {
                               case 's':
                                 if (op == "i64x2.extmul_low_i32x4_s"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extmul_low_i32x4_u"sv) {
-                                  auto ret = makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI64x2);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI64x2));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -7881,9 +7448,8 @@ switch (buf[0]) {
                       }
                       case 'r':
                         if (op == "i64x2.extract_lane"sv) {
-                          auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecI64x2, 2);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecI64x2, 2));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -7896,16 +7462,14 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "i64x2.ge_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeSVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "i64x2.gt_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtSVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7915,23 +7479,20 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'a':
                     if (op == "i64x2.laneselect"sv) {
-                      auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'e':
                     if (op == "i64x2.le_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeSVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "i64x2.lt_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtSVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7939,25 +7500,22 @@ switch (buf[0]) {
               }
               case 'm':
                 if (op == "i64x2.mul"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::MulVecI64x2);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecI64x2));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'n': {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "i64x2.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "i64x2.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -7965,9 +7523,8 @@ switch (buf[0]) {
               }
               case 'r':
                 if (op == "i64x2.replace_lane"sv) {
-                  auto ret = makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI64x2, 2);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI64x2, 2));
+                  return Ok{};
                 }
                 goto parse_error;
               case 's': {
@@ -7976,25 +7533,22 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case 'l':
                         if (op == "i64x2.shl"sv) {
-                          auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI64x2);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI64x2));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'r': {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i64x2.shr_s"sv) {
-                              auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI64x2);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI64x2));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64x2.shr_u"sv) {
-                              auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI64x2);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI64x2));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -8005,16 +7559,14 @@ switch (buf[0]) {
                   }
                   case 'p':
                     if (op == "i64x2.splat"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::SplatVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i64x2.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubVecI64x2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI64x2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8032,34 +7584,30 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'b':
                 if (op == "i8x16.abs"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::AbsVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'd': {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i8x16.add"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::AddVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_': {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i8x16.add_sat_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AddSatSVecI8x16);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatSVecI8x16));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i8x16.add_sat_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::AddSatUVecI8x16);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatUVecI8x16));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -8070,16 +7618,14 @@ switch (buf[0]) {
               }
               case 'l':
                 if (op == "i8x16.all_true"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::AllTrueVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'v':
                 if (op == "i8x16.avgr_u"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::AvgrUVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AvgrUVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -8087,34 +7633,30 @@ switch (buf[0]) {
           }
           case 'b':
             if (op == "i8x16.bitmask"sv) {
-              auto ret = makeUnary(ctx, pos, UnaryOp::BitmaskVecI8x16);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI8x16));
+              return Ok{};
             }
             goto parse_error;
           case 'e': {
             switch (buf[7]) {
               case 'q':
                 if (op == "i8x16.eq"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::EqVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'x': {
                 switch (buf[19]) {
                   case 's':
                     if (op == "i8x16.extract_lane_s"sv) {
-                      auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneSVecI8x16, 16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneSVecI8x16, 16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.extract_lane_u"sv) {
-                      auto ret = makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneUVecI8x16, 16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneUVecI8x16, 16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8129,16 +7671,14 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.ge_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeSVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.ge_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GeUVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8148,16 +7688,14 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.gt_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtSVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.gt_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::GtUVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8170,25 +7708,22 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'a':
                 if (op == "i8x16.laneselect"sv) {
-                  auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'e': {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.le_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeSVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.le_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LeUVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8198,16 +7733,14 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.lt_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtSVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.lt_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::LtUVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8222,16 +7755,14 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i8x16.max_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxSVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxSVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.max_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MaxUVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxUVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8241,16 +7772,14 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i8x16.min_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinSVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinSVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.min_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::MinUVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinUVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8265,16 +7794,14 @@ switch (buf[0]) {
                 switch (buf[19]) {
                   case 's':
                     if (op == "i8x16.narrow_i16x8_s"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NarrowSVecI16x8ToVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowSVecI16x8ToVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.narrow_i16x8_u"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NarrowUVecI16x8ToVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowUVecI16x8ToVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8284,16 +7811,14 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "i8x16.ne"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::NeVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "i8x16.neg"sv) {
-                      auto ret = makeUnary(ctx, pos, UnaryOp::NegVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8304,25 +7829,22 @@ switch (buf[0]) {
           }
           case 'p':
             if (op == "i8x16.popcnt"sv) {
-              auto ret = makeUnary(ctx, pos, UnaryOp::PopcntVecI8x16);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PopcntVecI8x16));
+              return Ok{};
             }
             goto parse_error;
           case 'r': {
             switch (buf[8]) {
               case 'l':
                 if (op == "i8x16.relaxed_swizzle"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::RelaxedSwizzleVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedSwizzleVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'p':
                 if (op == "i8x16.replace_lane"sv) {
-                  auto ret = makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI8x16, 16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI8x16, 16));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -8334,25 +7856,22 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 'l':
                     if (op == "i8x16.shl"sv) {
-                      auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'r': {
                     switch (buf[10]) {
                       case 's':
                         if (op == "i8x16.shr_s"sv) {
-                          auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI8x16);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI8x16));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i8x16.shr_u"sv) {
-                          auto ret = makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI8x16);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI8x16));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -8360,9 +7879,8 @@ switch (buf[0]) {
                   }
                   case 'u':
                     if (op == "i8x16.shuffle"sv) {
-                      auto ret = makeSIMDShuffle(ctx, pos);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDShuffle(ctx, pos));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -8370,34 +7888,30 @@ switch (buf[0]) {
               }
               case 'p':
                 if (op == "i8x16.splat"sv) {
-                  auto ret = makeUnary(ctx, pos, UnaryOp::SplatVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'u': {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i8x16.sub"sv) {
-                      auto ret = makeBinary(ctx, pos, BinaryOp::SubVecI8x16);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI8x16));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_': {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i8x16.sub_sat_s"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::SubSatSVecI8x16);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatSVecI8x16));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i8x16.sub_sat_u"sv) {
-                          auto ret = makeBinary(ctx, pos, BinaryOp::SubSatUVecI8x16);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatUVecI8x16));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -8408,9 +7922,8 @@ switch (buf[0]) {
               }
               case 'w':
                 if (op == "i8x16.swizzle"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::SwizzleVecI8x16);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SwizzleVecI8x16));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -8421,9 +7934,8 @@ switch (buf[0]) {
       }
       case 'f':
         if (op == "if"sv) {
-          auto ret = makeIf(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeIf(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -8435,23 +7947,20 @@ switch (buf[0]) {
         switch (buf[6]) {
           case 'g':
             if (op == "local.get"sv) {
-              auto ret = makeLocalGet(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeLocalGet(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 's':
             if (op == "local.set"sv) {
-              auto ret = makeLocalSet(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeLocalSet(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 't':
             if (op == "local.tee"sv) {
-              auto ret = makeLocalTee(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeLocalTee(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -8459,9 +7968,8 @@ switch (buf[0]) {
       }
       case 'o':
         if (op == "loop"sv) {
-          auto ret = makeLoop(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeLoop(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -8473,25 +7981,22 @@ switch (buf[0]) {
         switch (buf[14]) {
           case 'n':
             if (op == "memory.atomic.notify"sv) {
-              auto ret = makeAtomicNotify(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeAtomicNotify(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'w': {
             switch (buf[18]) {
               case '3':
                 if (op == "memory.atomic.wait32"sv) {
-                  auto ret = makeAtomicWait(ctx, pos, Type::i32);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeAtomicWait(ctx, pos, Type::i32));
+                  return Ok{};
                 }
                 goto parse_error;
               case '6':
                 if (op == "memory.atomic.wait64"sv) {
-                  auto ret = makeAtomicWait(ctx, pos, Type::i64);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeAtomicWait(ctx, pos, Type::i64));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -8502,37 +8007,32 @@ switch (buf[0]) {
       }
       case 'c':
         if (op == "memory.copy"sv) {
-          auto ret = makeMemoryCopy(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeMemoryCopy(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'f':
         if (op == "memory.fill"sv) {
-          auto ret = makeMemoryFill(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeMemoryFill(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'g':
         if (op == "memory.grow"sv) {
-          auto ret = makeMemoryGrow(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeMemoryGrow(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'i':
         if (op == "memory.init"sv) {
-          auto ret = makeMemoryInit(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeMemoryInit(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 's':
         if (op == "memory.size"sv) {
-          auto ret = makeMemorySize(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeMemorySize(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;
@@ -8540,16 +8040,14 @@ switch (buf[0]) {
   }
   case 'n':
     if (op == "nop"sv) {
-      auto ret = makeNop(ctx, pos);
-      CHECK_ERR(ret);
-      return *ret;
+      CHECK_ERR(makeNop(ctx, pos));
+      return Ok{};
     }
     goto parse_error;
   case 'p':
     if (op == "pop"sv) {
-      auto ret = makePop(ctx, pos);
-      CHECK_ERR(ret);
-      return *ret;
+      CHECK_ERR(makePop(ctx, pos));
+      return Ok{};
     }
     goto parse_error;
   case 'r': {
@@ -8558,46 +8056,40 @@ switch (buf[0]) {
         switch (buf[4]) {
           case 'a':
             if (op == "ref.as_non_null"sv) {
-              auto ret = makeRefAs(ctx, pos, RefAsNonNull);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRefAs(ctx, pos, RefAsNonNull));
+              return Ok{};
             }
             goto parse_error;
           case 'c':
             if (op == "ref.cast"sv) {
-              auto ret = makeRefCast(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRefCast(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'e':
             if (op == "ref.eq"sv) {
-              auto ret = makeRefEq(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRefEq(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'f':
             if (op == "ref.func"sv) {
-              auto ret = makeRefFunc(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRefFunc(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'i': {
             switch (buf[5]) {
               case '3':
                 if (op == "ref.i31"sv) {
-                  auto ret = makeRefI31(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeRefI31(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case 's':
                 if (op == "ref.is_null"sv) {
-                  auto ret = makeRefIsNull(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeRefIsNull(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -8605,16 +8097,14 @@ switch (buf[0]) {
           }
           case 'n':
             if (op == "ref.null"sv) {
-              auto ret = makeRefNull(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRefNull(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 't':
             if (op == "ref.test"sv) {
-              auto ret = makeRefTest(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRefTest(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -8624,43 +8114,38 @@ switch (buf[0]) {
         switch (buf[3]) {
           case 'h':
             if (op == "rethrow"sv) {
-              auto ret = makeRethrow(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeRethrow(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'u': {
             switch (buf[6]) {
               case '\0':
                 if (op == "return"sv) {
-                  auto ret = makeReturn(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeReturn(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case '_': {
                 switch (buf[11]) {
                   case '\0':
                     if (op == "return_call"sv) {
-                      auto ret = makeCall(ctx, pos, /*isReturn=*/true);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeCall(ctx, pos, /*isReturn=*/true));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_': {
                     switch (buf[12]) {
                       case 'i':
                         if (op == "return_call_indirect"sv) {
-                          auto ret = makeCallIndirect(ctx, pos, /*isReturn=*/true);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeCallIndirect(ctx, pos, /*isReturn=*/true));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "return_call_ref"sv) {
-                          auto ret = makeCallRef(ctx, pos, /*isReturn=*/true);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeCallRef(ctx, pos, /*isReturn=*/true));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -8682,9 +8167,8 @@ switch (buf[0]) {
     switch (buf[1]) {
       case 'e':
         if (op == "select"sv) {
-          auto ret = makeSelect(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeSelect(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 't': {
@@ -8697,25 +8181,22 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case 'i':
                         if (op == "string.as_iter"sv) {
-                          auto ret = makeStringAs(ctx, pos, StringAsIter);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringAs(ctx, pos, StringAsIter));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'w': {
                         switch (buf[13]) {
                           case '1':
                             if (op == "string.as_wtf16"sv) {
-                              auto ret = makeStringAs(ctx, pos, StringAsWTF16);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringAs(ctx, pos, StringAsWTF16));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "string.as_wtf8"sv) {
-                              auto ret = makeStringAs(ctx, pos, StringAsWTF8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringAs(ctx, pos, StringAsWTF8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -8728,25 +8209,22 @@ switch (buf[0]) {
                     switch (buf[9]) {
                       case 'm':
                         if (op == "string.compare"sv) {
-                          auto ret = makeStringEq(ctx, pos, StringEqCompare);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringEq(ctx, pos, StringEqCompare));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'n': {
                         switch (buf[10]) {
                           case 'c':
                             if (op == "string.concat"sv) {
-                              auto ret = makeStringConcat(ctx, pos);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringConcat(ctx, pos));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "string.const"sv) {
-                              auto ret = makeStringConst(ctx, pos);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringConst(ctx, pos));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -8763,16 +8241,14 @@ switch (buf[0]) {
                             switch (buf[24]) {
                               case '\0':
                                 if (op == "string.encode_lossy_utf8"sv) {
-                                  auto ret = makeStringEncode(ctx, pos, StringEncodeLossyUTF8);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeLossyUTF8));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.encode_lossy_utf8_array"sv) {
-                                  auto ret = makeStringEncode(ctx, pos, StringEncodeLossyUTF8Array);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeLossyUTF8Array));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -8782,16 +8258,14 @@ switch (buf[0]) {
                             switch (buf[18]) {
                               case '\0':
                                 if (op == "string.encode_utf8"sv) {
-                                  auto ret = makeStringEncode(ctx, pos, StringEncodeUTF8);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeUTF8));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.encode_utf8_array"sv) {
-                                  auto ret = makeStringEncode(ctx, pos, StringEncodeUTF8Array);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeUTF8Array));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -8803,16 +8277,14 @@ switch (buf[0]) {
                                 switch (buf[19]) {
                                   case '\0':
                                     if (op == "string.encode_wtf16"sv) {
-                                      auto ret = makeStringEncode(ctx, pos, StringEncodeWTF16);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF16));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case '_':
                                     if (op == "string.encode_wtf16_array"sv) {
-                                      auto ret = makeStringEncode(ctx, pos, StringEncodeWTF16Array);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF16Array));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -8822,16 +8294,14 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case '\0':
                                     if (op == "string.encode_wtf8"sv) {
-                                      auto ret = makeStringEncode(ctx, pos, StringEncodeWTF8);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF8));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case '_':
                                     if (op == "string.encode_wtf8_array"sv) {
-                                      auto ret = makeStringEncode(ctx, pos, StringEncodeWTF8Array);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF8Array));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -8845,9 +8315,8 @@ switch (buf[0]) {
                       }
                       case 'q':
                         if (op == "string.eq"sv) {
-                          auto ret = makeStringEq(ctx, pos, StringEqEqual);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringEq(ctx, pos, StringEqEqual));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -8855,48 +8324,42 @@ switch (buf[0]) {
                   }
                   case 'f':
                     if (op == "string.from_code_point"sv) {
-                      auto ret = makeStringNew(ctx, pos, StringNewFromCodePoint, false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStringNew(ctx, pos, StringNewFromCodePoint, false));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'h':
                     if (op == "string.hash"sv) {
-                      auto ret = makeStringMeasure(ctx, pos, StringMeasureHash);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureHash));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "string.is_usv_sequence"sv) {
-                      auto ret = makeStringMeasure(ctx, pos, StringMeasureIsUSV);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureIsUSV));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'm': {
                     switch (buf[15]) {
                       case 'u':
                         if (op == "string.measure_utf8"sv) {
-                          auto ret = makeStringMeasure(ctx, pos, StringMeasureUTF8);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureUTF8));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'w': {
                         switch (buf[18]) {
                           case '1':
                             if (op == "string.measure_wtf16"sv) {
-                              auto ret = makeStringMeasure(ctx, pos, StringMeasureWTF16);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureWTF16));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "string.measure_wtf8"sv) {
-                              auto ret = makeStringMeasure(ctx, pos, StringMeasureWTF8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureWTF8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -8911,16 +8374,14 @@ switch (buf[0]) {
                         switch (buf[21]) {
                           case '\0':
                             if (op == "string.new_lossy_utf8"sv) {
-                              auto ret = makeStringNew(ctx, pos, StringNewLossyUTF8, false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringNew(ctx, pos, StringNewLossyUTF8, false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '_':
                             if (op == "string.new_lossy_utf8_array"sv) {
-                              auto ret = makeStringNew(ctx, pos, StringNewLossyUTF8Array, false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringNew(ctx, pos, StringNewLossyUTF8Array, false));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -8930,9 +8391,8 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case '\0':
                             if (op == "string.new_utf8"sv) {
-                              auto ret = makeStringNew(ctx, pos, StringNewUTF8, false);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8, false));
+                              return Ok{};
                             }
                             goto parse_error;
                           case '_': {
@@ -8941,16 +8401,14 @@ switch (buf[0]) {
                                 switch (buf[21]) {
                                   case '\0':
                                     if (op == "string.new_utf8_array"sv) {
-                                      auto ret = makeStringNew(ctx, pos, StringNewUTF8Array, false);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8Array, false));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   case '_':
                                     if (op == "string.new_utf8_array_try"sv) {
-                                      auto ret = makeStringNew(ctx, pos, StringNewUTF8Array, true);
-                                      CHECK_ERR(ret);
-                                      return *ret;
+                                      CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8Array, true));
+                                      return Ok{};
                                     }
                                     goto parse_error;
                                   default: goto parse_error;
@@ -8958,9 +8416,8 @@ switch (buf[0]) {
                               }
                               case 't':
                                 if (op == "string.new_utf8_try"sv) {
-                                  auto ret = makeStringNew(ctx, pos, StringNewUTF8, true);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8, true));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -8975,16 +8432,14 @@ switch (buf[0]) {
                             switch (buf[16]) {
                               case '\0':
                                 if (op == "string.new_wtf16"sv) {
-                                  auto ret = makeStringNew(ctx, pos, StringNewWTF16, false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF16, false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.new_wtf16_array"sv) {
-                                  auto ret = makeStringNew(ctx, pos, StringNewWTF16Array, false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF16Array, false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -8994,16 +8449,14 @@ switch (buf[0]) {
                             switch (buf[15]) {
                               case '\0':
                                 if (op == "string.new_wtf8"sv) {
-                                  auto ret = makeStringNew(ctx, pos, StringNewWTF8, false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF8, false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.new_wtf8_array"sv) {
-                                  auto ret = makeStringNew(ctx, pos, StringNewWTF8Array, false);
-                                  CHECK_ERR(ret);
-                                  return *ret;
+                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF8Array, false));
+                                  return Ok{};
                                 }
                                 goto parse_error;
                               default: goto parse_error;
@@ -9024,30 +8477,26 @@ switch (buf[0]) {
                     switch (buf[16]) {
                       case 'a':
                         if (op == "stringview_iter.advance"sv) {
-                          auto ret = makeStringIterMove(ctx, pos, StringIterMoveAdvance);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringIterMove(ctx, pos, StringIterMoveAdvance));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'n':
                         if (op == "stringview_iter.next"sv) {
-                          auto ret = makeStringIterNext(ctx, pos);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringIterNext(ctx, pos));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "stringview_iter.rewind"sv) {
-                          auto ret = makeStringIterMove(ctx, pos, StringIterMoveRewind);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringIterMove(ctx, pos, StringIterMoveRewind));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 's':
                         if (op == "stringview_iter.slice"sv) {
-                          auto ret = makeStringSliceIter(ctx, pos);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStringSliceIter(ctx, pos));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -9059,23 +8508,20 @@ switch (buf[0]) {
                         switch (buf[17]) {
                           case 'g':
                             if (op == "stringview_wtf16.get_codeunit"sv) {
-                              auto ret = makeStringWTF16Get(ctx, pos);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringWTF16Get(ctx, pos));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 'l':
                             if (op == "stringview_wtf16.length"sv) {
-                              auto ret = makeStringMeasure(ctx, pos, StringMeasureWTF16View);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureWTF16View));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "stringview_wtf16.slice"sv) {
-                              auto ret = makeStringSliceWTF(ctx, pos, StringSliceWTF16);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringSliceWTF(ctx, pos, StringSliceWTF16));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -9085,16 +8531,14 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case 'a':
                             if (op == "stringview_wtf8.advance"sv) {
-                              auto ret = makeStringWTF8Advance(ctx, pos);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringWTF8Advance(ctx, pos));
+                              return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "stringview_wtf8.slice"sv) {
-                              auto ret = makeStringSliceWTF(ctx, pos, StringSliceWTF8);
-                              CHECK_ERR(ret);
-                              return *ret;
+                              CHECK_ERR(makeStringSliceWTF(ctx, pos, StringSliceWTF8));
+                              return Ok{};
                             }
                             goto parse_error;
                           default: goto parse_error;
@@ -9115,25 +8559,22 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case '\0':
                     if (op == "struct.get"sv) {
-                      auto ret = makeStructGet(ctx, pos);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStructGet(ctx, pos));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_': {
                     switch (buf[11]) {
                       case 's':
                         if (op == "struct.get_s"sv) {
-                          auto ret = makeStructGet(ctx, pos, true);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStructGet(ctx, pos, true));
+                          return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "struct.get_u"sv) {
-                          auto ret = makeStructGet(ctx, pos, false);
-                          CHECK_ERR(ret);
-                          return *ret;
+                          CHECK_ERR(makeStructGet(ctx, pos, false));
+                          return Ok{};
                         }
                         goto parse_error;
                       default: goto parse_error;
@@ -9146,16 +8587,14 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case '\0':
                     if (op == "struct.new"sv) {
-                      auto ret = makeStructNew(ctx, pos, false);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStructNew(ctx, pos, false));
+                      return Ok{};
                     }
                     goto parse_error;
                   case '_':
                     if (op == "struct.new_default"sv) {
-                      auto ret = makeStructNew(ctx, pos, true);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeStructNew(ctx, pos, true));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9163,9 +8602,8 @@ switch (buf[0]) {
               }
               case 's':
                 if (op == "struct.set"sv) {
-                  auto ret = makeStructSet(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeStructSet(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -9183,25 +8621,22 @@ switch (buf[0]) {
         switch (buf[6]) {
           case 'f':
             if (op == "table.fill"sv) {
-              auto ret = makeTableFill(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeTableFill(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'g': {
             switch (buf[7]) {
               case 'e':
                 if (op == "table.get"sv) {
-                  auto ret = makeTableGet(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeTableGet(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'r':
                 if (op == "table.grow"sv) {
-                  auto ret = makeTableGrow(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeTableGrow(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -9211,16 +8646,14 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'e':
                 if (op == "table.set"sv) {
-                  auto ret = makeTableSet(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeTableSet(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'i':
                 if (op == "table.size"sv) {
-                  auto ret = makeTableSize(ctx, pos);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeTableSize(ctx, pos));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -9231,32 +8664,28 @@ switch (buf[0]) {
       }
       case 'h':
         if (op == "throw"sv) {
-          auto ret = makeThrow(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeThrow(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'r':
         if (op == "try"sv) {
-          auto ret = makeTry(ctx, pos);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeTry(ctx, pos));
+          return Ok{};
         }
         goto parse_error;
       case 'u': {
         switch (buf[6]) {
           case 'e':
             if (op == "tuple.extract"sv) {
-              auto ret = makeTupleExtract(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeTupleExtract(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           case 'm':
             if (op == "tuple.make"sv) {
-              auto ret = makeTupleMake(ctx, pos);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeTupleMake(ctx, pos));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -9267,9 +8696,8 @@ switch (buf[0]) {
   }
   case 'u':
     if (op == "unreachable"sv) {
-      auto ret = makeUnreachable(ctx, pos);
-      CHECK_ERR(ret);
-      return *ret;
+      CHECK_ERR(makeUnreachable(ctx, pos));
+      return Ok{};
     }
     goto parse_error;
   case 'v': {
@@ -9280,16 +8708,14 @@ switch (buf[0]) {
             switch (buf[8]) {
               case '\0':
                 if (op == "v128.and"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::AndVec128);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndVec128));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'n':
                 if (op == "v128.andnot"sv) {
-                  auto ret = makeBinary(ctx, pos, BinaryOp::AndNotVec128);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndNotVec128));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -9297,9 +8723,8 @@ switch (buf[0]) {
           }
           case 'y':
             if (op == "v128.any_true"sv) {
-              auto ret = makeUnary(ctx, pos, UnaryOp::AnyTrueVec128);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AnyTrueVec128));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -9307,25 +8732,22 @@ switch (buf[0]) {
       }
       case 'b':
         if (op == "v128.bitselect"sv) {
-          auto ret = makeSIMDTernary(ctx, pos, SIMDTernaryOp::Bitselect);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::Bitselect));
+          return Ok{};
         }
         goto parse_error;
       case 'c':
         if (op == "v128.const"sv) {
-          auto ret = makeConst(ctx, pos, Type::v128);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeConst(ctx, pos, Type::v128));
+          return Ok{};
         }
         goto parse_error;
       case 'l': {
         switch (buf[9]) {
           case '\0':
             if (op == "v128.load"sv) {
-              auto ret = makeLoad(ctx, pos, Type::v128, /*signed=*/false, 16, /*isAtomic=*/false);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeLoad(ctx, pos, Type::v128, /*signed=*/false, 16, /*isAtomic=*/false));
+              return Ok{};
             }
             goto parse_error;
           case '1': {
@@ -9334,16 +8756,14 @@ switch (buf[0]) {
                 switch (buf[12]) {
                   case 'l':
                     if (op == "v128.load16_lane"sv) {
-                      auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load16LaneVec128, 2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load16LaneVec128, 2));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 's':
                     if (op == "v128.load16_splat"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16SplatVec128, 2);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16SplatVec128, 2));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9353,16 +8773,14 @@ switch (buf[0]) {
                 switch (buf[14]) {
                   case 's':
                     if (op == "v128.load16x4_s"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16x4SVec128, 8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16x4SVec128, 8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "v128.load16x4_u"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16x4UVec128, 8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16x4UVec128, 8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9377,23 +8795,20 @@ switch (buf[0]) {
                 switch (buf[12]) {
                   case 'l':
                     if (op == "v128.load32_lane"sv) {
-                      auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load32LaneVec128, 4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load32LaneVec128, 4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 's':
                     if (op == "v128.load32_splat"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32SplatVec128, 4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32SplatVec128, 4));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'z':
                     if (op == "v128.load32_zero"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32ZeroVec128, 4);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32ZeroVec128, 4));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9403,16 +8818,14 @@ switch (buf[0]) {
                 switch (buf[14]) {
                   case 's':
                     if (op == "v128.load32x2_s"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32x2SVec128, 8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32x2SVec128, 8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "v128.load32x2_u"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32x2UVec128, 8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32x2UVec128, 8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9425,23 +8838,20 @@ switch (buf[0]) {
             switch (buf[12]) {
               case 'l':
                 if (op == "v128.load64_lane"sv) {
-                  auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load64LaneVec128, 8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load64LaneVec128, 8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 's':
                 if (op == "v128.load64_splat"sv) {
-                  auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load64SplatVec128, 8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load64SplatVec128, 8));
+                  return Ok{};
                 }
                 goto parse_error;
               case 'z':
                 if (op == "v128.load64_zero"sv) {
-                  auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load64ZeroVec128, 8);
-                  CHECK_ERR(ret);
-                  return *ret;
+                  CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load64ZeroVec128, 8));
+                  return Ok{};
                 }
                 goto parse_error;
               default: goto parse_error;
@@ -9453,16 +8863,14 @@ switch (buf[0]) {
                 switch (buf[11]) {
                   case 'l':
                     if (op == "v128.load8_lane"sv) {
-                      auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load8LaneVec128, 1);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load8LaneVec128, 1));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 's':
                     if (op == "v128.load8_splat"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8SplatVec128, 1);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8SplatVec128, 1));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9472,16 +8880,14 @@ switch (buf[0]) {
                 switch (buf[13]) {
                   case 's':
                     if (op == "v128.load8x8_s"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8x8SVec128, 8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8x8SVec128, 8));
+                      return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "v128.load8x8_u"sv) {
-                      auto ret = makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8x8UVec128, 8);
-                      CHECK_ERR(ret);
-                      return *ret;
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8x8UVec128, 8));
+                      return Ok{};
                     }
                     goto parse_error;
                   default: goto parse_error;
@@ -9495,53 +8901,46 @@ switch (buf[0]) {
       }
       case 'n':
         if (op == "v128.not"sv) {
-          auto ret = makeUnary(ctx, pos, UnaryOp::NotVec128);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NotVec128));
+          return Ok{};
         }
         goto parse_error;
       case 'o':
         if (op == "v128.or"sv) {
-          auto ret = makeBinary(ctx, pos, BinaryOp::OrVec128);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::OrVec128));
+          return Ok{};
         }
         goto parse_error;
       case 's': {
         switch (buf[10]) {
           case '\0':
             if (op == "v128.store"sv) {
-              auto ret = makeStore(ctx, pos, Type::v128, 16, /*isAtomic=*/false);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeStore(ctx, pos, Type::v128, 16, /*isAtomic=*/false));
+              return Ok{};
             }
             goto parse_error;
           case '1':
             if (op == "v128.store16_lane"sv) {
-              auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store16LaneVec128, 2);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store16LaneVec128, 2));
+              return Ok{};
             }
             goto parse_error;
           case '3':
             if (op == "v128.store32_lane"sv) {
-              auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store32LaneVec128, 4);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store32LaneVec128, 4));
+              return Ok{};
             }
             goto parse_error;
           case '6':
             if (op == "v128.store64_lane"sv) {
-              auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store64LaneVec128, 8);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store64LaneVec128, 8));
+              return Ok{};
             }
             goto parse_error;
           case '8':
             if (op == "v128.store8_lane"sv) {
-              auto ret = makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store8LaneVec128, 1);
-              CHECK_ERR(ret);
-              return *ret;
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store8LaneVec128, 1));
+              return Ok{};
             }
             goto parse_error;
           default: goto parse_error;
@@ -9549,9 +8948,8 @@ switch (buf[0]) {
       }
       case 'x':
         if (op == "v128.xor"sv) {
-          auto ret = makeBinary(ctx, pos, BinaryOp::XorVec128);
-          CHECK_ERR(ret);
-          return *ret;
+          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::XorVec128));
+          return Ok{};
         }
         goto parse_error;
       default: goto parse_error;

--- a/src/parser/context-decls.cpp
+++ b/src/parser/context-decls.cpp
@@ -68,7 +68,6 @@ Result<> ParseDeclsCtx::addFunc(Name name,
                                 ImportNames* import,
                                 TypeUseT type,
                                 std::optional<LocalsT>,
-                                std::optional<InstrsT>,
                                 Index pos) {
   if (import && hasNonImport) {
     return in.err(pos, "import after non-import");

--- a/src/parser/context-defs.cpp
+++ b/src/parser/context-defs.cpp
@@ -55,7 +55,6 @@ Result<> ParseDefsCtx::addFunc(Name,
                                ImportNames*,
                                TypeUseT,
                                std::optional<LocalsT>,
-                               std::optional<InstrsT>,
                                Index pos) {
   CHECK_ERR(withLoc(pos, irBuilder.visitEnd()));
   auto body = irBuilder.build();

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -272,8 +272,6 @@ template<typename Ctx> struct TypeParserCtx {
 };
 
 struct NullInstrParserCtx {
-  using InstrT = Ok;
-  using InstrsT = Ok;
   using ExprT = Ok;
 
   using FieldIdxT = Ok;
@@ -284,12 +282,7 @@ struct NullInstrParserCtx {
 
   using MemargT = Ok;
 
-  InstrsT makeInstrs() { return Ok{}; }
-  void appendInstr(InstrsT&, InstrT) {}
-  InstrsT finishInstrs(InstrsT&) { return Ok{}; }
-
-  ExprT makeExpr(InstrsT) { return Ok{}; }
-  Result<ExprT> instrToExpr(InstrT) { return Ok{}; }
+  Result<> makeExpr() { return Ok{}; }
 
   template<typename HeapTypeT> FieldIdxT getFieldFromIdx(HeapTypeT, uint32_t) {
     return Ok{};
@@ -309,118 +302,122 @@ struct NullInstrParserCtx {
   MemargT getMemarg(uint64_t, uint32_t) { return Ok{}; }
 
   template<typename BlockTypeT>
-  InstrT makeBlock(Index, std::optional<Name>, BlockTypeT) {
+  Result<> makeBlock(Index, std::optional<Name>, BlockTypeT) {
     return Ok{};
   }
   template<typename BlockTypeT>
-  InstrT makeIf(Index, std::optional<Name>, BlockTypeT) {
+  Result<> makeIf(Index, std::optional<Name>, BlockTypeT) {
     return Ok{};
   }
-  InstrT visitEnd(Index, InstrsT) { return Ok{}; }
-  InstrT visitElse(Index) { return Ok{}; }
+  Result<> visitEnd(Index) { return Ok{}; }
+  Result<> visitElse(Index) { return Ok{}; }
 
-  InstrT makeUnreachable(Index) { return Ok{}; }
-  InstrT makeNop(Index) { return Ok{}; }
-  InstrT makeBinary(Index, BinaryOp) { return Ok{}; }
-  InstrT makeUnary(Index, UnaryOp) { return Ok{}; }
-  template<typename ResultsT> InstrT makeSelect(Index, ResultsT*) {
+  Result<> makeUnreachable(Index) { return Ok{}; }
+  Result<> makeNop(Index) { return Ok{}; }
+  Result<> makeBinary(Index, BinaryOp) { return Ok{}; }
+  Result<> makeUnary(Index, UnaryOp) { return Ok{}; }
+  template<typename ResultsT> Result<> makeSelect(Index, ResultsT*) {
     return Ok{};
   }
-  InstrT makeDrop(Index) { return Ok{}; }
-  InstrT makeMemorySize(Index, MemoryIdxT*) { return Ok{}; }
-  InstrT makeMemoryGrow(Index, MemoryIdxT*) { return Ok{}; }
-  InstrT makeLocalGet(Index, LocalIdxT) { return Ok{}; }
-  InstrT makeLocalTee(Index, LocalIdxT) { return Ok{}; }
-  InstrT makeLocalSet(Index, LocalIdxT) { return Ok{}; }
-  InstrT makeGlobalGet(Index, GlobalIdxT) { return Ok{}; }
-  InstrT makeGlobalSet(Index, GlobalIdxT) { return Ok{}; }
+  Result<> makeDrop(Index) { return Ok{}; }
+  Result<> makeMemorySize(Index, MemoryIdxT*) { return Ok{}; }
+  Result<> makeMemoryGrow(Index, MemoryIdxT*) { return Ok{}; }
+  Result<> makeLocalGet(Index, LocalIdxT) { return Ok{}; }
+  Result<> makeLocalTee(Index, LocalIdxT) { return Ok{}; }
+  Result<> makeLocalSet(Index, LocalIdxT) { return Ok{}; }
+  Result<> makeGlobalGet(Index, GlobalIdxT) { return Ok{}; }
+  Result<> makeGlobalSet(Index, GlobalIdxT) { return Ok{}; }
 
-  InstrT makeI32Const(Index, uint32_t) { return Ok{}; }
-  InstrT makeI64Const(Index, uint64_t) { return Ok{}; }
-  InstrT makeF32Const(Index, float) { return Ok{}; }
-  InstrT makeF64Const(Index, double) { return Ok{}; }
-  InstrT makeLoad(Index, Type, bool, int, bool, MemoryIdxT*, MemargT) {
+  Result<> makeI32Const(Index, uint32_t) { return Ok{}; }
+  Result<> makeI64Const(Index, uint64_t) { return Ok{}; }
+  Result<> makeF32Const(Index, float) { return Ok{}; }
+  Result<> makeF64Const(Index, double) { return Ok{}; }
+  Result<> makeLoad(Index, Type, bool, int, bool, MemoryIdxT*, MemargT) {
     return Ok{};
   }
-  InstrT makeStore(Index, Type, int, bool, MemoryIdxT*, MemargT) {
+  Result<> makeStore(Index, Type, int, bool, MemoryIdxT*, MemargT) {
     return Ok{};
   }
-  InstrT makeAtomicRMW(Index, AtomicRMWOp, Type, int, MemoryIdxT*, MemargT) {
+  Result<> makeAtomicRMW(Index, AtomicRMWOp, Type, int, MemoryIdxT*, MemargT) {
     return Ok{};
   }
-  InstrT makeAtomicCmpxchg(Index, Type, int, MemoryIdxT*, MemargT) {
+  Result<> makeAtomicCmpxchg(Index, Type, int, MemoryIdxT*, MemargT) {
     return Ok{};
   }
-  InstrT makeAtomicWait(Index, Type, MemoryIdxT*, MemargT) { return Ok{}; }
-  InstrT makeAtomicNotify(Index, MemoryIdxT*, MemargT) { return Ok{}; }
-  InstrT makeAtomicFence(Index) { return Ok{}; }
-  InstrT makeSIMDExtract(Index, SIMDExtractOp, uint8_t) { return Ok{}; }
-  InstrT makeSIMDReplace(Index, SIMDReplaceOp, uint8_t) { return Ok{}; }
-  InstrT makeSIMDShuffle(Index, const std::array<uint8_t, 16>&) { return Ok{}; }
-  InstrT makeSIMDTernary(Index, SIMDTernaryOp) { return Ok{}; }
-  InstrT makeSIMDShift(Index, SIMDShiftOp) { return Ok{}; }
-  InstrT makeSIMDLoad(Index, SIMDLoadOp, MemoryIdxT*, MemargT) { return Ok{}; }
-  InstrT makeSIMDLoadStoreLane(
+  Result<> makeAtomicWait(Index, Type, MemoryIdxT*, MemargT) { return Ok{}; }
+  Result<> makeAtomicNotify(Index, MemoryIdxT*, MemargT) { return Ok{}; }
+  Result<> makeAtomicFence(Index) { return Ok{}; }
+  Result<> makeSIMDExtract(Index, SIMDExtractOp, uint8_t) { return Ok{}; }
+  Result<> makeSIMDReplace(Index, SIMDReplaceOp, uint8_t) { return Ok{}; }
+  Result<> makeSIMDShuffle(Index, const std::array<uint8_t, 16>&) {
+    return Ok{};
+  }
+  Result<> makeSIMDTernary(Index, SIMDTernaryOp) { return Ok{}; }
+  Result<> makeSIMDShift(Index, SIMDShiftOp) { return Ok{}; }
+  Result<> makeSIMDLoad(Index, SIMDLoadOp, MemoryIdxT*, MemargT) {
+    return Ok{};
+  }
+  Result<> makeSIMDLoadStoreLane(
     Index, SIMDLoadStoreLaneOp, MemoryIdxT*, MemargT, uint8_t) {
     return Ok{};
   }
-  InstrT makeMemoryInit(Index, MemoryIdxT*, DataIdxT) { return Ok{}; }
-  InstrT makeDataDrop(Index, DataIdxT) { return Ok{}; }
+  Result<> makeMemoryInit(Index, MemoryIdxT*, DataIdxT) { return Ok{}; }
+  Result<> makeDataDrop(Index, DataIdxT) { return Ok{}; }
 
-  InstrT makeMemoryCopy(Index, MemoryIdxT*, MemoryIdxT*) { return Ok{}; }
-  InstrT makeMemoryFill(Index, MemoryIdxT*) { return Ok{}; }
+  Result<> makeMemoryCopy(Index, MemoryIdxT*, MemoryIdxT*) { return Ok{}; }
+  Result<> makeMemoryFill(Index, MemoryIdxT*) { return Ok{}; }
 
-  InstrT makeReturn(Index) { return Ok{}; }
-  template<typename HeapTypeT> InstrT makeRefNull(Index, HeapTypeT) {
+  Result<> makeReturn(Index) { return Ok{}; }
+  template<typename HeapTypeT> Result<> makeRefNull(Index, HeapTypeT) {
     return Ok{};
   }
-  InstrT makeRefIsNull(Index) { return Ok{}; }
+  Result<> makeRefIsNull(Index) { return Ok{}; }
 
-  InstrT makeRefEq(Index) { return Ok{}; }
+  Result<> makeRefEq(Index) { return Ok{}; }
 
-  InstrT makeRefI31(Index) { return Ok{}; }
-  InstrT makeI31Get(Index, bool) { return Ok{}; }
+  Result<> makeRefI31(Index) { return Ok{}; }
+  Result<> makeI31Get(Index, bool) { return Ok{}; }
 
-  template<typename HeapTypeT> InstrT makeStructNew(Index, HeapTypeT) {
+  template<typename HeapTypeT> Result<> makeStructNew(Index, HeapTypeT) {
     return Ok{};
   }
-  template<typename HeapTypeT> InstrT makeStructNewDefault(Index, HeapTypeT) {
+  template<typename HeapTypeT> Result<> makeStructNewDefault(Index, HeapTypeT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  InstrT makeStructGet(Index, HeapTypeT, FieldIdxT, bool) {
+  Result<> makeStructGet(Index, HeapTypeT, FieldIdxT, bool) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  InstrT makeStructSet(Index, HeapTypeT, FieldIdxT) {
+  Result<> makeStructSet(Index, HeapTypeT, FieldIdxT) {
     return Ok{};
   }
-  template<typename HeapTypeT> InstrT makeArrayNew(Index, HeapTypeT) {
+  template<typename HeapTypeT> Result<> makeArrayNew(Index, HeapTypeT) {
     return Ok{};
   }
-  template<typename HeapTypeT> InstrT makeArrayNewDefault(Index, HeapTypeT) {
-    return Ok{};
-  }
-  template<typename HeapTypeT>
-  InstrT makeArrayNewData(Index, HeapTypeT, DataIdxT) {
+  template<typename HeapTypeT> Result<> makeArrayNewDefault(Index, HeapTypeT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  InstrT makeArrayNewElem(Index, HeapTypeT, DataIdxT) {
+  Result<> makeArrayNewData(Index, HeapTypeT, DataIdxT) {
     return Ok{};
   }
-  template<typename HeapTypeT> InstrT makeArrayGet(Index, HeapTypeT, bool) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> InstrT makeArraySet(Index, HeapTypeT) {
-    return Ok{};
-  }
-  InstrT makeArrayLen(Index) { return Ok{}; }
   template<typename HeapTypeT>
-  InstrT makeArrayCopy(Index, HeapTypeT, HeapTypeT) {
+  Result<> makeArrayNewElem(Index, HeapTypeT, DataIdxT) {
     return Ok{};
   }
-  template<typename HeapTypeT> InstrT makeArrayFill(Index, HeapTypeT) {
+  template<typename HeapTypeT> Result<> makeArrayGet(Index, HeapTypeT, bool) {
+    return Ok{};
+  }
+  template<typename HeapTypeT> Result<> makeArraySet(Index, HeapTypeT) {
+    return Ok{};
+  }
+  Result<> makeArrayLen(Index) { return Ok{}; }
+  template<typename HeapTypeT>
+  Result<> makeArrayCopy(Index, HeapTypeT, HeapTypeT) {
+    return Ok{};
+  }
+  template<typename HeapTypeT> Result<> makeArrayFill(Index, HeapTypeT) {
     return Ok{};
   }
 };
@@ -509,7 +506,6 @@ struct ParseDeclsCtx : NullTypeParserCtx, NullInstrParserCtx {
                    ImportNames* import,
                    TypeUseT type,
                    std::optional<LocalsT>,
-                   std::optional<InstrsT>,
                    Index pos);
 
   Result<Memory*>
@@ -745,7 +741,6 @@ struct ParseModuleTypesCtx : TypeParserCtx<ParseModuleTypesCtx>,
                    ImportNames*,
                    TypeUse type,
                    std::optional<LocalsT> locals,
-                   std::optional<InstrsT>,
                    Index pos) {
     auto& f = wasm.functions[index];
     if (!type.type.isSignature()) {
@@ -790,10 +785,6 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   using GlobalTypeT = Ok;
   using TypeUseT = HeapType;
 
-  // Keep track of instructions internally rather than letting the general
-  // parser collect them.
-  using InstrT = Ok;
-  using InstrsT = Ok;
   using ExprT = Expression*;
 
   using FieldIdxT = Index;
@@ -853,14 +844,6 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   Result<HeapType> getBlockTypeFromTypeUse(Index pos, HeapType type) {
     return type;
   }
-
-  Ok makeInstrs() { return Ok{}; }
-
-  void appendInstr(Ok&, InstrT instr) {}
-
-  Result<InstrsT> finishInstrs(Ok&) { return Ok{}; }
-
-  Result<Expression*> instrToExpr(Ok&) { return irBuilder.build(); }
 
   GlobalTypeT makeGlobalType(Mutability, TypeT) { return Ok{}; }
 
@@ -957,7 +940,6 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
                    ImportNames*,
                    TypeUseT,
                    std::optional<LocalsT>,
-                   std::optional<InstrsT>,
                    Index pos);
 
   Result<> addGlobal(Name,
@@ -977,7 +959,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return Builder::addVar(func, name, type);
   }
 
-  Result<Expression*> makeExpr(InstrsT& instrs) { return irBuilder.build(); }
+  Result<Expression*> makeExpr() { return irBuilder.build(); }
 
   Memarg getMemarg(uint64_t offset, uint32_t align) { return {offset, align}; }
 
@@ -1007,9 +989,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
       irBuilder.makeIf(label ? *label : Name{}, type.getSignature().results));
   }
 
-  Result<> visitEnd(Index pos, InstrsT) {
-    return withLoc(pos, irBuilder.visitEnd());
-  }
+  Result<> visitEnd(Index pos) { return withLoc(pos, irBuilder.visitEnd()); }
 
   Result<> visitElse(Index pos) { return withLoc(pos, irBuilder.visitElse()); }
 

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -668,8 +668,6 @@ template<typename Ctx> Result<> foldedinstrs(Ctx& ctx) {
 }
 
 template<typename Ctx> Result<> instrs(Ctx& ctx) {
-  bool parsedFolded = false;
-
   while (true) {
     // Try to parse a folded instruction tree.
     if (!foldedinstrs(ctx).getErr()) {
@@ -682,10 +680,6 @@ template<typename Ctx> Result<> instrs(Ctx& ctx) {
     } else {
       break;
     }
-  }
-
-  if (requireFolded && !parsedFolded) {
-    return ctx.in.err("expected folded instructions");
   }
 
   return Ok{};

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -42,175 +42,128 @@ template<typename Ctx> Result<typename Ctx::MemTypeT> memtype(Ctx&);
 template<typename Ctx> Result<typename Ctx::GlobalTypeT> globaltype(Ctx&);
 
 // Instructions
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> foldedBlockinstr(Ctx&);
-template<typename Ctx>
-MaybeResult<typename Ctx::InstrT> unfoldedBlockinstr(Ctx&);
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> blockinstr(Ctx&);
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> plaininstr(Ctx&);
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> instr(Ctx&);
-template<typename Ctx>
-Result<typename Ctx::InstrsT> instrs(Ctx&, bool requireFolded = false);
-template<typename Ctx> Result<typename Ctx::InstrsT> foldedinstrs(Ctx&);
+template<typename Ctx> MaybeResult<> foldedBlockinstr(Ctx&);
+template<typename Ctx> MaybeResult<> unfoldedBlockinstr(Ctx&);
+template<typename Ctx> MaybeResult<> blockinstr(Ctx&);
+template<typename Ctx> MaybeResult<> plaininstr(Ctx&);
+template<typename Ctx> MaybeResult<> instr(Ctx&);
+template<typename Ctx> Result<> foldedinstrs(Ctx&);
+template<typename Ctx> Result<> instrs(Ctx&);
 template<typename Ctx> Result<typename Ctx::ExprT> expr(Ctx&);
 template<typename Ctx> Result<typename Ctx::MemargT> memarg(Ctx&, uint32_t);
 template<typename Ctx> Result<typename Ctx::BlockTypeT> blocktype(Ctx&);
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> block(Ctx&, bool);
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> ifelse(Ctx&, bool);
+template<typename Ctx> MaybeResult<> block(Ctx&, bool);
+template<typename Ctx> MaybeResult<> ifelse(Ctx&, bool);
+template<typename Ctx> Result<> makeUnreachable(Ctx&, Index);
+template<typename Ctx> Result<> makeNop(Ctx&, Index);
+template<typename Ctx> Result<> makeBinary(Ctx&, Index, BinaryOp op);
+template<typename Ctx> Result<> makeUnary(Ctx&, Index, UnaryOp op);
+template<typename Ctx> Result<> makeSelect(Ctx&, Index);
+template<typename Ctx> Result<> makeDrop(Ctx&, Index);
+template<typename Ctx> Result<> makeMemorySize(Ctx&, Index);
+template<typename Ctx> Result<> makeMemoryGrow(Ctx&, Index);
+template<typename Ctx> Result<> makeLocalGet(Ctx&, Index);
+template<typename Ctx> Result<> makeLocalTee(Ctx&, Index);
+template<typename Ctx> Result<> makeLocalSet(Ctx&, Index);
+template<typename Ctx> Result<> makeGlobalGet(Ctx&, Index);
+template<typename Ctx> Result<> makeGlobalSet(Ctx&, Index);
+template<typename Ctx> Result<> makeBlock(Ctx&, Index);
+template<typename Ctx> Result<> makeThenOrElse(Ctx&, Index);
+template<typename Ctx> Result<> makeConst(Ctx&, Index, Type type);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeUnreachable(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeNop(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBinary(Ctx&, Index, BinaryOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeUnary(Ctx&, Index, UnaryOp op);
-template<typename Ctx> Result<typename Ctx::InstrT> makeSelect(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeDrop(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeMemorySize(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeMemoryGrow(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeLocalGet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeLocalTee(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeLocalSet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeGlobalGet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeGlobalSet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeBlock(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeThenOrElse(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeConst(Ctx&, Index, Type type);
-template<typename Ctx>
-Result<typename Ctx::InstrT>
+Result<>
 makeLoad(Ctx&, Index, Type type, bool signed_, int bytes, bool isAtomic);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStore(Ctx&, Index, Type type, int bytes, bool isAtomic);
+Result<> makeStore(Ctx&, Index, Type type, int bytes, bool isAtomic);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeAtomicRMW(Ctx&, Index, AtomicRMWOp op, Type type, uint8_t bytes);
+Result<> makeAtomicRMW(Ctx&, Index, AtomicRMWOp op, Type type, uint8_t bytes);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeAtomicCmpxchg(Ctx&, Index, Type type, uint8_t bytes);
+Result<> makeAtomicCmpxchg(Ctx&, Index, Type type, uint8_t bytes);
+template<typename Ctx> Result<> makeAtomicWait(Ctx&, Index, Type type);
+template<typename Ctx> Result<> makeAtomicNotify(Ctx&, Index);
+template<typename Ctx> Result<> makeAtomicFence(Ctx&, Index);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeAtomicWait(Ctx&, Index, Type type);
+Result<> makeSIMDExtract(Ctx&, Index, SIMDExtractOp op, size_t lanes);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeAtomicNotify(Ctx&, Index);
+Result<> makeSIMDReplace(Ctx&, Index, SIMDReplaceOp op, size_t lanes);
+template<typename Ctx> Result<> makeSIMDShuffle(Ctx&, Index);
+template<typename Ctx> Result<> makeSIMDTernary(Ctx&, Index, SIMDTernaryOp op);
+template<typename Ctx> Result<> makeSIMDShift(Ctx&, Index, SIMDShiftOp op);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeAtomicFence(Ctx&, Index);
+Result<> makeSIMDLoad(Ctx&, Index, SIMDLoadOp op, int bytes);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDExtract(Ctx&, Index, SIMDExtractOp op, size_t lanes);
+Result<> makeSIMDLoadStoreLane(Ctx&, Index, SIMDLoadStoreLaneOp op, int bytes);
+template<typename Ctx> Result<> makeMemoryInit(Ctx&, Index);
+template<typename Ctx> Result<> makeDataDrop(Ctx&, Index);
+template<typename Ctx> Result<> makeMemoryCopy(Ctx&, Index);
+template<typename Ctx> Result<> makeMemoryFill(Ctx&, Index);
+template<typename Ctx> Result<> makePop(Ctx&, Index);
+template<typename Ctx> Result<> makeIf(Ctx&, Index);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDReplace(Ctx&, Index, SIMDReplaceOp op, size_t lanes);
+Result<> makeMaybeBlock(Ctx&, Index, size_t i, Type type);
+template<typename Ctx> Result<> makeLoop(Ctx&, Index);
+template<typename Ctx> Result<> makeCall(Ctx&, Index, bool isReturn);
+template<typename Ctx> Result<> makeCallIndirect(Ctx&, Index, bool isReturn);
+template<typename Ctx> Result<> makeBreak(Ctx&, Index);
+template<typename Ctx> Result<> makeBreakTable(Ctx&, Index);
+template<typename Ctx> Result<> makeReturn(Ctx&, Index);
+template<typename Ctx> Result<> makeRefNull(Ctx&, Index);
+template<typename Ctx> Result<> makeRefIsNull(Ctx&, Index);
+template<typename Ctx> Result<> makeRefFunc(Ctx&, Index);
+template<typename Ctx> Result<> makeRefEq(Ctx&, Index);
+template<typename Ctx> Result<> makeTableGet(Ctx&, Index);
+template<typename Ctx> Result<> makeTableSet(Ctx&, Index);
+template<typename Ctx> Result<> makeTableSize(Ctx&, Index);
+template<typename Ctx> Result<> makeTableGrow(Ctx&, Index);
+template<typename Ctx> Result<> makeTableFill(Ctx&, Index);
+template<typename Ctx> Result<> makeTry(Ctx&, Index);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeSIMDShuffle(Ctx&, Index);
+Result<> makeTryOrCatchBody(Ctx&, Index, Type type, bool isTry);
+template<typename Ctx> Result<> makeThrow(Ctx&, Index);
+template<typename Ctx> Result<> makeRethrow(Ctx&, Index);
+template<typename Ctx> Result<> makeTupleMake(Ctx&, Index);
+template<typename Ctx> Result<> makeTupleExtract(Ctx&, Index);
+template<typename Ctx> Result<> makeCallRef(Ctx&, Index, bool isReturn);
+template<typename Ctx> Result<> makeRefI31(Ctx&, Index);
+template<typename Ctx> Result<> makeI31Get(Ctx&, Index, bool signed_);
+template<typename Ctx> Result<> makeRefTest(Ctx&, Index);
+template<typename Ctx> Result<> makeRefCast(Ctx&, Index);
+template<typename Ctx> Result<> makeBrOnNull(Ctx&, Index, bool onFail = false);
+template<typename Ctx> Result<> makeBrOnCast(Ctx&, Index, bool onFail = false);
+template<typename Ctx> Result<> makeStructNew(Ctx&, Index, bool default_);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeSIMDTernary(Ctx&, Index, SIMDTernaryOp op);
+Result<> makeStructGet(Ctx&, Index, bool signed_ = false);
+template<typename Ctx> Result<> makeStructSet(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayNew(Ctx&, Index, bool default_);
+template<typename Ctx> Result<> makeArrayNewData(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayNewElem(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayNewFixed(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayGet(Ctx&, Index, bool signed_ = false);
+template<typename Ctx> Result<> makeArraySet(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayLen(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayCopy(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayFill(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayInitData(Ctx&, Index);
+template<typename Ctx> Result<> makeArrayInitElem(Ctx&, Index);
+template<typename Ctx> Result<> makeRefAs(Ctx&, Index, RefAsOp op);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeSIMDShift(Ctx&, Index, SIMDShiftOp op);
+Result<> makeStringNew(Ctx&, Index, StringNewOp op, bool try_);
+template<typename Ctx> Result<> makeStringConst(Ctx&, Index);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDLoad(Ctx&, Index, SIMDLoadOp op, int bytes);
+Result<> makeStringMeasure(Ctx&, Index, StringMeasureOp op);
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDLoadStoreLane(Ctx&, Index, SIMDLoadStoreLaneOp op, int bytes);
-template<typename Ctx> Result<typename Ctx::InstrT> makeMemoryInit(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeDataDrop(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeMemoryCopy(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeMemoryFill(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makePop(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeIf(Ctx&, Index);
+Result<> makeStringEncode(Ctx&, Index, StringEncodeOp op);
+template<typename Ctx> Result<> makeStringConcat(Ctx&, Index);
+template<typename Ctx> Result<> makeStringEq(Ctx&, Index, StringEqOp);
+template<typename Ctx> Result<> makeStringAs(Ctx&, Index, StringAsOp op);
+template<typename Ctx> Result<> makeStringWTF8Advance(Ctx&, Index);
+template<typename Ctx> Result<> makeStringWTF16Get(Ctx&, Index);
+template<typename Ctx> Result<> makeStringIterNext(Ctx&, Index);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeMaybeBlock(Ctx&, Index, size_t i, Type type);
-template<typename Ctx> Result<typename Ctx::InstrT> makeLoop(Ctx&, Index);
+Result<> makeStringIterMove(Ctx&, Index, StringIterMoveOp op);
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeCall(Ctx&, Index, bool isReturn);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeCallIndirect(Ctx&, Index, bool isReturn);
-template<typename Ctx> Result<typename Ctx::InstrT> makeBreak(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeBreakTable(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeReturn(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefNull(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefIsNull(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefFunc(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefEq(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTableGet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTableSet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTableSize(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTableGrow(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTableFill(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTry(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeTryOrCatchBody(Ctx&, Index, Type type, bool isTry);
-template<typename Ctx> Result<typename Ctx::InstrT> makeThrow(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRethrow(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeTupleMake(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTupleExtract(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeCallRef(Ctx&, Index, bool isReturn);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefI31(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeI31Get(Ctx&, Index, bool signed_);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefTest(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeRefCast(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBrOnNull(Ctx&, Index, bool onFail = false);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBrOnCast(Ctx&, Index, bool onFail = false);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStructNew(Ctx&, Index, bool default_);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStructGet(Ctx&, Index, bool signed_ = false);
-template<typename Ctx> Result<typename Ctx::InstrT> makeStructSet(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNew(Ctx&, Index, bool default_);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNewData(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNewElem(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNewFixed(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayGet(Ctx&, Index, bool signed_ = false);
-template<typename Ctx> Result<typename Ctx::InstrT> makeArraySet(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeArrayLen(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeArrayCopy(Ctx&, Index);
-template<typename Ctx> Result<typename Ctx::InstrT> makeArrayFill(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayInitData(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayInitElem(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefAs(Ctx&, Index, RefAsOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringNew(Ctx&, Index, StringNewOp op, bool try_);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringConst(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringMeasure(Ctx&, Index, StringMeasureOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringEncode(Ctx&, Index, StringEncodeOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringConcat(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringEq(Ctx&, Index, StringEqOp);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringAs(Ctx&, Index, StringAsOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringWTF8Advance(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringWTF16Get(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringIterNext(Ctx&, Index);
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringIterMove(Ctx&, Index, StringIterMoveOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringSliceWTF(Ctx&, Index, StringSliceWTFOp op);
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringSliceIter(Ctx&, Index);
+Result<> makeStringSliceWTF(Ctx&, Index, StringSliceWTFOp op);
+template<typename Ctx> Result<> makeStringSliceIter(Ctx&, Index);
 
 // Modules
 template<typename Ctx> MaybeResult<Index> maybeTypeidx(Ctx& ctx);
@@ -592,8 +545,7 @@ template<typename Ctx> Result<typename Ctx::GlobalTypeT> globaltype(Ctx& ctx) {
 // ============
 
 // blockinstr ::= block | loop | if-else | try-catch
-template<typename Ctx>
-MaybeResult<typename Ctx::InstrT> foldedBlockinstr(Ctx& ctx) {
+template<typename Ctx> MaybeResult<> foldedBlockinstr(Ctx& ctx) {
   if (auto i = block(ctx, true)) {
     return i;
   }
@@ -604,8 +556,7 @@ MaybeResult<typename Ctx::InstrT> foldedBlockinstr(Ctx& ctx) {
   return {};
 }
 
-template<typename Ctx>
-MaybeResult<typename Ctx::InstrT> unfoldedBlockinstr(Ctx& ctx) {
+template<typename Ctx> MaybeResult<> unfoldedBlockinstr(Ctx& ctx) {
   if (auto i = block(ctx, false)) {
     return i;
   }
@@ -616,7 +567,7 @@ MaybeResult<typename Ctx::InstrT> unfoldedBlockinstr(Ctx& ctx) {
   return {};
 }
 
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> blockinstr(Ctx& ctx) {
+template<typename Ctx> MaybeResult<> blockinstr(Ctx& ctx) {
   if (auto i = foldedBlockinstr(ctx)) {
     return i;
   }
@@ -627,7 +578,7 @@ template<typename Ctx> MaybeResult<typename Ctx::InstrT> blockinstr(Ctx& ctx) {
 }
 
 // plaininstr ::= ... all plain instructions ...
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> plaininstr(Ctx& ctx) {
+template<typename Ctx> MaybeResult<> plaininstr(Ctx& ctx) {
   auto pos = ctx.in.getPos();
   auto keyword = ctx.in.takeKeyword();
   if (!keyword) {
@@ -640,7 +591,7 @@ template<typename Ctx> MaybeResult<typename Ctx::InstrT> plaininstr(Ctx& ctx) {
 }
 
 // instr ::= plaininstr | blockinstr
-template<typename Ctx> MaybeResult<typename Ctx::InstrT> instr(Ctx& ctx) {
+template<typename Ctx> MaybeResult<> instr(Ctx& ctx) {
   // Check for valid strings that are not instructions.
   if (auto tok = ctx.in.peek()) {
     if (auto keyword = tok->getKeyword()) {
@@ -659,89 +610,75 @@ template<typename Ctx> MaybeResult<typename Ctx::InstrT> instr(Ctx& ctx) {
   return {};
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrsT> instrs(Ctx& ctx, bool requireFolded) {
-  auto insts = ctx.makeInstrs();
+template<typename Ctx> Result<> foldedinstrs(Ctx& ctx) {
+  if (auto blockinst = foldedBlockinstr(ctx)) {
+    CHECK_ERR(blockinst);
+    return Ok{};
+  }
+  // Parse an arbitrary number of folded instructions.
+  if (ctx.in.takeLParen()) {
+    // A stack of (start, end) position pairs defining the positions of
+    // instructions that need to be parsed after their folded children.
+    std::vector<std::pair<Index, std::optional<Index>>> foldedInstrs;
+
+    // Begin a folded instruction. Push its start position and a placeholder
+    // end position.
+    foldedInstrs.push_back({ctx.in.getPos(), {}});
+    while (!foldedInstrs.empty()) {
+      // Consume everything up to the next paren. This span will be parsed as
+      // an instruction later after its folded children have been parsed.
+      if (!ctx.in.takeUntilParen()) {
+        return ctx.in.err(foldedInstrs.back().first,
+                          "unterminated folded instruction");
+      }
+
+      if (!foldedInstrs.back().second) {
+        // The folded instruction we just started should end here.
+        foldedInstrs.back().second = ctx.in.getPos();
+      }
+
+      // We have either the start of a new folded child or the end of the last
+      // one.
+      if (auto blockinst = foldedBlockinstr(ctx)) {
+        CHECK_ERR(blockinst);
+      } else if (ctx.in.takeLParen()) {
+        foldedInstrs.push_back({ctx.in.getPos(), {}});
+      } else if (ctx.in.takeRParen()) {
+        auto [start, end] = foldedInstrs.back();
+        assert(end && "Should have found end of instruction");
+        foldedInstrs.pop_back();
+
+        WithPosition with(ctx, start);
+        if (auto inst = plaininstr(ctx)) {
+          CHECK_ERR(inst);
+        } else {
+          return ctx.in.err(start, "expected folded instruction");
+        }
+
+        if (ctx.in.getPos() != *end) {
+          return ctx.in.err("expected end of instruction");
+        }
+      } else {
+        WASM_UNREACHABLE("expected paren");
+      }
+    }
+    return Ok{};
+  }
+  return ctx.in.err("expected folded instruction");
+}
+
+template<typename Ctx> Result<> instrs(Ctx& ctx) {
   bool parsedFolded = false;
 
   while (true) {
-    if (auto blockinst = foldedBlockinstr(ctx)) {
-      CHECK_ERR(blockinst);
-      ctx.appendInstr(insts, *blockinst);
-      parsedFolded = true;
-      if (requireFolded) {
-        // Do not continue to parse another sibling folded instruction.
-        break;
-      }
-      continue;
-    }
-    // Parse an arbitrary number of folded instructions.
-    if (ctx.in.takeLParen()) {
-      // A stack of (start, end) position pairs defining the positions of
-      // instructions that need to be parsed after their folded children.
-      std::vector<std::pair<Index, std::optional<Index>>> foldedInstrs;
-
-      // Begin a folded instruction. Push its start position and a placeholder
-      // end position.
-      foldedInstrs.push_back({ctx.in.getPos(), {}});
-      while (!foldedInstrs.empty()) {
-        // Consume everything up to the next paren. This span will be parsed as
-        // an instruction later after its folded children have been parsed.
-        if (!ctx.in.takeUntilParen()) {
-          return ctx.in.err(foldedInstrs.back().first,
-                            "unterminated folded instruction");
-        }
-
-        if (!foldedInstrs.back().second) {
-          // The folded instruction we just started should end here.
-          foldedInstrs.back().second = ctx.in.getPos();
-        }
-
-        // We have either the start of a new folded child or the end of the last
-        // one.
-        if (auto blockinst = foldedBlockinstr(ctx)) {
-          CHECK_ERR(blockinst);
-          ctx.appendInstr(insts, *blockinst);
-          parsedFolded = true;
-        } else if (ctx.in.takeLParen()) {
-          foldedInstrs.push_back({ctx.in.getPos(), {}});
-        } else if (ctx.in.takeRParen()) {
-          auto [start, end] = foldedInstrs.back();
-          assert(end && "Should have found end of instruction");
-          foldedInstrs.pop_back();
-
-          WithPosition with(ctx, start);
-          if (auto inst = plaininstr(ctx)) {
-            CHECK_ERR(inst);
-            ctx.appendInstr(insts, *inst);
-            parsedFolded = true;
-          } else {
-            return ctx.in.err(start, "expected folded instruction");
-          }
-
-          if (ctx.in.getPos() != *end) {
-            return ctx.in.err("expected end of instruction");
-          }
-        } else {
-          WASM_UNREACHABLE("expected paren");
-        }
-      }
-      if (requireFolded) {
-        // Do not continue to parse another sibling folded instruction.
-        break;
-      }
+    // Try to parse a folded instruction tree.
+    if (!foldedinstrs(ctx).getErr()) {
       continue;
     }
 
-    if (requireFolded) {
-      // Do not continue to parse a non-folded instruction.
-      break;
-    }
-
-    // A non-folded instruction.
+    // Otherwise parse a non-folded instruction.
     if (auto inst = instr(ctx)) {
       CHECK_ERR(inst);
-      ctx.appendInstr(insts, *inst);
     } else {
       break;
     }
@@ -751,17 +688,12 @@ Result<typename Ctx::InstrsT> instrs(Ctx& ctx, bool requireFolded) {
     return ctx.in.err("expected folded instructions");
   }
 
-  return ctx.finishInstrs(insts);
-}
-
-template<typename Ctx> Result<typename Ctx::InstrsT> foldedinstrs(Ctx& ctx) {
-  return instrs(ctx, true);
+  return Ok{};
 }
 
 template<typename Ctx> Result<typename Ctx::ExprT> expr(Ctx& ctx) {
-  auto insts = instrs(ctx);
-  CHECK_ERR(insts);
-  return ctx.makeExpr(*insts);
+  CHECK_ERR(instrs(ctx));
+  return ctx.makeExpr();
 }
 
 // memarg_n ::= o:offset a:align_n
@@ -804,8 +736,7 @@ template<typename Ctx> Result<typename Ctx::BlockTypeT> blocktype(Ctx& ctx) {
 
 // block ::= 'block' label blocktype instr* 'end' id?   if id = {} or id = label
 //         | '(' 'block' label blocktype instr* ')'
-template<typename Ctx>
-MaybeResult<typename Ctx::InstrT> block(Ctx& ctx, bool folded) {
+template<typename Ctx> MaybeResult<> block(Ctx& ctx, bool folded) {
   auto pos = ctx.in.getPos();
 
   if (folded) {
@@ -825,8 +756,7 @@ MaybeResult<typename Ctx::InstrT> block(Ctx& ctx, bool folded) {
 
   ctx.makeBlock(pos, label, *type);
 
-  auto insts = instrs(ctx);
-  CHECK_ERR(insts);
+  CHECK_ERR(instrs(ctx));
 
   if (folded) {
     if (!ctx.in.takeRParen()) {
@@ -842,14 +772,13 @@ MaybeResult<typename Ctx::InstrT> block(Ctx& ctx, bool folded) {
     }
   }
 
-  return ctx.visitEnd(pos, std::move(*insts));
+  return ctx.visitEnd(pos);
 }
 
 // if ::= 'if' label blocktype instr1* ('else' id1? instr2*)? 'end' id2?
 //      | '(' 'if' label blocktype instr* '(' 'then' instr1* ')'
 //            ('(' 'else' instr2* ')')? ')'
-template<typename Ctx>
-MaybeResult<typename Ctx::InstrT> ifelse(Ctx& ctx, bool folded) {
+template<typename Ctx> MaybeResult<> ifelse(Ctx& ctx, bool folded) {
   auto pos = ctx.in.getPos();
 
   if (folded) {
@@ -877,8 +806,7 @@ MaybeResult<typename Ctx::InstrT> ifelse(Ctx& ctx, bool folded) {
     return ctx.in.err("expected 'then' before if instructions");
   }
 
-  auto insts = instrs(ctx);
-  CHECK_ERR(insts);
+  CHECK_ERR(instrs(ctx));
 
   if (folded && !ctx.in.takeRParen()) {
     return ctx.in.err("expected ')' at end of then block");
@@ -893,8 +821,7 @@ MaybeResult<typename Ctx::InstrT> ifelse(Ctx& ctx, bool folded) {
 
     ctx.visitElse(pos);
 
-    auto elseInsts = instrs(ctx);
-    CHECK_ERR(elseInsts);
+    CHECK_ERR(instrs(ctx));
 
     if (folded && !ctx.in.takeRParen()) {
       return ctx.in.err("expected ')' at end of else block");
@@ -916,97 +843,82 @@ MaybeResult<typename Ctx::InstrT> ifelse(Ctx& ctx, bool folded) {
     return ctx.in.err("end label does not match if label");
   }
 
-  return ctx.visitEnd(pos, std::move(*insts));
+  return ctx.visitEnd(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeUnreachable(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeUnreachable(Ctx& ctx, Index pos) {
   return ctx.makeUnreachable(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeNop(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeNop(Ctx& ctx, Index pos) {
   return ctx.makeNop(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBinary(Ctx& ctx, Index pos, BinaryOp op) {
+template<typename Ctx> Result<> makeBinary(Ctx& ctx, Index pos, BinaryOp op) {
   return ctx.makeBinary(pos, op);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeUnary(Ctx& ctx, Index pos, UnaryOp op) {
+template<typename Ctx> Result<> makeUnary(Ctx& ctx, Index pos, UnaryOp op) {
   return ctx.makeUnary(pos, op);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeSelect(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeSelect(Ctx& ctx, Index pos) {
   auto res = results(ctx);
   CHECK_ERR(res);
   return ctx.makeSelect(pos, res.getPtr());
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeDrop(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeDrop(Ctx& ctx, Index pos) {
   return ctx.makeDrop(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeMemorySize(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeMemorySize(Ctx& ctx, Index pos) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   return ctx.makeMemorySize(pos, mem.getPtr());
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeMemoryGrow(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeMemoryGrow(Ctx& ctx, Index pos) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   return ctx.makeMemoryGrow(pos, mem.getPtr());
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeLocalGet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeLocalGet(Ctx& ctx, Index pos) {
   auto local = localidx(ctx);
   CHECK_ERR(local);
   return ctx.makeLocalGet(pos, *local);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeLocalTee(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeLocalTee(Ctx& ctx, Index pos) {
   auto local = localidx(ctx);
   CHECK_ERR(local);
   return ctx.makeLocalTee(pos, *local);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeLocalSet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeLocalSet(Ctx& ctx, Index pos) {
   auto local = localidx(ctx);
   CHECK_ERR(local);
   return ctx.makeLocalSet(pos, *local);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeGlobalGet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeGlobalGet(Ctx& ctx, Index pos) {
   auto global = globalidx(ctx);
   CHECK_ERR(global);
   return ctx.makeGlobalGet(pos, *global);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeGlobalSet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeGlobalSet(Ctx& ctx, Index pos) {
   auto global = globalidx(ctx);
   CHECK_ERR(global);
   return ctx.makeGlobalSet(pos, *global);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBlock(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeBlock(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeConst(Ctx& ctx, Index pos, Type type) {
+template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
   assert(type.isBasic());
   switch (type.getBasic()) {
     case Type::i32:
@@ -1039,7 +951,7 @@ Result<typename Ctx::InstrT> makeConst(Ctx& ctx, Index pos, Type type) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeLoad(
+Result<> makeLoad(
   Ctx& ctx, Index pos, Type type, bool signed_, int bytes, bool isAtomic) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
@@ -1049,8 +961,7 @@ Result<typename Ctx::InstrT> makeLoad(
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStore(Ctx& ctx, Index pos, Type type, int bytes, bool isAtomic) {
+Result<> makeStore(Ctx& ctx, Index pos, Type type, int bytes, bool isAtomic) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
@@ -1059,7 +970,7 @@ makeStore(Ctx& ctx, Index pos, Type type, int bytes, bool isAtomic) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
+Result<>
 makeAtomicRMW(Ctx& ctx, Index pos, AtomicRMWOp op, Type type, uint8_t bytes) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
@@ -1069,8 +980,7 @@ makeAtomicRMW(Ctx& ctx, Index pos, AtomicRMWOp op, Type type, uint8_t bytes) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeAtomicCmpxchg(Ctx& ctx, Index pos, Type type, uint8_t bytes) {
+Result<> makeAtomicCmpxchg(Ctx& ctx, Index pos, Type type, uint8_t bytes) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
@@ -1078,8 +988,7 @@ makeAtomicCmpxchg(Ctx& ctx, Index pos, Type type, uint8_t bytes) {
   return ctx.makeAtomicCmpxchg(pos, type, bytes, mem.getPtr(), *arg);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeAtomicWait(Ctx& ctx, Index pos, Type type) {
+template<typename Ctx> Result<> makeAtomicWait(Ctx& ctx, Index pos, Type type) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, type == Type::i32 ? 4 : 8);
@@ -1087,8 +996,7 @@ Result<typename Ctx::InstrT> makeAtomicWait(Ctx& ctx, Index pos, Type type) {
   return ctx.makeAtomicWait(pos, type, mem.getPtr(), *arg);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeAtomicNotify(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeAtomicNotify(Ctx& ctx, Index pos) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, 4);
@@ -1096,14 +1004,12 @@ Result<typename Ctx::InstrT> makeAtomicNotify(Ctx& ctx, Index pos) {
   return ctx.makeAtomicNotify(pos, mem.getPtr(), *arg);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeAtomicFence(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeAtomicFence(Ctx& ctx, Index pos) {
   return ctx.makeAtomicFence(pos);
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDExtract(Ctx& ctx, Index pos, SIMDExtractOp op, size_t) {
+Result<> makeSIMDExtract(Ctx& ctx, Index pos, SIMDExtractOp op, size_t) {
   auto lane = ctx.in.takeU8();
   if (!lane) {
     return ctx.in.err("expected lane index");
@@ -1112,8 +1018,7 @@ makeSIMDExtract(Ctx& ctx, Index pos, SIMDExtractOp op, size_t) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDReplace(Ctx& ctx, Index pos, SIMDReplaceOp op, size_t lanes) {
+Result<> makeSIMDReplace(Ctx& ctx, Index pos, SIMDReplaceOp op, size_t lanes) {
   auto lane = ctx.in.takeU8();
   if (!lane) {
     return ctx.in.err("expected lane index");
@@ -1121,8 +1026,7 @@ makeSIMDReplace(Ctx& ctx, Index pos, SIMDReplaceOp op, size_t lanes) {
   return ctx.makeSIMDReplace(pos, op, *lane);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeSIMDShuffle(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeSIMDShuffle(Ctx& ctx, Index pos) {
   std::array<uint8_t, 16> lanes;
   for (int i = 0; i < 16; ++i) {
     auto lane = ctx.in.takeU8();
@@ -1135,20 +1039,17 @@ Result<typename Ctx::InstrT> makeSIMDShuffle(Ctx& ctx, Index pos) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDTernary(Ctx& ctx, Index pos, SIMDTernaryOp op) {
+Result<> makeSIMDTernary(Ctx& ctx, Index pos, SIMDTernaryOp op) {
   return ctx.makeSIMDTernary(pos, op);
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDShift(Ctx& ctx, Index pos, SIMDShiftOp op) {
+Result<> makeSIMDShift(Ctx& ctx, Index pos, SIMDShiftOp op) {
   return ctx.makeSIMDShift(pos, op);
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeSIMDLoad(Ctx& ctx, Index pos, SIMDLoadOp op, int bytes) {
+Result<> makeSIMDLoad(Ctx& ctx, Index pos, SIMDLoadOp op, int bytes) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
@@ -1157,11 +1058,11 @@ makeSIMDLoad(Ctx& ctx, Index pos, SIMDLoadOp op, int bytes) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
+Result<>
 makeSIMDLoadStoreLane(Ctx& ctx, Index pos, SIMDLoadStoreLaneOp op, int bytes) {
   auto reset = ctx.in.getPos();
 
-  auto retry = [&]() -> Result<typename Ctx::InstrT> {
+  auto retry = [&]() -> Result<> {
     // We failed to parse. Maybe the lane index was accidentally parsed as the
     // optional memory index. Try again without parsing a memory index.
     WithPosition with(ctx, reset);
@@ -1187,11 +1088,10 @@ makeSIMDLoadStoreLane(Ctx& ctx, Index pos, SIMDLoadStoreLaneOp op, int bytes) {
   return ctx.makeSIMDLoadStoreLane(pos, op, mem.getPtr(), *arg, *lane);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeMemoryInit(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeMemoryInit(Ctx& ctx, Index pos) {
   auto reset = ctx.in.getPos();
 
-  auto retry = [&]() -> Result<typename Ctx::InstrT> {
+  auto retry = [&]() -> Result<> {
     // We failed to parse. Maybe the data index was accidentally parsed as the
     // optional memory index. Try again without parsing a memory index.
     WithPosition with(ctx, reset);
@@ -1211,15 +1111,13 @@ Result<typename Ctx::InstrT> makeMemoryInit(Ctx& ctx, Index pos) {
   return ctx.makeMemoryInit(pos, mem.getPtr(), *data);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeDataDrop(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeDataDrop(Ctx& ctx, Index pos) {
   auto data = dataidx(ctx);
   CHECK_ERR(data);
   return ctx.makeDataDrop(pos, *data);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeMemoryCopy(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeMemoryCopy(Ctx& ctx, Index pos) {
   auto destMem = maybeMemidx(ctx);
   CHECK_ERR(destMem);
   std::optional<typename Ctx::MemoryIdxT> srcMem = std::nullopt;
@@ -1231,175 +1129,144 @@ Result<typename Ctx::InstrT> makeMemoryCopy(Ctx& ctx, Index pos) {
   return ctx.makeMemoryCopy(pos, destMem.getPtr(), srcMem ? &*srcMem : nullptr);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeMemoryFill(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeMemoryFill(Ctx& ctx, Index pos) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   return ctx.makeMemoryFill(pos, mem.getPtr());
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makePop(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makePop(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeIf(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeIf(Ctx& ctx, Index pos) {
+Result<> makeMaybeBlock(Ctx& ctx, Index pos, size_t i, Type type) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeLoop(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeCall(Ctx& ctx, Index pos, bool isReturn) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeMaybeBlock(Ctx& ctx, Index pos, size_t i, Type type) {
+Result<> makeCallIndirect(Ctx& ctx, Index pos, bool isReturn) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeLoop(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeBreak(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeCall(Ctx& ctx, Index pos, bool isReturn) {
+template<typename Ctx> Result<> makeBreakTable(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeCallIndirect(Ctx& ctx, Index pos, bool isReturn) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBreak(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBreakTable(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeReturn(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeReturn(Ctx& ctx, Index pos) {
   return ctx.makeReturn(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefNull(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeRefNull(Ctx& ctx, Index pos) {
   auto t = heaptype(ctx);
   CHECK_ERR(t);
   return ctx.makeRefNull(pos, *t);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefIsNull(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeRefIsNull(Ctx& ctx, Index pos) {
   return ctx.makeRefIsNull(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefFunc(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeRefFunc(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefEq(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeRefEq(Ctx& ctx, Index pos) {
   return ctx.makeRefEq(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTableGet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeTableGet(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTableSet(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTableSize(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTableGrow(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTableFill(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTry(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeTableSet(Ctx& ctx, Index pos) {
+Result<> makeTryOrCatchBody(Ctx& ctx, Index pos, Type type, bool isTry) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeThrow(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeRethrow(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTupleMake(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTupleExtract(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeTableSize(Ctx& ctx, Index pos) {
+Result<> makeCallRef(Ctx& ctx, Index pos, bool isReturn) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTableGrow(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTableFill(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTry(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeTryOrCatchBody(Ctx& ctx, Index pos, Type type, bool isTry) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeThrow(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRethrow(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTupleMake(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeTupleExtract(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeCallRef(Ctx& ctx, Index pos, bool isReturn) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefI31(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeRefI31(Ctx& ctx, Index pos) {
   return ctx.makeRefI31(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeI31Get(Ctx& ctx, Index pos, bool signed_) {
+template<typename Ctx> Result<> makeI31Get(Ctx& ctx, Index pos, bool signed_) {
   return ctx.makeI31Get(pos, signed_);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefTest(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeRefTest(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeRefCast(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeBrOnNull(Ctx& ctx, Index pos, bool onFail) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeBrOnCast(Ctx& ctx, Index pos, bool onFail) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefCast(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBrOnNull(Ctx& ctx, Index pos, bool onFail) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeBrOnCast(Ctx& ctx, Index pos, bool onFail) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStructNew(Ctx& ctx, Index pos, bool default_) {
+Result<> makeStructNew(Ctx& ctx, Index pos, bool default_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   if (default_) {
@@ -1409,7 +1276,7 @@ Result<typename Ctx::InstrT> makeStructNew(Ctx& ctx, Index pos, bool default_) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeStructGet(Ctx& ctx, Index pos, bool signed_) {
+Result<> makeStructGet(Ctx& ctx, Index pos, bool signed_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto field = fieldidx(ctx, *type);
@@ -1417,8 +1284,7 @@ Result<typename Ctx::InstrT> makeStructGet(Ctx& ctx, Index pos, bool signed_) {
   return ctx.makeStructGet(pos, *type, *field, signed_);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStructSet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeStructSet(Ctx& ctx, Index pos) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto field = fieldidx(ctx, *type);
@@ -1427,7 +1293,7 @@ Result<typename Ctx::InstrT> makeStructSet(Ctx& ctx, Index pos) {
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNew(Ctx& ctx, Index pos, bool default_) {
+Result<> makeArrayNew(Ctx& ctx, Index pos, bool default_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   if (default_) {
@@ -1436,8 +1302,7 @@ Result<typename Ctx::InstrT> makeArrayNew(Ctx& ctx, Index pos, bool default_) {
   return ctx.makeArrayNew(pos, *type);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNewData(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayNewData(Ctx& ctx, Index pos) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto data = dataidx(ctx);
@@ -1445,8 +1310,7 @@ Result<typename Ctx::InstrT> makeArrayNewData(Ctx& ctx, Index pos) {
   return ctx.makeArrayNewData(pos, *type, *data);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNewElem(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayNewElem(Ctx& ctx, Index pos) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto data = dataidx(ctx);
@@ -1454,32 +1318,28 @@ Result<typename Ctx::InstrT> makeArrayNewElem(Ctx& ctx, Index pos) {
   return ctx.makeArrayNewElem(pos, *type, *data);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayNewFixed(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayNewFixed(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayGet(Ctx& ctx, Index pos, bool signed_) {
+Result<> makeArrayGet(Ctx& ctx, Index pos, bool signed_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   return ctx.makeArrayGet(pos, *type, signed_);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArraySet(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArraySet(Ctx& ctx, Index pos) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   return ctx.makeArraySet(pos, *type);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayLen(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayLen(Ctx& ctx, Index pos) {
   return ctx.makeArrayLen(pos);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayCopy(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayCopy(Ctx& ctx, Index pos) {
   auto destType = typeidx(ctx);
   CHECK_ERR(destType);
   auto srcType = typeidx(ctx);
@@ -1487,95 +1347,80 @@ Result<typename Ctx::InstrT> makeArrayCopy(Ctx& ctx, Index pos) {
   return ctx.makeArrayCopy(pos, *destType, *srcType);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayFill(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayFill(Ctx& ctx, Index pos) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   return ctx.makeArrayFill(pos, *type);
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayInitData(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeArrayInitData(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeArrayInitElem(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeRefAs(Ctx& ctx, Index pos, RefAsOp op) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeArrayInitElem(Ctx& ctx, Index pos) {
+Result<> makeStringNew(Ctx& ctx, Index pos, StringNewOp op, bool try_) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeStringConst(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeRefAs(Ctx& ctx, Index pos, RefAsOp op) {
+Result<> makeStringMeasure(Ctx& ctx, Index pos, StringMeasureOp op) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringNew(Ctx& ctx, Index pos, StringNewOp op, bool try_) {
+Result<> makeStringEncode(Ctx& ctx, Index pos, StringEncodeOp op) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeStringConcat(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringConst(Ctx& ctx, Index pos) {
+Result<> makeStringEq(Ctx& ctx, Index pos, StringEqOp op) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringMeasure(Ctx& ctx, Index pos, StringMeasureOp op) {
+Result<> makeStringAs(Ctx& ctx, Index pos, StringAsOp op) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeStringWTF8Advance(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeStringWTF16Get(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeStringIterNext(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringEncode(Ctx& ctx, Index pos, StringEncodeOp op) {
+Result<> makeStringIterMove(Ctx& ctx, Index pos, StringIterMoveOp op) {
   return ctx.in.err("unimplemented instruction");
 }
 
 template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringConcat(Ctx& ctx, Index pos) {
+Result<> makeStringSliceWTF(Ctx& ctx, Index pos, StringSliceWTFOp op) {
   return ctx.in.err("unimplemented instruction");
 }
 
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringEq(Ctx& ctx, Index pos, StringEqOp op) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringAs(Ctx& ctx, Index pos, StringAsOp op) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringWTF8Advance(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringWTF16Get(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringIterNext(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringIterMove(Ctx& ctx, Index pos, StringIterMoveOp op) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT>
-makeStringSliceWTF(Ctx& ctx, Index pos, StringSliceWTFOp op) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<typename Ctx::InstrT> makeStringSliceIter(Ctx& ctx, Index pos) {
+template<typename Ctx> Result<> makeStringSliceIter(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 
@@ -1905,13 +1750,7 @@ template<typename Ctx> MaybeResult<> func(Ctx& ctx) {
       CHECK_ERR(l);
       localVars = *l;
     }
-  }
-
-  std::optional<typename Ctx::InstrsT> insts;
-  if (!import) {
-    auto i = instrs(ctx);
-    CHECK_ERR(i);
-    insts = *i;
+    CHECK_ERR(instrs(ctx));
   }
 
   if (!ctx.in.takeRParen()) {
@@ -1919,7 +1758,7 @@ template<typename Ctx> MaybeResult<> func(Ctx& ctx) {
   }
 
   CHECK_ERR(
-    ctx.addFunc(name, *exports, import.getPtr(), *type, localVars, insts, pos));
+    ctx.addFunc(name, *exports, import.getPtr(), *type, localVars, pos));
   return Ok{};
 }
 
@@ -2050,9 +1889,8 @@ template<typename Ctx> MaybeResult<> data(Ctx& ctx) {
     }
     offset = *e;
   } else if (ctx.in.takeLParen()) {
-    auto inst = instr(ctx);
-    CHECK_ERR(inst);
-    auto offsetExpr = ctx.instrToExpr(*inst);
+    CHECK_ERR(instr(ctx));
+    auto offsetExpr = ctx.makeExpr();
     CHECK_ERR(offsetExpr);
     offset = *offsetExpr;
     if (!ctx.in.takeRParen()) {


### PR DESCRIPTION
The new wat parser previously returned InstrT types when parsing individual
instructions and collected InstrsT types when parsing sequences of instructions.
However, instructions were always actually tracked in the internal state of the
parsing context, so these types never held any interesting or necessary data.
Simplify the parser by removing these types and leaning into the pattern that
the parser context will keep track of parsed instructions.

This allows for a much cleaner separation between the `instrs` and
`foldedinstrs` parser functions.