### PR TITLE
[NFC] Refactor SupertypesFirst utility

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -45,15 +45,14 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes() {
     : HeapTypeOrdering::SupertypesFirstBase<SupertypesFirst> {
     GlobalTypeRewriter& parent;
 
-    SupertypesFirst(GlobalTypeRewriter& parent,
-                    const std::vector<HeapType>& types)
-      : SupertypesFirstBase(types), parent(parent) {}
+    SupertypesFirst(GlobalTypeRewriter& parent) : parent(parent) {}
     std::optional<HeapType> getSuperType(HeapType type) {
       return parent.getSuperType(type);
     }
   };
 
-  for (auto type : SupertypesFirst(*this, privateTypes)) {
+  SupertypesFirst sortedTypes(*this);
+  for (auto type : sortedTypes.sort(privateTypes)) {
     typeIndices[type] = i++;
   }
 

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -35,13 +35,15 @@ struct SupertypesFirstBase
   // track membership in the input collection.
   InsertOrderedMap<HeapType, bool> typeSet;
 
-  template<typename T> SupertypesFirstBase(const T& types) {
+  SupertypeProvider& self() { return *static_cast<SupertypeProvider*>(this); }
+
+  template<typename T> SupertypeProvider& sort(const T& types) {
     for (auto type : types) {
       typeSet[type] = false;
     }
     // Find the supertypes that are in the collection.
     for (auto [type, _] : typeSet) {
-      if (auto super = type.getSuperType()) {
+      if (auto super = self().getSuperType(type)) {
         if (auto it = typeSet.find(*super); it != typeSet.end()) {
           it->second = true;
         }
@@ -53,11 +55,12 @@ struct SupertypesFirstBase
         this->push(type);
       }
     }
+    return self();
   }
 
   void pushPredecessors(HeapType type) {
     // Do not visit types that weren't in the input collection.
-    if (auto super = static_cast<SupertypeProvider*>(this)->getSuperType(type);
+    if (auto super = self().getSuperType(type);
         super && typeSet.count(*super)) {
       this->push(*super);
     }


### PR DESCRIPTION
Move the topological sort from the constructor to a separate method. This CRTP
utility calls into its subclass to query supertype relationships, but doing so
in the base class constructor means that the subclass has not been fully
initialized yet, which can cause problems.