### PR TITLE
Add getGeneralSuperType() that includes basic supers, and use in fuzzer

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -122,7 +122,6 @@ struct SubTypes {
     }
 
     // Add the max depths of basic types.
-    // TODO: update when we get structtype
     for (auto type : types) {
       HeapType basic;
       if (type.isStruct()) {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -25,8 +25,6 @@ high chance for set at start of loop
     high chance of a tee in that case => loop var
 */
 
-// TODO Generate exception handling instructions
-
 #include "ir/branch-utils.h"
 #include "ir/memory-utils.h"
 #include "ir/struct-utils.h"
@@ -399,8 +397,3 @@ private:
 };
 
 } // namespace wasm
-
-// XXX Switch class has a condition?! is it real? should the node type be the
-// value type if it exists?!
-
-// TODO copy an existing function and replace just one node in it

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -765,8 +765,7 @@ void TranslateToFuzzReader::recombine(Function* func) {
 
       while (1) {
         ret.push_back(Type(heapType, nullability));
-        // TODO: handle basic supertypes too
-        auto super = heapType.getSuperType();
+        auto super = heapType.getGeneralSuperType();
         if (!super) {
           break;
         }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -372,6 +372,11 @@ public:
   // else an empty optional.
   std::optional<HeapType> getSuperType() const;
 
+  // As getSuperType, but also handles basic types (i.e., the other function
+  // returns an empty optional if there is a basic supertype, but this does
+  // not).
+  std::optional<HeapType> getGeneralSuperType() const;
+
   // Return the depth of this heap type in the nominal type hierarchy, i.e. the
   // number of supertypes in its supertype chain.
   size_t getDepth() const;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1218,6 +1218,47 @@ std::optional<HeapType> HeapType::getSuperType() const {
   return {};
 }
 
+std::optional<HeapType> HeapType::getGeneralSuperType() const {
+  auto ret = getSuperType();
+  if (ret) {
+    return ret;
+  }
+
+  // There may be a basic supertype.
+  if (isBasic()) {
+    switch (getBasic()) {
+      case ext:
+      case noext:
+      case func:
+      case nofunc:
+      case any:
+      case none:
+      case string:
+      case stringview_wtf8:
+      case stringview_wtf16:
+      case stringview_iter:
+        return {};
+      case eq:
+        return any;
+      case i31:
+      case struct_:
+      case array:
+        return eq;
+    }
+  }
+
+  auto* info = getHeapTypeInfo(*this);
+  switch (info->kind) {
+    case HeapTypeInfo::SignatureKind:
+      return func;
+    case HeapTypeInfo::StructKind:
+      return struct_;
+    case HeapTypeInfo::ArrayKind:
+      return array;
+  }
+  WASM_UNREACHABLE("unexpected kind");
+}
+
 size_t HeapType::getDepth() const {
   size_t depth = 0;
   std::optional<HeapType> super;

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -552,20 +552,6 @@ TEST_F(PossibleContentsTest, TestStructCones) {
   auto C = types[2];
   auto D = types[3];
   auto E = types[4];
-
-  // Verify all supertype relations work as expected.
-  ASSERT_FALSE(HeapType(HeapType::any).getGeneralSuperType());
-  ASSERT_EQ(HeapType(HeapType::eq).getGeneralSuperType(), HeapType::any);
-  ASSERT_EQ(HeapType(HeapType::struct_).getGeneralSuperType(), HeapType::eq);
-  ASSERT_EQ(A.getGeneralSuperType(), HeapType::struct_);
-  ASSERT_EQ(B.getGeneralSuperType(), A);
-  ASSERT_EQ(C.getGeneralSuperType(), A);
-  ASSERT_EQ(D.getGeneralSuperType(), C);
-
-  // Verify that getSuperType (not 'general' only returns non-basic types).
-  ASSERT_FALSE(HeapType(HeapType::any).getSuperType());
-  ASSERT_FALSE(HeapType(HeapType::eq).getSuperType());
-  ASSERT_FALSE(HeapType(HeapType::struct_).getSuperType());
   ASSERT_FALSE(A.getSuperType());
   ASSERT_EQ(B.getSuperType(), A);
   ASSERT_EQ(C.getSuperType(), A);

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -552,9 +552,24 @@ TEST_F(PossibleContentsTest, TestStructCones) {
   auto C = types[2];
   auto D = types[3];
   auto E = types[4];
-  ASSERT_TRUE(B.getSuperType() == A);
-  ASSERT_TRUE(C.getSuperType() == A);
-  ASSERT_TRUE(D.getSuperType() == C);
+
+  // Verify all supertype relations work as expected.
+  ASSERT_FALSE(HeapType(HeapType::any).getGeneralSuperType());
+  ASSERT_EQ(HeapType(HeapType::eq).getGeneralSuperType(), HeapType::any);
+  ASSERT_EQ(HeapType(HeapType::struct_).getGeneralSuperType(), HeapType::eq);
+  ASSERT_EQ(A.getGeneralSuperType(), HeapType::struct_);
+  ASSERT_EQ(B.getGeneralSuperType(), A);
+  ASSERT_EQ(C.getGeneralSuperType(), A);
+  ASSERT_EQ(D.getGeneralSuperType(), C);
+
+  // Verify that getSuperType (not 'general' only returns non-basic types).
+  ASSERT_FALSE(HeapType(HeapType::any).getSuperType());
+  ASSERT_FALSE(HeapType(HeapType::eq).getSuperType());
+  ASSERT_FALSE(HeapType(HeapType::struct_).getSuperType());
+  ASSERT_FALSE(A.getSuperType());
+  ASSERT_EQ(B.getSuperType(), A);
+  ASSERT_EQ(C.getSuperType(), A);
+  ASSERT_EQ(D.getSuperType(), C);
 
   auto nullA = Type(A, Nullable);
   auto nullB = Type(B, Nullable);

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -1118,15 +1118,15 @@ TEST_F(TypeTest, TestSupertypes) {
   // Non-basic types.
   HeapType struct1, struct2, array1, array2, sig1, sig2;
   {
-    TypeBuilder builder(4);
+    TypeBuilder builder(6);
     builder[0].setOpen() = Struct();
-    builder[1].setOpen().subTypeOf(builder[1]) = Struct();
+    builder[1].setOpen().subTypeOf(builder[0]) = Struct();
     auto array = Array(Field(Type::i32, Immutable));
     builder[2].setOpen() = array;
-    builder[3].setOpen().subTypeOf(builder[3]) = array;
+    builder[3].setOpen().subTypeOf(builder[2]) = array;
     auto sig = Signature(Type::none, Type::none);
     builder[4].setOpen() = sig;
-    builder[5].setOpen().subTypeOf(builder[5]) = sig;
+    builder[5].setOpen().subTypeOf(builder[4]) = sig;
     auto result = builder.build();
     ASSERT_TRUE(result);
     auto built = *result;

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,47 +1,45 @@
 total
  [exports]      : 7       
- [funcs]        : 12      
+ [funcs]        : 13      
  [globals]      : 1       
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 3       
+ [table-data]   : 2       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 575     
- [vars]         : 17      
- ArrayLen       : 1       
- ArrayNew       : 4       
+ [total]        : 578     
+ [vars]         : 23      
+ ArrayGet       : 3       
+ ArrayLen       : 4       
+ ArrayNew       : 5       
  ArrayNewFixed  : 1       
- AtomicCmpxchg  : 1       
- Binary         : 75      
- Block          : 68      
- Break          : 6       
- Call           : 15      
- CallRef        : 1       
- Const          : 148     
+ ArraySet       : 1       
+ AtomicRMW      : 1       
+ Binary         : 81      
+ Block          : 70      
+ Break          : 5       
+ Call           : 20      
+ Const          : 122     
  Drop           : 4       
- GlobalGet      : 28      
- GlobalSet      : 28      
- I31Get         : 1       
- If             : 24      
- Load           : 20      
- LocalGet       : 33      
- LocalSet       : 22      
+ GlobalGet      : 30      
+ GlobalSet      : 30      
+ If             : 26      
+ Load           : 19      
+ LocalGet       : 45      
+ LocalSet       : 32      
  Loop           : 4       
- MemoryFill     : 2       
- Nop            : 7       
- RefFunc        : 6       
- RefI31         : 3       
- RefIsNull      : 1       
- RefNull        : 7       
- RefTest        : 1       
- Return         : 7       
+ Pop            : 1       
+ RefAs          : 3       
+ RefFunc        : 5       
+ RefI31         : 1       
+ RefNull        : 9       
+ RefTest        : 3       
+ Return         : 5       
  SIMDExtract    : 1       
- Select         : 2       
- Store          : 2       
- StructNew      : 7       
+ StructNew      : 6       
  StructSet      : 1       
- TupleMake      : 3       
- Unary          : 24      
- Unreachable    : 17      
+ Try            : 1       
+ TupleMake      : 1       
+ Unary          : 22      
+ Unreachable    : 16      


### PR DESCRIPTION
With this, the fuzzer can replace e.g. an `eq` expression with a specific struct type,
because now it is away that struct types have `eq` as their ancestor.