### PR TITLE
MemoryPacking: Ignore empty segments

### DIFF
--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -270,6 +270,13 @@ bool MemoryPacking::canSplit(const std::unique_ptr<DataSegment>& segment,
     return false;
   }
 
+  if (segment->data.empty()) {
+    // Ignore empty segments, leaving them in place. We may not need them, but
+    // leave that for RemoveUnusedModuleElements to decide (as they may trap
+    // during startup if out of bounds, which is an effect).
+    return false;
+  }
+
   for (auto* referrer : referrers) {
     if (auto* curr = referrer->dynCast<MemoryInit>()) {
       if (segment->isPassive) {

--- a/test/lit/passes/memory-packing_all-features.wast
+++ b/test/lit/passes/memory-packing_all-features.wast
@@ -18,9 +18,12 @@
   ;; CHECK:      (memory $0 2048 2048)
   (memory $0 2048 2048)
   (import "env" "memoryBase" (global $memoryBase i32))
-  (data (i32.const 4066) "") ;; empty
+  (data (i32.const 4066) "") ;; empty; leave it as is
+                             ;; (remove-unused-module-elements handles such
+                             ;; things, taking into account possible traps etc.)
 )
 
+;; CHECK:      (data $0 (i32.const 4066) "")
 (module
   ;; CHECK:      (import "env" "memoryBase" (global $memoryBase i32))
 
@@ -2319,6 +2322,8 @@
  (memory $0 1 1 shared)
  (data (i32.const 0) "")
  (data "foo")
+ ;; CHECK:      (data $0 (i32.const 0) "")
+
  ;; CHECK:      (data $1 "foo")
 
  ;; CHECK:      (func $0 (type $0)


### PR DESCRIPTION
They might trap. Leave that for RemoveUnusedModuleElements.

Fixes #6230 