### PR TITLE
[Parser] Parse remaining heap and reference types

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -97,17 +97,22 @@ struct NullTypeParserCtx {
   using ElemListT = Ok;
   using DataStringT = Ok;
 
-  HeapTypeT makeFunc() { return Ok{}; }
-  HeapTypeT makeAny() { return Ok{}; }
-  HeapTypeT makeExtern() { return Ok{}; }
-  HeapTypeT makeEq() { return Ok{}; }
-  HeapTypeT makeI31() { return Ok{}; }
+  HeapTypeT makeFuncType() { return Ok{}; }
+  HeapTypeT makeAnyType() { return Ok{}; }
+  HeapTypeT makeExternType() { return Ok{}; }
+  HeapTypeT makeEqType() { return Ok{}; }
+  HeapTypeT makeI31Type() { return Ok{}; }
   HeapTypeT makeStructType() { return Ok{}; }
   HeapTypeT makeArrayType() { return Ok{}; }
+  HeapTypeT makeExnType() { return Ok{}; }
   HeapTypeT makeStringType() { return Ok{}; }
   HeapTypeT makeStringViewWTF8Type() { return Ok{}; }
   HeapTypeT makeStringViewWTF16Type() { return Ok{}; }
   HeapTypeT makeStringViewIterType() { return Ok{}; }
+  HeapTypeT makeNoneType() { return Ok{}; }
+  HeapTypeT makeNoextType() { return Ok{}; }
+  HeapTypeT makeNofuncType() { return Ok{}; }
+  HeapTypeT makeNoexnType() { return Ok{}; }
 
   TypeT makeI32() { return Ok{}; }
   TypeT makeI64() { return Ok{}; }
@@ -187,17 +192,22 @@ template<typename Ctx> struct TypeParserCtx {
 
   Ctx& self() { return *static_cast<Ctx*>(this); }
 
-  HeapTypeT makeFunc() { return HeapType::func; }
-  HeapTypeT makeAny() { return HeapType::any; }
-  HeapTypeT makeExtern() { return HeapType::ext; }
-  HeapTypeT makeEq() { return HeapType::eq; }
-  HeapTypeT makeI31() { return HeapType::i31; }
+  HeapTypeT makeFuncType() { return HeapType::func; }
+  HeapTypeT makeAnyType() { return HeapType::any; }
+  HeapTypeT makeExternType() { return HeapType::ext; }
+  HeapTypeT makeEqType() { return HeapType::eq; }
+  HeapTypeT makeI31Type() { return HeapType::i31; }
   HeapTypeT makeStructType() { return HeapType::struct_; }
   HeapTypeT makeArrayType() { return HeapType::array; }
+  HeapTypeT makeExnType() { return HeapType::exn; }
   HeapTypeT makeStringType() { return HeapType::string; }
   HeapTypeT makeStringViewWTF8Type() { return HeapType::stringview_wtf8; }
   HeapTypeT makeStringViewWTF16Type() { return HeapType::stringview_wtf16; }
   HeapTypeT makeStringViewIterType() { return HeapType::stringview_iter; }
+  HeapTypeT makeNoneType() { return HeapType::none; }
+  HeapTypeT makeNoextType() { return HeapType::noext; }
+  HeapTypeT makeNofuncType() { return HeapType::nofunc; }
+  HeapTypeT makeNoexnType() { return HeapType::noexn; }
 
   TypeT makeI32() { return Type::i32; }
   TypeT makeI64() { return Type::i64; }

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -236,25 +236,28 @@ template<typename Ctx> WithPosition(Ctx& ctx, Index) -> WithPosition<Ctx>;
 //            | 'extern'  => extern
 template<typename Ctx> Result<typename Ctx::HeapTypeT> heaptype(Ctx& ctx) {
   if (ctx.in.takeKeyword("func"sv)) {
-    return ctx.makeFunc();
+    return ctx.makeFuncType();
   }
   if (ctx.in.takeKeyword("any"sv)) {
-    return ctx.makeAny();
+    return ctx.makeAnyType();
   }
   if (ctx.in.takeKeyword("extern"sv)) {
-    return ctx.makeExtern();
+    return ctx.makeExternType();
   }
   if (ctx.in.takeKeyword("eq"sv)) {
-    return ctx.makeEq();
+    return ctx.makeEqType();
   }
   if (ctx.in.takeKeyword("i31"sv)) {
-    return ctx.makeI31();
+    return ctx.makeI31Type();
   }
   if (ctx.in.takeKeyword("struct"sv)) {
     return ctx.makeStructType();
   }
   if (ctx.in.takeKeyword("array"sv)) {
     return ctx.makeArrayType();
+  }
+  if (ctx.in.takeKeyword("exn"sv)) {
+    return ctx.makeExnType();
   }
   if (ctx.in.takeKeyword("string"sv)) {
     return ctx.makeStringType();
@@ -267,6 +270,18 @@ template<typename Ctx> Result<typename Ctx::HeapTypeT> heaptype(Ctx& ctx) {
   }
   if (ctx.in.takeKeyword("stringview_iter"sv)) {
     return ctx.makeStringViewIterType();
+  }
+  if (ctx.in.takeKeyword("none"sv)) {
+    return ctx.makeNoneType();
+  }
+  if (ctx.in.takeKeyword("noextern"sv)) {
+    return ctx.makeNoextType();
+  }
+  if (ctx.in.takeKeyword("nofunc"sv)) {
+    return ctx.makeNofuncType();
+  }
+  if (ctx.in.takeKeyword("noexn"sv)) {
+    return ctx.makeNoexnType();
   }
   auto type = typeidx(ctx);
   CHECK_ERR(type);
@@ -283,25 +298,28 @@ template<typename Ctx> Result<typename Ctx::HeapTypeT> heaptype(Ctx& ctx) {
 //           | '(' ref null? t:heaptype ')' => ref null? t
 template<typename Ctx> MaybeResult<typename Ctx::TypeT> reftype(Ctx& ctx) {
   if (ctx.in.takeKeyword("funcref"sv)) {
-    return ctx.makeRefType(ctx.makeFunc(), Nullable);
+    return ctx.makeRefType(ctx.makeFuncType(), Nullable);
   }
   if (ctx.in.takeKeyword("externref"sv)) {
-    return ctx.makeRefType(ctx.makeExtern(), Nullable);
+    return ctx.makeRefType(ctx.makeExternType(), Nullable);
   }
   if (ctx.in.takeKeyword("anyref"sv)) {
-    return ctx.makeRefType(ctx.makeAny(), Nullable);
+    return ctx.makeRefType(ctx.makeAnyType(), Nullable);
   }
   if (ctx.in.takeKeyword("eqref"sv)) {
-    return ctx.makeRefType(ctx.makeEq(), Nullable);
+    return ctx.makeRefType(ctx.makeEqType(), Nullable);
   }
   if (ctx.in.takeKeyword("i31ref"sv)) {
-    return ctx.makeRefType(ctx.makeI31(), Nullable);
+    return ctx.makeRefType(ctx.makeI31Type(), Nullable);
   }
   if (ctx.in.takeKeyword("structref"sv)) {
     return ctx.makeRefType(ctx.makeStructType(), Nullable);
   }
   if (ctx.in.takeKeyword("arrayref"sv)) {
     return ctx.makeRefType(ctx.makeArrayType(), Nullable);
+  }
+  if (ctx.in.takeKeyword("exnref"sv)) {
+    return ctx.makeRefType(ctx.makeExnType(), Nullable);
   }
   if (ctx.in.takeKeyword("stringref"sv)) {
     return ctx.makeRefType(ctx.makeStringType(), Nullable);
@@ -314,6 +332,18 @@ template<typename Ctx> MaybeResult<typename Ctx::TypeT> reftype(Ctx& ctx) {
   }
   if (ctx.in.takeKeyword("stringview_iter"sv)) {
     return ctx.makeRefType(ctx.makeStringViewIterType(), Nullable);
+  }
+  if (ctx.in.takeKeyword("nullref"sv)) {
+    return ctx.makeRefType(ctx.makeNoneType(), Nullable);
+  }
+  if (ctx.in.takeKeyword("nullexternref"sv)) {
+    return ctx.makeRefType(ctx.makeNoextType(), Nullable);
+  }
+  if (ctx.in.takeKeyword("nullfuncref"sv)) {
+    return ctx.makeRefType(ctx.makeNofuncType(), Nullable);
+  }
+  if (ctx.in.takeKeyword("nullexnref"sv)) {
+    return ctx.makeRefType(ctx.makeNoexnType(), Nullable);
   }
 
   if (!ctx.in.takeSExprStart("ref"sv)) {

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -214,9 +214,27 @@
  ;; CHECK:      (type $submany (sub final $many (func (param i32 i64 f32 f64) (result anyref (ref func)))))
  (type $submany (sub final $many (func (param i32 i64 f32 f64) (result anyref (ref func)))))
 
+ ;; CHECK:      (type $all-types (struct (field externref) (field (ref extern)) (field funcref) (field (ref func)) (field anyref) (field (ref any)) (field eqref) (field (ref eq)) (field i31ref) (field (ref i31)) (field structref) (field (ref struct)) (field arrayref) (field (ref array)) (field exnref) (field (ref exn)) (field stringref) (field (ref string)) (field stringview_wtf8) (field (ref stringview_wtf8)) (field stringview_wtf16) (field (ref stringview_wtf16)) (field stringview_iter) (field (ref stringview_iter)) (field nullref) (field (ref none)) (field nullexternref) (field (ref noextern)) (field nullfuncref) (field (ref nofunc)) (field nullexnref) (field (ref noexn))))
+ (type $all-types (struct externref (ref extern)
+                          funcref (ref func)
+                          anyref (ref any)
+                          eqref (ref eq)
+                          i31ref (ref i31)
+                          structref (ref struct)
+                          arrayref (ref array)
+                          exnref (ref exn)
+                          stringref (ref string)
+                          stringview_wtf8 (ref stringview_wtf8)
+                          stringview_wtf16 (ref stringview_wtf16)
+                          stringview_iter (ref stringview_iter)
+                          nullref (ref none)
+                          nullexternref (ref noextern)
+                          nullfuncref (ref nofunc)
+                          nullexnref (ref noexn)))
+
  ;; imported memories
  (memory (export "mem") (export "mem2") (import "" "mem") 0)
- ;; CHECK:      (type $90 (func (param (ref $s0) (ref $s1) (ref $s2) (ref $s3) (ref $s4) (ref $s5) (ref $s6) (ref $s7) (ref $s8) (ref $a0) (ref $a1) (ref $a2) (ref $a3) (ref $subvoid) (ref $submany))))
+ ;; CHECK:      (type $91 (func (param (ref $s0) (ref $s1) (ref $s2) (ref $s3) (ref $s4) (ref $s5) (ref $s6) (ref $s7) (ref $s8) (ref $a0) (ref $a1) (ref $a2) (ref $a3) (ref $subvoid) (ref $submany) (ref $all-types))))
 
  ;; CHECK:      (import "" "mem" (memory $mimport$0 0))
 
@@ -4724,7 +4742,7 @@
   )
  )
 
- ;; CHECK:      (func $use-types (type $90) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany))
+ ;; CHECK:      (func $use-types (type $91) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany)) (param $15 (ref $all-types))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $use-types
@@ -4743,5 +4761,6 @@
   (param (ref $a3))
   (param (ref $subvoid))
   (param (ref $submany))
+  (param (ref $all-types))
  )
 )


### PR DESCRIPTION
Parse types like `exnref` and `nofunc` that we did not previously support.