### PR TITLE
Use C++11 raw string literal to embed intrinsics file. NFC

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -1,13 +1,6 @@
-file(READ wasm-intrinsics.wat WASM_INTRINSICS_WAT HEX)
 set(CMAKE_CONFIGURE_DEPENDS wasm-intrinsics.wat)
 
-string(REGEX MATCHALL "([A-Fa-f0-9][A-Fa-f0-9])" SEPARATED_HEX ${WASM_INTRINSICS_WAT})
-
-foreach (hex IN LISTS SEPARATED_HEX)
-  string(APPEND WASM_INTRINSICS_EMBED "0x${hex},")
-endforeach ()
-string(APPEND WASM_INTRINSICS_EMBED "0x00")
-
+file(READ wasm-intrinsics.wat WASM_INTRINSICS_WAT)
 configure_file(WasmIntrinsics.cpp.in WasmIntrinsics.cpp @ONLY)
 
 FILE(GLOB passes_HEADERS *.h)

--- a/src/passes/WasmIntrinsics.cpp.in
+++ b/src/passes/WasmIntrinsics.cpp.in
@@ -1,9 +1,7 @@
 #include "passes/intrinsics-module.h"
 
-static const char theModule[] = {
-@WASM_INTRINSICS_EMBED@
-};
-
 namespace wasm {
-const char* IntrinsicsModuleWast = theModule;
+const char* IntrinsicsModuleWast = R"""(
+@WASM_INTRINSICS_WAT@
+)""";
 }


### PR DESCRIPTION
Followup to #6206

See https://en.cppreference.com/w/cpp/language/string_literal