### PR TITLE
[analysis] Improve lattice fuzzer

### DIFF
--- a/src/analysis/lattices/inverted.h
+++ b/src/analysis/lattices/inverted.h
@@ -35,7 +35,7 @@ template<FullLattice L> struct Inverted {
   Element getBottom() const noexcept { return lattice.getTop(); }
   Element getTop() const noexcept { return lattice.getBottom(); }
   LatticeComparison compare(const Element& a, const Element& b) const noexcept {
-    return reverseComparison(lattice.compare(a, b));
+    return lattice.compare(b, a);
   }
   bool join(Element& self, Element other) const noexcept {
     return lattice.meet(self, other);

--- a/src/analysis/lattices/lift.h
+++ b/src/analysis/lattices/lift.h
@@ -40,6 +40,7 @@ template<Lattice L> struct Lift {
   };
 
   L lattice;
+
   Lift(L&& lattice) : lattice(std::move(lattice)) {}
 
   Element getBottom() const noexcept { return {std::nullopt}; }


### PR DESCRIPTION
Implement new `RandomLattice` and `RandomFullLattice` utilities that are
lattices randomly created from other lattices. By recursively using themselves
as the parameter lattices for lattices like `Inverted` and `Lift`, these random
lattices can become arbitrarily nested.

Decouple the checking of lattice properties from the checking of transfer
function properties by creating a new, standalone `checkLatticeProperties`
function.