### PR TITLE
Inlining: Copy no-inline flags when copying a function

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -36,6 +36,9 @@ Function* copyFunction(Function* func, Module& out, Name newName) {
   ret->body = ExpressionManipulator::copy(func->body, out);
   ret->module = func->module;
   ret->base = func->base;
+  ret->noFullInline = func->noFullInline;
+  ret->noPartialInline = func->noPartialInline;
+
   // TODO: copy Stack IR
   assert(!func->stackIR);
   return out.addFunction(std::move(ret));


### PR DESCRIPTION
Those fields should be copied together with all the rest of the metadata that
already is. This was just missed in the prior PR.

Testing this is quite hard atm but I believe @gkdn 's PR #6151 will test it as
@gkdn noticed this.