### PR TITLE
[Outlining] Filter Local Set

### DIFF
--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -58,11 +58,13 @@ void HashStringifyWalker::addUniqueSymbol(SeparatorReason reason) {
   assert((uint32_t)nextSeparatorVal >= nextVal);
   hashString.push_back((uint32_t)nextSeparatorVal);
   nextSeparatorVal--;
+  exprs.push_back(nullptr);
 }
 
 void HashStringifyWalker::visitExpression(Expression* curr) {
   auto [it, inserted] = exprToCounter.insert({curr, nextVal});
   hashString.push_back(it->second);
+  exprs.push_back(curr);
   if (inserted) {
     nextVal++;
   }
@@ -101,6 +103,62 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
     }
     if (!seenEndIdx) {
       seen.insert(idxToInsert.begin(), idxToInsert.end());
+      result.push_back(substring);
+    }
+  }
+
+  return result;
+}
+
+std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filter(
+  const std::vector<SuffixTree::RepeatedSubstring> substrings,
+  const std::vector<Expression*> exprs,
+  std::function<bool(const Expression&)> condition) {
+
+  struct FilterStringifyWalker : public StringifyWalker<FilterStringifyWalker> {
+    bool hasFilterValue = false;
+    std::function<bool(const Expression&)> condition;
+
+    FilterStringifyWalker(std::function<bool(const Expression&)> condition)
+      : condition(condition){};
+
+    void walk(Expression* curr) {
+      hasFilterValue = false;
+      Super::walk(curr);
+    }
+
+    void addUniqueSymbol(SeparatorReason reason) {}
+
+    void visitExpression(Expression* curr) {
+      if (condition(*curr)) {
+        hasFilterValue = true;
+      }
+    }
+  };
+
+  FilterStringifyWalker walker = FilterStringifyWalker(condition);
+
+  std::vector<SuffixTree::RepeatedSubstring> result;
+  for (auto substring : substrings) {
+    bool hasFilterValue = false;
+    for (auto idx = substring.StartIndices[0],
+              endIdx = substring.StartIndices[0] + substring.Length;
+         idx < endIdx;
+         idx++) {
+      Expression* curr = exprs[idx];
+      if (Properties::isControlFlowStructure(curr)) {
+        walker.walk(curr);
+        if (walker.hasFilterValue) {
+          hasFilterValue = true;
+          break;
+        }
+      }
+      if (curr->is<LocalSet>()) {
+        hasFilterValue = true;
+        break;
+      }
+    }
+    if (!hasFilterValue) {
       result.push_back(substring);
     }
   }

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -234,11 +234,11 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
 // Functions that filter vectors of SuffixTree::RepeatedSubstring
 struct StringifyProcessor {
   static std::vector<SuffixTree::RepeatedSubstring>
-  dedupe(const std::vector<SuffixTree::RepeatedSubstring> substrings);
+  dedupe(const std::vector<SuffixTree::RepeatedSubstring>&& substrings);
   static std::vector<SuffixTree::RepeatedSubstring>
-  filter(const std::vector<SuffixTree::RepeatedSubstring> substrings,
+  filter(const std::vector<SuffixTree::RepeatedSubstring>&& substrings,
          const std::vector<Expression*> exprs,
-         std::function<bool(const Expression&)> condition);
+         std::function<bool(const Expression*)> condition);
 };
 
 } // namespace wasm

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -178,7 +178,6 @@ struct StringifyWalker
 
   void doWalkModule(Module* module);
   void doWalkFunction(Function* func);
-  void walk(Expression* curr);
   static void scan(SubType* self, Expression** currp);
   static void doVisitExpression(SubType* self, Expression** currp);
 
@@ -226,6 +225,7 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
   // when evaluating if expressions.
   std::unordered_map<Expression*, uint32_t, StringifyHasher, StringifyEquator>
     exprToCounter;
+  std::vector<Expression*> exprs;
 
   void addUniqueSymbol(SeparatorReason reason);
   void visitExpression(Expression* curr);
@@ -234,7 +234,11 @@ struct HashStringifyWalker : public StringifyWalker<HashStringifyWalker> {
 // Functions that filter vectors of SuffixTree::RepeatedSubstring
 struct StringifyProcessor {
   static std::vector<SuffixTree::RepeatedSubstring>
-  dedupe(const std::vector<SuffixTree::RepeatedSubstring>);
+  dedupe(const std::vector<SuffixTree::RepeatedSubstring> substrings);
+  static std::vector<SuffixTree::RepeatedSubstring>
+  filter(const std::vector<SuffixTree::RepeatedSubstring> substrings,
+         const std::vector<Expression*> exprs,
+         std::function<bool(const Expression&)> condition);
 };
 
 } // namespace wasm

--- a/src/support/suffix_tree.h
+++ b/src/support/suffix_tree.h
@@ -38,6 +38,7 @@
 #include "llvm/Support/Allocator.h"
 #include <cassert>
 #include <cstddef>
+#include <ostream>
 #include <vector>
 
 #include "support/suffix_tree_node.h"
@@ -63,6 +64,19 @@ public:
       return Length == other.Length && StartIndices == other.StartIndices;
     }
   };
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  RepeatedSubstring substring) {
+    os << "SuffixTree::RepeatedSubstring{" << substring.Length
+       << "u, (std::vector<unsigned>{";
+    for (unsigned idx = 0; idx < substring.StartIndices.size(); idx++) {
+      os << substring.StartIndices[idx];
+      if (idx != substring.StartIndices.size() - 1) {
+        os << ", ";
+      }
+    }
+    return os << "})}";
+  }
 
 private:
   /// Maintains internal nodes in the tree.

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -295,7 +295,7 @@ TEST_F(StringifyTest, DedupeSubstrings) {
   auto hashString = hashStringifyModule(&wasm);
   std::vector<SuffixTree::RepeatedSubstring> substrings =
     repeatSubstrings(hashString);
-  auto result = StringifyProcessor::dedupe(substrings);
+  auto result = StringifyProcessor::dedupe(std::move(substrings));
 
   EXPECT_EQ(
     result,
@@ -333,11 +333,11 @@ TEST_F(StringifyTest, FilterLocalSets) {
   HashStringifyWalker stringify = HashStringifyWalker();
   stringify.walkModule(&wasm);
   auto substrings = repeatSubstrings(stringify.hashString);
-  auto result = StringifyProcessor::dedupe(substrings);
+  auto result = StringifyProcessor::dedupe(std::move(substrings));
 
   result = StringifyProcessor::filter(
-    substrings, stringify.exprs, [](const Expression& curr) {
-      return curr.is<LocalSet>();
+    std::move(substrings), stringify.exprs, [](const Expression* curr) {
+      return curr->is<LocalSet>();
     });
 
   EXPECT_EQ(


### PR DESCRIPTION
Adds a general purpose walker named FilterStringifyWalker, intended to walk control flow and take note of whether any of the expressions satisfy the `condition`.

Also includes an `<<` overload for SuffixTree::RepeatedSubstring to make debugging easier.