### PR TITLE
OnceReduction: Consider calls to "once" functions in "once" functions

### DIFF
--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -217,8 +217,7 @@ struct BlockInfo {
 // optimization, but that would require more code - it might be more efficient,
 // though).
 struct Optimizer
-  : public WalkerPass<
-      CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>> {
+  : public WalkerPass<CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>> {
   bool isFunctionParallel() override { return true; }
 
   Optimizer(OptInfo& optInfo) : optInfo(optInfo) {}
@@ -240,8 +239,8 @@ struct Optimizer
   }
 
   void doWalkFunction(Function* func) {
-    using Parent = WalkerPass<
-      CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>>;
+    using Parent =
+      WalkerPass<CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>>;
 
     // Walk the function to builds the CFG.
     Parent::doWalkFunction(func);

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -258,7 +258,6 @@ struct Optimizer
   }
 
   void doWalkFunction(Function* func) {
-std::cout << "dWF " << func->name << '\n';
     using Parent =
       WalkerPass<CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>>;
 
@@ -288,7 +287,6 @@ std::cout << "dWF " << func->name << '\n';
       // Note that we take a reference here, which is how the data we accumulate
       // ends up stored. The blocks we dominate will see it later.
       auto& onceGlobalsWritten = onceGlobalsWrittenVec[i];
-std::cout << "  in block " << i << "\n";
 
       // Note information from our immediate dominator.
       // TODO: we could also intersect information from all of our preds.
@@ -314,7 +312,6 @@ std::cout << "  in block " << i << "\n";
         auto optimizeOnce = [&](Name globalName) {
           assert(optInfo.onceGlobals.at(globalName));
           auto res = onceGlobalsWritten.emplace(globalName);
-std::cout << "    set global as set " << globalName << '\n';
           if (!res.second) {
             // This global has already been written, so this expr is not needed,
             // regardless of whether it is a global.set or a call.
@@ -335,7 +332,6 @@ std::cout << "    set global as set " << globalName << '\n';
             optimizeOnce(set->name);
           }
         } else if (auto* call = expr->dynCast<Call>()) {
-std::cout << "    see call to " << call->target << "\n";
           auto target = call->target;
           if (optInfo.onceFuncs.at(target).is()) {
             // The global used by the "once" func is written.
@@ -348,17 +344,12 @@ std::cout << "    see call to " << call->target << "\n";
           // Note as written all globals the called function is known to write.
           for (auto globalName :
                optInfo.onceGlobalsSetInFuncs.at(target)) {
-std::cout << "    also noting " << globalName << '\n';
             onceGlobalsWritten.insert(globalName);
           }
         } else {
           WASM_UNREACHABLE("invalid expr");
         }
       }
-
-std::cout << "end of bb " << i << "\n";
-for (auto g : onceGlobalsWrittenVec[i]) std::cout << "  " << g << '\n';
-
     }
 
     // As a result of the above optimization, we can now figure out which "once"
@@ -366,8 +357,6 @@ for (auto g : onceGlobalsWrittenVec[i]) std::cout << "  " << g << '\n';
     // the intersection of globals set in all exit paths.
     std::optional<std::unordered_set<Name>> intersection;
     auto intersect = [&](std::unordered_set<Name>& globals) {
-std::cout << "intersect\n";
-for (auto g : globals) std::cout << "  " << g << '\n';
       if (!intersection) {
         // This is the first thing to intersect. Just copy the values (we can
         // move them as nothing else will read |onceGlobalsWrittenVec| once we
@@ -388,8 +377,6 @@ for (auto g : globals) std::cout << "  " << g << '\n';
       }
     };
     for (Index i = 0; i < basicBlocks.size(); i++) {
-std::cout << "bb " << i << "\n";
-for (auto g : onceGlobalsWrittenVec[i]) std::cout << "  " << g << '\n';
       auto* block = basicBlocks[i].get();
       if (i == 1 && optInfo.onceFuncs.at(func->name).is()) {
         // This is the second basic block in a "once" function, that is, it is
@@ -501,7 +488,6 @@ struct OnceReduction : public Pass {
     }
 
     while (1) {
-std::cout << "iter\n";
       // Initialize all the items in the new data structure that will be
       // populated.
       for (auto& func : module->functions) {

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -362,7 +362,7 @@ struct Optimizer
       //  }
       //
       // Now there are two functions there, but we cannot assume that both have
-      // been called by the time that foo exits: imagine that we called bar
+      // been called by the time that any call to foo exits: imagine that we called bar
       // which calls foo, that is, bar is on the stack when we get to foo; then
       // if bar is an "only" function as well, it will early-exit (since it set
       // its global), and any setting of baz in its body has not yet been

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -355,6 +355,7 @@ struct Optimizer
       // exits.
       entryBlockIndex = 2;
     }
+    assert(entryBlockIndex < onceGlobalsWrittenVec.size());
     optInfo.newOnceGlobalsSetInFuncs[func->name] =
       std::move(onceGlobalsWrittenVec[entryBlockIndex]);
   }

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -221,7 +221,8 @@ struct BlockInfo {
 // optimization, but that would require more code - it might be more efficient,
 // though).
 struct Optimizer
-  : public WalkerPass<CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>> {
+  : public WalkerPass<
+      CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>> {
   bool isFunctionParallel() override { return true; }
 
   Optimizer(OptInfo& optInfo) : optInfo(optInfo) {}
@@ -258,8 +259,8 @@ struct Optimizer
   }
 
   void doWalkFunction(Function* func) {
-    using Parent =
-      WalkerPass<CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>>;
+    using Parent = WalkerPass<
+      CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>>;
 
     // Walk the function to builds the CFG.
     Parent::doWalkFunction(func);
@@ -342,8 +343,7 @@ struct Optimizer
           }
 
           // Note as written all globals the called function is known to write.
-          for (auto globalName :
-               optInfo.onceGlobalsSetInFuncs.at(target)) {
+          for (auto globalName : optInfo.onceGlobalsSetInFuncs.at(target)) {
             onceGlobalsWritten.insert(globalName);
           }
         } else {

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -204,8 +204,8 @@ struct BlockInfo {
   // writes to "once" globals.
   std::vector<Expression*> exprs;
 
-  // Whether this basic block has a branch to return to the caller.
-  bool mayReturn = false;
+  // Whether this basic block may exit back to the caller.
+  bool mayExit = false;
 };
 
 // Performs optimization in all functions. This reads onceGlobalsSetInFuncs in
@@ -235,9 +235,9 @@ struct Optimizer
     if (currBasicBlock) {
       ShallowEffectAnalyzer effects(getPassOptions(), *getModule(), curr);
       if (effects.branchesOut || effects.throws()) {
-        // This returns to the caller, either by branching out (return or
+        // This may exit to the caller, either by branching out (return or
         // call_return, etc.) or by throwing.
-        currBasicBlock->contents.mayReturn = true;
+        currBasicBlock->contents.mayExit = true;
       }
     }
   }
@@ -399,7 +399,7 @@ struct Optimizer
       // We need to consider all exits here: Those that may return due to an
       // instruction (like return or call_return) and also the exit block, which
       // returns implicitly at the end of the function.
-      if (block->contents.mayReturn || block == exit) {
+      if (block->contents.mayExit || block == exit) {
         intersect(onceGlobalsWrittenVec[i]);
       }
     }

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1620,7 +1620,7 @@
   )
 )
 
-;; Test a self-loop. Nothing new can be optimized here, but we should not error.
+;; Test a self-loop.
 (module
   ;; CHECK:      (type $0 (func))
 

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1701,6 +1701,7 @@
     )
     (global.set $once.1 (i32.const 1))
     (call $once)
+    ;; As above, by symmetry, we cannot remove this second call.
     (call $once.2)
     (call $import
       (i32.const 1)
@@ -1716,7 +1717,7 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT:  (call $import
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
@@ -1728,6 +1729,7 @@
     )
     (global.set $once.2 (i32.const 1))
     (call $once)
+    ;; As above, by symmetry, we cannot remove this second call.
     (call $once.1)
     (call $import
       (i32.const 2)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1571,5 +1571,16 @@
     (call $do-once)
     (call $once)
   )
-)
 
+  ;; CHECK:      (func $caller2 (type $0)
+  ;; CHECK-NEXT:  (call $once)
+  ;; CHECK-NEXT:  (call $do-once)
+  ;; CHECK-NEXT: )
+  (func $caller2
+    ;; Reverse order of the above. We cannot optimize here: $do-once does
+    ;; nothing aside from call $once, but all we know is that it is not a "once"
+    ;; function itself, and we only remove calls to "once" functions.
+    (call $once)
+    (call $do-once)
+  )
+)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1427,3 +1427,54 @@
     (call $once)
   )
 )
+
+(module
+  (global $once (mut i32) (i32.const 0))
+
+  (global $once.1 (mut i32) (i32.const 0))
+
+  (func $once
+    ;; A minimal "once" function, which calls another.
+    (if
+      (global.get $once)
+      (return)
+    )
+    (global.set $once (i32.const 1))
+    (call $once.1)
+  )
+
+  (func $once.1
+    ;; Another minimal "once" function, which calls the first, forming a loop.
+    (if
+      (global.get $once.1)
+      (return)
+    )
+    (global.set $once.1 (i32.const 1))
+    (call $once)
+  )
+
+  (func $caller
+    ;; Call a once function more than once. The second call will become a nop.
+    (call $once)
+    (call $once)
+  )
+
+  (func $caller$1
+    ;; Two calls to the second function. Again, the second becomes a nop.
+    (call $once.1)
+    (call $once.1)
+  )
+
+  (func $caller$2
+    ;; A mix of calls. We can still remove the second, because we know the first
+    ;; will call it.
+    (call $once)
+    (call $once.1)
+  )
+
+  (func $caller$3
+    ;; Reverse of the above; again, we can nop the second.
+    (call $once.1)
+    (call $once)
+  )
+)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1428,6 +1428,7 @@
   )
 )
 
