### PR TITLE
Support function contexts in IRBuilder

### DIFF
--- a/src/parser/context-defs.cpp
+++ b/src/parser/context-defs.cpp
@@ -57,9 +57,6 @@ Result<> ParseDefsCtx::addFunc(Name,
                                std::optional<LocalsT>,
                                Index pos) {
   CHECK_ERR(withLoc(pos, irBuilder.visitEnd()));
-  auto body = irBuilder.build();
-  CHECK_ERR(withLoc(pos, body));
-  wasm.functions[index]->body = *body;
   return Ok{};
 }
 

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -816,9 +816,10 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
 
   IRBuilder irBuilder;
 
-  void setFunction(Function* func) {
+  Result<> visitFunctionStart(Function* func) {
     this->func = func;
-    irBuilder.setFunction(func);
+    CHECK_ERR(irBuilder.visitFunctionStart(func));
+    return Ok{};
   }
 
   ParseDefsCtx(std::string_view in,

--- a/src/parser/wat-parser.cpp
+++ b/src/parser/wat-parser.cpp
@@ -157,8 +157,7 @@ Result<> parseModule(Module& wasm, std::string_view input) {
 
     for (Index i = 0; i < decls.funcDefs.size(); ++i) {
       ctx.index = i;
-      ctx.setFunction(wasm.functions[i].get());
-      CHECK_ERR(ctx.irBuilder.makeBlock(Name{}, ctx.func->getResults()));
+      CHECK_ERR(ctx.visitFunctionStart(wasm.functions[i].get()));
       WithPosition with(ctx, decls.funcDefs[i].pos);
       auto parsed = func(ctx);
       CHECK_ERR(parsed);

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -7,27 +7,25 @@
 
  ;; CHECK:      (type $void (sub (func)))
 
+ ;; CHECK:      (type $1 (func (result i32)))
+
  ;; CHECK:      (type $ret2 (func (result i32 i32)))
  (type $ret2 (func (result i32 i32)))
 
  (rec
-  ;; CHECK:      (type $2 (func (result i32)))
-
   ;; CHECK:      (type $pair (struct (field (mut i32)) (field (mut i64))))
+
+  ;; CHECK:      (type $4 (func (param i32 i64)))
 
   ;; CHECK:      (type $a1 (array i64))
 
-  ;; CHECK:      (type $5 (func (param i32 i64)))
-
   ;; CHECK:      (type $a2 (array (mut f32)))
 
-  ;; CHECK:      (type $7 (func (result i32 i64)))
+  ;; CHECK:      (type $7 (func (param i32)))
 
-  ;; CHECK:      (type $8 (func (param i32)))
+  ;; CHECK:      (type $8 (func (param i32 i32 i32)))
 
-  ;; CHECK:      (type $9 (func (param i32 i32 i32)))
-
-  ;; CHECK:      (type $10 (func (param v128 i32) (result v128)))
+  ;; CHECK:      (type $9 (func (param v128 i32) (result v128)))
 
   ;; CHECK:      (type $packed-i8 (array (mut i8)))
 
@@ -35,29 +33,31 @@
 
   ;; CHECK:      (type $many (sub (func (param i32 i64 f32 f64) (result anyref (ref func)))))
 
-  ;; CHECK:      (type $14 (func (param i32 i32)))
+  ;; CHECK:      (type $13 (func (param i32 i32)))
 
-  ;; CHECK:      (type $15 (func (param i32 i32 f64 f64)))
+  ;; CHECK:      (type $14 (func (param i32 i32 f64 f64)))
 
-  ;; CHECK:      (type $16 (func (param i64)))
+  ;; CHECK:      (type $15 (func (param i64)))
 
-  ;; CHECK:      (type $17 (func (param v128) (result i32)))
+  ;; CHECK:      (type $16 (func (param v128) (result i32)))
 
-  ;; CHECK:      (type $18 (func (param v128 v128) (result v128)))
+  ;; CHECK:      (type $17 (func (param v128 v128) (result v128)))
 
-  ;; CHECK:      (type $19 (func (param v128 v128 v128) (result v128)))
+  ;; CHECK:      (type $18 (func (param v128 v128 v128) (result v128)))
 
-  ;; CHECK:      (type $20 (func (param i32 i64 v128)))
+  ;; CHECK:      (type $19 (func (param i32 i64 v128)))
 
-  ;; CHECK:      (type $21 (func (param i32 i32 i64 i64)))
+  ;; CHECK:      (type $20 (func (param i32 i32 i64 i64)))
 
-  ;; CHECK:      (type $22 (func (param i32) (result i32)))
+  ;; CHECK:      (type $21 (func (param i32) (result i32)))
 
-  ;; CHECK:      (type $23 (func (param i32 i64) (result i32 i64)))
+  ;; CHECK:      (type $22 (func (param i32 i64) (result i32 i64)))
 
-  ;; CHECK:      (type $24 (func (param i64) (result i32 i64)))
+  ;; CHECK:      (type $23 (func (param i64) (result i32 i64)))
 
-  ;; CHECK:      (type $25 (func (param i32) (result i32 i64)))
+  ;; CHECK:      (type $24 (func (param i32) (result i32 i64)))
+
+  ;; CHECK:      (type $25 (func (result i32 i64)))
 
   ;; CHECK:      (type $26 (func (param anyref) (result i32)))
 
@@ -225,15 +225,18 @@
  ;; CHECK:      (export "f5.1" (func $fimport$1))
 
  ;; CHECK:      (func $0 (type $void)
+ ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
 
- ;; CHECK:      (func $f1 (type $8) (param $0 i32)
+ ;; CHECK:      (func $f1 (type $7) (param $0 i32)
+ ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $f1 (param i32))
- ;; CHECK:      (func $f2 (type $8) (param $x i32)
+ ;; CHECK:      (func $f2 (type $7) (param $x i32)
+ ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $f2 (param $x i32))
- ;; CHECK:      (func $f3 (type $2) (result i32)
+ ;; CHECK:      (func $f3 (type $1) (result i32)
  ;; CHECK-NEXT:  (i32.const 0)
  ;; CHECK-NEXT: )
  (func $f3 (result i32)
@@ -243,6 +246,7 @@
  ;; CHECK-NEXT:  (local $0 i32)
  ;; CHECK-NEXT:  (local $1 i64)
  ;; CHECK-NEXT:  (local $l f32)
+ ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $f4 (type 17) (local i32 i64) (local $l f32))
  (func (export "f5.0") (export "f5.1") (import "mod" "f5"))
@@ -307,7 +311,7 @@
   nop
  )
 
- ;; CHECK:      (func $add (type $2) (result i32)
+ ;; CHECK:      (func $add (type $1) (result i32)
  ;; CHECK-NEXT:  (i32.add
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (i32.const 2)
@@ -319,7 +323,7 @@
   i32.add
  )
 
- ;; CHECK:      (func $add-folded (type $2) (result i32)
+ ;; CHECK:      (func $add-folded (type $1) (result i32)
  ;; CHECK-NEXT:  (i32.add
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (i32.const 2)
@@ -332,7 +336,7 @@
   )
  )
 
- ;; CHECK:      (func $add-stacky (type $2) (result i32)
+ ;; CHECK:      (func $add-stacky (type $1) (result i32)
  ;; CHECK-NEXT:  (local $scratch i32)
  ;; CHECK-NEXT:  (i32.add
  ;; CHECK-NEXT:   (block (result i32)
@@ -352,7 +356,7 @@
   i32.add
  )
 
- ;; CHECK:      (func $add-stacky-2 (type $2) (result i32)
+ ;; CHECK:      (func $add-stacky-2 (type $1) (result i32)
  ;; CHECK-NEXT:  (local $scratch i32)
  ;; CHECK-NEXT:  (i32.add
  ;; CHECK-NEXT:   (i32.const 1)
@@ -372,7 +376,7 @@
   i32.add
  )
 
- ;; CHECK:      (func $add-stacky-3 (type $2) (result i32)
+ ;; CHECK:      (func $add-stacky-3 (type $1) (result i32)
  ;; CHECK-NEXT:  (local $scratch i32)
  ;; CHECK-NEXT:  (local.set $scratch
  ;; CHECK-NEXT:   (i32.add
@@ -390,7 +394,7 @@
   nop
  )
 
- ;; CHECK:      (func $add-stacky-4 (type $2) (result i32)
+ ;; CHECK:      (func $add-stacky-4 (type $1) (result i32)
  ;; CHECK-NEXT:  (local $scratch i32)
  ;; CHECK-NEXT:  (local $scratch_1 i32)
  ;; CHECK-NEXT:  (local $scratch_2 i32)
@@ -424,7 +428,7 @@
   nop
  )
 
- ;; CHECK:      (func $add-unreachable (type $2) (result i32)
+ ;; CHECK:      (func $add-unreachable (type $1) (result i32)
  ;; CHECK-NEXT:  (i32.add
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:   (i32.const 1)
@@ -436,7 +440,7 @@
   i32.add
  )
 
- ;; CHECK:      (func $add-unreachable-2 (type $2) (result i32)
+ ;; CHECK:      (func $add-unreachable-2 (type $1) (result i32)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:  )
@@ -451,7 +455,7 @@
   i32.add
  )
 
- ;; CHECK:      (func $add-unreachable-3 (type $2) (result i32)
+ ;; CHECK:      (func $add-unreachable-3 (type $1) (result i32)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:  )
@@ -672,7 +676,7 @@
   drop
  )
 
- ;; CHECK:      (func $locals (type $14) (param $0 i32) (param $x i32)
+ ;; CHECK:      (func $locals (type $13) (param $0 i32) (param $x i32)
  ;; CHECK-NEXT:  (local $2 i32)
  ;; CHECK-NEXT:  (local $y i32)
  ;; CHECK-NEXT:  (drop
@@ -813,21 +817,19 @@
 
  ;; CHECK:      (func $multivalue-nested (type $ret2) (result i32 i32)
  ;; CHECK-NEXT:  (local $scratch (i32 i32))
- ;; CHECK-NEXT:  (block (result i32 i32)
- ;; CHECK-NEXT:   (nop)
- ;; CHECK-NEXT:   (local.set $scratch
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (local.set $scratch
+ ;; CHECK-NEXT:   (block (result i32 i32)
  ;; CHECK-NEXT:    (block (result i32 i32)
- ;; CHECK-NEXT:     (block (result i32 i32)
- ;; CHECK-NEXT:      (tuple.make
- ;; CHECK-NEXT:       (i32.const 0)
- ;; CHECK-NEXT:       (i32.const 1)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     (tuple.make
+ ;; CHECK-NEXT:      (i32.const 0)
+ ;; CHECK-NEXT:      (i32.const 1)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (nop)
- ;; CHECK-NEXT:   (local.get $scratch)
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT:  (local.get $scratch)
  ;; CHECK-NEXT: )
  (func $multivalue-nested (type $ret2)
   block (type $ret2)
@@ -973,7 +975,7 @@
   end
  )
 
- ;; CHECK:      (func $if-else-result (type $2) (result i32)
+ ;; CHECK:      (func $if-else-result (type $1) (result i32)
  ;; CHECK-NEXT:  (if (result i32)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 1)
@@ -989,7 +991,7 @@
   end
  )
 
- ;; CHECK:      (func $if-else-labeled-result (type $2) (result i32)
+ ;; CHECK:      (func $if-else-labeled-result (type $1) (result i32)
  ;; CHECK-NEXT:  (block $l (result i32)
  ;; CHECK-NEXT:   (if (result i32)
  ;; CHECK-NEXT:    (i32.const 0)
@@ -1135,7 +1137,7 @@
   )
  )
 
- ;; CHECK:      (func $if-else-folded-result (type $2) (result i32)
+ ;; CHECK:      (func $if-else-folded-result (type $1) (result i32)
  ;; CHECK-NEXT:  (if (result i32)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 1)
@@ -1154,7 +1156,7 @@
   )
  )
 
- ;; CHECK:      (func $if-else-folded-labeled-result (type $2) (result i32)
+ ;; CHECK:      (func $if-else-folded-labeled-result (type $1) (result i32)
  ;; CHECK-NEXT:  (block $l (result i32)
  ;; CHECK-NEXT:   (if (result i32)
  ;; CHECK-NEXT:    (i32.const 0)
@@ -1320,7 +1322,7 @@
   end $l
  )
 
- ;; CHECK:      (func $loop-result (type $2) (result i32)
+ ;; CHECK:      (func $loop-result (type $1) (result i32)
  ;; CHECK-NEXT:  (loop (result i32)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
@@ -1331,7 +1333,7 @@
   end
  )
 
- ;; CHECK:      (func $loop-labeled-result (type $2) (result i32)
+ ;; CHECK:      (func $loop-labeled-result (type $1) (result i32)
  ;; CHECK-NEXT:  (loop $l (result i32)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
@@ -1401,7 +1403,7 @@
   )
  )
 
- ;; CHECK:      (func $loop-folded-result (type $2) (result i32)
+ ;; CHECK:      (func $loop-folded-result (type $1) (result i32)
  ;; CHECK-NEXT:  (loop (result i32)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
@@ -1412,7 +1414,7 @@
   )
  )
 
- ;; CHECK:      (func $loop-folded-labeled-result (type $2) (result i32)
+ ;; CHECK:      (func $loop-folded-labeled-result (type $1) (result i32)
  ;; CHECK-NEXT:  (loop $l (result i32)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
@@ -1423,7 +1425,7 @@
   )
  )
 
- ;; CHECK:      (func $binary (type $15) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 f64)
+ ;; CHECK:      (func $binary (type $14) (param $0 i32) (param $1 i32) (param $2 f64) (param $3 f64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.add
  ;; CHECK-NEXT:    (local.get $0)
@@ -1448,7 +1450,7 @@
   drop
  )
 
- ;; CHECK:      (func $unary (type $16) (param $0 i64)
+ ;; CHECK:      (func $unary (type $15) (param $0 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i64.eqz
  ;; CHECK-NEXT:    (local.get $0)
@@ -1461,7 +1463,7 @@
   drop
  )
 
- ;; CHECK:      (func $select (type $9) (param $0 i32) (param $1 i32) (param $2 i32)
+ ;; CHECK:      (func $select (type $8) (param $0 i32) (param $1 i32) (param $2 i32)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (select
  ;; CHECK-NEXT:    (local.get $0)
@@ -1534,7 +1536,7 @@
   drop
  )
 
- ;; CHECK:      (func $memory-grow (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $memory-grow (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (memory.grow $mem
  ;; CHECK-NEXT:    (local.get $0)
@@ -1573,7 +1575,7 @@
   global.set 4
  )
 
- ;; CHECK:      (func $load (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $load (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.load $mem offset=42
  ;; CHECK-NEXT:    (local.get $0)
@@ -1602,7 +1604,7 @@
   drop
  )
 
- ;; CHECK:      (func $store (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $store (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (i32.store $mem offset=42 align=1
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (i32.const 0)
@@ -1628,7 +1630,7 @@
   f32.store $mem-i64
  )
 
- ;; CHECK:      (func $atomic-rmw (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $atomic-rmw (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.atomic.rmw16.add_u $mem
  ;; CHECK-NEXT:    (local.get $0)
@@ -1653,7 +1655,7 @@
   drop
  )
 
- ;; CHECK:      (func $atomic-cmpxchg (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $atomic-cmpxchg (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.atomic.rmw8.cmpxchg_u $mem
  ;; CHECK-NEXT:    (local.get $0)
@@ -1682,7 +1684,7 @@
   drop
  )
 
- ;; CHECK:      (func $atomic-wait (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $atomic-wait (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (memory.atomic.wait32 $mem
  ;; CHECK-NEXT:    (local.get $0)
@@ -1711,7 +1713,7 @@
   drop
  )
 
- ;; CHECK:      (func $atomic-notify (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $atomic-notify (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (memory.atomic.notify $mem offset=8
  ;; CHECK-NEXT:    (local.get $0)
@@ -1743,7 +1745,7 @@
   atomic.fence
  )
 
- ;; CHECK:      (func $simd-extract (type $17) (param $0 v128) (result i32)
+ ;; CHECK:      (func $simd-extract (type $16) (param $0 v128) (result i32)
  ;; CHECK-NEXT:  (i32x4.extract_lane 3
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -1753,7 +1755,7 @@
   i32x4.extract_lane 3
  )
 
- ;; CHECK:      (func $simd-replace (type $10) (param $0 v128) (param $1 i32) (result v128)
+ ;; CHECK:      (func $simd-replace (type $9) (param $0 v128) (param $1 i32) (result v128)
  ;; CHECK-NEXT:  (i32x4.replace_lane 2
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -1765,7 +1767,7 @@
   i32x4.replace_lane 2
  )
 
- ;; CHECK:      (func $simd-shuffle (type $18) (param $0 v128) (param $1 v128) (result v128)
+ ;; CHECK:      (func $simd-shuffle (type $17) (param $0 v128) (param $1 v128) (result v128)
  ;; CHECK-NEXT:  (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -1777,7 +1779,7 @@
   i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
  )
 
- ;; CHECK:      (func $simd-ternary (type $19) (param $0 v128) (param $1 v128) (param $2 v128) (result v128)
+ ;; CHECK:      (func $simd-ternary (type $18) (param $0 v128) (param $1 v128) (param $2 v128) (result v128)
  ;; CHECK-NEXT:  (v128.bitselect
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -1791,7 +1793,7 @@
   v128.bitselect
  )
 
- ;; CHECK:      (func $simd-shift (type $10) (param $0 v128) (param $1 i32) (result v128)
+ ;; CHECK:      (func $simd-shift (type $9) (param $0 v128) (param $1 i32) (result v128)
  ;; CHECK-NEXT:  (i8x16.shl
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -1803,7 +1805,7 @@
   i8x16.shl
  )
 
- ;; CHECK:      (func $simd-load (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $simd-load (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (v128.load8x8_s $mem offset=8
  ;; CHECK-NEXT:    (local.get $0)
@@ -1824,7 +1826,7 @@
   drop
  )
 
- ;; CHECK:      (func $simd-load-store-lane (type $20) (param $0 i32) (param $1 i64) (param $2 v128)
+ ;; CHECK:      (func $simd-load-store-lane (type $19) (param $0 i32) (param $1 i64) (param $2 v128)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (v128.load16_lane $mem 7
  ;; CHECK-NEXT:    (local.get $0)
@@ -1846,7 +1848,7 @@
   v128.store64_lane 3 align=4 0
  )
 
- ;; CHECK:      (func $memory-init (type $9) (param $0 i32) (param $1 i32) (param $2 i32)
+ ;; CHECK:      (func $memory-init (type $8) (param $0 i32) (param $1 i32) (param $2 i32)
  ;; CHECK-NEXT:  (memory.init $mem-i32 $passive
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -1887,7 +1889,7 @@
   data.drop $passive
  )
 
- ;; CHECK:      (func $memory-copy (type $21) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i64)
+ ;; CHECK:      (func $memory-copy (type $20) (param $0 i32) (param $1 i32) (param $2 i64) (param $3 i64)
  ;; CHECK-NEXT:  (memory.copy $mem $mem
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -1919,7 +1921,7 @@
   memory.copy $mem-i64 3
  )
 
- ;; CHECK:      (func $memory-fill (type $5) (param $0 i32) (param $1 i64)
+ ;; CHECK:      (func $memory-fill (type $4) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (memory.fill $mem
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (i32.const 1)
@@ -1958,7 +1960,7 @@
   return
  )
 
- ;; CHECK:      (func $return-one (type $22) (param $0 i32) (result i32)
+ ;; CHECK:      (func $return-one (type $21) (param $0 i32) (result i32)
  ;; CHECK-NEXT:  (return
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -1968,7 +1970,7 @@
   return
  )
 
- ;; CHECK:      (func $return-two (type $23) (param $0 i32) (param $1 i64) (result i32 i64)
+ ;; CHECK:      (func $return-two (type $22) (param $0 i32) (param $1 i64) (result i32 i64)
  ;; CHECK-NEXT:  (return
  ;; CHECK-NEXT:   (tuple.make
  ;; CHECK-NEXT:    (local.get $0)
@@ -1982,7 +1984,7 @@
   return
  )
 
- ;; CHECK:      (func $return-two-first-unreachable (type $24) (param $0 i64) (result i32 i64)
+ ;; CHECK:      (func $return-two-first-unreachable (type $23) (param $0 i64) (result i32 i64)
  ;; CHECK-NEXT:  (return
  ;; CHECK-NEXT:   (tuple.make
  ;; CHECK-NEXT:    (unreachable)
@@ -1996,7 +1998,7 @@
   return
  )
 
- ;; CHECK:      (func $return-two-second-unreachable (type $25) (param $0 i32) (result i32 i64)
+ ;; CHECK:      (func $return-two-second-unreachable (type $24) (param $0 i32) (result i32 i64)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -2258,6 +2260,7 @@
  )
 
  ;; CHECK:      (func $use-types (type $59) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany))
+ ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $use-types
   (param (ref $s0))


### PR DESCRIPTION
Add a `visitFunctionStart` function to IRBuilder and make it responsible for
setting the function's body when the context is closed. This will simplify
outlining, will be necessary to support branches to function scope properly, and
removes an extra block around function bodies in the new wat parser.