### PR TITLE
Implement more TypeGeneralizing transfer functions

### DIFF
--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -579,19 +579,15 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   }
 
   void visitRefCast(RefCast* curr) {
-    // In principle, we do not have to require anything of the input. However,
-    // if our goal is to eliminate casts, then we want the input to be a subtype
-    // of the output, so we don't want the input to be generalized too much.
-    // Propagate the requirement on our output to our input if we can, and
-    // otherwise keep the input type unchanged. Unfortunately we cannot fall
-    // back to requiring nothing of our input because that would not be
-    // monotonic.
-    auto req = pop();
-    if (req == Type::none) {
-      push(Type::none);
-    } else {
-      push(Type::getLeastUpperBound(curr->ref->type, req));
-    }
+    // We do not have to require anything of the input, and not doing so might
+    // allow us generalize the output of previous casts enough that they can be
+    // optimized out. On the other hand, allowing the input to this cast to be
+    // generalized might prevent us from optimizing this cast out, so this is
+    // not a clear-cut decision. For now, leave the input unconstrained for
+    // simplicity. TODO: Experiment with requiring the LUB of the output
+    // requirement and the current input instead.
+    pop();
+    push(Type::none);
   }
 
   void visitBrOn(BrOn* curr) {

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -800,9 +800,12 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     // Model the copy as a get + set.
     ArraySet set;
     set.ref = curr->destRef;
+    set.index = nullptr;
+    set.value = nullptr;
     visitArraySet(&set);
     ArrayGet get;
     get.ref = curr->srcRef;
+    get.index = nullptr;
     get.type = srcType.getArray().element.type;
     visitArrayGet(&get);
   }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -293,14 +293,24 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     WASM_UNREACHABLE("TODO");
   }
 
+  template<typename T> void handleCall(T* curr, Type params) {
+    if (curr->type.isRef()) {
+      pop();
+    }
+    for (auto param : params) {
+      // Cannot generalize beyond param types without interprocedural analysis.
+      if (param.isRef()) {
+        push(param);
+      }
+    }
+  }
+
   void visitCall(Call* curr) {
-    // TODO: pop ref types from results, push ref types from params
-    WASM_UNREACHABLE("TODO");
+    handleCall(curr, wasm.getFunction(curr->target)->getParams());
   }
 
   void visitCallIndirect(CallIndirect* curr) {
-    // TODO: pop ref types from results, push ref types from params
-    WASM_UNREACHABLE("TODO");
+    handleCall(curr, curr->heapType.getSignature().params);
   }
 
   void visitLocalGet(LocalGet* curr) {

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -474,12 +474,28 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     push(eqref);
   }
 
