### PR TITLE
Update IRBuilder to visit control flow correctly

### DIFF
--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -93,6 +93,11 @@ struct ReconstructStringifyWalker
       ASSERT_OK(existingBuilder.visitBlockStart(curr->block));
       DBG(desc = "Block Start for ");
     } else if (auto curr = reason.getIfStart()) {
+      // IR builder needs the condition of the If pushed onto the builder before
+      // visitIfStart(), which will expect to be able to pop the condition.
+      // This is always okay to do because the correct condition was installed
+      // onto the If when the outer scope was visited.
+      existingBuilder.push(curr->iff->condition);
       ASSERT_OK(existingBuilder.visitIfStart(curr->iff));
       DBG(desc = "If Start for ");
     } else if (reason.getEnd()) {

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -198,6 +198,7 @@ public:
   visitSwitch(Switch*, std::optional<Index> defaultLabel = std::nullopt);
   [[nodiscard]] Result<> visitCall(Call*);
   [[nodiscard]] Result<> visitCallRef(CallRef*);
+  void push(Expression*);
 
 private:
   Module& wasm;
@@ -381,7 +382,6 @@ private:
   [[nodiscard]] Result<Name> getLabelName(Index label);
   [[nodiscard]] Result<Index> addScratchLocal(Type);
   [[nodiscard]] Result<Expression*> pop();
-  void push(Expression*);
 
   struct HoistedVal {
     // The index in the stack of the original value-producing expression.

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -52,6 +52,10 @@ public:
   // initialized to initialize the child fields and refinalize it.
   [[nodiscard]] Result<> visit(Expression*);
 
+  // Like visit, but pushes the expression onto the stack as-is without popping
+  // any children or refinalization.
+  void push(Expression*);
+
   // Handle the boundaries of control flow structures. Users may choose to use
   // the corresponding `makeXYZ` function below instead of `visitXYZStart`, but
   // either way must call `visitEnd` and friends at the appropriate times.
@@ -198,7 +202,6 @@ public:
   visitSwitch(Switch*, std::optional<Index> defaultLabel = std::nullopt);
   [[nodiscard]] Result<> visitCall(Call*);
   [[nodiscard]] Result<> visitCallRef(CallRef*);
-  void push(Expression*);
 
 private:
   Module& wasm;
@@ -309,7 +312,7 @@ private:
       WASM_UNREACHABLE("unexpected scope kind");
     }
     Name getOriginalLabel() {
-      if (getFunction()) {
+      if (std::get_if<NoScope>(&scope) || getFunction()) {
         return Name{};
       }
       if (auto* block = getBlock()) {
@@ -401,6 +404,8 @@ private:
 
   [[nodiscard]] Result<Expression*> getBranchValue(Name labelName,
                                                    std::optional<Index> label);
+
+  void dump();
 };
 
 } // namespace wasm

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -187,7 +187,7 @@ public:
 
   // Private functions that must be public for technical reasons.
   [[nodiscard]] Result<> visitExpression(Expression*);
-  [[nodiscard]] Result<> visitBlock(Block*);
+  [[nodiscard]] Result<> visitIf(If*);
   [[nodiscard]] Result<> visitReturn(Return*);
   [[nodiscard]] Result<> visitStructNew(StructNew*);
   [[nodiscard]] Result<> visitArrayNew(ArrayNew*);

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -21,6 +21,14 @@
 #include "ir/utils.h"
 #include "wasm-ir-builder.h"
 
+#define IR_BUILDER_DEBUG 1
+
+#if IR_BUILDER_DEBUG
+#define DBG(statement) statement
+#else
+#define DBG(statement)
+#endif
+
 using namespace std::string_literals;
 
 namespace wasm {
@@ -145,6 +153,7 @@ void IRBuilder::push(Expression* expr) {
     scope.unreachable = true;
   }
   scope.exprStack.push_back(expr);
+  DBG(std::cerr << "IRBuilder::push: ");
 }
 
 Result<Expression*> IRBuilder::pop() {

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -243,3 +243,54 @@
     )
   )
 )
+
+
+;; Tests that outlining works correctly with If control flow
+(module
+  ;; CHECK:      (type $0 (func (param i32)))
+
+  ;; CHECK:      (type $1 (func))
+
+  ;; CHECK:      (func $outline$
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 10)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
+  ;; CHECK:      (func $a (param $0 i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (local.get $0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $outline$)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $a (param i32)
+    (if
+      (i32.eqz
+        (local.get 0)
+      )
+      (drop
+        (i32.const 10)
+      )
+    )
+  )
+  ;; CHECK:      (func $b (param $0 i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.eqz
+  ;; CHECK-NEXT:    (local.get $0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $outline$)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $b (param i32)
+    (if
+      (i32.eqz
+        (local.get 0)
+      )
+      (drop
+        (i32.const 10)
+      )
+    )
+  )
+)


### PR DESCRIPTION
Besides `If`, no control flow structure consumes values from the stack. Fix a
bug in IRBuilder that was causing it to pop control flow children. Also fix a
follow on bug in outlining where it did not make the If condition available on
the stack when starting to visit an If. This required making `push()` part of
the public API of IRBuilder.

As a drive-by, also add helpful debug logging to IRBuilder.