### PR TITLE
Allow updating basic HeapTypes in GlobalTypeRewriter::mapTypes

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -176,9 +176,6 @@ void GlobalTypeRewriter::mapTypes(const TypeMap& oldToNewTypes) {
     }
 
     HeapType getNew(HeapType type) {
-      if (type.isBasic()) {
-        return type;
-      }
       auto iter = oldToNewTypes.find(type);
       if (iter != oldToNewTypes.end()) {
         return iter->second;


### PR DESCRIPTION
This was perhaps an optimization? This change is needed for an upcoming
PR that lowers away strings, as it will replace the `string` HeapType with
`extern`.