### PR TITLE
Make blockifyWithName correctly use name and type

### DIFF
--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1338,11 +1338,14 @@ public:
       block = any->dynCast<Block>();
     }
     if (!block || block->name.is()) {
-      block = makeBlock(any);
+      block = makeBlock(name, any);
+    } else {
+      block->name = name;
     }
-    block->name = name;
     if (append) {
       block->list.push_back(append);
+    }
+    if (append || type) {
       block->finalize(type);
     }
     return block;


### PR DESCRIPTION
- This passes `name` to `makeBlock` call, because `makeBlock` uses `BranchSeeker` when finalizing only when the block has a `name`.
- This also refinalizes the block when an optional `type` is given.

This was spun off from #6210, but I'm not sure how to add a standalone test for this.