### PR TITLE
[NFC] Simplify LiteralUtils::canMakeZero

### DIFF
--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -29,9 +29,7 @@ inline Expression* makeFromInt32(int32_t x, Type type, Module& wasm) {
   return ret;
 }
 
-inline bool canMakeZero(Type type) {
-  return type.isDefaultable();
-}
+inline bool canMakeZero(Type type) { return type.isDefaultable(); }
 
 inline Expression* makeZero(Type type, Module& wasm) {
   assert(canMakeZero(type));

--- a/src/ir/literal-utils.h
+++ b/src/ir/literal-utils.h
@@ -30,17 +30,7 @@ inline Expression* makeFromInt32(int32_t x, Type type, Module& wasm) {
 }
 
 inline bool canMakeZero(Type type) {
-  if (type.isNonNullable()) {
-    return false;
-  }
-  if (type.isTuple()) {
-    for (auto t : type) {
-      if (t.isNonNullable()) {
-        return false;
-      }
-    }
-  }
-  return true;
+  return type.isDefaultable();
 }
 
 inline Expression* makeZero(Type type, Module& wasm) {


### PR DESCRIPTION
Seen while auditing all uses of isNonNullable in the codebase.