### PR TITLE
Provide Module& parameter to operateOnScopeNameUsesAndSentTypes

### DIFF
--- a/src/abi/stack.h
+++ b/src/abi/stack.h
@@ -84,7 +84,7 @@ getStackSpace(Index local, Function* func, Index size, Module& wasm) {
       block->list.push_back(makeStackRestore());
       block->list.push_back(
         builder.makeReturn(builder.makeLocalGet(temp, ret->value->type)));
-      block->finalize();
+      block->finalize(&wasm);
       *ptr = block;
     } else {
       // restore, then return
@@ -105,7 +105,7 @@ getStackSpace(Index local, Function* func, Index size, Module& wasm) {
     block->list.push_back(makeStackRestore());
     block->list.push_back(builder.makeLocalGet(temp, func->getResults()));
   }
-  block->finalize();
+  block->finalize(&wasm);
   func->body = block;
 }
 

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1093,7 +1093,7 @@ BinaryenExpressionRef BinaryenBlock(BinaryenModuleRef module,
   if (type != BinaryenTypeAuto()) {
     ret->finalize(Type(type));
   } else {
-    ret->finalize();
+    ret->finalize((Module*)module);
   }
   return static_cast<Expression*>(ret);
 }
@@ -1985,8 +1985,9 @@ void BinaryenExpressionSetType(BinaryenExpressionRef expr, BinaryenType type) {
 void BinaryenExpressionPrint(BinaryenExpressionRef expr) {
   std::cout << *(Expression*)expr << '\n';
 }
-void BinaryenExpressionFinalize(BinaryenExpressionRef expr) {
-  ReFinalizeNode().visit((Expression*)expr);
+void BinaryenExpressionFinalize(BinaryenExpressionRef expr,
+                                BinaryenModuleRef module) {
+  ReFinalizeNode(*(Module*)module).visit((Expression*)expr);
 }
 
 BinaryenExpressionRef BinaryenExpressionCopy(BinaryenExpressionRef expr,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1169,7 +1169,8 @@ BINARYEN_API void BinaryenExpressionSetType(BinaryenExpressionRef expr,
 // Prints text format of the given expression to stdout.
 BINARYEN_API void BinaryenExpressionPrint(BinaryenExpressionRef expr);
 // Re-finalizes an expression after it has been modified.
-BINARYEN_API void BinaryenExpressionFinalize(BinaryenExpressionRef expr);
+BINARYEN_API void BinaryenExpressionFinalize(BinaryenExpressionRef expr,
+                                             BinaryenModuleRef module);
 // Makes a deep copy of the given expression.
 BINARYEN_API BinaryenExpressionRef
 BinaryenExpressionCopy(BinaryenExpressionRef expr, BinaryenModuleRef module);

--- a/src/cfg/Relooper.cpp
+++ b/src/cfg/Relooper.cpp
@@ -64,10 +64,11 @@ static wasm::Expression* HandleFollowupMultiples(wasm::Expression* Ret,
     }
     for (auto& [Id, Body] : Multiple->InnerMap) {
       Curr->name = Builder.getBlockBreakName(Id);
-      Curr->finalize(); // it may now be reachable, via a break
+      Curr->finalize(
+        &Builder.getModule()); // it may now be reachable, via a break
       auto* Outer = Builder.makeBlock(Curr);
       Outer->list.push_back(Body->Render(Builder, InLoop));
-      Outer->finalize(); // TODO: not really necessary
+      Outer->finalize(&Builder.getModule()); // TODO: not really necessary
       Curr = Outer;
     }
     Parent->Next = Parent->Next->Next;
@@ -91,15 +92,15 @@ static wasm::Expression* HandleFollowupMultiples(wasm::Expression* Ret,
       } else {
         for (auto* Entry : Loop->Entries) {
           Curr->name = Builder.getBlockBreakName(Entry->Id);
-          Curr->finalize();
+          Curr->finalize(&Builder.getModule());
           auto* Outer = Builder.makeBlock(Curr);
-          Outer->finalize(); // TODO: not really necessary
+          Outer->finalize(&Builder.getModule()); // TODO: not really necessary
           Curr = Outer;
         }
       }
     }
   }
-  Curr->finalize();
+  Curr->finalize(&Builder.getModule());
   return Curr;
 }
 
@@ -132,7 +133,7 @@ Branch::Render(RelooperBuilder& Builder, Block* Target, bool SetLabel) {
     assert(Ancestor);
     Ret->list.push_back(Builder.makeShapeContinue(Ancestor->Id));
   }
-  Ret->finalize();
+  Ret->finalize(&Builder.getModule());
   return Ret;
 }
 
