### PR TITLE
[EH] Add --experimental-new-eh option

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -225,6 +225,11 @@ struct PassOptions {
   // that needs lowering, then we lower it, then we can optimize it again to the
   // original form).
   bool targetJS = false;
+  // After running all requested transformations / optimizations, translate the
+  // instruction to use the new EH instructions at the end. Depending on the
+  // optimization level specified, this may do some more post-translation
+  // optimizations.
+  bool experimentalNewEH = false;
   // Arbitrary string arguments from the commandline, which we forward to
   // passes.
   std::unordered_map<std::string, std::string> arguments;

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -723,6 +723,12 @@ void PassRunner::addDefaultGlobalOptimizationPostPasses() {
   }
   // may allow more inlining/dae/etc., need --converge for that
   addIfNoDWARFIssues("directize");
+
+  // Translate to use the new EH instructions if requested.
+  if (wasm->features.hasExceptionHandling() && options.experimentalNewEH) {
+    addIfNoDWARFIssues("translate-to-new-eh");
+  }
+
   // perform Stack IR optimizations here, at the very end of the
   // optimization pipeline
   if (options.optimizeLevel >= 2 || options.shrinkLevel >= 1) {

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -612,6 +612,15 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --skip-pass,-sp                               Skip a pass (do not run it)
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --experimental-new-eh                         After running all requested
+;; CHECK-NEXT:                                                 transformations / optimizations,
+;; CHECK-NEXT:                                                 translate the instruction to use
+;; CHECK-NEXT:                                                 the new EH instructions at the
+;; CHECK-NEXT:                                                 end. Depending on the
+;; CHECK-NEXT:                                                 optimization level specified,
+;; CHECK-NEXT:                                                 this may do some more
+;; CHECK-NEXT:                                                 post-translation optimizations.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -571,6 +571,15 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --skip-pass,-sp                               Skip a pass (do not run it)
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --experimental-new-eh                         After running all requested
+;; CHECK-NEXT:                                                 transformations / optimizations,
+;; CHECK-NEXT:                                                 translate the instruction to use
+;; CHECK-NEXT:                                                 the new EH instructions at the
+;; CHECK-NEXT:                                                 end. Depending on the
+;; CHECK-NEXT:                                                 optimization level specified,
+;; CHECK-NEXT:                                                 this may do some more
+;; CHECK-NEXT:                                                 post-translation optimizations.
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------


### PR DESCRIPTION
This adds `--experimental-new-eh` option to `wasm-opt`. The difference between this and `--translate-to-new-eh` is, `--translate-to-new-eh` just runs `TranslateToNewEH` pass, while `--experimental-new-eh` attaches `TranslateToNewEH` pass at the end of the whole optimization pipeline. So if no other passes or optimization options (`-On`) are specified, it is equivalent to `--translate-to-new-eh`. If other optimization passes are specified, it runs them and at the end run the translator to ensure the new EH instructions are emitted. The reason we are doing this this way is that the optimization pipeline as a whole does not support the new EH instruction yet, but we would like to provide an option to emit a reasonably OK code with the new EH instructions.

This also means when the optimization level > 3, it will also run the StackIR optimization after the translation.

Not sure how to test the output of this option, given that there is not much point in testing the default optimization passes, and it is also not clear how to print the stack IR if the stack ir generation and optimization runs as a part of the pipeline and not the explicit command line options.