### PR TITLE
[Outlining] Adds filter tests

### DIFF
--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -83,6 +83,18 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
 
+  ;; CHECK:      (func $outline$ (param $0 i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.get $0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
   ;; CHECK:      (func $c
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT: )
@@ -178,18 +190,6 @@
 ;; Tests multiple sequences being outlined from the same source function into different
 ;; outlined functions.
 (module
-  ;; CHECK:      (type $0 (func))
-
-  ;; CHECK:      (func $outline$
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.add
-  ;; CHECK-NEXT:    (i32.const 0)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-
-  ;; CHECK:      (func $outline$_4
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.sub
   ;; CHECK-NEXT:    (i32.const 3)
@@ -288,35 +288,6 @@
       )
 
 ;; Tests that local.get instructions are correctly filtered from being outlined.
-;; CHECK:      (func $outline$
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (i32.const 0)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (i32.const 0)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (i32.const 1)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $outline$_4 (param $0 i32)
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (local.get $0)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (i32.const 2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (drop
-;; CHECK-NEXT:   (i32.sub
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:    (i32.const 4)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
 (module
   ;; CHECK:      (type $0 (func (param i32) (result i32)))
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -445,3 +445,41 @@
     )
   )
 )
+
+;; TODO: Add a test that makes sure we filter returns correctly
+(module
+  ;; CHECK:      (type $0 (func (result i32)))
+
+  ;; CHECK:      (func $o (result i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (return
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $o (result i32)
+    (drop (i32.const 0))
+	(drop (i32.const 1))
+	(return (i32.const 2))
+  )
+  ;; CHECK:      (func $p (result i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (return
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $p (result i32)
+    (drop (i32.const 0))
+	(drop (i32.const 1))
+	(return (i32.const 2))
+  )
+)

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -286,104 +286,67 @@
       (drop
         (i32.const 10)
       )
+    )
+  )
+)
 
 ;; Tests that local.get instructions are correctly filtered from being outlined.
 (module
-  ;; CHECK:      (type $0 (func (param i32) (result i32)))
+  ;; CHECK:      (type $0 (func (param i32)))
 
-  ;; CHECK:      (func $j (param $0 i32) (result i32)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 7)
-  ;; CHECK-NEXT:  )
+  ;; CHECK:      (func $j (param $0 i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.add
   ;; CHECK-NEXT:    (local.get $0)
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 2)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (return
-  ;; CHECK-NEXT:   (i32.const 4)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $j (param i32) (result i32)
-    (drop (i32.const 7))
+  (func $j (param i32)
     (drop (i32.add
       (local.get 0)
       (i32.const 1)))
-    (drop (i32.const 2))
-    (return (i32.const 4))
   )
-  ;; CHECK:      (func $k (param $0 i32) (result i32)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
-  ;; CHECK-NEXT:  )
+  ;; CHECK:      (func $k (param $0 i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.add
   ;; CHECK-NEXT:    (local.get $0)
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 2)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (return
-  ;; CHECK-NEXT:   (i32.const 5)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $k (param i32) (result i32)
-    (drop (i32.const 0))
+  (func $k (param i32)
     (drop (i32.add
       (local.get 0)
       (i32.const 1)))
-    (drop (i32.const 2))
-    (return (i32.const 5))
   )
 )
 
 ;; Tests local.set instructions are correctly filtered from being outlined.
 (module
-  ;; CHECK:      (type $0 (func (result i32)))
+  ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (func $l (result i32)
+  ;; CHECK:      (func $l
   ;; CHECK-NEXT:  (local $i i32)
   ;; CHECK-NEXT:  (local.set $i
   ;; CHECK-NEXT:   (i32.const 7)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 2)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (return
-  ;; CHECK-NEXT:   (i32.const 4)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $l (result i32)
-	(local $i i32)
+  (func $l
+    (local $i i32)
     (local.set $i
       (i32.const 7))
-    (drop (i32.const 2))
-    (return (i32.const 4))
   )
-  ;; CHECK:      (func $m (result i32)
+  ;; CHECK:      (func $m
   ;; CHECK-NEXT:  (local $i i32)
   ;; CHECK-NEXT:  (local.set $i
   ;; CHECK-NEXT:   (i32.const 7)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 2)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (return
-  ;; CHECK-NEXT:   (i32.const 4)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $m (result i32)
-	(local $i i32)
+  (func $m
+    (local $i i32)
     (local.set $i
       (i32.const 7))
-    (drop (i32.const 2))
-    (return (i32.const 4))
   )
 )
 
@@ -398,9 +361,6 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (br $label1)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (i32.const 4)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (br $label1)
@@ -410,7 +370,6 @@
     (block $label1
       (drop (i32.const 4))
       (br $label1)
-      (drop (i32.const 2))
       (drop (i32.const 4))
       (br $label1)
     )
@@ -422,35 +381,19 @@
   ;; CHECK:      (type $0 (func (result i32)))
 
   ;; CHECK:      (func $o (result i32)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (return
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $o (result i32)
-    (drop (i32.const 0))
-	(drop (i32.const 1))
 	(return (i32.const 2))
   )
   ;; CHECK:      (func $p (result i32)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (return
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $p (result i32)
-    (drop (i32.const 0))
-	(drop (i32.const 1))
 	(return (i32.const 2))
   )
 )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -303,9 +303,12 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $a (param i32)
-    (drop (i32.add
-      (local.get 0)
-      (i32.const 1)))
+    (drop
+      (i32.add
+        (local.get 0)
+        (i32.const 1)
+      )
+    )
   )
   ;; CHECK:      (func $b (param $0 i32)
   ;; CHECK-NEXT:  (drop
@@ -316,9 +319,12 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $b (param i32)
-    (drop (i32.add
-      (local.get 0)
-      (i32.const 1)))
+    (drop
+      (i32.add
+        (local.get 0)
+        (i32.const 1)
+      )
+    )
   )
 )
 
@@ -335,7 +341,8 @@
   (func $a
     (local $i i32)
     (local.set $i
-      (i32.const 7))
+      (i32.const 7)
+    )
   )
   ;; CHECK:      (func $b
   ;; CHECK-NEXT:  (local $i i32)
@@ -346,7 +353,8 @@
   (func $b
     (local $i i32)
     (local.set $i
-      (i32.const 7))
+      (i32.const 7)
+    )
   )
 )
 
@@ -368,9 +376,13 @@
   ;; CHECK-NEXT: )
   (func $a
     (block $label1
-      (drop (i32.const 4))
+      (drop
+        (i32.const 4)
+      )
       (br $label1)
-      (drop (i32.const 4))
+      (drop
+        (i32.const 4)
+      )
       (br $label1)
     )
   )
@@ -386,7 +398,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $a (result i32)
-    (return (i32.const 2))
+    (return
+      (i32.const 2)
+    )
   )
   ;; CHECK:      (func $b (result i32)
   ;; CHECK-NEXT:  (return
@@ -394,6 +408,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $b (result i32)
-    (return (i32.const 2))
+    (return
+      (i32.const 2)
+    )
   )
 )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -83,19 +83,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
 
-  ;; CHECK:      (func $outline$ (param $0 i32)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (local.get $0)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 2)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-
-  ;; CHECK:      (func $c
+  ;; CHECK:      (func $a
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT: )
   (func $a
@@ -106,7 +94,7 @@
       (i32.const 2)
     )
   )
-  ;; CHECK:      (func $d
+  ;; CHECK:      (func $b
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT: )
   (func $b
@@ -139,7 +127,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
 
-  ;; CHECK:      (func $e
+  ;; CHECK:      (func $a
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 6)
@@ -162,7 +150,7 @@
       (i32.const 6)
     )
   )
-  ;; CHECK:      (func $f
+  ;; CHECK:      (func $b
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 7)
@@ -190,6 +178,18 @@
 ;; Tests multiple sequences being outlined from the same source function into different
 ;; outlined functions.
 (module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (func $outline$
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.add
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
+  ;; CHECK:      (func $outline$_4
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.sub
   ;; CHECK-NEXT:    (i32.const 3)
@@ -198,7 +198,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
 
-  ;; CHECK:      (func $g
+  ;; CHECK:      (func $a
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT:  (call $outline$_4)
   ;; CHECK-NEXT: )
@@ -216,6 +216,9 @@
       )
     )
   )
+  ;; CHECK:      (func $b
+  ;; CHECK-NEXT:  (call $outline$_4)
+  ;; CHECK-NEXT: )
   (func $b
     (drop
       (i32.sub
@@ -224,6 +227,9 @@
       )
     )
   )
+  ;; CHECK:      (func $c
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT: )
   (func $c
     (drop
       (i32.add
@@ -288,7 +294,7 @@
 (module
   ;; CHECK:      (type $0 (func (param i32)))
 
-  ;; CHECK:      (func $j (param $0 i32)
+  ;; CHECK:      (func $a (param $0 i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.add
   ;; CHECK-NEXT:    (local.get $0)
@@ -296,12 +302,12 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $j (param i32)
+  (func $a (param i32)
     (drop (i32.add
       (local.get 0)
       (i32.const 1)))
   )
-  ;; CHECK:      (func $k (param $0 i32)
+  ;; CHECK:      (func $b (param $0 i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.add
   ;; CHECK-NEXT:    (local.get $0)
@@ -309,7 +315,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $k (param i32)
+  (func $b (param i32)
     (drop (i32.add
       (local.get 0)
       (i32.const 1)))
@@ -320,24 +326,24 @@
 (module
   ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (func $l
+  ;; CHECK:      (func $a
   ;; CHECK-NEXT:  (local $i i32)
   ;; CHECK-NEXT:  (local.set $i
   ;; CHECK-NEXT:   (i32.const 7)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $l
+  (func $a
     (local $i i32)
     (local.set $i
       (i32.const 7))
   )
-  ;; CHECK:      (func $m
+  ;; CHECK:      (func $b
   ;; CHECK-NEXT:  (local $i i32)
   ;; CHECK-NEXT:  (local.set $i
   ;; CHECK-NEXT:   (i32.const 7)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $m
+  (func $b
     (local $i i32)
     (local.set $i
       (i32.const 7))
@@ -348,7 +354,7 @@
 (module
   ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (func $n
+  ;; CHECK:      (func $a
   ;; CHECK-NEXT:  (block $label1
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (i32.const 4)
@@ -360,7 +366,7 @@
   ;; CHECK-NEXT:   (br $label1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $n
+  (func $a
     (block $label1
       (drop (i32.const 4))
       (br $label1)
@@ -374,20 +380,20 @@
 (module
   ;; CHECK:      (type $0 (func (result i32)))
 
-  ;; CHECK:      (func $o (result i32)
+  ;; CHECK:      (func $a (result i32)
   ;; CHECK-NEXT:  (return
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $o (result i32)
+  (func $a (result i32)
     (return (i32.const 2))
   )
-  ;; CHECK:      (func $p (result i32)
+  ;; CHECK:      (func $b (result i32)
   ;; CHECK-NEXT:  (return
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $p (result i32)
+  (func $b (result i32)
     (return (i32.const 2))
   )
 )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -372,7 +372,7 @@
   )
 )
 
-;; Tests that local.set instructions are correctly filtered from being outlined.
+;; Tests local.set instructions are correctly filtered from being outlined.
 (module
   ;; CHECK:      (type $0 (func (result i32)))
 
@@ -416,7 +416,7 @@
   )
 )
 
-;; TODO: Add a test that makes sure we filter branches correctly
+;; Tests branch instructions are correctly filtered from being outlined.
 (module
   ;; CHECK:      (type $0 (func))
 
@@ -446,7 +446,7 @@
   )
 )
 
-;; TODO: Add a test that makes sure we filter returns correctly
+;; Tests return instructions are correctly filtered from being outlined.
 (module
   ;; CHECK:      (type $0 (func (result i32)))
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -216,9 +216,6 @@
       )
     )
   )
-  ;; CHECK:      (func $h
-  ;; CHECK-NEXT:  (call $outline$_4)
-  ;; CHECK-NEXT: )
   (func $b
     (drop
       (i32.sub
@@ -227,9 +224,6 @@
       )
     )
   )
-  ;; CHECK:      (func $i
-  ;; CHECK-NEXT:  (call $outline$)
-  ;; CHECK-NEXT: )
   (func $c
     (drop
       (i32.add
@@ -386,7 +380,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $o (result i32)
-	(return (i32.const 2))
+    (return (i32.const 2))
   )
   ;; CHECK:      (func $p (result i32)
   ;; CHECK-NEXT:  (return
@@ -394,6 +388,6 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $p (result i32)
-	(return (i32.const 2))
+    (return (i32.const 2))
   )
 )


### PR DESCRIPTION
Adds tests that ensure outlining is skipping repeat sequences that include local.get, local.set, br, and return instructions.