### PR TITLE
Asyncify: Simpify if into i32.or

### DIFF
--- a/test/lit/passes/asyncify-wasm64.wast
+++ b/test/lit/passes/asyncify-wasm64.wast
@@ -135,12 +135,11 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $9)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -335,12 +334,11 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $9)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -510,12 +508,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $7)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -550,12 +547,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $7)
   ;; CHECK-NEXT:          (i32.const 1)
@@ -716,12 +712,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $4)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -871,12 +866,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $4)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -1020,12 +1014,11 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $3)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -1177,12 +1170,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $5)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify-wasm64_pass-arg=in-secondary-memory.wast
+++ b/test/lit/passes/asyncify-wasm64_pass-arg=in-secondary-memory.wast
@@ -128,12 +128,11 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $9)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify.wast
+++ b/test/lit/passes/asyncify.wast
@@ -134,12 +134,11 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $9)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -334,12 +333,11 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $9)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -509,12 +507,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $7)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -549,12 +546,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $7)
   ;; CHECK-NEXT:          (i32.const 1)
@@ -715,12 +711,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $4)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -870,12 +865,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $4)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -1019,12 +1013,11 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $3)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -1176,12 +1169,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $5)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify_enable-multivalue.wast
+++ b/test/lit/passes/asyncify_enable-multivalue.wast
@@ -119,12 +119,11 @@
   ;; CHECK-NEXT:        (call $stuff)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -224,12 +223,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -456,12 +454,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -576,12 +573,11 @@
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (block
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $6)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -740,12 +736,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -946,12 +941,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $12)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -1105,12 +1099,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $3)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -1251,12 +1244,11 @@
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:         (if
-  ;; CHECK-NEXT:          (if (result i32)
+  ;; CHECK-NEXT:          (i32.or
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (global.get $__asyncify_state)
   ;; CHECK-NEXT:            (i32.const 0)
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (i32.const 1)
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (local.get $4)
   ;; CHECK-NEXT:            (i32.const 0)
@@ -1289,12 +1281,11 @@
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:         (if
-  ;; CHECK-NEXT:          (if (result i32)
+  ;; CHECK-NEXT:          (i32.or
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (global.get $__asyncify_state)
   ;; CHECK-NEXT:            (i32.const 0)
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (i32.const 1)
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (local.get $4)
   ;; CHECK-NEXT:            (i32.const 1)
@@ -1460,12 +1451,11 @@
   ;; CHECK-NEXT:            )
   ;; CHECK-NEXT:           )
   ;; CHECK-NEXT:           (if
-  ;; CHECK-NEXT:            (if (result i32)
+  ;; CHECK-NEXT:            (i32.or
   ;; CHECK-NEXT:             (i32.eq
   ;; CHECK-NEXT:              (global.get $__asyncify_state)
   ;; CHECK-NEXT:              (i32.const 0)
   ;; CHECK-NEXT:             )
-  ;; CHECK-NEXT:             (i32.const 1)
   ;; CHECK-NEXT:             (i32.eq
   ;; CHECK-NEXT:              (local.get $6)
   ;; CHECK-NEXT:              (i32.const 0)
@@ -1628,12 +1618,11 @@
   ;; CHECK-NEXT:            )
   ;; CHECK-NEXT:           )
   ;; CHECK-NEXT:           (if
-  ;; CHECK-NEXT:            (if (result i32)
+  ;; CHECK-NEXT:            (i32.or
   ;; CHECK-NEXT:             (i32.eq
   ;; CHECK-NEXT:              (global.get $__asyncify_state)
   ;; CHECK-NEXT:              (i32.const 0)
   ;; CHECK-NEXT:             )
-  ;; CHECK-NEXT:             (i32.const 1)
   ;; CHECK-NEXT:             (i32.eq
   ;; CHECK-NEXT:              (local.get $6)
   ;; CHECK-NEXT:              (i32.const 0)
@@ -1810,12 +1799,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $3)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -1969,12 +1957,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (loop $l
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $5)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -2144,12 +2131,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (loop $l
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -2280,12 +2266,11 @@
   ;; CHECK-NEXT:        (call $boring)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -2312,12 +2297,11 @@
   ;; CHECK-NEXT:        (call $boring)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 1)
@@ -2418,12 +2402,11 @@
   ;; CHECK-NEXT:        (call $boring-deep)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -2450,12 +2433,11 @@
   ;; CHECK-NEXT:        (call $boring)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 1)
@@ -2550,12 +2532,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)

--- a/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
@@ -66,12 +66,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -177,12 +176,11 @@
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (block
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $6)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -332,12 +330,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
@@ -41,7 +41,16 @@
 
   ;; CHECK:      (func $calls-import (; has Stack IR ;)
   ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (call $import)
+  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
+  ;; CHECK-NEXT:    (block
+  ;; CHECK-NEXT:     (call $import)
+  ;; CHECK-NEXT:     (br $__asyncify_unwind
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (i32.store
   ;; CHECK-NEXT:   (i32.load
   ;; CHECK-NEXT:    (global.get $__asyncify_data)

--- a/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
@@ -41,16 +41,7 @@
 
   ;; CHECK:      (func $calls-import (; has Stack IR ;)
   ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local.set $0
-  ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (call $import)
-  ;; CHECK-NEXT:     (br $__asyncify_unwind
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (call $import)
   ;; CHECK-NEXT:  (i32.store
   ;; CHECK-NEXT:   (i32.load
   ;; CHECK-NEXT:    (global.get $__asyncify_data)

--- a/test/lit/passes/asyncify_mod-asyncify-never-unwind.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-never-unwind.wast
@@ -72,12 +72,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -189,12 +188,11 @@
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (block
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $6)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -350,12 +348,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify_mod-asyncify-never-unwind_O.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-never-unwind_O.wast
@@ -41,8 +41,11 @@
 
   ;; CHECK:      (func $calls-import (; has Stack IR ;)
   ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (select
+  ;; CHECK-NEXT:   (i32.or
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (global.get $__asyncify_state)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.eqz
   ;; CHECK-NEXT:     (if (result i32)
   ;; CHECK-NEXT:      (i32.eq
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
@@ -66,8 +69,6 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (i32.const 0)
-  ;; CHECK-NEXT:     (global.get $__asyncify_state)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (call $import)

--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -40,8 +40,11 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (if (result i32)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
@@ -65,8 +68,6 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -134,8 +135,11 @@
   ;; CHECK-NEXT:  (local.set $1
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (if (result i32)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
@@ -159,8 +163,6 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (local.get $1)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -234,8 +236,11 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (if (result i32)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
@@ -259,8 +264,6 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -382,11 +385,12 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
-  ;; CHECK-NEXT:       (local.get $2)
-  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (local.get $2)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -465,7 +469,6 @@
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (select
-  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:       (i32.eq
@@ -473,32 +476,36 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (select
-  ;; CHECK-NEXT:       (if (result i32)
-  ;; CHECK-NEXT:        (i32.eq
-  ;; CHECK-NEXT:         (global.get $__asyncify_state)
-  ;; CHECK-NEXT:         (i32.const 2)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (block (result i32)
-  ;; CHECK-NEXT:         (i32.store
-  ;; CHECK-NEXT:          (global.get $__asyncify_data)
-  ;; CHECK-NEXT:          (i32.sub
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:         (i32.eq
+  ;; CHECK-NEXT:          (global.get $__asyncify_state)
+  ;; CHECK-NEXT:          (i32.const 2)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (block (result i32)
+  ;; CHECK-NEXT:          (i32.store
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           (i32.sub
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:            (i32.const 4)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (i32.load
   ;; CHECK-NEXT:           (i32.load
   ;; CHECK-NEXT:            (global.get $__asyncify_data)
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (i32.const 4)
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.load
-  ;; CHECK-NEXT:          (i32.load
-  ;; CHECK-NEXT:           (global.get $__asyncify_data)
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (local.get $1)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -545,7 +552,6 @@
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (select
-  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (local.tee $1
   ;; CHECK-NEXT:        (select
@@ -581,6 +587,7 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (block (result i32)
   ;; CHECK-NEXT:       (if
   ;; CHECK-NEXT:        (i32.eq
@@ -606,10 +613,13 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $2)
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       (i32.or
+  ;; CHECK-NEXT:        (i32.eqz
+  ;; CHECK-NEXT:         (global.get $__asyncify_state)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (i32.eqz
+  ;; CHECK-NEXT:         (local.get $2)
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
@@ -629,7 +639,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:     (i32.and
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $1)
@@ -639,14 +649,14 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (i32.eq
   ;; CHECK-NEXT:        (local.get $2)
   ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 1)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -757,13 +767,6 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (i32.and
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (global.get $__asyncify_state)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (local.get $2)
@@ -771,6 +774,14 @@
   ;; CHECK-NEXT:       (i32.eq
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
   ;; CHECK-NEXT:        (i32.const 2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (local.get $1)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
@@ -831,7 +842,6 @@
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
   ;; CHECK-NEXT:     (select
-  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (i32.or
   ;; CHECK-NEXT:       (local.tee $1
   ;; CHECK-NEXT:        (select
@@ -867,32 +877,36 @@
   ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (select
-  ;; CHECK-NEXT:       (if (result i32)
-  ;; CHECK-NEXT:        (i32.eq
-  ;; CHECK-NEXT:         (global.get $__asyncify_state)
-  ;; CHECK-NEXT:         (i32.const 2)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (block (result i32)
-  ;; CHECK-NEXT:         (i32.store
-  ;; CHECK-NEXT:          (global.get $__asyncify_data)
-  ;; CHECK-NEXT:          (i32.sub
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:         (i32.eq
+  ;; CHECK-NEXT:          (global.get $__asyncify_state)
+  ;; CHECK-NEXT:          (i32.const 2)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (block (result i32)
+  ;; CHECK-NEXT:          (i32.store
+  ;; CHECK-NEXT:           (global.get $__asyncify_data)
+  ;; CHECK-NEXT:           (i32.sub
+  ;; CHECK-NEXT:            (i32.load
+  ;; CHECK-NEXT:             (global.get $__asyncify_data)
+  ;; CHECK-NEXT:            )
+  ;; CHECK-NEXT:            (i32.const 4)
+  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (i32.load
   ;; CHECK-NEXT:           (i32.load
   ;; CHECK-NEXT:            (global.get $__asyncify_data)
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (i32.const 4)
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.load
-  ;; CHECK-NEXT:          (i32.load
-  ;; CHECK-NEXT:           (global.get $__asyncify_data)
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (local.get $2)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (local.get $2)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -1033,11 +1047,12 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (loop $l
   ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (local.get $1)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
@@ -1170,11 +1185,12 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (loop $l
   ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (select
-  ;; CHECK-NEXT:        (local.get $2)
-  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:      (i32.or
+  ;; CHECK-NEXT:       (i32.eqz
   ;; CHECK-NEXT:        (global.get $__asyncify_state)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (local.get $2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
@@ -1281,11 +1297,12 @@
   ;; CHECK-NEXT:     (call $boring)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -1308,13 +1325,14 @@
   ;; CHECK-NEXT:     (call $boring)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.eq
   ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:       (i32.const 1)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
   ;; CHECK-NEXT:      (call $import)
@@ -1393,11 +1411,12 @@
   ;; CHECK-NEXT:     (call $boring-deep)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
@@ -1420,13 +1439,14 @@
   ;; CHECK-NEXT:     (call $boring)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (select
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.eq
   ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:       (i32.const 1)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:      (global.get $__asyncify_state)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
   ;; CHECK-NEXT:      (call $import)
@@ -1477,8 +1497,11 @@
   ;; CHECK-NEXT:  (local.set $0
   ;; CHECK-NEXT:   (block $__asyncify_unwind (result i32)
   ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (select
+  ;; CHECK-NEXT:     (i32.or
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (global.get $__asyncify_state)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.eqz
   ;; CHECK-NEXT:       (if (result i32)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
@@ -1502,8 +1525,6 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:       (global.get $__asyncify_state)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block

--- a/test/lit/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.wast
@@ -82,12 +82,11 @@
   ;; CHECK-NEXT:        (call $nothing)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.wast
@@ -80,12 +80,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -176,12 +175,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-ignore-imports.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-ignore-imports.wast
@@ -141,12 +141,11 @@
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $3)
   ;; CHECK-NEXT:          (i32.const 0)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-ignore-indirect.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-ignore-indirect.wast
@@ -77,12 +77,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -192,12 +191,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -368,12 +366,11 @@
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:         (if
-  ;; CHECK-NEXT:          (if (result i32)
+  ;; CHECK-NEXT:          (i32.or
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (global.get $__asyncify_state)
   ;; CHECK-NEXT:            (i32.const 0)
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (i32.const 1)
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (local.get $4)
   ;; CHECK-NEXT:            (i32.const 0)
@@ -406,12 +403,11 @@
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:         (if
-  ;; CHECK-NEXT:          (if (result i32)
+  ;; CHECK-NEXT:          (i32.or
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (global.get $__asyncify_state)
   ;; CHECK-NEXT:            (i32.const 0)
   ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (i32.const 1)
   ;; CHECK-NEXT:           (i32.eq
   ;; CHECK-NEXT:            (local.get $4)
   ;; CHECK-NEXT:            (i32.const 1)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.wast
@@ -118,12 +118,11 @@
   ;; CHECK-NEXT:        (call $stuff)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -223,12 +222,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -448,12 +446,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -568,12 +565,11 @@
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (block
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $6)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -732,12 +728,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -937,12 +932,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $11)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -1095,12 +1089,11 @@
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (if
-  ;; CHECK-NEXT:         (if (result i32)
+  ;; CHECK-NEXT:         (i32.or
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (global.get $__asyncify_state)
   ;; CHECK-NEXT:           (i32.const 0)
   ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:          (i32.const 1)
   ;; CHECK-NEXT:          (i32.eq
   ;; CHECK-NEXT:           (local.get $3)
   ;; CHECK-NEXT:           (i32.const 0)
@@ -1300,12 +1293,11 @@
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (loop $l
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $2)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -1436,12 +1428,11 @@
   ;; CHECK-NEXT:        (call $boring)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -1468,12 +1459,11 @@
   ;; CHECK-NEXT:        (call $boring)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 1)
@@ -1574,12 +1564,11 @@
   ;; CHECK-NEXT:        (call $boring-deep)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -1606,12 +1595,11 @@
   ;; CHECK-NEXT:        (call $boring)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $1)
   ;; CHECK-NEXT:          (i32.const 1)
@@ -1706,12 +1694,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-onlylist@foo,bar.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-onlylist@foo,bar.wast
@@ -68,12 +68,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -158,12 +157,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)

--- a/test/lit/passes/asyncify_pass-arg=asyncify-verbose.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-verbose.wast
@@ -68,12 +68,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -158,12 +157,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)
@@ -248,12 +246,11 @@
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (if (result i32)
+  ;; CHECK-NEXT:       (i32.or
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (global.get $__asyncify_state)
   ;; CHECK-NEXT:         (i32.const 0)
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (i32.const 1)
   ;; CHECK-NEXT:        (i32.eq
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:         (i32.const 0)

--- a/test/lit/passes/asyncify_pass-arg=in-secondary-memory.wast
+++ b/test/lit/passes/asyncify_pass-arg=in-secondary-memory.wast
@@ -138,12 +138,11 @@
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (nop)
   ;; CHECK-NEXT:       (if
-  ;; CHECK-NEXT:        (if (result i32)
+  ;; CHECK-NEXT:        (i32.or
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (global.get $__asyncify_state)
   ;; CHECK-NEXT:          (i32.const 0)
   ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (i32.const 1)
   ;; CHECK-NEXT:         (i32.eq
   ;; CHECK-NEXT:          (local.get $9)
   ;; CHECK-NEXT:          (i32.const 0)
@@ -347,12 +346,11 @@
   ;; SIZE-NEXT:       (nop)
   ;; SIZE-NEXT:       (nop)
   ;; SIZE-NEXT:       (if
-  ;; SIZE-NEXT:        (if (result i32)
+  ;; SIZE-NEXT:        (i32.or
   ;; SIZE-NEXT:         (i32.eq
   ;; SIZE-NEXT:          (global.get $__asyncify_state)
   ;; SIZE-NEXT:          (i32.const 0)
   ;; SIZE-NEXT:         )
-  ;; SIZE-NEXT:         (i32.const 1)
   ;; SIZE-NEXT:         (i32.eq
   ;; SIZE-NEXT:          (local.get $9)
   ;; SIZE-NEXT:          (i32.const 0)


### PR DESCRIPTION
```wast
(if (result i32)
  (expr0)
  (i32.const 1)
  (expr1)
)
```
can be written as
```wast
(i32.or
  (expr0)
  (expr1)
)
```

Also this removes some unused variables and methods.

This also adds an optimization for
```wast
(i32.eqz                                                                   
  (global.get $__asyncify_state)                                            
)
```
in `--mod-asyncify-always-and-only-unwind` to fix an unexpected regression caused by this.