### PR TITLE
[Parser] Templatize lexing of integers

### DIFF
--- a/src/parser/input-impl.h
+++ b/src/parser/input-impl.h
@@ -100,7 +100,7 @@ inline std::optional<uint64_t> ParseInput::takeOffset() {
       if (subLexer == subLexer.end()) {
         return {};
       }
-      if (auto o = subLexer->getU64()) {
+      if (auto o = subLexer->getU<uint64_t>()) {
         ++subLexer;
         if (subLexer == subLexer.end()) {
           ++lexer;
@@ -122,7 +122,7 @@ inline std::optional<uint32_t> ParseInput::takeAlign() {
       if (subLexer == subLexer.end()) {
         return {};
       }
-      if (auto a = subLexer->getU32()) {
+      if (auto a = subLexer->getU<uint32_t>()) {
         ++subLexer;
         if (subLexer == subLexer.end()) {
           ++lexer;
@@ -134,9 +134,9 @@ inline std::optional<uint32_t> ParseInput::takeAlign() {
   return {};
 }
 
-inline std::optional<uint64_t> ParseInput::takeU64() {
+template<typename T> inline std::optional<T> ParseInput::takeU() {
   if (auto t = peek()) {
-    if (auto n = t->getU64()) {
+    if (auto n = t->getU<T>()) {
       ++lexer;
       return n;
     }
@@ -144,67 +144,33 @@ inline std::optional<uint64_t> ParseInput::takeU64() {
   return std::nullopt;
 }
 
-inline std::optional<int64_t> ParseInput::takeS64() {
+template<typename T> inline std::optional<T> ParseInput::takeI() {
   if (auto t = peek()) {
-    if (auto n = t->getS64()) {
+    if (auto n = t->getI<T>()) {
       ++lexer;
       return n;
     }
   }
-  return {};
+  return std::nullopt;
 }
 
-inline std::optional<int64_t> ParseInput::takeI64() {
-  if (auto t = peek()) {
-    if (auto n = t->getI64()) {
-      ++lexer;
-      return n;
-    }
-  }
-  return {};
+inline std::optional<uint64_t> ParseInput::takeU64() {
+  return takeU<uint64_t>();
+}
+
+inline std::optional<uint64_t> ParseInput::takeI64() {
+  return takeI<uint64_t>();
 }
 
 inline std::optional<uint32_t> ParseInput::takeU32() {
-  if (auto t = peek()) {
-    if (auto n = t->getU32()) {
-      ++lexer;
-      return n;
-    }
-  }
-  return std::nullopt;
+  return takeU<uint64_t>();
 }
 
-inline std::optional<int32_t> ParseInput::takeS32() {
-  if (auto t = peek()) {
-    if (auto n = t->getS32()) {
-      ++lexer;
-      return n;
-    }
-  }
-  return {};
+inline std::optional<uint32_t> ParseInput::takeI32() {
+  return takeI<uint32_t>();
 }
 
-inline std::optional<int32_t> ParseInput::takeI32() {
-  if (auto t = peek()) {
-    if (auto n = t->getI32()) {
-      ++lexer;
-      return n;
-    }
-  }
-  return {};
-}
-
-inline std::optional<uint8_t> ParseInput::takeU8() {
-  if (auto t = peek()) {
-    if (auto n = t->getU32()) {
-      if (n <= std::numeric_limits<uint8_t>::max()) {
-        ++lexer;
-        return uint8_t(*n);
-      }
-    }
-  }
-  return {};
-}
+inline std::optional<uint8_t> ParseInput::takeU8() { return takeU<uint8_t>(); }
 
 inline std::optional<double> ParseInput::takeF64() {
   if (auto t = peek()) {

--- a/src/parser/input.h
+++ b/src/parser/input.h
@@ -51,11 +51,9 @@ struct ParseInput {
   std::optional<uint64_t> takeOffset();
   std::optional<uint32_t> takeAlign();
   std::optional<uint64_t> takeU64();
-  std::optional<int64_t> takeS64();
-  std::optional<int64_t> takeI64();
+  std::optional<uint64_t> takeI64();
   std::optional<uint32_t> takeU32();
-  std::optional<int32_t> takeS32();
-  std::optional<int32_t> takeI32();
+  std::optional<uint32_t> takeI32();
   std::optional<uint8_t> takeU8();
   std::optional<double> takeF64();
   std::optional<float> takeF32();
@@ -67,6 +65,11 @@ struct ParseInput {
   Index getPos();
   [[nodiscard]] Err err(Index pos, std::string reason);
   [[nodiscard]] Err err(std::string reason) { return err(getPos(), reason); }
+
+private:
+  template<typename T> std::optional<T> takeU();
+  template<typename T> std::optional<T> takeS();
+  template<typename T> std::optional<T> takeI();
 };
 
 #include "input-impl.h"

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -125,12 +125,10 @@ struct Token {
     }
     return {};
   }
-  std::optional<uint64_t> getU64() const;
-  std::optional<int64_t> getS64() const;
-  std::optional<uint64_t> getI64() const;
-  std::optional<uint32_t> getU32() const;
-  std::optional<int32_t> getS32() const;
-  std::optional<uint32_t> getI32() const;
+
+  template<typename T> std::optional<T> getU() const;
+  template<typename T> std::optional<T> getS() const;
+  template<typename T> std::optional<T> getI() const;
   std::optional<double> getF64() const;
   std::optional<float> getF32() const;
   std::optional<std::string_view> getString() const;

--- a/test/gtest/wat-lexer.cpp
+++ b/test/gtest/wat-lexer.cpp
@@ -380,21 +380,21 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    ASSERT_TRUE(lexer->getU32());
-    ASSERT_TRUE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    ASSERT_TRUE(lexer->getU<uint32_t>());
+    ASSERT_TRUE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0ull);
-    EXPECT_EQ(*lexer->getS64(), 0ll);
-    EXPECT_EQ(*lexer->getI64(), 0ull);
-    EXPECT_EQ(*lexer->getU32(), 0u);
-    EXPECT_EQ(*lexer->getS32(), 0);
-    EXPECT_EQ(*lexer->getI32(), 0u);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0ull);
+    EXPECT_EQ(*lexer->getU<uint32_t>(), 0u);
+    EXPECT_EQ(*lexer->getS<int32_t>(), 0);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0u);
     EXPECT_EQ(*lexer->getF64(), 0.0);
     EXPECT_EQ(*lexer->getF32(), 0.0);
     EXPECT_FALSE(std::signbit(*lexer->getF64()));
@@ -404,19 +404,19 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    ASSERT_TRUE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    ASSERT_TRUE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0ll);
-    EXPECT_EQ(*lexer->getI64(), 0ull);
-    EXPECT_EQ(*lexer->getS32(), 0);
-    EXPECT_EQ(*lexer->getI32(), 0u);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0ull);
+    EXPECT_EQ(*lexer->getS<int32_t>(), 0);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0u);
     EXPECT_EQ(*lexer->getF64(), 0.0);
     EXPECT_EQ(*lexer->getF32(), 0.0);
     EXPECT_FALSE(std::signbit(*lexer->getF64()));
@@ -426,19 +426,19 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("-0"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    ASSERT_TRUE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    ASSERT_TRUE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0ll);
-    EXPECT_EQ(*lexer->getI64(), 0ull);
-    EXPECT_EQ(*lexer->getS32(), 0);
-    EXPECT_EQ(*lexer->getI32(), 0u);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0ull);
+    EXPECT_EQ(*lexer->getS<int32_t>(), 0);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0u);
     EXPECT_EQ(*lexer->getF64(), -0.0);
     EXPECT_EQ(*lexer->getF32(), -0.0);
     ASSERT_TRUE(std::signbit(*lexer->getF64()));
@@ -448,21 +448,21 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0x7fff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    ASSERT_TRUE(lexer->getU32());
-    ASSERT_TRUE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    ASSERT_TRUE(lexer->getU<uint32_t>());
+    ASSERT_TRUE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0x7fffffffull);
-    EXPECT_EQ(*lexer->getS64(), 0x7fffffffll);
-    EXPECT_EQ(*lexer->getI64(), 0x7fffffffull);
-    EXPECT_EQ(*lexer->getU32(), 0x7fffffffu);
-    EXPECT_EQ(*lexer->getS32(), 0x7fffffff);
-    EXPECT_EQ(*lexer->getI32(), 0x7fffffffu);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0x7fffffffull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x7fffffffll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x7fffffffull);
+    EXPECT_EQ(*lexer->getU<uint32_t>(), 0x7fffffffu);
+    EXPECT_EQ(*lexer->getS<int32_t>(), 0x7fffffff);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0x7fffffffu);
     EXPECT_EQ(*lexer->getF64(), 0x7fffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0x7fffffff.p0f);
   }
@@ -470,20 +470,20 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0x8000_0000"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    ASSERT_TRUE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    ASSERT_TRUE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0x80000000ull);
-    EXPECT_EQ(*lexer->getS64(), 0x80000000ll);
-    EXPECT_EQ(*lexer->getI64(), 0x80000000ull);
-    EXPECT_EQ(*lexer->getU32(), 0x80000000u);
-    EXPECT_EQ(*lexer->getI32(), 0x80000000u);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0x80000000ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x80000000ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x80000000ull);
+    EXPECT_EQ(*lexer->getU<uint32_t>(), 0x80000000u);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0x80000000u);
     EXPECT_EQ(*lexer->getF64(), 0x80000000.p0);
     EXPECT_EQ(*lexer->getF32(), 0x80000000.p0f);
   }
@@ -491,19 +491,19 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0x7fff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    ASSERT_TRUE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    ASSERT_TRUE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0x7fffffffll);
-    EXPECT_EQ(*lexer->getI64(), 0x7fffffffull);
-    EXPECT_EQ(*lexer->getS32(), 0x7fffffff);
-    EXPECT_EQ(*lexer->getI32(), 0x7fffffffu);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x7fffffffll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x7fffffffull);
+    EXPECT_EQ(*lexer->getS<int32_t>(), 0x7fffffff);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0x7fffffffu);
     EXPECT_EQ(*lexer->getF64(), 0x7fffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0x7fffffff.p0f);
   }
