### PR TITLE
[Parser] Support string-style identifiers

### DIFF
--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -53,6 +53,12 @@ struct RParenTok {
 };
 
 struct IdTok {
+  // Whether this ID has `$"..."` format
+  bool isStr;
+
+  // If the ID is a string ID and contains escapes, this is its contents.
+  std::optional<std::string> str;
+
   bool operator==(const IdTok&) const { return true; }
   friend std::ostream& operator<<(std::ostream&, const IdTok&);
 };
@@ -81,6 +87,7 @@ struct FloatTok {
 };
 
 struct StringTok {
+  // If the string contains escapes, this is its contents.
   std::optional<std::string> str;
 
   bool operator==(const StringTok& other) const { return str == other.str; }
@@ -111,14 +118,6 @@ struct Token {
 
   bool isRParen() const { return std::get_if<RParenTok>(&data); }
 
-  std::optional<std::string_view> getID() const {
-    if (std::get_if<IdTok>(&data)) {
-      // Drop leading '$'.
-      return span.substr(1);
-    }
-    return {};
-  }
-
   std::optional<std::string_view> getKeyword() const {
     if (std::get_if<KeywordTok>(&data)) {
       return span;
@@ -132,6 +131,7 @@ struct Token {
   std::optional<double> getF64() const;
   std::optional<float> getF32() const;
   std::optional<std::string_view> getString() const;
+  std::optional<std::string_view> getID() const;
 
   bool operator==(const Token&) const;
   friend std::ostream& operator<<(std::ostream& os, const Token&);

--- a/test/gtest/wat-lexer.cpp
+++ b/test/gtest/wat-lexer.cpp
@@ -1377,6 +1377,33 @@ TEST(LexerTest, LexIdent) {
     Lexer lexer("$"sv);
     EXPECT_TRUE(lexer.empty());
   }
+
+  // String IDs
+  {
+    Lexer lexer("$\"\"");
+    ASSERT_FALSE(lexer.empty());
+    Token expected{"$\"\""sv, IdTok{true, std::nullopt}};
+    EXPECT_EQ(*lexer, expected);
+    EXPECT_TRUE(lexer->getID());
+    EXPECT_EQ(*lexer->getID(), ""sv);
+  }
+  {
+    Lexer lexer("$\"hello\"");
+    ASSERT_FALSE(lexer.empty());
+    Token expected{"$\"hello\""sv, IdTok{true, std::nullopt}};
+    EXPECT_EQ(*lexer, expected);
+    EXPECT_TRUE(lexer->getID());
+    EXPECT_EQ(*lexer->getID(), "hello"sv);
+  }
+  {
+    // _$_£_€_𐍈_
+    auto unicode = "$\"_\\u{24}_\\u{00a3}_\\u{20AC}_\\u{10348}_\""sv;
+    Lexer lexer(unicode);
+    ASSERT_FALSE(lexer.empty());
+    std::string escaped{"_$_\xC2\xA3_\xE2\x82\xAC_\xF0\x90\x8D\x88_"};
+    Token expected{unicode, IdTok{true, {escaped}}};
+    EXPECT_EQ(*lexer, expected);
+  }
 }
 
 TEST(LexerTest, LexString) {

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -380,7 +380,7 @@
  ;; CHECK:      (elem $passive-2 anyref (struct.new_default $s0) (struct.new_default $s0))
  (elem $passive-2 anyref (item struct.new $s0) (struct.new $s0))
 
- ;; CHECK:      (elem declare func $ref-func $ref-is-null $table-fill $table-grow $table-set)
+ ;; CHECK:      (elem declare func $ref-func $table-fill $table-grow $table-set)
  (elem declare func 0 1 2 3)
 
  (elem $declare-2 declare funcref (item ref.func 0) (ref.func 1) (item (ref.func 2)))
@@ -466,6 +466,11 @@
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $f4 (type 18) (local i32 i64) (local $l f32))
+
+ ;; CHECK:      (func $"[quoted_name]" (type $void)
+ ;; CHECK-NEXT:  (nop)
+ ;; CHECK-NEXT: )
+ (func $"[quoted_name]")
 
  ;; CHECK:      (func $nop-skate (type $void)
  ;; CHECK-NEXT:  (nop)
@@ -3622,13 +3627,13 @@
  ;; CHECK-NEXT:   (ref.func $ref-func)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (ref.func $ref-is-null)
+ ;; CHECK-NEXT:   (ref.func $ref-func)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 154
+  ref.func 156
   drop
  )
 


### PR DESCRIPTION
In addition to normal identifiers, support parsing identifiers of the format
`$"..."`. This format is not yet allowed by the standard, but it is a popular
proposed extension (see https://github.com/WebAssembly/spec/issues/617 and
https://github.com/WebAssembly/annotations/issues/21).

Binaryen has historically allowed a similar format and has supported arbitrary
non-standard identifier characters, so it's much easier to support this extended
syntax than to fix everything to use the restricted standard syntax.