### PR TITLE
Rename getSuperType to getDeclaredSuperType

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -406,7 +406,7 @@ Counts getHeapTypeCounts(Module& wasm, bool prune = false) {
       }
     }
 
-    if (auto super = ht.getSuperType()) {
+    if (auto super = ht.getDeclaredSuperType()) {
       if (!counts.count(*super)) {
         newTypes.insert(*super);
         // We should unconditionally count supertypes, but while the type system

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1559,7 +1559,7 @@ void TNHOracle::infer() {
       }
       while (1) {
         typeFunctions[type].push_back(func.get());
-        if (auto super = type.getSuperType()) {
+        if (auto super = type.getDeclaredSuperType()) {
           type = *super;
         } else {
           break;

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -269,7 +269,7 @@ private:
 
       if (toSuperTypes) {
         // Propagate shared fields to the supertype.
-        if (auto superType = type.getSuperType()) {
+        if (auto superType = type.getDeclaredSuperType()) {
           auto& superInfos = combinedInfos[*superType];
           auto& superFields = superType->getStruct().fields;
           for (Index i = 0; i < superFields.size(); i++) {

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -86,7 +86,7 @@ struct SubTypes {
       SubTypesFirstSort(const SubTypes& parent) : parent(parent) {
         for (auto type : parent.types) {
           // The roots are types with no supertype.
-          if (!type.getSuperType()) {
+          if (!type.getDeclaredSuperType()) {
             push(type);
           }
         }
@@ -198,7 +198,7 @@ struct SubTypes {
 private:
   // Add a type to the graph.
   void note(HeapType type) {
-    if (auto super = type.getSuperType()) {
+    if (auto super = type.getDeclaredSuperType()) {
       typeSubTypes[*super].push_back(type);
     }
   }

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -46,8 +46,8 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes() {
     GlobalTypeRewriter& parent;
 
     SupertypesFirst(GlobalTypeRewriter& parent) : parent(parent) {}
-    std::optional<HeapType> getSuperType(HeapType type) {
-      return parent.getSuperType(type);
+    std::optional<HeapType> getDeclaredSuperType(HeapType type) {
+      return parent.getDeclaredSuperType(type);
     }
   };
 
@@ -106,7 +106,7 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes() {
     }
 
     // Apply a super, if there is one
-    if (auto super = getSuperType(type)) {
+    if (auto super = getDeclaredSuperType(type)) {
       if (auto it = typeIndices.find(*super); it != typeIndices.end()) {
         assert(it->second < i);
         typeBuilder[i].subTypeOf(typeBuilder[it->second]);

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -384,8 +384,8 @@ public:
   // Subclasses can override this method to modify supertypes. The new
   // supertype, if any, must be a supertype (or the same as) the original
   // supertype.
-  virtual std::optional<HeapType> getSuperType(HeapType oldType) {
-    return oldType.getSuperType();
+  virtual std::optional<HeapType> getDeclaredSuperType(HeapType oldType) {
+    return oldType.getDeclaredSuperType();
   }
 
   // Map an old type to a temp type. This can be called from the above hooks,
@@ -506,9 +506,9 @@ public:
     sig.params = getUpdatedTypeList(oldSig.params);
     sig.results = getUpdatedTypeList(oldSig.results);
   }
-  std::optional<HeapType> getSuperType(HeapType oldType) override {
+  std::optional<HeapType> getDeclaredSuperType(HeapType oldType) override {
     // If the super is mapped, get it from the mapping.
-    auto super = oldType.getSuperType();
+    auto super = oldType.getDeclaredSuperType();
     if (super) {
       if (auto it = mapping.find(*super); it != mapping.end()) {
         return it->second;

--- a/src/passes/AbstractTypeRefining.cpp
+++ b/src/passes/AbstractTypeRefining.cpp
@@ -269,14 +269,14 @@ struct AbstractTypeRefining : public Pass {
       AbstractTypeRefiningTypeMapper(Module& wasm, const TypeUpdates& mapping)
         : TypeMapper(wasm, mapping) {}
 
-      std::optional<HeapType> getSuperType(HeapType oldType) override {
-        auto super = oldType.getSuperType();
+      std::optional<HeapType> getDeclaredSuperType(HeapType oldType) override {
+        auto super = oldType.getDeclaredSuperType();
 
         // Go up the chain of supertypes, skipping things we are mapping away,
         // as those things will not appear in the output. This skips B in the
         // example above.
         while (super && mapping.count(*super)) {
-          super = super->getSuperType();
+          super = super->getDeclaredSuperType();
         }
         return super;
       }

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -170,7 +170,7 @@ struct GlobalStructInference : public Pass {
         // empty, below.
         typeGlobals.erase(type);
 
-        auto super = type.getSuperType();
+        auto super = type.getDeclaredSuperType();
         if (!super) {
           break;
         }
@@ -184,7 +184,7 @@ struct GlobalStructInference : public Pass {
     for (auto& [type, globals] : typeGlobalsCopy) {
       auto curr = type;
       while (1) {
-        auto super = curr.getSuperType();
+        auto super = curr.getDeclaredSuperType();
         if (!super) {
           break;
         }

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -184,7 +184,7 @@ struct SignaturePruning : public Pass {
       if (!subTypes.getImmediateSubTypes(type).empty()) {
         continue;
       }
-      if (auto super = type.getSuperType()) {
+      if (auto super = type.getDeclaredSuperType()) {
         if (super->isSignature()) {
           continue;
         }

--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -148,7 +148,7 @@ struct SignatureRefining : public Pass {
     for (auto& [type, info] : allInfo) {
       if (!subTypes.getImmediateSubTypes(type).empty()) {
         info.canModify = false;
-      } else if (type.getSuperType()) {
+      } else if (type.getDeclaredSuperType()) {
         // Also avoid modifying types with supertypes, as we do not handle
         // contravariance here. That is, when we refine parameters we look for
         // a more refined type, but the type must be *less* refined than the

--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -169,8 +169,8 @@ struct MergeableSupertypesFirst
 
   MergeableSupertypesFirst(TypeMerging& merging) : merging(merging) {}
 
-  std::optional<HeapType> getSuperType(HeapType type) {
-    if (auto super = type.getSuperType()) {
+  std::optional<HeapType> getDeclaredSuperType(HeapType type) {
+    if (auto super = type.getDeclaredSuperType()) {
       return merging.getMerged(*super);
     }
     return std::nullopt;
@@ -291,7 +291,7 @@ bool TypeMerging::merge(MergeKind kind) {
   // Similar to the above, but look up or create a partition associated with the
   // type's supertype and top-level shape rather than its identity.
   auto ensureShapePartition = [&](HeapType type) -> Partitions::iterator {
-    auto super = type.getSuperType();
+    auto super = type.getDeclaredSuperType();
     if (super) {
       super = getMerged(*super);
     }
@@ -321,7 +321,7 @@ bool TypeMerging::merge(MergeKind kind) {
 
     switch (kind) {
       case Supertypes: {
-        auto super = type.getSuperType();
+        auto super = type.getDeclaredSuperType();
         if (super && shapeEq(type, *super)) {
           // The current type and its supertype have the same top-level
           // structure and are not distinguished, so add the current type to its
@@ -454,7 +454,7 @@ TypeMerging::splitSupertypePartition(const std::vector<HeapType>& types) {
   std::unordered_map<HeapType, Index> partitionIndices;
   MergeableSupertypesFirst sortedTypes(*this);
   for (auto type : sortedTypes.sort(types)) {
-    auto super = type.getSuperType();
+    auto super = type.getDeclaredSuperType();
     if (super && includedTypes.count(*super)) {
       // We must already have a partition for the supertype we can add to.
       auto index = partitionIndices.at(*super);

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -148,7 +148,7 @@ struct TypeRefining : public Pass {
     auto& subTypes = propagator.subTypes;
     UniqueDeferredQueue<HeapType> work;
     for (auto type : subTypes.types) {
-      if (type.isStruct() && !type.getSuperType()) {
+      if (type.isStruct() && !type.getDeclaredSuperType()) {
         work.push(type);
       }
     }
@@ -170,7 +170,7 @@ struct TypeRefining : public Pass {
       }
 
       // Next ensure proper subtyping of this struct's fields versus its super.
-      if (auto super = type.getSuperType()) {
+      if (auto super = type.getDeclaredSuperType()) {
         auto& superFields = super->getStruct().fields;
         for (Index i = 0; i < superFields.size(); i++) {
           auto newSuperType = finalInfos[*super][i].getLUB();

--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -107,7 +107,7 @@ std::vector<HeapType> ensureTypesAreInNewRecGroup(RecGroup recGroup,
           assert(type.isArray());
           builder[i] = type.getArray();
         }
-        if (auto super = type.getSuperType()) {
+        if (auto super = type.getDeclaredSuperType()) {
           builder[i].subTypeOf(*super);
         }
         builder[i].setOpen(type.isOpen());

--- a/src/passes/Unsubtyping.cpp
+++ b/src/passes/Unsubtyping.cpp
@@ -201,7 +201,7 @@ struct Unsubtyping
   void analyzePublicTypes(Module& wasm) {
     // We cannot change supertypes for anything public.
     for (auto type : ModuleUtils::getPublicHeapTypes(wasm)) {
-      if (auto super = type.getSuperType()) {
+      if (auto super = type.getDeclaredSuperType()) {
         noteSubtype(type, *super);
       }
     }
@@ -276,7 +276,7 @@ struct Unsubtyping
       Unsubtyping& parent;
       Rewriter(Unsubtyping& parent, Module& wasm)
         : GlobalTypeRewriter(wasm), parent(parent) {}
-      std::optional<HeapType> getSuperType(HeapType type) override {
+      std::optional<HeapType> getDeclaredSuperType(HeapType type) override {
         if (auto it = parent.supertypes.find(type);
             it != parent.supertypes.end() && !it->second.isBasic()) {
           return it->second;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -766,7 +766,7 @@ void TranslateToFuzzReader::recombine(Function* func) {
       while (1) {
         ret.push_back(Type(heapType, nullability));
         // TODO: handle basic supertypes too
-        auto super = heapType.getSuperType();
+        auto super = heapType.getDeclaredSuperType();
         if (!super) {
           break;
         }
@@ -3885,7 +3885,7 @@ HeapType TranslateToFuzzReader::getSuperType(HeapType type) {
   std::vector<HeapType> supers;
   while (1) {
     supers.push_back(type);
-    if (auto super = type.getSuperType()) {
+    if (auto super = type.getDeclaredSuperType()) {
       type = *super;
     } else {
       break;

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -657,7 +657,7 @@ void Inhabitator::markNullable(FieldPos field) {
       // Mark the field null in all supertypes. If the supertype field is
       // already nullable or does not exist, that's ok and this will have no
       // effect.
-      while (auto super = curr.getSuperType()) {
+      while (auto super = curr.getDeclaredSuperType()) {
         nullables.insert({*super, idx});
         curr = *super;
       }
@@ -666,12 +666,12 @@ void Inhabitator::markNullable(FieldPos field) {
       // Find the top type for which this field exists and mark the field
       // nullable in all of its subtypes.
       if (curr.isArray()) {
-        while (auto super = curr.getSuperType()) {
+        while (auto super = curr.getDeclaredSuperType()) {
           curr = *super;
         }
       } else {
         assert(curr.isStruct());
-        while (auto super = curr.getSuperType()) {
+        while (auto super = curr.getDeclaredSuperType()) {
           if (super->getStruct().fields.size() <= idx) {
             break;
           }
@@ -885,7 +885,7 @@ std::vector<HeapType> Inhabitator::build() {
 
   // Establish supertypes and finality.
   for (size_t i = 0; i < types.size(); ++i) {
-    if (auto super = types[i].getSuperType()) {
+    if (auto super = types[i].getDeclaredSuperType()) {
       if (auto it = typeIndices.find(*super); it != typeIndices.end()) {
         builder[i].subTypeOf(builder[it->second]);
       } else {

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -43,7 +43,7 @@ struct SupertypesFirstBase
     }
     // Find the supertypes that are in the collection.
     for (auto [type, _] : typeSet) {
-      if (auto super = self().getSuperType(type)) {
+      if (auto super = self().getDeclaredSuperType(type)) {
         if (auto it = typeSet.find(*super); it != typeSet.end()) {
           it->second = true;
         }
@@ -60,7 +60,7 @@ struct SupertypesFirstBase
 
   void pushPredecessors(HeapType type) {
     // Do not visit types that weren't in the input collection.
-    if (auto super = self().getSuperType(type);
+    if (auto super = self().getDeclaredSuperType(type);
         super && typeSet.count(*super)) {
       this->push(*super);
     }
@@ -71,8 +71,8 @@ struct SupertypesFirst : SupertypesFirstBase<SupertypesFirst> {
   template<typename T>
   SupertypesFirst(const T& types) : SupertypesFirstBase(types) {}
 
-  std::optional<HeapType> getSuperType(HeapType type) {
-    return type.getSuperType();
+  std::optional<HeapType> getDeclaredSuperType(HeapType type) {
+    return type.getDeclaredSuperType();
   }
 };
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -368,9 +368,9 @@ public:
   const Struct& getStruct() const;
   Array getArray() const;
 
-  // If there is a nontrivial (i.e. non-basic) nominal supertype, return it,
-  // else an empty optional.
-  std::optional<HeapType> getSuperType() const;
+  // If there is a nontrivial (i.e. non-basic, one that was declared by the
+  // module) nominal supertype, return it, else an empty optional.
+  std::optional<HeapType> getDeclaredSuperType() const;
 
   // Return the depth of this heap type in the nominal type hierarchy, i.e. the
   // number of supertypes in its supertype chain.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -244,7 +244,7 @@ void WasmBinaryWriter::writeTypes() {
   // be safe to treat as final, i.e. types without subtypes.
   std::vector<bool> hasSubtypes(indexedTypes.types.size());
   for (auto type : indexedTypes.types) {
-    if (auto super = type.getSuperType()) {
+    if (auto super = type.getDeclaredSuperType()) {
       hasSubtypes[indexedTypes.indices[*super]] = true;
     }
   }
@@ -264,7 +264,7 @@ void WasmBinaryWriter::writeTypes() {
     lastGroup = currGroup;
     // Emit the type definition.
     BYN_TRACE("write " << type << std::endl);
-    auto super = type.getSuperType();
+    auto super = type.getDeclaredSuperType();
     if (super || type.isOpen()) {
       if (type.isOpen()) {
         o << S32LEB(BinaryConsts::EncodedType::Sub);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -906,7 +906,7 @@ FeatureSet Type::getFeatures() const {
           }
 
           if (heapType->isStruct() || heapType->isArray() ||
-              heapType->getRecGroup().size() > 1 || heapType->getSuperType()) {
+              heapType->getRecGroup().size() > 1 || heapType->getDeclaredSuperType()) {
             feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
           } else if (heapType->isSignature()) {
             // This is a function reference, which requires reference types and
@@ -1207,7 +1207,7 @@ Array HeapType::getArray() const {
   return getHeapTypeInfo(*this)->array;
 }
 
-std::optional<HeapType> HeapType::getSuperType() const {
+std::optional<HeapType> HeapType::getDeclaredSuperType() const {
   if (isBasic()) {
     return {};
   }
@@ -1221,7 +1221,7 @@ std::optional<HeapType> HeapType::getSuperType() const {
 size_t HeapType::getDepth() const {
   size_t depth = 0;
   std::optional<HeapType> super;
-  for (auto curr = *this; (super = curr.getSuperType()); curr = *super) {
+  for (auto curr = *this; (super = curr.getDeclaredSuperType()); curr = *super) {
     ++depth;
   }
   // In addition to the explicit supertypes we just traversed over, there is
@@ -1344,7 +1344,7 @@ std::vector<HeapType> HeapType::getHeapTypeChildren() const {
 
 std::vector<HeapType> HeapType::getReferencedHeapTypes() const {
   auto types = getHeapTypeChildren();
-  if (auto super = getSuperType()) {
+  if (auto super = getDeclaredSuperType()) {
     types.push_back(*super);
   }
   return types;
@@ -1776,7 +1776,7 @@ std::ostream& TypePrinter::print(HeapType type) {
   }
 
   bool useSub = false;
-  auto super = type.getSuperType();
+  auto super = type.getDeclaredSuperType();
   if (super || type.isOpen()) {
     useSub = true;
     os << "(sub ";

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -906,7 +906,8 @@ FeatureSet Type::getFeatures() const {
           }
 
           if (heapType->isStruct() || heapType->isArray() ||
-              heapType->getRecGroup().size() > 1 || heapType->getDeclaredSuperType()) {
+              heapType->getRecGroup().size() > 1 ||
+              heapType->getDeclaredSuperType()) {
             feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
           } else if (heapType->isSignature()) {
             // This is a function reference, which requires reference types and
@@ -1221,7 +1222,8 @@ std::optional<HeapType> HeapType::getDeclaredSuperType() const {
 size_t HeapType::getDepth() const {
   size_t depth = 0;
   std::optional<HeapType> super;
-  for (auto curr = *this; (super = curr.getDeclaredSuperType()); curr = *super) {
+  for (auto curr = *this; (super = curr.getDeclaredSuperType());
+       curr = *super) {
     ++depth;
   }
   // In addition to the explicit supertypes we just traversed over, there is

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -552,9 +552,9 @@ TEST_F(PossibleContentsTest, TestStructCones) {
   auto C = types[2];
   auto D = types[3];
   auto E = types[4];
-  ASSERT_TRUE(B.getSuperType() == A);
-  ASSERT_TRUE(C.getSuperType() == A);
-  ASSERT_TRUE(D.getSuperType() == C);
+  ASSERT_TRUE(B.getDeclaredSuperType() == A);
+  ASSERT_TRUE(C.getDeclaredSuperType() == A);
+  ASSERT_TRUE(D.getDeclaredSuperType() == C);
 
   auto nullA = Type(A, Nullable);
   auto nullB = Type(B, Nullable);


### PR DESCRIPTION
A later PR will add `getSuperType` which will mean "get the general super type -
either declared, or not".

See discussion in #6005