@@ -511,17 +511,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0x8000_0000"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0x80000000ll);
-    EXPECT_EQ(*lexer->getI64(), 0x80000000ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x80000000ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x80000000ull);
     EXPECT_EQ(*lexer->getF64(), 0x80000000.p0);
     EXPECT_EQ(*lexer->getF32(), 0x80000000.p0f);
   }
@@ -529,19 +529,19 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("-0x8000_0000"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    ASSERT_TRUE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    ASSERT_TRUE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), -0x80000000ll);
-    EXPECT_EQ(*lexer->getI64(), -0x80000000ull);
-    EXPECT_EQ(*lexer->getS32(), -0x7fffffffll - 1);
-    EXPECT_EQ(*lexer->getI32(), -0x80000000u);
+    EXPECT_EQ(*lexer->getS<int64_t>(), -0x80000000ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), -0x80000000ull);
+    EXPECT_EQ(*lexer->getS<int32_t>(), -0x7fffffffll - 1);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), -0x80000000u);
     EXPECT_EQ(*lexer->getF64(), -0x80000000.p0);
     EXPECT_EQ(*lexer->getF32(), -0x80000000.p0f);
   }
@@ -549,17 +549,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("-0x8000_0001"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), -0x80000001ll);
-    EXPECT_EQ(*lexer->getI64(), -0x80000001ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), -0x80000001ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), -0x80000001ull);
     EXPECT_EQ(*lexer->getF64(), -0x80000001.p0);
     EXPECT_EQ(*lexer->getF32(), -0x80000001.p0f);
   }
