### PR TITLE
[Parser] Parse try/catch/catch_all/delegate

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -709,15 +709,13 @@ class Node:
 def instruction_parser(new_parser=False):
     """Build a trie out of all the instructions, then emit it as C++ code."""
     global instructions
-    if new_parser:
-        # Filter out instructions that the new parser does not need.
-        instructions = [(inst, code) for (inst, code) in instructions
-                        if inst not in ('block', 'loop', 'if', 'then', 'else')]
     trie = Node()
     inst_length = 0
     for inst, expr in instructions:
-        if new_parser and inst in {"then", "else"}:
-            # These are not real instructions! skip them.
+        if new_parser and inst in {"block", "loop", "if", "try", "then",
+                                   "else"}:
+            # These are either control flow handled manually or not real
+            # instructions. Skip them.
             continue
         inst_length = max(inst_length, len(inst))
         trie.insert(inst, expr)

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -8649,12 +8649,6 @@ switch (buf[0]) {
           return Ok{};
         }
         goto parse_error;
-      case 'r':
-        if (op == "try"sv) {
-          CHECK_ERR(makeTry(ctx, pos));
-          return Ok{};
-        }
-        goto parse_error;
       case 'u': {
         switch (buf[6]) {
           case 'e':

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -946,6 +946,15 @@ template<typename Ctx> MaybeResult<> trycatch(Ctx& ctx, bool folded) {
     auto label = labelidx(ctx, true);
     CHECK_ERR(label);
 
+    if (folded) {
+      if (!ctx.in.takeRParen()) {
+        return ctx.in.err("expected ')' at end of delegate");
+      }
+      if (!ctx.in.takeRParen()) {
+        return ctx.in.err("expected ')' at end of try");
+      }
+    }
+
     CHECK_ERR(ctx.visitDelegate(delegatePos, *label));
     return Ok{};
   }

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -64,13 +64,21 @@ public:
   [[nodiscard]] Result<> visitIfStart(If* iff, Name label = {});
   [[nodiscard]] Result<> visitElse();
   [[nodiscard]] Result<> visitLoopStart(Loop* iff);
+  [[nodiscard]] Result<> visitTryStart(Try* tryy, Name label = {});
+  [[nodiscard]] Result<> visitCatch(Name tag);
+  [[nodiscard]] Result<> visitCatchAll();
+  [[nodiscard]] Result<> visitDelegate(Index label);
   [[nodiscard]] Result<> visitEnd();
 
   // Binaryen IR uses names to refer to branch targets, but in general there may
   // be branches to constructs that do not yet have names, so in IRBuilder we
   // use indices to refer to branch targets instead, just as the binary format
   // does. This function converts a branch target name to the correct index.
-  [[nodiscard]] Result<Index> getLabelIndex(Name label);
+  //
+  // Labels in delegates need special handling because the indexing needs to be
+  // relative to the try's enclosing scope rather than the try itself.
+  [[nodiscard]] Result<Index> getLabelIndex(Name label,
+                                            bool inDelegate = false);
 
   // Instead of calling visit, call makeXYZ to have the IRBuilder allocate the
   // nodes. This is generally safer than calling `visit` because the function
@@ -145,7 +153,7 @@ public:
   // [[nodiscard]] Result<> makeTableGrow();
   // [[nodiscard]] Result<> makeTableFill();
   // [[nodiscard]] Result<> makeTableCopy();
-  // [[nodiscard]] Result<> makeTry();
+  [[nodiscard]] Result<> makeTry(Name label, Type type);
   [[nodiscard]] Result<> makeThrow(Name tag);
   // [[nodiscard]] Result<> makeRethrow();
   // [[nodiscard]] Result<> makeTupleMake();
@@ -232,8 +240,27 @@ private:
     struct LoopScope {
       Loop* loop;
     };
-    using Scope = std::
-      variant<NoScope, FuncScope, BlockScope, IfScope, ElseScope, LoopScope>;
+    struct TryScope {
+      Try* tryy;
+      Name originalLabel;
+    };
+    struct CatchScope {
+      Try* tryy;
+      Name originalLabel;
+    };
+    struct CatchAllScope {
+      Try* tryy;
+      Name originalLabel;
+    };
+    using Scope = std::variant<NoScope,
+                               FuncScope,
+                               BlockScope,
+                               IfScope,
+                               ElseScope,
+                               LoopScope,
+                               TryScope,
+                               CatchScope,
+                               CatchAllScope>;
 
     // The control flow structure we are building expressions for.
     Scope scope;
@@ -264,6 +291,15 @@ private:
       return ScopeCtx(ElseScope{iff, originalLabel}, label);
     }
     static ScopeCtx makeLoop(Loop* loop) { return ScopeCtx(LoopScope{loop}); }
+    static ScopeCtx makeTry(Try* tryy, Name originalLabel = {}) {
+      return ScopeCtx(TryScope{tryy, originalLabel});
+    }
+    static ScopeCtx makeCatch(Try* tryy, Name originalLabel, Name label) {
+      return ScopeCtx(CatchScope{tryy, originalLabel}, label);
+    }
+    static ScopeCtx makeCatchAll(Try* tryy, Name originalLabel, Name label) {
+      return ScopeCtx(CatchAllScope{tryy, originalLabel}, label);
+    }
 
     bool isNone() { return std::get_if<NoScope>(&scope); }
     Function* getFunction() {
@@ -296,6 +332,24 @@ private:
       }
       return nullptr;
     }
