### PR TITLE
[analysis][NFC] Refactor lattice unit tests

### DIFF
--- a/src/analysis/lattices/flat.h
+++ b/src/analysis/lattices/flat.h
@@ -51,6 +51,13 @@ public:
     bool isTop() const noexcept { return std::get_if<Top>(this); }
     const T* getVal() const noexcept { return std::get_if<T>(this); }
     T* getVal() noexcept { return std::get_if<T>(this); }
+    bool operator==(const Element& other) const noexcept {
+      return ((isBottom() && other.isBottom()) || (isTop() && other.isTop()) ||
+              (getVal() && other.getVal() && *getVal() == *other.getVal()));
+    }
+    bool operator!=(const Element& other) const noexcept {
+      return !(*this == other);
+    }
   };
 
   Element getBottom() const noexcept { return Element{Bot{}}; }


### PR DESCRIPTION
Many of the lattice tests were essentially copy-pasted from one lattice to the
next because they all tested isomorphic subsets of the various lattices,
specifically in the shape of a diamond. Refactor the code so that all lattices
that have tests of this shape use the same utility test functions.