### PR TITLE
[Parser] Go back to "sub final" intead of "sub open"

### DIFF
--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -2094,7 +2094,7 @@ template<typename Ctx> MaybeResult<> subtype(Ctx& ctx) {
   }
 
   if (ctx.in.takeSExprStart("sub"sv)) {
-    if (ctx.in.takeKeyword("open"sv)) {
+    if (!ctx.in.takeKeyword("final"sv)) {
       ctx.setOpen();
     }
     if (auto super = maybeTypeidx(ctx)) {

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -29,7 +29,7 @@
 
   ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $s0 (struct ))
-  (type $s0 (sub (struct)))
+  (type $s0 (struct))
   ;; CHECK:       (type $s1 (struct ))
   (type $s1 (struct (field)))
  )
@@ -198,17 +198,17 @@
  (type $any-array (array (mut anyref)))
 
  (rec
-   (type $void (sub open (func)))
+   (type $void (sub (func)))
  )
 
  ;; CHECK:      (type $subvoid (sub final $void (func)))
- (type $subvoid (sub $void (func)))
+ (type $subvoid (sub final $void (func)))
 
- (type $many (sub open (func (param $x i32) (param i64 f32) (param) (param $y f64)
+ (type $many (sub (func (param $x i32) (param i64 f32) (param) (param $y f64)
                              (result anyref (ref func)))))
 
  ;; CHECK:      (type $submany (sub final $many (func (param i32 i64 f32 f64) (result anyref (ref func)))))
- (type $submany (sub $many (func (param i32 i64 f32 f64) (result anyref (ref func)))))
+ (type $submany (sub final $many (func (param i32 i64 f32 f64) (result anyref (ref func)))))
 
  ;; imported memories
  (memory (export "mem") (export "mem2") (import "" "mem") 0)


### PR DESCRIPTION
The planned spec change to use "sub open" never came together, so the standard
format remains "sub final".