### PR TITLE
[analysis][NFC] Create a TransferFunction concept

### DIFF
--- a/src/analysis/cfg-impl.h
+++ b/src/analysis/cfg-impl.h
@@ -27,7 +27,7 @@ namespace wasm::analysis {
 template<typename T> struct _indirect_ptr_iterator {
   using iterator_category = std::random_access_iterator_tag;
   using value_type = T;
-  using different_type = off_t;
+  using difference_type = off_t;
   using reference = const T&;
   using pointer = const T*;
 
@@ -75,6 +75,10 @@ template<typename T> struct _indirect_ptr_iterator {
     return it;
   }
 
+  off_t operator-(const _indirect_ptr_iterator& other) const {
+    return ptr - other.ptr;
+  }
+
   bool operator==(const _indirect_ptr_iterator& other) const {
     return ptr == other.ptr;
   }
@@ -98,7 +102,16 @@ template<typename T> struct _indirect_ptr_iterator {
   bool operator>=(const _indirect_ptr_iterator& other) const {
     return ptr >= other.ptr;
   }
+
+  friend _indirect_ptr_iterator operator+(off_t n,
+                                          const _indirect_ptr_iterator& it) {
+    return it + n;
+  }
 };
+
+#if __cplusplus >= 202002L
+static_assert(std::random_access_iterator<_indirect_ptr_iterator<int>>);
+#endif
 
 template<typename T>
 _indirect_ptr_iterator<T> operator+(int n,

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -17,6 +17,10 @@
 #ifndef wasm_analysis_lattice_h
 #define wasm_analysis_lattice_h
 
+#if __cplusplus >= 202002L
+#include <concepts>
+#endif
+
 namespace wasm::analysis {
 
 enum LatticeComparison { NO_RELATION, EQUAL, LESS, GREATER };
@@ -34,8 +38,6 @@ inline LatticeComparison reverseComparison(LatticeComparison comparison) {
 }
 
 #if __cplusplus >= 202002L
-
-#include <concepts>
 
 template<typename L>
 concept Lattice = requires(const L& lattice,

--- a/src/analysis/transfer-function.h
+++ b/src/analysis/transfer-function.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_analysis_transfer_function_h
+#define wasm_analysis_transfer_function_h
+
+#if __cplusplus >= 202002L
+#include <concepts>
+#include <iterator>
+#include <ranges>
+#endif
+
+#include <queue>
+
+#include "cfg.h"
+#include "lattice.h"
+
+namespace wasm::analysis {
+
+#if __cplusplus >= 202002L
+
+template<typename T>
+concept BasicBlockInputRange =
+  std::ranges::input_range<T> &&
+  std::is_same<std::ranges::range_value_t<T>, BasicBlock>::value;
+
+template<typename TxFn, typename L>
+concept TransferFunctionImpl = requires(TxFn& txfn,
+                                        const CFG& cfg,
+                                        BasicBlock* bb,
+                                        typename L::Element& elem,
+                                        std::queue<const BasicBlock*>& bbq) {
+  // Apply the transfer function to update a lattice element with information
+  // from a basic block.
+  { txfn.transfer(bb, elem) } noexcept -> std::same_as<void>;
+  // Initializes the worklist of basic blocks, which can affect performance
+  // depending on the direction of the analysis. TODO: Unlock performance
+  // benefits while exposing fewer implementation details.
+  { txfn.enqueueWorklist(cfg, bbq) } noexcept -> std::same_as<void>;
+  // Get a range over the basic blocks that depend on the given block.
+  { txfn.getDependents(bb) } noexcept -> BasicBlockInputRange;
+};
+
+#define TransferFunction TransferFunctionImpl<L>
+
+#else
+
+#define TransferFunction typename
+
+#endif // __cplusplus >= 202002L
+
+} // namespace wasm::analysis
+
+#endif // wasm_analysis_transfer_function_h

--- a/src/analysis/visitor-transfer-function.h
+++ b/src/analysis/visitor-transfer-function.h
@@ -35,7 +35,8 @@ protected:
 public:
   // Returns an iterable to all the BasicBlocks which depend on currBlock for
   // information.
-  BasicBlock::BasicBlockIterable getDependents(const BasicBlock* currBlock) {
+  BasicBlock::BasicBlockIterable
+  getDependents(const BasicBlock* currBlock) noexcept {
     if constexpr (Direction == AnalysisDirection::Backward) {
       return currBlock->preds();
     } else {
@@ -46,7 +47,8 @@ public:
   // Executes the transfer function on all the expressions of the corresponding
   // CFG node, starting with the node's input state, and changes the input state
   // to the final output state of the node in place.
-  void transfer(const BasicBlock* cfgBlock, typename L::Element& inputState) {
+  void transfer(const BasicBlock* cfgBlock,
+                typename L::Element& inputState) noexcept {
     // If the block is empty, we propagate the state by inputState =
     // outputState.
 
@@ -71,7 +73,8 @@ public:
   // analysis, we push all the blocks in order, while for backward analysis, we
   // push them in reverse order, so that later blocks are evaluated before
   // earlier ones.
-  void enqueueWorklist(CFG& cfg, std::queue<const BasicBlock*>& worklist) {
+  void enqueueWorklist(const CFG& cfg,
+                       std::queue<const BasicBlock*>& worklist) noexcept {
     if constexpr (Direction == AnalysisDirection::Backward) {
       for (auto it = cfg.rbegin(); it != cfg.rend(); ++it) {
         worklist.push(&(*it));


### PR DESCRIPTION
Factor the static assertions for transfer functions out into a new
transfer-function.h header. The concept requires the `getDependents` method to
return an input range of basic blocks, and to satisfy that requirement, fix up
_indirect_ptr_iterator in cfg-impl.h so that it is a proper iterator. Remove
part of the lattice fuzzer that was using a placeholder transfer function in a
way that does not satisfy the new type constraints; most of that code will be
overhauled in the future anyway.