### PR TITLE
wasm-ctor-eval: Properly eval strings

### DIFF
--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -838,8 +838,9 @@ public:
     // GC data (structs and arrays) must be handled with the special global-
     // creating logic later down. But MVP types as well as i31s (even
     // externalized i31s) can be handled by the general makeConstantExpression
-    // logic (which knows how to handle externalization, for i31s).
-    if (!value.isData()) {
+    // logic (which knows how to handle externalization, for i31s; and it also
+    // can handle string constants).
+    if (!value.isData() || value.type.getHeapType().isString()) {
       return builder.makeConstantExpression(original);
     }
 
@@ -889,12 +890,6 @@ public:
       } else if (heapType.isArray()) {
         // TODO: for repeated identical values, can use ArrayNew
         init = builder.makeArrayNewFixed(heapType, args);
-      } else if (heapType.isString()) {
-        std::string s;
-        for (auto c : values) {
-          s += char(c.getInteger());
-        }
-        init = builder.makeStringConst(s);
       } else {
         WASM_UNREACHABLE("bad gc type");
       }

--- a/test/lit/ctor-eval/string.wast
+++ b/test/lit/ctor-eval/string.wast
@@ -5,9 +5,6 @@
 ;; the output, as precomputing a string results in an identical string.
 
 (module
- ;; CHECK:      (type $0 (func (result anyref)))
-
- ;; CHECK:      (global $global (ref string) (string.const "one"))
  (global $global (ref string) (string.const "one"))
 
  (export "test" (func $test))
@@ -16,8 +13,10 @@
   (global.get $global)
  )
 )
+;; CHECK:      (type $0 (func (result anyref)))
+
 ;; CHECK:      (export "test" (func $test_1))
 
 ;; CHECK:      (func $test_1 (type $0) (result anyref)
-;; CHECK-NEXT:  (global.get $global)
+;; CHECK-NEXT:  (string.const "one")
 ;; CHECK-NEXT: )


### PR DESCRIPTION
#6244 tried to do this but was not quite right. It treated a string like an array
or a struct, which means create a global for it. But just creating a global isn't
enough, as it needs to also be sorted in the right place etc. which requires
changes in other places. But there is a much simpler solution here: string
constants are just constants, which we can emit in-line, so do that.