### PR TITLE
[test] Fix wasm2js stale check failure

### DIFF
--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -43,7 +43,7 @@ def check_for_stale_files():
     for f in all_files:
         prefix = f.split('.')[0]
         if prefix in [t.split('.')[0] for t in assert_tests]:
-          continue
+            continue
         if prefix not in all_tests:
             shared.fail_with_error('orphan test output: %s' % f)
 

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -41,9 +41,9 @@ def check_for_stale_files():
 
     all_files = os.listdir(shared.get_test_dir('wasm2js'))
     for f in all_files:
-        if f in assert_tests:
-            continue
         prefix = f.split('.')[0]
+        if prefix in [t.split('.')[0] for t in assert_tests]:
+          continue
         if prefix not in all_tests:
             shared.fail_with_error('orphan test output: %s' % f)
 


### PR DESCRIPTION
I tried to exclude wasm2js asserts tests from `check_for_stale_files` in #6164, but ended up doing it incorrectly. The file I checked for was `wasm2js.wast.asserts`, while the output I should have excluded was `wasm2js.asserts.js`. This fixes the code so we now check the prefix and not the filename.

This is currently breaking the main branch, which was caused by me landing multiple PRs at once. Sorry for the breakage. Landing this will fix it.