### PR TITLE
[Parser] Parse tuple types

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -78,6 +78,7 @@ struct TypeUse {
 struct NullTypeParserCtx {
   using IndexT = Ok;
   using HeapTypeT = Ok;
+  using TupleElemListT = Ok;
   using TypeT = Ok;
   using ParamsT = Ok;
   using ResultsT = size_t;
@@ -121,6 +122,10 @@ struct NullTypeParserCtx {
   TypeT makeV128() { return Ok{}; }
 
   TypeT makeRefType(HeapTypeT, Nullability) { return Ok{}; }
+
+  TupleElemListT makeTupleElemList() { return Ok{}; }
+  void appendTupleElem(TupleElemListT&, TypeT) {}
+  TypeT makeTupleType(TupleElemListT) { return Ok{}; }
 
   ParamsT makeParams() { return Ok{}; }
   void appendParam(ParamsT&, Name, TypeT) {}
@@ -219,7 +224,13 @@ template<typename Ctx> struct TypeParserCtx {
     return Type(ht, nullability);
   }
 
-  TypeT makeTupleType(const std::vector<Type> types) { return Tuple(types); }
+  std::vector<Type> makeTupleElemList() { return {}; }
+  void appendTupleElem(std::vector<Type>& elems, Type elem) {
+    elems.push_back(elem);
+  }
+  Result<TypeT> makeTupleType(const std::vector<Type>& types) {
+    return Tuple(types);
+  }
 
   ParamsT makeParams() { return {}; }
   void appendParam(ParamsT& params, Name id, TypeT type) {

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -457,6 +457,8 @@
  ;; CHECK-NEXT: )
  (func $f4 (type 18) (local i32 i64) (local $l f32))
 
+ (func $tuple-locals (local (tuple i32 i32)))
+
  ;; CHECK:      (func $nop-skate (type $void)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (nop)

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -457,6 +457,10 @@
  ;; CHECK-NEXT: )
  (func $f4 (type 18) (local i32 i64) (local $l f32))
 
+ ;; CHECK:      (func $tuple-locals (type $void)
+ ;; CHECK-NEXT:  (local $0 (tuple i32 i32))
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT: )
  (func $tuple-locals (local (tuple i32 i32)))
 
  ;; CHECK:      (func $nop-skate (type $void)
@@ -3521,7 +3525,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 151
+  ref.func 152
   drop
  )
 


### PR DESCRIPTION
Use the new `(tuple ...)` syntax. Enforce that tuples have a valid number of
elements and are not nested to avoid assertion failures when parsing invalid
input.