### PR TITLE
Add more context to errors in legacy wat parser

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -83,7 +83,7 @@ public:
   template<typename T> bool operator!=(T t) { return !(*this == t); }
 
   // printing
-  friend std::ostream& operator<<(std::ostream& o, Element& e);
+  friend std::ostream& operator<<(std::ostream& o, const Element& e);
   void dump();
 };
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -511,7 +511,7 @@ Name SExpressionWasmBuilder::getTableName(Element& s) {
     size_t offset = parseIndex(s);
     if (offset >= tableNames.size()) {
       throw ParseException(
-        "unknown table in getTableName"s + s.toString(), s.line, s.col);
+        "unknown table in getTableName: "s + s.toString(), s.line, s.col);
     }
     return tableNames[offset];
   }
@@ -525,7 +525,7 @@ Name SExpressionWasmBuilder::getElemSegmentName(Element& s) {
     size_t offset = parseIndex(s);
     if (offset >= elemSegmentNames.size()) {
       throw ParseException(
-        "unknown elem segment"s + s.toString(), s.line, s.col);
+        "unknown elem segment: "s + s.toString(), s.line, s.col);
     }
     return elemSegmentNames[offset];
   }

--- a/test/lit/parse-bad-nominal-types.wast
+++ b/test/lit/parse-bad-nominal-types.wast
@@ -2,17 +2,17 @@
 
 ;; RUN: foreach %s %t not wasm-opt -all 2>&1 | filecheck %s
 
-;; CHECK: [parse exception: unknown supertype (at 2:24)]
+;; CHECK: [parse exception: unknown supertype: ( type $bad-func ( sub $bad ( func ) ) ) (at 2:24)]
 (module
   (type $bad-func (sub $bad (func)))
 )
 
-;; CHECK: [parse exception: unknown supertype (at 2:26)]
+;; CHECK: [parse exception: unknown supertype: ( type $bad-struct ( sub $bad ( struct ) ) ) (at 2:26)]
 (module
   (type $bad-struct (sub $bad (struct)))
 )
 
-;; CHECK: [parse exception: unknown supertype (at 2:25)]
+;; CHECK: [parse exception: unknown supertype: ( type $bad-array ( sub $bad ( array i32 ) ) ) (at 2:25)]
 (module
   (type $bad-array (sub $bad (array i32)))
 )

--- a/test/lit/parse-bad-tuple-extract-index.wast
+++ b/test/lit/parse-bad-tuple-extract-index.wast
@@ -2,7 +2,7 @@
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: [parse exception: Bad index on tuple.extract (at 9:17)]
+;; CHECK: [parse exception: Bad index on tuple.extract: ( tuple.extract 2 ( tuple.make ( i32.const 0 ) ( i64.const 1 ) ) ) (at 9:17)]
 
 (module
  (func


### PR DESCRIPTION
To make the error messages more useful, especially when parsing extremely large
wat files, print the erroneous fragments along with the existing error messages.