### PR TITLE
[Outlining] Adds SuffixTree::RepeatSubstring dedupe test

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -11,13 +11,8 @@ string(APPEND WASM_INTRINSICS_EMBED "0x00")
 
 configure_file(WasmIntrinsics.cpp.in WasmIntrinsics.cpp @ONLY)
 
-set(passes_HEADERS
-  call-utils.h
-  intrinsics-module.h
-  opt-utils.h
-  param-utils.h
-  passes.h
-)
+FILE(GLOB passes_HEADERS *.h)
+
 set(passes_SOURCES
   param-utils.cpp
   pass.cpp
@@ -49,6 +44,7 @@ set(passes_SOURCES
   GlobalStructInference.cpp
   GlobalTypeOptimization.cpp
   GUFA.cpp
+  hash-stringify-walker.cpp
   Heap2Local.cpp
   I64ToI32Lowering.cpp
   Inlining.cpp
@@ -129,13 +125,8 @@ set(passes_SOURCES
 # suffix_tree_node source files no longer depend on LLVM code in the
 # third_party folder
 if(EMSCRIPTEN)
-  add_library(passes OBJECT ${passes_SOURCES})
-else()
-  set(passes_with_suffix_tree_SOURCES
-    stringify-walker.h
-    stringify-walker-impl.h
-  	hash-stringify-walker.cpp
-	${passes_SOURCES}
-  )
-  add_library(passes OBJECT ${passes_with_suffix_tree_SOURCES})
+  list(REMOVE_ITEM passes_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/stringify-walker.h)
+  list(REMOVE_ITEM passes_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/stringify-walker-impl.h)
+  list(REMOVE_ITEM passes_SOURCES "hash-stringify-walker.cpp")
 endif()
+add_library(passes OBJECT ${passes_SOURCES})

--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -11,7 +11,13 @@ string(APPEND WASM_INTRINSICS_EMBED "0x00")
 
 configure_file(WasmIntrinsics.cpp.in WasmIntrinsics.cpp @ONLY)
 
-FILE(GLOB passes_HEADERS *.h)
+set(passes_HEADERS
+  call-utils.h
+  intrinsics-module.h
+  opt-utils.h
+  param-utils.h
+  passes.h
+)
 set(passes_SOURCES
   param-utils.cpp
   pass.cpp
@@ -43,7 +49,6 @@ set(passes_SOURCES
   GlobalStructInference.cpp
   GlobalTypeOptimization.cpp
   GUFA.cpp
-  hash-stringify-walker.cpp
   Heap2Local.cpp
   I64ToI32Lowering.cpp
   Inlining.cpp
@@ -120,4 +125,17 @@ set(passes_SOURCES
   ${CMAKE_CURRENT_BINARY_DIR}/WasmIntrinsics.cpp
   ${passes_HEADERS}
 )
-add_library(passes OBJECT ${passes_SOURCES})
+# The below condition is intended for removal once the suffix_tree and
+# suffix_tree_node source files no longer depend on LLVM code in the
+# third_party folder
+if(EMSCRIPTEN)
+  add_library(passes OBJECT ${passes_SOURCES})
+else()
+  set(passes_with_suffix_tree_SOURCES
+    stringify-walker.h
+    stringify-walker-impl.h
+  	hash-stringify-walker.cpp
+	${passes_SOURCES}
+  )
+  add_library(passes OBJECT ${passes_with_suffix_tree_SOURCES})
+endif()

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -67,34 +67,4 @@ void HashStringifyWalker::visitExpression(Expression* curr) {
     nextVal++;
   }
 }
-
-std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
-  const std::vector<SuffixTree::RepeatedSubstring> substrings) {
-  std::set<uint32_t> seen;
-  std::vector<SuffixTree::RepeatedSubstring> result;
-  for (auto substring : substrings) {
-    std::vector<uint32_t> idxToInsert;
-    bool seenEndIdx = false;
-    for (auto startIdx : substring.StartIndices) {
-      // We are using the end index to ensure that each repeated substring
-      // reported by the SuffixTree is unique. This is because LLVM's SuffixTree
-      // reports back repeat sequences that are substrings of longer repeat
-      // sequences with the same endIdx, and we generally prefer to outline
-      // longer repeat sequences.
-      uint32_t endIdx = substring.Length + startIdx;
-      if (auto found = seen.find(endIdx); found != seen.end()) {
-        seenEndIdx = true;
-        continue;
-      }
-      idxToInsert.push_back(endIdx);
-    }
-    if (!seenEndIdx) {
-      seen.insert(idxToInsert.begin(), idxToInsert.end());
-      result.push_back(substring);
-    }
-  }
-
-  return result;
-}
-
 } // namespace wasm

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -68,16 +68,19 @@ void HashStringifyWalker::visitExpression(Expression* curr) {
   }
 }
 
-std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(const std::vector<SuffixTree::RepeatedSubstring> substrings) {
+std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
+  const std::vector<SuffixTree::RepeatedSubstring> substrings) {
   std::set<uint32_t> seen;
   std::vector<SuffixTree::RepeatedSubstring> result;
   for (auto substring : substrings) {
-    std::vector <uint32_t> idxToInsert;
+    std::vector<uint32_t> idxToInsert;
     bool seenEndIdx = false;
     for (auto startIdx : substring.StartIndices) {
       // We are using the end index to ensure that each repeated substring
       // reported by the SuffixTree is unique. This is because LLVM's SuffixTree
-      // reports back repeat sequences that are substrings of longer repeat sequences with the same endIdx, and we generally prefer to outline longer repeat sequences.
+      // reports back repeat sequences that are substrings of longer repeat
+      // sequences with the same endIdx, and we generally prefer to outline
+      // longer repeat sequences.
       uint32_t endIdx = substring.Length + startIdx;
       if (auto found = seen.find(endIdx); found != seen.end()) {
         seenEndIdx = true;

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -67,4 +67,5 @@ void HashStringifyWalker::visitExpression(Expression* curr) {
     nextVal++;
   }
 }
+
 } // namespace wasm

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -68,4 +68,30 @@ void HashStringifyWalker::visitExpression(Expression* curr) {
   }
 }
 
+std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(const std::vector<SuffixTree::RepeatedSubstring> substrings) {
+  std::set<uint32_t> seen;
+  std::vector<SuffixTree::RepeatedSubstring> result;
+  for (auto substring : substrings) {
+    std::vector <uint32_t> idxToInsert;
+    bool seenEndIdx = false;
+    for (auto startIdx : substring.StartIndices) {
+      // We are using the end index to ensure that each repeated substring
+      // reported by the SuffixTree is unique. This is because LLVM's SuffixTree
+      // reports back repeat sequences that are substrings of longer repeat sequences with the same endIdx, and we generally prefer to outline longer repeat sequences.
+      uint32_t endIdx = substring.Length + startIdx;
+      if (auto found = seen.find(endIdx); found != seen.end()) {
+        seenEndIdx = true;
+        continue;
+      }
+      idxToInsert.push_back(endIdx);
+    }
+    if (!seenEndIdx) {
+      seen.insert(idxToInsert.begin(), idxToInsert.end());
+      result.push_back(substring);
+    }
+  }
+
+  return result;
+}
+
 } // namespace wasm

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -68,4 +68,33 @@ void HashStringifyWalker::visitExpression(Expression* curr) {
   }
 }
 
