### PR TITLE
OnceReduction: Optimize bodies of trivial "once" functions

### DIFF
--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -217,8 +217,7 @@ struct BlockInfo {
 // optimization, but that would require more code - it might be more efficient,
 // though).
 struct Optimizer
-  : public WalkerPass<
-      CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>> {
+  : public WalkerPass<CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>> {
   bool isFunctionParallel() override { return true; }
 
   Optimizer(OptInfo& optInfo) : optInfo(optInfo) {}
@@ -240,8 +239,8 @@ struct Optimizer
   }
 
   void doWalkFunction(Function* func) {
-    using Parent = WalkerPass<
-      CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>>;
+    using Parent =
+      WalkerPass<CFGWalker<Optimizer, Visitor<Optimizer>, BlockInfo>>;
 
     // Walk the function to builds the CFG.
     Parent::doWalkFunction(func);

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -517,7 +517,7 @@ struct OnceReduction : public Pass {
           //  1. foo has been called before. Then we early-exit in BEFORE, and
           //     in AFTER we call bar which will early-exit (since foo was
           //     called, which means bar was at least entered, which set its
-          //     global; bar might be on the stack, if it called up, so it has
+          //     global; bar might be on the stack, if it called foo, so it has
           //     not necessarily fully executed - this is a tricky situation to
           //     handle in general, like recursive imports of modules in various
           //     languages - but we do not bar has been *entered*, which means

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -520,7 +520,7 @@ struct OnceReduction : public Pass {
           //     global; bar might be on the stack, if it called foo, so it has
           //     not necessarily fully executed - this is a tricky situation to
           //     handle in general, like recursive imports of modules in various
-          //     languages - but we do not bar has been *entered*, which means
+          //     languages - but we do know bar has been *entered*, which means
           //     the global was set).
           //  2. foo has never been called before. In this case in BEFORE we set
           //     the global and call bar, and in AFTER we also call bar.

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -474,6 +474,15 @@ struct OnceReduction : public Pass {
       auto& list = body->cast<Block>()->list;
       if (list.size() == 2) {
         // No payload at all; we don't need the early-exit code then.
+        //
+        // Note that this overlaps with SimplifyGlobals' optimization on
+        // "read-only-to-write" globals: with no payload, this global is really
+        // only read in order to write itself, and nothing more, so there is no
+        // observable behavior we need to preserve, and the global can be
+        // removed. We might as well handle this case here as well since we've
+        // done all the work up to here, and it is just one line to implement
+        // the nopping out. (And doing so here can accelerate the optimization
+        // pipeline by not needing to wait until the next SimplifyGlobals.)
         ExpressionManipulator::nop(body);
         continue;
       }

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -258,7 +258,6 @@ struct Optimizer
   }
 
   void doWalkFunction(Function* func) {
-std::cout << "dWF " << func->name << '\n';
     using Parent =
       WalkerPass<CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>>;
 
@@ -288,7 +287,6 @@ std::cout << "dWF " << func->name << '\n';
       // Note that we take a reference here, which is how the data we accumulate
       // ends up stored. The blocks we dominate will see it later.
       auto& onceGlobalsWritten = onceGlobalsWrittenVec[i];
-std::cout << "  in block " << i << "\n";
 
       // Note information from our immediate dominator.
       // TODO: we could also intersect information from all of our preds.
@@ -314,7 +312,6 @@ std::cout << "  in block " << i << "\n";
         auto optimizeOnce = [&](Name globalName) {
           assert(optInfo.onceGlobals.at(globalName));
           auto res = onceGlobalsWritten.emplace(globalName);
-std::cout << "    set global as set " << globalName << '\n';
           if (!res.second) {
             // This global has already been written, so this expr is not needed,
             // regardless of whether it is a global.set or a call.
@@ -335,7 +332,6 @@ std::cout << "    set global as set " << globalName << '\n';
             optimizeOnce(set->name);
           }
         } else if (auto* call = expr->dynCast<Call>()) {
-std::cout << "    see call to " << call->target << "\n";
           auto target = call->target;
           if (optInfo.onceFuncs.at(target).is()) {
             // The global used by the "once" func is written.
@@ -348,17 +344,12 @@ std::cout << "    see call to " << call->target << "\n";
           // Note as written all globals the called function is known to write.
           for (auto globalName :
                optInfo.onceGlobalsSetInFuncs.at(target)) {
-std::cout << "    also noting " << globalName << '\n';
             onceGlobalsWritten.insert(globalName);
           }
         } else {
           WASM_UNREACHABLE("invalid expr");
         }
       }
-
-std::cout << "end of bb " << i << "\n";
-for (auto g : onceGlobalsWrittenVec[i]) std::cout << "  " << g << '\n';
-
     }
 
     // As a result of the above optimization, we can now figure out which "once"
@@ -366,8 +357,6 @@ for (auto g : onceGlobalsWrittenVec[i]) std::cout << "  " << g << '\n';
     // the intersection of globals set in all exit paths.
     std::optional<std::unordered_set<Name>> intersection;
     auto intersect = [&](std::unordered_set<Name>& globals) {
-std::cout << "intersect\n";
-for (auto g : globals) std::cout << "  " << g << '\n';
       if (!intersection) {
         // This is the first thing to intersect. Just copy the values (we can
         // move them as nothing else will read |onceGlobalsWrittenVec| once we
@@ -388,8 +377,6 @@ for (auto g : globals) std::cout << "  " << g << '\n';
       }
     };
     for (Index i = 0; i < basicBlocks.size(); i++) {
-std::cout << "bb " << i << "\n";
-for (auto g : onceGlobalsWrittenVec[i]) std::cout << "  " << g << '\n';
       auto* block = basicBlocks[i].get();
       if (i == 1 && optInfo.onceFuncs.at(func->name).is()) {
         // This is the second basic block in a "once" function, that is, it is
@@ -501,7 +488,6 @@ struct OnceReduction : public Pass {
     }
 
     while (1) {
-std::cout << "iter\n";
       // Initialize all the items in the new data structure that will be
       // populated.
       for (auto& func : module->functions) {

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -494,8 +494,8 @@ struct OnceReduction : public Pass {
       if (auto* call = payload->dynCast<Call>()) {
         if (optInfo.onceFuncs.at(call->target).is()) {
           // All this "once" function does is call another. We do not need the
-          // early-exit logic in this one, then, because of the following logic.
-          // We are comparing these forms:
+          // early-exit logic in this one, then, because of the following
+          // reasoning. We are comparing these forms:
           //
           //  // BEFORE
           //  function foo() {
@@ -517,7 +517,11 @@ struct OnceReduction : public Pass {
           //  1. foo has been called before. Then we early-exit in BEFORE, and
           //     in AFTER we call bar which will early-exit (since foo was
           //     called, which means bar was at least entered, which set its
-          //     global).
+          //     global; bar might be on the stack, if it called up, so it has
+          //     not necessarily fully executed - this is a tricky situation to
+          //     handle in general, like recursive imports of modules in various
+          //     languages - but we do not bar has been *entered*, which means
+          //     the global was set).
           //  2. foo has never been called before. In this case in BEFORE we set
           //     the global and call bar, and in AFTER we also call bar.
           //

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -362,7 +362,7 @@ struct Optimizer
       //  }
       //
       // Now there are two functions there, but we cannot assume that both have
-      // been called by the time that foo exits: imagine that we called bar
+      // been called by the time that any call to foo exits: imagine that we called bar
       // which calls foo, that is, bar is on the stack when we get to foo; then
       // if bar is an "only" function as well, it will early-exit (since it set
       // its global), and any setting of baz in its body has not yet been

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -355,6 +355,7 @@ struct Optimizer
       // exits.
       entryBlockIndex = 2;
     }
+    assert(entryBlockIndex < onceGlobalsWrittenVec.size());
     optInfo.newOnceGlobalsSetInFuncs[func->name] =
       std::move(onceGlobalsWrittenVec[entryBlockIndex]);
   }

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -221,7 +221,8 @@ struct BlockInfo {
 // optimization, but that would require more code - it might be more efficient,
 // though).
 struct Optimizer
-  : public WalkerPass<CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>> {
+  : public WalkerPass<
+      CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>> {
   bool isFunctionParallel() override { return true; }
 
   Optimizer(OptInfo& optInfo) : optInfo(optInfo) {}
@@ -258,8 +259,8 @@ struct Optimizer
   }
 
   void doWalkFunction(Function* func) {
-    using Parent =
-      WalkerPass<CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>>;
+    using Parent = WalkerPass<
+      CFGWalker<Optimizer, UnifiedExpressionVisitor<Optimizer>, BlockInfo>>;
 
     // Walk the function to builds the CFG.
     Parent::doWalkFunction(func);
@@ -342,8 +343,7 @@ struct Optimizer
           }
 
           // Note as written all globals the called function is known to write.
-          for (auto globalName :
-               optInfo.onceGlobalsSetInFuncs.at(target)) {
+          for (auto globalName : optInfo.onceGlobalsSetInFuncs.at(target)) {
             onceGlobalsWritten.insert(globalName);
           }
         } else {

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -204,8 +204,8 @@ struct BlockInfo {
   // writes to "once" globals.
   std::vector<Expression*> exprs;
 
-  // Whether this basic block has a branch to return to the caller.
-  bool mayReturn = false;
+  // Whether this basic block may exit back to the caller.
+  bool mayExit = false;
 };
 
 // Performs optimization in all functions. This reads onceGlobalsSetInFuncs in
@@ -235,9 +235,9 @@ struct Optimizer
     if (currBasicBlock) {
       ShallowEffectAnalyzer effects(getPassOptions(), *getModule(), curr);
       if (effects.branchesOut || effects.throws()) {
-        // This returns to the caller, either by branching out (return or
+        // This may exit to the caller, either by branching out (return or
         // call_return, etc.) or by throwing.
-        currBasicBlock->contents.mayReturn = true;
+        currBasicBlock->contents.mayExit = true;
       }
     }
   }
@@ -399,7 +399,7 @@ struct Optimizer
       // We need to consider all exits here: Those that may return due to an
       // instruction (like return or call_return) and also the exit block, which
       // returns implicitly at the end of the function.
-      if (block->contents.mayReturn || block == exit) {
+      if (block->contents.mayExit || block == exit) {
         intersect(onceGlobalsWrittenVec[i]);
       }
     }

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1503,18 +1503,25 @@
   )
 
   ;; CHECK:      (func $once.1 (type $0)
-  ;; CHECK-NEXT:  (nop)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (global.get $once.1)
+  ;; CHECK-NEXT:   (return)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $once.1
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (call $once)
   ;; CHECK-NEXT: )
   (func $once.1
+    ;; This early-exit logic looks removable, since we call another "once"
+    ;; function. However, we remove that function's early-exit logic, so we
+    ;; cannot do so here (it would risk an infinite loop).
     (if
       (global.get $once.1)
       (return)
     )
     (global.set $once.1 (i32.const 1))
     (call $once) ;; This call was added.
-    ;; XXX infinite recursion!!1
   )
 
   ;; CHECK:      (func $caller (type $0)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1787,7 +1787,14 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (global.get $once)
+  ;; CHECK-NEXT:   (return)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $once
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (call $other)
   ;; CHECK-NEXT: )
   (func $once
     ;; We should not remove this early-exit logic.
@@ -1800,12 +1807,15 @@
     (call $other)
   )
 
+  ;; CHECK:      (func $other (type $0)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
   (func $other
   )
 
   ;; CHECK:      (func $caller (type $0)
-  ;; CHECK-NEXT:  (call $do-once)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (call $other)
+  ;; CHECK-NEXT:  (call $once)
   ;; CHECK-NEXT: )
   (func $caller
     ;; There is nothing to optimize here.
@@ -1815,7 +1825,7 @@
 
   ;; CHECK:      (func $caller2 (type $0)
   ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT:  (call $do-once)
+  ;; CHECK-NEXT:  (call $other)
   ;; CHECK-NEXT: )
   (func $caller2
     ;; Reverse order of the above. Also nothing to do.

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1620,7 +1620,7 @@
   )
 )
 
-;; Test a self-loop. Nothing new can be optimized here, but we should not error.
+;; Test a self-loop.
 (module
   ;; CHECK:      (type $0 (func))
 

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1701,6 +1701,7 @@
     )
     (global.set $once.1 (i32.const 1))
     (call $once)
+    ;; As above, by symmetry, we cannot remove this second call.
     (call $once.2)
     (call $import
       (i32.const 1)
@@ -1716,7 +1717,7 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT:  (call $import
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
@@ -1728,6 +1729,7 @@
     )
     (global.set $once.2 (i32.const 1))
     (call $once)
+    ;; As above, by symmetry, we cannot remove this second call.
     (call $once.1)
     (call $import
       (i32.const 2)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1571,5 +1571,16 @@
     (call $do-once)
     (call $once)
   )
-)
 
+  ;; CHECK:      (func $caller2 (type $0)
+  ;; CHECK-NEXT:  (call $once)
+  ;; CHECK-NEXT:  (call $do-once)
+  ;; CHECK-NEXT: )
+  (func $caller2
+    ;; Reverse order of the above. We cannot optimize here: $do-once does
+    ;; nothing aside from call $once, but all we know is that it is not a "once"
+    ;; function itself, and we only remove calls to "once" functions.
+    (call $once)
+    (call $do-once)
+  )
+)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1427,3 +1427,54 @@
     (call $once)
   )
 )
+
+(module
+  (global $once (mut i32) (i32.const 0))
+
+  (global $once.1 (mut i32) (i32.const 0))
+
+  (func $once
+    ;; A minimal "once" function, which calls another.
+    (if
+      (global.get $once)
+      (return)
+    )
+    (global.set $once (i32.const 1))
+    (call $once.1)
+  )
+
+  (func $once.1
+    ;; Another minimal "once" function, which calls the first, forming a loop.
+    (if
+      (global.get $once.1)
+      (return)
+    )
+    (global.set $once.1 (i32.const 1))
+    (call $once)
+  )
+
+  (func $caller
+    ;; Call a once function more than once. The second call will become a nop.
+    (call $once)
+    (call $once)
+  )
+
+  (func $caller$1
+    ;; Two calls to the second function. Again, the second becomes a nop.
+    (call $once.1)
+    (call $once.1)
+  )
+
+  (func $caller$2
+    ;; A mix of calls. We can still remove the second, because we know the first
+    ;; will call it.
+    (call $once)
+    (call $once.1)
+  )
+
+  (func $caller$3
+    ;; Reverse of the above; again, we can nop the second.
+    (call $once.1)
+    (call $once)
+  )
+)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -11,7 +11,7 @@
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
-    ;; A minimal "once" function.
+    ;; A minimal "once" function. It is so trivial we can remove its body.
     (if
       (global.get $once)
       (return)
@@ -1402,7 +1402,8 @@
   ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $once
-    ;; A minimal "once" function, which calls another.
+    ;; A minimal "once" function, which calls another. We can remove the first
+    ;; two lines here (the early-exit logic).
     (if
       (global.get $once)
       (return)
@@ -1513,6 +1514,7 @@
     )
     (global.set $once.1 (i32.const 1))
     (call $once) ;; This call was added.
+    ;; XXX infinite recursion!!1
   )
 
   ;; CHECK:      (func $caller (type $0)

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1446,7 +1446,7 @@
 
   ;; CHECK:      (func $caller$2 (type $0)
   ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $caller$2
     ;; A mix of calls. We can still remove the second, because we know the first
@@ -1546,7 +1546,7 @@
 
   ;; CHECK:      (func $caller$2 (type $0)
   ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $caller$2
     ;; Again, the second becomes a nop.
@@ -1556,7 +1556,7 @@
 
   ;; CHECK:      (func $caller$3 (type $0)
   ;; CHECK-NEXT:  (call $once.1)
-  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (call $once)
   ;; CHECK-NEXT: )
   (func $caller$3
     ;; An improvement compared to the previous module, now we can optimize the

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1416,7 +1416,8 @@
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once.1
-    ;; Another minimal "once" function.
+    ;; Another minimal "once" function. It has no payload and we can empty it
+    ;; out.
     (if
       (global.get $once.1)
       (return)
@@ -1449,8 +1450,10 @@
   ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $caller$2
-    ;; A mix of calls. We can still remove the second, because we know the first
-    ;; will call it.
+    ;; A mix of calls. We can remove the second in principle, because we know
+    ;; the first will call it, but we leave that for later optimizations
+    ;; ($once turns into a call to $once.1 that inlining will remove, and then
+    ;; we'll have two identical calls here).
     (call $once)
     (call $once.1)
   )
@@ -1460,8 +1463,8 @@
   ;; CHECK-NEXT:  (call $once)
   ;; CHECK-NEXT: )
   (func $caller$3
-    ;; Reverse of the above; now we cannot optimize, as $once.1 does not call
-    ;; $once.
+    ;; Reverse of the above; again we cannot optimize (as $once.1 does not call
+    ;; $once).
     (call $once.1)
     (call $once)
   )
@@ -1494,6 +1497,8 @@
   ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $once
+    ;; This "once" function calls another, and so we can remove the early-exit
+    ;; logic.
     (if
       (global.get $once)
       (return)
@@ -1549,7 +1554,8 @@
   ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $caller$2
-    ;; Again, the second becomes a nop.
+    ;; The second could become a nop, but we leave that for later optimizations
+    ;; (after inlining the call to $once becomes a call to $once.1).
     (call $once)
     (call $once.1)
   )
@@ -1559,8 +1565,7 @@
   ;; CHECK-NEXT:  (call $once)
   ;; CHECK-NEXT: )
   (func $caller$3
-    ;; An improvement compared to the previous module, now we can optimize the
-    ;; second one.
+    ;; Reverse order, same result (no optimization).
     (call $once.1)
     (call $once)
   )

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1428,6 +1428,7 @@
   )
 )
 
+;; Test calls of other "once" functions in "once" functions.
 (module
   ;; CHECK:      (type $0 (func))
 
@@ -1582,68 +1583,5 @@
     ;; function itself, and we only remove calls to "once" functions.
     (call $once)
     (call $do-once)
-  )
-)
-
-;; As above, but now $do-once has some internal structure.
-(module
-
-  ;; CHECK:      (type $0 (func))
-
-  ;; CHECK:      (type $1 (func (result i32)))
-
-  ;; CHECK:      (import "a" "b" (func $import (type $1) (result i32)))
-  (import "a" "b" (func $import (result i32)))
-
-  ;; CHECK:      (global $once (mut i32) (i32.const 0))
-  (global $once (mut i32) (i32.const 0))
-
-  ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $once
-    (if
-      (global.get $once)
-      (return)
-    )
-    (global.set $once (i32.const 1))
-  )
-
-  ;; CHECK:      (func $do-once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (call $import)
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (call $once)
-  ;; CHECK-NEXT:    (return)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT: )
-  (func $do-once
-    ;; $once is called in all places we exit from the function, so when we
-    ;; exit we know it has been called, and we can optimize in $caller.
-    (if
-      (call $import)
-      (block
-        (call $once)
-        (return)
-      )
-    )
-    (call $once)
-  )
-
-  ;; CHECK:      (func $caller (type $0)
-  ;; CHECK-NEXT:  (call $do-once)
-  ;; CHECK-NEXT:  (call $once)
-  ;; CHECK-NEXT: )
-  (func $caller
-    (call $do-once)
-    (call $once) ;; XXX debug
   )
 )

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -1529,3 +1529,47 @@
     (call $caller$4)
   )
 )
+
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (global $once (mut i32) (i32.const 0))
+  (global $once (mut i32) (i32.const 0))
+
+  ;; CHECK:      (func $once (type $0)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (global.get $once)
+  ;; CHECK-NEXT:   (return)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (global.set $once
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $once
+    ;; A minimal "once" function.
+    (if
+      (global.get $once)
+      (return)
+    )
+    (global.set $once (i32.const 1))
+  )
+
+  ;; CHECK:      (func $do-once (type $0)
+  ;; CHECK-NEXT:  (call $once)
+  ;; CHECK-NEXT: )
+  (func $do-once
+    ;; Call the once function.
+    (call $once)
+  )
+
+  ;; CHECK:      (func $caller (type $0)
+  ;; CHECK-NEXT:  (call $do-once)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $caller
+    ;; The first proves the second is not needed, and can be nopped.
+    (call $do-once)
+    (call $once)
+  )
+)
+

--- a/test/lit/passes/once-reduction.wast
+++ b/test/lit/passes/once-reduction.wast
@@ -8,13 +8,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     ;; A minimal "once" function.
@@ -476,13 +470,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 42)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     (if
@@ -599,13 +587,7 @@
   (global $once (mut i32) (global.get $import))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     (if
@@ -900,13 +882,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     (if
@@ -940,13 +916,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     (if
@@ -1081,13 +1051,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     (if
@@ -1287,13 +1251,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     (if
@@ -1439,13 +1397,8 @@
   (global $once.1 (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $once
@@ -1459,13 +1412,7 @@
   )
 
   ;; CHECK:      (func $once.1 (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once.1)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once.1
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once.1
     ;; Another minimal "once" function.
@@ -1541,13 +1488,8 @@
   (global $once.1 (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (call $once.1)
   ;; CHECK-NEXT: )
   (func $once
@@ -1560,13 +1502,8 @@
   )
 
   ;; CHECK:      (func $once.1 (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once.1)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once.1
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (call $once)
   ;; CHECK-NEXT: )
   (func $once.1
@@ -1786,13 +1723,7 @@
   (global $once (mut i32) (i32.const 0))
 
   ;; CHECK:      (func $once (type $0)
-  ;; CHECK-NEXT:  (if
-  ;; CHECK-NEXT:   (global.get $once)
-  ;; CHECK-NEXT:   (return)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (global.set $once
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $once
     ;; A minimal "once" function.


### PR DESCRIPTION
In particular, if the body just calls another "once" function, then we can
skip the early-exit logic (see details in the comment in the new code).

Followup/replacement of #6055 

cc @gkdn 