### PR TITLE
Update `tuple.make` text format to include arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - The `tuple.make` pseudoinstruction now requires an immediate giving its
+   arity. For example, to make a tuple of two elements, use `tuple.make 2`.
 
 v116
 ----

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -392,7 +392,7 @@ def pick_initial_contents():
         #    (struct.new $other)
         #    (struct.new $other)
         #    (tuple.extract 1
-        #     (tuple.make
+        #     (tuple.make 2
         #      (i32.const 0)
         #      (i32.const 0)
         #     )

--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -24,7 +24,7 @@
 //       (func $foo
 //        (drop
 //         (block (result funcref (ref $none))
-//          (tuple.make
+//          (tuple.make 2
 //           (ref.null func)
 //           (ref.func $foo)
 //          )

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1985,7 +1985,10 @@ struct PrintExpressionContents
     }
     restoreNormalColor(o);
   }
-  void visitTupleMake(TupleMake* curr) { printMedium(o, "tuple.make"); }
+  void visitTupleMake(TupleMake* curr) {
+    printMedium(o, "tuple.make ");
+    o << curr->operands.size();
+  }
   void visitTupleExtract(TupleExtract* curr) {
     printMedium(o, "tuple.extract ");
     o << curr->index;

--- a/src/passes/TupleOptimization.cpp
+++ b/src/passes/TupleOptimization.cpp
@@ -20,7 +20,7 @@
 // like this:
 //
 //  (local.set $tuple
-//    (tuple.make (A) (B) (C)))
+//    (tuple.make 3 (A) (B) (C)))
 //  (use
 //    (tuple.extract 0
 //      (local.get $tuple)))

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2843,7 +2843,11 @@ Expression* SExpressionWasmBuilder::makeRethrow(Element& s) {
 
 Expression* SExpressionWasmBuilder::makeTupleMake(Element& s) {
   auto ret = allocator.alloc<TupleMake>();
-  parseCallOperands(s, 1, s.size(), ret);
+  size_t arity = std::stoll(s[1]->toString());
+  if (arity != s.size() - 2) {
+    throw SParseException("unexpected number of elements", s, *s[1]);
+  }
+  parseCallOperands(s, 2, s.size(), ret);
   ret->finalize();
   return ret;
 }

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -1728,7 +1728,7 @@ console.log("# TupleMake");
   assert(
     theTupleMake.toText()
     ==
-    "(tuple.make\n (i32.const 6)\n (i32.const 7)\n)\n"
+    "(tuple.make 2\n (i32.const 6)\n (i32.const 7)\n)\n"
   );
 
   module.dispose();
@@ -1765,7 +1765,7 @@ console.log("# TupleExtract");
   assert(
     theTupleExtract.toText()
     ==
-    "(tuple.extract 0\n (tuple.make\n  (f64.const 3)\n  (f64.const 4)\n )\n)\n"
+    "(tuple.extract 0\n (tuple.make 2\n  (f64.const 3)\n  (f64.const 4)\n )\n)\n"
   );
 
   module.dispose();

--- a/test/binaryen.js/expressions.js.txt
+++ b/test/binaryen.js/expressions.js.txt
@@ -317,14 +317,14 @@
 (rethrow $l1)
 
 # TupleMake
-(tuple.make
+(tuple.make 2
  (i32.const 6)
  (i32.const 7)
 )
 
 # TupleExtract
 (tuple.extract 0
- (tuple.make
+ (tuple.make 2
   (f64.const 3)
   (f64.const 4)
  )

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -2131,7 +2131,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (atomic.fence)
       (drop
-       (tuple.make
+       (tuple.make 4
         (i32.const 13)
         (i64.const 37)
         (f32.const 1.2999999523162842)
@@ -2140,7 +2140,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (tuple.extract 2
-        (tuple.make
+        (tuple.make 4
          (i32.const 13)
          (i64.const 37)
          (f32.const 1.2999999523162842)
@@ -4235,7 +4235,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (atomic.fence)
       (drop
-       (tuple.make
+       (tuple.make 4
         (i32.const 13)
         (i64.const 37)
         (f32.const 1.2999999523162842)
@@ -4244,7 +4244,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (tuple.extract 2
-        (tuple.make
+        (tuple.make 4
          (i32.const 13)
          (i64.const 37)
          (f32.const 1.2999999523162842)

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -2194,7 +2194,7 @@ BinaryenFeatureAll: 131071
       )
       (atomic.fence)
       (drop
-       (tuple.make
+       (tuple.make 4
         (i32.const 13)
         (i64.const 37)
         (f32.const 1.2999999523162842)
@@ -2203,7 +2203,7 @@ BinaryenFeatureAll: 131071
       )
       (drop
        (tuple.extract 2
-        (tuple.make
+        (tuple.make 4
          (i32.const 13)
          (i64.const 37)
          (f32.const 1.2999999523162842)

--- a/test/lit/blocktype.wast
+++ b/test/lit/blocktype.wast
@@ -32,7 +32,7 @@
  ;; RTRIP-NEXT:    (local.set $0
  ;; RTRIP-NEXT:     (call $f1)
  ;; RTRIP-NEXT:    )
- ;; RTRIP-NEXT:    (tuple.make
+ ;; RTRIP-NEXT:    (tuple.make 2
  ;; RTRIP-NEXT:     (tuple.extract 0
  ;; RTRIP-NEXT:      (local.get $0)
  ;; RTRIP-NEXT:     )
@@ -42,7 +42,7 @@
  ;; RTRIP-NEXT:    )
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
- ;; RTRIP-NEXT:  (tuple.make
+ ;; RTRIP-NEXT:  (tuple.make 2
  ;; RTRIP-NEXT:   (tuple.extract 0
  ;; RTRIP-NEXT:    (local.get $1)
  ;; RTRIP-NEXT:   )
@@ -71,7 +71,7 @@
  ;; RTRIP-NEXT:    (local.set $0
  ;; RTRIP-NEXT:     (call $f2)
  ;; RTRIP-NEXT:    )
- ;; RTRIP-NEXT:    (tuple.make
+ ;; RTRIP-NEXT:    (tuple.make 2
  ;; RTRIP-NEXT:     (tuple.extract 0
  ;; RTRIP-NEXT:      (local.get $0)
  ;; RTRIP-NEXT:     )
@@ -81,7 +81,7 @@
  ;; RTRIP-NEXT:    )
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
- ;; RTRIP-NEXT:  (tuple.make
+ ;; RTRIP-NEXT:  (tuple.make 2
  ;; RTRIP-NEXT:   (tuple.extract 0
  ;; RTRIP-NEXT:    (local.get $1)
  ;; RTRIP-NEXT:   )

--- a/test/lit/ctor-eval/multivalue-local.wast
+++ b/test/lit/ctor-eval/multivalue-local.wast
@@ -24,7 +24,7 @@
    )
   )
   (local.set $1
-   (tuple.make
+   (tuple.make 2
     (local.get $0)   ;; This will turn into 42.
     (i32.const 1000)
    )

--- a/test/lit/multivalue-stack-ir.wast
+++ b/test/lit/multivalue-stack-ir.wast
@@ -33,7 +33,7 @@
   ;; f32 on the stack where an f32 and i32 would be expected. We disable stack
   ;; IR optimizations on tuples to avoid this.
   (local.set $pair
-   (tuple.make
+   (tuple.make 2
     (f32.const 0)
     (i32.const 0)
    )

--- a/test/lit/multivalue.wast
+++ b/test/lit/multivalue.wast
@@ -8,19 +8,19 @@
  ;; CHECK:      (import "env" "pair" (func $pair (type $0) (result i32 i64)))
  (import "env" "pair" (func $pair (result i32 i64)))
  ;; CHECK:      (global $g1 (mut i32) (i32.const 0))
- (global $g1 (mut (i32 i64)) (tuple.make (i32.const 0) (i64.const 0)))
+ (global $g1 (mut (i32 i64)) (tuple.make 2 (i32.const 0) (i64.const 0)))
  ;; CHECK:      (global $g2 (mut i64) (i64.const 0))
- (global $g2 (i32 i64) (tuple.make (i32.const 0) (i64.const 0)))
+ (global $g2 (i32 i64) (tuple.make 2 (i32.const 0) (i64.const 0)))
 
  ;; CHECK:      (func $triple (type $5) (result i32 i64 f32)
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 3
  ;; CHECK-NEXT:   (i32.const 42)
  ;; CHECK-NEXT:   (i64.const 7)
  ;; CHECK-NEXT:   (f32.const 13)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $triple (result i32 i64 f32)
-  (tuple.make
+  (tuple.make 3
    (i32.const 42)
    (i64.const 7)
    (f32.const 13)
@@ -183,7 +183,7 @@
  ;; CHECK-NEXT:    (local.get $7)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 3
  ;; CHECK-NEXT:   (local.get $3)
  ;; CHECK-NEXT:   (local.get $1)
  ;; CHECK-NEXT:   (local.get $x)
@@ -194,7 +194,7 @@
   (local.set $x
    (call $triple)
   )
-  (tuple.make
+  (tuple.make 3
    (tuple.extract 2
     (local.get $x)
    )
@@ -218,7 +218,7 @@
  ;; CHECK-NEXT: )
  (func $unreachable (result i64)
   (tuple.extract 1
-   (tuple.make
+   (tuple.make 3
     (i32.const 42)
     (i64.const 7)
     (unreachable)
@@ -244,14 +244,14 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (global.get $g2)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (global.get $global$2)
  ;; CHECK-NEXT:   (global.get $global$3)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $global (result i32 i64)
   (global.set $g1
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 7)
    )
@@ -309,7 +309,7 @@
  ;; CHECK-NEXT: )
  (func $drop-tuple-make
   (drop
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 42)
    )
@@ -321,7 +321,7 @@
  ;; CHECK-NEXT:  (local $1 i32)
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:     (i64.const 42)
  ;; CHECK-NEXT:    )
@@ -346,7 +346,7 @@
  (func $drop-block
   (drop
    (block $block (result i32 i64)
-    (tuple.make
+    (tuple.make 2
      (i32.const 42)
      (i64.const 42)
     )
@@ -357,7 +357,7 @@
  ;; Test multivalue control structures
  ;; CHECK:      (func $mv-return (type $0) (result i32 i64)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (i32.const 42)
  ;; CHECK-NEXT:    (i64.const 42)
  ;; CHECK-NEXT:   )
@@ -365,7 +365,7 @@
  ;; CHECK-NEXT: )
  (func $mv-return (result i32 i64)
   (return
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 42)
    )
@@ -374,7 +374,7 @@
 
  ;; CHECK:      (func $mv-return-in-block (type $0) (result i32 i64)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (i32.const 42)
  ;; CHECK-NEXT:    (i64.const 42)
  ;; CHECK-NEXT:   )
@@ -383,7 +383,7 @@
  (func $mv-return-in-block (result i32 i64)
   (block (result i32 i64)
    (return
-    (tuple.make
+    (tuple.make 2
      (i32.const 42)
      (i64.const 42)
     )
@@ -396,14 +396,14 @@
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
  ;; CHECK-NEXT:    (br $label$1
- ;; CHECK-NEXT:     (tuple.make
+ ;; CHECK-NEXT:     (tuple.make 2
  ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:      (i64.const 42)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (tuple.extract 0
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
@@ -415,7 +415,7 @@
  (func $mv-block-break (result i32 i64)
   (block $l (result i32 i64)
    (br $l
-    (tuple.make
+    (tuple.make 2
      (i32.const 42)
      (i64.const 42)
     )
@@ -430,14 +430,14 @@
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
  ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (br_if $label$1
- ;; CHECK-NEXT:      (tuple.make
+ ;; CHECK-NEXT:      (tuple.make 2
  ;; CHECK-NEXT:       (i32.const 42)
  ;; CHECK-NEXT:       (i64.const 42)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (i32.const 1)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (tuple.extract 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
@@ -447,7 +447,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (tuple.extract 0
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
@@ -459,7 +459,7 @@
  (func $mv-block-br-if (result i32 i64)
   (block $l (result i32 i64)
    (br_if $l
-    (tuple.make
+    (tuple.make 2
      (i32.const 42)
      (i64.const 42)
     )
@@ -473,19 +473,19 @@
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (if (type $2) (result i32 i64 externref)
  ;; CHECK-NEXT:    (i32.const 1)
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 3
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:     (i64.const 42)
  ;; CHECK-NEXT:     (ref.null noextern)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 3
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:     (i64.const 42)
  ;; CHECK-NEXT:     (ref.null noextern)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 3
  ;; CHECK-NEXT:   (tuple.extract 0
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
@@ -500,12 +500,12 @@
  (func $mv-if (result i32 i64 externref)
   (if (result i32 i64 externref)
    (i32.const 1)
-   (tuple.make
+   (tuple.make 3
     (i32.const 42)
     (i64.const 42)
     (ref.null extern)
    )
-   (tuple.make
+   (tuple.make 3
     (i32.const 42)
     (i64.const 42)
     (ref.null extern)
@@ -517,13 +517,13 @@
  ;; CHECK-NEXT:  (local $0 (i32 i64))
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (loop $label$1 (type $0) (result i32 i64)
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:     (i64.const 42)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (tuple.extract 0
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
@@ -534,7 +534,7 @@
  ;; CHECK-NEXT: )
  (func $mv-loop (result i32 i64)
   (loop (result i32 i64)
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 42)
    )
@@ -549,7 +549,7 @@
  ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (block $label$2 (type $0) (result i32 i64)
  ;; CHECK-NEXT:      (br_table $label$1 $label$2
- ;; CHECK-NEXT:       (tuple.make
+ ;; CHECK-NEXT:       (tuple.make 2
  ;; CHECK-NEXT:        (i32.const 42)
  ;; CHECK-NEXT:        (i64.const 42)
  ;; CHECK-NEXT:       )
@@ -557,7 +557,7 @@
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (tuple.extract 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
@@ -567,7 +567,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (tuple.extract 0
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
@@ -580,7 +580,7 @@
   (block $a (result i32 i64)
    (block $b (result i32 i64)
     (br_table $a $b
-     (tuple.make
+     (tuple.make 2
       (i32.const 42)
       (i64.const 42)
      )

--- a/test/lit/parse-bad-tuple-extract-index.wast
+++ b/test/lit/parse-bad-tuple-extract-index.wast
@@ -2,12 +2,12 @@
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: [parse exception: Bad index on tuple.extract: ( tuple.extract 2 ( tuple.make ( i32.const 0 ) ( i64.const 1 ) ) ) (at 9:17)]
+;; CHECK: [parse exception: Bad index on tuple.extract: ( tuple.extract 2 ( tuple.make  2 ( i32.const 0 ) ( i64.const 1 ) ) ) (at 9:17)]
 
 (module
  (func
   (tuple.extract 2
-   (tuple.make
+   (tuple.make 2
     (i32.const 0)
     (i64.const 1)
    )

--- a/test/lit/passes/asyncify_enable-multivalue.wast
+++ b/test/lit/passes/asyncify_enable-multivalue.wast
@@ -1758,7 +1758,7 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (tuple.make
+  ;; CHECK-NEXT:     (tuple.make 2
   ;; CHECK-NEXT:      (i32.load
   ;; CHECK-NEXT:       (local.get $5)
   ;; CHECK-NEXT:      )

--- a/test/lit/passes/coalesce-locals-gc-nn.wast
+++ b/test/lit/passes/coalesce-locals-gc-nn.wast
@@ -6,13 +6,13 @@
  ;; CHECK-NEXT:  (local $1 ((ref any) (ref any)))
  ;; CHECK-NEXT:  (local $2 ((ref any) (ref any)))
  ;; CHECK-NEXT:  (local.set $1
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (local.set $2
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
@@ -48,13 +48,13 @@
   ;; of current limitations on tuple handling in this pass, so we are mainly
   ;; testing for not crashing here.
   (local.set $x
-   (tuple.make
+   (tuple.make 2
     (local.get $any)
     (local.get $any)
    )
   )
   (local.set $y
-   (tuple.make
+   (tuple.make 2
     (local.get $any)
     (local.get $any)
    )

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -16,13 +16,13 @@
  ;; CHECK:      (global $global (ref null $array) (ref.null none))
  (global $global (ref null $array) (ref.null $array))
 
- ;; CHECK:      (global $nn-tuple-global (mut ((ref any) i32)) (tuple.make
+ ;; CHECK:      (global $nn-tuple-global (mut ((ref any) i32)) (tuple.make 2
  ;; CHECK-NEXT:  (ref.i31
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (i32.const 1)
  ;; CHECK-NEXT: ))
- (global $nn-tuple-global (mut ((ref any) i32)) (tuple.make (ref.i31 (i32.const 0)) (i32.const 1)))
+ (global $nn-tuple-global (mut ((ref any) i32)) (tuple.make 2 (ref.i31 (i32.const 0)) (i32.const 1)))
 
 
  ;; CHECK:      (func $test-dead-get-non-nullable (type $6) (param $0 (ref struct))
@@ -286,7 +286,7 @@
  ;; CHECK:      (func $test (type $10) (param $0 (ref any)) (result (ref any) i32)
  ;; CHECK-NEXT:  (local $1 (anyref i32))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:    (i32.const 0)
  ;; CHECK-NEXT:   )
@@ -294,13 +294,13 @@
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (local.set $1
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (local.get $0)
  ;; CHECK-NEXT:     (i32.const 1)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (local.set $1
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (local.get $0)
  ;; CHECK-NEXT:     (i32.const 2)
  ;; CHECK-NEXT:    )
@@ -311,7 +311,7 @@
  ;; CHECK-NEXT:    (local.set $1
  ;; CHECK-NEXT:     (if (type $1) (result (ref any) i32)
  ;; CHECK-NEXT:      (i32.const 0)
- ;; CHECK-NEXT:      (tuple.make
+ ;; CHECK-NEXT:      (tuple.make 2
  ;; CHECK-NEXT:       (ref.as_non_null
  ;; CHECK-NEXT:        (tuple.extract 0
  ;; CHECK-NEXT:         (local.get $1)
@@ -321,7 +321,7 @@
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (tuple.make
+ ;; CHECK-NEXT:      (tuple.make 2
  ;; CHECK-NEXT:       (ref.as_non_null
  ;; CHECK-NEXT:        (tuple.extract 0
  ;; CHECK-NEXT:         (local.get $1)
@@ -333,7 +333,7 @@
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (ref.as_non_null
  ;; CHECK-NEXT:      (tuple.extract 0
  ;; CHECK-NEXT:       (local.get $1)
@@ -345,7 +345,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (ref.as_non_null
  ;; CHECK-NEXT:    (tuple.extract 0
  ;; CHECK-NEXT:     (local.get $1)
@@ -361,7 +361,7 @@
   (local $y ((ref any) i32))
   ;; This store is dead and will be removed.
   (local.set $x
-   (tuple.make
+   (tuple.make 2
     (local.get $any)
     (i32.const 0)
    )
@@ -370,13 +370,13 @@
    (i32.const 0)
    ;; These two sets will remain.
    (local.set $x
-    (tuple.make
+    (tuple.make 2
      (local.get $any)
      (i32.const 1)
     )
    )
    (local.set $x
-    (tuple.make
+    (tuple.make 2
      (local.get $any)
      (i32.const 2)
     )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -243,7 +243,7 @@
  ;; CHECK-NEXT:    (call $refine-return-tuple)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (local.get $i31)
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:  )
@@ -258,7 +258,7 @@
    )
   )
 
-  (tuple.make
+  (tuple.make 2
    (local.get $i31)
    (i32.const 1)
   )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -4206,7 +4206,7 @@
 
   ;; CHECK:      (func $tuples (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
@@ -4214,7 +4214,7 @@
   ;; CHECK-NEXT: )
   (func $tuples
     (drop
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -302,7 +302,7 @@
   ;; CHECK:      (func $nondefaultable (type $0)
   ;; CHECK-NEXT:  (local $x (funcref funcref))
   ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (ref.func $i32)
   ;; CHECK-NEXT:    (ref.func $i32)
   ;; CHECK-NEXT:   )
@@ -313,7 +313,7 @@
     ;; This tuple is assigned non-nullable values, which means the subtype is
     ;; nondefaultable, and we must not apply it.
     (local.set $x
-      (tuple.make
+      (tuple.make 2
         (ref.func $i32)
         (ref.func $i32)
       )

--- a/test/lit/passes/optimize-instructions-multivalue.wast
+++ b/test/lit/passes/optimize-instructions-multivalue.wast
@@ -68,7 +68,7 @@
   (func $extract-make (param $x i32) (param $y i32) (result i32)
     ;; An extraction from a make can be simplified to just get the right lane.
     (tuple.extract 0
-      (tuple.make
+      (tuple.make 2
         (local.get $x)
         (local.get $y)
       )
@@ -87,7 +87,7 @@
   (func $extract-make-2 (param $x i32) (param $y i32) (result i32)
     ;; As above, but the second lane.
     (tuple.extract 1
-      (tuple.make
+      (tuple.make 2
         (local.get $x)
         (local.get $y)
       )
@@ -96,7 +96,7 @@
 
   ;; CHECK:      (func $extract-make-unreachable (param $x i32) (param $y i32) (result i32)
   ;; CHECK-NEXT:  (tuple.extract 0
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:    (local.get $y)
   ;; CHECK-NEXT:   )
@@ -104,7 +104,7 @@
   ;; CHECK-NEXT: )
   (func $extract-make-unreachable (param $x i32) (param $y i32) (result i32)
     (tuple.extract 0
-      (tuple.make
+      (tuple.make 2
         (unreachable) ;; because of this we should do nothing
         (local.get $y)
       )

--- a/test/lit/passes/optimize-stack-ir.wast
+++ b/test/lit/passes/optimize-stack-ir.wast
@@ -1404,7 +1404,7 @@
   ;; CHECK-NEXT:  (local $f32 f32)
   ;; CHECK-NEXT:  f32.const 0
   ;; CHECK-NEXT:  i32.const 0
-  ;; CHECK-NEXT:  tuple.make
+  ;; CHECK-NEXT:  tuple.make 2
   ;; CHECK-NEXT:  local.set $pair
   ;; CHECK-NEXT:  local.get $pair
   ;; CHECK-NEXT:  tuple.extract 0
@@ -1416,7 +1416,7 @@
     ;; We should not optimize out this get-set pair in Stack IR since we can do
     ;; better in the binary writer.
     (local.set $pair
-      (tuple.make
+      (tuple.make 2
         (f32.const 0)
         (i32.const 0)
       )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -634,7 +634,7 @@
   ;; CHECK:      (type $1 (func))
 
   ;; CHECK:      (func $outline$ (type $0) (result i32 i32)
-  ;; CHECK-NEXT:  (tuple.make
+  ;; CHECK-NEXT:  (tuple.make 2
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/poppify-globals.wast
+++ b/test/lit/passes/poppify-globals.wast
@@ -14,7 +14,7 @@
   (global $tuple$1 f64 (f64.const 0)) ;; interfering name!
 
   (global $tuple (mut (i32 i64 f32))
-    (tuple.make (global.get $foo) (i64.const 1) (f32.const 2))
+    (tuple.make 3 (global.get $foo) (i64.const 1) (f32.const 2))
   )
 
   (global $other-tuple (i32 i64 f32) (global.get $tuple))
@@ -56,7 +56,7 @@
   ;; CHECK-NEXT: )
   (func $global-set-tuple
     (global.set $tuple
-      (tuple.make
+      (tuple.make 3
         (i32.const 0)
         (i64.const 1)
         (f32.const 2)

--- a/test/lit/passes/poppify.wast
+++ b/test/lit/passes/poppify.wast
@@ -282,7 +282,7 @@
   ;; CHECK-NEXT:  (i64.const 1)
   ;; CHECK-NEXT: )
   (func $tuple (result i32 i64)
-    (tuple.make
+    (tuple.make 2
       (i32.const 0)
       (i64.const 1)
     )
@@ -301,7 +301,7 @@
   ;; CHECK-NEXT: )
   (func $extract-first (result i32)
     (tuple.extract 0
-      (tuple.make
+      (tuple.make 3
         (i32.const 0)
         (i64.const 1)
         (f32.const 2)
@@ -327,7 +327,7 @@
   ;; CHECK-NEXT: )
   (func $extract-middle (result i64)
     (tuple.extract 1
-      (tuple.make
+      (tuple.make 3
         (i32.const 0)
         (i64.const 1)
         (f32.const 2)
@@ -353,7 +353,7 @@
   ;; CHECK-NEXT: )
   (func $extract-last (result f32)
     (tuple.extract 2
-      (tuple.make
+      (tuple.make 3
         (i32.const 0)
         (i64.const 1)
         (f32.const 2)
@@ -385,7 +385,7 @@
   ;; CHECK-NEXT: )
   (func $drop-tuple
     (drop
-      (tuple.make
+      (tuple.make 2
         (i32.const 0)
         (i64.const 1)
       )
@@ -434,7 +434,7 @@
   (func $local-set-tuple
     (local $x (i32 i64))
     (local.set $x
-      (tuple.make
+      (tuple.make 2
         (i32.const 0)
         (i64.const 1)
       )
@@ -458,7 +458,7 @@
   (func $local-tee-tuple (result i32 i64)
     (local $x (i32 i64))
     (local.tee $x
-      (tuple.make
+      (tuple.make 2
         (i32.const 0)
         (i64.const 1)
       )
@@ -477,7 +477,7 @@
   (func $break-tuple (result i32 i64)
     (block $l (result i32 i64)
       (br $l
-        (tuple.make
+        (tuple.make 2
           (i32.const 0)
           (i64.const 1)
         )
@@ -494,7 +494,7 @@
   ;; CHECK-NEXT: )
   (func $return-tuple (result i32 i64)
     (return
-      (tuple.make
+      (tuple.make 2
         (i32.const 0)
         (i64.const 1)
       )

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -767,7 +767,7 @@
  ;; CHECK:      (func $odd-cast-and-get-tuple (type $3)
  ;; CHECK-NEXT:  (local $temp ((ref null $B) i32))
  ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:    (i32.const 10)
  ;; CHECK-NEXT:   )
@@ -785,7 +785,7 @@
   (local $temp ((ref null $B) i32))
   ;; As above, but with a tuple.
   (local.set $temp
-   (tuple.make
+   (tuple.make 2
     (ref.cast (ref null $B)
      (ref.null $A)
     )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -330,7 +330,7 @@
   ;; CHECK-NEXT:   (block $block (type $2) (result i32 i32)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (br_if $block
-  ;; CHECK-NEXT:      (tuple.make
+  ;; CHECK-NEXT:      (tuple.make 2
   ;; CHECK-NEXT:       (i32.const 1)
   ;; CHECK-NEXT:       (call $restructure-br_if
   ;; CHECK-NEXT:        (i32.const 2)
@@ -339,7 +339,7 @@
   ;; CHECK-NEXT:      (i32.const 3)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (tuple.make
+  ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 4)
   ;; CHECK-NEXT:     (i32.const 5)
   ;; CHECK-NEXT:    )
@@ -351,7 +351,7 @@
       (block $block (result i32 i32)
         (drop
           (br_if $block
-            (tuple.make
+            (tuple.make 2
               (i32.const 1)
               ;; Add a side effect to prevent us turning $block into a
               ;; restructured if - instead, we will try a restructured select.
@@ -364,7 +364,7 @@
             (i32.const 3)
           )
         )
-        (tuple.make
+        (tuple.make 2
           (i32.const 4)
           (i32.const 5)
         )

--- a/test/lit/passes/roundtrip.wast
+++ b/test/lit/passes/roundtrip.wast
@@ -9,7 +9,7 @@
  ;; CHECK-NEXT:  (local $1 funcref)
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (block $label$1 (type $1) (result funcref (ref $none))
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (ref.null nofunc)
  ;; CHECK-NEXT:     (ref.func $foo)
  ;; CHECK-NEXT:    )
@@ -35,7 +35,7 @@
   (drop
    ;; a tuple type with a non-nullable element, that must be carefully handled
    (block $block (result funcref (ref $none))
-    (tuple.make
+    (tuple.make 2
      (ref.null func)
      (ref.func $foo)
     )

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -55,7 +55,7 @@
   ;; CHECK-NEXT:  (try $try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (local.set $nn
-  ;; CHECK-NEXT:     (tuple.make
+  ;; CHECK-NEXT:     (tuple.make 3
   ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:      (ref.as_non_null
   ;; CHECK-NEXT:       (ref.null none)
@@ -66,7 +66,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch_all
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (tuple.make
+  ;; CHECK-NEXT:     (tuple.make 3
   ;; CHECK-NEXT:      (tuple.extract 0
   ;; CHECK-NEXT:       (local.get $nn)
   ;; CHECK-NEXT:      )
@@ -87,7 +87,7 @@
     ;; Same as above, but now the local is a tuple containing a non-nullable element
     (local $nn (i32 (ref any) i64))
     (local.set $nn
-      (tuple.make
+      (tuple.make 3
         (i32.const 0)
         (ref.as_non_null
           (ref.null any)
@@ -166,7 +166,7 @@
     (if
       (i32.const 0)
       (local.set $temp
-        (tuple.make
+        (tuple.make 2
           (ref.func $if-return-tuple-nn)
           (ref.null none)
         )

--- a/test/lit/passes/stack-ir-non-nullable.wast
+++ b/test/lit/passes/stack-ir-non-nullable.wast
@@ -343,7 +343,7 @@
  ;; CHECK-NEXT:  (local $temp (i32 (ref eq)))
  ;; CHECK-NEXT:  i32.const 0
  ;; CHECK-NEXT:  local.get $param
- ;; CHECK-NEXT:  tuple.make
+ ;; CHECK-NEXT:  tuple.make 2
  ;; CHECK-NEXT:  local.set $temp
  ;; CHECK-NEXT:  local.get $temp
  ;; CHECK-NEXT:  tuple.extract 1
@@ -354,13 +354,13 @@
  ;; CHECK-NEXT:   i32.const 2
  ;; CHECK-NEXT:   i32.const 3
  ;; CHECK-NEXT:   ref.i31
- ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   tuple.make 2
  ;; CHECK-NEXT:   local.set $temp
  ;; CHECK-NEXT:  else
  ;; CHECK-NEXT:   i32.const 4
  ;; CHECK-NEXT:   i32.const 5
  ;; CHECK-NEXT:   ref.i31
- ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   tuple.make 2
  ;; CHECK-NEXT:   local.set $temp
  ;; CHECK-NEXT:  end
  ;; CHECK-NEXT:  local.get $temp
@@ -372,7 +372,7 @@
   ;; than a non-nullable reference by itself. We cannot remove the first set
   ;; here.
   (local.set $temp
-   (tuple.make
+   (tuple.make 2
     (i32.const 0)
     (local.get $param)
    )
@@ -387,7 +387,7 @@
     )
    )
    (local.set $temp
-    (tuple.make
+    (tuple.make 2
      (i32.const 2)
      (i31.new
       (i32.const 3)
@@ -395,7 +395,7 @@
     )
    )
    (local.set $temp
-    (tuple.make
+    (tuple.make 2
      (i32.const 4)
      (i31.new
       (i32.const 5)
@@ -412,7 +412,7 @@
  ;; CHECK-NEXT:  (local $temp (i32 eqref))
  ;; CHECK-NEXT:  i32.const 0
  ;; CHECK-NEXT:  local.get $param
- ;; CHECK-NEXT:  tuple.make
+ ;; CHECK-NEXT:  tuple.make 2
  ;; CHECK-NEXT:  local.set $temp
  ;; CHECK-NEXT:  local.get $temp
  ;; CHECK-NEXT:  tuple.extract 1
@@ -423,13 +423,13 @@
  ;; CHECK-NEXT:   i32.const 2
  ;; CHECK-NEXT:   i32.const 3
  ;; CHECK-NEXT:   ref.i31
- ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   tuple.make 2
  ;; CHECK-NEXT:   local.set $temp
  ;; CHECK-NEXT:  else
  ;; CHECK-NEXT:   i32.const 4
  ;; CHECK-NEXT:   i32.const 5
  ;; CHECK-NEXT:   ref.i31
- ;; CHECK-NEXT:   tuple.make
+ ;; CHECK-NEXT:   tuple.make 2
  ;; CHECK-NEXT:   local.set $temp
  ;; CHECK-NEXT:  end
  ;; CHECK-NEXT:  local.get $temp
@@ -440,7 +440,7 @@
   ;; As the last testcase, but now $temp is a defaultable tuple. We still do not
   ;; optimize away the set here, as we ignore tuples in local2stack.
   (local.set $temp
-   (tuple.make
+   (tuple.make 2
     (i32.const 0)
     (local.get $param)
    )
@@ -455,7 +455,7 @@
     )
    )
    (local.set $temp
-    (tuple.make
+    (tuple.make 2
      (i32.const 2)
      (i31.new
       (i32.const 3)
@@ -463,7 +463,7 @@
     )
    )
    (local.set $temp
-    (tuple.make
+    (tuple.make 2
      (i32.const 4)
      (i31.new
       (i32.const 5)

--- a/test/lit/passes/tuple-optimization.wast
+++ b/test/lit/passes/tuple-optimization.wast
@@ -18,7 +18,7 @@
     ;; This tuple local can be optimized into separate locals per lane. The
     ;; tuple local itself then has no uses and other passes will remove it.
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -108,7 +108,7 @@
   (func $set-and-gets
     (local $tuple (i32 i32))
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -172,7 +172,7 @@
     (local $tuple2 (i32 i32))
     (local.set $tuple
       (local.tee $tuple2
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -225,7 +225,7 @@
     (drop
       (tuple.extract 0
         (local.tee $tuple
-          (tuple.make
+          (tuple.make 2
             (i32.const 1)
             (i32.const 2)
           )
@@ -237,7 +237,7 @@
   ;; CHECK:      (func $just-tee-bad (type $1) (result i32 i32)
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local.tee $tuple
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
@@ -247,7 +247,7 @@
     (local $tuple (i32 i32))
     ;; This tee goes somewhere we cannot handle, so we do not optimize here.
     (local.tee $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -283,7 +283,7 @@
     ;; still optimize both.
     (local.set $tuple
       (local.tee $tuple2
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -296,7 +296,7 @@
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (local.tee $tuple2
-  ;; CHECK-NEXT:    (tuple.make
+  ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )
@@ -311,7 +311,7 @@
     ;; being optimized too, due to the copy between them.
     (local.set $tuple
       (local.tee $tuple2
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -325,7 +325,7 @@
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (local.tee $tuple2
-  ;; CHECK-NEXT:    (tuple.make
+  ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )
@@ -339,7 +339,7 @@
     ;; As above, but now the set is bad.
     (local.set $tuple
       (local.tee $tuple2
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -385,7 +385,7 @@
     (local $tuple2 (i32 i32))
     ;; We can optimize both these tuples.
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -403,7 +403,7 @@
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
@@ -417,7 +417,7 @@
     (local $tuple (i32 i32))
     (local $tuple2 (i32 i32))
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -433,7 +433,7 @@
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
@@ -447,7 +447,7 @@
     (local $tuple (i32 i32))
     (local $tuple2 (i32 i32))
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -482,7 +482,7 @@
   ;; CHECK:      (func $make-extract-no-local (type $0)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (tuple.extract 0
-  ;; CHECK-NEXT:    (tuple.make
+  ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )
@@ -494,7 +494,7 @@
     ;; help on this kind of thing.
     (drop
       (tuple.extract 0
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -516,7 +516,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (tuple.extract 0
-  ;; CHECK-NEXT:    (tuple.make
+  ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )
@@ -526,7 +526,7 @@
   (func $make-extract-no-local-but-other
     (local $tuple (i32 i32))
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -535,7 +535,7 @@
     ;; is an unrelated local that can be optimized. We should remain as before.
     (drop
       (tuple.extract 0
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -547,7 +547,7 @@
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (block (type $1) (result i32 i32)
-  ;; CHECK-NEXT:    (tuple.make
+  ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )
@@ -559,7 +559,7 @@
     ;; We do not handle blocks yet, so this is not optimized.
     (local.set $tuple
       (block (result i32 i32)
-        (tuple.make
+        (tuple.make 2
           (i32.const 1)
           (i32.const 2)
         )
@@ -571,7 +571,7 @@
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local $nontuple f64)
   ;; CHECK-NEXT:  (local.set $tuple
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
@@ -603,7 +603,7 @@
     (local $tuple (i32 i32))
     (local $nontuple f64)
     (local.set $tuple
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
@@ -686,7 +686,7 @@
         (local.tee $tuple
           (local.tee $tuple2
             (local.tee $tuple3
-              (tuple.make
+              (tuple.make 2
                 (i32.const 1)
                 (i32.const 2)
               )
@@ -759,7 +759,7 @@
     (local $tuple3 (i32 i32 i32))
     ;; A chain of 3 copied tuples.
     (local.set $tuple
-      (tuple.make
+      (tuple.make 3
         (i32.const 1)
         (i32.const 2)
         (i32.const 3)
@@ -794,7 +794,7 @@
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32 i32))
   ;; CHECK-NEXT:  (local $tuple3 (i32 i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
-  ;; CHECK-NEXT:   (tuple.make
+  ;; CHECK-NEXT:   (tuple.make 3
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:    (i32.const 3)
@@ -830,7 +830,7 @@
     ;; As above, but a get at the very end prevents the entire chain from being
     ;; optimized.
     (local.set $tuple
-      (tuple.make
+      (tuple.make 3
         (i32.const 1)
         (i32.const 2)
         (i32.const 3)
@@ -871,7 +871,7 @@
   ;; CHECK-NEXT:    (local.get $tuple)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (tuple.make
+  ;; CHECK-NEXT:  (tuple.make 2
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )
@@ -887,7 +887,7 @@
         (local.get $tuple)
       )
     )
-    (tuple.make
+    (tuple.make 2
       (i32.const 1)
       (i32.const 2)
     )
@@ -931,13 +931,13 @@
     (local $tuple2 (i32 i32))
     (local $tuple3 (i32 i32 i32))
     (local.set $tuple2
-      (tuple.make
+      (tuple.make 2
         (i32.const 1)
         (i32.const 2)
       )
     )
     (local.set $tuple3
-      (tuple.make
+      (tuple.make 3
         (tuple.extract 0
           (local.get $tuple2)
         )
@@ -998,14 +998,14 @@
     (local $tuple2 (i32 i32))
     (local $tuple3 (i32 i32 i32))
     (local.set $tuple3
-      (tuple.make
+      (tuple.make 3
         (i32.const 1)
         (i32.const 2)
         (i32.const 3)
       )
     )
     (local.set $tuple2
-      (tuple.make
+      (tuple.make 2
         (tuple.extract 0
           (local.get $tuple3)
         )

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -705,7 +705,7 @@
 
  ;; CHECK:      (func $return-many (type $4) (result (ref $super1) (ref $super2))
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (struct.new_default $sub1)
  ;; CHECK-NEXT:    (struct.new_default $sub2)
  ;; CHECK-NEXT:   )
@@ -714,7 +714,7 @@
  (func $return-many (result (ref $super1) (ref $super2))
   ;; This requires $sub1 <: $super1 and $sub2 <: super2.
   (return
-   (tuple.make
+   (tuple.make 2
     (struct.new $sub1)
     (struct.new $sub2)
    )

--- a/test/lit/passes/vacuum_all-features.wast
+++ b/test/lit/passes/vacuum_all-features.wast
@@ -1295,7 +1295,7 @@
     ;; the way.
     (drop
      (br_if $block
-      (tuple.make
+      (tuple.make 2
        (ref.func $1)
        (i32.const 0)
       )
@@ -1303,7 +1303,7 @@
      )
     )
     (nop)
-    (tuple.make
+    (tuple.make 2
      (ref.func $1)
      (i32.const 1)
     )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -574,7 +574,7 @@
  )
 
  ;; CHECK:      (func $add-twice (type $ret2) (result i32 i32)
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (i32.add
  ;; CHECK-NEXT:    (i32.const 1)
  ;; CHECK-NEXT:    (i32.const 2)
@@ -596,7 +596,7 @@
 
  ;; CHECK:      (func $add-twice-stacky (type $ret2) (result i32 i32)
  ;; CHECK-NEXT:  (local $scratch i32)
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (block (result i32)
  ;; CHECK-NEXT:    (local.set $scratch
  ;; CHECK-NEXT:     (i32.add
@@ -625,7 +625,7 @@
 
  ;; CHECK:      (func $add-twice-stacky-2 (type $ret2) (result i32 i32)
  ;; CHECK-NEXT:  (local $scratch i32)
- ;; CHECK-NEXT:  (tuple.make
+ ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (i32.add
  ;; CHECK-NEXT:    (i32.const 1)
  ;; CHECK-NEXT:    (i32.const 2)
@@ -870,7 +870,7 @@
  ;; CHECK-NEXT:      (block (result i32)
  ;; CHECK-NEXT:       (local.set $scratch_1
  ;; CHECK-NEXT:        (block $1 (type $ret2) (result i32 i32)
- ;; CHECK-NEXT:         (tuple.make
+ ;; CHECK-NEXT:         (tuple.make 2
  ;; CHECK-NEXT:          (block $2 (result i32)
  ;; CHECK-NEXT:           (local.set $scratch
  ;; CHECK-NEXT:            (block $3 (result i32)
@@ -924,7 +924,7 @@
  ;; CHECK-NEXT:  (local.set $scratch
  ;; CHECK-NEXT:   (block (type $ret2) (result i32 i32)
  ;; CHECK-NEXT:    (block (type $ret2) (result i32 i32)
- ;; CHECK-NEXT:     (tuple.make
+ ;; CHECK-NEXT:     (tuple.make 2
  ;; CHECK-NEXT:      (i32.const 0)
  ;; CHECK-NEXT:      (i32.const 1)
  ;; CHECK-NEXT:     )
@@ -1602,7 +1602,7 @@
  ;; CHECK:      (func $try-catch-params (type $5) (result i32 i64)
  ;; CHECK-NEXT:  (try (type $5) (result i32 i64)
  ;; CHECK-NEXT:   (do
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 0)
  ;; CHECK-NEXT:     (i64.const 1)
  ;; CHECK-NEXT:    )
@@ -2167,7 +2167,7 @@
  ;; CHECK:      (func $br-multivalue (type $5) (result i32 i64)
  ;; CHECK-NEXT:  (block $label (type $5) (result i32 i64)
  ;; CHECK-NEXT:   (br $label
- ;; CHECK-NEXT:    (tuple.make
+ ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 0)
  ;; CHECK-NEXT:     (i64.const 1)
  ;; CHECK-NEXT:    )
@@ -2187,7 +2187,7 @@
  ;; CHECK-NEXT:     (f32.const 0)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (br $label
- ;; CHECK-NEXT:     (tuple.make
+ ;; CHECK-NEXT:     (tuple.make 2
  ;; CHECK-NEXT:      (i32.const 1)
  ;; CHECK-NEXT:      (i64.const 2)
  ;; CHECK-NEXT:     )
@@ -2290,7 +2290,7 @@
  ;; CHECK-NEXT:  (block $a (type $5) (result i32 i64)
  ;; CHECK-NEXT:   (block $b (type $5) (result i32 i64)
  ;; CHECK-NEXT:    (br_table $a $b
- ;; CHECK-NEXT:     (tuple.make
+ ;; CHECK-NEXT:     (tuple.make 2
  ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:      (i64.const 42)
  ;; CHECK-NEXT:     )
@@ -2858,7 +2858,7 @@
 
  ;; CHECK:      (func $return-two (type $29) (param $0 i32) (param $1 i64) (result i32 i64)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
@@ -2872,7 +2872,7 @@
 
  ;; CHECK:      (func $return-two-first-unreachable (type $30) (param $0 i64) (result i32 i64)
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
@@ -2889,7 +2889,7 @@
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make
+ ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )

--- a/test/passes/precompute-propagate_all-features.txt
+++ b/test/passes/precompute-propagate_all-features.txt
@@ -274,18 +274,18 @@
   (local $i32s (i32 i32))
   (local $i64s (i64 i64))
   (local.set $i32s
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i32.const 0)
    )
   )
   (local.set $i64s
-   (tuple.make
+   (tuple.make 2
     (i64.const 42)
     (i64.const 0)
    )
   )
-  (tuple.make
+  (tuple.make 2
    (i32.const 42)
    (i64.const 0)
   )

--- a/test/passes/precompute-propagate_all-features.wast
+++ b/test/passes/precompute-propagate_all-features.wast
@@ -184,18 +184,18 @@
    (local $i32s (i32 i32))
    (local $i64s (i64 i64))
    (local.set $i32s
-    (tuple.make
+    (tuple.make 2
      (i32.const 42)
      (i32.const 0)
     )
    )
    (local.set $i64s
-    (tuple.make
+    (tuple.make 2
      (i64.const 42)
      (i64.const 0)
     )
    )
-   (tuple.make
+   (tuple.make 2
     (tuple.extract 0
      (local.get $i32s)
     )

--- a/test/passes/precompute_all-features.txt
+++ b/test/passes/precompute_all-features.txt
@@ -245,7 +245,7 @@
   )
  )
  (func $tuple-precompute (type $5) (result i32 i64)
-  (tuple.make
+  (tuple.make 2
    (i32.const 42)
    (i64.const 42)
   )

--- a/test/passes/precompute_all-features.wast
+++ b/test/passes/precompute_all-features.wast
@@ -49,15 +49,15 @@
       )
     )
     (drop
-     (tuple.make
+     (tuple.make 2
       (tuple.extract 0
-       (tuple.make
+       (tuple.make 2
         (i32.const 42)
         (i32.const 0)
        )
       )
       (tuple.extract 1
-       (tuple.make
+       (tuple.make 2
         (i64.const 0)
         (i64.const 42)
        )
@@ -354,15 +354,15 @@
    )
   )
   (func $tuple-precompute (result i32 i64)
-   (tuple.make
+   (tuple.make 2
     (tuple.extract 0
-     (tuple.make
+     (tuple.make 2
       (i32.const 42)
       (i32.const 0)
      )
     )
     (tuple.extract 1
-     (tuple.make
+     (tuple.make 2
       (i64.const 0)
       (i64.const 42)
      )

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -197,14 +197,14 @@
    (i32.const 1)
    (block $topmost (type $5) (result i32 i64)
     (block $block1 (type $5) (result i32 i64)
-     (tuple.make
+     (tuple.make 2
       (i32.const 12)
       (i64.const 12)
      )
     )
    )
    (block $block3 (type $5) (result i32 i64)
-    (tuple.make
+    (tuple.make 2
      (i32.const 27)
      (i64.const 27)
     )

--- a/test/passes/remove-unused-brs_enable-multivalue.wast
+++ b/test/passes/remove-unused-brs_enable-multivalue.wast
@@ -195,13 +195,13 @@
       (if (result i32 i64)
         (i32.const 1)
         (block $block1 (result i32 i64)
-          (tuple.make
+          (tuple.make 2
             (i32.const 12)
             (i64.const 12)
           )
         )
         (block $block3 (result i32 i64)
-          (tuple.make
+          (tuple.make 2
             (i32.const 27)
             (i64.const 27)
           )

--- a/test/passes/rse_all-features.txt
+++ b/test/passes/rse_all-features.txt
@@ -51,13 +51,13 @@
  (func $tuple-value (type $0)
   (local $x (i32 i64))
   (local.set $x
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 42)
    )
   )
   (drop
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 42)
    )

--- a/test/passes/rse_all-features.wast
+++ b/test/passes/rse_all-features.wast
@@ -23,10 +23,10 @@
   (func $tuple-value
     (local $x (i32 i64))
     (local.set $x
-      (tuple.make (i32.const 42) (i64.const 42))
+      (tuple.make 2 (i32.const 42) (i64.const 42))
     )
     (local.set $x
-      (tuple.make (i32.const 42) (i64.const 42))
+      (tuple.make 2 (i32.const 42) (i64.const 42))
     )
   )
   (func $unreach

--- a/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
+++ b/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
@@ -18,7 +18,7 @@
 (module
  (type $0 (func (result v128 externref)))
  (func $foo (type $0) (result v128 externref)
-  (tuple.make
+  (tuple.make 2
    (v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000)
    (ref.null noextern)
   )

--- a/test/passes/strip-target-features_roundtrip_print-features_all-features.wast
+++ b/test/passes/strip-target-features_roundtrip_print-features_all-features.wast
@@ -2,8 +2,8 @@
 ;; even if the target features section is stripped first
 
 (module
-  (func $foo (result v128 externref )
-    (tuple.make
+  (func $foo (result v128 externref)
+    (tuple.make 2
       (v128.const i32x4 0 0 0 0)
       (ref.null extern)
     )

--- a/test/spec/multivalue.wast
+++ b/test/spec/multivalue.wast
@@ -1,7 +1,7 @@
 (module
- (global $global_pair (mut (i32 i64)) (tuple.make (i32.const 0) (i64.const 0)))
+ (global $global_pair (mut (i32 i64)) (tuple.make 2 (i32.const 0) (i64.const 0)))
  (func $pair (export "pair") (result i32 i64)
-  (tuple.make
+  (tuple.make 2
    (i32.const 42)
    (i64.const 7)
   )
@@ -15,7 +15,7 @@
  )
  (func (export "tuple-global-set")
   (global.set $global_pair
-   (tuple.make
+   (tuple.make 2
     (i32.const 42)
     (i64.const 7)
    )
@@ -27,9 +27,9 @@
  )
 )
 
-(assert_return (invoke "pair") (tuple.make (i32.const 42) (i64.const 7)))
-(assert_return (invoke "tuple-local") (tuple.make (i32.const 0) (i64.const 0)))
-(assert_return (invoke "tuple-global-get") (tuple.make (i32.const 0) (i64.const 0)))
+(assert_return (invoke "pair") (tuple.make 2 (i32.const 42) (i64.const 7)))
+(assert_return (invoke "tuple-local") (tuple.make 2 (i32.const 0) (i64.const 0)))
+(assert_return (invoke "tuple-global-get") (tuple.make 2 (i32.const 0) (i64.const 0)))
 (assert_return (invoke "tuple-global-set"))
-(assert_return (invoke "tuple-global-get") (tuple.make (i32.const 42) (i64.const 7)))
-(assert_return (invoke "tail-call") (tuple.make (i32.const 42) (i64.const 7)))
+(assert_return (invoke "tuple-global-get") (tuple.make 2 (i32.const 42) (i64.const 7)))
+(assert_return (invoke "tail-call") (tuple.make 2 (i32.const 42) (i64.const 7)))

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -213,7 +213,7 @@ class FeatureValidationTest(utils.BinaryenTestCase):
         module = '''
         (module
          (func $foo (result i32 i64)
-          (tuple.make
+          (tuple.make 2
            (i32.const 42)
            (i64.const 42)
           )
@@ -237,7 +237,7 @@ class FeatureValidationTest(utils.BinaryenTestCase):
          (func $foo
           (drop
            (block (result i32 i64)
-            (tuple.make
+            (tuple.make 2
              (i32.const 42)
              (i64.const 42)
             )


### PR DESCRIPTION
Previously, the number of tuple elements was inferred from the number of
s-expression children of the `tuple.make` expression, but that scheme would not
work in the new wat parser, where s-expressions are optional and cannot be
semantically meaningful.

Update the text format to take the number of tuple elements (i.e. the tuple
arity) as an immediate. This new format will be able to be implemented in the
new parser as follow-on work.