### PR TITLE
Add an arity immediate to tuple.extract

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -391,7 +391,7 @@ def pick_initial_contents():
         #   (select
         #    (struct.new $other)
         #    (struct.new $other)
-        #    (tuple.extract 1
+        #    (tuple.extract 2 1
         #     (tuple.make 2
         #      (i32.const 0)
         #      (i32.const 0)

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -1998,6 +1998,7 @@ struct PrintExpressionContents
   }
   void visitTupleExtract(TupleExtract* curr) {
     printMedium(o, "tuple.extract ");
+    o << curr->tuple->type.size() << " ";
     o << curr->index;
   }
   void visitRefI31(RefI31* curr) { printMedium(o, "ref.i31"); }

--- a/src/passes/TupleOptimization.cpp
+++ b/src/passes/TupleOptimization.cpp
@@ -22,7 +22,7 @@
 //  (local.set $tuple
 //    (tuple.make 3 (A) (B) (C)))
 //  (use
-//    (tuple.extract 0
+//    (tuple.extract 3 0
 //      (local.get $tuple)))
 //
 // If there are no other uses, then we just need one of the three lanes. By

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2872,11 +2872,16 @@ Expression* SExpressionWasmBuilder::makeTupleMake(Element& s) {
 
 Expression* SExpressionWasmBuilder::makeTupleExtract(Element& s) {
   auto ret = allocator.alloc<TupleExtract>();
-  ret->index = parseIndex(*s[1]);
-  ret->tuple = parseExpression(s[2]);
-  if (ret->tuple->type != Type::unreachable &&
-      ret->index >= ret->tuple->type.size()) {
-    throw SParseException("Bad index on tuple.extract", s, *s[1]);
+  size_t arity = std::stoll(s[1]->toString());
+  ret->index = parseIndex(*s[2]);
+  ret->tuple = parseExpression(s[3]);
+  if (ret->tuple->type != Type::unreachable) {
+    if (arity != ret->tuple->type.size()) {
+      throw SParseException("Unexpected tuple.extract arity", s, *s[1]);
+    }
+    if (ret->index >= ret->tuple->type.size()) {
+      throw SParseException("Bad index on tuple.extract", s, *s[2]);
+    }
   }
   ret->finalize();
   return ret;

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -1765,7 +1765,7 @@ console.log("# TupleExtract");
   assert(
     theTupleExtract.toText()
     ==
-    "(tuple.extract 0\n (tuple.make 2\n  (f64.const 3)\n  (f64.const 4)\n )\n)\n"
+    "(tuple.extract 2 0\n (tuple.make 2\n  (f64.const 3)\n  (f64.const 4)\n )\n)\n"
   );
 
   module.dispose();

--- a/test/binaryen.js/expressions.js.txt
+++ b/test/binaryen.js/expressions.js.txt
@@ -323,7 +323,7 @@
 )
 
 # TupleExtract
-(tuple.extract 0
+(tuple.extract 2 0
  (tuple.make 2
   (f64.const 3)
   (f64.const 4)

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -2139,7 +2139,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        )
       )
       (drop
-       (tuple.extract 2
+       (tuple.extract 4 2
         (tuple.make 4
          (i32.const 13)
          (i64.const 37)
@@ -4243,7 +4243,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        )
       )
       (drop
-       (tuple.extract 2
+       (tuple.extract 4 2
         (tuple.make 4
          (i32.const 13)
          (i64.const 37)

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -2202,7 +2202,7 @@ BinaryenFeatureAll: 131071
        )
       )
       (drop
-       (tuple.extract 2
+       (tuple.extract 4 2
         (tuple.make 4
          (i32.const 13)
          (i64.const 37)

--- a/test/exception-handling.wast
+++ b/test/exception-handling.wast
@@ -30,7 +30,7 @@
       (catch $e-i32-i64
         (local.set $x (pop i32 i64))
         (drop
-          (tuple.extract 0
+          (tuple.extract 2 0
             (local.get $x)
           )
         )

--- a/test/exception-handling.wast.from-wast
+++ b/test/exception-handling.wast.from-wast
@@ -42,7 +42,7 @@
      (pop i32 i64)
     )
     (drop
-     (tuple.extract 0
+     (tuple.extract 2 0
       (local.get $x)
      )
     )

--- a/test/exception-handling.wast.fromBinary
+++ b/test/exception-handling.wast.fromBinary
@@ -47,12 +47,12 @@
     (local.set $x
      (block (result i32)
       (local.set $3
-       (tuple.extract 0
+       (tuple.extract 2 0
         (local.get $2)
        )
       )
       (local.set $1
-       (tuple.extract 1
+       (tuple.extract 2 1
         (local.get $2)
        )
       )

--- a/test/exception-handling.wast.fromBinary.noDebugInfo
+++ b/test/exception-handling.wast.fromBinary.noDebugInfo
@@ -47,12 +47,12 @@
     (local.set $0
      (block (result i32)
       (local.set $3
-       (tuple.extract 0
+       (tuple.extract 2 0
         (local.get $2)
        )
       )
       (local.set $1
-       (tuple.extract 1
+       (tuple.extract 2 1
         (local.get $2)
        )
       )

--- a/test/lit/basic/types-function-references.wast
+++ b/test/lit/basic/types-function-references.wast
@@ -206,19 +206,19 @@
   ;; CHECK-BIN-NEXT:  (drop
   ;; CHECK-BIN-NEXT:   (block (result i32)
   ;; CHECK-BIN-NEXT:    (local.set $2
-  ;; CHECK-BIN-NEXT:     (tuple.extract 0
+  ;; CHECK-BIN-NEXT:     (tuple.extract 3 0
   ;; CHECK-BIN-NEXT:      (local.get $0)
   ;; CHECK-BIN-NEXT:     )
   ;; CHECK-BIN-NEXT:    )
   ;; CHECK-BIN-NEXT:    (drop
   ;; CHECK-BIN-NEXT:     (block (result (ref null $mixed_results))
   ;; CHECK-BIN-NEXT:      (local.set $1
-  ;; CHECK-BIN-NEXT:       (tuple.extract 1
+  ;; CHECK-BIN-NEXT:       (tuple.extract 3 1
   ;; CHECK-BIN-NEXT:        (local.get $0)
   ;; CHECK-BIN-NEXT:       )
   ;; CHECK-BIN-NEXT:      )
   ;; CHECK-BIN-NEXT:      (drop
-  ;; CHECK-BIN-NEXT:       (tuple.extract 2
+  ;; CHECK-BIN-NEXT:       (tuple.extract 3 2
   ;; CHECK-BIN-NEXT:        (local.get $0)
   ;; CHECK-BIN-NEXT:       )
   ;; CHECK-BIN-NEXT:      )
@@ -444,19 +444,19 @@
 ;; CHECK-BIN-NODEBUG-NEXT:  (drop
 ;; CHECK-BIN-NODEBUG-NEXT:   (block (result i32)
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.set $2
-;; CHECK-BIN-NODEBUG-NEXT:     (tuple.extract 0
+;; CHECK-BIN-NODEBUG-NEXT:     (tuple.extract 3 0
 ;; CHECK-BIN-NODEBUG-NEXT:      (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:     )
 ;; CHECK-BIN-NODEBUG-NEXT:    )
 ;; CHECK-BIN-NODEBUG-NEXT:    (drop
 ;; CHECK-BIN-NODEBUG-NEXT:     (block (result (ref null $0))
 ;; CHECK-BIN-NODEBUG-NEXT:      (local.set $1
-;; CHECK-BIN-NODEBUG-NEXT:       (tuple.extract 1
+;; CHECK-BIN-NODEBUG-NEXT:       (tuple.extract 3 1
 ;; CHECK-BIN-NODEBUG-NEXT:        (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:       )
 ;; CHECK-BIN-NODEBUG-NEXT:      )
 ;; CHECK-BIN-NODEBUG-NEXT:      (drop
-;; CHECK-BIN-NODEBUG-NEXT:       (tuple.extract 2
+;; CHECK-BIN-NODEBUG-NEXT:       (tuple.extract 3 2
 ;; CHECK-BIN-NODEBUG-NEXT:        (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:       )
 ;; CHECK-BIN-NODEBUG-NEXT:      )

--- a/test/lit/blocktype.wast
+++ b/test/lit/blocktype.wast
@@ -33,20 +33,20 @@
  ;; RTRIP-NEXT:     (call $f1)
  ;; RTRIP-NEXT:    )
  ;; RTRIP-NEXT:    (tuple.make 2
- ;; RTRIP-NEXT:     (tuple.extract 0
+ ;; RTRIP-NEXT:     (tuple.extract 2 0
  ;; RTRIP-NEXT:      (local.get $0)
  ;; RTRIP-NEXT:     )
- ;; RTRIP-NEXT:     (tuple.extract 1
+ ;; RTRIP-NEXT:     (tuple.extract 2 1
  ;; RTRIP-NEXT:      (local.get $0)
  ;; RTRIP-NEXT:     )
  ;; RTRIP-NEXT:    )
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
  ;; RTRIP-NEXT:  (tuple.make 2
- ;; RTRIP-NEXT:   (tuple.extract 0
+ ;; RTRIP-NEXT:   (tuple.extract 2 0
  ;; RTRIP-NEXT:    (local.get $1)
  ;; RTRIP-NEXT:   )
- ;; RTRIP-NEXT:   (tuple.extract 1
+ ;; RTRIP-NEXT:   (tuple.extract 2 1
  ;; RTRIP-NEXT:    (local.get $1)
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
@@ -72,20 +72,20 @@
  ;; RTRIP-NEXT:     (call $f2)
  ;; RTRIP-NEXT:    )
  ;; RTRIP-NEXT:    (tuple.make 2
- ;; RTRIP-NEXT:     (tuple.extract 0
+ ;; RTRIP-NEXT:     (tuple.extract 2 0
  ;; RTRIP-NEXT:      (local.get $0)
  ;; RTRIP-NEXT:     )
- ;; RTRIP-NEXT:     (tuple.extract 1
+ ;; RTRIP-NEXT:     (tuple.extract 2 1
  ;; RTRIP-NEXT:      (local.get $0)
  ;; RTRIP-NEXT:     )
  ;; RTRIP-NEXT:    )
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
  ;; RTRIP-NEXT:  (tuple.make 2
- ;; RTRIP-NEXT:   (tuple.extract 0
+ ;; RTRIP-NEXT:   (tuple.extract 2 0
  ;; RTRIP-NEXT:    (local.get $1)
  ;; RTRIP-NEXT:   )
- ;; RTRIP-NEXT:   (tuple.extract 1
+ ;; RTRIP-NEXT:   (tuple.extract 2 1
  ;; RTRIP-NEXT:    (local.get $1)
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )

--- a/test/lit/ctor-eval/multivalue-local.wast
+++ b/test/lit/ctor-eval/multivalue-local.wast
@@ -35,7 +35,7 @@
   ;; Use the locals so they are not trivally removed.
   (i32.add
    (local.get $0)
-   (tuple.extract 0
+   (tuple.extract 2 0
     (local.get $1)
    )
   )

--- a/test/lit/multivalue-stack-ir.wast
+++ b/test/lit/multivalue-stack-ir.wast
@@ -39,7 +39,7 @@
    )
   )
   (local.set $f32
-   (tuple.extract 0
+   (tuple.extract 2 0
     (local.get $pair)
    )
   )

--- a/test/lit/multivalue.wast
+++ b/test/lit/multivalue.wast
@@ -36,19 +36,19 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (block (result i32)
  ;; CHECK-NEXT:   (local.set $2
- ;; CHECK-NEXT:    (tuple.extract 0
+ ;; CHECK-NEXT:    (tuple.extract 3 0
  ;; CHECK-NEXT:     (local.get $0)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block (result i64)
  ;; CHECK-NEXT:     (local.set $1
- ;; CHECK-NEXT:      (tuple.extract 1
+ ;; CHECK-NEXT:      (tuple.extract 3 1
  ;; CHECK-NEXT:       (local.get $0)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (drop
- ;; CHECK-NEXT:      (tuple.extract 2
+ ;; CHECK-NEXT:      (tuple.extract 3 2
  ;; CHECK-NEXT:       (local.get $0)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
@@ -59,7 +59,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $get-first (result i32)
-  (tuple.extract 0
+  (tuple.extract 3 0
    (call $triple)
   )
  )
@@ -75,19 +75,19 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block (result i32)
  ;; CHECK-NEXT:    (local.set $3
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 3 0
  ;; CHECK-NEXT:      (local.get $1)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (block (result i64)
  ;; CHECK-NEXT:      (local.set $2
- ;; CHECK-NEXT:       (tuple.extract 1
+ ;; CHECK-NEXT:       (tuple.extract 3 1
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (drop
- ;; CHECK-NEXT:       (tuple.extract 2
+ ;; CHECK-NEXT:       (tuple.extract 3 2
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
@@ -100,7 +100,7 @@
  ;; CHECK-NEXT:  (local.get $0)
  ;; CHECK-NEXT: )
  (func $get-second (result i64)
-  (tuple.extract 1
+  (tuple.extract 3 1
    (call $triple)
   )
  )
@@ -116,19 +116,19 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block (result i32)
  ;; CHECK-NEXT:    (local.set $3
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 3 0
  ;; CHECK-NEXT:      (local.get $1)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (block (result i64)
  ;; CHECK-NEXT:      (local.set $2
- ;; CHECK-NEXT:       (tuple.extract 1
+ ;; CHECK-NEXT:       (tuple.extract 3 1
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (local.set $0
- ;; CHECK-NEXT:       (tuple.extract 2
+ ;; CHECK-NEXT:       (tuple.extract 3 2
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
@@ -141,7 +141,7 @@
  ;; CHECK-NEXT:  (local.get $0)
  ;; CHECK-NEXT: )
  (func $get-third (result f32)
-  (tuple.extract 2
+  (tuple.extract 3 2
    (call $triple)
   )
  )
@@ -161,19 +161,19 @@
  ;; CHECK-NEXT:  (local.set $x
  ;; CHECK-NEXT:   (block (result i32)
  ;; CHECK-NEXT:    (local.set $7
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 3 0
  ;; CHECK-NEXT:      (local.get $5)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (local.set $1
  ;; CHECK-NEXT:     (block (result i64)
  ;; CHECK-NEXT:      (local.set $6
- ;; CHECK-NEXT:       (tuple.extract 1
+ ;; CHECK-NEXT:       (tuple.extract 3 1
  ;; CHECK-NEXT:        (local.get $5)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (local.set $3
- ;; CHECK-NEXT:       (tuple.extract 2
+ ;; CHECK-NEXT:       (tuple.extract 3 2
  ;; CHECK-NEXT:        (local.get $5)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
@@ -195,13 +195,13 @@
    (call $triple)
   )
   (tuple.make 3
-   (tuple.extract 2
+   (tuple.extract 3 2
     (local.get $x)
    )
-   (tuple.extract 1
+   (tuple.extract 3 1
     (local.get $x)
    )
-   (tuple.extract 0
+   (tuple.extract 3 0
     (local.get $x)
    )
   )
@@ -217,7 +217,7 @@
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $unreachable (result i64)
-  (tuple.extract 1
+  (tuple.extract 3 1
    (tuple.make 3
     (i32.const 42)
     (i64.const 7)
@@ -257,7 +257,7 @@
    )
   )
   (drop
-   (tuple.extract 1
+   (tuple.extract 2 1
     (global.get $g1)
    )
   )
@@ -274,12 +274,12 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block (result i32)
  ;; CHECK-NEXT:    (local.set $1
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 2 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
@@ -330,12 +330,12 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block (result i32)
  ;; CHECK-NEXT:    (local.set $1
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 2 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
@@ -404,10 +404,10 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 2
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -438,20 +438,20 @@
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (tuple.make 2
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 2 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 2
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -486,13 +486,13 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 3
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 3 0
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 3 1
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 2
+ ;; CHECK-NEXT:   (tuple.extract 3 2
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -524,10 +524,10 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 2
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -558,20 +558,20 @@
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (tuple.make 2
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 2 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 2
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/parse-bad-tuple-extract-index.wast
+++ b/test/lit/parse-bad-tuple-extract-index.wast
@@ -2,11 +2,11 @@
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: [parse exception: Bad index on tuple.extract: ( tuple.extract 2 ( tuple.make  2 ( i32.const 0 ) ( i64.const 1 ) ) ) (at 9:17)]
+;; CHECK: [parse exception: Bad index on tuple.extract: ( tuple.extract 2 2 ( tuple.make  2 ( i32.const 0 ) ( i64.const 1 ) ) ) (at 9:19)]
 
 (module
  (func
-  (tuple.extract 2
+  (tuple.extract 2 2
    (tuple.make 2
     (i32.const 0)
     (i64.const 1)

--- a/test/lit/passes/asyncify_enable-multivalue.wast
+++ b/test/lit/passes/asyncify_enable-multivalue.wast
@@ -1867,13 +1867,13 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.store
   ;; CHECK-NEXT:    (local.get $6)
-  ;; CHECK-NEXT:    (tuple.extract 0
+  ;; CHECK-NEXT:    (tuple.extract 2 0
   ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i64.store offset=4 align=4
   ;; CHECK-NEXT:    (local.get $6)
-  ;; CHECK-NEXT:    (tuple.extract 1
+  ;; CHECK-NEXT:    (tuple.extract 2 1
   ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/coalesce-locals-gc-nn.wast
+++ b/test/lit/passes/coalesce-locals-gc-nn.wast
@@ -18,22 +18,22 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (call $nn-locals
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (call $nn-locals
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (local.get $2)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (call $nn-locals
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (call $nn-locals
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $2)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -60,22 +60,22 @@
    )
   )
   (call $nn-locals
-   (tuple.extract 0
+   (tuple.extract 2 0
     (local.get $x)
    )
   )
   (call $nn-locals
-   (tuple.extract 0
+   (tuple.extract 2 0
     (local.get $y)
    )
   )
   (call $nn-locals
-   (tuple.extract 1
+   (tuple.extract 2 1
     (local.get $x)
    )
   )
   (call $nn-locals
-   (tuple.extract 1
+   (tuple.extract 2 1
     (local.get $y)
    )
   )

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -313,21 +313,21 @@
  ;; CHECK-NEXT:      (i32.const 0)
  ;; CHECK-NEXT:      (tuple.make 2
  ;; CHECK-NEXT:       (ref.as_non_null
- ;; CHECK-NEXT:        (tuple.extract 0
+ ;; CHECK-NEXT:        (tuple.extract 2 0
  ;; CHECK-NEXT:         (local.get $1)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (tuple.extract 1
+ ;; CHECK-NEXT:       (tuple.extract 2 1
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:      (tuple.make 2
  ;; CHECK-NEXT:       (ref.as_non_null
- ;; CHECK-NEXT:        (tuple.extract 0
+ ;; CHECK-NEXT:        (tuple.extract 2 0
  ;; CHECK-NEXT:         (local.get $1)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (tuple.extract 1
+ ;; CHECK-NEXT:       (tuple.extract 2 1
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
@@ -335,11 +335,11 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (ref.as_non_null
- ;; CHECK-NEXT:      (tuple.extract 0
+ ;; CHECK-NEXT:      (tuple.extract 2 0
  ;; CHECK-NEXT:       (local.get $1)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $1)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
@@ -347,11 +347,11 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 2
  ;; CHECK-NEXT:   (ref.as_non_null
- ;; CHECK-NEXT:    (tuple.extract 0
+ ;; CHECK-NEXT:    (tuple.extract 2 0
  ;; CHECK-NEXT:     (local.get $1)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (tuple.extract 1
+ ;; CHECK-NEXT:   (tuple.extract 2 1
  ;; CHECK-NEXT:    (local.get $1)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -239,7 +239,7 @@
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local $i31 i31ref)
  ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (tuple.extract 0
+ ;; CHECK-NEXT:   (tuple.extract 2 0
  ;; CHECK-NEXT:    (call $refine-return-tuple)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -253,7 +253,7 @@
   (local $i31 (ref null i31))
 
   (local.set $temp
-   (tuple.extract 0
+   (tuple.extract 2 0
     (call $refine-return-tuple)
    )
   )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2164,7 +2164,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (tuple.extract 1
+  ;; CHECK-NEXT:     (tuple.extract 2 1
   ;; CHECK-NEXT:      (pop anyref anyref)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -2182,7 +2182,7 @@
       (do)
       (catch $tag
         (drop
-          (tuple.extract 0
+          (tuple.extract 2 0
             (pop (ref null any) (ref null any))
           )
         )
@@ -2193,7 +2193,7 @@
       (do)
       (catch $tag
         (drop
-          (tuple.extract 1
+          (tuple.extract 2 1
             (pop (ref null any) (ref null any))
           )
         )

--- a/test/lit/passes/optimize-instructions-multivalue.wast
+++ b/test/lit/passes/optimize-instructions-multivalue.wast
@@ -5,7 +5,7 @@
   ;; CHECK:      (func $if-identical-arms-tuple (param $x i32) (result i32)
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
-  ;; CHECK-NEXT:  (tuple.extract 0
+  ;; CHECK-NEXT:  (tuple.extract 2 0
   ;; CHECK-NEXT:   (if (type $2) (result i32 i32)
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:    (local.get $tuple)
@@ -19,10 +19,10 @@
     (if (result i32)
       (local.get $x)
       ;; The tuple.extract can be hoisted out.
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple2)
       )
     )
@@ -31,10 +31,10 @@
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
   ;; CHECK-NEXT:  (select
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (local.get $tuple)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (local.get $tuple2)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (local.get $x)
@@ -46,10 +46,10 @@
     (select
       ;; The tuple.extract cannot be hoisted out, as the spec disallows a
       ;; select with multiple values in its arms.
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple2)
       )
       (local.get $x)
@@ -67,7 +67,7 @@
   ;; CHECK-NEXT: )
   (func $extract-make (param $x i32) (param $y i32) (result i32)
     ;; An extraction from a make can be simplified to just get the right lane.
-    (tuple.extract 0
+    (tuple.extract 2 0
       (tuple.make 2
         (local.get $x)
         (local.get $y)
@@ -86,7 +86,7 @@
   ;; CHECK-NEXT: )
   (func $extract-make-2 (param $x i32) (param $y i32) (result i32)
     ;; As above, but the second lane.
-    (tuple.extract 1
+    (tuple.extract 2 1
       (tuple.make 2
         (local.get $x)
         (local.get $y)
@@ -95,7 +95,7 @@
   )
 
   ;; CHECK:      (func $extract-make-unreachable (param $x i32) (param $y i32) (result i32)
-  ;; CHECK-NEXT:  (tuple.extract 0
+  ;; CHECK-NEXT:  (tuple.extract 1 0
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:    (local.get $y)
@@ -103,7 +103,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $extract-make-unreachable (param $x i32) (param $y i32) (result i32)
-    (tuple.extract 0
+    (tuple.extract 2 0
       (tuple.make 2
         (unreachable) ;; because of this we should do nothing
         (local.get $y)

--- a/test/lit/passes/optimize-stack-ir.wast
+++ b/test/lit/passes/optimize-stack-ir.wast
@@ -1407,7 +1407,7 @@
   ;; CHECK-NEXT:  tuple.make 2
   ;; CHECK-NEXT:  local.set $pair
   ;; CHECK-NEXT:  local.get $pair
-  ;; CHECK-NEXT:  tuple.extract 0
+  ;; CHECK-NEXT:  tuple.extract 2 0
   ;; CHECK-NEXT:  local.set $f32
   ;; CHECK-NEXT: )
   (func $tuple-local2stack
@@ -1422,7 +1422,7 @@
       )
     )
     (local.set $f32
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $pair)
       )
     )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -649,11 +649,11 @@
   ;; CHECK-NEXT:     (local.set $scratch
   ;; CHECK-NEXT:      (call $outline$)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (tuple.extract 0
+  ;; CHECK-NEXT:     (tuple.extract 2 0
   ;; CHECK-NEXT:      (local.get $scratch)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (tuple.extract 1
+  ;; CHECK-NEXT:    (tuple.extract 2 1
   ;; CHECK-NEXT:     (local.get $scratch)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -664,11 +664,11 @@
   ;; CHECK-NEXT:     (local.set $scratch_1
   ;; CHECK-NEXT:      (call $outline$)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (tuple.extract 0
+  ;; CHECK-NEXT:     (tuple.extract 2 0
   ;; CHECK-NEXT:      (local.get $scratch_1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (tuple.extract 1
+  ;; CHECK-NEXT:    (tuple.extract 2 1
   ;; CHECK-NEXT:     (local.get $scratch_1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/poppify.wast
+++ b/test/lit/passes/poppify.wast
@@ -300,7 +300,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $extract-first (result i32)
-    (tuple.extract 0
+    (tuple.extract 3 0
       (tuple.make 3
         (i32.const 0)
         (i64.const 1)
@@ -326,7 +326,7 @@
   ;; CHECK-NEXT:  (local.get $0)
   ;; CHECK-NEXT: )
   (func $extract-middle (result i64)
-    (tuple.extract 1
+    (tuple.extract 3 1
       (tuple.make 3
         (i32.const 0)
         (i64.const 1)
@@ -352,7 +352,7 @@
   ;; CHECK-NEXT:  (local.get $0)
   ;; CHECK-NEXT: )
   (func $extract-last (result f32)
-    (tuple.extract 2
+    (tuple.extract 3 2
       (tuple.make 3
         (i32.const 0)
         (i64.const 1)

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -794,7 +794,7 @@
   )
   (drop
    (struct.get $B 0
-    (tuple.extract 0
+    (tuple.extract 2 0
      (local.get $temp)
     )
    )

--- a/test/lit/passes/roundtrip.wast
+++ b/test/lit/passes/roundtrip.wast
@@ -18,12 +18,12 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block (result funcref)
  ;; CHECK-NEXT:    (local.set $1
- ;; CHECK-NEXT:     (tuple.extract 0
+ ;; CHECK-NEXT:     (tuple.extract 2 0
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -67,15 +67,15 @@
   ;; CHECK-NEXT:   (catch_all
   ;; CHECK-NEXT:    (tuple.drop 3
   ;; CHECK-NEXT:     (tuple.make 3
-  ;; CHECK-NEXT:      (tuple.extract 0
+  ;; CHECK-NEXT:      (tuple.extract 3 0
   ;; CHECK-NEXT:       (local.get $nn)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (ref.as_non_null
-  ;; CHECK-NEXT:       (tuple.extract 1
+  ;; CHECK-NEXT:       (tuple.extract 3 1
   ;; CHECK-NEXT:        (local.get $nn)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (tuple.extract 2
+  ;; CHECK-NEXT:      (tuple.extract 3 2
   ;; CHECK-NEXT:       (local.get $nn)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )

--- a/test/lit/passes/stack-ir-non-nullable.wast
+++ b/test/lit/passes/stack-ir-non-nullable.wast
@@ -346,7 +346,7 @@
  ;; CHECK-NEXT:  tuple.make 2
  ;; CHECK-NEXT:  local.set $temp
  ;; CHECK-NEXT:  local.get $temp
- ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT:  tuple.extract 2 1
  ;; CHECK-NEXT:  i32.const 1
  ;; CHECK-NEXT:  ref.i31
  ;; CHECK-NEXT:  ref.eq
@@ -364,7 +364,7 @@
  ;; CHECK-NEXT:   local.set $temp
  ;; CHECK-NEXT:  end
  ;; CHECK-NEXT:  local.get $temp
- ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT:  tuple.extract 2 1
  ;; CHECK-NEXT: )
  (func $if-nondefaultable (param $param (ref eq)) (result (ref eq))
   (local $temp (i32 (ref eq)))
@@ -379,7 +379,7 @@
   )
   (if
    (ref.eq
-    (tuple.extract 1
+    (tuple.extract 2 1
      (local.get $temp)
     )
     (i31.new
@@ -403,7 +403,7 @@
     )
    )
   )
-  (tuple.extract 1
+  (tuple.extract 2 1
    (local.get $temp)
   )
  )
@@ -415,7 +415,7 @@
  ;; CHECK-NEXT:  tuple.make 2
  ;; CHECK-NEXT:  local.set $temp
  ;; CHECK-NEXT:  local.get $temp
- ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT:  tuple.extract 2 1
  ;; CHECK-NEXT:  i32.const 1
  ;; CHECK-NEXT:  ref.i31
  ;; CHECK-NEXT:  ref.eq
@@ -433,7 +433,7 @@
  ;; CHECK-NEXT:   local.set $temp
  ;; CHECK-NEXT:  end
  ;; CHECK-NEXT:  local.get $temp
- ;; CHECK-NEXT:  tuple.extract 1
+ ;; CHECK-NEXT:  tuple.extract 2 1
  ;; CHECK-NEXT: )
  (func $if-defaultable (param $param (ref null eq)) (result (ref null eq))
   (local $temp (i32 (ref null eq)))
@@ -447,7 +447,7 @@
   )
   (if
    (ref.eq
-    (tuple.extract 1
+    (tuple.extract 2 1
      (local.get $temp)
     )
     (i31.new
@@ -471,7 +471,7 @@
     )
    )
   )
-  (tuple.extract 1
+  (tuple.extract 2 1
    (local.get $temp)
   )
  )

--- a/test/lit/passes/tuple-optimization.wast
+++ b/test/lit/passes/tuple-optimization.wast
@@ -41,12 +41,12 @@
     ;; The default value of the tuple lanes is used here in the new locals we
     ;; add.
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple)
       )
     )
@@ -55,12 +55,12 @@
   ;; CHECK:      (func $just-get-bad (type $1) (result i32 i32)
   ;; CHECK-NEXT:  (local $tuple (i32 i32))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (local.get $tuple)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 1
+  ;; CHECK-NEXT:   (tuple.extract 2 1
   ;; CHECK-NEXT:    (local.get $tuple)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -69,12 +69,12 @@
   (func $just-get-bad (result i32 i32)
     (local $tuple (i32 i32))
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple)
       )
     )
@@ -114,18 +114,18 @@
       )
     )
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple)
       )
     )
     ;; Add another get for more coverage
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
     )
@@ -180,23 +180,23 @@
     )
     ;; Read the first tuple.
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple)
       )
     )
     ;; Read the second tuple.
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple2)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple2)
       )
     )
@@ -223,7 +223,7 @@
   (func $just-tee
     (local $tuple (i32 i32))
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.tee $tuple
           (tuple.make 2
             (i32.const 1)
@@ -481,7 +481,7 @@
 
   ;; CHECK:      (func $make-extract-no-local (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
@@ -493,7 +493,7 @@
     ;; Tuple operations without locals. We do nothing here; other passes can
     ;; help on this kind of thing.
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (tuple.make 2
           (i32.const 1)
           (i32.const 2)
@@ -515,7 +515,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (tuple.make 2
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:     (i32.const 2)
@@ -534,7 +534,7 @@
     ;; The code below is as in the previous testcase, but now before us there
     ;; is an unrelated local that can be optimized. We should remain as before.
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (tuple.make 2
           (i32.const 1)
           (i32.const 2)
@@ -580,12 +580,12 @@
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 1 0
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 1
+  ;; CHECK-NEXT:   (tuple.extract 1 1
   ;; CHECK-NEXT:    (local.tee $tuple
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -613,12 +613,12 @@
       (unreachable)
     )
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (unreachable)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.tee $tuple
           (unreachable)
         )
@@ -682,7 +682,7 @@
     (local $tuple2 (i32 i32))
     (local $tuple3 (i32 i32))
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.tee $tuple
           (local.tee $tuple2
             (local.tee $tuple3
@@ -773,17 +773,17 @@
     )
     ;; Read from each.
     (drop
-      (tuple.extract 0
+      (tuple.extract 3 0
         (local.get $tuple)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 3 1
         (local.get $tuple2)
       )
     )
     (drop
-      (tuple.extract 2
+      (tuple.extract 3 2
         (local.get $tuple3)
       )
     )
@@ -807,17 +807,17 @@
   ;; CHECK-NEXT:   (local.get $tuple2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 3 0
   ;; CHECK-NEXT:    (local.get $tuple)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 1
+  ;; CHECK-NEXT:   (tuple.extract 3 1
   ;; CHECK-NEXT:    (local.get $tuple2)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 2
+  ;; CHECK-NEXT:   (tuple.extract 3 2
   ;; CHECK-NEXT:    (local.get $tuple3)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -844,17 +844,17 @@
     )
     ;; Read from each.
     (drop
-      (tuple.extract 0
+      (tuple.extract 3 0
         (local.get $tuple)
       )
     )
     (drop
-      (tuple.extract 1
+      (tuple.extract 3 1
         (local.get $tuple2)
       )
     )
     (drop
-      (tuple.extract 2
+      (tuple.extract 3 2
         (local.get $tuple3)
       )
     )
@@ -867,7 +867,7 @@
   ;; CHECK-NEXT:   (call $set-call)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (local.get $tuple)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -883,7 +883,7 @@
       (call $set-call)
     )
     (drop
-      (tuple.extract 0
+      (tuple.extract 2 0
         (local.get $tuple)
       )
     )
@@ -938,10 +938,10 @@
     )
     (local.set $tuple3
       (tuple.make 3
-        (tuple.extract 0
+        (tuple.extract 2 0
           (local.get $tuple2)
         )
-        (tuple.extract 1
+        (tuple.extract 2 1
           (local.get $tuple2)
         )
         (i32.const 3)
@@ -949,12 +949,12 @@
     )
     ;; Read from each.
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple2)
       )
     )
     (drop
-      (tuple.extract 2
+      (tuple.extract 3 2
         (local.get $tuple3)
       )
     )
@@ -1006,22 +1006,22 @@
     )
     (local.set $tuple2
       (tuple.make 2
-        (tuple.extract 0
+        (tuple.extract 3 0
           (local.get $tuple3)
         )
-        (tuple.extract 1
+        (tuple.extract 3 1
           (local.get $tuple3)
         )
       )
     )
     ;; Read from each.
     (drop
-      (tuple.extract 1
+      (tuple.extract 2 1
         (local.get $tuple2)
       )
     )
     (drop
-      (tuple.extract 2
+      (tuple.extract 3 2
         (local.get $tuple3)
       )
     )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -884,13 +884,13 @@
  ;; CHECK-NEXT:         )
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (tuple.extract 0
+ ;; CHECK-NEXT:       (tuple.extract 2 0
  ;; CHECK-NEXT:        (local.get $scratch_1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (drop
- ;; CHECK-NEXT:      (tuple.extract 1
+ ;; CHECK-NEXT:      (tuple.extract 2 1
  ;; CHECK-NEXT:       (local.get $scratch_1)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
@@ -3008,13 +3008,13 @@
  ;; CHECK-NEXT:        (local.get $1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (tuple.extract 0
+ ;; CHECK-NEXT:      (tuple.extract 2 0
  ;; CHECK-NEXT:       (local.get $scratch)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $scratch)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
@@ -3034,13 +3034,13 @@
  ;; CHECK-NEXT:        (local.get $2)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (tuple.extract 0
+ ;; CHECK-NEXT:      (tuple.extract 2 0
  ;; CHECK-NEXT:       (local.get $scratch_5)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (tuple.extract 1
+ ;; CHECK-NEXT:     (tuple.extract 2 1
  ;; CHECK-NEXT:      (local.get $scratch_5)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )

--- a/test/passes/precompute-propagate_all-features.wast
+++ b/test/passes/precompute-propagate_all-features.wast
@@ -196,10 +196,10 @@
     )
    )
    (tuple.make 2
-    (tuple.extract 0
+    (tuple.extract 2 0
      (local.get $i32s)
     )
-    (tuple.extract 1
+    (tuple.extract 2 1
      (local.get $i64s)
     )
    )

--- a/test/passes/precompute_all-features.wast
+++ b/test/passes/precompute_all-features.wast
@@ -50,13 +50,13 @@
     )
     (tuple.drop 2
      (tuple.make 2
-      (tuple.extract 0
+      (tuple.extract 2 0
        (tuple.make 2
         (i32.const 42)
         (i32.const 0)
        )
       )
-      (tuple.extract 1
+      (tuple.extract 2 1
        (tuple.make 2
         (i64.const 0)
         (i64.const 42)
@@ -355,13 +355,13 @@
   )
   (func $tuple-precompute (result i32 i64)
    (tuple.make 2
-    (tuple.extract 0
+    (tuple.extract 2 0
      (tuple.make 2
       (i32.const 42)
       (i32.const 0)
      )
     )
-    (tuple.extract 1
+    (tuple.extract 2 1
      (tuple.make 2
       (i64.const 0)
       (i64.const 42)

--- a/test/spec/exception-handling.wast
+++ b/test/spec/exception-handling.wast
@@ -84,7 +84,7 @@
         (local.set $x
           (pop i32 f32)
         )
-        (tuple.extract 0
+        (tuple.extract 2 0
           (local.get $x)
         )
       )


### PR DESCRIPTION
Once support for tuple.extract lands in the new WAT parser, this arity immediate
will let the parser determine how many values it should pop off the stack to
serve as the tuple operand to `tuple.extract`. This will usually coincide with
the arity of a tuple-producing instruction on top of the stack, but in the
spirit of treating the input as a proper stack machine, it will not have to and
the parser will still work correctly.