### PR TITLE
Update pop text syntax

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2023,11 +2023,8 @@ struct PrintExpressionContents
   void visitNop(Nop* curr) { printMinor(o, "nop"); }
   void visitUnreachable(Unreachable* curr) { printMinor(o, "unreachable"); }
   void visitPop(Pop* curr) {
-    prepareColor(o) << "pop";
-    for (auto type : curr->type) {
-      o << ' ';
-      printType(type);
-    }
+    prepareColor(o) << "pop ";
+    printType(curr->type);
     restoreNormalColor(o);
   }
   void visitTupleMake(TupleMake* curr) {

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -2394,11 +2394,10 @@ Expression* SExpressionWasmBuilder::makeMemoryFill(Element& s) {
 
 Expression* SExpressionWasmBuilder::makePop(Element& s) {
   auto ret = allocator.alloc<Pop>();
-  std::vector<Type> types;
-  for (size_t i = 1; i < s.size(); ++i) {
-    types.push_back(elementToType(*s[i]));
+  if (s.size() != 2) {
+    throw SParseException("expected 'pop <valtype>'", s);
   }
-  ret->type = Type(types);
+  ret->type = elementToType(*s[1]);
   ret->finalize();
   return ret;
 }

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -2237,7 +2237,7 @@ BinaryenFeatureAll: 131071
        (pop externref)
       )
       (tuple.drop 4
-       (pop i32 i64 f32 f64)
+       (pop (tuple i32 i64 f32 f64))
       )
       (drop
        (memory.size)

--- a/test/lit/basic/exception-handling-old.wast
+++ b/test/lit/basic/exception-handling-old.wast
@@ -115,7 +115,7 @@
   ;; CHECK-TEXT-NEXT:   )
   ;; CHECK-TEXT-NEXT:   (catch $e-i32-i64
   ;; CHECK-TEXT-NEXT:    (local.set $x
-  ;; CHECK-TEXT-NEXT:     (pop i32 i64)
+  ;; CHECK-TEXT-NEXT:     (pop (tuple i32 i64))
   ;; CHECK-TEXT-NEXT:    )
   ;; CHECK-TEXT-NEXT:    (drop
   ;; CHECK-TEXT-NEXT:     (tuple.extract 2 0
@@ -139,7 +139,7 @@
   ;; CHECK-BIN-NEXT:   )
   ;; CHECK-BIN-NEXT:   (catch $e-i32-i64
   ;; CHECK-BIN-NEXT:    (local.set $2
-  ;; CHECK-BIN-NEXT:     (pop i32 i64)
+  ;; CHECK-BIN-NEXT:     (pop (tuple i32 i64))
   ;; CHECK-BIN-NEXT:    )
   ;; CHECK-BIN-NEXT:    (local.set $x
   ;; CHECK-BIN-NEXT:     (block (result i32)
@@ -168,7 +168,7 @@
         (throw $e-i32-i64 (i32.const 0) (i64.const 0))
       )
       (catch $e-i32-i64
-        (local.set $x (pop i32 i64))
+        (local.set $x (pop (tuple i32 i64)))
         (drop
           (tuple.extract 2 0
             (local.get $x)
@@ -1387,7 +1387,7 @@
 ;; CHECK-BIN-NODEBUG-NEXT:   )
 ;; CHECK-BIN-NODEBUG-NEXT:   (catch $tag$2
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.set $2
-;; CHECK-BIN-NODEBUG-NEXT:     (pop i32 i64)
+;; CHECK-BIN-NODEBUG-NEXT:     (pop (tuple i32 i64))
 ;; CHECK-BIN-NODEBUG-NEXT:    )
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.set $0
 ;; CHECK-BIN-NODEBUG-NEXT:     (block (result i32)

--- a/test/lit/passes/catch-pop-fixup-eh-old.wast
+++ b/test/lit/passes/catch-pop-fixup-eh-old.wast
@@ -334,7 +334,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $e-i32-f32
   ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (pop i32 f32)
+  ;; CHECK-NEXT:     (pop (tuple i32 f32))
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (throw $e-i32
   ;; CHECK-NEXT:     (block (result i32)
@@ -354,7 +354,7 @@
         (throw $e-i32
           ;; This tests a pop taking a tuple type.
           (block (result i32)
-            (local.set $x (pop i32 f32))
+            (local.set $x (pop (tuple i32 f32)))
             (i32.const 0)
           )
         )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2150,7 +2150,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag
   ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop anyref anyref)
+  ;; CHECK-NEXT:     (pop (tuple anyref anyref))
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
@@ -2169,7 +2169,7 @@
   ;; CHECK-NEXT:   (catch $tag
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (tuple.extract 2 1
-  ;; CHECK-NEXT:      (pop anyref anyref)
+  ;; CHECK-NEXT:      (pop (tuple anyref anyref))
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -2187,7 +2187,7 @@
       (catch $tag
         (drop
           (tuple.extract 2 0
-            (pop (ref null any) (ref null any))
+            (pop (tuple (ref null any) (ref null any)))
           )
         )
       )
@@ -2198,7 +2198,7 @@
       (catch $tag
         (drop
           (tuple.extract 2 1
-            (pop (ref null any) (ref null any))
+            (pop (tuple (ref null any) (ref null any)))
           )
         )
       )

--- a/test/lit/passes/poppify.wast
+++ b/test/lit/passes/poppify.wast
@@ -482,7 +482,7 @@
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (i64.const 1)
   ;; CHECK-NEXT:   (br $l
-  ;; CHECK-NEXT:    (pop i32 i64)
+  ;; CHECK-NEXT:    (pop (tuple i32 i64))
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -501,7 +501,7 @@
   ;; CHECK-NEXT:  (i32.const 0)
   ;; CHECK-NEXT:  (i64.const 1)
   ;; CHECK-NEXT:  (return
-  ;; CHECK-NEXT:   (pop i32 i64)
+  ;; CHECK-NEXT:   (pop (tuple i32 i64))
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $return-tuple (result i32 i64)

--- a/test/lit/passes/translate-eh-old-to-new.wast
+++ b/test/lit/passes/translate-eh-old-to-new.wast
@@ -232,7 +232,7 @@
       )
       (catch $e-i32-i64
         (tuple.drop 2
-          (pop i32 i64)
+          (pop (tuple i32 i64))
         )
       )
       (catch_all
@@ -294,7 +294,7 @@
       )
       (catch $e-i32-i64
         (tuple.drop 2
-          (pop i32 i64)
+          (pop (tuple i32 i64))
         )
         (rethrow $l0)
       )
@@ -515,7 +515,7 @@
       )
       (catch $e-i32-i64
         (tuple.drop 2
-          (pop i32 i64)
+          (pop (tuple i32 i64))
         )
         (i32.const 1)
       )
@@ -584,7 +584,7 @@
       )
       (catch $e-i32-i64
         (tuple.drop 2
-          (pop i32 i64)
+          (pop (tuple i32 i64))
         )
         (rethrow $l0)
       )
@@ -856,7 +856,7 @@
         )
       )
       (catch $e-i32-i64
-        (pop i32 i64)
+        (pop (tuple i32 i64))
       )
       (catch_all
         (tuple.make 2
@@ -932,7 +932,7 @@
       )
       (catch $e-i32-i64
         (tuple.drop 2
-          (pop i32 i64)
+          (pop (tuple i32 i64))
         )
         (rethrow $l0)
       )
@@ -1050,7 +1050,7 @@
       )
       (catch $e-i32-i64
         (tuple.drop 2
-          (pop i32 i64)
+          (pop (tuple i32 i64))
         )
         (rethrow $l0)
       )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -1824,7 +1824,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (catch $tag-pair
- ;; CHECK-NEXT:    (pop i32 i64)
+ ;; CHECK-NEXT:    (pop (tuple i32 i64))
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )

--- a/test/spec/exception-handling-old.wast
+++ b/test/spec/exception-handling-old.wast
@@ -82,7 +82,7 @@
       )
       (catch $e-i32-f32
         (local.set $x
-          (pop i32 f32)
+          (pop (tuple i32 f32))
         )
         (tuple.extract 2 0
           (local.get $x)


### PR DESCRIPTION
Rather than `(pop valtype*)`, use `(pop valtype)`, where `valtype` is now
allowed to be a tuple. This will make it possible to parse un-folded multivalue
pops in the new text parser. The alternative would have been to put an arity in
the syntax like we have for other tuple instructions, but that's much uglier.