### PR TITLE
[analysis] Allow joining a single vector element efficiently

### DIFF
--- a/src/analysis/lattices/inverted.h
+++ b/src/analysis/lattices/inverted.h
@@ -37,10 +37,14 @@ template<FullLattice L> struct Inverted {
   LatticeComparison compare(const Element& a, const Element& b) const noexcept {
     return lattice.compare(b, a);
   }
-  bool join(Element& joinee, Element joiner) const noexcept {
+
+  template<typename Elem>
+  bool join(Element& joinee, const Elem& joiner) const noexcept {
     return lattice.meet(joinee, joiner);
   }
-  bool meet(Element& meetee, Element meeter) const noexcept {
+
+  template<typename Elem>
+  bool meet(Element& meetee, const Elem& meeter) const noexcept {
     return lattice.join(meetee, meeter);
   }
 };

--- a/src/analysis/lattices/shared.h
+++ b/src/analysis/lattices/shared.h
@@ -106,7 +106,8 @@ template<Lattice L> struct Shared {
     return false;
   }
 
-  bool join(Element& joinee, const typename L::Element& joiner) const noexcept {
+  template<typename Elem>
+  bool join(Element& joinee, const Elem& joiner) const noexcept {
     if (lattice.join(val, joiner)) {
       // We have moved to the next value in our ascending chain. Assign it a new
       // sequence number and update joinee with that sequence number.

--- a/test/gtest/lattices.cpp
+++ b/test/gtest/lattices.cpp
@@ -478,6 +478,30 @@ TEST(VectorLattice, Meet) {
     vector, {false, false}, {false, true}, {true, false}, {true, true});
 }
 
+TEST(VectorLattice, JoinSingleton) {
+  using Vec = analysis::Vector<analysis::Bool>;
+  Vec vector{analysis::Bool{}, 2};
+  auto elem = vector.getBottom();
+
+  EXPECT_FALSE(vector.join(elem, Vec::SingletonElement(0, false)));
+  EXPECT_EQ(elem, (std::vector{false, false}));
+
+  EXPECT_TRUE(vector.join(elem, Vec::SingletonElement(1, true)));
+  EXPECT_EQ(elem, (std::vector{false, true}));
+}
+
+TEST(VectorLattice, MeetSingleton) {
+  using Vec = analysis::Vector<analysis::Bool>;
+  Vec vector{analysis::Bool{}, 2};
+  auto elem = vector.getTop();
+
+  EXPECT_FALSE(vector.meet(elem, Vec::SingletonElement(1, true)));
+  EXPECT_EQ(elem, (std::vector{true, true}));
+
+  EXPECT_TRUE(vector.meet(elem, Vec::SingletonElement(0, false)));
+  EXPECT_EQ(elem, (std::vector{false, true}));
+}
+
 TEST(TupleLattice, GetBottom) {
   analysis::Tuple<analysis::Bool, analysis::UInt32> tuple{analysis::Bool{},
                                                           analysis::UInt32{}};
@@ -654,6 +678,25 @@ TEST(SharedLattice, Join) {
     EXPECT_FALSE(shared.join(elem, two));
     EXPECT_EQ(elem, two);
   }
+}
+
+TEST(SharedLattice, JoinVecSingleton) {
+  using Vec = analysis::Vector<analysis::Bool>;
+  analysis::Shared<Vec> shared{analysis::Vector{analysis::Bool{}, 2}};
+
+  auto elem = shared.getBottom();
+  EXPECT_TRUE(shared.join(elem, Vec::SingletonElement(1, true)));
+  EXPECT_EQ(*elem, (std::vector{false, true}));
+}
+
+TEST(SharedLattice, JoinInvertedVecSingleton) {
+  using Vec = analysis::Vector<analysis::Bool>;
+  analysis::Shared<analysis::Inverted<Vec>> shared{
+    analysis::Inverted{analysis::Vector{analysis::Bool{}, 2}}};
+
+  auto elem = shared.getBottom();
+  EXPECT_TRUE(shared.join(elem, Vec::SingletonElement(1, false)));
+  EXPECT_EQ(*elem, (std::vector{true, false}));
 }
 
 TEST(StackLattice, GetBottom) {


### PR DESCRIPTION
Previously, modifying a single vector element of a `Shared<Vector>` element
required materializing a full vector to do the join. When there is just a single
element to update, materializing all the other elements with bottom value is
useless work. Add a `Vector<L>::SingletonElement` utility that represents but
does not materialize a vector with a single non-bottom element and allow it to
be passed to `Vector<L>::join`. Also update `Shared` and `Inverted` so that
`SingletonElement` joins still work on vectors wrapped in those other lattices.