### PR TITLE
wasm-s-parser: Add context in validation errors

### DIFF
--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -73,7 +73,10 @@ public:
 
   // string methods
   IString str() const;
+  // convert a string to a string
   std::string toString() const;
+  // convert anything to a string
+  std::string forceString() const;
   Element* setString(IString str__, bool dollared__, bool quoted__);
   Element* setMetadata(size_t line_, size_t col_, SourceLocation* startLoc_);
 

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -83,7 +83,7 @@ public:
   template<typename T> bool operator!=(T t) { return !(*this == t); }
 
   // printing
-  friend std::ostream& operator<<(std::ostream& o, Element& e);
+  friend std::ostream& operator<<(std::ostream& o, const Element& e);
   void dump();
 };
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -121,7 +121,8 @@ std::string Element::toString() const {
 std::string Element::forceString() const {
   std::stringstream ss;
   ss << *this;
-  return ss.str();
+  // Limit the size to something reasonable for printing out.
+  return ss.str().substr(0, 80);
 }
 
 Element* Element::setString(IString str__, bool dollared__, bool quoted__) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -531,14 +531,16 @@ Name SExpressionWasmBuilder::getElemSegmentName(Element& s) {
 bool SExpressionWasmBuilder::isMemory64(Name memoryName) {
   auto* memory = wasm.getMemoryOrNull(memoryName);
   if (!memory) {
-    throw ParseException("invalid memory name in isMemory64");
+    throw ParseException("invalid memory name in isMemory64: "s +
+                         memoryName.toString());
   }
   return memory->is64();
 }
 
 Name SExpressionWasmBuilder::getMemoryNameAtIdx(Index i) {
   if (i >= memoryNames.size()) {
-    throw ParseException("unknown memory in getMemoryName");
+    throw ParseException("unknown memory in getMemoryName: "s +
+                         std::to_string(i));
   }
   return memoryNames[i];
 }
@@ -1718,7 +1720,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
     if (positive[0] == 'n' && positive[1] == 'a' && positive[2] == 'n') {
       const char* modifier = positive[3] == ':' ? positive + 4 : nullptr;
       if (!(modifier ? positive[4] == '0' && positive[5] == 'x' : 1)) {
-        throw ParseException("bad nan input");
+        throw ParseException("bad nan input: "s + str);
       }
       switch (type.getBasic()) {
         case Type::f32: {
@@ -1727,7 +1729,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
             if (istr.fail()) {
-              throw ParseException("invalid f32 format");
+              throw ParseException("invalid f32 format: "s + str);
             }
             pattern |= 0x7f800000U;
           } else {
@@ -1748,7 +1750,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
             std::istringstream istr(modifier);
             istr >> std::hex >> pattern;
             if (istr.fail()) {
-              throw ParseException("invalid f64 format");
+              throw ParseException("invalid f64 format: "s + str);
             }
             pattern |= 0x7ff0000000000000ULL;
           } else {
@@ -1796,7 +1798,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
         uint32_t temp;
         istr >> std::hex >> temp;
         if (istr.fail()) {
-          throw ParseException("invalid i32 format");
+          throw ParseException("invalid i32 format: "s + str);
         }
         ret->value = Literal(negative ? -temp : temp);
       } else {
@@ -1804,7 +1806,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
         uint32_t temp;
         istr >> temp;
         if (istr.fail()) {
-          throw ParseException("invalid i32 format");
+          throw ParseException("invalid i32 format: "s + str);
         }
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
@@ -1821,7 +1823,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
         uint64_t temp;
         istr >> std::hex >> temp;
         if (istr.fail()) {
-          throw ParseException("invalid i64 format");
+          throw ParseException("invalid i64 format: "s + str);
         }
         ret->value = Literal(negative ? -temp : temp);
       } else {
@@ -1829,7 +1831,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
         uint64_t temp;
         istr >> temp;
         if (istr.fail()) {
-          throw ParseException("invalid i64 format");
+          throw ParseException("invalid i64 format: "s + str);
         }
         ret->value = Literal(str[0] == '-' ? -temp : temp);
       }
@@ -1853,7 +1855,7 @@ static Expression* parseConst(IString s, Type type, MixedArena& allocator) {
     }
   }
   if (ret->value.type != type) {
-    throw ParseException("parsed type does not match expected type");
+    throw ParseException("parsed type does not match expected type: "s + str);
   }
   return ret;
 }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -105,10 +105,9 @@ IString Element::str() const {
 }
 
 std::string Element::toString() const {
-  if (!isStr()) {
-    throw SParseException("expected string", *this);
-  }
-  return str_.toString();
+  std::stringstream ss;
+  ss << *this;
+  return ss.str();
 }
 
 Element* Element::setString(IString str__, bool dollared__, bool quoted__) {
@@ -127,7 +126,7 @@ Element::setMetadata(size_t line_, size_t col_, SourceLocation* startLoc_) {
   return this;
 }
 
-std::ostream& operator<<(std::ostream& o, Element& e) {
+std::ostream& operator<<(std::ostream& o, const Element& e) {
   if (e.isList_) {
     o << '(';
     for (auto item : e.list_) {
@@ -977,7 +976,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
     if (super) {
       auto it = typeIndices.find(super->toString());
       if (!super->dollared() || it == typeIndices.end()) {
-        throw SParseException("unknown supertype", *super);
+        throw SParseException("unknown supertype", elem);
       }
       builder[index].subTypeOf(builder[it->second]);
     }
@@ -991,7 +990,7 @@ void SExpressionWasmBuilder::preParseHeapTypes(Element& module) {
     msg << "Invalid type: " << err->reason;
     for (auto& [name, index] : typeIndices) {
       if (index == err->index) {
-        Fatal() << msg.str() << " at type $" << name;
+        Fatal() << msg.str() << " at type " << name;
       }
     }
     // No name, just report the index.

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -55,12 +55,12 @@ namespace wasm {
 struct SParseException : public ParseException {
   // Receive an element and report its contents, line and column.
   SParseException(std::string text, const Element& s) :
-    ParseException(text + ": " + s.toString(), s.line, s.col) {}
+    ParseException(text + ": " + s.forceString(), s.line, s.col) {}
 
   // Receive a parent and child element. We print out the full parent for
   // context, but report the child line and column inside it.
   SParseException(std::string text, const Element& parent, const Element& child) :
-    ParseException(text + ": " + parent.toString(), child.line, child.col) {}
+    ParseException(text + ": " + parent.forceString(), child.line, child.col) {}
 };
 
 static Name STRUCT("struct"), FIELD("field"), ARRAY("array"), REC("rec"),
@@ -111,6 +111,13 @@ IString Element::str() const {
 }
 
 std::string Element::toString() const {
+  if (!isStr()) {
+    throw SParseException("expected string", *this);
+  }
+  return str_.toString();
+}
+
+std::string Element::forceString() const {
   std::stringstream ss;
   ss << *this;
   return ss.str();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -27,6 +27,8 @@
 #include "wasm-binary.h"
 #include "wasm-builder.h"
 
+using namespace std::string_literals;
+
 #define abort_on(str)                                                          \
   { throw ParseException(std::string("abort_on ") + str); }
 #define element_assert(condition)                                              \
@@ -3507,7 +3509,7 @@ void SExpressionWasmBuilder::parseExport(Element& s) {
     ex->kind = ExternalKind::Function;
   }
   if (wasm.getExportOrNull(ex->name)) {
-    throw SParseException("duplicate export", s;
+    throw SParseException("duplicate export", s);
   }
   wasm.addExport(ex.release());
 }

--- a/test/lit/parse-bad-nominal-types.wast
+++ b/test/lit/parse-bad-nominal-types.wast
@@ -2,17 +2,17 @@
 
 ;; RUN: foreach %s %t not wasm-opt -all 2>&1 | filecheck %s
 
-;; CHECK: [parse exception: unknown supertype (at 2:24)]
+;; CHECK: [parse exception: unknown supertype: ( type $bad-func ( sub $bad ( func ) ) ) (at 2:24)]
 (module
   (type $bad-func (sub $bad (func)))
 )
 
-;; CHECK: [parse exception: unknown supertype (at 2:26)]
+;; CHECK: [parse exception: unknown supertype: ( type $bad-struct ( sub $bad ( struct ) ) ) (at 2:26)]
 (module
   (type $bad-struct (sub $bad (struct)))
 )
 
-;; CHECK: [parse exception: unknown supertype (at 2:25)]
+;; CHECK: [parse exception: unknown supertype: ( type $bad-array ( sub $bad ( array i32 ) ) ) (at 2:25)]
 (module
   (type $bad-array (sub $bad (array i32)))
 )

--- a/test/lit/parse-bad-tuple-extract-index.wast
+++ b/test/lit/parse-bad-tuple-extract-index.wast
@@ -2,7 +2,7 @@
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: [parse exception: Bad index on tuple.extract (at 9:17)]
+;; CHECK: [parse exception: Bad index on tuple.extract: ( tuple.extract 2 ( tuple.make ( i32.const 0 ) ( i64.const 1 ) ) ) (at 9:17)]
 
 (module
  (func


### PR DESCRIPTION
Instead of just reporting the reason and line + column, also log out the element
the error occurred at.

Supercedes #5980