### PR TITLE
[analysis][NFC] Rename parameters to join and meet methods

### DIFF
--- a/src/analysis/lattices/bool.h
+++ b/src/analysis/lattices/bool.h
@@ -30,16 +30,16 @@ struct Bool {
   LatticeComparison compare(Element a, Element b) const noexcept {
     return a > b ? GREATER : a == b ? EQUAL : LESS;
   }
-  bool join(Element& self, Element other) const noexcept {
-    if (!self && other) {
-      self = other;
+  bool join(Element& joinee, Element joiner) const noexcept {
+    if (!joinee && joiner) {
+      joinee = joiner;
       return true;
     }
     return false;
   }
-  bool meet(Element& self, Element other) const noexcept {
-    if (self && !other) {
-      self = other;
+  bool meet(Element& meetee, Element meeter) const noexcept {
+    if (meetee && !meeter) {
+      meetee = meeter;
       return true;
     }
     return false;

--- a/src/analysis/lattices/flat.h
+++ b/src/analysis/lattices/flat.h
@@ -69,13 +69,13 @@ public:
     }
   }
 
-  bool join(Element& self, const Element& other) const noexcept {
-    switch (compare(self, other)) {
+  bool join(Element& joinee, const Element& joiner) const noexcept {
+    switch (compare(joinee, joiner)) {
       case LESS:
-        self = other;
+        joinee = joiner;
         return true;
       case NO_RELATION:
-        self = Element{Top{}};
+        joinee = Element{Top{}};
         return true;
       case GREATER:
       case EQUAL:

--- a/src/analysis/lattices/int.h
+++ b/src/analysis/lattices/int.h
@@ -38,16 +38,16 @@ struct Integer {
   LatticeComparison compare(Element a, Element b) const noexcept {
     return a > b ? GREATER : a == b ? EQUAL : LESS;
   }
-  bool join(Element& self, Element other) const noexcept {
-    if (self < other) {
-      self = other;
+  bool join(Element& joinee, Element joiner) const noexcept {
+    if (joinee < joiner) {
+      joinee = joiner;
       return true;
     }
     return false;
   }
-  bool meet(Element& self, Element other) const noexcept {
-    if (self > other) {
-      self = other;
+  bool meet(Element& meetee, Element meeter) const noexcept {
+    if (meetee > meeter) {
+      meetee = meeter;
       return true;
     }
     return false;

--- a/src/analysis/lattices/inverted.h
+++ b/src/analysis/lattices/inverted.h
@@ -37,11 +37,11 @@ template<FullLattice L> struct Inverted {
   LatticeComparison compare(const Element& a, const Element& b) const noexcept {
     return lattice.compare(b, a);
   }
-  bool join(Element& self, Element other) const noexcept {
-    return lattice.meet(self, other);
+  bool join(Element& joinee, Element joiner) const noexcept {
+    return lattice.meet(joinee, joiner);
   }
-  bool meet(Element& self, Element other) const noexcept {
-    return lattice.join(self, other);
+  bool meet(Element& meetee, Element meeter) const noexcept {
+    return lattice.join(meetee, meeter);
   }
 };
 

--- a/src/analysis/lattices/lift.h
+++ b/src/analysis/lattices/lift.h
@@ -60,16 +60,16 @@ template<Lattice L> struct Lift {
     }
   }
 
-  bool join(Element& self, const Element& other) const noexcept {
-    if (self.isBottom() && other.isBottom()) {
+  bool join(Element& joinee, const Element& joiner) const noexcept {
+    if (joinee.isBottom() && joiner.isBottom()) {
       return false;
-    } else if (self.isBottom()) {
-      self = other;
+    } else if (joinee.isBottom()) {
+      joinee = joiner;
       return true;
-    } else if (other.isBottom()) {
+    } else if (joiner.isBottom()) {
       return false;
     } else {
-      return lattice.join(*self, *other);
+      return lattice.join(*joinee, *joiner);
     }
   }
 };

--- a/src/analysis/lattices/powerset-impl.h
+++ b/src/analysis/lattices/powerset-impl.h
@@ -79,17 +79,17 @@ inline size_t FiniteIntPowersetLattice::Element::count() const {
 // both sides. We return true if a bit is flipped in-place on the left so the
 // worklist algorithm will know if when to enqueue more work.
 inline bool
-FiniteIntPowersetLattice::join(Element& self,
-                               const Element& other) const noexcept {
+FiniteIntPowersetLattice::join(Element& joinee,
+                               const Element& joiner) const noexcept {
   // Both must be from powerset lattice of the same set.
-  assert(other.bitvector.size() == self.bitvector.size());
+  assert(joiner.bitvector.size() == joinee.bitvector.size());
 
   bool modified = false;
-  for (size_t i = 0; i < self.bitvector.size(); ++i) {
-    // Bit is flipped on self only if self is false and other is true when self
-    // and other are OR'ed together.
-    modified |= (!self.bitvector[i] && other.bitvector[i]);
-    self.bitvector[i] = self.bitvector[i] || other.bitvector[i];
+  for (size_t i = 0; i < joinee.bitvector.size(); ++i) {
+    // Bit is flipped on joinee only if joinee is false and joiner is true when
+    // joinee and joiner are OR'ed together.
+    modified |= (!joinee.bitvector[i] && joiner.bitvector[i]);
+    joinee.bitvector[i] = joinee.bitvector[i] || joiner.bitvector[i];
   }
 
   return modified;

--- a/src/analysis/lattices/powerset.h
+++ b/src/analysis/lattices/powerset.h
@@ -85,10 +85,10 @@ public:
   // Returns an instance of the bottom lattice element.
   Element getBottom() const noexcept;
 
-  // Modifies `self` to be the join (aka least upper bound) of `self` and
-  // `other`. Returns true if `self` was modified, i.e. if it was not already an
-  // upper bound of `other`.
-  bool join(Element& self, const Element& other) const noexcept;
+  // Modifies `joinee` to be the join (aka least upper bound) of `joinee` and
+  // `joiner`. Returns true if `joinee` was modified, i.e. if it was not already
+  // an upper bound of `joiner`.
+  bool join(Element& joinee, const Element& joiner) const noexcept;
 };
 
 // A layer of abstraction over FiniteIntPowersetLattice which maps
@@ -150,8 +150,8 @@ public:
 
   Element getBottom() const noexcept { return intLattice.getBottom(); }
 
-  bool join(Element& self, const Element& other) const noexcept {
-    return intLattice.join(self, other);
+  bool join(Element& joinee, const Element& joiner) const noexcept {
+    return intLattice.join(joinee, joiner);
   }
 };
 

--- a/src/analysis/lattices/stack.h
+++ b/src/analysis/lattices/stack.h
@@ -215,25 +215,25 @@ public:
     }
   }
 
-  // When taking the LUB, we take the LUBs of the elements of each stack
-  // starting from the top of the stack. So, LUB([b, a], [b', a']) is
-  // [LUB(b, b'), LUB(a, a')]. If one stack is higher than the other,
-  // the bottom of the higher stack will be kept, while the LUB of the
-  // corresponding tops of each stack will be taken. For instance,
-  // LUB([d, c, b, a], [b', a']) is [d, c, LUB(b, b'), LUB(a, a')].
+  // When taking the join, we take the joins of the elements of each stack
+  // starting from the top of the stack. So, join([b, a], [b', a']) is [join(b,
+  // b'), join(a, a')]. If one stack is higher than the other, the bottom of the
+  // higher stack will be kept, while the join of the corresponding tops of each
+  // stack will be taken. For instance, join([d, c, b, a], [b', a']) is [d, c,
+  // join(b, b'), join(a, a')].
   //
-  // We start at the top because it makes taking the LUB of stacks with
-  // different scope easier, as mentioned at the top of the file. It also
-  // fits with the conception of the stack starting at the top and having
-  // an infinite bottom, which allows stacks of different height and scope
-  // to be easily joined.
-  bool join(Element& self, const Element& other) const noexcept {
+  // We start at the top because it makes taking the join of stacks with
+  // different scope easier, as mentioned at the top of the file. It also fits
+  // with the conception of the stack starting at the top and having an infinite
+  // bottom, which allows stacks of different height and scope to be easily
+  // joined.
+  bool join(Element& joinee, const Element& joiner) const noexcept {
     // Top element cases, since top elements don't actually have the stack
     // value.
-    if (self.isTop()) {
+    if (joinee.isTop()) {
       return false;
-    } else if (other.isTop()) {
-      self.stackValue.reset();
+    } else if (joiner.isTop()) {
+      joinee.stackValue.reset();
       return true;
     }
 
@@ -242,18 +242,18 @@ public:
     // Merge the shorter height stack with the top of the longer height
     // stack. We do this by taking the LUB of each pair of matching elements
     // from both stacks.
-    auto selfIt = self.stackValue->rbegin();
-    auto otherIt = other.stackValue->crbegin();
-    for (; selfIt != self.stackValue->rend() &&
-           otherIt != other.stackValue->crend();
-         ++selfIt, ++otherIt) {
-      modified |= lattice.join(*selfIt, *otherIt);
+    auto joineeIt = joinee.stackValue->rbegin();
+    auto joinerIt = joiner.stackValue->crbegin();
+    for (; joineeIt != joinee.stackValue->rend() &&
+           joinerIt != joiner.stackValue->crend();
+         ++joineeIt, ++joinerIt) {
+      modified |= lattice.join(*joineeIt, *joinerIt);
     }
 
-    // If the other stack is higher, append the bottom of it to our current
+    // If the joiner stack is higher, append the bottom of it to our current
     // stack.
-    for (; otherIt != other.stackValue->crend(); ++otherIt) {
-      self.stackValue->push_front(*otherIt);
+    for (; joinerIt != joiner.stackValue->crend(); ++joinerIt) {
+      joinee.stackValue->push_front(*joinerIt);
       modified = true;
     }
 


### PR DESCRIPTION
Since these methods, which operate on lattice elements, moved to the lattice
types, it no longer makes much sense for their parameters to be called `self`
and `other`. Rename them to `joinee` and `joiner` for joins and `meetee` and
`meeter` for meets.