### PR TITLE
Add tuple.drop validation

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2123,6 +2123,11 @@ void FunctionValidator::visitDrop(Drop* curr) {
                  curr->value->type == Type::unreachable,
                curr,
                "can only drop a valid value");
+  if (curr->value->type.isTuple()) {
+    shouldBeTrue(getModule()->features.hasMultivalue(),
+                 curr,
+                 "Tuples drops are not allowed unless multivalue is enabled");
+  }
 }
 
 void FunctionValidator::visitReturn(Return* curr) {


### PR DESCRIPTION
Without this fuzzer testcases fail if the initial content has a `tuple.drop` but multivalue
is disabled (then the initial content validates erroneously, and that content is remixed
into more content using multivalue which fails to validate).