### PR TITLE
[NFC] LocalGraph: Move definition to logical place

### DIFF
--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -155,8 +155,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
         std::cout << "  last set " << val.second << '\n';
       }
 #endif
-      std::vector<std::vector<LocalGet*>> allGets;
-      allGets.resize(numLocals);
+
+      // Track all gets in this block, by index.
+      std::vector<std::vector<LocalGet*>> allGets(numLocals);
 
       // go through the block, finding each get and adding it to its index,
       // and seeing how sets affect that
@@ -224,7 +225,6 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
             }
           }
         }
-        gets.clear();
         currentIteration++;
       }
     }

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -104,8 +104,6 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
     };
 
     auto numLocals = func->getNumLocals();
-    std::vector<std::vector<LocalGet*>> allGets;
-    allGets.resize(numLocals);
     std::vector<FlowBlock*> work;
 
     // Convert input blocks (basicBlocks) into more efficient flow blocks to
@@ -157,9 +155,13 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
         std::cout << "  last set " << val.second << '\n';
       }
 #endif
+      std::vector<std::vector<LocalGet*>> allGets;
+      allGets.resize(numLocals);
+
       // go through the block, finding each get and adding it to its index,
       // and seeing how sets affect that
       auto& actions = block.actions;
+
       // move towards the front, handling things as we go
       for (int i = int(actions.size()) - 1; i >= 0; i--) {
         auto* action = actions[i];


### PR DESCRIPTION
`allGets` was declared in a scope that kept it alive for all blocks, and at
the end of the loop we clear the gets for a particular block. That's clumsy,
and makes a followup harder, so this PR moves it to the natural place for it.
(That is, it moves it to the scope that handles a particular block, and removes
the manual clearing-out of the get at the end of the loop iteration.) Optimizing
compilers are smart enough to be efficient about stack allocations
of objects inside loops anyhow (which I measured).

Helps #6042.