+std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
+  const std::vector<SuffixTree::RepeatedSubstring> substrings) {
+  std::set<uint32_t> seen;
+  std::vector<SuffixTree::RepeatedSubstring> result;
+  for (auto substring : substrings) {
+    std::vector<uint32_t> idxToInsert;
+    bool seenEndIdx = false;
+    for (auto startIdx : substring.StartIndices) {
+      // We are using the end index to ensure that each repeated substring
+      // reported by the SuffixTree is unique. This is because LLVM's SuffixTree
+      // reports back repeat sequences that are substrings of longer repeat
+      // sequences with the same endIdx, and we generally prefer to outline
+      // longer repeat sequences.
+      uint32_t endIdx = substring.Length + startIdx;
+      if (auto found = seen.find(endIdx); found != seen.end()) {
+        seenEndIdx = true;
+        continue;
+      }
+      idxToInsert.push_back(endIdx);
+    }
+    if (!seenEndIdx) {
+      seen.insert(idxToInsert.begin(), idxToInsert.end());
+      result.push_back(substring);
+    }
+  }
+
+  return result;
+}
+
 } // namespace wasm

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -20,7 +20,6 @@
 #include "ir/iteration.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
-#include "support/suffix_tree.h"
 #include "wasm-traversal.h"
 #include <queue>
 

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -134,11 +134,6 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
   void visitExpression(Expression* curr);
 };
 
