### PR TITLE
wasm-metadce: Improve name deduplication

### DIFF
--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -307,9 +307,12 @@ struct MetaDCEGraph {
 private:
   // gets a unique name for the graph
   Name getName(std::string prefix1, std::string prefix2) {
+    auto base = prefix1 + '$' + prefix2;
+    if (nodes.find(base) == nodes.end()) {
+      return base;
+    }
     while (1) {
-      auto curr =
-        Name(prefix1 + '$' + prefix2 + '$' + std::to_string(nameIndex++));
+      Name curr = base + '$' + std::to_string(nameIndex++);
       if (nodes.find(curr) == nodes.end()) {
         return curr;
       }

--- a/test/metadce/corners.wast.dced.stdout
+++ b/test/metadce/corners.wast.dced.stdout
@@ -1,2 +1,2 @@
-unused: global$UNUSEDTOP$2
+unused: global$UNUSEDTOP
 unused: ignorable import

--- a/test/metadce/name_collision.wast
+++ b/test/metadce/name_collision.wast
@@ -1,8 +1,8 @@
 (module
   ;; This export is given the name "func$other" in the graph.text file, which
-  ;; collides with the internal name we give the function. A unique name should
-  ;; be generated for the function in the stdout that mentions it is unused,
-  ;; specifically we see
+  ;; collides with the internal name we give the function $other. A unique name
+  ;; should be generated for the function in the stdout that mentions it is
+  ;; unused, specifically
   ;;
   ;;  unused: func$other$0
   ;;
@@ -12,6 +12,7 @@
   ;; This function is used by the export.
   (func $test)
 
-  ;; This function is not used.
+  ;; This function is not used, and as mentioned above it will be called
+  ;; func$other$0 in the output.
   (func $other)
 )

--- a/test/metadce/name_collision.wast
+++ b/test/metadce/name_collision.wast
@@ -1,0 +1,8 @@
+(module
+  ;; This export is given the name "func$test" in the graph.text file, which
+  ;; collides with the internal name we give the function. A unique name should
+  ;; be generated for the function.
+  (export "test" (func $test))
+
+  (func $test)
+)

--- a/test/metadce/name_collision.wast
+++ b/test/metadce/name_collision.wast
@@ -1,8 +1,17 @@
 (module
-  ;; This export is given the name "func$test" in the graph.text file, which
+  ;; This export is given the name "func$other" in the graph.text file, which
   ;; collides with the internal name we give the function. A unique name should
-  ;; be generated for the function.
+  ;; be generated for the function in the stdout that mentions it is unused,
+  ;; specifically we see
+  ;;
+  ;;  unused: func$other$0
+  ;;
+  ;; (the $0 suffix keeps it unique).
   (export "test" (func $test))
 
+  ;; This function is used by the export.
   (func $test)
+
+  ;; This function is not used.
+  (func $other)
 )

--- a/test/metadce/name_collision.wast.dced
+++ b/test/metadce/name_collision.wast.dced
@@ -1,0 +1,7 @@
+(module
+ (type $0 (func))
+ (export "test" (func $test))
+ (func $test (type $0)
+  (nop)
+ )
+)

--- a/test/metadce/name_collision.wast.dced.stdout
+++ b/test/metadce/name_collision.wast.dced.stdout
@@ -1,0 +1,1 @@
+unused: func$other$0

--- a/test/metadce/name_collision.wast.graph.txt
+++ b/test/metadce/name_collision.wast.graph.txt
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "func$test",
+    "root": true,
+    "export": "test"
+  }
+]

--- a/test/metadce/name_collision.wast.graph.txt
+++ b/test/metadce/name_collision.wast.graph.txt
@@ -1,6 +1,6 @@
 [
   {
-    "name": "func$test",
+    "name": "func$other",
     "root": true,
     "export": "test"
   }

--- a/test/metadce/no-outside.wast.dced.stdout
+++ b/test/metadce/no-outside.wast.dced.stdout
@@ -1,4 +1,4 @@
-unused: export$wasm_func$4
-unused: export$wasm_func_unused$5
-unused: func$a_wasm_func$0
-unused: func$an_unused_wasm_func$1
+unused: export$wasm_func
+unused: export$wasm_func_unused
+unused: func$a_wasm_func
+unused: func$an_unused_wasm_func

--- a/test/metadce/outside.wast.dced.stdout
+++ b/test/metadce/outside.wast.dced.stdout
@@ -1,3 +1,3 @@
-unused: export$wasm_func_unused$10
-unused: func$an_unused_wasm_func$1
-unused: global$__THREW__unused$4
+unused: export$wasm_func_unused
+unused: func$an_unused_wasm_func
+unused: global$__THREW__unused

--- a/test/metadce/rooted-export.wast.dced.stdout
+++ b/test/metadce/rooted-export.wast.dced.stdout
@@ -1,4 +1,4 @@
-unused: export$wasm_func_a$4
-unused: export$wasm_tag_a$5
-unused: func$a_wasm_func$0
-unused: tag$a_wasm_tag$2
+unused: export$wasm_func_a
+unused: export$wasm_tag_a
+unused: func$a_wasm_func
+unused: tag$a_wasm_tag

--- a/test/metadce/spanning_cycle_unrooted.wast.dced.stdout
+++ b/test/metadce/spanning_cycle_unrooted.wast.dced.stdout
@@ -1,3 +1,3 @@
-unused: func$a_wasm_func$0
+unused: func$a_wasm_func
 unused: outside_js_function
 unused: wasm_export

--- a/test/metadce/threaded_unrooted.wast.dced.stdout
+++ b/test/metadce/threaded_unrooted.wast.dced.stdout
@@ -1,7 +1,7 @@
-unused: func$wasm_func_1$0
-unused: func$wasm_func_2$1
-unused: func$wasm_func_3$2
-unused: func$wasm_func_4$3
+unused: func$wasm_func_1
+unused: func$wasm_func_2
+unused: func$wasm_func_3
+unused: func$wasm_func_4
 unused: outside_js_function1
 unused: outside_js_function2
 unused: outside_js_function3

--- a/test/metadce/threaded_unrooted_cycle.wast.dced.stdout
+++ b/test/metadce/threaded_unrooted_cycle.wast.dced.stdout
@@ -1,7 +1,7 @@
-unused: func$wasm_func_1$0
-unused: func$wasm_func_2$1
-unused: func$wasm_func_3$2
-unused: func$wasm_func_4$3
+unused: func$wasm_func_1
+unused: func$wasm_func_2
+unused: func$wasm_func_3
+unused: func$wasm_func_4
 unused: outside_js_function1
 unused: outside_js_function2
 unused: outside_js_function3


### PR DESCRIPTION
Avoid adding suffixes when we don't need them to keep names unique.

As background, the suffixes are not used by emcc at all, so they are just
for internal use in the tool. How that works is that metadce gets as input
the list of things the user cares about, with names for them, so it knows
the proper names to give imports and exports, and makes up names for
other things. Those made up names will not be read by the user, so we
can make them prettier as this PR does without breaking anything.

The main benefit of this PR is to make debugging easier. It will also
make a followup PR simpler which will extend wasm-metadce to
fully support multiple tables and segments.