### PR TITLE
Fix a bug with unreachable control flow in IRBuilder

### DIFF
--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -238,6 +238,7 @@ private:
 
     // The branch label name for this scope. Always fresh, never shadowed.
     Name label;
+    bool labelUsed = false;
 
     std::vector<Expression*> exprStack;
     // Whether we have seen an unreachable instruction and are in

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -570,10 +570,17 @@ Result<> IRBuilder::visitEnd() {
   CHECK_ERR(expr);
 
   // If the scope expression cannot be directly labeled, we may need to wrap it
-  // in a block.
+  // in a block. It's possible that the scope expression becomes typed
+  // unreachable when it is finalized, but if the wrapper block is targeted by
+  // any branches, the target block needs to have the original non-unreachable
+  // type of the scope expression.
+  auto originalScopeType = scope.getResultType();
   auto maybeWrapForLabel = [&](Expression* curr) -> Expression* {
     if (scope.label) {
-      return builder.makeBlock(scope.label, {curr}, scope.getResultType());
+      return builder.makeBlock(scope.label,
+                               {curr},
+                               scope.labelUsed ? originalScopeType
+                                               : scope.getResultType());
     }
     return curr;
   };
@@ -624,6 +631,7 @@ Result<Name> IRBuilder::getLabelName(Index label) {
     // The scope does not already have a name, so we need to create one.
     scopeLabel = makeFresh("label");
   }
+  (*scope)->labelUsed = true;
   return scopeLabel;
 }
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -1257,6 +1257,48 @@
   end
  )
 
+ ;; CHECK:      (func $if-else-brs (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (if
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:    (br $label)
+ ;; CHECK-NEXT:    (br $label)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $if-else-brs
+  i32.const 0
+  if
+   br 0
+  else
+   br 0
+  end
+ )
+
+ ;; CHECK:      (func $if-else-brs-i32 (type $1) (result i32)
+ ;; CHECK-NEXT:  (block $label (result i32)
+ ;; CHECK-NEXT:   (if (result i32)
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:    (br $label
+ ;; CHECK-NEXT:     (i32.const 1)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (br $label
+ ;; CHECK-NEXT:     (i32.const 2)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $if-else-brs-i32 (result i32)
+  i32.const 0
+  if (result i32)
+   i32.const 1
+   br 0
+  else
+   i32.const 2
+   br 0
+  end
+ )
+
  ;; CHECK:      (func $loop (type $void)
  ;; CHECK-NEXT:  (loop
  ;; CHECK-NEXT:   (nop)
@@ -2332,7 +2374,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 107
+  ref.func 109
   drop
  )
 


### PR DESCRIPTION
When branches target control flow structures other than blocks or loops, the
IRBuilder wraps those control flow structures with an extra block for the
branches to target in Binaryen IR. Usually that block has the same type as the
control flow structure it wraps, but when the control flow structure is
unreachable because all its bodies are unreachable, the wrapper block may still
need to have a non-unreachable type if it is targeted by branches.

Previously the wrapper block would also be unreachable in that case. Fix the bug
by tracking whether the wrapper block will be targeted by any branches and use
the control flow structure's original, non-unreachable type if so.