-struct StringifyProcessor {
-  static std::vector<SuffixTree::RepeatedSubstring>
-  dedupe(const std::vector<SuffixTree::RepeatedSubstring>);
-};
-
 } // namespace wasm
 
 #endif // wasm_passes_stringify_walker_h

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -20,6 +20,7 @@
 #include "ir/iteration.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
+#include "support/suffix_tree.h"
 #include "wasm-traversal.h"
 #include <queue>
 
@@ -131,6 +132,12 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
 
   void addUniqueSymbol();
   void visitExpression(Expression* curr);
+};
+
+// Functions that filter vectors of SuffixTree::RepeatedSubstring
+struct StringifyProcessor {
+  static std::vector<SuffixTree::RepeatedSubstring>
+  dedupe(const std::vector<SuffixTree::RepeatedSubstring>);
 };
 
 } // namespace wasm

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -20,9 +20,9 @@
 #include "ir/iteration.h"
 #include "ir/module-utils.h"
 #include "ir/utils.h"
+#include "support/suffix_tree.h"
 #include "wasm-traversal.h"
 #include <queue>
-#include "support/suffix_tree.h"
 
 namespace wasm {
 
@@ -135,7 +135,8 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
 };
 
 struct StringifyProcessor {
-  static std::vector<SuffixTree::RepeatedSubstring> dedupe(const std::vector<SuffixTree::RepeatedSubstring>);
+  static std::vector<SuffixTree::RepeatedSubstring>
+  dedupe(const std::vector<SuffixTree::RepeatedSubstring>);
 };
 
 } // namespace wasm

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -22,6 +22,7 @@
 #include "ir/utils.h"
 #include "wasm-traversal.h"
 #include <queue>
+#include "support/suffix_tree.h"
 
 namespace wasm {
 
@@ -131,6 +132,10 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
 
   void addUniqueSymbol();
   void visitExpression(Expression* curr);
+};
+
+struct StringifyProcessor {
+  static std::vector<SuffixTree::RepeatedSubstring> dedupe(const std::vector<SuffixTree::RepeatedSubstring>);
 };
 
 } // namespace wasm

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -2,6 +2,8 @@
 #include "passes/stringify-walker.h"
 #include "print-test.h"
 #include "support/suffix_tree.h"
+#include "wasm-io.h"
+#include <iostream>
 
 using namespace wasm;
 
@@ -260,4 +262,129 @@ TEST_F(StringifyTest, Substrings) {
       SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{32, 19, 28})},
       // 7, 6 appears at idx 11 and again at 24
       SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})}}));
