### PR TITLE
mark operator== as const

### DIFF
--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -287,7 +287,7 @@ struct Value {
     return *this;
   }
 
-  bool operator==(const Value& other) {
+  bool operator==(const Value& other) const {
     if (type != other.type) {
       return false;
     }


### PR DESCRIPTION
C++20 will automatically generate an operator== with reversed operand order, which is ambiguous with the written operator== when one argument is marked const and the other isn't.

Even outside the context of C++20, I believe this is semantically correct.