+;; Test calls of other "once" functions in "once" functions.
 (module
   ;; CHECK:      (type $0 (func))
 
@@ -1582,68 +1583,5 @@
     ;; function itself, and we only remove calls to "once" functions.
     (call $once)
     (call $do-once)
-  )
-)
-
-;; As above, but now $do-once has some internal structure.
-(module
-
-  ;; CHECK:      (type $0 (func))
-
-  ;; CHECK:      (type $1 (func (result i32)))
-
-  ;; CHECK:      (import "a" "b" (func $import (type $1) (result i32)))
-  (import "a" "b" (func $import (result i32)))
-
-  ;; CHECK:      (global $once (mut i32) (i32.const 0))
-  (global $once (mut i32) (i32.const 0))
-
-  ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $once
-    (if
-      (global.get $once)
-      (return)
-    )
-    (global.set $once (i32.const 1))
-  )
-
-  ;; CHECK:      (func $do-once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (call $once)
-  ;; CHECK-NEXT:    (return)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT: )
-  (func $do-once
-    ;; $once is called in all places we exit from the function, so when we
-    ;; exit we know it has been called, and we can optimize in $caller.
-    (if
-      (call $import)
-      (block
-        (call $once)
-        (return)
-      )
-    )
-    (call $once)
-  )
-
-  ;; CHECK:      (func $caller (type $0)
-  ;; CHECK-NEXT:  (call $do-once)
-  ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT: )
-  (func $caller
-    (call $do-once)
-    (call $once) ;; XXX debug
   )
 )

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1529,3 +1529,47 @@
     (call $caller$4)
   )
 )
