### PR TITLE
[test] Make get_tests return only files

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -386,6 +386,7 @@ def get_tests(test_dir, extensions=[], recursive=False):
         tests += glob.glob(os.path.join(test_dir, star + ext), recursive=True)
     if options.test_name_filter:
         tests = fnmatch.filter(tests, options.test_name_filter)
+    tests = [item for item in tests if os.path.isfile(item)]
     return sorted(tests)
 
 

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -41,6 +41,8 @@ def check_for_stale_files():
 
     all_files = os.listdir(shared.get_test_dir('wasm2js'))
     for f in all_files:
+        if f in assert_tests:
+            continue
         prefix = f.split('.')[0]
         if prefix not in all_tests:
             shared.fail_with_error('orphan test output: %s' % f)


### PR DESCRIPTION
Currently `get_tests` returns files and directories, especially when the extension is not given. This makes `get_tests` return a directory like `test/wasm2js/` as a test.

`wasm2js.py`'s `check_for_stale_files` errors out when there are files within `test/wasm2js/` whose basenames don't match any files within any of `test/`, `test/spec/`, `test/wasm2js/`.
https://github.com/WebAssembly/binaryen/blob/1d615b38dd4152494d2f4d3520c8b1d917624a30/scripts/test/wasm2js.py#L33-L46

`wasm2js.wast.asserts` is apparently a special case for asserts test: https://github.com/WebAssembly/binaryen/blob/1d615b38dd4152494d2f4d3520c8b1d917624a30/scripts/test/wasm2js.py#L28 and this doesn't seem to have the matching `wast` tests in the three test directories. But it just happened to not error out because `get_tests` returns directory names too and one of them was `wasm2js` (`test/wasm2js/` directory).

This makes `get_tests` return only files, and make files in `assert_tests` not error out additionally.