+}
+
+TEST_F(StringifyTest, DedupeSubstrings) {
+  Module wasm;
+  parseWast(wasm, dupModuleText);
+
+  HashStringifyWalker stringify = HashStringifyWalker();
+  stringify.walkModule(&wasm);
+
+  SuffixTree st(stringify.hashString);
+  std::vector<SuffixTree::RepeatedSubstring> substrings(st.begin(), st.end());
+  std::sort(
+    substrings.begin(),
+    substrings.end(),
+    [](SuffixTree::RepeatedSubstring a, SuffixTree::RepeatedSubstring b) {
+      size_t aWeight = a.Length * a.StartIndices.size();
+      size_t bWeight = b.Length * b.StartIndices.size();
+      if (aWeight == bWeight) {
+        return a.StartIndices[0] < b.StartIndices[0];
+      }
+      return aWeight > bWeight;
+    });
+
+  // dedupe
+  std::set<uint32_t> seen;
+  std::vector<SuffixTree::RepeatedSubstring> dedupedSubstrings;
+  for (auto substring : substrings) {
+    bool seenEndIdx = false;
+    for (auto startIdx : substring.StartIndices) {
+      // We are tracking the endIdx in this manner because LLVM's SuffixTree
+      // duplicates substrings of substrings with the same endIdx
+      uint32_t endIdx = substring.Length + startIdx;
+      if (auto result = seen.find(endIdx); result != seen.end()) {
+        seenEndIdx = true;
+      }
+    }
+    if (!seenEndIdx) {
+      for (auto startIdx : substring.StartIndices) {
+        seen.insert(startIdx + substring.Length);
+      }
+      dedupedSubstrings.push_back(substring);
+    }
+  }
+
+  EXPECT_EQ(
+    dedupedSubstrings,
+    (std::vector<SuffixTree::RepeatedSubstring>{
+      // 5, 6, 7, 6 appears at idx 9 and again at 22
+      SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
+      // 10, 11, 6 appears at idx 18 and again at 27
+      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})}}));
+}
+
+TEST_F(StringifyTest, ArbitraryWasm) {
+  Module wasm;
+  ModuleReader reader;
+
+  try {
+    reader.read("bin/binaryen_wasm.wasm", wasm);
+  } catch (ParseException& p) {
+    p.dump(std::cerr);
+    std::cerr << '\n';
+    Fatal() << "error parsing wasm";
+  } catch (std::bad_alloc&) {
+    Fatal() << "error building module, std::bad_alloc (possibly invalid "
+               "request for silly amounts of memory)";
+  }
+
+  HashStringifyWalker stringify = HashStringifyWalker();
+  stringify.walkModule(&wasm);
+
+  SuffixTree st(stringify.hashString);
+  std::vector<SuffixTree::RepeatedSubstring> substrings(st.begin(), st.end());
+  std::sort(
+    substrings.begin(),
+    substrings.end(),
+    [](SuffixTree::RepeatedSubstring a, SuffixTree::RepeatedSubstring b) {
+      size_t aWeight = a.Length * a.StartIndices.size();
+      size_t bWeight = b.Length * b.StartIndices.size();
+      if (aWeight == bWeight) {
+        return a.StartIndices[0] < b.StartIndices[0];
+      }
+      return aWeight > bWeight;
+    });
+
+  // dedupe
+  std::set<uint32_t> seen;
+  std::vector<SuffixTree::RepeatedSubstring> dedupedSubstrings;
+  for (auto substring : substrings) {
+    bool seenEndIdx = false;
+    for (auto startIdx : substring.StartIndices) {
+      // We are tracking the endIdx in this manner because LLVM's SuffixTree
+      // duplicates substrings of substrings with the same endIdx
+      uint32_t endIdx = substring.Length + startIdx;
+      if (auto result = seen.find(endIdx); result != seen.end()) {
+        seenEndIdx = true;
+      }
+    }
+    if (!seenEndIdx) {
+      for (auto startIdx : substring.StartIndices) {
+        seen.insert(startIdx + substring.Length);
+      }
+      dedupedSubstrings.push_back(substring);
+    }
+  }
+
+  std::cout << substrings.size() << " substrings found" << std::endl;
+
+  for (SuffixTree::RepeatedSubstring& rs : dedupedSubstrings) {
+    size_t startIndex = rs.StartIndices[0];
+    std::cout << rs.StartIndices.size() << ": ";
+    for (size_t i = startIndex; i < startIndex + rs.Length; i++) {
+      std::cout << stringify.hashString[i] << " ("
+                << ShallowExpression{stringify.exprs[i], &wasm} << "), ";
+    }
+    std::cout << std::endl;
+  }
+
+  EXPECT_EQ(
+    dedupedSubstrings,
+    (std::vector<SuffixTree::RepeatedSubstring>{
+      // 5, 6, 7, 6 appears at idx 9 and again at 22
+      SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
+      // 10, 11, 6 appears at idx 18 and again at 27
+      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})}}));
 }

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -1,8 +1,6 @@
 #include "passes/stringify-walker.h"
 #include "print-test.h"
 #include "support/suffix_tree.h"
