### PR TITLE
[Parser] Parse rethrow

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -418,6 +418,7 @@ struct NullInstrParserCtx {
   Result<> makeTableFill(Index, TableIdxT*) { return Ok{}; }
   Result<> makeTableCopy(Index, TableIdxT*, TableIdxT*) { return Ok{}; }
   Result<> makeThrow(Index, TagIdxT) { return Ok{}; }
+  Result<> makeRethrow(Index, LabelIdxT) { return Ok{}; }
   template<typename HeapTypeT> Result<> makeCallRef(Index, HeapTypeT, bool) {
     return Ok{};
   }
@@ -1570,6 +1571,10 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
 
   Result<> makeThrow(Index pos, Name tag) {
     return withLoc(pos, irBuilder.makeThrow(tag));
+  }
+
+  Result<> makeRethrow(Index pos, Index label) {
+    return withLoc(pos, irBuilder.makeRethrow(label));
   }
 
   Result<> makeCallRef(Index pos, HeapType type, bool isReturn) {

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -1480,7 +1480,9 @@ template<typename Ctx> Result<> makeThrow(Ctx& ctx, Index pos) {
 }
 
 template<typename Ctx> Result<> makeRethrow(Ctx& ctx, Index pos) {
-  return ctx.in.err("unimplemented instruction");
+  auto label = labelidx(ctx);
+  CHECK_ERR(label);
+  return ctx.makeRethrow(pos, *label);
 }
 
 template<typename Ctx> Result<> makeTupleMake(Ctx& ctx, Index pos) {

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -156,7 +156,7 @@ public:
   [[nodiscard]] Result<> makeTableCopy(Name destTable, Name srcTable);
   [[nodiscard]] Result<> makeTry(Name label, Type type);
   [[nodiscard]] Result<> makeThrow(Name tag);
-  // [[nodiscard]] Result<> makeRethrow();
+  [[nodiscard]] Result<> makeRethrow(Index label);
   // [[nodiscard]] Result<> makeTupleMake();
   // [[nodiscard]] Result<> makeTupleExtract();
   [[nodiscard]] Result<> makeRefI31();
@@ -459,6 +459,7 @@ private:
   Result<Expression*> finishScope(Block* block = nullptr);
 
   [[nodiscard]] Result<Name> getLabelName(Index label);
+  [[nodiscard]] Result<Name> getDelegateLabelName(Index label);
   [[nodiscard]] Result<Index> addScratchLocal(Type);
   [[nodiscard]] Result<Expression*> pop();
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -2124,6 +2124,62 @@
   end
  )
 
+ ;; CHECK:      (func $rethrow-try-nested (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try $__delegate__label
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (rethrow $__delegate__label)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $rethrow-try-nested
+  try
+  catch $empty
+   block
+    try
+     ;; Same as before, but now the rethrow is in the inner try instead of the
+     ;; inner catch.
+     rethrow 2
+    end
+   end
+  end
+ )
+
+ ;; CHECK:      (func $rethrow-try-nested-named (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (rethrow $__delegate__l)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $rethrow-try-nested-named
+  try $l
+  catch $empty
+   block
+    try
+     rethrow $l
+    end
+   end
+  end
+ )
+
  ;; CHECK:      (func $label-siblings (type $void)
  ;; CHECK-NEXT:  (block $l
  ;; CHECK-NEXT:   (br $l)
@@ -3022,7 +3078,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 133
+  ref.func 135
   drop
  )
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -2024,6 +2024,106 @@
   )
  )
 
+ ;; CHECK:      (func $rethrow (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try $__delegate__label
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (rethrow $__delegate__label)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $rethrow
+  try
+  catch $empty
+   rethrow 0
+  end
+ )
+
+ ;; CHECK:      (func $rethrow-named (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (rethrow $__delegate__l)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $rethrow-named
+  try $l
+  catch $empty
+   rethrow $l
+  end
+ )
+
+ ;; CHECK:      (func $rethrow-nested (type $void)
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (try $__delegate__label
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (nop)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (catch $empty
+ ;; CHECK-NEXT:       (rethrow $__delegate__label)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $rethrow-nested
+  try
+  catch $empty
+   block
+    try
+    catch $empty
+     rethrow 2
+    end
+   end
+  end
+ )
+
+ ;; CHECK:      (func $rethrow-nested-named (type $void)
+ ;; CHECK-NEXT:  (block $l
+ ;; CHECK-NEXT:   (try $__delegate__l
+ ;; CHECK-NEXT:    (do
+ ;; CHECK-NEXT:     (nop)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (catch $empty
+ ;; CHECK-NEXT:     (try
+ ;; CHECK-NEXT:      (do
+ ;; CHECK-NEXT:       (nop)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (catch $empty
+ ;; CHECK-NEXT:       (rethrow $__delegate__l)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $rethrow-nested-named
+  try $l
+  catch $empty
+   block
+    try
+    catch $empty
+     rethrow $l
+    end
+   end
+  end
+ )
+
  ;; CHECK:      (func $label-siblings (type $void)
  ;; CHECK-NEXT:  (block $l
  ;; CHECK-NEXT:   (br $l)
@@ -2922,7 +3022,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 129
+  ref.func 133
   drop
  )
 


### PR DESCRIPTION
Like `delegate`, rethrow takes a `Try` label. Refactor the delegate handling so
that `Try` can share its logic.