@@ -170,7 +171,7 @@ wasm::Expression* Block::Render(RelooperBuilder& Builder, bool InLoop) {
   }
 
   if (!ProcessedBranchesOut.size()) {
-    Ret->finalize();
+    Ret->finalize(&Builder.getModule());
     return Ret;
   }
 
@@ -407,7 +408,7 @@ wasm::Expression* Block::Render(RelooperBuilder& Builder, bool InLoop) {
   if (Root) {
     Ret->list.push_back(Root);
   }
-  Ret->finalize();
+  Ret->finalize(&Builder.getModule());
 
   return Ret;
 }

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -51,6 +51,11 @@ namespace wasm {
 struct TypeUpdater
   : public ExpressionStackWalker<TypeUpdater,
                                  UnifiedExpressionVisitor<TypeUpdater>> {
+
+  Module& wasm;
+
+  TypeUpdater(Module& wasm) : wasm(wasm) {}
+
   // Part 1: Scanning
 
   // track names to their blocks, so that when we remove a break to
@@ -172,8 +177,9 @@ struct TypeUpdater
   // adds (or removes) breaks depending on break/switch contents
   void discoverBreaks(Expression* curr, int change) {
     BranchUtils::operateOnScopeNameUsesAndSentTypes(
-      curr,
-      [&](Name& name, Type type) { noteBreakChange(name, change, type); });
+      wasm, curr, [&](Name& name, Type type) {
+        noteBreakChange(name, change, type);
+      });
     // TODO: it may be faster to accumulate all changes to a set first, then
     // call noteBreakChange on the unique values, as a switch can be quite
     // large and have lots of repeated targets.

--- a/src/passes/AlignmentLowering.cpp
+++ b/src/passes/AlignmentLowering.cpp
@@ -235,7 +235,7 @@ struct AlignmentLowering : public WalkerPass<PostWalker<AlignmentLowering>> {
     } else {
       WASM_UNREACHABLE("invalid size");
     }
-    block->finalize();
+    block->finalize(getModule());
     return block;
   }
 

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -935,7 +935,7 @@ struct AsyncifyFlow : public Pass {
       // something valid (which the optimizer can remove later).
       block->list.push_back(builder->makeUnreachable());
     }
-    block->finalize();
+    block->finalize(module);
     func->body = block;
     // Making things like returns conditional may alter types.
     ReFinalize().walkFunctionInModule(func, module);
@@ -1062,7 +1062,7 @@ private:
               for (auto j = begin; j <= i; j++) {
                 block->list.push_back(list[j]);
               }
-              block->finalize();
+              block->finalize(module);
               list[begin] = makeMaybeSkip(block);
               for (auto j = begin + 1; j <= i; j++) {
                 list[j] = builder->makeNop();
@@ -1536,7 +1536,7 @@ private:
       }
       block->list.push_back(builder->makeLocalSet(i, load));
     }
-    block->finalize();
+    block->finalize(getModule());
     return block;
   }
 
@@ -1578,7 +1578,7 @@ private:
       }
     }
     block->list.push_back(builder->makeIncStackPos(offset));
-    block->finalize();
+    block->finalize(getModule());
     return block;
   }
 
@@ -1831,7 +1831,7 @@ private:
         builder.makeBinary(
           Abstract::getBinary(pointerType, Abstract::GtU), stackPos, stackEnd),
         builder.makeUnreachable()));
