### PR TITLE
wasm-reduce: Improve tryToReduceCurrentToConst()

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1166,19 +1166,23 @@ struct Reducer
     if (!curr->type.isNumber()) {
       return false;
     }
-    auto* c = builder->makeConst(Literal::makeZero(curr->type));
-    if (ExpressionAnalyzer::equal(c, curr)) {
+    auto* existing = curr->dynCast<Const>();
+    if (existing && existing->value.isZero()) {
       // It's already a zero.
       return false;
     }
+    auto* c = builder->makeConst(Literal::makeZero(curr->type));
     if (tryToReplaceCurrent(c)) {
       return true;
     }
-    // It's not a zero. Try to make it a 1, if it isn't already.
-    c->value = Literal::makeOne(curr->type);
-    if (ExpressionAnalyzer::equal(c, curr)) {
+    // It's not a zero, and can't be replaced with a zero. Try to make it a one,
+    // if it isn't already.
+    if (existing &&
+        existing->value == Literal::makeFromInt32(1, existing->type)) {
+      // It's already a one.
       return false;
     }
+    c->value = Literal::makeOne(curr->type);
     return tryToReplaceCurrent(c);
   }
 


### PR DESCRIPTION
Avoid replacing with the exact same thing in the case of RefNull and a default
tuple.

Also be more careful with handling of numbers. Before we exited immediately
if we saw a number, but we can try to replace a number with a 0 or a 1, even
if it was a number before. That is, we consider 1 simpler than 12345678, and
0 simpler than 1.