### PR TITLE
[IRBuilder] Add visitCallIndirect and makeCallIndirect

### DIFF
--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -84,7 +84,8 @@ public:
                                     Index defaultLabel);
   // Unlike Builder::makeCall, this assumes the function already exists.
   [[nodiscard]] Result<> makeCall(Name func, bool isReturn);
-  // [[nodiscard]] Result<> makeCallIndirect();
+  [[nodiscard]] Result<>
+  makeCallIndirect(Name func, HeapType heapType, bool isReturn);
   [[nodiscard]] Result<> makeLocalGet(Index local);
   [[nodiscard]] Result<> makeLocalSet(Index local);
   [[nodiscard]] Result<> makeLocalTee(Index local);
@@ -201,6 +202,7 @@ public:
   [[nodiscard]] Result<>
   visitSwitch(Switch*, std::optional<Index> defaultLabel = std::nullopt);
   [[nodiscard]] Result<> visitCall(Call*);
+  [[nodiscard]] Result<> visitCallIndirect(CallIndirect*);
   [[nodiscard]] Result<> visitCallRef(CallRef*);
 
 private:

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -84,8 +84,7 @@ public:
                                     Index defaultLabel);
   // Unlike Builder::makeCall, this assumes the function already exists.
   [[nodiscard]] Result<> makeCall(Name func, bool isReturn);
-  [[nodiscard]] Result<>
-  makeCallIndirect(Name func, HeapType heapType, bool isReturn);
+  // [[nodiscard]] Result<> makeCallIndirect();
   [[nodiscard]] Result<> makeLocalGet(Index local);
   [[nodiscard]] Result<> makeLocalSet(Index local);
   [[nodiscard]] Result<> makeLocalTee(Index local);

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -702,15 +702,7 @@ Result<> IRBuilder::makeCall(Name func, bool isReturn) {
   return Ok{};
 }
 
-Result<>
-IRBuilder::makeCallIndirect(Name table, HeapType heapType, bool isReturn) {
-  CallIndirect curr(wasm.allocator);
-  curr.table = table;
-  CHECK_ERR(visitCallIndirect(&curr));
-  push(builder.makeCallIndirect(
-    curr.table, curr.target, curr.operands, curr.heapType, isReturn));
-  return Ok{};
-}
+// Result<> IRBuilder::makeCallIndirect() {}
 
 Result<> IRBuilder::makeLocalGet(Index local) {
   push(builder.makeLocalGet(local, func->getLocalType(local)));

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -511,27 +511,30 @@
   (table funcref)
   (func
     (call_indirect
-      (param i32)
+      (param i32 i32)
       (i32.const 0)
-      (i32.const 0)
+      (i32.const 1)
+      (i32.const 2)
     )
     (call_indirect
-      (param i32)
+      (param i32 i32)
       (i32.const 0)
-      (i32.const 0)
+      (i32.const 1)
+      (i32.const 2)
     )
   )
 )
 ;; CHECK:      (type $0 (func))
 
-;; CHECK:      (type $1 (func (param i32)))
+;; CHECK:      (type $1 (func (param i32 i32)))
 
 ;; CHECK:      (table $0 0 funcref)
 
 ;; CHECK:      (func $outline$ (type $0)
 ;; CHECK-NEXT:  (call_indirect $0 (type $1)
 ;; CHECK-NEXT:   (i32.const 0)
-;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 1)
+;; CHECK-NEXT:   (i32.const 2)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -505,3 +505,37 @@
     )
   )
 )
+
+;; Test outlining works with call_indirect
+(module
+  (table funcref)
+  (func
+    (call_indirect
+      (param i32)
+      (i32.const 0)
+      (i32.const 0)
+    )
+    (call_indirect
+      (param i32)
+      (i32.const 0)
+      (i32.const 0)
+    )
+  )
+)
+;; CHECK:      (type $0 (func))
+
+;; CHECK:      (type $1 (func (param i32)))
+
+;; CHECK:      (table $0 0 funcref)
+
+;; CHECK:      (func $outline$ (type $0)
+;; CHECK-NEXT:  (call_indirect $0 (type $1)
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:   (i32.const 0)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $0 (type $0)
+;; CHECK-NEXT:  (call $outline$)
+;; CHECK-NEXT:  (call $outline$)
+;; CHECK-NEXT: )


### PR DESCRIPTION
Adds support for call_indirect to wasm-ir-builder. Tests this works by outlining a sequence including call_indirect.