-      body->finalize();
+      body->finalize(module);
       auto func = builder.makeFunction(
         name, Signature(Type(params), Type::none), {}, body);
       module->addFunction(std::move(func));

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -484,7 +484,11 @@ private:
     auto oldType = curr->type;
     // NB: we template-specialize so that this calls the proper finalizer for
     //     the type
-    curr->finalize();
+    if (Block* currBlock = curr->template dynCast<Block>()) {
+      currBlock->finalize(getModule());
+    } else {
+      curr->finalize();
+    }
     // ensure the replacement has the same type, so the outside is not surprised
     block->finalize(oldType);
     replaceCurrent(block);
@@ -726,7 +730,7 @@ private:
         // change)
         auto* toplevel = old->dynCast<Block>();
         if (toplevel) {
-          toplevel->finalize();
+          toplevel->finalize(getModule());
         }
         if (old->type != Type::unreachable) {
           inner->list.push_back(builder.makeReturn(old));
@@ -735,7 +739,7 @@ private:
         }
       }
     }
-    inner->finalize();
+    inner->finalize(getModule());
     auto* outer = builder.makeBlock();
     outer->list.push_back(inner);
     while (!mergeable.empty()) {

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -169,7 +169,7 @@ struct Flatten
         }
         iff->finalize();
         if (prelude) {
-          ReFinalizeNode().visit(prelude);
+          ReFinalizeNode(*getModule()).visit(prelude);
           ourPreludes.push_back(prelude);
         }
         replaceCurrent(rep);
@@ -332,7 +332,7 @@ struct Flatten
     // continue for general handling of everything, control flow or otherwise
     curr = getCurrent(); // we may have replaced it
     // we have changed children
-    ReFinalizeNode().visit(curr);
+    ReFinalizeNode(*getModule()).visit(curr);
     if (curr->type == Type::unreachable) {
       ourPreludes.push_back(curr);
       replaceCurrent(builder.makeUnreachable());
@@ -393,7 +393,7 @@ private:
     auto* ret = Builder(*getModule()).makeBlock(thePreludes);
     thePreludes.clear();
     ret->list.push_back(after);
-    ret->finalize();
+    ret->finalize(getModule());
     return ret;
   }
 

--- a/src/passes/JSPI.cpp
+++ b/src/passes/JSPI.cpp
@@ -212,7 +212,7 @@ private:
       resultsType = Type::i32;
       block->list.push_back(builder.makeConst(0));
     }
-    block->finalize();
+    block->finalize(module);
     auto wrapperFunc =
       Builder::makeFunction(wrapperName,
                             std::move(namedWrapperParams),
@@ -273,7 +273,7 @@ private:
       block->list.push_back(
         builder.makeLocalGet(*returnIndex, stub->getResults()));
     }
-    block->finalize();
+    block->finalize(module);
     call->type = im->getResults();
     stub->body = block;
     wrapperIm->type = Signature(Type(params), call->type);

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -278,7 +278,7 @@ private:
                          {I64Utilities::getI64High(builder, index)},
                          Type::none));
       block->list.push_back(I64Utilities::getI64Low(builder, index));
