### PR TITLE
Update the text syntax for tuple types

### DIFF
--- a/src/shared-constants.h
+++ b/src/shared-constants.h
@@ -62,6 +62,7 @@ extern Name PRINT;
 extern Name EXIT;
 extern Name SHARED;
 extern Name TAG;
+extern Name TUPLE;
 
 } // namespace wasm
 

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1393,12 +1393,15 @@ Type SExpressionWasmBuilder::elementToType(Element& s) {
     }
     return Type(parseHeapType(*s[i]), nullable);
   }
-  // It's a tuple.
-  std::vector<Type> types;
-  for (size_t i = 0; i < s.size(); ++i) {
-    types.push_back(elementToType(*list[i]));
+  if (elementStartsWith(s, TUPLE)) {
+    // It's a tuple.
+    std::vector<Type> types;
+    for (size_t i = 1; i < s.size(); ++i) {
+      types.push_back(elementToType(*list[i]));
+    }
+    return Type(types);
   }
-  return Type(types);
+  throw SParseException(std::string("expected type, got list"), s);
 }
 
 Type SExpressionWasmBuilder::stringToLaneType(const char* str) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1952,11 +1952,9 @@ std::ostream& TypePrinter::print(HeapType type) {
 }
 
 std::ostream& TypePrinter::print(const Tuple& tuple) {
-  os << '(';
-  auto sep = "";
+  os << "(tuple";
   for (Type type : tuple) {
-    os << sep;
-    sep = " ";
+    os << ' ';
     print(type);
   }
   return os << ')';

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -99,6 +99,7 @@ Name PRINT("print");
 Name EXIT("exit");
 Name SHARED("shared");
 Name TAG("tag");
+Name TUPLE("tuple");
 
 // Expressions
 

--- a/test/example/typeinfo.txt
+++ b/test/example/typeinfo.txt
@@ -40,10 +40,10 @@ i31ref
 (ref null $array.0)
 
 ;; Tuple
-()
+(tuple)
 none
-(i32 f64)
-(i32 f64)
+(tuple i32 f64)
+(tuple i32 f64)
 
 ;; Signature of references (param/result)
 (func (param (ref null $struct.0)) (result (ref $array.0)))
@@ -77,8 +77,8 @@ none
 (ref null $array.0)
 
 ;; Tuple of references
-((ref $func.0) (ref null $func.0) (ref $struct.0) (ref null $struct.0) (ref $array.0) (ref null $array.0))
-((ref $func.0) (ref null $func.0) (ref $struct.0) (ref null $struct.0) (ref $array.0) (ref null $array.0))
+(tuple (ref $func.0) (ref null $func.0) (ref $struct.0) (ref null $struct.0) (ref $array.0) (ref null $array.0))
+(tuple (ref $func.0) (ref null $func.0) (ref $struct.0) (ref null $struct.0) (ref $array.0) (ref null $array.0))
 
 ;; Recursive (not really)
 (func (param (ref $func.0)))

--- a/test/gtest/cfg.cpp
+++ b/test/gtest/cfg.cpp
@@ -270,9 +270,9 @@ TEST_F(CFGTest, LinearReachingDefinitions) {
   auto moduleText = R"wasm(
     (module
       (func $bar
-        (local $a (i32))
-        (local $b (i32))
-        (local $c (i32))
+        (local $a i32)
+        (local $b i32)
+        (local $c i32)
         (local.set $a
           (i32.const 1)
         )
@@ -335,8 +335,8 @@ TEST_F(CFGTest, ReachingDefinitionsIf) {
   auto moduleText = R"wasm(
     (module
       (func $bar
-        (local $a (i32))
-        (local $b (i32))
+        (local $a i32)
+        (local $b i32)
         (local.set $a
           (i32.const 1)
         )
@@ -406,7 +406,7 @@ TEST_F(CFGTest, ReachingDefinitionsIf) {
 TEST_F(CFGTest, ReachingDefinitionsLoop) {
   auto moduleText = R"wasm(
     (module
-      (func $bar (param $a (i32)) (param $b (i32))
+      (func $bar (param $a i32) (param $b i32)
         (loop $loop
           (drop
             (local.get $a)

--- a/test/lit/basic/exception-handling-old.wast
+++ b/test/lit/basic/exception-handling-old.wast
@@ -105,7 +105,7 @@
   )
 
   ;; CHECK-TEXT:      (func $try-catch-multivalue-tag (type $0)
-  ;; CHECK-TEXT-NEXT:  (local $x (i32 i64))
+  ;; CHECK-TEXT-NEXT:  (local $x (tuple i32 i64))
   ;; CHECK-TEXT-NEXT:  (try $try
   ;; CHECK-TEXT-NEXT:   (do
   ;; CHECK-TEXT-NEXT:    (throw $e-i32-i64
@@ -128,7 +128,7 @@
   ;; CHECK-BIN:      (func $try-catch-multivalue-tag (type $0)
   ;; CHECK-BIN-NEXT:  (local $x i32)
   ;; CHECK-BIN-NEXT:  (local $1 i64)
-  ;; CHECK-BIN-NEXT:  (local $2 (i32 i64))
+  ;; CHECK-BIN-NEXT:  (local $2 (tuple i32 i64))
   ;; CHECK-BIN-NEXT:  (local $3 i32)
   ;; CHECK-BIN-NEXT:  (try $label$3
   ;; CHECK-BIN-NEXT:   (do
@@ -162,7 +162,7 @@
   ;; CHECK-BIN-NEXT:   )
   ;; CHECK-BIN-NEXT:  )
   ;; CHECK-BIN-NEXT: )
-  (func $try-catch-multivalue-tag (local $x (i32 i64))
+  (func $try-catch-multivalue-tag (local $x (tuple i32 i64))
     (try
       (do
         (throw $e-i32-i64 (i32.const 0) (i64.const 0))
@@ -1376,7 +1376,7 @@
 ;; CHECK-BIN-NODEBUG:      (func $3 (type $0)
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $0 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $1 i64)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $2 (i32 i64))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $2 (tuple i32 i64))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $3 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (try $label$3
 ;; CHECK-BIN-NODEBUG-NEXT:   (do

--- a/test/lit/basic/exception-handling.wast
+++ b/test/lit/basic/exception-handling.wast
@@ -237,9 +237,9 @@
   ;; CHECK-TEXT-NEXT:  )
   ;; CHECK-TEXT-NEXT: )
   ;; CHECK-BIN:      (func $try-table-multivalue-tag (type $0)
-  ;; CHECK-BIN-NEXT:  (local $0 (i32 i64))
+  ;; CHECK-BIN-NEXT:  (local $0 (tuple i32 i64))
   ;; CHECK-BIN-NEXT:  (local $1 i32)
-  ;; CHECK-BIN-NEXT:  (local $2 (i32 i64 exnref))
+  ;; CHECK-BIN-NEXT:  (local $2 (tuple i32 i64 exnref))
   ;; CHECK-BIN-NEXT:  (local $3 i64)
   ;; CHECK-BIN-NEXT:  (local $4 i32)
   ;; CHECK-BIN-NEXT:  (block $label$1
@@ -419,7 +419,7 @@
   ;; CHECK-TEXT-NEXT:  )
   ;; CHECK-TEXT-NEXT: )
   ;; CHECK-BIN:      (func $try-table-all-catch-clauses-i32-tag (type $0)
-  ;; CHECK-BIN-NEXT:  (local $0 (i32 exnref))
+  ;; CHECK-BIN-NEXT:  (local $0 (tuple i32 exnref))
   ;; CHECK-BIN-NEXT:  (local $1 i32)
   ;; CHECK-BIN-NEXT:  (block $label$1
   ;; CHECK-BIN-NEXT:   (drop
@@ -517,10 +517,10 @@
   ;; CHECK-TEXT-NEXT:  )
   ;; CHECK-TEXT-NEXT: )
   ;; CHECK-BIN:      (func $try-table-all-catch-clauses-multivalue-tag (type $0)
-  ;; CHECK-BIN-NEXT:  (local $0 (i32 i64 exnref))
+  ;; CHECK-BIN-NEXT:  (local $0 (tuple i32 i64 exnref))
   ;; CHECK-BIN-NEXT:  (local $1 i64)
   ;; CHECK-BIN-NEXT:  (local $2 i32)
-  ;; CHECK-BIN-NEXT:  (local $3 (i32 i64))
+  ;; CHECK-BIN-NEXT:  (local $3 (tuple i32 i64))
   ;; CHECK-BIN-NEXT:  (local $4 i32)
   ;; CHECK-BIN-NEXT:  (block $label$1
   ;; CHECK-BIN-NEXT:   (local.set $3
@@ -810,9 +810,9 @@
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
 ;; CHECK-BIN-NODEBUG:      (func $5 (type $0)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (i32 i64))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (tuple i32 i64))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $1 i32)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $2 (i32 i64 exnref))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $2 (tuple i32 i64 exnref))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $3 i64)
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $4 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (block $label$1
@@ -899,7 +899,7 @@
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
 ;; CHECK-BIN-NODEBUG:      (func $7 (type $0)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (i32 exnref))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (tuple i32 exnref))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $1 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (block $label$1
 ;; CHECK-BIN-NODEBUG-NEXT:   (drop
@@ -942,10 +942,10 @@
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
 ;; CHECK-BIN-NODEBUG:      (func $8 (type $0)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (i32 i64 exnref))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (tuple i32 i64 exnref))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $1 i64)
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $2 i32)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $3 (i32 i64))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $3 (tuple i32 i64))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $4 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (block $label$1
 ;; CHECK-BIN-NODEBUG-NEXT:   (local.set $3

--- a/test/lit/basic/typed_continuations_resume.wast
+++ b/test/lit/basic/typed_continuations_resume.wast
@@ -61,7 +61,7 @@
  ;; CHECK-TEXT-NEXT:  )
  ;; CHECK-TEXT-NEXT: )
  ;; CHECK-BIN:      (func $go (type $3) (param $x (ref $ct)) (result i32)
- ;; CHECK-BIN-NEXT:  (local $1 (i32 (ref $ct)))
+ ;; CHECK-BIN-NEXT:  (local $1 (tuple i32 (ref $ct)))
  ;; CHECK-BIN-NEXT:  (local $2 i32)
  ;; CHECK-BIN-NEXT:  (local.set $1
  ;; CHECK-BIN-NEXT:   (block $label$1 (type $2) (result i32 (ref $ct))
@@ -135,7 +135,7 @@
 ;; CHECK-BIN-NODEBUG:      (tag $tag$0 (param i32) (result i32))
 
 ;; CHECK-BIN-NODEBUG:      (func $0 (type $3) (param $0 (ref $1)) (result i32)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $1 (i32 (ref $1)))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $1 (tuple i32 (ref $1)))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $2 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $1
 ;; CHECK-BIN-NODEBUG-NEXT:   (block $label$1 (type $2) (result i32 (ref $1))

--- a/test/lit/basic/types-function-references.wast
+++ b/test/lit/basic/types-function-references.wast
@@ -174,7 +174,7 @@
   )
 
   ;; CHECK-TEXT:      (func $type-only-in-tuple-local (type $void)
-  ;; CHECK-TEXT-NEXT:  (local $x (i32 (ref null $=>anyref) f64))
+  ;; CHECK-TEXT-NEXT:  (local $x (tuple i32 (ref null $=>anyref) f64))
   ;; CHECK-TEXT-NEXT:  (nop)
   ;; CHECK-TEXT-NEXT: )
   ;; CHECK-BIN:      (func $type-only-in-tuple-local (type $void)
@@ -184,7 +184,7 @@
   ;; CHECK-BIN-NEXT:  (nop)
   ;; CHECK-BIN-NEXT: )
   (func $type-only-in-tuple-local
-    (local $x (i32 (ref null $=>anyref) f64))
+    (local $x (tuple i32 (ref null $=>anyref) f64))
   )
 
   ;; CHECK-TEXT:      (func $type-only-in-tuple-block (type $void)
@@ -195,7 +195,7 @@
   ;; CHECK-TEXT-NEXT:  )
   ;; CHECK-TEXT-NEXT: )
   ;; CHECK-BIN:      (func $type-only-in-tuple-block (type $void)
-  ;; CHECK-BIN-NEXT:  (local $0 (i32 (ref null $mixed_results) f64))
+  ;; CHECK-BIN-NEXT:  (local $0 (tuple i32 (ref null $mixed_results) f64))
   ;; CHECK-BIN-NEXT:  (local $1 (ref null $mixed_results))
   ;; CHECK-BIN-NEXT:  (local $2 i32)
   ;; CHECK-BIN-NEXT:  (local.set $0
@@ -433,7 +433,7 @@
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
 ;; CHECK-BIN-NODEBUG:      (func $8 (type $1)
-;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (i32 (ref null $0) f64))
+;; CHECK-BIN-NODEBUG-NEXT:  (local $0 (tuple i32 (ref null $0) f64))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $1 (ref null $0))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local $2 i32)
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $0

--- a/test/lit/blocktype.wast
+++ b/test/lit/blocktype.wast
@@ -25,8 +25,8 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  ;; RTRIP:      (func $f1 (type $f1) (result (ref $f1) (ref $f2))
- ;; RTRIP-NEXT:  (local $0 ((ref $f1) (ref $f2)))
- ;; RTRIP-NEXT:  (local $1 ((ref $f1) (ref $f2)))
+ ;; RTRIP-NEXT:  (local $0 (tuple (ref $f1) (ref $f2)))
+ ;; RTRIP-NEXT:  (local $1 (tuple (ref $f1) (ref $f2)))
  ;; RTRIP-NEXT:  (local.set $1
  ;; RTRIP-NEXT:   (loop $label$1 (type $f1) (result (ref $f1) (ref $f2))
  ;; RTRIP-NEXT:    (local.set $0
@@ -64,8 +64,8 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  ;; RTRIP:      (func $f2 (type $f2) (result (ref $f2) (ref $f1))
- ;; RTRIP-NEXT:  (local $0 ((ref $f2) (ref $f1)))
- ;; RTRIP-NEXT:  (local $1 ((ref $f2) (ref $f1)))
+ ;; RTRIP-NEXT:  (local $0 (tuple (ref $f2) (ref $f1)))
+ ;; RTRIP-NEXT:  (local $1 (tuple (ref $f2) (ref $f1)))
  ;; RTRIP-NEXT:  (local.set $1
  ;; RTRIP-NEXT:   (loop $label$1 (type $f2) (result (ref $f2) (ref $f1))
  ;; RTRIP-NEXT:    (local.set $0

--- a/test/lit/ctor-eval/multivalue-local.wast
+++ b/test/lit/ctor-eval/multivalue-local.wast
@@ -11,7 +11,7 @@
 
  (func $multivalue-local (export "multivalue-local") (result i32)
   (local $0 i32)
-  (local $1 (i32 i32))
+  (local $1 (tuple i32 i32))
 
   ;; We can eval this line. But we will stop evalling at the line after it, the
   ;; import call. As a result we'll only have a partial evalling of this

--- a/test/lit/multivalue-stack-ir.wast
+++ b/test/lit/multivalue-stack-ir.wast
@@ -26,7 +26,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $test
-  (local $pair (f32 i32))
+  (local $pair (tuple f32 i32))
   (local $f32 f32)
   ;; Normally this get-set pair would be eliminated by stack IR optimizations,
   ;; but then the binary writer's tuple optimizations would leave the only the

--- a/test/lit/multivalue.wast
+++ b/test/lit/multivalue.wast
@@ -8,9 +8,9 @@
  ;; CHECK:      (import "env" "pair" (func $pair (type $0) (result i32 i64)))
  (import "env" "pair" (func $pair (result i32 i64)))
  ;; CHECK:      (global $g1 (mut i32) (i32.const 0))
- (global $g1 (mut (i32 i64)) (tuple.make 2 (i32.const 0) (i64.const 0)))
+ (global $g1 (mut (tuple i32 i64)) (tuple.make 2 (i32.const 0) (i64.const 0)))
  ;; CHECK:      (global $g2 (mut i64) (i64.const 0))
- (global $g2 (i32 i64) (tuple.make 2 (i32.const 0) (i64.const 0)))
+ (global $g2 (tuple i32 i64) (tuple.make 2 (i32.const 0) (i64.const 0)))
 
  ;; CHECK:      (func $triple (type $5) (result i32 i64 f32)
  ;; CHECK-NEXT:  (tuple.make 3
@@ -28,7 +28,7 @@
  )
 
  ;; CHECK:      (func $get-first (type $6) (result i32)
- ;; CHECK-NEXT:  (local $0 (i32 i64 f32))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64 f32))
  ;; CHECK-NEXT:  (local $1 i64)
  ;; CHECK-NEXT:  (local $2 i32)
  ;; CHECK-NEXT:  (local.set $0
@@ -66,7 +66,7 @@
 
  ;; CHECK:      (func $get-second (type $3) (result i64)
  ;; CHECK-NEXT:  (local $0 i64)
- ;; CHECK-NEXT:  (local $1 (i32 i64 f32))
+ ;; CHECK-NEXT:  (local $1 (tuple i32 i64 f32))
  ;; CHECK-NEXT:  (local $2 i64)
  ;; CHECK-NEXT:  (local $3 i32)
  ;; CHECK-NEXT:  (local.set $1
@@ -107,7 +107,7 @@
 
  ;; CHECK:      (func $get-third (type $7) (result f32)
  ;; CHECK-NEXT:  (local $0 f32)
- ;; CHECK-NEXT:  (local $1 (i32 i64 f32))
+ ;; CHECK-NEXT:  (local $1 (tuple i32 i64 f32))
  ;; CHECK-NEXT:  (local $2 i64)
  ;; CHECK-NEXT:  (local $3 i32)
  ;; CHECK-NEXT:  (local.set $1
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:  (local $2 i64)
  ;; CHECK-NEXT:  (local $3 f32)
  ;; CHECK-NEXT:  (local $4 f32)
- ;; CHECK-NEXT:  (local $5 (i32 i64 f32))
+ ;; CHECK-NEXT:  (local $5 (tuple i32 i64 f32))
  ;; CHECK-NEXT:  (local $6 i64)
  ;; CHECK-NEXT:  (local $7 i32)
  ;; CHECK-NEXT:  (local.set $5
@@ -190,7 +190,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $reverse (result f32 i64 i32)
-  (local $x (i32 i64 f32))
+  (local $x (tuple i32 i64 f32))
   (local.set $x
    (call $triple)
   )
@@ -266,7 +266,7 @@
 
  ;; Test lowering of multivalue drops
  ;; CHECK:      (func $drop-call (type $1)
- ;; CHECK-NEXT:  (local $0 (i32 i64))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
  ;; CHECK-NEXT:  (local $1 i32)
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (call $pair)
@@ -317,7 +317,7 @@
  )
 
  ;; CHECK:      (func $drop-block (type $1)
- ;; CHECK-NEXT:  (local $0 (i32 i64))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
  ;; CHECK-NEXT:  (local $1 i32)
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
@@ -392,7 +392,7 @@
  )
 
  ;; CHECK:      (func $mv-block-break (type $0) (result i32 i64)
- ;; CHECK-NEXT:  (local $0 (i32 i64))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
  ;; CHECK-NEXT:    (br $label$1
@@ -424,8 +424,8 @@
  )
 
  ;; CHECK:      (func $mv-block-br-if (type $0) (result i32 i64)
- ;; CHECK-NEXT:  (local $0 (i32 i64))
- ;; CHECK-NEXT:  (local $1 (i32 i64))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
+ ;; CHECK-NEXT:  (local $1 (tuple i32 i64))
  ;; CHECK-NEXT:  (local.set $1
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
  ;; CHECK-NEXT:    (local.set $0
@@ -469,7 +469,7 @@
  )
 
  ;; CHECK:      (func $mv-if (type $2) (result i32 i64 externref)
- ;; CHECK-NEXT:  (local $0 (i32 i64 externref))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64 externref))
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (if (type $2) (result i32 i64 externref)
  ;; CHECK-NEXT:    (i32.const 1)
@@ -522,7 +522,7 @@
  )
 
  ;; CHECK:      (func $mv-loop (type $0) (result i32 i64)
- ;; CHECK-NEXT:  (local $0 (i32 i64))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (loop $label$1 (type $0) (result i32 i64)
  ;; CHECK-NEXT:    (tuple.make 2
@@ -550,8 +550,8 @@
  )
 
  ;; CHECK:      (func $mv-switch (type $0) (result i32 i64)
- ;; CHECK-NEXT:  (local $0 (i32 i64))
- ;; CHECK-NEXT:  (local $1 (i32 i64))
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
+ ;; CHECK-NEXT:  (local $1 (tuple i32 i64))
  ;; CHECK-NEXT:  (local.set $1
  ;; CHECK-NEXT:   (block $label$1 (type $0) (result i32 i64)
  ;; CHECK-NEXT:    (local.set $0

--- a/test/lit/passes/asyncify_enable-multivalue.wast
+++ b/test/lit/passes/asyncify_enable-multivalue.wast
@@ -870,7 +870,7 @@
   )
   ;; CHECK:      (func $many-locals (param $x i32) (result i32)
   ;; CHECK-NEXT:  (local $y i32)
-  ;; CHECK-NEXT:  (local $z (f32 i64))
+  ;; CHECK-NEXT:  (local $z (tuple f32 i64))
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
   ;; CHECK-NEXT:  (local $5 i32)
@@ -1070,7 +1070,7 @@
   ;; CHECK-NEXT: )
   (func $many-locals (param $x i32) (result i32)
     (local $y i32)
-    (local $z (f32 i64))
+    (local $z (tuple f32 i64))
     (loop $l
       (local.set $x
         (i32.add (local.get $y) (i32.const 1))
@@ -1836,11 +1836,11 @@
     (return (i32.const 3))
   )
   ;; CHECK:      (func $calls-mv
-  ;; CHECK-NEXT:  (local $x (i32 i64))
-  ;; CHECK-NEXT:  (local $1 (i32 i64))
+  ;; CHECK-NEXT:  (local $x (tuple i32 i64))
+  ;; CHECK-NEXT:  (local $1 (tuple i32 i64))
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
-  ;; CHECK-NEXT:  (local $4 (i32 i64))
+  ;; CHECK-NEXT:  (local $4 (tuple i32 i64))
   ;; CHECK-NEXT:  (local $5 i32)
   ;; CHECK-NEXT:  (local $6 i32)
   ;; CHECK-NEXT:  (if
@@ -2001,7 +2001,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $calls-mv
-    (local $x (i32 i64))
+    (local $x (tuple i32 i64))
     (local.set $x (call $import-mv))
   )
   ;; CHECK:      (func $calls-loop (param $x i32)

--- a/test/lit/passes/catch-pop-fixup-eh-old.wast
+++ b/test/lit/passes/catch-pop-fixup-eh-old.wast
@@ -326,8 +326,8 @@
   )
 
   ;; CHECK:      (func $pop-tuple-within-block (type $0)
-  ;; CHECK-NEXT:  (local $x (i32 f32))
-  ;; CHECK-NEXT:  (local $1 (i32 f32))
+  ;; CHECK-NEXT:  (local $x (tuple i32 f32))
+  ;; CHECK-NEXT:  (local $1 (tuple i32 f32))
   ;; CHECK-NEXT:  (try $try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (nop)
@@ -347,7 +347,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $pop-tuple-within-block (local $x (i32 f32))
+  (func $pop-tuple-within-block (local $x (tuple i32 f32))
     (try
       (do)
       (catch $e-i32-f32

--- a/test/lit/passes/coalesce-locals-gc-nn.wast
+++ b/test/lit/passes/coalesce-locals-gc-nn.wast
@@ -3,8 +3,8 @@
 
 (module
  ;; CHECK:      (func $nn-locals (type $0) (param $0 (ref any))
- ;; CHECK-NEXT:  (local $1 ((ref any) (ref any)))
- ;; CHECK-NEXT:  (local $2 ((ref any) (ref any)))
+ ;; CHECK-NEXT:  (local $1 (tuple (ref any) (ref any)))
+ ;; CHECK-NEXT:  (local $2 (tuple (ref any) (ref any)))
  ;; CHECK-NEXT:  (local.set $1
  ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
@@ -41,8 +41,8 @@
  (func $nn-locals (param $any (ref any))
   ;; When computing interferences, coalesce locals should not error on tuples
   ;; that contain non-nullable locals.
-  (local $x ((ref any) (ref any)))
-  (local $y ((ref any) (ref any)))
+  (local $x (tuple (ref any) (ref any)))
+  (local $y (tuple (ref any) (ref any)))
   ;; Set values into the tuple locals and use them.
   ;; Note that while the values are the same, we do not optimize them because
   ;; of current limitations on tuple handling in this pass, so we are mainly

--- a/test/lit/passes/coalesce-locals-gc.wast
+++ b/test/lit/passes/coalesce-locals-gc.wast
@@ -16,13 +16,13 @@
  ;; CHECK:      (global $global (ref null $array) (ref.null none))
  (global $global (ref null $array) (ref.null $array))
 
- ;; CHECK:      (global $nn-tuple-global (mut ((ref any) i32)) (tuple.make 2
+ ;; CHECK:      (global $nn-tuple-global (mut (tuple (ref any) i32)) (tuple.make 2
  ;; CHECK-NEXT:  (ref.i31
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (i32.const 1)
  ;; CHECK-NEXT: ))
- (global $nn-tuple-global (mut ((ref any) i32)) (tuple.make 2 (ref.i31 (i32.const 0)) (i32.const 1)))
+ (global $nn-tuple-global (mut (tuple (ref any) i32)) (tuple.make 2 (ref.i31 (i32.const 0)) (i32.const 1)))
 
 
  ;; CHECK:      (func $test-dead-get-non-nullable (type $6) (param $0 (ref struct))
@@ -284,7 +284,7 @@
  )
 
  ;; CHECK:      (func $test (type $10) (param $0 (ref any)) (result (ref any) i32)
- ;; CHECK-NEXT:  (local $1 (anyref i32))
+ ;; CHECK-NEXT:  (local $1 (tuple anyref i32))
  ;; CHECK-NEXT:  (tuple.drop 2
  ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (local.get $0)
@@ -365,8 +365,8 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $test (param $any (ref any)) (result (ref any) i32)
-  (local $x ((ref any) i32))
-  (local $y ((ref any) i32))
+  (local $x (tuple (ref any) i32))
+  (local $y (tuple (ref any) i32))
   ;; This store is dead and will be removed.
   (local.set $x
    (tuple.make 2

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2139,7 +2139,7 @@
   (tag $tag (param (ref null any)) (param (ref null any)))
 
   ;; CHECK:      (func $func (type $1)
-  ;; CHECK-NEXT:  (local $0 (anyref anyref))
+  ;; CHECK-NEXT:  (local $0 (tuple anyref anyref))
   ;; CHECK-NEXT:  (throw $tag
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:   (struct.new_default $struct)

--- a/test/lit/passes/j2cl.wast
+++ b/test/lit/passes/j2cl.wast
@@ -32,7 +32,7 @@
   ;; CHECK:      (global $field2@Foo (mut anyref) (ref.null none))
 
   ;; CHECK:      (global $referredField@Foo i32 (i32.const 42))
-  (global $referredField@Foo (i32) (i32.const 42))
+  (global $referredField@Foo i32 (i32.const 42))
 
   ;; CHECK:      (global $field1@Foo anyref (struct.new $A
   ;; CHECK-NEXT:  (global.get $referredField@Foo)

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -256,7 +256,7 @@
   ;; CHECK-NEXT: )
   (func $multiple-iterations-refinalize-call-ref
     (local $f (ref null $ret-any))
-    (local $x (anyref))
+    (local $x anyref)
     (local.set $f
       (ref.func $ret-i31)
     )
@@ -286,7 +286,7 @@
   ;; CHECK-NEXT: )
   (func $multiple-iterations-refinalize-call-ref-bottom
     (local $f (ref null $ret-any))
-    (local $x (anyref))
+    (local $x anyref)
     ;; Same as above, but now we refine $f to nullfuncref. Check that we don't crash.
     (local.set $f
       (ref.null nofunc)
@@ -308,7 +308,7 @@
   )
 
   ;; CHECK:      (func $nondefaultable (type $0)
-  ;; CHECK-NEXT:  (local $x (funcref funcref))
+  ;; CHECK-NEXT:  (local $x (tuple funcref funcref))
   ;; CHECK-NEXT:  (local.set $x
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (ref.func $i32)
@@ -317,7 +317,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $nondefaultable
-    (local $x (funcref funcref))
+    (local $x (tuple funcref funcref))
     ;; This tuple is assigned non-nullable values, which means the subtype is
     ;; nondefaultable, and we must not apply it.
     (local.set $x

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -1931,7 +1931,7 @@
       ;; However, we do not remove it, as it may be necessary for validation,
       ;; and we hope other opts help out here.
       (ref.cast (ref null $B)
-        (block (result (eqref))
+        (block (result eqref)
           (call $ref-cast-static-fallthrough-remaining-child
             (local.get $x)
           )

--- a/test/lit/passes/optimize-instructions-multivalue.wast
+++ b/test/lit/passes/optimize-instructions-multivalue.wast
@@ -3,8 +3,8 @@
 
 (module
   ;; CHECK:      (func $if-identical-arms-tuple (param $x i32) (result i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (tuple.extract 2 0
   ;; CHECK-NEXT:   (if (type $2) (result i32 i32)
   ;; CHECK-NEXT:    (local.get $x)
@@ -18,8 +18,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $if-identical-arms-tuple (param $x i32) (result i32)
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     (if (result i32)
       (local.get $x)
       ;; The tuple.extract can be hoisted out.
@@ -36,8 +36,8 @@
     )
   )
   ;; CHECK:      (func $select-identical-arms-tuple (param $x i32) (result i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (select
   ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (local.get $tuple)
@@ -49,8 +49,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $select-identical-arms-tuple (param $x i32) (result i32)
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     (select
       ;; The tuple.extract cannot be hoisted out, as the spec disallows a
       ;; select with multiple values in its arms.

--- a/test/lit/passes/optimize-stack-ir.wast
+++ b/test/lit/passes/optimize-stack-ir.wast
@@ -1432,7 +1432,7 @@
   )
 
   ;; CHECK:      (func $tuple-local2stack (type $FUNCSIG$v)
-  ;; CHECK-NEXT:  (local $pair (f32 i32))
+  ;; CHECK-NEXT:  (local $pair (tuple f32 i32))
   ;; CHECK-NEXT:  (local $f32 f32)
   ;; CHECK-NEXT:  f32.const 0
   ;; CHECK-NEXT:  i32.const 0
@@ -1443,7 +1443,7 @@
   ;; CHECK-NEXT:  local.set $f32
   ;; CHECK-NEXT: )
   (func $tuple-local2stack
-    (local $pair (f32 i32))
+    (local $pair (tuple f32 i32))
     (local $f32 f32)
     ;; We should not optimize out this get-set pair in Stack IR since we can do
     ;; better in the binary writer.

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -685,8 +685,8 @@
   ;; CHECK-NEXT: )
 
   ;; CHECK:      (func $a (type $1)
-  ;; CHECK-NEXT:  (local $scratch (i32 i32))
-  ;; CHECK-NEXT:  (local $scratch_1 (i32 i32))
+  ;; CHECK-NEXT:  (local $scratch (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $scratch_1 (tuple i32 i32))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.add
   ;; CHECK-NEXT:    (tuple.extract 2 0

--- a/test/lit/passes/poppify-globals.wast
+++ b/test/lit/passes/poppify-globals.wast
@@ -13,11 +13,11 @@
   ;; CHECK:      (global $tuple$1 f64 (f64.const 0))
   (global $tuple$1 f64 (f64.const 0)) ;; interfering name!
 
-  (global $tuple (mut (i32 i64 f32))
+  (global $tuple (mut (tuple i32 i64 f32))
     (tuple.make 3 (global.get $foo) (i64.const 1) (f32.const 2))
   )
 
-  (global $other-tuple (i32 i64 f32) (global.get $tuple))
+  (global $other-tuple (tuple i32 i64 f32) (global.get $tuple))
 
   ;; CHECK:      (global $tuple$2 (mut f32) (f32.const 2))
 

--- a/test/lit/passes/poppify.wast
+++ b/test/lit/passes/poppify.wast
@@ -405,14 +405,14 @@
   )
 
   ;; CHECK:      (func $local-get-tuple (type $1) (result i32 i64)
-  ;; CHECK-NEXT:  (local $x (i32 i64))
+  ;; CHECK-NEXT:  (local $x (tuple i32 i64))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i64)
   ;; CHECK-NEXT:  (local.get $1)
   ;; CHECK-NEXT:  (local.get $2)
   ;; CHECK-NEXT: )
   (func $local-get-tuple (result i32 i64)
-    (local $x (i32 i64))
+    (local $x (tuple i32 i64))
     (local.get $x)
   )
 
@@ -431,7 +431,7 @@
   )
 
   ;; CHECK:      (func $local-set-tuple (type $2)
-  ;; CHECK-NEXT:  (local $x (i32 i64))
+  ;; CHECK-NEXT:  (local $x (tuple i32 i64))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i64)
   ;; CHECK-NEXT:  (i32.const 0)
@@ -444,7 +444,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $local-set-tuple
-    (local $x (i32 i64))
+    (local $x (tuple i32 i64))
     (local.set $x
       (tuple.make 2
         (i32.const 0)
@@ -454,7 +454,7 @@
   )
 
   ;; CHECK:      (func $local-tee-tuple (type $1) (result i32 i64)
-  ;; CHECK-NEXT:  (local $x (i32 i64))
+  ;; CHECK-NEXT:  (local $x (tuple i32 i64))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i64)
   ;; CHECK-NEXT:  (i32.const 0)
@@ -468,7 +468,7 @@
   ;; CHECK-NEXT:  (local.get $2)
   ;; CHECK-NEXT: )
   (func $local-tee-tuple (result i32 i64)
-    (local $x (i32 i64))
+    (local $x (tuple i32 i64))
     (local.tee $x
       (tuple.make 2
         (i32.const 0)

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -45,7 +45,7 @@
    ;; the fallthrough value should be used. for that to be possible with a block
    ;; we need for it not to have a name, which is why --remove-unused-names is
    ;; run
-   (block (result (funcref))
+   (block (result funcref)
     ;; make a call so the block is not trivially removable
     (drop
      (call $test-fallthrough)
@@ -781,7 +781,7 @@
  )
 
  ;; CHECK:      (func $odd-cast-and-get-tuple (type $3)
- ;; CHECK-NEXT:  (local $temp ((ref null $B) i32))
+ ;; CHECK-NEXT:  (local $temp (tuple (ref null $B) i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (tuple.make 2
  ;; CHECK-NEXT:    (ref.null none)
@@ -798,7 +798,7 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $odd-cast-and-get-tuple
-  (local $temp ((ref null $B) i32))
+  (local $temp (tuple (ref null $B) i32))
   ;; As above, but with a tuple.
   (local.set $temp
    (tuple.make 2
@@ -1173,7 +1173,7 @@
  )
 
  ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $19) (result anyref i32)
- ;; CHECK-NEXT:  (local $x ((ref any) i32))
+ ;; CHECK-NEXT:  (local $x (tuple (ref any) i32))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
@@ -1188,7 +1188,7 @@
  (func $get-nonnullable-in-unreachable-tuple (result anyref i32)
   ;; As $get-nonnullable-in-unreachable but the local is a tuple (so we need to
   ;; check isDefaultable, and not just isNullable).
-  (local $x ((ref any) i32))
+  (local $x (tuple (ref any) i32))
   (local.set $x
    (unreachable)
   )

--- a/test/lit/passes/roundtrip.wast
+++ b/test/lit/passes/roundtrip.wast
@@ -5,7 +5,7 @@
  ;; CHECK:      (type $none (func))
  (type $none (func))
  ;; CHECK:      (func $foo (type $none)
- ;; CHECK-NEXT:  (local $0 (funcref (ref $none)))
+ ;; CHECK-NEXT:  (local $0 (tuple funcref (ref $none)))
  ;; CHECK-NEXT:  (local $1 funcref)
  ;; CHECK-NEXT:  (local.set $0
  ;; CHECK-NEXT:   (block $label$1 (type $1) (result funcref (ref $none))

--- a/test/lit/passes/rse-eh.wast
+++ b/test/lit/passes/rse-eh.wast
@@ -194,7 +194,7 @@
   ;; CHECK:      (func $nested-try_table2 (type $0)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (local $exn exnref)
-  ;; CHECK-NEXT:  (local $pair (i32 exnref))
+  ;; CHECK-NEXT:  (local $pair (tuple i32 exnref))
   ;; CHECK-NEXT:  (block $catch_all0
   ;; CHECK-NEXT:   (try_table (catch_all $catch_all0)
   ;; CHECK-NEXT:    (local.set $pair
@@ -226,7 +226,7 @@
   (func $nested-try_table2
     (local $x i32)
     (local $exn exnref)
-    (local $pair (i32 exnref))
+    (local $pair (tuple i32 exnref))
     (block $catch_all0
       (try_table (catch_all $catch_all0)
         (local.set $pair
@@ -254,7 +254,7 @@
   ;; CHECK:      (func $nested-try_table3 (type $0)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (local $exn exnref)
-  ;; CHECK-NEXT:  (local $pair (i32 exnref))
+  ;; CHECK-NEXT:  (local $pair (tuple i32 exnref))
   ;; CHECK-NEXT:  (block $catch_all0
   ;; CHECK-NEXT:   (try_table (catch_all $catch_all0)
   ;; CHECK-NEXT:    (block $outer1
@@ -287,7 +287,7 @@
   (func $nested-try_table3
     (local $x i32)
     (local $exn exnref)
-    (local $pair (i32 exnref))
+    (local $pair (tuple i32 exnref))
     (block $catch_all0
       (try_table (catch_all $catch_all0)
         (block $outer1

--- a/test/lit/passes/rse-gc.wast
+++ b/test/lit/passes/rse-gc.wast
@@ -12,7 +12,7 @@
 
  ;; CHECK:      (func $test (type $3)
  ;; CHECK-NEXT:  (local $single (ref func))
- ;; CHECK-NEXT:  (local $tuple ((ref any) (ref any)))
+ ;; CHECK-NEXT:  (local $tuple (tuple (ref any) (ref any)))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $test
@@ -21,7 +21,7 @@
   ;; it, so no sets can be redundant in that sense).
   (local $single (ref func))
   ;; A non-nullable tuple.
-  (local $tuple ((ref any) (ref any)))
+  (local $tuple (tuple (ref any) (ref any)))
  )
 
  ;; CHECK:      (func $needs-refinalize (type $4) (param $b (ref $B)) (result anyref)

--- a/test/lit/passes/simplify-locals-gc-nn.wast
+++ b/test/lit/passes/simplify-locals-gc-nn.wast
@@ -50,7 +50,7 @@
   )
 
   ;; CHECK:      (func $test-nn-tuple (type $0)
-  ;; CHECK-NEXT:  (local $nn (i32 anyref i64))
+  ;; CHECK-NEXT:  (local $nn (tuple i32 anyref i64))
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (try $try
   ;; CHECK-NEXT:   (do
@@ -85,7 +85,7 @@
   ;; CHECK-NEXT: )
   (func $test-nn-tuple
     ;; Same as above, but now the local is a tuple containing a non-nullable element
-    (local $nn (i32 (ref any) i64))
+    (local $nn (tuple i32 (ref any) i64))
     (local.set $nn
       (tuple.make 3
         (i32.const 0)
@@ -151,7 +151,7 @@
   )
 
   ;; CHECK:      (func $if-return-tuple-nn (type $0)
-  ;; CHECK-NEXT:  (local $temp ((ref func) nullref))
+  ;; CHECK-NEXT:  (local $temp (tuple (ref func) nullref))
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -160,7 +160,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $if-return-tuple-nn
-    (local $temp ((ref func) (ref null none)))
+    (local $temp (tuple (ref func) (ref null none)))
     ;; We should not emit a return value for this if, as the tuple has a non-
     ;; nullable element, so it is nondefaultable.
     ;;

--- a/test/lit/passes/stack-ir-non-nullable.wast
+++ b/test/lit/passes/stack-ir-non-nullable.wast
@@ -368,7 +368,7 @@
  )
 
  ;; CHECK:      (func $if-nondefaultable (type $1) (param $param (ref eq)) (result (ref eq))
- ;; CHECK-NEXT:  (local $temp (i32 (ref eq)))
+ ;; CHECK-NEXT:  (local $temp (tuple i32 (ref eq)))
  ;; CHECK-NEXT:  i32.const 0
  ;; CHECK-NEXT:  local.get $param
  ;; CHECK-NEXT:  tuple.make 2
@@ -395,7 +395,7 @@
  ;; CHECK-NEXT:  tuple.extract 2 1
  ;; CHECK-NEXT: )
  (func $if-nondefaultable (param $param (ref eq)) (result (ref eq))
-  (local $temp (i32 (ref eq)))
+  (local $temp (tuple i32 (ref eq)))
   ;; As the original testcase, but now $temp is a nondefaultable tuple rather
   ;; than a non-nullable reference by itself. We cannot remove the first set
   ;; here.
@@ -441,7 +441,7 @@
  )
 
  ;; CHECK:      (func $if-defaultable (type $4) (param $param eqref) (result eqref)
- ;; CHECK-NEXT:  (local $temp (i32 eqref))
+ ;; CHECK-NEXT:  (local $temp (tuple i32 eqref))
  ;; CHECK-NEXT:  i32.const 0
  ;; CHECK-NEXT:  local.get $param
  ;; CHECK-NEXT:  tuple.make 2
@@ -468,7 +468,7 @@
  ;; CHECK-NEXT:  tuple.extract 2 1
  ;; CHECK-NEXT: )
  (func $if-defaultable (param $param (ref null eq)) (result (ref null eq))
-  (local $temp (i32 (ref null eq)))
+  (local $temp (tuple i32 (ref null eq)))
   ;; As the last testcase, but now $temp is a defaultable tuple. We still do not
   ;; optimize away the set here, as we ignore tuples in local2stack.
   (local.set $temp

--- a/test/lit/passes/translate-eh-old-to-new.wast
+++ b/test/lit/passes/translate-eh-old-to-new.wast
@@ -149,7 +149,7 @@
   ;; CHECK:      (func $try-none-tag-single-with-rethrow (type $1)
   ;; CHECK-NEXT:  (local $0 exnref)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 (i32 exnref))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 exnref))
   ;; CHECK-NEXT:  (block $outer0
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all2 (result exnref)
@@ -205,7 +205,7 @@
   )
 
   ;; CHECK:      (func $try-none-tag-tuple (type $1)
-  ;; CHECK-NEXT:  (local $0 (i32 i64))
+  ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
   ;; CHECK-NEXT:  (block $outer0
   ;; CHECK-NEXT:   (block $catch_all2
   ;; CHECK-NEXT:    (local.set $0
@@ -243,8 +243,8 @@
 
   ;; CHECK:      (func $try-none-tag-tuple-with-rethrow (type $1)
   ;; CHECK-NEXT:  (local $0 exnref)
-  ;; CHECK-NEXT:  (local $1 (i32 i64))
-  ;; CHECK-NEXT:  (local $2 (i32 i64 exnref))
+  ;; CHECK-NEXT:  (local $1 (tuple i32 i64))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 i64 exnref))
   ;; CHECK-NEXT:  (block $outer0
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all2 (result exnref)
@@ -419,7 +419,7 @@
   ;; CHECK:      (func $try-single-tag-single-with-rethrow (type $2) (result i32)
   ;; CHECK-NEXT:  (local $0 exnref)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 (i32 exnref))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 exnref))
   ;; CHECK-NEXT:  (block $outer0 (result i32)
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all2 (result exnref)
@@ -481,7 +481,7 @@
   )
 
   ;; CHECK:      (func $try-single-tag-tuple (type $2) (result i32)
-  ;; CHECK-NEXT:  (local $0 (i32 i64))
+  ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
   ;; CHECK-NEXT:  (block $outer0 (result i32)
   ;; CHECK-NEXT:   (block $catch_all2
   ;; CHECK-NEXT:    (local.set $0
@@ -527,8 +527,8 @@
 
   ;; CHECK:      (func $try-single-tag-tuple-with-rethrow (type $2) (result i32)
   ;; CHECK-NEXT:  (local $0 exnref)
-  ;; CHECK-NEXT:  (local $1 (i32 i64))
-  ;; CHECK-NEXT:  (local $2 (i32 i64 exnref))
+  ;; CHECK-NEXT:  (local $1 (tuple i32 i64))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 i64 exnref))
   ;; CHECK-NEXT:  (block $outer0 (result i32)
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all2 (result exnref)
@@ -751,7 +751,7 @@
   ;; CHECK:      (func $try-tuple-tag-single-with-rethrow (type $0) (result i32 i64)
   ;; CHECK-NEXT:  (local $0 exnref)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 (i32 exnref))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 exnref))
   ;; CHECK-NEXT:  (block $outer0 (type $0) (result i32 i64)
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all2 (result exnref)
@@ -819,7 +819,7 @@
   )
 
   ;; CHECK:      (func $try-tuple-tag-tuple (type $0) (result i32 i64)
-  ;; CHECK-NEXT:  (local $0 (i32 i64))
+  ;; CHECK-NEXT:  (local $0 (tuple i32 i64))
   ;; CHECK-NEXT:  (block $outer0 (type $0) (result i32 i64)
   ;; CHECK-NEXT:   (block $catch_all2
   ;; CHECK-NEXT:    (local.set $0
@@ -869,8 +869,8 @@
 
   ;; CHECK:      (func $try-tuple-tag-tuple-with-rethrow (type $0) (result i32 i64)
   ;; CHECK-NEXT:  (local $0 exnref)
-  ;; CHECK-NEXT:  (local $1 (i32 i64))
-  ;; CHECK-NEXT:  (local $2 (i32 i64 exnref))
+  ;; CHECK-NEXT:  (local $1 (tuple i32 i64))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 i64 exnref))
   ;; CHECK-NEXT:  (block $outer0 (type $0) (result i32 i64)
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all2 (result exnref)
@@ -961,9 +961,9 @@
   ;; CHECK:      (func $multiple-catches-and-catch_all (type $1)
   ;; CHECK-NEXT:  (local $0 exnref)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 (i32 i64))
-  ;; CHECK-NEXT:  (local $3 (i32 exnref))
-  ;; CHECK-NEXT:  (local $4 (i32 i64 exnref))
+  ;; CHECK-NEXT:  (local $2 (tuple i32 i64))
+  ;; CHECK-NEXT:  (local $3 (tuple i32 exnref))
+  ;; CHECK-NEXT:  (local $4 (tuple i32 i64 exnref))
   ;; CHECK-NEXT:  (block $outer0
   ;; CHECK-NEXT:   (local.set $0
   ;; CHECK-NEXT:    (block $catch_all4 (result exnref)

--- a/test/lit/passes/tuple-optimization.wast
+++ b/test/lit/passes/tuple-optimization.wast
@@ -3,7 +3,7 @@
 
 (module
   ;; CHECK:      (func $just-set (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local.set $1
@@ -14,7 +14,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $just-set
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     ;; This tuple local can be optimized into separate locals per lane. The
     ;; tuple local itself then has no uses and other passes will remove it.
     (local.set $tuple
@@ -26,7 +26,7 @@
   )
 
   ;; CHECK:      (func $just-get (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (drop
@@ -37,7 +37,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $just-get
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     ;; The default value of the tuple lanes is used here in the new locals we
     ;; add.
     (drop
@@ -53,7 +53,7 @@
   )
 
   ;; CHECK:      (func $just-get-bad (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (local.get $tuple)
@@ -67,7 +67,7 @@
   ;; CHECK-NEXT:  (local.get $tuple)
   ;; CHECK-NEXT: )
   (func $just-get-bad (result i32 i32)
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     (drop
       (tuple.extract 2 0
         (local.get $tuple)
@@ -84,7 +84,7 @@
   )
 
   ;; CHECK:      (func $set-and-gets (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (block
@@ -106,7 +106,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $set-and-gets
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     (local.set $tuple
       (tuple.make 2
         (i32.const 1)
@@ -132,8 +132,8 @@
   )
 
   ;; CHECK:      (func $tee (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
@@ -168,8 +168,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $tee
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     (local.set $tuple
       (local.tee $tuple2
         (tuple.make 2
@@ -203,7 +203,7 @@
   )
 
   ;; CHECK:      (func $just-tee (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (drop
@@ -221,7 +221,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $just-tee
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     (drop
       (tuple.extract 2 0
         (local.tee $tuple
@@ -235,7 +235,7 @@
   )
 
   ;; CHECK:      (func $just-tee-bad (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local.tee $tuple
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
@@ -244,7 +244,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $just-tee-bad (result i32 i32)
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     ;; This tee goes somewhere we cannot handle, so we do not optimize here.
     (local.tee $tuple
       (tuple.make 2
@@ -255,8 +255,8 @@
   )
 
   ;; CHECK:      (func $no-uses (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
@@ -277,8 +277,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $no-uses
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     ;; The set has no uses, and the tee only has an immediate use. We can
     ;; still optimize both.
     (local.set $tuple
@@ -292,8 +292,8 @@
   )
 
   ;; CHECK:      (func $corruption-tee (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (local.tee $tuple2
   ;; CHECK-NEXT:    (tuple.make 2
@@ -305,8 +305,8 @@
   ;; CHECK-NEXT:  (local.get $tuple2)
   ;; CHECK-NEXT: )
   (func $corruption-tee (result i32 i32)
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     ;; As above, but the tee's tuple is bad and it prevents the other from
     ;; being optimized too, due to the copy between them.
     (local.set $tuple
@@ -321,8 +321,8 @@
   )
 
   ;; CHECK:      (func $corruption-set (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (local.tee $tuple2
   ;; CHECK-NEXT:    (tuple.make 2
@@ -334,8 +334,8 @@
   ;; CHECK-NEXT:  (local.get $tuple)
   ;; CHECK-NEXT: )
   (func $corruption-set (result i32 i32)
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     ;; As above, but now the set is bad.
     (local.set $tuple
       (local.tee $tuple2
@@ -349,8 +349,8 @@
   )
 
   ;; CHECK:      (func $set-after-set (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
@@ -381,8 +381,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $set-after-set
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     ;; We can optimize both these tuples.
     (local.set $tuple
       (tuple.make 2
@@ -400,8 +400,8 @@
   )
 
   ;; CHECK:      (func $corruption-first-set (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
@@ -414,8 +414,8 @@
   ;; CHECK-NEXT:  (local.get $tuple)
   ;; CHECK-NEXT: )
   (func $corruption-first-set (result i32 i32)
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     (local.set $tuple
       (tuple.make 2
         (i32.const 1)
@@ -430,8 +430,8 @@
   )
 
   ;; CHECK:      (func $corruption-second-set (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (i32.const 1)
@@ -444,8 +444,8 @@
   ;; CHECK-NEXT:  (local.get $tuple2)
   ;; CHECK-NEXT: )
   (func $corruption-second-set (result i32 i32)
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
     (local.set $tuple
       (tuple.make 2
         (i32.const 1)
@@ -460,7 +460,7 @@
 
   ;; CHECK:      (func $other (type $0)
   ;; CHECK-NEXT:  (local $other f64)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $other
   ;; CHECK-NEXT:   (local.tee $other
   ;; CHECK-NEXT:    (local.get $other)
@@ -471,7 +471,7 @@
     ;; A non-tuple local and all operations on it should be ignored.
     (local $other f64)
     ;; A tuple local with no uses at all should be ignored.
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     (local.set $other
       (local.tee $other
         (local.get $other)
@@ -503,7 +503,7 @@
   )
 
   ;; CHECK:      (func $make-extract-no-local-but-other (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (block
@@ -524,7 +524,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $make-extract-no-local-but-other
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     (local.set $tuple
       (tuple.make 2
         (i32.const 1)
@@ -544,7 +544,7 @@
   )
 
   ;; CHECK:      (func $set-of-block (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (block (type $1) (result i32 i32)
   ;; CHECK-NEXT:    (tuple.make 2
@@ -555,7 +555,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $set-of-block
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     ;; We do not handle blocks yet, so this is not optimized.
     (local.set $tuple
       (block (result i32 i32)
@@ -568,7 +568,7 @@
   )
 
   ;; CHECK:      (func $unreachability (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local $nontuple f64)
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (tuple.make 2
@@ -600,7 +600,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $unreachability
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     (local $nontuple f64)
     (local.set $tuple
       (tuple.make 2
@@ -638,9 +638,9 @@
   )
 
   ;; CHECK:      (func $tee-chain (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple3 (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple3 (tuple i32 i32))
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
   ;; CHECK-NEXT:  (local $5 i32)
@@ -678,9 +678,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $tee-chain
-    (local $tuple (i32 i32))
-    (local $tuple2 (i32 i32))
-    (local $tuple3 (i32 i32))
+    (local $tuple (tuple i32 i32))
+    (local $tuple2 (tuple i32 i32))
+    (local $tuple3 (tuple i32 i32))
     (drop
       (tuple.extract 2 0
         (local.tee $tuple
@@ -698,9 +698,9 @@
   )
 
   ;; CHECK:      (func $chain-3 (type $0)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32 i32))
-  ;; CHECK-NEXT:  (local $tuple3 (i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple3 (tuple i32 i32 i32))
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
   ;; CHECK-NEXT:  (local $5 i32)
@@ -754,9 +754,9 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $chain-3
-    (local $tuple (i32 i32 i32))
-    (local $tuple2 (i32 i32 i32))
-    (local $tuple3 (i32 i32 i32))
+    (local $tuple (tuple i32 i32 i32))
+    (local $tuple2 (tuple i32 i32 i32))
+    (local $tuple3 (tuple i32 i32 i32))
     ;; A chain of 3 copied tuples.
     (local.set $tuple
       (tuple.make 3
@@ -790,9 +790,9 @@
   )
 
   ;; CHECK:      (func $chain-3-corruption (type $2) (result i32 i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32 i32))
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32 i32))
-  ;; CHECK-NEXT:  (local $tuple3 (i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple3 (tuple i32 i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (tuple.make 3
   ;; CHECK-NEXT:    (i32.const 1)
@@ -824,9 +824,9 @@
   ;; CHECK-NEXT:  (local.get $tuple)
   ;; CHECK-NEXT: )
   (func $chain-3-corruption (result i32 i32 i32)
-    (local $tuple (i32 i32 i32))
-    (local $tuple2 (i32 i32 i32))
-    (local $tuple3 (i32 i32 i32))
+    (local $tuple (tuple i32 i32 i32))
+    (local $tuple2 (tuple i32 i32 i32))
+    (local $tuple3 (tuple i32 i32 i32))
     ;; As above, but a get at the very end prevents the entire chain from being
     ;; optimized.
     (local.set $tuple
@@ -862,7 +862,7 @@
   )
 
   ;; CHECK:      (func $set-call (type $1) (result i32 i32)
-  ;; CHECK-NEXT:  (local $tuple (i32 i32))
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i32))
   ;; CHECK-NEXT:  (local.set $tuple
   ;; CHECK-NEXT:   (call $set-call)
   ;; CHECK-NEXT:  )
@@ -877,7 +877,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $set-call (result i32 i32)
-    (local $tuple (i32 i32))
+    (local $tuple (tuple i32 i32))
     ;; Setting from a call prevents optimization.
     (local.set $tuple
       (call $set-call)
@@ -894,8 +894,8 @@
   )
 
   ;; CHECK:      (func $two-2-three (type $0)
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple3 (i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple3 (tuple i32 i32 i32))
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
@@ -928,8 +928,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $two-2-three
-    (local $tuple2 (i32 i32))
-    (local $tuple3 (i32 i32 i32))
+    (local $tuple2 (tuple i32 i32))
+    (local $tuple3 (tuple i32 i32 i32))
     (local.set $tuple2
       (tuple.make 2
         (i32.const 1)
@@ -961,8 +961,8 @@
   )
 
   ;; CHECK:      (func $three-2-two (type $0)
-  ;; CHECK-NEXT:  (local $tuple2 (i32 i32))
-  ;; CHECK-NEXT:  (local $tuple3 (i32 i32 i32))
+  ;; CHECK-NEXT:  (local $tuple2 (tuple i32 i32))
+  ;; CHECK-NEXT:  (local $tuple3 (tuple i32 i32 i32))
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
@@ -995,8 +995,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $three-2-two
-    (local $tuple2 (i32 i32))
-    (local $tuple3 (i32 i32 i32))
+    (local $tuple2 (tuple i32 i32))
+    (local $tuple3 (tuple i32 i32 i32))
     (local.set $tuple3
       (tuple.make 3
         (i32.const 1)

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -53,7 +53,7 @@
  ;; CHECK:      (func $unconstrained (type $void)
  ;; CHECK-NEXT:  (local $x i32)
  ;; CHECK-NEXT:  (local $y anyref)
- ;; CHECK-NEXT:  (local $z (anyref i32))
+ ;; CHECK-NEXT:  (local $z (tuple anyref i32))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $unconstrained
@@ -62,7 +62,7 @@
   ;; There is no constraint on the type of this local, so make it top.
   (local $y i31ref)
   ;; We cannot optimize tuple locals yet, so leave it unchanged.
-  (local $z (anyref i32))
+  (local $z (tuple anyref i32))
  )
 
  ;; CHECK:      (func $implicit-return (type $1) (result eqref)

--- a/test/lit/validation/bad-non-nullable-locals.wast
+++ b/test/lit/validation/bad-non-nullable-locals.wast
@@ -68,7 +68,7 @@
   (func $tuple
     ;; Since this tuple local has a non-nullable element, it is subject to the
     ;; non-nullability rules.
-    (local $x (i32 (ref any) i64))
+    (local $x (tuple i32 (ref any) i64))
     (tuple.drop 3
       (local.get $x)
     )

--- a/test/lit/validation/nn-locals-bad-call_ref.wast
+++ b/test/lit/validation/nn-locals-bad-call_ref.wast
@@ -17,7 +17,7 @@
       )
       (catch $tag
         (drop
-          (pop (i32))
+          (pop i32)
         )
         ;; The path to here is from a possible exception thrown in the call_ref.
         ;; This is a regression test for call_ref not being seen as possibly

--- a/test/lit/validation/nn-tuples.wast
+++ b/test/lit/validation/nn-tuples.wast
@@ -7,10 +7,10 @@
 
 (module
   ;; CHECK:      (func $foo (type $0)
-  ;; CHECK-NEXT:  (local $tuple ((ref any) (ref any)))
+  ;; CHECK-NEXT:  (local $tuple (tuple (ref any) (ref any)))
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $foo
-    (local $tuple ((ref any) (ref any)))
+    (local $tuple (tuple (ref any) (ref any)))
   )
 )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -964,7 +964,7 @@
 
  ;; CHECK:      (func $block-mix (type $void)
  ;; CHECK-NEXT:  (local $scratch i32)
- ;; CHECK-NEXT:  (local $scratch_1 (i32 i32))
+ ;; CHECK-NEXT:  (local $scratch_1 (tuple i32 i32))
  ;; CHECK-NEXT:  (local $scratch_2 i32)
  ;; CHECK-NEXT:  (block $0
  ;; CHECK-NEXT:   (drop
@@ -1019,7 +1019,7 @@
 
 
  ;; CHECK:      (func $multivalue-nested (type $ret2) (result i32 i32)
- ;; CHECK-NEXT:  (local $scratch (i32 i32))
+ ;; CHECK-NEXT:  (local $scratch (tuple i32 i32))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (local.set $scratch
  ;; CHECK-NEXT:   (block (type $ret2) (result i32 i32)
@@ -3754,9 +3754,9 @@
  ;; CHECK-NEXT:  (local $0 (ref null $void))
  ;; CHECK-NEXT:  (local $1 (ref null $ret2))
  ;; CHECK-NEXT:  (local $2 (ref null $many))
- ;; CHECK-NEXT:  (local $scratch (i32 i32))
+ ;; CHECK-NEXT:  (local $scratch (tuple i32 i32))
  ;; CHECK-NEXT:  (local $scratch_4 i32)
- ;; CHECK-NEXT:  (local $scratch_5 (anyref (ref func)))
+ ;; CHECK-NEXT:  (local $scratch_5 (tuple anyref (ref func)))
  ;; CHECK-NEXT:  (local $scratch_6 anyref)
  ;; CHECK-NEXT:  (call_ref $void
  ;; CHECK-NEXT:   (local.get $0)

--- a/test/passes/precompute-propagate_all-features.txt
+++ b/test/passes/precompute-propagate_all-features.txt
@@ -297,8 +297,8 @@
   (local.get $x)
  )
  (func $tuple-local (type $3) (result i32 i64)
-  (local $i32s (i32 i32))
-  (local $i64s (i64 i64))
+  (local $i32s (tuple i32 i32))
+  (local $i64s (tuple i64 i64))
   (local.set $i32s
    (tuple.make 2
     (i32.const 42)

--- a/test/passes/precompute-propagate_all-features.wast
+++ b/test/passes/precompute-propagate_all-features.wast
@@ -209,8 +209,8 @@
    (local.get $x)
   )
   (func $tuple-local (result i32 i64)
-   (local $i32s (i32 i32))
-   (local $i64s (i64 i64))
+   (local $i32s (tuple i32 i32))
+   (local $i64s (tuple i64 i64))
    (local.set $i32s
     (tuple.make 2
      (i32.const 42)

--- a/test/passes/rse_all-features.txt
+++ b/test/passes/rse_all-features.txt
@@ -49,7 +49,7 @@
   )
  )
  (func $tuple-value (type $0)
-  (local $x (i32 i64))
+  (local $x (tuple i32 i64))
   (local.set $x
    (tuple.make 2
     (i32.const 42)

--- a/test/passes/rse_all-features.wast
+++ b/test/passes/rse_all-features.wast
@@ -21,7 +21,7 @@
     (local.set $a (i32.const 0))
   )
   (func $tuple-value
-    (local $x (i32 i64))
+    (local $x (tuple i32 i64))
     (local.set $x
       (tuple.make 2 (i32.const 42) (i64.const 42))
     )

--- a/test/spec/exception-handling-old.wast
+++ b/test/spec/exception-handling-old.wast
@@ -75,7 +75,7 @@
     )
   )
 
-  (func (export "try_throw_multivalue_catch") (result i32) (local $x (i32 f32))
+  (func (export "try_throw_multivalue_catch") (result i32) (local $x (tuple i32 f32))
     (try (result i32)
       (do
         (throw $e-i32-f32 (i32.const 5) (f32.const 1.5))

--- a/test/spec/multivalue.wast
+++ b/test/spec/multivalue.wast
@@ -1,5 +1,5 @@
 (module
- (global $global_pair (mut (i32 i64)) (tuple.make 2 (i32.const 0) (i64.const 0)))
+ (global $global_pair (mut (tuple i32 i64)) (tuple.make 2 (i32.const 0) (i64.const 0)))
  (func $pair (export "pair") (result i32 i64)
   (tuple.make 2
    (i32.const 42)
@@ -7,7 +7,7 @@
   )
  )
  (func (export "tuple-local") (result i32 i64)
-  (local $x (i32 i64))
+  (local $x (tuple i32 i64))
   (local.get $x)
  )
  (func (export "tuple-global-get") (result i32 i64)

--- a/test/unit/test_poppy_validation.py
+++ b/test/unit/test_poppy_validation.py
@@ -59,7 +59,7 @@ class PoppyValidationTest(utils.BinaryenTestCase):
         )
         '''
         self.check_invalid(module, "block element has incompatible type")
-        self.check_invalid(module, "required: (i32 i32), available: (f32 i32)")
+        self.check_invalid(module, "required: (tuple i32 i32), available: (tuple f32 i32)")
 
     def test_incorrect_pop_type(self):
         module = '''


### PR DESCRIPTION
Instead of e.g. `(i32 i32)`, use `(tuple i32 i32)`. Having a keyword to
introduce the s-expression is more consistent with the rest of the language.