@@ -567,20 +567,20 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0xffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    ASSERT_TRUE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    ASSERT_TRUE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    ASSERT_TRUE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    ASSERT_TRUE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0xffffffffull);
-    EXPECT_EQ(*lexer->getS64(), 0xffffffffll);
-    EXPECT_EQ(*lexer->getI64(), 0xffffffffull);
-    EXPECT_EQ(*lexer->getU32(), 0xffffffffu);
-    EXPECT_EQ(*lexer->getI32(), 0xffffffffu);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0xffffffffull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0xffffffffll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0xffffffffull);
+    EXPECT_EQ(*lexer->getU<uint32_t>(), 0xffffffffu);
+    EXPECT_EQ(*lexer->getI<uint32_t>(), 0xffffffffu);
     EXPECT_EQ(*lexer->getF64(), 0xffffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0xffffffff.p0f);
   }
@@ -588,18 +588,18 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0x1_0000_0000"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0x100000000ull);
-    EXPECT_EQ(*lexer->getS64(), 0x100000000ll);
-    EXPECT_EQ(*lexer->getI64(), 0x100000000ull);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0x100000000ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x100000000ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x100000000ull);
     EXPECT_EQ(*lexer->getF64(), 0x100000000.p0);
     EXPECT_EQ(*lexer->getF32(), 0x100000000.p0f);
   }
