### PR TITLE
Rename CMake vars for modified intrinsics file

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -2,12 +2,18 @@ file(READ wasm-intrinsics.wat WASM_INTRINSICS_WAT HEX)
 
 string(REGEX MATCHALL "([A-Fa-f0-9][A-Fa-f0-9])" SEPARATED_HEX ${WASM_INTRINSICS_WAT})
 
-set(WASM_INTRINSICS_SIZE 1)
+# WASM_INTRINSICS_EMBED_2 and WASM_INTRINSICS_SIZE_2 should be renamed each time
+# the content of the wat file changes. This is not strictly necessary, as CMake
+# should use the fresh contents each time, but even just re-running CMake
+# manually is not enough in practice (one needs to also erase the CMake temp
+# files, or use a fresh build dir). Renaming the vars keeps things working
+# smoothly for people with existing checkouts.
+set(WASM_INTRINSICS_SIZE_2 1)
 foreach (hex IN LISTS SEPARATED_HEX)
-  string(APPEND WASM_INTRINSICS_EMBED "0x${hex},")
-  math(EXPR WASM_INTRINSICS_SIZE "${WASM_INTRINSICS_SIZE}+1")
+  string(APPEND WASM_INTRINSICS_EMBED_2 "0x${hex},")
+  math(EXPR WASM_INTRINSICS_SIZE_2 "${WASM_INTRINSICS_SIZE_2}+1")
 endforeach ()
-string(APPEND WASM_INTRINSICS_EMBED "0x00")
+string(APPEND WASM_INTRINSICS_EMBED_2 "0x00")
 
 configure_file(WasmIntrinsics.cpp.in WasmIntrinsics.cpp @ONLY)
 

--- a/src/passes/WasmIntrinsics.cpp.in
+++ b/src/passes/WasmIntrinsics.cpp.in
@@ -1,7 +1,7 @@
 #include "passes/intrinsics-module.h"
 
-static const char theModule[@WASM_INTRINSICS_SIZE@] = {
-@WASM_INTRINSICS_EMBED@
+static const char theModule[@WASM_INTRINSICS_SIZE_2@] = {
+@WASM_INTRINSICS_EMBED_2@
 };
 
 namespace wasm {


### PR DESCRIPTION
The intrinsics file changed in #6201 and somehow CMake doesn't automatically
update itself, and needs a manual step for people with existing checkouts (a new
fresh checkout always works). To avoid annoyance for existing checkouts, rename
the vars, which forces CMake to recompute the contents.