### PR TITLE
Typed Continuations: Allow result types on tags

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2946,8 +2946,14 @@ void PrintSExpression::visitImportedTag(Tag* curr) {
   emitImportHeader(curr);
   o << "(tag ";
   printName(curr->name, o);
-  o << maybeSpace;
-  printParamType(curr->sig.params);
+  if (curr->sig.params != Type::none) {
+    o << maybeSpace;
+    printParamType(curr->sig.params);
+  }
+  if (curr->sig.results != Type::none) {
+    o << maybeSpace;
+    printResultType(curr->sig.results);
+  }
   o << "))";
   o << maybeNewLine;
 }
@@ -2957,8 +2963,14 @@ void PrintSExpression::visitDefinedTag(Tag* curr) {
   o << '(';
   printMedium(o, "tag ");
   printName(curr->name, o);
-  o << maybeSpace;
-  printParamType(curr->sig.params);
+  if (curr->sig.params != Type::none) {
+    o << maybeSpace;
+    printParamType(curr->sig.params);
+  }
+  if (curr->sig.results != Type::none) {
+    o << maybeSpace;
+    printResultType(curr->sig.results);
+  }
   o << ")" << maybeNewLine;
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2374,6 +2374,12 @@ void FunctionValidator::visitTry(Try* curr) {
       getStream() << "tag name is invalid: " << tagName << "\n";
     }
 
+    if (!shouldBeEqual(tag->sig.results, Type(Type::none), curr, "")) {
+      getStream()
+        << "catch's tag (" << tagName
+        << ") has result values, which is not allowed for exception handling";
+    }
+
     auto* catchBody = curr->catchBodies[i];
     auto pops = EHUtils::findPops(catchBody);
     if (tag->sig.params == Type::none) {
@@ -2432,6 +2438,11 @@ void FunctionValidator::visitThrow(Throw* curr) {
   if (!shouldBeTrue(!!tag, curr, "throw's tag must exist")) {
     return;
   }
+  shouldBeEqual(
+    tag->sig.results,
+    Type(Type::none),
+    curr,
+    "tags with result types must not be used for exception handling");
   if (!shouldBeTrue(curr->operands.size() == tag->sig.params.size(),
                     curr,
                     "tag's param numbers must match")) {
@@ -3674,10 +3685,12 @@ static void validateTags(Module& module, ValidationInfo& info) {
       "Tags require exception-handling [--enable-exception-handling]");
   }
   for (auto& curr : module.tags) {
-    info.shouldBeEqual(curr->sig.results,
-                       Type(Type::none),
-                       curr->name,
-                       "Tag type's result type should be none");
+    if (curr->sig.results != Type(Type::none)) {
+      info.shouldBeTrue(module.features.hasTypedContinuations(),
+                        curr->name,
+                        "Tags with result types require typed continuations "
+                        "feature [--enable-typed-continuations]");
+    }
     if (curr->sig.params.isTuple()) {
       info.shouldBeTrue(
         module.features.hasMultivalue(),

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -8,7 +8,7 @@
  (tag $e-i64 (param i64))
  (tag $e-i32-i64 (param i32 i64))
  (tag $e-eqref (param eqref))
- (tag $e-empty (param))
+ (tag $e-empty)
  (func $foo (type $0)
   (nop)
  )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -8,7 +8,7 @@
  (tag $e-i64 (param i64))
  (tag $e-i32-i64 (param i32 i64))
  (tag $e-eqref (param eqref))
- (tag $e-empty (param))
+ (tag $e-empty)
  (func $foo (type $0)
   (nop)
  )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -8,7 +8,7 @@
  (tag $tag$1 (param i64))
  (tag $tag$2 (param i32 i64))
  (tag $tag$3 (param eqref))
- (tag $tag$4 (param))
+ (tag $tag$4)
  (func $0 (type $0)
   (nop)
  )

--- a/test/lit/merge/fusing.wat
+++ b/test/lit/merge/fusing.wat
@@ -32,7 +32,7 @@
 
   ;; CHECK:      (memory $second.mem 2)
 
-  ;; CHECK:      (tag $exn (param))
+  ;; CHECK:      (tag $exn)
 
   ;; CHECK:      (export "foo" (func $first.foo))
 

--- a/test/lit/passes/coalesce-locals-eh.wast
+++ b/test/lit/passes/coalesce-locals-eh.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s --coalesce-locals -all -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (tag $e (param))
+  ;; CHECK:      (tag $e)
 
   ;; CHECK:      (func $bar (type $1) (result i32)
   ;; CHECK-NEXT:  (i32.const 1984)

--- a/test/lit/passes/dce-eh.wast
+++ b/test/lit/passes/dce-eh.wast
@@ -4,7 +4,7 @@
 ;; If either try body or catch body is reachable, the whole try construct is
 ;; reachable
 (module
-  ;; CHECK:      (tag $e (param))
+  ;; CHECK:      (tag $e)
 
   ;; CHECK:      (func $foo (type $0)
   ;; CHECK-NEXT:  (nop)

--- a/test/lit/passes/global-effects.wast
+++ b/test/lit/passes/global-effects.wast
@@ -14,21 +14,21 @@
 
   ;; WITHOUT:      (type $2 (func (param i32)))
 
-  ;; WITHOUT:      (tag $tag (param))
+  ;; WITHOUT:      (tag $tag)
   ;; INCLUDE:      (type $0 (func))
 
   ;; INCLUDE:      (type $1 (func (result i32)))
 
   ;; INCLUDE:      (type $2 (func (param i32)))
 
-  ;; INCLUDE:      (tag $tag (param))
+  ;; INCLUDE:      (tag $tag)
   ;; DISCARD:      (type $0 (func))
 
   ;; DISCARD:      (type $1 (func (result i32)))
 
   ;; DISCARD:      (type $2 (func (param i32)))
 
-  ;; DISCARD:      (tag $tag (param))
+  ;; DISCARD:      (tag $tag)
   (tag $tag)
 
   ;; WITHOUT:      (func $main (type $0)

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -1903,7 +1903,7 @@
   ;; CHECK:      (tag $something (param anyref))
   (tag $something (param (ref null any)))
 
-  ;; CHECK:      (tag $empty (param))
+  ;; CHECK:      (tag $empty)
   (tag $empty (param))
 
   ;; CHECK:      (func $func (type $0)

--- a/test/lit/passes/rse-eh.wast
+++ b/test/lit/passes/rse-eh.wast
@@ -4,7 +4,7 @@
 (module
   ;; CHECK:      (tag $e (param i32))
   (tag $e (param i32))
-  ;; CHECK:      (tag $e2 (param))
+  ;; CHECK:      (tag $e2)
   (tag $e2)
 
   ;; CHECK:      (func $try1 (type $0)

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -1240,7 +1240,7 @@
 
   ;; CHECK:      (type $6 (func))
 
-  ;; CHECK:      (tag $tag (param))
+  ;; CHECK:      (tag $tag)
   (tag $tag)
 
   ;; CHECK:      (func $struct.new (type $4) (param $extern externref) (result anyref)

--- a/test/metadce/tag.wast.dced
+++ b/test/metadce/tag.wast.dced
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
- (import "env" "imported_tag" (tag $t0 (param)))
- (tag $t1 (param))
+ (import "env" "imported_tag" (tag $t0))
+ (tag $t1)
  (export "test" (func $test))
  (func $test (type $0)
   (try $try

--- a/test/spec/exception-handling.wast
+++ b/test/spec/exception-handling.wast
@@ -615,3 +615,41 @@
   )
   "catch's body (e-i32)'s pop's location is not valid"
 )
+
+(assert_invalid
+  (module
+    (tag $e-i32 (param i32) (result i32))
+    (tag $e-f32 (param f32))
+    (func (export "try_throw_nocatch") (result i32)
+      (try (result i32)
+        (do
+          (throw $e-i32 (i32.const 5))
+        )
+        (catch $e-f32
+          (drop (pop f32))
+          (i32.const 3)
+        )
+      )
+    )
+  )
+  "tags with result types must not be used for exception handling"
+)
+
+(assert_invalid
+  (module
+    (tag $e-i32 (param i32))
+    (tag $e-f32 (param f32) (result i32))
+    (func (export "try_throw_nocatch") (result i32)
+      (try (result i32)
+        (do
+          (throw $e-i32 (i32.const 5))
+        )
+        (catch $e-f32
+          (drop (pop f32))
+          (i32.const 3)
+        )
+      )
+    )
+  )
+  "catch's tag (e-f32) has result values, which is not allowed for exception handling"
+)

--- a/test/spec/tags.wast
+++ b/test/spec/tags.wast
@@ -15,11 +15,6 @@
 )
 
 (assert_invalid
-  (module (tag $e (param i32) (result i32)))
-  "Tag type's result type should be none"
-)
-
-(assert_invalid
   (module (tag $e (attr 1) (param i32)))
   "Currently only attribute 0 is supported"
 )

--- a/test/tags.wast.from-wast
+++ b/test/tags.wast.from-wast
@@ -6,7 +6,7 @@
  (import "env" "im1" (tag $eimport$1 (param i32 f32)))
  (tag $2 (param i32))
  (tag $e (param i32 f32))
- (tag $empty (param))
+ (tag $empty)
  (tag $e-params0 (param i32 f32))
  (tag $e-params1 (param i32 f32))
  (tag $e-export (param i32))

--- a/test/tags.wast.fromBinary
+++ b/test/tags.wast.fromBinary
@@ -6,7 +6,7 @@
  (import "env" "im1" (tag $eimport$1 (param i32 f32)))
  (tag $tag$0 (param i32))
  (tag $e (param i32 f32))
- (tag $empty (param))
+ (tag $empty)
  (tag $e-params0 (param i32 f32))
  (tag $e-params1 (param i32 f32))
  (tag $e-export (param i32))

--- a/test/tags.wast.fromBinary.noDebugInfo
+++ b/test/tags.wast.fromBinary.noDebugInfo
@@ -6,7 +6,7 @@
  (import "env" "im1" (tag $eimport$1 (param i32 f32)))
  (tag $tag$0 (param i32))
  (tag $tag$1 (param i32 f32))
- (tag $tag$2 (param))
+ (tag $tag$2)
  (tag $tag$3 (param i32 f32))
  (tag $tag$4 (param i32 f32))
  (tag $tag$5 (param i32))

--- a/test/try-delegate.wasm.fromBinary
+++ b/test/try-delegate.wasm.fromBinary
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (tag $tag$0 (param))
+ (tag $tag$0)
  (func $0
   (try $label$6
    (do

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -51,6 +51,12 @@ class FeatureValidationTest(utils.BinaryenTestCase):
         self.check_feature(module, error, '--enable-gc',
                            ['--enable-reference-types'])
 
+    def check_typed_continuations(self, module, error):
+        # Typed continuations implies function references (which is provided by
+        # gc in binaryen, and implies reference types) and exceptions
+        self.check_feature(module, error, '--enable-typed-continuations',
+                           ['--enable-gc', '--enable-reference-types', '--enable-exception-handling'])
+
     def test_v128_signature(self):
         module = '''
         (module
@@ -277,6 +283,16 @@ class FeatureValidationTest(utils.BinaryenTestCase):
         )
         '''
         self.check_gc(module, 'all used types should be allowed')
+
+    def test_tag_results(self):
+        module = '''
+        (module
+         (tag $foo (result i32))
+        )
+        '''
+        self.check_typed_continuations(module,
+                                       'Tags with result types require typed '
+                                       'continuations feature [--enable-typed-continuations]')
 
 
 class TargetFeaturesSectionTest(utils.BinaryenTestCase):


### PR DESCRIPTION
This PR is part of a series that adds basic support for the [typed continuations proposal](https://github.com/wasmfx/specfx).

This PR relaxes the restriction that tags must not have `result`s , only `param`s. Tags with results must not be used for exception handling and are only allowed if the typed continuations feature is enabled.

As a minor point, this PR also changes the printing of tags without `param`s: To make the presentation consistent, `(param)` is omitted when printing a tag.