### PR TITLE
[Parser][NFC] Filter out unused instructions in gen-s-parser.py

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -708,6 +708,11 @@ class Node:
 
 def instruction_parser(new_parser=False):
     """Build a trie out of all the instructions, then emit it as C++ code."""
+    global instructions
+    if new_parser:
+        # Filter out instructions that the new parser does not need.
+        instructions = [(inst, code) for (inst, code) in instructions
+                        if inst not in ('block', 'loop', 'if', 'then', 'else')]
     trie = Node()
     inst_length = 0
     for inst, expr in instructions:

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3727,77 +3727,66 @@ switch (buf[0]) {
     }
   }
   case 'b': {
-    switch (buf[1]) {
-      case 'l':
-        if (op == "block"sv) {
-          CHECK_ERR(makeBlock(ctx, pos));
+    switch (buf[2]) {
+      case '\0':
+        if (op == "br"sv) {
+          CHECK_ERR(makeBreak(ctx, pos));
           return Ok{};
         }
         goto parse_error;
-      case 'r': {
-        switch (buf[2]) {
-          case '\0':
-            if (op == "br"sv) {
+      case '_': {
+        switch (buf[3]) {
+          case 'i':
+            if (op == "br_if"sv) {
               CHECK_ERR(makeBreak(ctx, pos));
               return Ok{};
             }
             goto parse_error;
-          case '_': {
-            switch (buf[3]) {
-              case 'i':
-                if (op == "br_if"sv) {
-                  CHECK_ERR(makeBreak(ctx, pos));
-                  return Ok{};
-                }
-                goto parse_error;
-              case 'o': {
-                switch (buf[6]) {
-                  case 'c': {
-                    switch (buf[10]) {
-                      case '\0':
-                        if (op == "br_on_cast"sv) {
-                          CHECK_ERR(makeBrOnCast(ctx, pos));
-                          return Ok{};
-                        }
-                        goto parse_error;
-                      case '_':
-                        if (op == "br_on_cast_fail"sv) {
-                          CHECK_ERR(makeBrOnCast(ctx, pos, true));
-                          return Ok{};
-                        }
-                        goto parse_error;
-                      default: goto parse_error;
+          case 'o': {
+            switch (buf[6]) {
+              case 'c': {
+                switch (buf[10]) {
+                  case '\0':
+                    if (op == "br_on_cast"sv) {
+                      CHECK_ERR(makeBrOnCast(ctx, pos));
+                      return Ok{};
                     }
-                  }
-                  case 'n': {
-                    switch (buf[7]) {
-                      case 'o':
-                        if (op == "br_on_non_null"sv) {
-                          CHECK_ERR(makeBrOnNull(ctx, pos, true));
-                          return Ok{};
-                        }
-                        goto parse_error;
-                      case 'u':
-                        if (op == "br_on_null"sv) {
-                          CHECK_ERR(makeBrOnNull(ctx, pos));
-                          return Ok{};
-                        }
-                        goto parse_error;
-                      default: goto parse_error;
+                    goto parse_error;
+                  case '_':
+                    if (op == "br_on_cast_fail"sv) {
+                      CHECK_ERR(makeBrOnCast(ctx, pos, true));
+                      return Ok{};
                     }
-                  }
+                    goto parse_error;
                   default: goto parse_error;
                 }
               }
-              case 't':
-                if (op == "br_table"sv) {
-                  CHECK_ERR(makeBreakTable(ctx, pos));
-                  return Ok{};
+              case 'n': {
+                switch (buf[7]) {
+                  case 'o':
+                    if (op == "br_on_non_null"sv) {
+                      CHECK_ERR(makeBrOnNull(ctx, pos, true));
+                      return Ok{};
+                    }
+                    goto parse_error;
+                  case 'u':
+                    if (op == "br_on_null"sv) {
+                      CHECK_ERR(makeBrOnNull(ctx, pos));
+                      return Ok{};
+                    }
+                    goto parse_error;
+                  default: goto parse_error;
                 }
-                goto parse_error;
+              }
               default: goto parse_error;
             }
           }
+          case 't':
+            if (op == "br_table"sv) {
+              CHECK_ERR(makeBreakTable(ctx, pos));
+              return Ok{};
+            }
+            goto parse_error;
           default: goto parse_error;
         }
       }
@@ -7935,43 +7924,26 @@ switch (buf[0]) {
           default: goto parse_error;
         }
       }
-      case 'f':
-        if (op == "if"sv) {
-          CHECK_ERR(makeIf(ctx, pos));
-          return Ok{};
-        }
-        goto parse_error;
       default: goto parse_error;
     }
   }
   case 'l': {
-    switch (buf[2]) {
-      case 'c': {
-        switch (buf[6]) {
-          case 'g':
-            if (op == "local.get"sv) {
-              CHECK_ERR(makeLocalGet(ctx, pos));
-              return Ok{};
-            }
-            goto parse_error;
-          case 's':
-            if (op == "local.set"sv) {
-              CHECK_ERR(makeLocalSet(ctx, pos));
-              return Ok{};
-            }
-            goto parse_error;
-          case 't':
-            if (op == "local.tee"sv) {
-              CHECK_ERR(makeLocalTee(ctx, pos));
-              return Ok{};
-            }
-            goto parse_error;
-          default: goto parse_error;
+    switch (buf[6]) {
+      case 'g':
+        if (op == "local.get"sv) {
+          CHECK_ERR(makeLocalGet(ctx, pos));
+          return Ok{};
         }
-      }
-      case 'o':
-        if (op == "loop"sv) {
-          CHECK_ERR(makeLoop(ctx, pos));
+        goto parse_error;
+      case 's':
+        if (op == "local.set"sv) {
+          CHECK_ERR(makeLocalSet(ctx, pos));
+          return Ok{};
+        }
+        goto parse_error;
+      case 't':
+        if (op == "local.tee"sv) {
+          CHECK_ERR(makeLocalTee(ctx, pos));
           return Ok{};
         }
         goto parse_error;

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -69,8 +69,6 @@ template<typename Ctx> Result<> makeLocalTee(Ctx&, Index);
 template<typename Ctx> Result<> makeLocalSet(Ctx&, Index);
 template<typename Ctx> Result<> makeGlobalGet(Ctx&, Index);
 template<typename Ctx> Result<> makeGlobalSet(Ctx&, Index);
-template<typename Ctx> Result<> makeBlock(Ctx&, Index);
-template<typename Ctx> Result<> makeThenOrElse(Ctx&, Index);
 template<typename Ctx> Result<> makeConst(Ctx&, Index, Type type);
 template<typename Ctx>
 Result<>
@@ -100,10 +98,6 @@ template<typename Ctx> Result<> makeDataDrop(Ctx&, Index);
 template<typename Ctx> Result<> makeMemoryCopy(Ctx&, Index);
 template<typename Ctx> Result<> makeMemoryFill(Ctx&, Index);
 template<typename Ctx> Result<> makePop(Ctx&, Index);
-template<typename Ctx> Result<> makeIf(Ctx&, Index);
-template<typename Ctx>
-Result<> makeMaybeBlock(Ctx&, Index, size_t i, Type type);
-template<typename Ctx> Result<> makeLoop(Ctx&, Index);
 template<typename Ctx> Result<> makeCall(Ctx&, Index, bool isReturn);
 template<typename Ctx> Result<> makeCallIndirect(Ctx&, Index, bool isReturn);
 template<typename Ctx> Result<> makeBreak(Ctx&, Index);
@@ -967,10 +961,6 @@ template<typename Ctx> Result<> makeGlobalSet(Ctx& ctx, Index pos) {
   return ctx.makeGlobalSet(pos, *global);
 }
 
-template<typename Ctx> Result<> makeBlock(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
 template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
   assert(type.isBasic());
   switch (type.getBasic()) {
@@ -1189,19 +1179,6 @@ template<typename Ctx> Result<> makeMemoryFill(Ctx& ctx, Index pos) {
 }
 
 template<typename Ctx> Result<> makePop(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx> Result<> makeIf(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx>
-Result<> makeMaybeBlock(Ctx& ctx, Index pos, size_t i, Type type) {
-  return ctx.in.err("unimplemented instruction");
-}
-
-template<typename Ctx> Result<> makeLoop(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 


### PR DESCRIPTION
The new wat parser parses block, if, loop, then, and else keywords directly
rather than depending on code generated from gen-s-parser.py. Filter these
keywords out in gen-s-parser.py when generating the new wat parser and delete
the stub functions that the removed generated code used to depend on.