### PR TITLE
README.md: eliminate spurious import in wasm-merge sample output

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,7 +630,6 @@ and then its name. The merged output is this:
 
 ```wat
 (module
-  (import "second" "bar" (func $second.bar))
   (import "outside" "log" (func $log (param i32)))
 
   (export "main" (func $func))


### PR DESCRIPTION
The `first` module's `(import "second" "bar"...` gets satisfied by the `second` module's `(export "bar" (func $func))` and goes away.