### PR TITLE
[Parser] Support standalone import definitions

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1249,6 +1249,11 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return Ok{};
   }
 
+  Result<>
+  addMemory(Name, const std::vector<Name>&, ImportNames*, TableTypeT, Index) {
+    return Ok{};
+  }
+
   Result<> addGlobal(Name,
                      const std::vector<Name>&,
                      ImportNames*,
@@ -1259,7 +1264,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   Result<> addImplicitElems(Type type, std::vector<Expression*>&& elems);
 
   Result<> addDeclareElem(Name, std::vector<Expression*>&&, Index) {
-    // TODO: Validate that referenced functions appear in a declaratve element
+    // TODO: Validate that referenced functions appear in a declarative element
     // segment.
     return Ok{};
   }
@@ -1272,6 +1277,11 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
 
   Result<>
   addData(Name, Name* mem, std::optional<ExprT> offset, DataStringT, Index pos);
+
+  Result<>
+  addTag(Name, const std::vector<Name>, ImportNames*, TypeUseT, Index) {
+    return Ok{};
+  }
 
   Result<> addExport(Index, Name value, Name name, ExternalKind kind) {
     wasm.addExport(builder.makeExport(name, value, kind));

--- a/src/parser/wat-parser.cpp
+++ b/src/parser/wat-parser.cpp
@@ -80,9 +80,13 @@ Result<> parseDefs(Ctx& ctx,
   for (auto& def : defs) {
     ctx.index = def.index;
     WithPosition with(ctx, def.pos);
-    auto parsed = parser(ctx);
-    CHECK_ERR(parsed);
-    assert(parsed);
+    if (auto parsed = parser(ctx)) {
+      CHECK_ERR(parsed);
+    } else {
+      auto im = import_(ctx);
+      assert(im);
+      CHECK_ERR(im);
+    }
   }
   return Ok{};
 }
@@ -174,9 +178,13 @@ Result<> parseModule(Module& wasm, std::string_view input) {
       ctx.index = i;
       CHECK_ERR(ctx.visitFunctionStart(wasm.functions[i].get()));
       WithPosition with(ctx, decls.funcDefs[i].pos);
-      auto parsed = func(ctx);
-      CHECK_ERR(parsed);
-      assert(parsed);
+      if (auto parsed = func(ctx)) {
+        CHECK_ERR(parsed);
+      } else {
+        auto im = import_(ctx);
+        assert(im);
+        CHECK_ERR(im);
+      }
     }
 
     // Parse exports.


### PR DESCRIPTION
We previously support the in-line import abbreviation, but now add support for
explicit, non-abbreviated imports as well.