### PR TITLE
[analysis] Implement a vector lattice

### DIFF
--- a/src/analysis/lattices/vector.h
+++ b/src/analysis/lattices/vector.h
@@ -47,7 +47,8 @@ template<Lattice L> struct Vector {
     return Element(size, lattice.getTop());
   }
 
-  // `a` <= `b` if their elements are pairwise <=, etc.
+  // `a` <= `b` if their elements are pairwise <=, etc. Unless we determine
+  // that there is no relation, we must check all the elements.
   LatticeComparison compare(const Element& a, const Element& b) const noexcept {
     assert(a.size() == size);
     assert(b.size() == size);


### PR DESCRIPTION
The vector lattice is nearly identical to the array lattice, except that the
size of the elements is specified at runtime when the lattice object is created
rather than at compile time. The code and tests are largely copy-pasted and
fixed up from the array implementation, but there are a couple differences.
First, initializing vector elements does not need the template magic used to
initialize array elements. Second, the obvious implementations of join and meet
do not work for vectors of bools because they might be specialized to be bit
vectors, so we need workarounds for that particular case.