### PR TITLE
C API: Add BinaryenTableGetType and BinaryenTableSetType

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5953,6 +5953,12 @@ BinaryenIndex BinaryenTableGetMax(BinaryenTableRef table) {
 void BinaryenTableSetMax(BinaryenTableRef table, BinaryenIndex max) {
   ((Table*)table)->max = max;
 }
+BinaryenType BinaryenTableGetType(BinaryenTableRef table) {
+  return ((Table*)table)->type.getID();
+}
+void BinaryenTableSetType(BinaryenTableRef table, BinaryenType tableType) {
+  ((Table*)table)->type = Type(tableType);
+}
 
 //
 // =========== ElementSegment operations ===========

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -3261,7 +3261,7 @@ BINARYEN_API void BinaryenTableSetMax(BinaryenTableRef table,
 // Gets the table type of the specified `Table`.
 BINARYEN_API BinaryenType BinaryenTableGetType(BinaryenTableRef table);
 // Sets the table type of the specified `Table`.
-BINARYEN_API void BinaryenTableSetType(BinaryenTableRef table, 
+BINARYEN_API void BinaryenTableSetType(BinaryenTableRef table,
                                        BinaryenType tableType);
 
 //

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -3258,6 +3258,11 @@ BINARYEN_API BinaryenIndex BinaryenTableGetMax(BinaryenTableRef table);
 // Sets the maximum number of pages of the specified `Table`.
 BINARYEN_API void BinaryenTableSetMax(BinaryenTableRef table,
                                       BinaryenIndex max);
+// Gets the table type of the specified `Table`.
+BINARYEN_API BinaryenType BinaryenTableGetType(BinaryenTableRef table);
+// Sets the table type of the specified `Table`.
+BINARYEN_API void BinaryenTableSetType(BinaryenTableRef table, 
+                                       BinaryenType tableType);
 
 //
 // ========== Elem Segment Operations ==========

--- a/test/example/c-api-multiple-tables.c
+++ b/test/example/c-api-multiple-tables.c
@@ -62,6 +62,11 @@ int main() {
     assert(BinaryenElementSegmentGetLength(elem1) == 1);
     assert(strcmp(BinaryenElementSegmentGetData(elem1, 0), funcNames[0]) == 0);
 
+    assert(BinaryenTableGetType(t2) == BinaryenTypeFuncref());
+    BinaryenTableSetType(t2, BinaryenTypeExternref());
+    assert(BinaryenTableGetType(t2) == BinaryenTypeExternref());
+    BinaryenTableSetType(t2, BinaryenTypeFuncref());
+
     assert(strcmp(BinaryenTableGetName(t2), "t2") == 0);
     BinaryenTableSetName(t2, "table2");
     BinaryenModuleUpdateMaps(module);


### PR DESCRIPTION
issue #6136 points out that Binaryen C API currently does not support getting and setting the element type of table, this pull request is intended to fix that.