### PR TITLE
[NFC] Add LocalLocation for future use

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1202,6 +1202,13 @@ struct InfoCollector
     assert(handledPops == totalPops);
 
     // Handle local.get/sets: each set must write to the proper gets.
+    //
+    // Note that we do not use LocalLocation because LocalGraph gives us more
+    // precise information: we generate direct links from sets to relevant gets
+    // rather than consider each local index a single location, which
+    // LocalLocation does. (LocalLocation is useful in cases where we do need a
+    // single location, such as when we consider what type to give the local;
+    // the type must be the same for all gets of that local.)
     LocalGraph localGraph(func, getModule());
 
     for (auto& [get, setsForGet] : localGraph.getSetses) {
@@ -2765,6 +2772,9 @@ void Flower::dump(Location location) {
     std::cout << "  tagloc " << loc->tag << " : " << loc->tupleIndex << '\n';
   } else if (auto* loc = std::get_if<ParamLocation>(&location)) {
     std::cout << "  paramloc " << loc->func->name << " : " << loc->index
+              << '\n';
+  } else if (auto* loc = std::get_if<LocalLocation>(&location)) {
+    std::cout << "  localloc " << loc->func->name << " : " << loc->index
               << '\n';
   } else if (auto* loc = std::get_if<ResultLocation>(&location)) {
     std::cout << "  resultloc $" << loc->func->name << " : " << loc->index

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -380,6 +380,15 @@ struct ParamLocation {
   }
 };
 
+// The location of a value in a local.
+struct LocalLocation {
+  Function* func;
+  Index index;
+  bool operator==(const LocalLocation& other) const {
+    return func == other.func && index == other.index;
+  }
+};
+
 // The location of one of the results of a function.
 struct ResultLocation {
   Function* func;
@@ -494,6 +503,7 @@ struct ConeReadLocation {
 // have.
 using Location = std::variant<ExpressionLocation,
                               ParamLocation,
+                              LocalLocation,
                               ResultLocation,
                               BreakTargetLocation,
                               GlobalLocation,
@@ -529,6 +539,13 @@ template<> struct hash<wasm::ExpressionLocation> {
 
 template<> struct hash<wasm::ParamLocation> {
   size_t operator()(const wasm::ParamLocation& loc) const {
+    return std::hash<std::pair<size_t, wasm::Index>>{}(
+      {size_t(loc.func), loc.index});
+  }
+};
+
+template<> struct hash<wasm::LocalLocation> {
+  size_t operator()(const wasm::LocalLocation& loc) const {
     return std::hash<std::pair<size_t, wasm::Index>>{}(
       {size_t(loc.func), loc.index});
   }


### PR DESCRIPTION
This is not needed in GUFA as it tracks local values precisely (each set is connected to
the gets that actually read from it), but in a future PR it will be useful to track local
values per index (each set is connected to all gets for that index, i.e., each local index
is a single "location").