### PR TITLE
NonNullable => !Defaultable in SimplifyLocals

### DIFF
--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -799,7 +799,7 @@ struct SimplifyLocals
     // TODO investigate more
     Index goodIndex = sinkables.begin()->first;
     auto localType = this->getFunction()->getLocalType(goodIndex);
-    if (localType.isNonNullable()) {
+    if (!localType.isDefaultable()) {
       return;
     }
 

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -794,7 +794,9 @@ struct SimplifyLocals
     // In other words, local.get is not necessarily free of effects if the local
     // is non-nullable - it must have been set already. We could check that
     // here, but running that linear-time check may not be worth it as this
-    // optimization is fairly minor, so just skip the non-nullable case.
+    // optimization is fairly minor, so just skip the non-nullable case (and in
+    // general, the non-defaultable case, of say a tuple with a non-nullable
+    // element).
     //
     // TODO investigate more
     Index goodIndex = sinkables.begin()->first;

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -149,4 +149,19 @@
       )
     )
   )
+
+  (func $if-return-tuple-nn
+    (local $temp ((ref func) (ref null none)))
+    ;; We should not emit a return value for this if, as the tuple has a non-
+    ;; nullable element, so it is nondefaultable.
+    (if
+      (i32.const 0)
+      (local.set $temp
+        (tuple.make
+          (ref.func $func)
+          (ref.null none)
+        )
+      )
+    )
+  )
 )

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -150,15 +150,24 @@
     )
   )
 
+  ;; CHECK:      (func $if-return-tuple-nn (type $0)
+  ;; CHECK-NEXT:  (local $temp ((ref func) nullref))
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (nop)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $if-return-tuple-nn
     (local $temp ((ref func) (ref null none)))
     ;; We should not emit a return value for this if, as the tuple has a non-
     ;; nullable element, so it is nondefaultable.
+    ;;
+    ;; Instead, we can remove the local.set entirely, as it has no gets.
     (if
       (i32.const 0)
       (local.set $temp
         (tuple.make
-          (ref.func $func)
+          (ref.func $if-return-tuple-nn)
           (ref.null none)
         )
       )


### PR DESCRIPTION
We handled references but not tuples in one place.