### PR TITLE
[test] Remove asm2wasm tests from scripts

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -192,9 +192,6 @@ def which(program):
                     return exe_file + '.bat'
 
 
-WATERFALL_BUILD_DIR = os.path.join(options.binaryen_test, 'wasm-install')
-BIN_DIR = os.path.abspath(os.path.join(WATERFALL_BUILD_DIR, 'wasm-install', 'bin'))
-
 NATIVECC = (os.environ.get('CC') or which('mingw32-gcc') or
             which('gcc') or which('clang'))
 NATIVEXX = (os.environ.get('CXX') or which('mingw32-g++') or

--- a/scripts/test/wasm_opt.py
+++ b/scripts/test/wasm_opt.py
@@ -124,16 +124,6 @@ def test_wasm_opt():
 
     print('\n[ checking wasm-opt debugInfo read-write... ]\n')
 
-    for t in shared.get_tests(shared.options.binaryen_test, ['.fromasm']):
-        if 'debugInfo' not in t:
-            continue
-        print('..', os.path.basename(t))
-        f = t + '.read-written'
-        support.run_command(shared.WASM_AS + [t, '--source-map=a.map', '-o', 'a.wasm', '-g'])
-        support.run_command(shared.WASM_OPT + ['a.wasm', '--input-source-map=a.map', '-o', 'b.wasm', '--output-source-map=b.map', '-g'])
-        actual = support.run_command(shared.WASM_DIS + ['b.wasm', '--source-map=b.map'])
-        shared.fail_if_not_identical_to_file(actual, f)
-
 
 def update_wasm_opt_tests():
     print('\n[ checking wasm-opt -o notation... ]\n')
@@ -203,16 +193,6 @@ def update_wasm_opt_tests():
         actual = actual.replace('printing before:\n', '')
         open(f, 'w').write(actual)
 
-    print('\n[ checking wasm-opt debugInfo read-write... ]\n')
-    for t in shared.get_tests(shared.options.binaryen_test, ['.fromasm']):
-        if 'debugInfo' not in t:
-            continue
-        print('..', os.path.basename(t))
-        f = t + '.read-written'
-        support.run_command(shared.WASM_AS + [t, '--source-map=a.map', '-o', 'a.wasm', '-g'])
-        support.run_command(shared.WASM_OPT + ['a.wasm', '--input-source-map=a.map', '-o', 'b.wasm', '--output-source-map=b.map', '-g'])
-        actual = support.run_command(shared.WASM_DIS + ['b.wasm', '--source-map=b.map'])
-        open(f, 'w').write(actual)
 
     print('\n[ checking binary format testcases... ]\n')
     for wast in shared.get_tests(shared.options.binaryen_test, ['.wast']):

--- a/scripts/test/wasm_opt.py
+++ b/scripts/test/wasm_opt.py
@@ -193,7 +193,6 @@ def update_wasm_opt_tests():
         actual = actual.replace('printing before:\n', '')
         open(f, 'w').write(actual)
 
-
     print('\n[ checking binary format testcases... ]\n')
     for wast in shared.get_tests(shared.options.binaryen_test, ['.wast']):
         for debug_info in [0, 1]:

--- a/test/lit/passes/inlining-optimizing_optimize-level=3.wast
+++ b/test/lit/passes/inlining-optimizing_optimize-level=3.wast
@@ -3,7 +3,6 @@
 
 ;; RUN: foreach %s %t wasm-opt --inlining-optimizing --optimize-level=3 -S -o - | filecheck %s
 
-;; similar to test/emcc_hello_world.fromasm.clamp ;;
 (module
  ;; CHECK:      (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))
  (type $FUNCSIG$iiii (func (param i32 i32 i32) (result i32)))


### PR DESCRIPTION
We don't have `*.fromasm` files anymore. Also `BIN_DIR` and `WATERFALL_BUILD_DIR` variables don't seem to be used as well.