### PR TITLE
Refine ref.test's castType during refinalization

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2549,6 +2549,10 @@ void FunctionValidator::visitRefTest(RefTest* curr) {
         curr->ref->type.isRef(), curr, "ref.test ref must have ref type")) {
     return;
   }
+  if (!shouldBeTrue(
+        curr->castType.isRef(), curr, "ref.test target must have ref type")) {
+    return;
+  }
   shouldBeEqual(
     curr->castType.getHeapType().getBottom(),
     curr->ref->type.getHeapType().getBottom(),

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -953,6 +953,8 @@ void RefTest::finalize() {
     type = Type::unreachable;
   } else {
     type = Type::i32;
+    // Do not unnecessarily lose type information.
+    castType = Type::getGreatestLowerBound(castType, ref->type);
   }
 }
 

--- a/test/lit/cast-to-basic.wast
+++ b/test/lit/cast-to-basic.wast
@@ -5,14 +5,14 @@
 ;; RUN: wasm-opt %s -all --roundtrip -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (func $test (type $1) (result i32)
+  ;; CHECK:      (func $test (type $1) (param $x structref) (result i32)
   ;; CHECK-NEXT:  (ref.test (ref struct)
-  ;; CHECK-NEXT:   (ref.null none)
+  ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $test (result i32)
+  (func $test (param $x (ref null struct)) (result i32)
     (ref.test (ref struct)
-      (ref.null none)
+      (local.get $x)
     )
   )
 

--- a/test/lit/heap-types.wast
+++ b/test/lit/heap-types.wast
@@ -8,12 +8,11 @@
 ;; RUN: foreach %s %t wasm-opt -all --roundtrip -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $struct.A (struct (field i32)))
   (type $struct.A (struct i32))
   (type $struct.B (struct i32))
   ;; CHECK:      (func $test (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (ref.test (ref $struct.A)
+  ;; CHECK-NEXT:   (ref.test (ref none)
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -639,7 +639,7 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (if (result i32)
  ;; CHECK-NEXT:    (local.get $x)
- ;; CHECK-NEXT:    (ref.test (ref $struct)
+ ;; CHECK-NEXT:    (ref.test (ref none)
  ;; CHECK-NEXT:     (ref.null none)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (i32.const 0)


### PR DESCRIPTION
Just like we do with other casts, refine the cast type to be the greatest lower
bound of its previous cast type and its input type. The difference is that the
output type of ref.test remains i32, but it's still useful to retain more
precise type information.