@@ -607,17 +607,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0xffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0xffffffffll);
-    EXPECT_EQ(*lexer->getI64(), 0xffffffffull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0xffffffffll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0xffffffffull);
     EXPECT_EQ(*lexer->getF64(), 0xffffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0xffffffff.p0f);
   }
@@ -625,17 +625,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0x1_0000_0000"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0x100000000ll);
-    EXPECT_EQ(*lexer->getI64(), 0x100000000ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x100000000ll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x100000000ull);
     EXPECT_EQ(*lexer->getF64(), 0x100000000.p0);
     EXPECT_EQ(*lexer->getF32(), 0x100000000.p0f);
   }
@@ -643,18 +643,18 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0x7fff_ffff_ffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0x7fffffffffffffffull);
-    EXPECT_EQ(*lexer->getS64(), 0x7fffffffffffffffll);
-    EXPECT_EQ(*lexer->getI64(), 0x7fffffffffffffffull);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0x7fffffffffffffffull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x7fffffffffffffffll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x7fffffffffffffffull);
     EXPECT_EQ(*lexer->getF64(), 0x7fffffffffffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0x7fffffffffffffff.p0f);
   }
@@ -662,17 +662,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0x7fff_ffff_ffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), 0x7fffffffffffffffll);
-    EXPECT_EQ(*lexer->getI64(), 0x7fffffffffffffffull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), 0x7fffffffffffffffll);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0x7fffffffffffffffull);
     EXPECT_EQ(*lexer->getF64(), 0x7fffffffffffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0x7fffffffffffffff.p0f);
   }
@@ -680,17 +680,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("-0x8000_0000_0000_0000"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    ASSERT_TRUE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    ASSERT_TRUE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getS64(), -0x7fffffffffffffffll - 1);
-    EXPECT_EQ(*lexer->getI64(), -0x8000000000000000ull);
+    EXPECT_EQ(*lexer->getS<int64_t>(), -0x7fffffffffffffffll - 1);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), -0x8000000000000000ull);
     EXPECT_EQ(*lexer->getF64(), -0x8000000000000000.p0);
     EXPECT_EQ(*lexer->getF32(), -0x8000000000000000.p0f);
   }
@@ -698,17 +698,17 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("0xffff_ffff_ffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    ASSERT_TRUE(lexer->getU64());
-    EXPECT_FALSE(lexer->getS64());
-    ASSERT_TRUE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    ASSERT_TRUE(lexer->getU<uint64_t>());
+    EXPECT_FALSE(lexer->getS<int64_t>());
+    ASSERT_TRUE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 
-    EXPECT_EQ(*lexer->getU64(), 0xffffffffffffffffull);
-    EXPECT_EQ(*lexer->getI64(), 0xffffffffffffffffull);
+    EXPECT_EQ(*lexer->getU<uint64_t>(), 0xffffffffffffffffull);
+    EXPECT_EQ(*lexer->getI<uint64_t>(), 0xffffffffffffffffull);
     EXPECT_EQ(*lexer->getF64(), 0xffffffffffffffff.p0);
     EXPECT_EQ(*lexer->getF32(), 0xffffffffffffffff.p0f);
   }
@@ -716,12 +716,12 @@ TEST(LexerTest, ClassifyInt) {
     Lexer lexer("+0xffff_ffff_ffff_ffff"sv);
     ASSERT_FALSE(lexer.empty());
 
-    EXPECT_FALSE(lexer->getU64());
-    EXPECT_FALSE(lexer->getS64());
-    EXPECT_FALSE(lexer->getI64());
-    EXPECT_FALSE(lexer->getU32());
-    EXPECT_FALSE(lexer->getS32());
-    EXPECT_FALSE(lexer->getI32());
+    EXPECT_FALSE(lexer->getU<uint64_t>());
+    EXPECT_FALSE(lexer->getS<int64_t>());
+    EXPECT_FALSE(lexer->getI<uint64_t>());
+    EXPECT_FALSE(lexer->getU<uint32_t>());
+    EXPECT_FALSE(lexer->getS<int32_t>());
+    EXPECT_FALSE(lexer->getI<uint32_t>());
     ASSERT_TRUE(lexer->getF64());
     ASSERT_TRUE(lexer->getF32());
 


### PR DESCRIPTION
Have a single implementation for lexing each of unsigned, signed, and
uninterpreted integers, each generic over the bit width of the integer. This
reduces duplication in the existing code and it will make it much easier to
support lexing more 8- and 16-bit integers.