### PR TITLE
[NFC] LocalGraph: Optimize params with no sets

### DIFF
--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -131,7 +131,7 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
 
     // We note which local indexes have local.sets, as that can help us
     // optimize later (if there are none at all).
-    std::unordered_set<Index> hasSet;
+    std::vector<bool> hasSet(numLocals, false);
 
     const size_t NULL_ITERATION = -1;
 
@@ -156,7 +156,7 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
       flowBlock.lastSets.reserve(block->contents.lastSets.size());
       for (auto set : block->contents.lastSets) {
         flowBlock.lastSets.emplace_back(set);
-        hasSet.insert(set.first);
+        hasSet[set.first] = true;
       }
     }
     assert(entryFlowBlock != nullptr);
@@ -197,7 +197,7 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
         if (gets.empty()) {
           continue;
         }
-        if (!hasUnreachable && !hasSet.count(index)) {
+        if (!hasUnreachable && !hasSet[index]) {
           // This local index has no sets, so we know all gets will end up
           // reaching the entry block. Do that here as an optimization to avoid
           // flowing through the (potentially very many) blocks in the function.

--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -122,7 +122,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
     for (Index i = 0; i < basicBlocks.size(); ++i) {
       auto* block = basicBlocks[i].get();
       basicToFlowMap[block] = &flowBlocks[i];
-      if (block->in.empty()) {
+      // Check for unreachable code. Note we ignore the entry block (index 0) as
+      // that is always reached when we are called.
+      if (i != 0 && block->in.empty()) {
         hasUnreachable = true;
       }
     }

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -229,7 +229,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $ref-comparisons (type $8) (param $x (ref null $struct)) (param $y (ref null $struct))
+ ;; CHECK:      (func $ref-comparisons (type $9) (param $x (ref null $struct)) (param $y (ref null $struct))
  ;; CHECK-NEXT:  (local $z (ref null $struct))
  ;; CHECK-NEXT:  (local $w (ref null $struct))
  ;; CHECK-NEXT:  (call $log
@@ -407,7 +407,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-different-params (type $9) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-different-params (type $10) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -723,7 +723,7 @@
   )
  )
 
- ;; CHECK:      (func $helper (type $10) (param $0 i32) (result i32)
+ ;; CHECK:      (func $helper (type $11) (param $0 i32) (result i32)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $helper (param i32) (result i32)
@@ -801,14 +801,14 @@
   )
  )
 
- ;; CHECK:      (func $receive-f64 (type $11) (param $0 f64)
+ ;; CHECK:      (func $receive-f64 (type $12) (param $0 f64)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $receive-f64 (param f64)
   (unreachable)
  )
 
- ;; CHECK:      (func $odd-cast-and-get-non-null (type $12) (param $temp (ref $func-return-i32))
+ ;; CHECK:      (func $odd-cast-and-get-non-null (type $13) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.cast (ref nofunc)
  ;; CHECK-NEXT:    (ref.func $receive-f64)
@@ -836,7 +836,7 @@
   )
  )
 
- ;; CHECK:      (func $new_block_unreachable (type $13) (result anyref)
+ ;; CHECK:      (func $new_block_unreachable (type $8) (result anyref)
  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block
@@ -1032,5 +1032,38 @@
     (i32.const 0x12345678)
    )
   )
+ )
+
+ ;; CHECK:      (func $get-nonnullable-in-unreachable (type $8) (result anyref)
+ ;; CHECK-NEXT:  (local $x (ref any))
+ ;; CHECK-NEXT:  (local.tee $x
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (local.get $x)
+ ;; CHECK-NEXT: )
+ (func $get-nonnullable-in-unreachable (result anyref)
+  (local $x (ref any))
+  ;; We cannot read a non-nullable local without setting it first, but it is ok
+  ;; to do so here because we are in unreachable code. We should also not error
+  ;; about this get seeming to read the default value from the function entry
+  ;; (because it does not, as the entry is not reachable from it). Nothing is
+  ;; expected to be optimized here.
+
+  ;; This unreachable set is needed for the later get to validate.
+  (local.set $x
+   (unreachable)
+  )
+  ;; This if is needed so we have an interesting enough CFG that a possible
+  ;; assertion can be hit about reading the default value from the entry in a
+  ;; later block.
+  (if
+   (i32.const 1)
+   (unreachable)
+  )
+  (local.get $x)
  )
 )


### PR DESCRIPTION
If a local index has no sets, then all gets of that index read from the entry block
(a param, or a zero for a local). This is actually a common case, where a param
has no other set, and so it is worth optimizing, which this PR does by avoiding
any flowing operation at all for that index: we just skip and write the entry block
as the source of information for such gets.

#6042 on `precompute-propagate` goes from 3 minutes to 2 seconds with this (!).
But that testcase is rather special in that it is a huge function with many, many
gets in it, so the overhead we remove here is very noticeable.