-  void visitTableGet(TableGet* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitTableSet(TableSet* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitTableGet(TableGet* curr) {
+    // Cannot generalize table types yet.
+    pop();
+  }
+
+  void visitTableSet(TableSet* curr) {
+    // Cannot generalize table types yet.
+    push(wasm.getTable(curr->table)->type);
+  }
+
   void visitTableSize(TableSize* curr) {}
   void visitTableGrow(TableGrow* curr) {}
-  void visitTableFill(TableFill* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitTableCopy(TableCopy* curr) { WASM_UNREACHABLE("TODO"); }
+
+  void visitTableFill(TableFill* curr) {
+    // Cannot generalize table types yet.
+    push(wasm.getTable(curr->table)->type);
+  }
+
+  void visitTableCopy(TableCopy* curr) {
+    // Cannot generalize table types yet.
+  }
+
   void visitTry(Try* curr) { WASM_UNREACHABLE("TODO"); }
   void visitThrow(Throw* curr) { WASM_UNREACHABLE("TODO"); }
   void visitRethrow(Rethrow* curr) { WASM_UNREACHABLE("TODO"); }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -250,7 +250,8 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitFunctionExit() {
     // We cannot change the types of results. Push a requirement that the stack
     // end up with the correct type.
-    if (auto result = func->getResults(); result.isRef()) {
+    auto result = func->getResults();
+    if (result.isRef()) {
       push(result);
     }
   }
@@ -401,7 +402,8 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   }
 
   void visitGlobalSet(GlobalSet* curr) {
-    if (auto type = wasm.getGlobal(curr->name)->type; type.isRef()) {
+    auto type = wasm.getGlobal(curr->name)->type;
+    if (type.isRef()) {
       // Cannot generalize globals without interprocedural analysis.
       push(type);
     }
@@ -688,7 +690,8 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     pop();
     if (!curr->isWithDefault()) {
       auto type = curr->type.getHeapType();
-      if (auto fieldType = type.getArray().element.type; fieldType.isRef()) {
+      auto fieldType = type.getArray().element.type;
+      if (fieldType.isRef()) {
         push(fieldType);
       }
     }
@@ -709,7 +712,8 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     // reference type needed to initialize the array, if any.
     pop();
     auto type = curr->type.getHeapType();
-    if (auto fieldType = type.getArray().element.type; fieldType.isRef()) {
+    auto fieldType = type.getArray().element.type;
+    if (fieldType.isRef()) {
       for (size_t i = 0, n = curr->values.size(); i < n; ++i) {
         push(fieldType);
       }
@@ -770,7 +774,8 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     }
     auto generalized = generalizeArrayType(type);
     push(Type(generalized, Nullable));
-    if (auto elemType = generalized.getArray().element.type; elemType.isRef()) {
+    auto elemType = generalized.getArray().element.type;
+    if (elemType.isRef()) {
       push(elemType);
     }
   }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -281,6 +281,7 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitBlock(Block* curr) {}
   void visitIf(If* curr) {}
   void visitLoop(Loop* curr) {}
+
   void visitBreak(Break* curr) {
     if (curr->condition) {
       // `br_if` pops everything but the sent value off the stack if the branch
@@ -457,9 +458,22 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitPop(Pop* curr) { WASM_UNREACHABLE("TODO"); }
 
   void visitRefNull(RefNull* curr) { pop(); }
-  void visitRefIsNull(RefIsNull* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitRefFunc(RefFunc* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitRefEq(RefEq* curr) { WASM_UNREACHABLE("TODO"); }
+
+  void visitRefIsNull(RefIsNull* curr) {
+    // ref.is_null works on any reference type, so do not impose any
+    // constraints. We still need to push something, so push bottom.
+    push(Type::none);
+  }
+
+  void visitRefFunc(RefFunc* curr) { pop(); }
+
+  void visitRefEq(RefEq* curr) {
+    // Both operands must be eqref.
+    auto eqref = Type(HeapType::eq, Nullable);
+    push(eqref);
+    push(eqref);
+  }
+
   void visitTableGet(TableGet* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTableSet(TableSet* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTableSize(TableSize* curr) {}

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -592,8 +592,30 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     }
   }
 
-  void visitBrOn(BrOn* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitStructNew(StructNew* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitBrOn(BrOn* curr) {
+    // Like br_if, these instructions do different things to the stack depending
+    // on whether the branch is taken or not. For branches that drop the tested
+    // value, we need to push a requirement for that value, but for branches
+    // that propagate the tested value, we need to propagate the existing
+    // requirement instead. Like br_if, these instructions will require extra
+    // basic blocks on the branches that drop values.
+    WASM_UNREACHABLE("TODO");
+  }
+
+  void visitStructNew(StructNew* curr) {
+    // We cannot yet generalize allocations. Push requirements for the types
+    // needed to initialize the struct.
+    pop();
+    if (!curr->isWithDefault()) {
+      auto type = curr->type.getHeapType();
+      for (const auto& field : type.getStruct().fields) {
+        if (field.type.isRef()) {
+          push(field.type);
+        }
+      }
+    }
+  }
+
   void visitStructGet(StructGet* curr) { WASM_UNREACHABLE("TODO"); }
   void visitStructSet(StructSet* curr) { WASM_UNREACHABLE("TODO"); }
   void visitArrayNew(ArrayNew* curr) { WASM_UNREACHABLE("TODO"); }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -333,8 +333,20 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     push(getLocal(curr->index));
   }
 
-  void visitGlobalGet(GlobalGet* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitGlobalSet(GlobalSet* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitGlobalGet(GlobalGet* curr) {
+    if (curr->type.isRef()) {
+      // Cannot generalize globals without interprocedural analysis.
+      pop();
+    }
+  }
+
+  void visitGlobalSet(GlobalSet* curr) {
+    if (auto type = wasm.getGlobal(curr->name)->type; type.isRef()) {
+      // Cannot generalize globals without interprocedural analysis.
+      push(type);
+    }
+  }
+
   void visitLoad(Load* curr) { WASM_UNREACHABLE("TODO"); }
   void visitStore(Store* curr) { WASM_UNREACHABLE("TODO"); }
   void visitAtomicRMW(AtomicRMW* curr) { WASM_UNREACHABLE("TODO"); }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -694,8 +694,15 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     }
   }
 
-  void visitArrayNewData(ArrayNewData* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitArrayNewElem(ArrayNewElem* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitArrayNewData(ArrayNewData* curr) {
+    // We cannot yet generalize allocations.
+    pop();
+  }
+
+  void visitArrayNewElem(ArrayNewElem* curr) {
+    // We cannot yet generalize allocations or tables.
+    pop();
+  }
 
   void visitArrayNewFixed(ArrayNewFixed* curr) {
     // We cannot yet generalize allocations. Push a requirements for the
@@ -766,7 +773,11 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     push(generalized.getArray().element.type);
   }
 
-  void visitArrayLen(ArrayLen* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitArrayLen(ArrayLen* curr) {
+    // The input must be an array.
+    push(Type(HeapType::array, Nullable));
+  }
+
   void visitArrayCopy(ArrayCopy* curr) { WASM_UNREACHABLE("TODO"); }
   void visitArrayFill(ArrayFill* curr) { WASM_UNREACHABLE("TODO"); }
   void visitArrayInitData(ArrayInitData* curr) { WASM_UNREACHABLE("TODO"); }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -347,51 +347,57 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
     }
   }
 
-  void visitLoad(Load* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitStore(Store* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitAtomicRMW(AtomicRMW* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitAtomicCmpxchg(AtomicCmpxchg* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitAtomicWait(AtomicWait* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitAtomicNotify(AtomicNotify* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitAtomicFence(AtomicFence* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDExtract(SIMDExtract* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDReplace(SIMDReplace* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDShuffle(SIMDShuffle* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDTernary(SIMDTernary* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDShift(SIMDShift* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDLoad(SIMDLoad* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitSIMDLoadStoreLane(SIMDLoadStoreLane* curr) {
-    WASM_UNREACHABLE("TODO");
-  }
-  void visitMemoryInit(MemoryInit* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitDataDrop(DataDrop* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitMemoryCopy(MemoryCopy* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitMemoryFill(MemoryFill* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitLoad(Load* curr) {}
+  void visitStore(Store* curr) {}
+  void visitAtomicRMW(AtomicRMW* curr) {}
+  void visitAtomicCmpxchg(AtomicCmpxchg* curr) {}
+  void visitAtomicWait(AtomicWait* curr) {}
+  void visitAtomicNotify(AtomicNotify* curr) {}
+  void visitAtomicFence(AtomicFence* curr) {}
+  void visitSIMDExtract(SIMDExtract* curr) {}
+  void visitSIMDReplace(SIMDReplace* curr) {}
+  void visitSIMDShuffle(SIMDShuffle* curr) {}
+  void visitSIMDTernary(SIMDTernary* curr) {}
+  void visitSIMDShift(SIMDShift* curr) {}
+  void visitSIMDLoad(SIMDLoad* curr) {}
+  void visitSIMDLoadStoreLane(SIMDLoadStoreLane* curr) {}
+  void visitMemoryInit(MemoryInit* curr) {}
+  void visitDataDrop(DataDrop* curr) {}
+  void visitMemoryCopy(MemoryCopy* curr) {}
+  void visitMemoryFill(MemoryFill* curr) {}
   void visitConst(Const* curr) {}
   void visitUnary(Unary* curr) {}
   void visitBinary(Binary* curr) {}
+
   void visitSelect(Select* curr) { WASM_UNREACHABLE("TODO"); }
+
   void visitDrop(Drop* curr) {
     if (curr->type.isRef()) {
       pop();
     }
   }
-  void visitReturn(Return* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitMemorySize(MemorySize* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitMemoryGrow(MemoryGrow* curr) { WASM_UNREACHABLE("TODO"); }
+
+  // This is handled by propagating the stack backward from the exit block.
+  void visitReturn(Return* curr) {}
+
+  void visitMemorySize(MemorySize* curr) {}
+  void visitMemoryGrow(MemoryGrow* curr) {}
+
   void visitUnreachable(Unreachable* curr) {
     // Require nothing about values flowing into an unreachable.
     clearStack();
   }
+
   void visitPop(Pop* curr) { WASM_UNREACHABLE("TODO"); }
+
   void visitRefNull(RefNull* curr) { WASM_UNREACHABLE("TODO"); }
   void visitRefIsNull(RefIsNull* curr) { WASM_UNREACHABLE("TODO"); }
   void visitRefFunc(RefFunc* curr) { WASM_UNREACHABLE("TODO"); }
   void visitRefEq(RefEq* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTableGet(TableGet* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTableSet(TableSet* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitTableSize(TableSize* curr) { WASM_UNREACHABLE("TODO"); }
-  void visitTableGrow(TableGrow* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitTableSize(TableSize* curr) {}
+  void visitTableGrow(TableGrow* curr) {}
   void visitTableFill(TableFill* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTableCopy(TableCopy* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTry(Try* curr) { WASM_UNREACHABLE("TODO"); }
@@ -399,8 +405,10 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitRethrow(Rethrow* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTupleMake(TupleMake* curr) { WASM_UNREACHABLE("TODO"); }
   void visitTupleExtract(TupleExtract* curr) { WASM_UNREACHABLE("TODO"); }
+
   void visitRefI31(RefI31* curr) { pop(); }
   void visitI31Get(I31Get* curr) { push(Type(HeapType::i31, Nullable)); }
+
   void visitCallRef(CallRef* curr) { WASM_UNREACHABLE("TODO"); }
   void visitRefTest(RefTest* curr) { WASM_UNREACHABLE("TODO"); }
   void visitRefCast(RefCast* curr) { WASM_UNREACHABLE("TODO"); }

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -369,7 +369,14 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitUnary(Unary* curr) {}
   void visitBinary(Binary* curr) {}
 
-  void visitSelect(Select* curr) { WASM_UNREACHABLE("TODO"); }
+  void visitSelect(Select* curr) {
+    if (curr->type.isRef()) {
+      // The inputs may be as general as the output.
+      auto type = pop();
+      push(type);
+      push(type);
+    }
+  }
 
   void visitDrop(Drop* curr) {
     if (curr->type.isRef()) {

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -813,7 +813,7 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitArrayInitData(ArrayInitData* curr) {
     auto type = curr->ref->type.getHeapType();
     if (type.isBottom()) {
-      // This will be emitted as unreahcalbe. Do not require anything of the
+      // This will be emitted as unreachable. Do not require anything of the
       // input, except that the ref remain bottom.
       clearStack();
       push(Type(HeapType::none, Nullable));
@@ -826,7 +826,7 @@ struct TransferFn : OverriddenVisitor<TransferFn> {
   void visitArrayInitElem(ArrayInitElem* curr) {
     auto type = curr->ref->type.getHeapType();
     if (type.isBottom()) {
-      // This will be emitted as unreahcalbe. Do not require anything of the
+      // This will be emitted as unreachable. Do not require anything of the
       // input, except that the ref remain bottom.
       clearStack();
       push(Type(HeapType::none, Nullable));

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2967,28 +2967,30 @@ void FunctionValidator::visitArrayCopy(ArrayCopy* curr) {
   if (curr->type == Type::unreachable) {
     return;
   }
-  if (!shouldBeSubType(curr->srcRef->type,
-                       Type(HeapType::array, Nullable),
-                       curr,
-                       "array.copy source should be an array reference")) {
+  if (!shouldBeTrue(curr->srcRef->type.isRef(),
+                    curr,
+                    "array.copy source should be a reference")) {
     return;
   }
-  if (!shouldBeSubType(curr->destRef->type,
-                       Type(HeapType::array, Nullable),
-                       curr,
-                       "array.copy destination should be an array reference")) {
+  if (!shouldBeTrue(curr->destRef->type.isRef(),
+                    curr,
+                    "array.copy destination should be a reference")) {
     return;
   }
   auto srcHeapType = curr->srcRef->type.getHeapType();
   auto destHeapType = curr->destRef->type.getHeapType();
-  if (srcHeapType == HeapType::none ||
-      !shouldBeTrue(srcHeapType.isArray(),
+  // Normally both types need to be references to specifc arrays, but if either
+  // of the types are bottom, we don't further constrain the other at all
+  // because this will be emitted as an unreachable.
+  if (srcHeapType.isBottom() || destHeapType.isBottom()) {
+    return;
+  }
+  if (!shouldBeTrue(srcHeapType.isArray(),
                     curr,
                     "array.copy source should be an array reference")) {
     return;
   }
-  if (destHeapType == HeapType::none ||
-      !shouldBeTrue(destHeapType.isArray(),
+  if (!shouldBeTrue(destHeapType.isArray(),
                     curr,
                     "array.copy destination should be an array reference")) {
     return;

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -27,8 +27,11 @@
  ;; CHECK:      (global $global-i32 (mut i32) (i32.const 0))
  (global $global-i32 (mut i32) (i32.const 0))
 
- ;; CHECK:      (table $t 0 0 funcref)
- (table $t 0 0 funcref)
+ ;; CHECK:      (table $func-table 0 0 funcref)
+ (table $func-table 0 0 funcref)
+
+ ;; CHECK:      (table $eq-table 0 0 eqref)
+ (table $eq-table 0 0 eqref)
 
  ;; CHECK:      (elem declare func $ref-func)
 
@@ -444,7 +447,7 @@
 
  ;; CHECK:      (func $call_indirect (type $2) (param $x eqref)
  ;; CHECK-NEXT:  (local $var eqref)
- ;; CHECK-NEXT:  (call_indirect $t (type $2)
+ ;; CHECK-NEXT:  (call_indirect $func-table (type $2)
  ;; CHECK-NEXT:   (local.get $var)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
@@ -591,6 +594,58 @@
     (local.get $var1)
     (local.get $var2)
    )
+  )
+ )
+
+ ;; CHECK:      (func $table-get (type $void)
+ ;; CHECK-NEXT:  (local $var anyref)
+ ;; CHECK-NEXT:  (local.set $var
+ ;; CHECK-NEXT:   (table.get $eq-table
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $table-get
+  (local $var eqref)
+  ;; No constraints on $var.
+  (local.set $var
+   (table.get $eq-table
+    (i32.const 0)
+   )
+  )
+ )
+
+ ;; CHECK:      (func $table-set (type $void)
+ ;; CHECK-NEXT:  (local $var eqref)
+ ;; CHECK-NEXT:  (table.set $eq-table
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:   (local.get $var)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $table-set
+  (local $var i31ref)
+  ;; Require typeof($var) <: eqref.
+  (table.set $eq-table
+   (i32.const 0)
+   (local.get $var)
+  )
+ )
+
+ ;; CHECK:      (func $table-fill (type $void)
+ ;; CHECK-NEXT:  (local $var eqref)
+ ;; CHECK-NEXT:  (table.fill $eq-table
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:   (local.get $var)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $table-fill
+  (local $var i31ref)
+  ;; Require typeof($var) <: eqref.
+  (table.fill $eq-table
+   (i32.const 0)
+   (local.get $var)
+   (i32.const 0)
   )
  )
 

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -4,9 +4,9 @@
 
 (module
 
- ;; CHECK:      (type $0 (func))
+ ;; CHECK:      (type $0 (func (result eqref)))
 
- ;; CHECK:      (type $1 (func (result eqref)))
+ ;; CHECK:      (type $1 (func))
 
  ;; CHECK:      (type $2 (func (param eqref)))
 
@@ -25,7 +25,7 @@
  ;; CHECK:      (table $t 0 0 funcref)
  (table $t 0 0 funcref)
 
- ;; CHECK:      (func $unconstrained (type $0)
+ ;; CHECK:      (func $unconstrained (type $1)
  ;; CHECK-NEXT:  (local $x i32)
  ;; CHECK-NEXT:  (local $y anyref)
  ;; CHECK-NEXT:  (local $z (anyref i32))
@@ -40,7 +40,7 @@
   (local $z (anyref i32))
  )
 
- ;; CHECK:      (func $implicit-return (type $1) (result eqref)
+ ;; CHECK:      (func $implicit-return (type $0) (result eqref)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (local.get $var)
  ;; CHECK-NEXT: )
@@ -51,7 +51,7 @@
   (local.get $var)
  )
 
- ;; CHECK:      (func $implicit-return-unreachable (type $1) (result eqref)
+ ;; CHECK:      (func $implicit-return-unreachable (type $0) (result eqref)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
@@ -63,7 +63,7 @@
   (local.get $var)
  )
 
- ;; CHECK:      (func $if (type $1) (result eqref)
+ ;; CHECK:      (func $if (type $0) (result eqref)
  ;; CHECK-NEXT:  (local $x eqref)
  ;; CHECK-NEXT:  (local $y eqref)
  ;; CHECK-NEXT:  (if (result eqref)
@@ -84,7 +84,7 @@
   )
  )
 
- ;; CHECK:      (func $local-set (type $0)
+ ;; CHECK:      (func $local-set (type $1)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (local.set $var
  ;; CHECK-NEXT:   (ref.i31
@@ -157,7 +157,7 @@
   )
  )
 
- ;; CHECK:      (func $local-get-set-chain (type $1) (result eqref)
+ ;; CHECK:      (func $local-get-set-chain (type $0) (result eqref)
  ;; CHECK-NEXT:  (local $a eqref)
  ;; CHECK-NEXT:  (local $b eqref)
  ;; CHECK-NEXT:  (local $c eqref)
@@ -185,7 +185,7 @@
   (local.get $c)
  )
 
- ;; CHECK:      (func $local-get-set-chain-out-of-order (type $1) (result eqref)
+ ;; CHECK:      (func $local-get-set-chain-out-of-order (type $0) (result eqref)
  ;; CHECK-NEXT:  (local $a eqref)
  ;; CHECK-NEXT:  (local $b eqref)
  ;; CHECK-NEXT:  (local $c eqref)
@@ -240,7 +240,7 @@
   )
  )
 
- ;; CHECK:      (func $i31-get (type $0)
+ ;; CHECK:      (func $i31-get (type $1)
  ;; CHECK-NEXT:  (local $nullable i31ref)
  ;; CHECK-NEXT:  (local $nonnullable i31ref)
  ;; CHECK-NEXT:  (local.set $nonnullable
@@ -316,7 +316,7 @@
   )
  )
 
- ;; CHECK:      (func $global-get (type $0)
+ ;; CHECK:      (func $global-get (type $1)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (local $i32 i32)
  ;; CHECK-NEXT:  (local.set $var
@@ -339,7 +339,7 @@
   )
  )
 
- ;; CHECK:      (func $global-set (type $0)
+ ;; CHECK:      (func $global-set (type $1)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (local $i32 i32)
  ;; CHECK-NEXT:  (global.set $global-eq
@@ -359,6 +359,27 @@
   ;; Non-reference typed globals are ok, too.
   (global.set $global-i32
    (local.get $i32)
+  )
+ )
+
+ ;; CHECK:      (func $select (type $0) (result eqref)
+ ;; CHECK-NEXT:  (local $var1 eqref)
+ ;; CHECK-NEXT:  (local $var2 eqref)
+ ;; CHECK-NEXT:  (select (result eqref)
+ ;; CHECK-NEXT:   (local.get $var1)
+ ;; CHECK-NEXT:   (local.get $var2)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $select (result eqref)
+  ;; Both of these will be generalized to eqref.
+  (local $var1 i31ref)
+  (local $var2 i31ref)
+  ;; Requires typeof($var1) <: eqref and typeof($var2) <: eqref.
+  (select (result i31ref)
+   (local.get $var1)
+   (local.get $var2)
+   (i32.const 0)
   )
  )
 )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -708,7 +708,7 @@
  ;; CHECK-NEXT: )
  (func $ref-cast-limited (result eqref)
   (local $var i31ref)
-  ;; Do not constrain $var.
+  ;; No constraint on $var.
   ;; TODO: We could eliminate the cast if we did constrain $var.
   (ref.cast i31ref
    (local.get $var)
@@ -723,7 +723,7 @@
  ;; CHECK-NEXT: )
  (func $ref-cast-more-limited (result nullref)
   (local $var i31ref)
-  ;; Do not constraint $var.
+  ;; No constraint on $var.
   (ref.cast nullref
    (local.get $var)
   )
@@ -737,7 +737,7 @@
  ;; CHECK-NEXT: )
  (func $ref-cast-lub (result structref)
   (local $var i31ref)
-  ;; Do not constrain $var.
+  ;; No constraint on $var.
   (ref.cast structref
    (local.get $var)
   )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -1001,19 +1001,32 @@
 )
 
 (module
- ;; CHECK:      (type $0 (func (result anyref)))
+ ;; CHECK:      (type $0 (func))
+
+ ;; CHECK:      (type $1 (func (result anyref)))
 
  ;; CHECK:      (type $super (sub (array eqref)))
  (type $super (sub (array (field eqref))))
+ ;; CHECK:      (type $super-mut (sub (array (mut eqref))))
+
+ ;; CHECK:      (type $bytes (array i8))
+
+ ;; CHECK:      (type $sub (sub $super (array i31ref)))
  (type $sub (sub $super (array (field i31ref))))
 
- ;; CHECK:      (type $2 (func))
-
- ;; CHECK:      (type $super-mut (sub (array (mut eqref))))
  (type $super-mut (sub (array (field (mut eqref)))))
  (type $sub-mut (sub $super-mut (array (field (mut eqref)))))
 
- ;; CHECK:      (func $array-new (type $0) (result anyref)
+ (type $bytes (array i8))
+
+ ;; CHECK:      (data $data "")
+
+ ;; CHECK:      (elem $elem i31ref)
+ (elem $elem i31ref)
+
+ (data $data "")
+
+ ;; CHECK:      (func $array-new (type $1) (result anyref)
  ;; CHECK-NEXT:  (local $val eqref)
  ;; CHECK-NEXT:  (array.new $super
  ;; CHECK-NEXT:   (local.get $val)
@@ -1029,7 +1042,47 @@
   )
  )
 
- ;; CHECK:      (func $array-new-fixed (type $0) (result anyref)
+ ;; CHECK:      (func $array-new-data (type $0)
+ ;; CHECK-NEXT:  (local $val anyref)
+ ;; CHECK-NEXT:  (local.set $val
+ ;; CHECK-NEXT:   (array.new_data $bytes $data
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-new-data
+  (local $val arrayref)
+  ;; No constraint on $val.
+  (local.set $val
+   (array.new_data $bytes $data
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+ )
+
+ ;; CHECK:      (func $array-new-elem (type $0)
+ ;; CHECK-NEXT:  (local $val anyref)
+ ;; CHECK-NEXT:  (local.set $val
+ ;; CHECK-NEXT:   (array.new_elem $sub $elem
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-new-elem
+  (local $val arrayref)
+  ;; No constraint on $val.
+  (local.set $val
+   (array.new_elem $sub $elem
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+ )
+
+ ;; CHECK:      (func $array-new-fixed (type $1) (result anyref)
  ;; CHECK-NEXT:  (local $val1 eqref)
  ;; CHECK-NEXT:  (local $val2 eqref)
  ;; CHECK-NEXT:  (array.new_fixed $super 2
@@ -1047,7 +1100,7 @@
   )
  )
 
- ;; CHECK:      (func $array-get (type $0) (result anyref)
+ ;; CHECK:      (func $array-get (type $1) (result anyref)
  ;; CHECK-NEXT:  (local $val (ref null $super))
  ;; CHECK-NEXT:  (array.get $super
  ;; CHECK-NEXT:   (local.get $val)
@@ -1063,7 +1116,7 @@
   )
  )
 
- ;; CHECK:      (func $array-get-impossible (type $0) (result anyref)
+ ;; CHECK:      (func $array-get-impossible (type $1) (result anyref)
  ;; CHECK-NEXT:  (local $val nullref)
  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
  ;; CHECK-NEXT:   (drop
@@ -1084,7 +1137,7 @@
   )
  )
 
- ;; CHECK:      (func $array-set (type $2)
+ ;; CHECK:      (func $array-set (type $0)
  ;; CHECK-NEXT:  (local $ref (ref null $super-mut))
  ;; CHECK-NEXT:  (local $val eqref)
  ;; CHECK-NEXT:  (array.set $super-mut
@@ -1105,7 +1158,7 @@
   )
  )
 
- ;; CHECK:      (func $array-set-impossible (type $2)
+ ;; CHECK:      (func $array-set-impossible (type $0)
  ;; CHECK-NEXT:  (local $ref nullref)
  ;; CHECK-NEXT:  (local $val anyref)
  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
@@ -1129,6 +1182,24 @@
    (local.get $ref)
    (i32.const 0)
    (local.get $val)
+  )
+ )
+
+ ;; CHECK:      (func $array-len (type $0)
+ ;; CHECK-NEXT:  (local $ref arrayref)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (array.len
+ ;; CHECK-NEXT:    (local.get $ref)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-len
+  (local $ref (ref null $super))
+  (drop
+   ;; Require that typeof($ref) <: arrayref.
+   (array.len
+    (local.get $ref)
+   )
   )
  )
 )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -701,44 +701,43 @@
  )
 
  ;; CHECK:      (func $ref-cast-limited (type $1) (result eqref)
- ;; CHECK-NEXT:  (local $var eqref)
+ ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (ref.cast i31ref
  ;; CHECK-NEXT:   (local.get $var)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $ref-cast-limited (result eqref)
   (local $var i31ref)
-  ;; Require that typeof($var) <: eqref so the cast can still be elimintated.
+  ;; Do not constrain $var.
+  ;; TODO: We could eliminate the cast if we did constrain $var.
   (ref.cast i31ref
    (local.get $var)
   )
  )
 
  ;; CHECK:      (func $ref-cast-more-limited (type $8) (result nullref)
- ;; CHECK-NEXT:  (local $var i31ref)
+ ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (ref.cast nullref
  ;; CHECK-NEXT:   (local.get $var)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $ref-cast-more-limited (result nullref)
   (local $var i31ref)
-  ;; Require that typeof($var) <: i31ref for montonicity, even though it would
-  ;; be nice if we could require nothing of it since we will not be able to
-  ;; eliminate this cast.
+  ;; Do not constraint $var.
   (ref.cast nullref
    (local.get $var)
   )
  )
 
  ;; CHECK:      (func $ref-cast-lub (type $9) (result structref)
- ;; CHECK-NEXT:  (local $var eqref)
+ ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (ref.cast nullref
  ;; CHECK-NEXT:   (local.get $var)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $ref-cast-lub (result structref)
   (local $var i31ref)
-  ;; Require that typeof($var) <: LUB(structref, i31ref).
+  ;; Do not constrain $var.
   (ref.cast structref
    (local.get $var)
   )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -999,3 +999,136 @@
   )
  )
 )
+
+(module
+ ;; CHECK:      (type $0 (func (result anyref)))
+
+ ;; CHECK:      (type $super (sub (array eqref)))
+ (type $super (sub (array (field eqref))))
+ (type $sub (sub $super (array (field i31ref))))
+
+ ;; CHECK:      (type $2 (func))
+
+ ;; CHECK:      (type $super-mut (sub (array (mut eqref))))
+ (type $super-mut (sub (array (field (mut eqref)))))
+ (type $sub-mut (sub $super-mut (array (field (mut eqref)))))
+
+ ;; CHECK:      (func $array-new (type $0) (result anyref)
+ ;; CHECK-NEXT:  (local $val eqref)
+ ;; CHECK-NEXT:  (array.new $super
+ ;; CHECK-NEXT:   (local.get $val)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-new (result anyref)
+  (local $val i31ref)
+  ;; Require that typeof($val) <: eqref.
+  (array.new $super
+   (local.get $val)
+   (i32.const 0)
+  )
+ )
+
+ ;; CHECK:      (func $array-new-fixed (type $0) (result anyref)
+ ;; CHECK-NEXT:  (local $val1 eqref)
+ ;; CHECK-NEXT:  (local $val2 eqref)
+ ;; CHECK-NEXT:  (array.new_fixed $super 2
+ ;; CHECK-NEXT:   (local.get $val1)
+ ;; CHECK-NEXT:   (local.get $val2)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-new-fixed (result anyref)
+  (local $val1 i31ref)
+  (local $val2 i31ref)
+  ;; Require that typeof($val1) <: eqref and that typeof($val2) <: eqref.
+  (array.new_fixed $super 2
+   (local.get $val1)
+   (local.get $val2)
+  )
+ )
+
+ ;; CHECK:      (func $array-get (type $0) (result anyref)
+ ;; CHECK-NEXT:  (local $val (ref null $super))
+ ;; CHECK-NEXT:  (array.get $super
+ ;; CHECK-NEXT:   (local.get $val)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-get (result anyref)
+  (local $val (ref null $sub))
+  ;; Require that typeof($val) <: (ref null $super).
+  (array.get $sub
+   (local.get $val)
+   (i32.const 0)
+  )
+ )
+
+ ;; CHECK:      (func $array-get-impossible (type $0) (result anyref)
+ ;; CHECK-NEXT:  (local $val nullref)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (local.get $val)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-get-impossible (result anyref)
+  (local $val nullref)
+  ;; Require that typeof($val) <: nullref.
+  (array.get $sub
+   (local.get $val)
+   (i32.const 0)
+  )
+ )
+
+ ;; CHECK:      (func $array-set (type $2)
+ ;; CHECK-NEXT:  (local $ref (ref null $super-mut))
+ ;; CHECK-NEXT:  (local $val eqref)
+ ;; CHECK-NEXT:  (array.set $super-mut
+ ;; CHECK-NEXT:   (local.get $ref)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:   (local.get $val)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-set
+  (local $ref (ref null $sub-mut))
+  (local $val i31ref)
+  ;; Require that typeof($ref) <: (ref null $super-mut) and that typeof($val) <:
+  ;; eqref.
+  (array.set $sub-mut
+   (local.get $ref)
+   (i32.const 0)
+   (local.get $val)
+  )
+ )
+
+ ;; CHECK:      (func $array-set-impossible (type $2)
+ ;; CHECK-NEXT:  (local $ref nullref)
+ ;; CHECK-NEXT:  (local $val anyref)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (local.get $ref)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (local.get $val)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $array-set-impossible
+  (local $ref nullref)
+  (local $val i31ref)
+  ;; Require that typeof($ref) <: nullref and do not constrain $ref.
+  (array.set $sub-mut
+   (local.get $ref)
+   (i32.const 0)
+   (local.get $val)
+  )
+ )
+)

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -6,17 +6,19 @@
 
  ;; CHECK:      (type $0 (func (result eqref)))
 
- ;; CHECK:      (type $1 (func))
+ ;; CHECK:      (type $1 (func (param eqref)))
 
- ;; CHECK:      (type $2 (func (param anyref)))
+ ;; CHECK:      (type $2 (func))
 
- ;; CHECK:      (type $3 (func (param i31ref)))
+ ;; CHECK:      (type $3 (func (param anyref)))
 
- ;; CHECK:      (type $4 (func (param anyref eqref)))
+ ;; CHECK:      (type $4 (func (param i31ref)))
 
- ;; CHECK:      (type $5 (func (param eqref)))
+ ;; CHECK:      (type $5 (func (param anyref eqref)))
 
- ;; CHECK:      (func $unconstrained (type $1)
+ ;; CHECK:      (table $t 0 0 funcref)
+ (table $t 0 0 funcref)
+ ;; CHECK:      (func $unconstrained (type $2)
  ;; CHECK-NEXT:  (local $x i32)
  ;; CHECK-NEXT:  (local $y anyref)
  ;; CHECK-NEXT:  (local $z (anyref i32))
@@ -75,7 +77,7 @@
   )
  )
 
- ;; CHECK:      (func $local-set (type $1)
+ ;; CHECK:      (func $local-set (type $2)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (local.set $var
  ;; CHECK-NEXT:   (ref.i31
@@ -94,7 +96,7 @@
   )
  )
 
- ;; CHECK:      (func $local-get-set (type $2) (param $dest anyref)
+ ;; CHECK:      (func $local-get-set (type $3) (param $dest anyref)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (local.set $dest
  ;; CHECK-NEXT:   (local.get $var)
@@ -109,7 +111,7 @@
   )
  )
 
- ;; CHECK:      (func $local-get-set-unreachable (type $3) (param $dest i31ref)
+ ;; CHECK:      (func $local-get-set-unreachable (type $4) (param $dest i31ref)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
@@ -126,7 +128,7 @@
   )
  )
 
- ;; CHECK:      (func $local-get-set-join (type $4) (param $dest1 anyref) (param $dest2 eqref)
+ ;; CHECK:      (func $local-get-set-join (type $5) (param $dest1 anyref) (param $dest2 eqref)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (local.set $dest1
  ;; CHECK-NEXT:   (local.get $var)
@@ -205,7 +207,7 @@
   (local.get $c)
  )
 
- ;; CHECK:      (func $local-tee (type $5) (param $dest eqref)
+ ;; CHECK:      (func $local-tee (type $1) (param $dest eqref)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (local.tee $dest
@@ -231,7 +233,7 @@
   )
  )
 
- ;; CHECK:      (func $i31-get (type $1)
+ ;; CHECK:      (func $i31-get (type $2)
  ;; CHECK-NEXT:  (local $nullable i31ref)
  ;; CHECK-NEXT:  (local $nonnullable i31ref)
  ;; CHECK-NEXT:  (local.set $nonnullable
@@ -272,6 +274,38 @@
    (i31.get_u
     (local.get $nonnullable)
    )
+  )
+ )
+
+ ;; CHECK:      (func $call (type $1) (param $x eqref)
+ ;; CHECK-NEXT:  (local $var eqref)
+ ;; CHECK-NEXT:  (call $call
+ ;; CHECK-NEXT:   (local.get $var)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $call (param $x eqref)
+  ;; This will be optimized to eqref.
+  (local $var i31ref)
+  ;; Requires typeof($var) <: eqref.
+  (call $call
+   (local.get $var)
+  )
+ )
+
+ ;; CHECK:      (func $call_indirect (type $1) (param $x eqref)
+ ;; CHECK-NEXT:  (local $var eqref)
+ ;; CHECK-NEXT:  (call_indirect $t (type $1)
+ ;; CHECK-NEXT:   (local.get $var)
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $call_indirect (param $x eqref)
+  ;; This will be optimized to eqref.
+  (local $var i31ref)
+  ;; Requires typeof($var) <: eqref.
+  (call_indirect (param eqref)
+   (local.get $var)
+   (i32.const 0)
   )
  )
 )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -460,14 +460,14 @@
   )
  )
 
- ;; CHECK:      (func $call_indirect (type $2) (param $x eqref)
+ ;; CHECK:      (func $call_indirect (type $void)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (call_indirect $func-table (type $2)
  ;; CHECK-NEXT:   (local.get $var)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $call_indirect (param $x eqref)
+ (func $call_indirect
   ;; This will be optimized to eqref.
   (local $var i31ref)
   ;; Requires typeof($var) <: eqref.

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -4,9 +4,10 @@
 
 (module
 
- ;; CHECK:      (type $0 (func (result eqref)))
+ ;; CHECK:      (type $void (func))
+ (type $void (func))
 
- ;; CHECK:      (type $1 (func))
+ ;; CHECK:      (type $1 (func (result eqref)))
 
  ;; CHECK:      (type $2 (func (param eqref)))
 
@@ -29,7 +30,9 @@
  ;; CHECK:      (table $t 0 0 funcref)
  (table $t 0 0 funcref)
 
- ;; CHECK:      (func $unconstrained (type $1)
+ ;; CHECK:      (elem declare func $ref-func)
+
+ ;; CHECK:      (func $unconstrained (type $void)
  ;; CHECK-NEXT:  (local $x i32)
  ;; CHECK-NEXT:  (local $y anyref)
  ;; CHECK-NEXT:  (local $z (anyref i32))
@@ -44,7 +47,7 @@
   (local $z (anyref i32))
  )
 
- ;; CHECK:      (func $implicit-return (type $0) (result eqref)
+ ;; CHECK:      (func $implicit-return (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (local.get $var)
  ;; CHECK-NEXT: )
@@ -55,7 +58,7 @@
   (local.get $var)
  )
 
- ;; CHECK:      (func $implicit-return-unreachable (type $0) (result eqref)
+ ;; CHECK:      (func $implicit-return-unreachable (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
@@ -67,7 +70,7 @@
   (local.get $var)
  )
 
- ;; CHECK:      (func $if (type $0) (result eqref)
+ ;; CHECK:      (func $if (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $x eqref)
  ;; CHECK-NEXT:  (local $y eqref)
  ;; CHECK-NEXT:  (if (result eqref)
@@ -88,7 +91,7 @@
   )
  )
 
- ;; CHECK:      (func $loop (type $0) (result eqref)
+ ;; CHECK:      (func $loop (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (loop $loop-in (result eqref)
  ;; CHECK-NEXT:   (local.get $var)
@@ -102,7 +105,7 @@
   )
  )
 
- ;; CHECK:      (func $br-sent (type $0) (result eqref)
+ ;; CHECK:      (func $br-sent (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $var1 anyref)
  ;; CHECK-NEXT:  (local $var2 eqref)
  ;; CHECK-NEXT:  (block $l (result eqref)
@@ -131,7 +134,7 @@
   )
  )
 
- ;; CHECK:      (func $br-no-sent (type $1)
+ ;; CHECK:      (func $br-no-sent (type $void)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (block $l
  ;; CHECK-NEXT:   (block
@@ -224,7 +227,7 @@
   )
  )
 
- ;; CHECK:      (func $local-set (type $1)
+ ;; CHECK:      (func $local-set (type $void)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (local.set $var
  ;; CHECK-NEXT:   (ref.i31
@@ -297,7 +300,7 @@
   )
  )
 
- ;; CHECK:      (func $local-get-set-chain (type $0) (result eqref)
+ ;; CHECK:      (func $local-get-set-chain (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $a eqref)
  ;; CHECK-NEXT:  (local $b eqref)
  ;; CHECK-NEXT:  (local $c eqref)
@@ -325,7 +328,7 @@
   (local.get $c)
  )
 
- ;; CHECK:      (func $local-get-set-chain-out-of-order (type $0) (result eqref)
+ ;; CHECK:      (func $local-get-set-chain-out-of-order (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $a eqref)
  ;; CHECK-NEXT:  (local $b eqref)
  ;; CHECK-NEXT:  (local $c eqref)
@@ -380,7 +383,7 @@
   )
  )
 
- ;; CHECK:      (func $i31-get (type $1)
+ ;; CHECK:      (func $i31-get (type $void)
  ;; CHECK-NEXT:  (local $nullable i31ref)
  ;; CHECK-NEXT:  (local $nonnullable i31ref)
  ;; CHECK-NEXT:  (local.set $nonnullable
@@ -456,7 +459,7 @@
   )
  )
 
- ;; CHECK:      (func $global-get (type $1)
+ ;; CHECK:      (func $global-get (type $void)
  ;; CHECK-NEXT:  (local $var anyref)
  ;; CHECK-NEXT:  (local $i32 i32)
  ;; CHECK-NEXT:  (local.set $var
@@ -479,7 +482,7 @@
   )
  )
 
- ;; CHECK:      (func $global-set (type $1)
+ ;; CHECK:      (func $global-set (type $void)
  ;; CHECK-NEXT:  (local $var eqref)
  ;; CHECK-NEXT:  (local $i32 i32)
  ;; CHECK-NEXT:  (global.set $global-eq
@@ -502,7 +505,7 @@
   )
  )
 
- ;; CHECK:      (func $select (type $0) (result eqref)
+ ;; CHECK:      (func $select (type $1) (result eqref)
  ;; CHECK-NEXT:  (local $var1 eqref)
  ;; CHECK-NEXT:  (local $var2 eqref)
  ;; CHECK-NEXT:  (select (result eqref)
@@ -520,6 +523,74 @@
    (local.get $var1)
    (local.get $var2)
    (i32.const 0)
+  )
+ )
+
+ ;; CHECK:      (func $ref-null (type $void)
+ ;; CHECK-NEXT:  (local $var anyref)
+ ;; CHECK-NEXT:  (local.set $var
+ ;; CHECK-NEXT:   (ref.null none)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $ref-null
+  (local $var i31ref)
+  ;; No constraints on $var.
+  (local.set $var
+   (ref.null none)
+  )
+ )
+
+ ;; CHECK:      (func $ref-is-null (type $void)
+ ;; CHECK-NEXT:  (local $var anyref)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (ref.is_null
+ ;; CHECK-NEXT:    (local.get $var)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $ref-is-null
+  (local $var i31ref)
+  (drop
+   ;; No constraints on $var.
+   (ref.is_null
+    (local.get $var)
+   )
+  )
+ )
+
+ ;; CHECK:      (func $ref-func (type $void)
+ ;; CHECK-NEXT:  (local $var funcref)
+ ;; CHECK-NEXT:  (local.set $var
+ ;; CHECK-NEXT:   (ref.func $ref-func)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $ref-func
+  (local $var (ref null $void))
+  ;; No constraints on $var.
+  (local.set $var
+   (ref.func $ref-func)
+  )
+ )
+
+ ;; CHECK:      (func $ref-eq (type $void)
+ ;; CHECK-NEXT:  (local $var1 eqref)
+ ;; CHECK-NEXT:  (local $var2 eqref)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (ref.eq
+ ;; CHECK-NEXT:    (local.get $var1)
+ ;; CHECK-NEXT:    (local.get $var2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $ref-eq
+  (local $var1 i31ref)
+  (local $var2 i31ref)
+  (drop
+   ;; Require that typeof($var1) <: eqref and that typeof($var2) <: eqref.
+   (ref.eq
+    (local.get $var1)
+    (local.get $var2)
+   )
   )
  )
 

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -141,6 +141,9 @@
   (local $var1 i31ref)
   (local $var2 i31ref)
   (block $l (result i31ref)
+   ;; The call will be DCEd out, but this test and the implementation for `br`
+   ;; should be forward-compatible with a future where we do not have to run DCE
+   ;; before this pass.
    (call $helper-any_any
     ;; No requirements on $var1
     (local.get $var1)
@@ -166,6 +169,7 @@
  (func $br-no-sent
   (local $var i31ref)
   (block $l
+   ;; This call is DCEd out just like in the previous test.
    (call $helper-any_any
     ;; No requirements on $var
     (local.get $var)


### PR DESCRIPTION
Finish the transfer functions for all expressions except for string
instructions, exception handling instructions, tuple instructions, and branch
instructions that carry values. The latter require more work in the CFG builder
because dropping the extra stack values happens after the branch but before the
target block.