+
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (global $once (mut i32) (i32.const 0))
+  (global $once (mut i32) (i32.const 0))
+
+  ;; CHECK:      (func $once (type $0)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (global.get $once)
+  ;; CHECK-NEXT:   (return)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $once
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $once
+    ;; A minimal "once" function.
+    (if
+      (global.get $once)
+      (return)
+    )
+    (global.set $once (i32.const 1))
+  )
+
+  ;; CHECK:      (func $do-once (type $0)
+  ;; CHECK-NEXT:  (call $once)
+  ;; CHECK-NEXT: )
+  (func $do-once
+    ;; Call the once function.
+    (call $once)
+  )
+
+  ;; CHECK:      (func $caller (type $0)
+  ;; CHECK-NEXT:  (call $do-once)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $caller
+    ;; The first proves the second is not needed, and can be nopped.
+    (call $do-once)
+    (call $once)
+  )
+)
+


### PR DESCRIPTION
Say that we have a "once" function like this:

```js
function once.A() {
  if (once.A.done) return;
  once.A.done = true;
  A();
  once.B();
}
```

This calls `A` the first time it is reached, and otherwise early-exits. It also calls
`once.B`, however, which may also be a once function. If it is, then we could
optimize this:

```js
once.A();
once.B(); // unneeded
```

After the first call we know the second will have executed, so it can be removed.

To make this work, two small fixes were needed: First, we need to not assume
that only the "once" global itself is the only global set in a "once" function.
Second, we need to look at the proper part of the "once" function when we
consider what it is known to always set (see details in the large new comment).