+    Try* getTry() {
+      if (auto* tryScope = std::get_if<TryScope>(&scope)) {
+        return tryScope->tryy;
+      }
+      return nullptr;
+    }
+    Try* getCatch() {
+      if (auto* catchScope = std::get_if<CatchScope>(&scope)) {
+        return catchScope->tryy;
+      }
+      return nullptr;
+    }
+    Try* getCatchAll() {
+      if (auto* catchAllScope = std::get_if<CatchAllScope>(&scope)) {
+        return catchAllScope->tryy;
+      }
+      return nullptr;
+    }
     Type getResultType() {
       if (auto* func = getFunction()) {
         return func->type.getSignature().results;
@@ -311,6 +365,15 @@ private:
       }
       if (auto* loop = getLoop()) {
         return loop->type;
+      }
+      if (auto* tryy = getTry()) {
+        return tryy->type;
+      }
+      if (auto* tryy = getCatch()) {
+        return tryy->type;
+      }
+      if (auto* tryy = getCatchAll()) {
+        return tryy->type;
       }
       WASM_UNREACHABLE("unexpected scope kind");
     }
@@ -329,6 +392,15 @@ private:
       }
       if (auto* loop = getLoop()) {
         return loop->name;
+      }
+      if (auto* tryScope = std::get_if<TryScope>(&scope)) {
+        return tryScope->originalLabel;
+      }
+      if (auto* catchScope = std::get_if<CatchScope>(&scope)) {
+        return catchScope->originalLabel;
+      }
+      if (auto* catchAllScope = std::get_if<CatchAllScope>(&scope)) {
+        return catchAllScope->originalLabel;
       }
       WASM_UNREACHABLE("unexpected scope kind");
     }

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -590,16 +590,6 @@ Result<Expression*> IRBuilder::finishScope(Block* block) {
     labelDepths.at(label).pop_back();
   }
 
-  // If this was a scope for a try, fix up its delegate label if necessary. See
-  // `visitDelegate` for details.
-  Try* tryy;
-  if ((tryy = scope.getTry()) || (tryy = scope.getCatch()) ||
-      (tryy = scope.getCatchAll())) {
-    if (tryy->name) {
-      tryy->name = Name(std::string("__delegate__") + tryy->name.toString());
-    }
-  }
-
   scopeStack.pop_back();
   return ret;
 }
