### PR TITLE
[NFC] Move InstrumentedPass logic out and use it in another place

### DIFF
--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1671,7 +1671,7 @@ struct Asyncify : public Pass {
     // practical to add code around each call, without affecting
     // anything else.
     {
-      PassUtils::WrappedPassRunner runner(module, instrumentedFuncs);
+      PassUtils::FilteredPassRunner runner(module, instrumentedFuncs);
       runner.add("flatten");
       // Dce is useful here, since AsyncifyFlow makes control flow conditional,
       // which may make unreachable code look reachable. It also lets us ignore
@@ -1712,7 +1712,7 @@ struct Asyncify : public Pass {
     // restore those locals). We also and optimize after as well to simplify
     // the code as much as possible.
     {
-      PassUtils::WrappedPassRunner runner(module, instrumentedFuncs);
+      PassUtils::FilteredPassRunner runner(module, instrumentedFuncs);
       if (optimize) {
         runner.addDefaultFunctionOptimizationPasses();
       }

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -315,6 +315,7 @@
 #include "ir/names.h"
 #include "ir/utils.h"
 #include "pass.h"
+#include "passes/pass-utils.h"
 #include "support/file.h"
 #include "support/string.h"
 #include "wasm-builder.h"
@@ -843,56 +844,6 @@ public:
                       makeGlobalGet(ASYNCIFY_STATE, Type::i32),
                       makeConst(Literal(int32_t(value))));
   }
-};
-
-// Proxy that runs wrapped pass for instrumented functions only
-struct InstrumentedProxy : public Pass {
-  std::unique_ptr<Pass> create() override {
-    return std::make_unique<InstrumentedProxy>(analyzer, pass->create());
-  }
-
-  InstrumentedProxy(ModuleAnalyzer* analyzer, std::unique_ptr<Pass> pass)
-    : analyzer(analyzer), pass(std::move(pass)) {}
-
-  bool isFunctionParallel() override { return pass->isFunctionParallel(); }
-
-  void runOnFunction(Module* module, Function* func) override {
-    if (!analyzer->needsInstrumentation(func)) {
-      return;
-    }
-    if (pass->getPassRunner() == nullptr) {
-      pass->setPassRunner(getPassRunner());
-    }
-    pass->runOnFunction(module, func);
-  }
-
-  bool modifiesBinaryenIR() override { return pass->modifiesBinaryenIR(); }
-
-  bool invalidatesDWARF() override { return pass->invalidatesDWARF(); }
-
-  bool addsEffects() override { return pass->addsEffects(); }
-
-  bool requiresNonNullableLocalFixups() override {
-    return pass->requiresNonNullableLocalFixups();
-  }
-
-private:
-  ModuleAnalyzer* analyzer;
-  std::unique_ptr<Pass> pass;
-};
-
-struct InstrumentedPassRunner : public PassRunner {
-  InstrumentedPassRunner(Module* wasm, ModuleAnalyzer* analyzer)
-    : PassRunner(wasm), analyzer(analyzer) {}
-
-protected:
-  void doAdd(std::unique_ptr<Pass> pass) override {
-    PassRunner::doAdd(
-      std::unique_ptr<Pass>(new InstrumentedProxy(analyzer, std::move(pass))));
-  }
-
-private:
-  ModuleAnalyzer* analyzer;
 };
 
 // Instrument control flow, around calls and adding skips for rewinding.
@@ -1706,12 +1657,21 @@ struct Asyncify : public Pass {
     // Add necessary globals before we emit code to use them.
     addGlobals(module, relocatable);
 
+    // Compute the set of functions we will instrument. All of the passes we run
+    // below only need to run there.
+    PassUtils::FuncSet instrumentedFuncs;
+    for (auto& func : module->functions) {
+      if (analyzer.needsInstrumentation(func.get())) {
+        instrumentedFuncs.insert(func.get());
+      }
+    }
+
     // Instrument the flow of code, adding code instrumentation and
     // skips for when rewinding. We do this on flat IR so that it is
     // practical to add code around each call, without affecting
     // anything else.
     {
-      InstrumentedPassRunner runner(module, &analyzer);
+      PassUtils::WrappedPassRunner runner(module, instrumentedFuncs);
       runner.add("flatten");
       // Dce is useful here, since AsyncifyFlow makes control flow conditional,
       // which may make unreachable code look reachable. It also lets us ignore
@@ -1752,7 +1712,7 @@ struct Asyncify : public Pass {
     // restore those locals). We also and optimize after as well to simplify
     // the code as much as possible.
     {
-      InstrumentedPassRunner runner(module, &analyzer);
+      PassUtils::WrappedPassRunner runner(module, instrumentedFuncs);
       if (optimize) {
         runner.addDefaultFunctionOptimizationPasses();
       }

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -26,9 +26,7 @@
 #include <passes/pass-utils.h>
 #include <wasm.h>
 
-namespace wasm {
-
-namespace OptUtils {
+namespace wasm::OptUtils {
 
 // Run useful optimizations after inlining new code into a set of functions.
 inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
@@ -88,7 +86,6 @@ inline void replaceFunctions(PassRunner* runner,
   }
 }
 
-} // namespace OptUtils
-} // namespace wasm
+} // namespace wasm::OptUtils
 
 #endif // wasm_passes_opt_utils_h

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -34,8 +34,7 @@ namespace OptUtils {
 inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
                                   Module* module,
                                   PassRunner* parentRunner) {
-  PassUtils::FilteredPassRunner runner(module, funcs);
-  runner.options = parentRunner->options;
+  PassUtils::FilteredPassRunner runner(module, funcs, parentRunner->options);
   runner.setIsNested(true);
   // this is especially useful after inlining
   runner.add("precompute-propagate");

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -30,12 +30,11 @@ namespace wasm {
 
 namespace OptUtils {
 
-// Run useful optimizations after inlining new code into a set
-// of functions.
+// Run useful optimizations after inlining new code into a set of functions.
 inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
                                   Module* module,
                                   PassRunner* parentRunner) {
-  PassUtils::WrappedPassRunner runner(module, funcs);
+  PassUtils::FilteredPassRunner runner(module, funcs);
   runner.options = parentRunner->options;
   runner.setIsNested(true);
   // this is especially useful after inlining

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -77,7 +77,7 @@ struct FilteredPassRunner : public PassRunner {
 
   FilteredPassRunner(Module* wasm,
                      const FuncSet& relevantFuncs,
-                     const PassOptions& options_)
+                     const PassOptions& options)
     : PassRunner(wasm, options), relevantFuncs(relevantFuncs) {}
 
 protected:

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -82,7 +82,8 @@ struct FilteredPassRunner : public PassRunner {
 
 protected:
   void doAdd(std::unique_ptr<Pass> pass) override {
-    PassRunner::doAdd(std::make_unique<FilteredPass>(std::move(pass), relevantFuncs));
+    PassRunner::doAdd(
+      std::make_unique<FilteredPass>(std::move(pass), relevantFuncs));
   }
 
 private:

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -22,9 +22,7 @@
 #include <pass.h>
 #include <wasm.h>
 
-namespace wasm {
-
-namespace PassUtils {
+namespace wasm::PassUtils {
 
 using FuncSet = std::unordered_set<Function*>;
 
@@ -92,7 +90,6 @@ private:
   const FuncSet& relevantFuncs;
 };
 
-} // namespace PassUtils
-} // namespace wasm
+} // namespace wasm::PassUtils
 
 #endif // wasm_passes_pass_utils_h

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -74,8 +74,8 @@ private:
   const FuncSet& relevantFuncs;
 };
 
-// A pass runner that wraps all passes, making them run only in select
-// functions.
+// A pass runner that wraps all passes, filtering so that they only run on
+// select functions.
 struct FilteredPassRunner : public PassRunner {
   FilteredPassRunner(Module* wasm, const FuncSet& relevantFuncs)
     : PassRunner(wasm), relevantFuncs(relevantFuncs) {}

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -47,6 +47,7 @@ struct WrappedPass : public Pass {
     if (!funcs.count(func)) {
       return;
     }
+    pass->setPassRunner(getPassRunner());
     pass->runOnFunction(module, func);
   }
 

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_passes_pass_utils_h
+#define wasm_passes_pass_utils_h
+
+#include <functional>
+#include <unordered_set>
+
+#include <ir/element-utils.h>
+#include <ir/module-utils.h>
+#include <pass.h>
+#include <wasm.h>
+
+namespace wasm {
+
+namespace PassUtils {
+
+using FuncSet = std::unordered_set<Function*>;
+
+// A wrapper around a parallel pass that runs that pass only on select
+// functions.
+struct WrappedPass : public Pass {
+  std::unique_ptr<Pass> create() override {
+    return std::make_unique<WrappedPass>(pass->create(), funcs);
+  }
+
+  WrappedPass(std::unique_ptr<Pass> pass, const FuncSet& funcs)
+    : pass(std::move(pass)), funcs(funcs) {}
+
+  bool isFunctionParallel() override { return pass->isFunctionParallel(); }
+
+  void runOnFunction(Module* module, Function* func) override {
+    if (!funcs.count(func)) {
+      return;
+    }
+    pass->runOnFunction(module, func);
+  }
+
+  bool modifiesBinaryenIR() override { return pass->modifiesBinaryenIR(); }
+
+  bool invalidatesDWARF() override { return pass->invalidatesDWARF(); }
+
+  bool addsEffects() override { return pass->addsEffects(); }
+
+  bool requiresNonNullableLocalFixups() override {
+    return pass->requiresNonNullableLocalFixups();
+  }
+
+private:
+  std::unique_ptr<Pass> pass;
+  const FuncSet& funcs;
+};
+
+// A pass runner that wraps all passes, making them run only in select
+// functions.
+struct WrappedPassRunner : public PassRunner {
+  WrappedPassRunner(Module* wasm, const FuncSet& funcs)
+    : PassRunner(wasm), funcs(funcs) {}
+
+protected:
+  void doAdd(std::unique_ptr<Pass> pass) override {
+    pass->setPassRunner(this);
+    PassRunner::doAdd(
+      std::make_unique<WrappedPass>(std::move(pass), funcs));
+  }
+
+private:
+  const FuncSet& funcs;
+};
+
+} // namespace PassUtils
+} // namespace wasm
+
+#endif // wasm_passes_pass_utils_h

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -17,11 +17,8 @@
 #ifndef wasm_passes_pass_utils_h
 #define wasm_passes_pass_utils_h
 
-#include <functional>
 #include <unordered_set>
 
-#include <ir/element-utils.h>
-#include <ir/module-utils.h>
 #include <pass.h>
 #include <wasm.h>
 

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -77,6 +77,11 @@ struct FilteredPassRunner : public PassRunner {
   FilteredPassRunner(Module* wasm, const FuncSet& relevantFuncs)
     : PassRunner(wasm), relevantFuncs(relevantFuncs) {}
 
+  FilteredPassRunner(Module* wasm,
+                     const FuncSet& relevantFuncs,
+                     const PassOptions& options_)
+    : PassRunner(wasm, options), relevantFuncs(relevantFuncs) {}
+
 protected:
   void doAdd(std::unique_ptr<Pass> pass) override {
     PassRunner::doAdd(

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -82,8 +82,7 @@ struct WrappedPassRunner : public PassRunner {
 
 protected:
   void doAdd(std::unique_ptr<Pass> pass) override {
-    PassRunner::doAdd(
-      std::make_unique<WrappedPass>(std::move(pass), funcs));
+    PassRunner::doAdd(std::make_unique<WrappedPass>(std::move(pass), funcs));
   }
 
 private:

--- a/src/passes/pass-utils.h
+++ b/src/passes/pass-utils.h
@@ -35,7 +35,7 @@ struct FilteredPass : public Pass {
     return std::make_unique<FilteredPass>(pass->create(), relevantFuncs);
   }
 
-  FilteredPass(std::unique_ptr<Pass> pass, const FuncSet& relevantFuncs)
+  FilteredPass(std::unique_ptr<Pass>&& pass, const FuncSet& relevantFuncs)
     : pass(std::move(pass)), relevantFuncs(relevantFuncs) {}
 
   bool isFunctionParallel() override {


### PR DESCRIPTION
Asyncify gained a way to wrap a pass so that it only runs on a given set of
functions, rather than on all functions, so the wrapper "filters" what the pass
operates on. That was useful in Asyncify as we wanted to only do work on
functions that Asyncify actually instrumented.

There is another place in the code that needs such functionality,
`optimizeAfterInlining`, which runs optimizations after we inline; again, we
only want to optimize on the functions we know are relevant because they
changed. To do that, move that logic out to a general place so it can be
reused. This makes the code there a lot less hackish.

While doing so make the logic only work on function-parallel passes. It
never did anyhow, but now it asserts on that. (It can't run on a general
pass because a general one does not provide an interface to affect which
functions it operates on; a general pass is entirely opaque in that way.)