### PR TITLE
Remove incorrect validation of segment sizes

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3656,7 +3656,6 @@ static void validateMemories(Module& module, ValidationInfo& info) {
 
 static void validateDataSegments(Module& module, ValidationInfo& info) {
   for (auto& segment : module.dataSegments) {
-    auto size = segment->data.size();
     if (segment->isPassive) {
       info.shouldBeTrue(
         module.features.hasBulkMemory(),
@@ -3693,14 +3692,6 @@ static void validateDataSegments(Module& module, ValidationInfo& info) {
         segment->offset,
         "memory segment offset should be constant");
       FunctionValidator(module, &info).validate(segment->offset);
-      // If the memory is imported we don't actually know its initial size.
-      // Specifically wasm dll's import a zero sized memory which is perfectly
-      // valid.
-      if (!memory->imported()) {
-        info.shouldBeTrue(size <= memory->initial * Memory::kPageSize,
-                          segment->data.size(),
-                          "segment size should fit in memory (initial)");
-      }
     }
   }
 }

--- a/test/lit/ctor-eval/flatten_too_big.wast
+++ b/test/lit/ctor-eval/flatten_too_big.wast
@@ -1,0 +1,18 @@
+;; The data segment here is at an offset too large to fit into the memory.
+;; wasm-ctor-eval will flatten memory, and as a result the segment will start
+;; at 0 and contain a great many 0's before that one 'a'. We should not report
+;; a validation error or other problem due to that. (We also have nothing to
+;; optimize here, so this test just checks we do not error.)
+
+;; RUN: wasm-ctor-eval %s --ctors=test --kept-exports=test --quiet -all
+
+(module
+ (memory $0 1 1)
+ (data (i32.const 123456) "a")
+
+ (export "test" (func $test))
+
+ (func $test
+ )
+)
+


### PR DESCRIPTION
This should be a runtime error, not a validator error. It caused a fuzzer failure on
wasm-ctor-eval.