### PR TITLE
Heap2Local: Fix an ordering issue with children having different interactions with a parent

### DIFF
--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -2112,7 +2112,7 @@
     ;; reference does not escape from the function, so we can optimize it into
     ;; locals, while the value read from the local is written to the heap, so it
     ;; does escape. However, we can optimize it after we optimize the first
-    ;; allocation way, which would happen if we ran another pass of heap2local
+    ;; allocation away, which would happen if we ran another pass of heap2local
     ;; (but we do not here).
     (struct.set $struct 0
       (struct.new_default $struct)


### PR DESCRIPTION
We had a simple rule that if we reach an expression twice then we give up, which makes
sense for say a block: if one allocation flows out of it, then another can't - it would get
mixed in with the other one, which is a case we don't optimize. However, there are
cases where a parent has multiple children and different interactions with them, like
a struct.set: the reference child does not escape, but the value child does. Before this
PR if we reached the value child first, we'd mark the parent as seen, and then the reference
child would see it isn't the first to get here, and not optimize.

To fix this, reorder the code to handle this case. The manner of interaction between the
child and the parent decides whether we mark the parent as seen and to be further
avoided.

Noticed by the determinism fuzzer, since the order of analysis mattered here.