-      block->finalize();
+      block->finalize(module);
       legal->body = block;
     } else {
       legal->body = call;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -254,7 +254,7 @@ static void optimizeBlock(Block* curr,
                 drop->finalize();
                 childBlock->list.back() = drop;
               }
-              childBlock->finalize();
+              childBlock->finalize(module);
               child = list[i] = childBlock;
               more = true;
               changed = true;
@@ -362,7 +362,7 @@ static void optimizeBlock(Block* curr,
         // Update the child.
         childList.swap(filtered);
         // We may have removed unreachable items.
-        childBlock->finalize();
+        childBlock->finalize(module);
         if (loop) {
           loop->finalize();
         }

--- a/src/passes/Poppify.cpp
+++ b/src/passes/Poppify.cpp
@@ -144,7 +144,8 @@ struct Poppifier : BinaryenIRWriter<Poppifier> {
 };
 
 Poppifier::Poppifier(Function* func, Module* module)
-  : BinaryenIRWriter<Poppifier>(func), module(module), builder(*module) {
+  : BinaryenIRWriter<Poppifier>(*module, func), module(module),
+    builder(*module) {
   // Start with a scope to emit top-level instructions into
   scopeStack.emplace_back(Scope::Func);
 

--- a/src/passes/ReReloop.cpp
+++ b/src/passes/ReReloop.cpp
@@ -53,7 +53,7 @@ struct ReReloop final : public Pass {
 
   CFG::Block* setCurrCFGBlock(CFG::Block* curr) {
     if (currCFGBlock) {
-      finishBlock();
+      finishBlock(*curr->relooper->Module);
     }
     return currCFGBlock = curr;
   }
@@ -64,7 +64,7 @@ struct ReReloop final : public Pass {
 
   Block* getCurrBlock() { return currCFGBlock->Code->cast<Block>(); }
 
-  void finishBlock() { getCurrBlock()->finalize(); }
+  void finishBlock(Module& wasm) { getCurrBlock()->finalize(&wasm); }
 
   // break handling
 
@@ -310,7 +310,7 @@ struct ReReloop final : public Pass {
       curr->run();
     }
     // finish the current block
-    finishBlock();
+    finishBlock(*module);
     // blocks that do not have any exits are dead ends in the relooper. we need
     // to make sure that are in fact dead ends, and do not flow control
     // anywhere. add a return as needed
@@ -320,7 +320,7 @@ struct ReReloop final : public Pass {
         block->list.push_back(function->getResults() == Type::none
                                 ? (Expression*)builder->makeReturn()
                                 : (Expression*)builder->makeUnreachable());
-        block->finalize();
+        block->finalize(module);
       }
     }
 #ifdef RERELOOP_DEBUG

--- a/src/passes/SimplifyLocals.cpp
+++ b/src/passes/SimplifyLocals.cpp
@@ -490,7 +490,7 @@ struct SimplifyLocals
     auto* set = (*item)->template cast<LocalSet>();
     block->list[block->list.size() - 1] = set->value;
     *item = builder.makeNop();
-    block->finalize();
+    block->finalize(this->getModule());
     assert(block->type != Type::none);
     loop->finalize();
     set->value = loop;
@@ -626,7 +626,7 @@ struct SimplifyLocals
     this->replaceCurrent(newLocalSet);
     sinkables.clear();
     anotherCycle = true;
-    block->finalize();
+    block->finalize(this->getModule());
   }
 
   // optimize local.sets from both sides of an if into a return value
@@ -710,7 +710,7 @@ struct SimplifyLocals
       ifTrueBlock->list[ifTrueBlock->list.size() - 1] =
         (*ifTrueItem)->template cast<LocalSet>()->value;
       ExpressionManipulator::nop(*ifTrueItem);
-      ifTrueBlock->finalize();
+      ifTrueBlock->finalize(this->getModule());
       assert(ifTrueBlock->type != Type::none);
     }
     if (iff->ifFalse->type != Type::unreachable) {
@@ -718,7 +718,7 @@ struct SimplifyLocals
       ifFalseBlock->list[ifFalseBlock->list.size() - 1] =
         (*ifFalseItem)->template cast<LocalSet>()->value;
       ExpressionManipulator::nop(*ifFalseItem);
-      ifFalseBlock->finalize();
+      ifFalseBlock->finalize(this->getModule());
       assert(ifFalseBlock->type != Type::none);
     }
     iff->finalize(); // update type
@@ -822,7 +822,7 @@ struct SimplifyLocals
     auto* set = (*item)->template cast<LocalSet>();
     ifTrueBlock->list[ifTrueBlock->list.size() - 1] = set->value;
     *item = builder.makeNop();
-    ifTrueBlock->finalize();
+    ifTrueBlock->finalize(this->getModule());
     assert(ifTrueBlock->type != Type::none);
     // Update the ifFalse side.
     iff->ifFalse = builder.makeLocalGet(set->index, localType);

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -170,7 +170,7 @@ struct SpillPointers
       auto temp = builder.addVar(func, operand->type);
       auto* set = builder.makeLocalSet(temp, operand);
       block->list.push_back(set);
-      block->finalize();
+      block->finalize(module);
       if (actualPointers.count(&operand) > 0) {
         // this is something we track, and it's moving - update
         actualPointers[&operand] = &set->value;
@@ -202,7 +202,7 @@ struct SpillPointers
     }
     // add the (modified) call
     block->list.push_back(call);
-    block->finalize();
+    block->finalize(module);
     *origin = block;
   }
 };

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -367,7 +367,7 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
           // we may be able to remove this, if there are no brs
           bool canPop = true;
           if (block->name.is()) {
-            BranchUtils::BranchSeeker seeker(block->name);
+            BranchUtils::BranchTypeSeeker seeker(*getModule(), block->name);
             Expression* temp = block;
             seeker.walk(temp);
             if (seeker.found && Type::hasLeastUpperBound(seeker.types)) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1351,7 +1351,7 @@ Expression* TranslateToFuzzReader::makeBlock(Type type) {
   if (type.isConcrete()) {
     ret->finalize(type);
   } else {
-    ret->finalize();
+    ret->finalize(&builder.getModule());
   }
   if (ret->type != type) {
     // e.g. we might want an unreachable block, but a child breaks to it

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -40,6 +40,8 @@ class Builder {
 public:
   Builder(Module& wasm) : wasm(wasm) {}
 
+  Module& getModule() { return wasm; }
+
   // make* functions create an expression instance.
 
   static std::unique_ptr<Function> makeFunction(Name name,
@@ -172,14 +174,14 @@ public:
     auto* ret = wasm.allocator.alloc<Block>();
     if (first) {
       ret->list.push_back(first);
-      ret->finalize();
+      ret->finalize(&wasm);
     }
     return ret;
   }
   Block* makeBlock(Name name, Expression* first = nullptr) {
     auto* ret = makeBlock(first);
     ret->name = name;
-    ret->finalize();
+    ret->finalize(&wasm);
     return ret;
   }
 
@@ -192,7 +194,7 @@ public:
   Block* makeBlock(const T& items) {
     auto* ret = wasm.allocator.alloc<Block>();
     ret->list.set(items);
-    ret->finalize();
+    ret->finalize(&wasm);
     return ret;
   }
 
@@ -1316,7 +1318,7 @@ public:
     }
     if (append) {
       block->list.push_back(append);
-      block->finalize();
+      block->finalize(&wasm);
     }
     return block;
   }
@@ -1341,7 +1343,7 @@ public:
     block->name = name;
     if (append) {
       block->list.push_back(append);
-      block->finalize();
+      block->finalize(&wasm);
     }
     return block;
   }
@@ -1351,7 +1353,7 @@ public:
   Block* makeSequence(Expression* left, Expression* right) {
     auto* block = makeBlock(left);
     block->list.push_back(right);
-    block->finalize();
+    block->finalize(&wasm);
     return block;
   }
 

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -159,7 +159,7 @@ private:
 template<typename SubType>
 class BinaryenIRWriter : public Visitor<BinaryenIRWriter<SubType>> {
 public:
-  BinaryenIRWriter(Function* func) : func(func) {}
+  BinaryenIRWriter(Module& wasm, Function* func) : wasm(wasm), func(func) {}
 
   void write();
 
@@ -172,6 +172,7 @@ public:
   void visitTry(Try* curr);
 
 protected:
+  Module& wasm;
   Function* func = nullptr;
 
 private:
@@ -413,8 +414,9 @@ public:
                            Function* func = nullptr,
                            bool sourceMap = false,
                            bool DWARF = false)
-    : BinaryenIRWriter<BinaryenIRToBinaryWriter>(func), parent(parent),
-      writer(parent, o, func, sourceMap, DWARF), sourceMap(sourceMap) {}
+    : BinaryenIRWriter<BinaryenIRToBinaryWriter>(*parent.getModule(), func),
+      parent(parent), writer(parent, o, func, sourceMap, DWARF),
+      sourceMap(sourceMap) {}
 
   void emit(Expression* curr) { writer.visit(curr); }
   void emitHeader() {
@@ -454,7 +456,7 @@ private:
 class StackIRGenerator : public BinaryenIRWriter<StackIRGenerator> {
 public:
   StackIRGenerator(Module& module, Function* func)
-    : BinaryenIRWriter<StackIRGenerator>(func), module(module) {}
+    : BinaryenIRWriter<StackIRGenerator>(module, func), module(module) {}
 
   void emit(Expression* curr);
   void emitScopeEnd(Expression* curr);

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -42,6 +42,8 @@
 
 namespace wasm {
 
+class Module;
+
 // An index in a wasm module
 using Index = uint32_t;
 
@@ -824,9 +826,11 @@ public:
   Name name;
   ExpressionList list;
 
+  void finalize();
+
   // set the type purely based on its contents. this scans the block, so it is
   // not fast.
-  void finalize();
+  void finalize(Module* wasm);
 
   // set the type given you know its type, which is the case when parsing
   // s-expression or binary, as explicit types are given. the only additional

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3106,7 +3106,7 @@ Expression* WasmBinaryReader::popNonVoidExpression() {
     assert(type == Type::unreachable);
     // nothing to do here - unreachable anyhow
   }
-  block->finalize();
+  block->finalize(&wasm);
   return block;
 }
 

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -192,7 +192,7 @@ Result<> IRBuilder::visit(Expression* curr) {
   } else {
     // TODO: Call more efficient versions of finalize() that take the known type
     // for other kinds of nodes as well, as done above.
-    ReFinalizeNode{}.visit(curr);
+    ReFinalizeNode{wasm}.visit(curr);
   }
   push(curr);
   return Ok{};

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1697,7 +1697,7 @@ Expression* SExpressionWasmBuilder::makeThenOrElse(Element& s) {
   for (; i < s.size(); i++) {
     ret->list.push_back(parseExpression(s[i]));
   }
-  ret->finalize();
+  ret->finalize(&wasm);
   return ret;
 }
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -175,6 +175,10 @@ handleUnreachable(Block* block,
 }
 
 void Block::finalize() {
+  // FIXME(frank-emrich) Anything to do here?
+}
+
+void Block::finalize(Module* wasm) {
   if (list.size() == 0) {
     type = Type::none;
     return;
@@ -189,7 +193,7 @@ void Block::finalize() {
   }
 
   // The default type is according to the value that flows out.
-  BranchUtils::BranchSeeker seeker(this->name);
+  BranchUtils::BranchTypeSeeker seeker(*wasm, this->name);
   Expression* temp = this;
   seeker.walk(temp);
   if (seeker.found) {


### PR DESCRIPTION
This PR performs the necessary plumbing to address a problem plaguing #6083:

In `BranchUtils::operateOnScopeNameUsesAndSentTypes`, `Resume` instructions need access to the module to obtain type information associated with tags in order to determine the types of values that may be sent to a block. The same will hold for exception handling instructions, once the updated proposal is implemented.

The most notable user of `operateOnScopeNameUsesAndSentTypes` is `BranchSeeker`, whose use sites potentially need to be updated. However, many existing users of `BranchSeeker` actually just call `BranchSeeker::has`. The latter can be implemented in terms of `operateOnScopeNameUses`, rather than `operateOnScopeNameUsesAndSentTypes`.

Thus, I have split `BranchSeeker` into two classes:
1. `BranchTypeSeeker` is like the old `BranchSeeker`, but without `has` or `count`. It is implemented in terms of `operateOnScopeNameUsesAndSentTypes` and therefore needs to be constructed with a `Module&`.
2. `BranchSeeker`  provides `has` and `count` as static members. It is now implemented in terms of `operateOnScopeNameUses`, meaning that the two functions can keep their original signatures.

Most changes in this PR then come from the fact that `Block::finalize()` uses (what is now called) `BranchTypeSeeker`, and therefore needs to be changed to `Block::finalize(Module* wasm)`. 

I have also added Block::finalize()`, which currently does nothing. I have deliberately not tried to identify places where it may be okay to call Block::finalize() and avoid the computation of types that flow into the block. 



