### PR TITLE
Add a `tuple.drop` text pseudoinstruction

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -559,6 +559,7 @@ instructions = [
     # Multivalue pseudoinstructions
     ("tuple.make",           "makeTupleMake(s)"),
     ("tuple.extract",        "makeTupleExtract(s)"),
+    ("tuple.drop",           "makeTupleDrop(s)"),
     ("pop",                  "makePop(s)"),
     # Typed function references instructions
     ("call_ref",             "makeCallRef(s, /*isReturn=*/false)"),

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3404,6 +3404,9 @@ switch (buf[0]) {
         goto parse_error;
       case 'u': {
         switch (buf[6]) {
+          case 'd':
+            if (op == "tuple.drop"sv) { return makeTupleDrop(s); }
+            goto parse_error;
           case 'e':
             if (op == "tuple.extract"sv) { return makeTupleExtract(s); }
             goto parse_error;
@@ -8651,6 +8654,12 @@ switch (buf[0]) {
         goto parse_error;
       case 'u': {
         switch (buf[6]) {
+          case 'd':
+            if (op == "tuple.drop"sv) {
+              CHECK_ERR(makeTupleDrop(ctx, pos));
+              return Ok{};
+            }
+            goto parse_error;
           case 'e':
             if (op == "tuple.extract"sv) {
               CHECK_ERR(makeTupleExtract(ctx, pos));

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -119,6 +119,7 @@ template<typename Ctx> Result<> makeThrow(Ctx&, Index);
 template<typename Ctx> Result<> makeRethrow(Ctx&, Index);
 template<typename Ctx> Result<> makeTupleMake(Ctx&, Index);
 template<typename Ctx> Result<> makeTupleExtract(Ctx&, Index);
+template<typename Ctx> Result<> makeTupleDrop(Ctx&, Index);
 template<typename Ctx> Result<> makeCallRef(Ctx&, Index, bool isReturn);
 template<typename Ctx> Result<> makeRefI31(Ctx&, Index);
 template<typename Ctx> Result<> makeI31Get(Ctx&, Index, bool signed_);
@@ -1470,6 +1471,10 @@ template<typename Ctx> Result<> makeTupleMake(Ctx& ctx, Index pos) {
 }
 
 template<typename Ctx> Result<> makeTupleExtract(Ctx& ctx, Index pos) {
+  return ctx.in.err("unimplemented instruction");
+}
+
+template<typename Ctx> Result<> makeTupleDrop(Ctx& ctx, Index pos) {
   return ctx.in.err("unimplemented instruction");
 }
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1910,7 +1910,14 @@ struct PrintExpressionContents
       printResultType(curr->type);
     }
   }
-  void visitDrop(Drop* curr) { printMedium(o, "drop"); }
+  void visitDrop(Drop* curr) {
+    if (curr->value->type.isTuple()) {
+      printMedium(o, "tuple.drop ");
+      o << curr->value->type.size();
+    } else {
+      printMedium(o, "drop");
+    }
+  }
   void visitReturn(Return* curr) { printMedium(o, "return"); }
   void visitMemorySize(MemorySize* curr) {
     printMedium(o, "memory.size");

--- a/src/wasm-s-parser.h
+++ b/src/wasm-s-parser.h
@@ -289,6 +289,7 @@ private:
   Expression* makeRethrow(Element& s);
   Expression* makeTupleMake(Element& s);
   Expression* makeTupleExtract(Element& s);
+  Expression* makeTupleDrop(Element& s);
   Expression* makeCallRef(Element& s, bool isReturn);
   Expression* makeRefI31(Element& s);
   Expression* makeI31Get(Element& s, bool signed_);

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -2130,7 +2130,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        )
       )
       (atomic.fence)
-      (drop
+      (tuple.drop 4
        (tuple.make 4
         (i32.const 13)
         (i64.const 37)
@@ -4234,7 +4234,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        )
       )
       (atomic.fence)
-      (drop
+      (tuple.drop 4
        (tuple.make 4
         (i32.const 13)
         (i64.const 37)

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -2193,7 +2193,7 @@ BinaryenFeatureAll: 131071
        )
       )
       (atomic.fence)
-      (drop
+      (tuple.drop 4
        (tuple.make 4
         (i32.const 13)
         (i64.const 37)
@@ -2229,7 +2229,7 @@ BinaryenFeatureAll: 131071
       (drop
        (pop externref)
       )
-      (drop
+      (tuple.drop 4
        (pop i32 i64 f32 f64)
       )
       (drop

--- a/test/lit/basic/types-function-references.wast
+++ b/test/lit/basic/types-function-references.wast
@@ -188,7 +188,7 @@
   )
 
   ;; CHECK-TEXT:      (func $type-only-in-tuple-block (type $void)
-  ;; CHECK-TEXT-NEXT:  (drop
+  ;; CHECK-TEXT-NEXT:  (tuple.drop 3
   ;; CHECK-TEXT-NEXT:   (block $block (type $3) (result i32 (ref null $mixed_results) f64)
   ;; CHECK-TEXT-NEXT:    (unreachable)
   ;; CHECK-TEXT-NEXT:   )
@@ -230,7 +230,7 @@
   ;; CHECK-BIN-NEXT:  )
   ;; CHECK-BIN-NEXT: )
   (func $type-only-in-tuple-block
-    (drop
+    (tuple.drop 3
       (block $block (result i32 (ref null $mixed_results) f64)
         (unreachable)
       )

--- a/test/lit/multivalue.wast
+++ b/test/lit/multivalue.wast
@@ -288,7 +288,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $drop-call
-  (drop
+  (tuple.drop 2
    (call $pair)
   )
  )
@@ -308,7 +308,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $drop-tuple-make
-  (drop
+  (tuple.drop 2
    (tuple.make 2
     (i32.const 42)
     (i64.const 42)
@@ -344,7 +344,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $drop-block
-  (drop
+  (tuple.drop 2
    (block $block (result i32 i64)
     (tuple.make 2
      (i32.const 42)

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -285,7 +285,7 @@
 
  ;; CHECK:      (func $test (type $10) (param $0 (ref any)) (result (ref any) i32)
  ;; CHECK-NEXT:  (local $1 (anyref i32))
- ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:  (tuple.drop 2
  ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:    (i32.const 0)

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2150,7 +2150,7 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
-  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:      (tuple.drop 2
   ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (ref.null none)
@@ -4205,7 +4205,7 @@
   )
 
   ;; CHECK:      (func $tuples (type $0)
-  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:  (tuple.drop 2
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (i32.const 2)
@@ -4213,7 +4213,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $tuples
-    (drop
+    (tuple.drop 2
       (tuple.make 2
         (i32.const 1)
         (i32.const 2)

--- a/test/lit/passes/poppify.wast
+++ b/test/lit/passes/poppify.wast
@@ -384,7 +384,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $drop-tuple
-    (drop
+    (tuple.drop 2
       (tuple.make 2
         (i32.const 0)
         (i64.const 1)

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -326,9 +326,9 @@
   )
 
   ;; CHECK:      (func $restructure-select-no-multivalue (type $1)
-  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:  (tuple.drop 2
   ;; CHECK-NEXT:   (block $block (type $2) (result i32 i32)
-  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:    (tuple.drop 2
   ;; CHECK-NEXT:     (br_if $block
   ;; CHECK-NEXT:      (tuple.make 2
   ;; CHECK-NEXT:       (i32.const 1)
@@ -347,9 +347,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $restructure-select-no-multivalue
-    (drop
+    (tuple.drop 2
       (block $block (result i32 i32)
-        (drop
+        (tuple.drop 2
           (br_if $block
             (tuple.make 2
               (i32.const 1)

--- a/test/lit/passes/roundtrip.wast
+++ b/test/lit/passes/roundtrip.wast
@@ -32,7 +32,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $foo
-  (drop
+  (tuple.drop 2
    ;; a tuple type with a non-nullable element, that must be carefully handled
    (block $block (result funcref (ref $none))
     (tuple.make 2

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -65,7 +65,7 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch_all
-  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:    (tuple.drop 3
   ;; CHECK-NEXT:     (tuple.make 3
   ;; CHECK-NEXT:      (tuple.extract 0
   ;; CHECK-NEXT:       (local.get $nn)
@@ -97,12 +97,12 @@
     )
     (try
       (do
-        (drop
+        (tuple.drop 3
           (local.get $nn)
         )
       )
       (catch_all
-        (drop
+        (tuple.drop 3
           (local.get $nn)
         )
       )

--- a/test/lit/passes/vacuum_all-features.wast
+++ b/test/lit/passes/vacuum_all-features.wast
@@ -1286,14 +1286,14 @@
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $1
-  (drop
+  (tuple.drop 2
    (block $block (result funcref i32)
     ;; we can vaccum out all parts of this block: the br_if is not taken, there
     ;; is a nop, and the tuple at the end goes to a dropped block anyhow. this
     ;; test specifically verifies handling of tuples containing non-nullable
     ;; types, for which we try to create a zero in an intermediate step along
     ;; the way.
-    (drop
+    (tuple.drop 2
      (br_if $block
       (tuple.make 2
        (ref.func $1)

--- a/test/lit/validation/bad-non-nullable-locals.wast
+++ b/test/lit/validation/bad-non-nullable-locals.wast
@@ -65,7 +65,7 @@
     ;; Since this tuple local has a non-nullable element, it is subject to the
     ;; non-nullability rules.
     (local $x (i32 (ref any) i64))
-    (drop
+    (tuple.drop 3
       (local.get $x)
     )
   )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -840,7 +840,7 @@
 
  ;; CHECK:      (func $block-folded (type $void)
  ;; CHECK-NEXT:  (nop)
- ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:  (tuple.drop 2
  ;; CHECK-NEXT:   (block $l (type $ret2) (result i32 i32)
  ;; CHECK-NEXT:    (nop)
  ;; CHECK-NEXT:    (nop)

--- a/test/passes/precompute_all-features.wast
+++ b/test/passes/precompute_all-features.wast
@@ -48,7 +48,7 @@
         (i32.const 1)
       )
     )
-    (drop
+    (tuple.drop 2
      (tuple.make 2
       (tuple.extract 0
        (tuple.make 2

--- a/test/passes/rse_all-features.txt
+++ b/test/passes/rse_all-features.txt
@@ -56,7 +56,7 @@
     (i64.const 42)
    )
   )
-  (drop
+  (tuple.drop 2
    (tuple.make 2
     (i32.const 42)
     (i64.const 42)

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -235,7 +235,7 @@ class FeatureValidationTest(utils.BinaryenTestCase):
         module = '''
         (module
          (func $foo
-          (drop
+          (tuple.drop 2
            (block (result i32 i64)
             (tuple.make 2
              (i32.const 42)


### PR DESCRIPTION
We previously overloaded `drop` to mean both normal drops of single values and
also drops of tuple values. That works fine in the legacy text parser since it
can infer parent-child relationships directly from the s-expression structure of
the input, so it knows that a drop should drop an entire tuple if the
tuple-producing instruction is a child of the drop. The new text parser,
however, is much more like the binary parser in that it uses instruction types
to create parent-child instructions. The new parser always assumes that `drop`
is meant to drop just a single value because that's what it does in WebAssembly.

Since we want to continue to let `Drop` IR expressions consume tuples, and since
we will need a way to write tests for that IR pattern that work with the new
parser, introduce a new pseudoinstruction, `tuple.drop`, to represent drops of
tuples. This pseudoinstruction only exists in the text format and it parses to
normal `Drop` expressions. `tuple.drop` takes the arity of its operand as an
immediate, which will let the new parser parse it correctly in the future.