### PR TITLE
[NFC] StackIR: Add comments on local2stack handling of tuples

### DIFF
--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -390,9 +390,9 @@ private:
 
     auto* set = insts[setIndex]->origin->cast<LocalSet>();
     if (func->isParam(set->index) ||
-        !func->getLocalType(set->index).isNonNullable()) {
+        func->getLocalType(set->index).isDefaultable()) {
       // This local cannot pose a problem for validation (params are always
-      // initialized, and nullable locals may be uninitialized).
+      // initialized, and defaultable locals may be uninitialized).
       return true;
     }
 

--- a/src/passes/StackIR.cpp
+++ b/src/passes/StackIR.cpp
@@ -389,10 +389,14 @@ private:
     assert(setIndex < getIndex);
 
     auto* set = insts[setIndex]->origin->cast<LocalSet>();
-    if (func->isParam(set->index) ||
-        func->getLocalType(set->index).isDefaultable()) {
+    auto localType = func->getLocalType(set->index);
+    // Note we do not need to handle tuples here, as the parent ignores them
+    // anyhow (hence we can check non-nullability instead of non-
+    // defaultability).
+    assert(localType.isSingle());
+    if (func->isParam(set->index) || !localType.isNonNullable()) {
       // This local cannot pose a problem for validation (params are always
-      // initialized, and defaultable locals may be uninitialized).
+      // initialized, and it is ok if nullable locals are uninitialized).
       return true;
     }
 

--- a/test/lit/passes/stack-ir-non-nullable.wast
+++ b/test/lit/passes/stack-ir-non-nullable.wast
@@ -339,6 +339,74 @@
   (local.get $temp)
  )
 
+ ;; CHECK:      (func $if-nondefaultable (type $1) (param $param (ref eq)) (result (ref eq))
+ ;; CHECK-NEXT:  (local $temp (i32 (ref eq)))
+ ;; CHECK-NEXT:  i32.const 0
+ ;; CHECK-NEXT:  local.get $param
+ ;; CHECK-NEXT:  tuple.make
+ ;; CHECK-NEXT:  local.set $temp
+ ;; CHECK-NEXT:  local.get $temp
+ ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT:  i32.const 1
+ ;; CHECK-NEXT:  ref.i31
+ ;; CHECK-NEXT:  ref.eq
+ ;; CHECK-NEXT:  if
+ ;; CHECK-NEXT:   i32.const 2
+ ;; CHECK-NEXT:   i32.const 3
+ ;; CHECK-NEXT:   ref.i31
+ ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   local.set $temp
+ ;; CHECK-NEXT:  else
+ ;; CHECK-NEXT:   i32.const 4
+ ;; CHECK-NEXT:   i32.const 5
+ ;; CHECK-NEXT:   ref.i31
+ ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   local.set $temp
+ ;; CHECK-NEXT:  end
+ ;; CHECK-NEXT:  local.get $temp
+ ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT: )
+ (func $if-nondefaultable (param $param (ref eq)) (result (ref eq))
+  (local $temp (i32 (ref eq)))
+  ;; As the original testcase, but now $temp is a nondefaultable tuple rather
+  ;; than a non-nullable reference by itself. We cannot remove the first set.
+  (local.set $temp
+   (tuple.make
+    (i32.const 0)
+    (local.get $param)
+   )
+  )
+  (if
+   (ref.eq
+    (tuple.extract 1
+     (local.get $temp)
+    )
+    (i31.new
+     (i32.const 1)
+    )
+   )
+   (local.set $temp
+    (tuple.make
+     (i32.const 2)
+     (i31.new
+      (i32.const 3)
+     )
+    )
+   )
+   (local.set $temp
+    (tuple.make
+     (i32.const 4)
+     (i31.new
+      (i32.const 5)
+     )
+    )
+   )
+  )
+  (tuple.extract 1
+   (local.get $temp)
+  )
+ )
+
  ;; CHECK:      (func $if-non-ref (type $4) (param $param i32) (result i32)
  ;; CHECK-NEXT:  (local $temp i32)
  ;; CHECK-NEXT:  local.get $param

--- a/test/lit/passes/stack-ir-non-nullable.wast
+++ b/test/lit/passes/stack-ir-non-nullable.wast
@@ -369,7 +369,8 @@
  (func $if-nondefaultable (param $param (ref eq)) (result (ref eq))
   (local $temp (i32 (ref eq)))
   ;; As the original testcase, but now $temp is a nondefaultable tuple rather
-  ;; than a non-nullable reference by itself. We cannot remove the first set.
+  ;; than a non-nullable reference by itself. We cannot remove the first set
+  ;; here.
   (local.set $temp
    (tuple.make
     (i32.const 0)
@@ -407,7 +408,75 @@
   )
  )
 
- ;; CHECK:      (func $if-non-ref (type $4) (param $param i32) (result i32)
+ ;; CHECK:      (func $if-defaultable (type $4) (param $param eqref) (result eqref)
+ ;; CHECK-NEXT:  (local $temp (i32 eqref))
+ ;; CHECK-NEXT:  i32.const 0
+ ;; CHECK-NEXT:  local.get $param
+ ;; CHECK-NEXT:  tuple.make
+ ;; CHECK-NEXT:  local.set $temp
+ ;; CHECK-NEXT:  local.get $temp
+ ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT:  i32.const 1
+ ;; CHECK-NEXT:  ref.i31
+ ;; CHECK-NEXT:  ref.eq
+ ;; CHECK-NEXT:  if
+ ;; CHECK-NEXT:   i32.const 2
+ ;; CHECK-NEXT:   i32.const 3
+ ;; CHECK-NEXT:   ref.i31
+ ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   local.set $temp
+ ;; CHECK-NEXT:  else
+ ;; CHECK-NEXT:   i32.const 4
+ ;; CHECK-NEXT:   i32.const 5
+ ;; CHECK-NEXT:   ref.i31
+ ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   local.set $temp
+ ;; CHECK-NEXT:  end
+ ;; CHECK-NEXT:  local.get $temp
+ ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT: )
+ (func $if-defaultable (param $param (ref null eq)) (result (ref null eq))
+  (local $temp (i32 (ref null eq)))
+  ;; As the last testcase, but now $temp is a defaultable tuple. We still do not
+  ;; optimize away the set here, as we ignore tuples in local2stack.
+  (local.set $temp
+   (tuple.make
+    (i32.const 0)
+    (local.get $param)
+   )
+  )
+  (if
+   (ref.eq
+    (tuple.extract 1
+     (local.get $temp)
+    )
+    (i31.new
+     (i32.const 1)
+    )
+   )
+   (local.set $temp
+    (tuple.make
+     (i32.const 2)
+     (i31.new
+      (i32.const 3)
+     )
+    )
+   )
+   (local.set $temp
+    (tuple.make
+     (i32.const 4)
+     (i31.new
+      (i32.const 5)
+     )
+    )
+   )
+  )
+  (tuple.extract 1
+   (local.get $temp)
+  )
+ )
+
+ ;; CHECK:      (func $if-non-ref (type $5) (param $param i32) (result i32)
  ;; CHECK-NEXT:  (local $temp i32)
  ;; CHECK-NEXT:  local.get $param
  ;; CHECK-NEXT:  i32.eqz


### PR DESCRIPTION
Also add testcases to be comprehensive and notice changes if we ever decide to
modify that behavior.

Seen while auditing all uses of `isNonNullable` in the codebase.