-#include "wasm-io.h"
-#include <iostream>
 
 using namespace wasm;
 

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -267,7 +267,8 @@ TEST_F(StringifyTest, DedupeSubstrings) {
   Module wasm;
   parseWast(wasm, dupModuleText);
   auto hashString = hashStringifyModule(&wasm);
-  std::vector<SuffixTree::RepeatedSubstring> substrings = repeatSubstrings(hashString);
+  std::vector<SuffixTree::RepeatedSubstring> substrings =
+    repeatSubstrings(hashString);
 
   auto result = StringifyProcessor::dedupe(substrings);
 
@@ -279,4 +280,3 @@ TEST_F(StringifyTest, DedupeSubstrings) {
       // 10, 11, 6 appears at idx 18 and again at 27
       SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})}}));
 }
-

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -260,21 +260,3 @@ TEST_F(StringifyTest, Substrings) {
       // 7, 6 appears at idx 11 and again at 24
       SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})}}));
 }
-
-TEST_F(StringifyTest, DedupeSubstrings) {
-  Module wasm;
-  parseWast(wasm, dupModuleText);
-  auto hashString = hashStringifyModule(&wasm);
-  std::vector<SuffixTree::RepeatedSubstring> substrings =
-    repeatSubstrings(hashString);
-
-  auto result = StringifyProcessor::dedupe(substrings);
-
-  EXPECT_EQ(
-    result,
-    (std::vector<SuffixTree::RepeatedSubstring>{
-      // 5, 6, 7, 6 appears at idx 9 and again at 22
-      SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
-      // 10, 11, 6 appears at idx 18 and again at 27
-      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})}}));
-}

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -1,3 +1,4 @@
+#include "ir/utils.h"
 #include "passes/stringify-walker.h"
 #include "print-test.h"
 #include "support/suffix_tree.h"

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -261,3 +261,20 @@ TEST_F(StringifyTest, Substrings) {
       // 7, 6 appears at idx 11 and again at 24
       SuffixTree::RepeatedSubstring{2u, (std::vector<unsigned>{11, 24})}}));
 }
+
+TEST_F(StringifyTest, DedupeSubstrings) {
+  Module wasm;
+  parseWast(wasm, dupModuleText);
+  auto hashString = hashStringifyModule(&wasm);
+  std::vector<SuffixTree::RepeatedSubstring> substrings =
+    repeatSubstrings(hashString);
+  auto result = StringifyProcessor::dedupe(substrings);
+
+  EXPECT_EQ(
+    result,
+    (std::vector<SuffixTree::RepeatedSubstring>{
+      // 5, 6, 7, 6 appears at idx 9 and again at 22
+      SuffixTree::RepeatedSubstring{4u, (std::vector<unsigned>{9, 22})},
+      // 10, 11, 6 appears at idx 18 and again at 27
+      SuffixTree::RepeatedSubstring{3u, (std::vector<unsigned>{18, 27})}}));
+}


### PR DESCRIPTION
This PR adds a StringProcessor struct intended to hold functions that filter vectors of SuffixTree::RepeatedSubstring, and a test of its first functionality, removing overlapping repeated substrings.