@@ -692,11 +682,11 @@ Result<> IRBuilder::visitDelegate(Index label) {
       // These labels must be different to satisfy the Binaryen validator. To
       // keep this complexity contained within the handling of trys and
       // delegates, pretend there is just the single normal label and add a
-      // prefix to it to generate the delegate label. The prefix is added on the
-      // try when its scope ends.
-      delegateTry->name = *getLabelName(label);
-      tryy->delegateTarget =
-        Name(std::string("__delegate__") + delegateTry->name.toString());
+      // prefix to it to generate the delegate label.
+      auto delegateName =
+        Name(std::string("__delegate__") + getLabelName(label)->toString());
+      delegateTry->name = delegateName;
+      tryy->delegateTarget = delegateName;
       break;
     } else if (delegateScope.getFunction()) {
       tryy->delegateTarget = DELEGATE_CALLER_TARGET;

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -772,7 +772,15 @@ Result<Index> IRBuilder::getLabelIndex(Name label, bool inDelegate) {
   if (inDelegate) {
     if (index == 0) {
       // The real label we're referencing, if it exists, has been shadowed by
-      // the `try`. Get the previous label with this name instead.
+      // the `try`. Get the previous label with this name instead. For example:
+      //
+      // block $l
+      //  try $l
+      //  delegate $l
+      // end
+      //
+      // The `delegate $l` should target the block, not the try, even though a
+      // normal branch to $l in the try's scope would target the try.
       if (it->second.size() <= 1) {
         return Err{"unexpected self-referencing label '"s + label.toString() +
                    "'"};

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -1515,6 +1515,373 @@
   )
  )
 
+ ;; CHECK:      (func $try (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try
+  try
+   nop
+  end
+ )
+
+ ;; CHECK:      (func $try-catch (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch $empty
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-catch
+  try
+  catch $empty
+  end
+ )
+
+ ;; CHECK:      (func $try-catch-params (type $5) (result i32 i64)
+ ;; CHECK-NEXT:  (try (type $5) (result i32 i64)
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:     (i32.const 0)
+ ;; CHECK-NEXT:     (i64.const 1)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch $tag-pair
+ ;; CHECK-NEXT:    (pop i32 i64)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-catch-params (result i32 i64)
+  try (result i32 i64)
+   i32.const 0
+   i64.const 1
+  catch $tag-pair
+  end
+ )
+
+
+ ;; CHECK:      (func $try-catch_all (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch_all
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-catch_all
+  try
+  catch_all
+  end
+ )
+
+ ;; CHECK:      (func $try-catch-catch_all (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch $empty
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch $timport$0
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch_all
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-catch-catch_all
+  try
+  catch $empty
+  catch 1
+  catch_all
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (delegate 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate
+  try
+  delegate 0
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-func-direct (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (delegate 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-func-direct
+  block $l
+   try
+   delegate 1
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-func-indirect-index (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (delegate 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-func-indirect-index
+  block $l
+   try
+   delegate 0
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-func-indirect-name (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (delegate 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-func-indirect-name
+  block $l
+   try
+   delegate $l
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-try-direct-index (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try $__delegate__label
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (nop)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (delegate $__delegate__label)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-try-direct-index
+  try
+   block
+    try
+    delegate 1
+   end
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-try-direct-name (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (nop)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (delegate $__delegate__l)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-try-direct-name
+  try $l
+   block
+    try
+    delegate $l
+   end
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-try-indirect-index (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try $__delegate__label
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (nop)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (delegate $__delegate__label)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-try-indirect-index
+  try
+   block
+    try
+    delegate 0
+   end
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-try-indirect-name (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try $__delegate__label
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (block $l
+ ;; CHECK-NEXT:      (try
+ ;; CHECK-NEXT:       (do
+ ;; CHECK-NEXT:        (nop)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (delegate $__delegate__label)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-try-indirect-name
+  try
+   block $l
+    try
+    delegate $l
+   end
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-try-shadowing (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (block $l_0
+ ;; CHECK-NEXT:      (block $l_1
+ ;; CHECK-NEXT:       (try
+ ;; CHECK-NEXT:        (do
+ ;; CHECK-NEXT:         (nop)
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (delegate $__delegate__l)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-try-shadowing
+  try $l
+   block $l
+    try $l
+    delegate $l
+   end
+  end $l
+ )
+
+ ;; CHECK:      (func $try-br-index (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (br $label)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (br $label)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch_all
+ ;; CHECK-NEXT:     (br $label)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-br-index
+  try
+   br 0
+  catch $empty
+   br 0
+  catch_all
+   br 0
+  end
+ )
+
+ ;; CHECK:      (func $try-br-name (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (br $l)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (br $l)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch_all
+ ;; CHECK-NEXT:     (br $l)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-br-name
+  try $l
+   br $l
+  catch $l $empty
+   br $l
+  catch_all $l
+   br $l
+  end $l
+ )
+
+ ;; CHECK:      (func $try-folded (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch $empty
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch $timport$0
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (catch_all
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-folded
+  (try
+   (do
+    nop
+    (nop)
+   )
+   (catch $empty
+    (nop)
+    nop
+   )
+   (catch 1
+    nop
+    (nop)
+   )
+   (catch_all
+    (nop)
+    nop
+   )
+  )
+ )
+
  ;; CHECK:      (func $label-siblings (type $void)
  ;; CHECK-NEXT:  (block $l
  ;; CHECK-NEXT:   (br $l)
@@ -2413,7 +2780,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 109
+  ref.func 126
   drop
  )
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -1791,6 +1791,78 @@
   end $l
  )
 
+ ;; CHECK:      (func $try-delegate-nested-catch-shadowing (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (block $l_0
+ ;; CHECK-NEXT:      (try
+ ;; CHECK-NEXT:       (do
+ ;; CHECK-NEXT:        (nop)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (catch $empty
+ ;; CHECK-NEXT:        (block $l_1
+ ;; CHECK-NEXT:         (try
+ ;; CHECK-NEXT:          (do
+ ;; CHECK-NEXT:           (nop)
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:          (delegate $__delegate__l)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-catch-shadowing
+  try $l
+   try $l
+   catch $empty
+    try $l
+    ;; goes to the outermost try, not the middle one
+    delegate $l
+   end
+  end
+ )
+
+ ;; CHECK:      (func $try-delegate-nested-catch_all-shadowing (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (block $l_0
+ ;; CHECK-NEXT:      (try
+ ;; CHECK-NEXT:       (do
+ ;; CHECK-NEXT:        (nop)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (catch_all
+ ;; CHECK-NEXT:        (block $l_1
+ ;; CHECK-NEXT:         (try
+ ;; CHECK-NEXT:          (do
+ ;; CHECK-NEXT:           (nop)
+ ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:          (delegate $__delegate__l)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-nested-catch_all-shadowing
+  try $l
+   try $l
+   catch_all
+    try $l
+    ;; goes to the outermost try, not the middle one
+    delegate $l
+   end
+  end
+ )
+
  ;; CHECK:      (func $try-br-index (type $void)
  ;; CHECK-NEXT:  (block $label
  ;; CHECK-NEXT:   (try
@@ -1879,6 +1951,21 @@
     (nop)
     nop
    )
+  )
+ )
+
+ ;; CHECK:      (func $try-delegate-folded (type $void)
+ ;; CHECK-NEXT:  (try
+ ;; CHECK-NEXT:   (do
+ ;; CHECK-NEXT:    (nop)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (delegate 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $try-delegate-folded
+  (try
+   (do)
+   (delegate 0)
   )
  )
 
@@ -2780,7 +2867,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 126
+  ref.func 129
   drop
  )
 


### PR DESCRIPTION
Parse the legacy v3 syntax for try/catch/catch_all/delegate in both its folded
and unfolded forms.

The first source of significant complexity is the optional IDs after `catch`
and `catch_all` in the unfolded form, which can be confused for tag indices and
require backtracking to parse correctly.

The second source of complexity is the handling of delegate labels, which are
relative to the try's parent scope despite being parsed after the try's scope
has already started. Handling this correctly requires punching a hole big
enough to drive a truck through through both the parser and IRBuilder
abstractions.