### PR TITLE
[NFC] Add explicit deduction guides for CTAD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ else()
     add_compile_flag("-Werror")
   endif()
   add_compile_flag("-Wextra")
+  add_compile_flag("-Wctad-maybe-unsupported")
   add_compile_flag("-Wno-unused-parameter")
   add_compile_flag("-Wno-dangling-pointer") # false positive in gcc
   add_compile_flag("-fno-omit-frame-pointer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,6 @@ else()
     add_compile_flag("-Werror")
   endif()
   add_compile_flag("-Wextra")
-  add_compile_flag("-Wctad-maybe-unsupported")
   add_compile_flag("-Wno-unused-parameter")
   add_compile_flag("-Wno-dangling-pointer") # false positive in gcc
   add_compile_flag("-fno-omit-frame-pointer")
@@ -280,6 +279,11 @@ else()
   add_compile_flag("-Wswitch") # we explicitly expect this in the code
   add_compile_flag("-Wimplicit-fallthrough")
   add_compile_flag("-Wnon-virtual-dtor")
+
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Google style requires this, so make sure we compile cleanly with it.
+    add_compile_flag("-Wctad-maybe-unsupported")
+  endif()
 
   if(WIN32)
     add_compile_flag("-D_GNU_SOURCE")

--- a/src/analysis/lattices/inverted.h
+++ b/src/analysis/lattices/inverted.h
@@ -49,6 +49,9 @@ template<FullLattice L> struct Inverted {
   }
 };
 
+// Deduction guide.
+template<typename L> Inverted(L&&) -> Inverted<L>;
+
 #if __cplusplus >= 202002L
 static_assert(Lattice<Inverted<Bool>>);
 #endif

--- a/src/analysis/lattices/lift.h
+++ b/src/analysis/lattices/lift.h
@@ -74,6 +74,9 @@ template<Lattice L> struct Lift {
   }
 };
 
+// Deduction guide.
+template<typename L> Lift(L&&) -> Lift<L>;
+
 #if __cplusplus >= 202002L
 static_assert(Lattice<Lift<Bool>>);
 #endif

--- a/src/analysis/lattices/shared.h
+++ b/src/analysis/lattices/shared.h
@@ -118,6 +118,9 @@ template<Lattice L> struct Shared {
   }
 };
 
+// Deduction guide.
+template<typename L> Shared(L&&) -> Shared<L>;
+
 #if __cplusplus >= 202002L
 static_assert(Lattice<Shared<Bool>>);
 #endif // __cplusplus >= 202002L

--- a/src/analysis/lattices/stack.h
+++ b/src/analysis/lattices/stack.h
@@ -179,6 +179,9 @@ template<Lattice L> struct Stack {
   }
 };
 
+// Deduction guide.
+template<typename L> Stack(L&&) -> Stack<L>;
+
 #if __cplusplus >= 202002L
 static_assert(Lattice<Stack<Bool>>);
 #endif

--- a/src/analysis/lattices/vector.h
+++ b/src/analysis/lattices/vector.h
@@ -151,6 +151,9 @@ private:
   }
 };
 
+// Deduction guide.
+template<typename L> Vector(L&&, size_t) -> Vector<L>;
+
 #if __cplusplus >= 202002L
 static_assert(FullLattice<Vector<Bool>>);
 static_assert(Lattice<Vector<Flat<bool>>>);

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -55,6 +55,10 @@ public:
   void print(std::ostream& os);
 };
 
+// Deduction guide.
+template<typename L, typename TxFn>
+MonotoneCFGAnalyzer(L&, TxFn&, CFG&) -> MonotoneCFGAnalyzer<L, TxFn>;
+
 } // namespace wasm::analysis
 
 #include "monotone-analyzer-impl.h"

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -95,6 +95,9 @@ struct IndexedTypeNameGenerator
   }
 };
 
+// Deduction guide.
+template<typename T> IndexedTypeNameGenerator(T&) -> IndexedTypeNameGenerator<>;
+
 // Prints heap types stored in a module, falling back to the given
 // FallbackGenerator if the module does not have a name for type type.
 template<typename FallbackGenerator = DefaultTypeNameGenerator>
@@ -121,6 +124,10 @@ struct ModuleTypeNameGenerator
     return fallback.getNames(type);
   }
 };
+
+// Deduction guide.
+template<typename T>
+ModuleTypeNameGenerator(const Module&) -> ModuleTypeNameGenerator<>;
 
 } // namespace wasm
 

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -126,7 +126,6 @@ struct ModuleTypeNameGenerator
 };
 
 // Deduction guide.
-template<typename T>
 ModuleTypeNameGenerator(const Module&) -> ModuleTypeNameGenerator<>;
 
 } // namespace wasm


### PR DESCRIPTION
Class template argument deduction (CTAD) is a C++17 feature that allows
variables to be declared with class template types without specifying the
template parameters. Deduction guides are a mechanism by which template authors
can control how the template parameters are inferred when CTAD is used. The
Google style guide prohibits the use of CTAD except where template authors opt
in to supporting it by providing explicit deduction guides. For compatibility
with users adhering to Google style, set the compiler flag to check this
condition and add the necessary deduction guides to make the compiler happy
again.