### PR TITLE
Fix the case of an unreachable entry in LocalGraph

### DIFF
--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -111,8 +111,9 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
     std::vector<FlowBlock*> work;
 
     // Track if we have unreachable code anywhere, as if we do that may inhibit
-    // certain optimizations below.
-    bool hasUnreachable = false;
+    // certain optimizations below. If there are fewer live blocks than the set
+    // of all blocks, then some are dead.
+    bool hasUnreachable = findLiveBlocks().size() < basicBlocks.size();
 
     // Convert input blocks (basicBlocks) into more efficient flow blocks to
     // improve memory access.
@@ -124,23 +125,6 @@ struct Flower : public CFGWalker<Flower, Visitor<Flower>, Info> {
     for (Index i = 0; i < basicBlocks.size(); ++i) {
       auto* block = basicBlocks[i].get();
       basicToFlowMap[block] = &flowBlocks[i];
-
-      // Check for unreachable code.
-      if (i != 0 && block->in.empty()) {
-        // This is not the entry block, and nothing reaches it, so it is
-        // unreachable.
-        hasUnreachable = true;
-      } else if (i == 0 && block->out.empty() && basicBlocks.size() > 1) {
-        // This is the entry block, and nothing leaves it, so anything after it
-        // is unreachable (and there are blocks after it). We need to handle
-        // this case because the former case skips the entry (since the entry
-        // always as zero incoming paths anyhow), but it is possible that the
-        // entry block is unreachable while later blocks *do* have incoming
-        // paths even though they *are* unreachable, for example, if the entry
-        // has no outgoing paths and the block after it is a loop (so it has an
-        // incoming path from itself).
-        hasUnreachable = true;
-      }
     }
 
     // We note which local indexes have local.sets, as that can help us

--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -30,6 +30,14 @@ namespace wasm {
 // (see the SSA pass for actually creating new local indexes based
 // on this).
 //
+// Note that this is not guaranteed to be precise in unreachable code. That is,
+// we do not make the effort to represent the exact sets for each get, and may
+// overestimate them (specifically, we may mark the entry value as possible,
+// even if unreachability prevents that; doing so helps simplify and optimize
+// the code, which we think is worthwhile for the possible annoyance in
+// debugging etc.; and it has no downside for optimization, since unreachable
+// code will be removed anyhow).
+//
 struct LocalGraph {
   // main API
 

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -442,10 +442,18 @@ private:
             if (getFunction()->isVar(get->index)) {
               auto localType = getFunction()->getLocalType(get->index);
               if (localType.isNonNullable()) {
-                Fatal() << "Non-nullable local accessing the default value in "
-                        << getFunction()->name << " (" << get->index << ')';
+                // This is a non-nullable local that seems to read the default
+                // value at the function entry. This is either an internal error
+                // or a case of unreachable code; the latter is possible as
+                // LocalGraph is not precise in unreachable code.
+                //
+                // We cannot set zeros here (as applying them, even in
+                // unreachable code, would not validate), so just mark this as
+                // a hopeless case to ignore.
+                values = {};
+              } else {
+                curr = Literal::makeZeros(localType);
               }
-              curr = Literal::makeZeros(localType);
             } else {
               // it's a param, so it's hopeless
               values = {};

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -1066,4 +1066,38 @@
   )
   (local.get $x)
  )
+
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $17) (param $x i32) (param $y (ref any))
+ ;; CHECK-NEXT:  (local $0 (ref any))
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT:  (local.set $0
+ ;; CHECK-NEXT:   (local.get $y)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (loop $loop
+ ;; CHECK-NEXT:   (br_if $loop
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $get-nonnullable-in-unreachable-entry (param $x i32) (param $y (ref any))
+  (local $0 (ref any))
+  ;; As above, but now the first basic block is unreachable, and we need to
+  ;; detect that specifically, as the block after it *does* have entries even
+  ;; though it is unreachable (it is a loop, and has itself as an entry).
+  (unreachable)
+  (local.set $0
+   (local.get $y)
+  )
+  (loop $loop
+   (br_if $loop
+    (local.get $x)
+   )
+   (drop
+    (local.get $0)
+   )
+  )
+ )
 )

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -229,7 +229,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $ref-comparisons (type $9) (param $x (ref null $struct)) (param $y (ref null $struct))
+ ;; CHECK:      (func $ref-comparisons (type $10) (param $x (ref null $struct)) (param $y (ref null $struct))
  ;; CHECK-NEXT:  (local $z (ref null $struct))
  ;; CHECK-NEXT:  (local $w (ref null $struct))
  ;; CHECK-NEXT:  (call $log
@@ -407,7 +407,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-different-params (type $10) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-different-params (type $11) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -723,7 +723,7 @@
   )
  )
 
- ;; CHECK:      (func $helper (type $11) (param $0 i32) (result i32)
+ ;; CHECK:      (func $helper (type $12) (param $0 i32) (result i32)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $helper (param i32) (result i32)
@@ -801,14 +801,14 @@
   )
  )
 
- ;; CHECK:      (func $receive-f64 (type $12) (param $0 f64)
+ ;; CHECK:      (func $receive-f64 (type $13) (param $0 f64)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $receive-f64 (param f64)
   (unreachable)
  )
 
- ;; CHECK:      (func $odd-cast-and-get-non-null (type $13) (param $temp (ref $func-return-i32))
+ ;; CHECK:      (func $odd-cast-and-get-non-null (type $14) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.cast (ref nofunc)
  ;; CHECK-NEXT:    (ref.func $receive-f64)
@@ -857,7 +857,7 @@
   )
  )
 
- ;; CHECK:      (func $br_on_cast-on-creation (type $14) (result (ref $empty))
+ ;; CHECK:      (func $br_on_cast-on-creation (type $15) (result (ref $empty))
  ;; CHECK-NEXT:  (block $label (result (ref $empty))
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (br_on_cast $label (ref $empty) (ref $empty)
@@ -952,7 +952,7 @@
   )
  )
 
- ;; CHECK:      (func $remove-set (type $15) (result (ref func))
+ ;; CHECK:      (func $remove-set (type $16) (result (ref func))
  ;; CHECK-NEXT:  (local $nn funcref)
  ;; CHECK-NEXT:  (local $i i32)
  ;; CHECK-NEXT:  (loop $loop
@@ -995,7 +995,7 @@
   )
  )
 
- ;; CHECK:      (func $strings (type $16) (param $param (ref string))
+ ;; CHECK:      (func $strings (type $17) (param $param (ref string))
  ;; CHECK-NEXT:  (local $s (ref string))
  ;; CHECK-NEXT:  (local.set $s
  ;; CHECK-NEXT:   (string.const "hello, world")
@@ -1067,7 +1067,7 @@
   (local.get $x)
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $17) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $9) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (local.set $0
@@ -1087,6 +1087,47 @@
   ;; As above, but now the first basic block is unreachable, and we need to
   ;; detect that specifically, as the block after it *does* have entries even
   ;; though it is unreachable (it is a loop, and has itself as an entry).
+  (unreachable)
+  (local.set $0
+   (local.get $y)
+  )
+  (loop $loop
+   (br_if $loop
+    (local.get $x)
+   )
+   (drop
+    (local.get $0)
+   )
+  )
+ )
+
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $9) (param $x i32) (param $y (ref any))
+ ;; CHECK-NEXT:  (local $0 (ref any))
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (local.get $x)
+ ;; CHECK-NEXT:   (nop)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT:  (local.set $0
+ ;; CHECK-NEXT:   (local.get $y)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (loop $loop
+ ;; CHECK-NEXT:   (br_if $loop
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $get-nonnullable-in-unreachable-later-loop (param $x i32) (param $y (ref any))
+  (local $0 (ref any))
+  ;; This |if| is added, which means the loop is later in the function.
+  ;; Otherwise this is the same as before.
+  (if
+   (local.get $x)
+   (nop)
+  )
   (unreachable)
   (local.set $0
    (local.get $y)


### PR DESCRIPTION
Followup to #6046 - the fuzzer found we missed handling the case of the entry itself
being unreachable and there being a loop after it, see code and testcase.

Also add a "dump" impl in that file which helps debugging.