### PR TITLE
NameTypes and TypeSSA : Prefer _ over $ in names, and lint away _N suffixes

### DIFF
--- a/src/passes/NameTypes.cpp
+++ b/src/passes/NameTypes.cpp
@@ -50,7 +50,7 @@ struct NameTypes : public Pass {
     // "Lint" the names a little. In particular a name with a "_7" or such
     // suffix, as TypeSSA creates, can be removed if it does not cause a
     // collision. This keeps the names unique while removing 'noise.'
-    for (auto& [type, names] : module->typeNames) {
+    for (auto& [_, names] : module->typeNames) {
       std::string name = names.name.toString();
       while (name.size() > 1 && isdigit(name.back())) {
         name.pop_back();

--- a/src/passes/NameTypes.cpp
+++ b/src/passes/NameTypes.cpp
@@ -50,17 +50,20 @@ struct NameTypes : public Pass {
     // "Lint" the names a little. In particular a name with a "_7" or such
     // suffix, as TypeSSA creates, can be removed if it does not cause a
     // collision. This keeps the names unique while removing 'noise.'
-    for (auto& [_, names] : module->typeNames) {
+    //
+    // Note we must iterate in a deterministic order here, so do it on |types|.
+    for (auto& type : types) {
+      auto& names = module->typeNames[type];
       std::string name = names.name.toString();
       while (name.size() > 1 && isdigit(name.back())) {
         name.pop_back();
       }
       if (name.size() > 1 && name.back() == '_') {
         name.pop_back();
-      }
-      if (!used.count(name)) {
-        names.name = name;
-        used.insert(name);
+        if (!used.count(name)) {
+          names.name = name;
+          used.insert(name);
+        }
       }
     }
   }

--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -285,7 +285,7 @@ struct TypeSSA : public Pass {
 
       // If the old type has a nice name, make a nice name for the new one.
       if (typeNames.count(oldType)) {
-        auto intendedName = typeNames[oldType].name.toString() + '$' +
+        auto intendedName = typeNames[oldType].name.toString() + '_' +
                             std::to_string(++nameCounter);
         auto newName =
           Names::getValidNameGivenExisting(intendedName, existingTypeNames);

--- a/test/lit/passes/name-types.wast
+++ b/test/lit/passes/name-types.wast
@@ -6,7 +6,7 @@
  (type $obnoxious-super-long-type-name_____________________________1 (struct))
 
  ;; A reasonable name that will be kept.
- ;; CHECK:      (type $type (struct ))
+ ;; CHECK:      (type $type_1 (struct ))
 
  ;; CHECK:      (type $reasonable-name (struct (field i32)))
  (type $reasonable-name (struct (field i32)))
@@ -31,9 +31,9 @@
  ;; CHECK:      (type $onelintable-name_8 (struct (field i32) (field i32) (field i32) (field i32)))
  (type $onelintable-name_8 (struct (field i32) (field i32) (field i32) (field i32)))
 
- ;; CHECK:      (type $type_0 (func (param (ref $type) (ref $reasonable-name) (ref $lintable-name) (ref $unlintable-name_7) (ref $unlintable-name) (ref $onelintable-name) (ref $onelintable-name_8))))
+ ;; CHECK:      (type $type (func (param (ref $type_1) (ref $reasonable-name) (ref $lintable-name) (ref $unlintable-name_7) (ref $unlintable-name) (ref $onelintable-name) (ref $onelintable-name_8))))
 
- ;; CHECK:      (func $foo (type $type_0) (param $x (ref $type)) (param $y (ref $reasonable-name)) (param $z (ref $lintable-name)) (param $w (ref $unlintable-name_7)) (param $t (ref $unlintable-name)) (param $a (ref $onelintable-name)) (param $b (ref $onelintable-name_8))
+ ;; CHECK:      (func $foo (type $type) (param $x (ref $type_1)) (param $y (ref $reasonable-name)) (param $z (ref $lintable-name)) (param $w (ref $unlintable-name_7)) (param $t (ref $unlintable-name)) (param $a (ref $onelintable-name)) (param $b (ref $onelintable-name_8))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $foo

--- a/test/lit/passes/name-types.wast
+++ b/test/lit/passes/name-types.wast
@@ -6,19 +6,44 @@
  (type $obnoxious-super-long-type-name_____________________________1 (struct))
 
  ;; A reasonable name that will be kept.
- ;; CHECK:      (type $type$1 (struct ))
+ ;; CHECK:      (type $type (struct ))
 
  ;; CHECK:      (type $reasonable-name (struct (field i32)))
  (type $reasonable-name (struct (field i32)))
 
- ;; CHECK:      (type $type$0 (func (param (ref $type$1) (ref $reasonable-name))))
+ ;; lintable is a name that can be polished up a bit. We'll remove the _7. But
+ ;; unlintable cannot be shortened because a conflict would occur. onelintable
+ ;; allows one of the two longer names to be shortened, but the second would
+ ;; conflict.
+ (type $lintable-name_7 (struct (field i64)))
 
- ;; CHECK:      (func $foo (type $type$0) (param $x (ref $type$1)) (param $y (ref $reasonable-name))
+ ;; CHECK:      (type $lintable-name (struct (field i64)))
+
+ ;; CHECK:      (type $unlintable-name_7 (struct (field f32)))
+ (type $unlintable-name_7 (struct (field f32)))
+
+ ;; CHECK:      (type $unlintable-name (struct (field f64)))
+ (type $unlintable-name (struct (field f64)))
+
+ (type $onelintable-name_6 (struct (field i32) (field i32) (field i32)))
+ ;; CHECK:      (type $onelintable-name (struct (field i32) (field i32) (field i32)))
+
+ ;; CHECK:      (type $onelintable-name_8 (struct (field i32) (field i32) (field i32) (field i32)))
+ (type $onelintable-name_8 (struct (field i32) (field i32) (field i32) (field i32)))
+
+ ;; CHECK:      (type $type_0 (func (param (ref $type) (ref $reasonable-name) (ref $lintable-name) (ref $unlintable-name_7) (ref $unlintable-name) (ref $onelintable-name) (ref $onelintable-name_8))))
+
+ ;; CHECK:      (func $foo (type $type_0) (param $x (ref $type)) (param $y (ref $reasonable-name)) (param $z (ref $lintable-name)) (param $w (ref $unlintable-name_7)) (param $t (ref $unlintable-name)) (param $a (ref $onelintable-name)) (param $b (ref $onelintable-name_8))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $foo
   ;; Use the types to keep them alive.
   (param $x (ref $obnoxious-super-long-type-name_____________________________1))
   (param $y (ref $reasonable-name))
+  (param $z (ref $lintable-name_7))
+  (param $w (ref $unlintable-name_7))
+  (param $t (ref $unlintable-name))
+  (param $a (ref $onelintable-name_6))
+  (param $b (ref $onelintable-name_8))
  )
 )

--- a/test/lit/passes/type-ssa.wast
+++ b/test/lit/passes/type-ssa.wast
@@ -10,24 +10,24 @@
   ;; CHECK:      (type $1 (func))
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct$1 (sub $struct (struct (field i32))))
+  ;; CHECK-NEXT:  (type $struct_1 (sub $struct (struct (field i32))))
 
-  ;; CHECK:       (type $struct$2 (sub $struct (struct (field i32))))
+  ;; CHECK:       (type $struct_2 (sub $struct (struct (field i32))))
 
-  ;; CHECK:       (type $struct$3 (sub $struct (struct (field i32))))
+  ;; CHECK:       (type $struct_3 (sub $struct (struct (field i32))))
 
-  ;; CHECK:       (type $struct$4 (sub $struct (struct (field i32))))
+  ;; CHECK:       (type $struct_4 (sub $struct (struct (field i32))))
 
-  ;; CHECK:       (type $struct$5 (sub $struct (struct (field i32))))
+  ;; CHECK:       (type $struct_5 (sub $struct (struct (field i32))))
 
-  ;; CHECK:      (global $g (ref $struct) (struct.new $struct$4
+  ;; CHECK:      (global $g (ref $struct) (struct.new $struct_4
   ;; CHECK-NEXT:  (i32.const 42)
   ;; CHECK-NEXT: ))
   (global $g (ref $struct) (struct.new $struct
     (i32.const 42)
   ))
 
-  ;; CHECK:      (global $h (ref $struct) (struct.new $struct$5
+  ;; CHECK:      (global $h (ref $struct) (struct.new $struct_5
   ;; CHECK-NEXT:  (i32.const 42)
   ;; CHECK-NEXT: ))
   (global $h (ref $struct) (struct.new $struct
@@ -36,10 +36,10 @@
 
   ;; CHECK:      (func $foo (type $1)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new_default $struct$1)
+  ;; CHECK-NEXT:   (struct.new_default $struct_1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new $struct$2
+  ;; CHECK-NEXT:   (struct.new $struct_2
   ;; CHECK-NEXT:    (i32.const 10)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -57,7 +57,7 @@
 
   ;; CHECK:      (func $another-func (type $1)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new $struct$3
+  ;; CHECK-NEXT:   (struct.new $struct_3
   ;; CHECK-NEXT:    (i32.const 100)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -139,18 +139,18 @@
   (type $struct (sub (struct (field (ref null any)))))
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct$1 (sub $struct (struct (field anyref))))
+  ;; CHECK-NEXT:  (type $struct_1 (sub $struct (struct (field anyref))))
 
-  ;; CHECK:       (type $struct$2 (sub $struct (struct (field anyref))))
+  ;; CHECK:       (type $struct_2 (sub $struct (struct (field anyref))))
 
-  ;; CHECK:       (type $struct$3 (sub $struct (struct (field anyref))))
+  ;; CHECK:       (type $struct_3 (sub $struct (struct (field anyref))))
 
   ;; CHECK:      (func $foo (type $0) (param $any anyref) (param $array arrayref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new_default $struct$1)
+  ;; CHECK-NEXT:   (struct.new_default $struct_1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new $struct$2
+  ;; CHECK-NEXT:   (struct.new $struct_2
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -160,7 +160,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new $struct$3
+  ;; CHECK-NEXT:   (struct.new $struct_3
   ;; CHECK-NEXT:    (local.get $array)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -216,17 +216,17 @@
   (elem func $array.new)
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $array$1 (sub $array (array (mut anyref))))
+  ;; CHECK-NEXT:  (type $array_1 (sub $array (array (mut anyref))))
 
-  ;; CHECK:       (type $array$2 (sub $array (array (mut anyref))))
+  ;; CHECK:       (type $array_2 (sub $array (array (mut anyref))))
 
-  ;; CHECK:       (type $array$3 (sub $array (array (mut anyref))))
+  ;; CHECK:       (type $array_3 (sub $array (array (mut anyref))))
 
-  ;; CHECK:       (type $array-func$4 (sub $array-func (array (mut funcref))))
+  ;; CHECK:       (type $array-func_4 (sub $array-func (array (mut funcref))))
 
-  ;; CHECK:       (type $array$5 (sub $array (array (mut anyref))))
+  ;; CHECK:       (type $array_5 (sub $array (array (mut anyref))))
 
-  ;; CHECK:       (type $array$6 (sub $array (array (mut anyref))))
+  ;; CHECK:       (type $array_6 (sub $array (array (mut anyref))))
 
   ;; CHECK:      (type $9 (func))
 
@@ -234,18 +234,18 @@
 
   ;; CHECK:      (func $array.new (type $1) (param $refined (ref i31)) (param $null-any anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new_default $array$1
+  ;; CHECK-NEXT:   (array.new_default $array_1
   ;; CHECK-NEXT:    (i32.const 5)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new $array$2
+  ;; CHECK-NEXT:   (array.new $array_2
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:    (i32.const 5)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new $array$3
+  ;; CHECK-NEXT:   (array.new $array_3
   ;; CHECK-NEXT:    (local.get $refined)
   ;; CHECK-NEXT:    (i32.const 5)
   ;; CHECK-NEXT:   )
@@ -289,7 +289,7 @@
 
   ;; CHECK:      (func $array.new_seg (type $9)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new_elem $array-func$4 $0
+  ;; CHECK-NEXT:   (array.new_elem $array-func_4 $0
   ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:    (i32.const 3)
   ;; CHECK-NEXT:   )
@@ -308,12 +308,12 @@
 
   ;; CHECK:      (func $array.new_fixed (type $1) (param $refined (ref i31)) (param $null-any anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new_fixed $array$5 1
+  ;; CHECK-NEXT:   (array.new_fixed $array_5 1
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new_fixed $array$6 1
+  ;; CHECK-NEXT:   (array.new_fixed $array_6 1
   ;; CHECK-NEXT:    (local.get $refined)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -369,14 +369,14 @@
   ;; CHECK:      (type $empty (sub (struct )))
   (type $empty (sub (struct)))
 
-  ;; CHECK:      (type $empty$1 (sub $empty (struct )))
+  ;; CHECK:      (type $empty_1 (sub $empty (struct )))
 
   ;; CHECK:      (type $2 (func (param anyref)))
 
   ;; CHECK:      (type $struct (sub (struct (field externref) (field anyref) (field externref))))
   (type $struct (sub (struct externref anyref externref)))
 
-  ;; CHECK:      (global $g (mut anyref) (struct.new_default $empty$1))
+  ;; CHECK:      (global $g (mut anyref) (struct.new_default $empty_1))
   (global $g (mut anyref) (struct.new $empty))
 
   ;; CHECK:      (func $0 (type $2) (param $param anyref)
@@ -428,13 +428,13 @@
   ;; CHECK:      (type $2 (func (param (ref $subarray))))
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $array$1 (sub $array (array (mut f32))))
+  ;; CHECK-NEXT:  (type $array_1 (sub $array (array (mut f32))))
 
   ;; CHECK:       (type $4 (struct (field (mut i32)) (field (mut i32)) (field (mut f64)) (field (mut f64)) (field (mut i32)) (field (mut f64)) (field (mut f64)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32))))
 
   ;; CHECK:      (func $1 (type $2) (param $ref (ref $subarray))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (array.new_default $array$1
+  ;; CHECK-NEXT:   (array.new_default $array_1
   ;; CHECK-NEXT:    (i32.const 64)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -455,15 +455,15 @@
   ;; CHECK:      (type $A (sub (struct )))
   (type $A (sub (struct)))
 
-  ;; CHECK:      (type $A$1 (sub $A (struct )))
+  ;; CHECK:      (type $A_1 (sub $A (struct )))
 
   ;; CHECK:      (type $2 (func (result (ref $A))))
 
   ;; CHECK:      (func $0 (type $2) (result (ref $A))
-  ;; CHECK-NEXT:  (block $label (result (ref $A$1))
+  ;; CHECK-NEXT:  (block $label (result (ref $A_1))
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (br_on_cast $label (ref $A$1) (ref $A$1)
-  ;; CHECK-NEXT:     (struct.new_default $A$1)
+  ;; CHECK-NEXT:    (br_on_cast $label (ref $A_1) (ref $A_1)
+  ;; CHECK-NEXT:     (struct.new_default $A_1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (unreachable)

--- a/test/lit/passes/type-ssa_and_merging.wast
+++ b/test/lit/passes/type-ssa_and_merging.wast
@@ -22,9 +22,9 @@
   ;; NOP:      (type $2 (func (result i32)))
 
   ;; NOP:      (import "a" "b" (func $import (type $2) (result i32)))
-  ;; YES:       (type $A$2 (sub $A (struct )))
+  ;; YES:       (type $A_2 (sub $A (struct )))
 
-  ;; YES:       (type $A$1 (sub $A (struct )))
+  ;; YES:       (type $A_1 (sub $A (struct )))
 
   ;; YES:      (import "a" "b" (func $import (type $0) (result i32)))
   (import "a" "b" (func $import (result i32)))

--- a/test/lit/recursive-types.wast
+++ b/test/lit/recursive-types.wast
@@ -8,47 +8,47 @@
   (type (func (param (ref null 1)) (result (ref null 1))))
   (type (func (param (ref null 0)) (result (ref null 1))))
   (rec
-    ;; CHECK:      (type $type$0 (func (param (ref null $type$0)) (result (ref null $type$0))))
+    ;; CHECK:      (type $type (func (param (ref null $type)) (result (ref null $type))))
 
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $f3 (sub (func (param (ref null $type$2)) (result (ref null $f3)))))
+    ;; CHECK-NEXT:  (type $f3 (sub (func (param (ref null $type_2)) (result (ref null $f3)))))
     (type $f3 (sub (func (param (ref null 4)) (result (ref null 3)))))
     (type (sub $f3 (func (param (ref null 3)) (result (ref null 4)))))
   )
 
-  ;; CHECK:       (type $type$2 (sub $f3 (func (param (ref null $f3)) (result (ref null $type$2)))))
+  ;; CHECK:       (type $type_2 (sub $f3 (func (param (ref null $f3)) (result (ref null $type_2)))))
 
-  ;; CHECK:      (type $type$1 (func (param (ref null $type$0)) (result (ref null $type$0))))
+  ;; CHECK:      (type $type_1 (func (param (ref null $type)) (result (ref null $type))))
 
-  ;; CHECK:      (func $foo (type $type$0) (param $0 (ref null $type$0)) (result (ref null $type$0))
+  ;; CHECK:      (func $foo (type $type) (param $0 (ref null $type)) (result (ref null $type))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $foo (type 0)
     (unreachable)
   )
 
-  ;; CHECK:      (func $bar (type $type$0) (param $0 (ref null $type$0)) (result (ref null $type$0))
+  ;; CHECK:      (func $bar (type $type) (param $0 (ref null $type)) (result (ref null $type))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $bar (type 1)
     (unreachable)
   )
 
-  ;; CHECK:      (func $baz (type $type$1) (param $0 (ref null $type$0)) (result (ref null $type$0))
+  ;; CHECK:      (func $baz (type $type_1) (param $0 (ref null $type)) (result (ref null $type))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $baz (type 2)
     (unreachable)
   )
 
-  ;; CHECK:      (func $qux (type $f3) (param $0 (ref null $type$2)) (result (ref null $f3))
+  ;; CHECK:      (func $qux (type $f3) (param $0 (ref null $type_2)) (result (ref null $f3))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $qux (type 3)
     (unreachable)
   )
 
-  ;; CHECK:      (func $quux (type $type$2) (param $0 (ref null $f3)) (result (ref null $type$2))
+  ;; CHECK:      (func $quux (type $type_2) (param $0 (ref null $f3)) (result (ref null $type_2))
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   (func $quux (type 4)


### PR DESCRIPTION
Apparently `$N` (e.g. `FooClass$5`) is a convention in Java for anonymous classes, so our
`$N` that we use to disambiguate could be confusing. As the way we disambiguate does
not matter, switch to using `_N`. This PR does that in both `TypeSSA` and `NameTypes`.

Also make `NameTypes` "lint" names as it goes. That pass tries to give types nice names,
leaving existing ones that seem ok, and renaming long or unnamed ones. This PR makes
it aware of the `_N` notation and it tries to remove it, if removing it does not cause a
collision. An example of how that helps is if TypeSSA creates a subtype `$Foo_0` and then
we manage to remove `$Foo`, then we can use the shorter name for the subtype.