### PR TITLE
fix: Avoid segfault in catch validator

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2372,38 +2372,36 @@ void FunctionValidator::visitTry(Try* curr) {
     auto* tag = getModule()->getTagOrNull(tagName);
     if (!shouldBeTrue(tag != nullptr, curr, "")) {
       getStream() << "tag name is invalid: " << tagName << "\n";
-    }
-
-    if (!shouldBeEqual(tag->sig.results, Type(Type::none), curr, "")) {
+    } else if (!shouldBeEqual(tag->sig.results, Type(Type::none), curr, "")) {
       getStream()
         << "catch's tag (" << tagName
         << ") has result values, which is not allowed for exception handling";
-    }
-
-    auto* catchBody = curr->catchBodies[i];
-    auto pops = EHUtils::findPops(catchBody);
-    if (tag->sig.params == Type::none) {
-      if (!shouldBeTrue(pops.empty(), curr, "")) {
-        getStream() << "catch's tag (" << tagName
-                    << ") doesn't have any params, but there are pops";
-      }
     } else {
-      if (shouldBeTrue(pops.size() == 1, curr, "")) {
-        auto* pop = *pops.begin();
-        if (!shouldBeSubType(tag->sig.params, pop->type, curr, "")) {
-          getStream()
-            << "catch's tag (" << tagName
-            << ")'s pop doesn't have the same type as the tag's params";
-        }
-        if (!shouldBeTrue(
-              EHUtils::containsValidDanglingPop(catchBody), curr, "")) {
-          getStream() << "catch's body (" << tagName
-                      << ")'s pop's location is not valid";
+      auto* catchBody = curr->catchBodies[i];
+      auto pops = EHUtils::findPops(catchBody);
+      if (tag->sig.params == Type::none) {
+        if (!shouldBeTrue(pops.empty(), curr, "")) {
+          getStream() << "catch's tag (" << tagName
+                      << ") doesn't have any params, but there are pops";
         }
       } else {
-        getStream() << "catch's tag (" << tagName
-                    << ") has params, so there should be a single pop within "
-                       "the catch body";
+        if (shouldBeTrue(pops.size() == 1, curr, "")) {
+          auto* pop = *pops.begin();
+          if (!shouldBeSubType(tag->sig.params, pop->type, curr, "")) {
+            getStream()
+              << "catch's tag (" << tagName
+              << ")'s pop doesn't have the same type as the tag's params";
+          }
+          if (!shouldBeTrue(
+                EHUtils::containsValidDanglingPop(catchBody), curr, "")) {
+            getStream() << "catch's body (" << tagName
+                        << ")'s pop's location is not valid";
+          }
+        } else {
+          getStream() << "catch's tag (" << tagName
+                      << ") has params, so there should be a single pop within "
+                         "the catch body";
+        }
       }
     }
   }

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -10,6 +10,7 @@ set(unittest_SOURCES
   suffix_tree.cpp
   type-builder.cpp
   wat-lexer.cpp
+  validator.cpp
 )
 
 # suffix_tree.cpp includes LLVM header using std::iterator (deprecated in C++17)

--- a/test/gtest/validator.cpp
+++ b/test/gtest/validator.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "wasm-validator.h"
+#include "shared-constants.h"
+#include "support/string.h"
+#include "wasm-binary.h"
+#include "wasm-builder.h"
+#include "gtest/gtest.h"
+
+using namespace wasm;
+
+
+// Check that the validator does not crash on missing tags in catch statements
+// (invalid parse, so cannot be reproduced with Python test suite)
+TEST(ValidatorTest, MissingCatchTag) {
+  WasmValidator validator;
+  Module module;
+  module.features.enable(FeatureSet::ExceptionHandling);
+  auto tryExp = module.allocator.alloc<Try>();
+  tryExp->name = "tst1";
+  auto bodyExp = module.allocator.alloc<Const>();
+  bodyExp->value = Literal(1);
+  tryExp->body = bodyExp;
+  tryExp->catchTags.push_back(wasm::Name("foo"));
+  auto catchBodyExp = module.allocator.alloc<Const>();
+  catchBodyExp->value = Literal(2);
+  tryExp->catchBodies.push_back(catchBodyExp);
+  Function function = Function();
+  function.body = tryExp;
+  WasmValidator::Flags flags = WasmValidator::FlagValues::Globally | WasmValidator::FlagValues::Quiet;
+  EXPECT_FALSE(validator.validate(&function, module, flags));
+}

--- a/test/gtest/validator.cpp
+++ b/test/gtest/validator.cpp
@@ -18,15 +18,14 @@
 #include <string>
 #include <vector>
 
-#include "wasm-validator.h"
 #include "shared-constants.h"
 #include "support/string.h"
 #include "wasm-binary.h"
 #include "wasm-builder.h"
+#include "wasm-validator.h"
 #include "gtest/gtest.h"
 
 using namespace wasm;
-
 
 // Check that the validator does not crash on missing tags in catch statements
 // (invalid parse, so cannot be reproduced with Python test suite)
@@ -45,6 +44,7 @@ TEST(ValidatorTest, MissingCatchTag) {
   tryExp->catchBodies.push_back(catchBodyExp);
   Function function = Function();
   function.body = tryExp;
-  WasmValidator::Flags flags = WasmValidator::FlagValues::Globally | WasmValidator::FlagValues::Quiet;
+  WasmValidator::Flags flags =
+    WasmValidator::FlagValues::Globally | WasmValidator::FlagValues::Quiet;
   EXPECT_FALSE(validator.validate(&function, module, flags));
 }


### PR DESCRIPTION
While working on testing some new [binaryen.ml](https://github.com/grain-lang/binaryen.ml) bindings for Grain, I came across a segmentation fault in the Binaryen WASM validator. The problem is that, if you construct a `try` expression which references a nonexistent tag in one of its `catch` blocks, the validation code successfully identifies the `null` pointer but then proceeds to try to read from it. I have updated the validation code to mitigate this problem and added in a unit test. I verified that backing out the change to `wasm-validator.cpp` causes the unit test file to segfault.

Note that this is not an issue that can be reproduced with the Python `check.py` test suite, since the s-expression parser will reject the malformed `try` block.

Apologies in advance for any faux pas in the test; I don't have much C++ experience.