### PR TITLE
[analysis][NFC] Rename `makeLeastUpperBound` to `join` and move it to lattice

### DIFF
--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -46,15 +46,16 @@ concept Lattice = requires(const L& lattice,
   // Lattices must have elements.
   typename L::Element;
   requires std::copyable<typename L::Element>;
-  // We need to be able to get the bottom element.
+  // Get the bottom element of this lattice.
   { lattice.getBottom() } noexcept -> std::same_as<typename L::Element>;
-  // Elements should be comparable. TODO: use <=> and std::three_way_comparable
-  // once we support C++20 everywhere.
+  // Compare two elements of this lattice. TODO: use <=> and
+  // std::three_way_comparable once we support C++20 everywhere.
   {
     lattice.compare(constElem, constElem)
   } noexcept -> std::same_as<LatticeComparison>;
-  // We need to be able to get the least upper bound of two elements and know
-  // whether any change was made.
+  // Modify `elem` in-place to be the join (aka least upper bound) of `elem` and
+  // `constElem`, returning true iff `elem` was modified, i.e. if it was not
+  // already an upper bound of `constElem`.
   { lattice.join(elem, constElem) } noexcept -> std::same_as<bool>;
 };
 

--- a/src/analysis/lattice.h
+++ b/src/analysis/lattice.h
@@ -55,7 +55,7 @@ concept Lattice = requires(const L& lattice,
   } noexcept -> std::same_as<LatticeComparison>;
   // We need to be able to get the least upper bound of two elements and know
   // whether any change was made.
-  { elem.makeLeastUpperBound(constElem) } noexcept -> std::same_as<bool>;
+  { lattice.join(elem, constElem) } noexcept -> std::same_as<bool>;
 };
 
 #else // __cplusplus >= 202002L

--- a/src/analysis/lattices/powerset-impl.h
+++ b/src/analysis/lattices/powerset-impl.h
@@ -78,17 +78,18 @@ inline size_t FiniteIntPowersetLattice::Element::count() const {
 // Least upper bound is implemented as a logical OR between the bitvectors on
 // both sides. We return true if a bit is flipped in-place on the left so the
 // worklist algorithm will know if when to enqueue more work.
-inline bool FiniteIntPowersetLattice::Element::makeLeastUpperBound(
-  const FiniteIntPowersetLattice::Element& other) noexcept {
+inline bool
+FiniteIntPowersetLattice::join(Element& self,
+                               const Element& other) const noexcept {
   // Both must be from powerset lattice of the same set.
-  assert(other.bitvector.size() == bitvector.size());
+  assert(other.bitvector.size() == self.bitvector.size());
 
   bool modified = false;
-  for (size_t i = 0; i < bitvector.size(); ++i) {
+  for (size_t i = 0; i < self.bitvector.size(); ++i) {
     // Bit is flipped on self only if self is false and other is true when self
     // and other are OR'ed together.
-    modified |= (!bitvector[i] && other.bitvector[i]);
-    bitvector[i] = bitvector[i] || other.bitvector[i];
+    modified |= (!self.bitvector[i] && other.bitvector[i]);
+    self.bitvector[i] = self.bitvector[i] || other.bitvector[i];
   }
 
   return modified;

--- a/src/analysis/lattices/powerset.h
+++ b/src/analysis/lattices/powerset.h
@@ -71,11 +71,6 @@ public:
     bool isTop() const { return count() == bitvector.size(); }
     bool isBottom() const { return count() == 0; }
 
-    // Calculates the LUB of this element with some other element and sets
-    // this element to the LUB in place. Returns true if this element before
-    // this method call was different than the LUB.
-    bool makeLeastUpperBound(const Element& other) noexcept;
-
     // Prints out the bits in the bitvector for a lattice element.
     void print(std::ostream& os);
 
@@ -89,6 +84,11 @@ public:
 
   // Returns an instance of the bottom lattice element.
   Element getBottom() const noexcept;
+
+  // Calculates the LUB of this element with some other element and sets
+  // this element to the LUB in place. Returns true if this element before
+  // this method call was different than the LUB.
+  bool join(Element& self, const Element& other) const noexcept;
 };
 
 // A layer of abstraction over FiniteIntPowersetLattice which maps
@@ -149,6 +149,10 @@ public:
   }
 
   Element getBottom() const noexcept { return intLattice.getBottom(); }
+
+  bool join(Element& self, const Element& other) const noexcept {
+    return intLattice.join(self, other);
+  }
 };
 
 } // namespace wasm::analysis

--- a/src/analysis/lattices/powerset.h
+++ b/src/analysis/lattices/powerset.h
@@ -85,9 +85,9 @@ public:
   // Returns an instance of the bottom lattice element.
   Element getBottom() const noexcept;
 
-  // Calculates the LUB of this element with some other element and sets
-  // this element to the LUB in place. Returns true if this element before
-  // this method call was different than the LUB.
+  // Modifies `self` to be the join (aka least upper bound) of `self` and
+  // `other`. Returns true if `self` was modified, i.e. if it was not already an
+  // upper bound of `other`.
   bool join(Element& self, const Element& other) const noexcept;
 };
 

--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -45,7 +45,7 @@ inline void MonotoneCFGAnalyzer<L, TxFn>::evaluate() {
     for (auto& dep : txfn.getDependents(cfg[i])) {
       // If the input state for the dependent block changes, we need to
       // re-analyze it.
-      if (states[dep.getIndex()].makeLeastUpperBound(state)) {
+      if (lattice.join(states[dep.getIndex()], state)) {
         worklist.push(dep.getIndex());
       }
     }

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -164,7 +164,7 @@ TEST_F(CFGTest, FinitePowersetLatticeFunctioning) {
   element2.print(ss);
   EXPECT_EQ(ss.str(), "100101");
   ss.str(std::string());
-  element2.makeLeastUpperBound(element1);
+  lattice.join(element2, element1);
   element2.print(ss);
   EXPECT_EQ(ss.str(), "101101");
 }
@@ -496,7 +496,7 @@ TEST_F(CFGTest, StackLatticeFunctioning) {
   EXPECT_EQ(stackLattice.compare(thirdStack, expectedStack),
             LatticeComparison::EQUAL);
 
-  EXPECT_EQ(thirdStack.makeLeastUpperBound(secondStack), true);
+  EXPECT_TRUE(stackLattice.join(thirdStack, secondStack));
 
   {
     expectedStack.stackTop().set(0, true);


### PR DESCRIPTION
In general, the operation of taking the least upper bound of two lattice
elements may depend on some state stored in the lattice object rather than in
the elements themselves. To avoid forcing the elements to be larger and more
complicated in that case (by storing a parent pointer back to the lattice), move
the least upper bound operation to make it a method of the lattice rather than
the lattice element. This is also more consistent with where we put e.g. the
`compare` method.

While we are at it, rename `makeLeastUpperBound` to `join`, which is much
shorter and nicer. Usually we avoid using esoteric mathematical jargon like
this, but "join" as a normal verb actually describes the operation nicely, so I
think it is ok in this case.