### PR TITLE
ConstantFieldPropagation: Fully handle copies

### DIFF
--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -119,7 +119,9 @@ struct FunctionStructValuesMap
 //   void noteDefault(Type fieldType, HeapType type, Index index, T& info);
 //
 // * Note a copied value (read from this field and written to the same, possibly
-//   in another object).
+//   in another object). Note that we require that the two types (the one read
+//   from, and written to) are identical; allowing subtyping is possible, but
+//   would add complexity amid diminishing returns.
 //
 //   void noteCopy(HeapType type, Index index, T& info);
 //

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -234,7 +234,12 @@ struct StructScanner
 // if we changed something.
 template<typename T> class TypeHierarchyPropagator {
 public:
+  // Constructor that gets a module and computes subtypes.
   TypeHierarchyPropagator(Module& wasm) : subTypes(wasm) {}
+
+  // Constructor that gets subtypes and uses them, avoiding a scan of a
+  // module. TODO: avoid a copy here?
+  TypeHierarchyPropagator(const SubTypes& subTypes) : subTypes(subTypes) {}
 
   SubTypes subTypes;
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -265,10 +265,15 @@ struct ConstantFieldPropagation : public Pass {
     //   ..
     //   A1->f0 = A2->f0; // Either of these might refer to an A, B, or C.
     //   ..
-    //   foo(C->f0);      // This can contain 20, if the copy involved a C.
+    //   foo(A->f0);      // These can contain 20,
+    //   foo(C->f0);      // if the copy read from B.
     //
     // To handle that, copied fields are treated like struct.set ones (by
-    // copying the struct.new data to struct.set).
+    // copying the struct.new data to struct.set). Note that we must propagate
+    // copying to subtypes first, as in the example above the struct.new values
+    // of subtypes must be taken into account (that is, A or a subtype is being
+    // copied, so we want to do the same thing for B and C as well as A, since
+    // a copy of A means it could be a copy of B or C).
     StructUtils::TypeHierarchyPropagator<Bool> boolPropagator(subTypes);
     boolPropagator.propagateToSubTypes(combinedCopyInfos);
     for (auto& [type, copied] : combinedCopyInfos) {

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -57,8 +57,7 @@ struct Bool {
   operator bool() const { return value; }
 
   bool combine(bool other) {
-    value = value || other;
-    return value;
+    return value = value || other;
   }
 };
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -222,6 +222,8 @@ struct ConstantFieldPropagation : public Pass {
     BoolStructValuesMap combinedCopyInfos;
     functionCopyInfos.combineInto(combinedCopyInfos);
 
+    SubTypes subTypes(*module);
+
     // Handle subtyping. |combinedInfo| so far contains data that represents
     // each struct.new and struct.set's operation on the struct type used in
     // that instruction. That is, if we do a struct.set to type T, the value was
@@ -267,8 +269,7 @@ struct ConstantFieldPropagation : public Pass {
     //
     // To handle that, copied fields are treated like struct.set ones (by
     // copying the struct.new data to struct.set).
-    StructUtils::TypeHierarchyPropagator<Bool> boolPropagator(
-      *module);
+    StructUtils::TypeHierarchyPropagator<Bool> boolPropagator(subTypes);
     boolPropagator.propagateToSubTypes(combinedCopyInfos);
     for (auto& [type, copied] : combinedCopyInfos) {
       for (Index i = 0; i < copied.size(); i++) {
@@ -279,7 +280,7 @@ struct ConstantFieldPropagation : public Pass {
     }
 
     StructUtils::TypeHierarchyPropagator<PossibleConstantValues> propagator(
-      *module);
+      subTypes);
     propagator.propagateToSuperTypes(combinedNewInfos);
     propagator.propagateToSuperAndSubTypes(combinedSetInfos);
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -56,9 +56,7 @@ struct Bool {
 
   operator bool() const { return value; }
 
-  bool combine(bool other) {
-    return value = value || other;
-  }
+  bool combine(bool other) { return value = value || other; }
 };
 
 using BoolStructValuesMap = StructUtils::StructValuesMap<Bool>;

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2292,3 +2292,110 @@
     )
   )
 )
+
+;; A type with type subtypes. A copy on the parent can affect either child.
+(module
+  (rec
+   ;; CHECK:      (rec
+   ;; CHECK-NEXT:  (type $A (sub (struct (field (mut i32)))))
+   (type $A (sub (struct (field (mut i32)))))
+
+   ;; CHECK:       (type $B1 (sub $A (struct (field (mut i32)))))
+   (type $B1 (sub $A (struct (field (mut i32)))))
+
+   ;; CHECK:       (type $B2 (sub $A (struct (field (mut i32)))))
+   (type $B2 (sub $A (struct (field (mut i32)))))
+  )
+
+  ;; CHECK:      (type $3 (func (param (ref null $A) (ref null $B1) (ref null $B2))))
+
+  ;; CHECK:      (func $test (type $3) (param $A (ref null $A)) (param $B1 (ref null $B1)) (param $B2 (ref null $B2))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $B1
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $B2
+  ;; CHECK-NEXT:    (i32.const 20)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.set $A 0
+  ;; CHECK-NEXT:   (local.get $A)
+  ;; CHECK-NEXT:   (struct.get $A 0
+  ;; CHECK-NEXT:    (local.get $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $A 0
+  ;; CHECK-NEXT:    (local.get $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $B1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $B2 0
+  ;; CHECK-NEXT:    (local.get $B2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $A (ref null $A)) (param $B1 (ref null $B1)) (param $B2 (ref null $B2))
+    ;; A and B1 agree on their value in their construction.
+    (drop
+      (struct.new $A
+        (i32.const 10)
+      )
+    )
+    (drop
+      (struct.new $B1
+        (i32.const 10)
+      )
+    )
+    (drop
+      (struct.new $B2
+        (i32.const 20) ;; this value is different from the others
+      )
+    )
+
+    ;; Copy on $A
+    (struct.set $A 0
+      (local.get $A)
+      (struct.get $A 0
+        (local.get $A)
+      )
+    )
+
+    ;; $A might read either child, so we can't infer.
+    (drop
+      (struct.get $A 0
+        (local.get $A)
+      )
+    )
+    ;; $B1 should be only able to read 10, but the copy opens the possibility
+    ;; of 20, so we can't optimize.
+    (drop
+      (struct.get $B1 0
+        (local.get $B1)
+      )
+    )
+    ;; As with $B1, the copy stops us.
+    (drop
+      (struct.get $B2 0
+        (local.get $B2)
+      )
+    )
+  )
+)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2399,3 +2399,115 @@
     )
   )
 )
+
+;; As above, but now the copy is on B1.
+(module
+  (rec
+   ;; CHECK:      (rec
+   ;; CHECK-NEXT:  (type $A (sub (struct (field (mut i32)))))
+   (type $A (sub (struct (field (mut i32)))))
+
+   ;; CHECK:       (type $B1 (sub $A (struct (field (mut i32)))))
+   (type $B1 (sub $A (struct (field (mut i32)))))
+
+   ;; CHECK:       (type $B2 (sub $A (struct (field (mut i32)))))
+   (type $B2 (sub $A (struct (field (mut i32)))))
+  )
+
+  ;; CHECK:      (type $3 (func (param (ref null $A) (ref null $B1) (ref null $B2))))
+
+  ;; CHECK:      (func $test (type $3) (param $A (ref null $A)) (param $B1 (ref null $B1)) (param $B2 (ref null $B2))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $B1
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $B2
+  ;; CHECK-NEXT:    (i32.const 20)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.set $B1 0
+  ;; CHECK-NEXT:   (local.get $B1)
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $B1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $A 0
+  ;; CHECK-NEXT:    (local.get $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $B1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $B2 0
+  ;; CHECK-NEXT:    (local.get $B2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $A (ref null $A)) (param $B1 (ref null $B1)) (param $B2 (ref null $B2))
+    (drop
+      (struct.new $A
+        (i32.const 10)
+      )
+    )
+    (drop
+      (struct.new $B1
+        (i32.const 10)
+      )
+    )
+    (drop
+      (struct.new $B2
+        (i32.const 20)
+      )
+    )
+
+    ;; This changed from $A to $B1.
+    (struct.set $B1 0
+      (local.get $B1)
+      (struct.get $B1 0
+        (local.get $B1)
+      )
+    )
+
+    ;; This might still read $B1 or $B2, with different values, so we can't
+    ;; optimize.
+    (drop
+      (struct.get $A 0
+        (local.get $A)
+      )
+    )
+    ;; The copy can't refer to a $B2, so we can optimize here, as a copy
+    ;; between $A and $B1 is not a problem (their values agree).
+    (drop
+      (struct.get $B1 0
+        (local.get $B1)
+      )
+    )
+    ;; The copy can't refer to a $B2, so we can optimize here.
+    (drop
+      (struct.get $B2 0
+        (local.get $B2)
+      )
+    )
+  )
+)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2337,13 +2337,8 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.as_non_null
-  ;; CHECK-NEXT:      (local.get $B1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   (struct.get $B1 0
+  ;; CHECK-NEXT:    (local.get $B1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2293,7 +2293,7 @@
   )
 )
 
-;; A type with type subtypes. A copy on the parent can affect either child.
+;; A type with two subtypes. A copy on the parent can affect either child.
 (module
   (rec
    ;; CHECK:      (rec
@@ -2498,7 +2498,7 @@
         (local.get $B1)
       )
     )
-    ;; The copy can't refer to a $B2, so we can optimize here.
+    ;; The copy can't refer to a $B2, so we can optimize here. TODO
     (drop
       (struct.get $B2 0
         (local.get $B2)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2491,8 +2491,7 @@
         (local.get $A)
       )
     )
-    ;; The copy can't refer to a $B2, so we can optimize here, as a copy
-    ;; between $A and $B1 is not a problem (their values agree).
+    ;; The copy can only refer to $B1, so we can optimize here.
     (drop
       (struct.get $B1 0
         (local.get $B1)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2511,3 +2511,114 @@
     )
   )
 )
+
+;; As above, but now the copy is on B2.
+(module
+  (rec
+   ;; CHECK:      (rec
+   ;; CHECK-NEXT:  (type $A (sub (struct (field (mut i32)))))
+   (type $A (sub (struct (field (mut i32)))))
+
+   ;; CHECK:       (type $B1 (sub $A (struct (field (mut i32)))))
+   (type $B1 (sub $A (struct (field (mut i32)))))
+
+   ;; CHECK:       (type $B2 (sub $A (struct (field (mut i32)))))
+   (type $B2 (sub $A (struct (field (mut i32)))))
+  )
+
+  ;; CHECK:      (type $3 (func (param (ref null $A) (ref null $B1) (ref null $B2))))
+
+  ;; CHECK:      (func $test (type $3) (param $A (ref null $A)) (param $B1 (ref null $B1)) (param $B2 (ref null $B2))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $B1
+  ;; CHECK-NEXT:    (i32.const 10)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.new $B2
+  ;; CHECK-NEXT:    (i32.const 20)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.set $B2 0
+  ;; CHECK-NEXT:   (local.get $B2)
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $B2)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 20)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $A 0
+  ;; CHECK-NEXT:    (local.get $A)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $B1 0
+  ;; CHECK-NEXT:    (local.get $B1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $B2)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 20)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $A (ref null $A)) (param $B1 (ref null $B1)) (param $B2 (ref null $B2))
+    (drop
+      (struct.new $A
+        (i32.const 10)
+      )
+    )
+    (drop
+      (struct.new $B1
+        (i32.const 10)
+      )
+    )
+    (drop
+      (struct.new $B2
+        (i32.const 20)
+      )
+    )
+
+    ;; This changed from $A to $B2.
+    (struct.set $B2 0
+      (local.get $B2)
+      (struct.get $B2 0
+        (local.get $B2)
+      )
+    )
+
+    ;; This might still read $B1 or $B2, with different values, so we can't
+    ;; optimize.
+    (drop
+      (struct.get $A 0
+        (local.get $A)
+      )
+    )
+    ;; The copy can't refer to a $B1, so we can optimize here. TODO
+    (drop
+      (struct.get $B1 0
+        (local.get $B1)
+      )
+    )
+    ;; $B2 is copied to itself, and nothing else, so we can optimize here.
+    (drop
+      (struct.get $B2 0
+        (local.get $B2)
+      )
+    )
+  )
+)


### PR DESCRIPTION
If we see `A->f0 = A->f0` then we might be copying fields not only between
instances of `A` but also of any subtypes of `A`, and so if some subtype has
value `x` then that `x` might now have reached any other subtype of `A`
(even in a sibling type, so long as `A` is their parent).

We already thought we were handling that, but the mechanism we used to
do so (copying New info to Set info, and letting Set info propagate) was not
enough.

Also add a small constructor to save the work of computing subTypes again.

Add TODOs for some cases that we could optimize regarding copies but
do not, yet.