### PR TITLE
Drop support for type annotations on array.len

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3160,14 +3160,7 @@ Expression* SExpressionWasmBuilder::makeArraySet(Element& s) {
 }
 
 Expression* SExpressionWasmBuilder::makeArrayLen(Element& s) {
-  // There may or may not be a type annotation.
-  Index i = 1;
-  try {
-    parseHeapType(*s[i]);
-    ++i;
-  } catch (...) {
-  }
-  auto ref = parseExpression(*s[i]);
+  auto ref = parseExpression(*s[1]);
   return Builder(wasm).makeArrayLen(ref);
 }
 

--- a/test/lit/arrays.wast
+++ b/test/lit/arrays.wast
@@ -60,8 +60,7 @@
  ;; ROUNDTRIP-NEXT:  )
  ;; ROUNDTRIP-NEXT: )
  (func $len (param $a (ref array)) (result i32)
-  ;; TODO: remove the unused type annotation
-  (array.len $byte-array
+  (array.len
    (local.get $a)
   )
  )
@@ -77,7 +76,7 @@
  ;; ROUNDTRIP-NEXT:  )
  ;; ROUNDTRIP-NEXT: )
  (func $impossible-len (param $none nullref) (result i32)
-  (array.len $byte-array
+  (array.len
    (local.get $none)
   )
  )
@@ -91,7 +90,7 @@
  ;; ROUNDTRIP-NEXT:  (unreachable)
  ;; ROUNDTRIP-NEXT: )
  (func $unreachable-len (param $a arrayref) (result i32)
-  (array.len $byte-array
+  (array.len
    (unreachable)
   )
  )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -4153,7 +4153,7 @@
   ;; CHECK-NEXT: )
   (func $arrays (param $B (ref $B))
     (drop
-      (array.len $B
+      (array.len
         (array.new_fixed $B 2
           (ref.null none)
           (ref.null none)

--- a/test/lit/passes/gufa-tnh.wast
+++ b/test/lit/passes/gufa-tnh.wast
@@ -1803,7 +1803,7 @@
       (i32.const 3)
     )
     (drop
-      (array.len $B
+      (array.len
         (local.get $array.len)
       )
     )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -366,7 +366,7 @@
       )
     )
     (drop
-      (array.len $array
+      (array.len
         (ref.as_non_null
           (local.get $y)
         )

--- a/test/passes/Oz_fuzz-exec_all-features.wast
+++ b/test/passes/Oz_fuzz-exec_all-features.wast
@@ -52,7 +52,7 @@
   )
   ;; The length should be 50
   (call $log
-   (array.len $bytes (local.get $x))
+   (array.len (local.get $x))
   )
   ;; The value should be 42
   (call $log
@@ -281,7 +281,7 @@
   )
   ;; The length should be 2
   (call $log
-   (array.len $bytes (local.get $x))
+   (array.len (local.get $x))
   )
   ;; The first value should be 42
   (call $log

--- a/test/spec/array.wast
+++ b/test/spec/array.wast
@@ -83,7 +83,7 @@
   )
 
   (func $len (param $v (ref $vec)) (result i32)
-    (array.len $vec (local.get $v))
+    (array.len (local.get $v))
   )
   (func (export "len") (result i32)
     (call $len (array.new_default $vec (i32.const 3)))


### PR DESCRIPTION
These type annotations were removed during the development of the GC proposal,
but we maintained support for parsing them to ease the transition. Now that GC
is shipped, remove support for the non-standard annotation and update our tests
accordingly.