### PR TITLE
[analysis] Add a "Shared" lattice to represent shared state

### DIFF
--- a/src/analysis/lattices/shared.h
+++ b/src/analysis/lattices/shared.h
@@ -17,7 +17,7 @@
 #ifndef wasm_analysis_lattices_shared_h
 #define wasm_analysis_lattices_shared_h
 
-#include <cstddef>
+#include <cstdint>
 
 #include "../lattice.h"
 #include "bool.h"

--- a/src/analysis/lattices/shared.h
+++ b/src/analysis/lattices/shared.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_analysis_lattices_shared_h
+#define wasm_analysis_lattices_shared_h
+
+#include <cstddef>
+
+#include "../lattice.h"
+#include "bool.h"
+
+namespace wasm::analysis {
+
+// A lattice whose elements are a single ascending chain in lattice `L`.
+// Internally, there is only ever a single monotonically increasing element of L
+// materialized. Dereferencing any element of the Shared lattice will produce
+// the current value of that single element of L, which is generally safe
+// because the current value always overapproximates the value at the time of
+// the Shared element's construction.
+template<Lattice L> struct Shared {
+  class Element {
+    const typename L::Element* val;
+    uint32_t seq = 0;
+
+    Element(const typename L::Element* val) : val(val) {}
+
+  public:
+    Element() = default;
+    Element(const Element&) = default;
+    Element(Element&&) = default;
+    Element& operator=(const Element&) = default;
+    Element& operator=(Element&&) = default;
+
+    // Only provide const references to the value to force all updates to go
+    // through our API.
+    const typename L::Element& operator*() const noexcept { return *val; }
+    const typename L::Element* operator->() const noexcept { return val; }
+
+    bool operator==(const Element& other) const noexcept {
+      assert(val == other.val);
+      return seq == other.seq;
+    }
+
+    bool operator!=(const Element& other) const noexcept {
+      return !(*this == other);
+    }
+
+    friend Shared;
+  };
+
+  L lattice;
+
+  // The current value that all elements point to and the current maximum
+  // sequence number. The sequence numbers monotonically increase along with
+  // `val` and serve to provide ordering between elements of this lattice.
+  mutable typename L::Element val;
+  mutable uint32_t seq = 0;
+
+  Shared(L&& l) : lattice(std::move(l)), val(lattice.getBottom()) {}
+
+  Element getBottom() const noexcept { return Element{&val}; }
+
+  LatticeComparison compare(const Element& a, const Element& b) const noexcept {
+    assert(a.val == b.val);
+    return a.seq < b.seq ? LESS : a.seq == b.seq ? EQUAL : GREATER;
+  }
+
+  bool join(Element& joinee, const Element& joiner) const noexcept {
+    assert(joinee.val == joiner.val);
+    if (joinee.seq < joiner.seq) {
+      joinee.seq = joiner.seq;
+      return true;
+    }
+    return false;
+  }
+
+  bool join(Element& joinee, const typename L::Element& joiner) const noexcept {
+    if (lattice.join(val, joiner)) {
+      // We have moved to the next value in our ascending chain. Assign it a new
+      // sequence number and update joinee with that sequence number.
+      joinee.seq = ++seq;
+      return true;
+    }
+    return false;
+  }
+};
+
+#if __cplusplus >= 202002L
+static_assert(Lattice<Shared<Bool>>);
+#endif // __cplusplus >= 202002L
+
+} // namespace wasm::analysis
+
+#endif // wasm_analysis_lattices_shared_h

--- a/src/analysis/lattices/shared.h
+++ b/src/analysis/lattices/shared.h
@@ -18,6 +18,7 @@
 #define wasm_analysis_lattices_shared_h
 
 #include <cstdint>
+#include <utility>
 
 #include "../lattice.h"
 #include "bool.h"

--- a/test/gtest/lattices.cpp
+++ b/test/gtest/lattices.cpp
@@ -558,13 +558,14 @@ TEST(SharedLattice, Compare) {
 
   auto zero = shared.getBottom();
 
-  auto one = zero;
+  auto one = shared.getBottom();
   shared.join(one, 1);
 
+  // This join will not change the value.
   auto uno = one;
   shared.join(uno, 1);
 
-  auto two = one;
+  auto two = shared.getBottom();
   shared.join(two, 2);
 
   EXPECT_EQ(shared.compare(zero, zero), analysis::EQUAL);
@@ -593,10 +594,10 @@ TEST(SharedLattice, Join) {
 
   auto zero = shared.getBottom();
 
-  auto one = zero;
+  auto one = shared.getBottom();
   shared.join(one, 1);
 
-  auto two = one;
+  auto two = shared.getBottom();
   shared.join(two, 2);
 
   {
@@ -612,6 +613,12 @@ TEST(SharedLattice, Join) {
   }
 
   {
+    auto elem = zero;
+    EXPECT_TRUE(shared.join(elem, two));
+    EXPECT_EQ(elem, two);
+  }
+
+  {
     auto elem = one;
     EXPECT_FALSE(shared.join(elem, zero));
     EXPECT_EQ(elem, one);
@@ -621,5 +628,29 @@ TEST(SharedLattice, Join) {
     auto elem = one;
     EXPECT_FALSE(shared.join(elem, one));
     EXPECT_EQ(elem, one);
+  }
+
+  {
+    auto elem = one;
+    EXPECT_TRUE(shared.join(elem, two));
+    EXPECT_EQ(elem, two);
+  }
+
+  {
+    auto elem = two;
+    EXPECT_FALSE(shared.join(elem, zero));
+    EXPECT_EQ(elem, two);
+  }
+
+  {
+    auto elem = two;
+    EXPECT_FALSE(shared.join(elem, one));
+    EXPECT_EQ(elem, two);
+  }
+
+  {
+    auto elem = two;
+    EXPECT_FALSE(shared.join(elem, two));
+    EXPECT_EQ(elem, two);
   }
 }


### PR DESCRIPTION
The analysis framework stores a separate lattice element for each basic block
being analyzed to represent the program state at the beginning of the block.
However, in many analyses a significant portion of program state is not
flow-sensitive, so does not benefit from having a separate copy per block. For
example, an analysis might track constraints on the types of locals that do not
vary across blocks, so it really only needs a single copy of the constrains for
each local. It would be correct to simply duplicate the state across blocks
anyway, but it would not be efficient.

To make it possible to share a single copy of a lattice element across basic
blocks, introduce a `Shared<L>` lattice. Mathematically, this lattice represents
a single ascending chain in the underlying lattice and its elements are ordered
according to sequence numbers corresponding to positions in that chain.
Concretely, though, the `Shared<L>` lattice only ever materializes a single,
monotonically increasing element of `L` and all of its elements provide access
to that shared underlying element.

`Shared<L>` will let us get the benefits of having mutable shared state in the
concrete implementation of analyses without losing the benefits of keeping those
analyses expressible purely in terms of the monotone framework.