### PR TITLE
[EH] Add validation for new instructions

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2492,7 +2492,7 @@ void FunctionValidator::visitTryTable(TryTable* curr) {
         << ") has result values, which is not allowed for exception handling";
     }
 
-    // Check types in sentTypes is valid
+    // Check types in sentTypes are valid.
     auto tagType = tag->sig.params;
     auto sentType = curr->sentTypes[i];
     if (tagType.size() == 0 && !curr->catchRefs[i]) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2479,7 +2479,6 @@ void FunctionValidator::visitTryTable(TryTable* curr) {
     Name tagName = curr->catchTags[i];
     if (!tagName) { // catch_all or catch_all_ref
       tagTypeSize = 0;
-
     } else { // catch or catch_ref
       // Check tag validity
       auto* tag = getModule()->getTagOrNull(tagName);

--- a/test/spec/exception-handling.wast
+++ b/test/spec/exception-handling.wast
@@ -1,0 +1,64 @@
+(assert_invalid
+  (module
+    (tag $e-i32 (param i32))
+    (func $f0
+      (try_table
+        (i32.const 0)
+      )
+    )
+  )
+  "try_table's type does not match try_table body's type"
+)
+
+(assert_invalid
+  (module
+    (tag $e-i32 (param i32))
+    (func $f0
+      (throw $e-i32 (f32.const 0))
+    )
+  )
+  "tag param types must match"
+)
+
+(assert_invalid
+  (module
+    (tag $e-i32 (param i32 f32))
+    (func $f0
+      (throw $e-i32 (f32.const 0))
+    )
+  )
+  "tag's param numbers must match"
+)
+
+(assert_invalid
+  (module
+    (func $f0
+      (block $l
+        (try_table (catch $e $l))
+      )
+    )
+  )
+  "catch's tag name is invalid: e"
+)
+
+(assert_invalid
+  (module
+    (tag $e (param i32) (result i32))
+    (func $f0
+      (throw $e (i32.const 5))
+    )
+  )
+  "tags with result types must not be used for exception handling"
+)
+
+(assert_invalid
+  (module
+    (tag $e (param i32) (result i32))
+    (func $f0
+      (block $l
+        (try_table (catch $e $l))
+      )
+    )
+  )
+  "catch's tag (e) has result values, which is not allowed for exception handling"
+)


### PR DESCRIPTION
This adds validation for the new EH instructions (`try_table` and `throw_ref`):
https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md

This also adds a spec test for checking invalid modules. We cannot check the executions yet because we don't have the interpreter implementation. The new test file also contains tests for the existing `throw`, because this is meant to replace the old spec test someday.