### PR TITLE
Print properly escaped names

### DIFF
--- a/test/lit/ctor-eval/array_new_data.wast
+++ b/test/lit/ctor-eval/array_new_data.wast
@@ -19,7 +19,7 @@
 
  ;; CHECK:      (func $test (type $0)
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (array.new_data $[i8] $1
+ ;; CHECK-NEXT:   (array.new_data $"[i8]" $1
  ;; CHECK-NEXT:    (i32.const 16)
  ;; CHECK-NEXT:    (i32.const 8)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/dae-gc-refine-params.wast
+++ b/test/lit/passes/dae-gc-refine-params.wast
@@ -156,7 +156,7 @@
  ;; CHECK-NEXT:    (local.get $y)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (local.set $2
- ;; CHECK-NEXT:    (struct.new_default ${})
+ ;; CHECK-NEXT:    (struct.new_default $"{}")
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $2)
@@ -352,7 +352,7 @@
 
  ;; CHECK:      (func $call-non-nullable-fixup (type $0)
  ;; CHECK-NEXT:  (call $non-nullable-fixup
- ;; CHECK-NEXT:   (struct.new_default ${})
+ ;; CHECK-NEXT:   (struct.new_default $"{}")
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $call-non-nullable-fixup
@@ -366,7 +366,7 @@
  ;; CHECK-NEXT:   (ref.null none)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (call $update-null
- ;; CHECK-NEXT:   (struct.new_default ${})
+ ;; CHECK-NEXT:   (struct.new_default $"{}")
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $call-update-null
@@ -395,7 +395,7 @@
  ;; CHECK:      (func $"get_null_{i32}" (type $5) (result (ref null ${i32}))
  ;; CHECK-NEXT:  (select (result (ref null ${i32}))
  ;; CHECK-NEXT:   (ref.null none)
- ;; CHECK-NEXT:   (struct.new_default ${i32})
+ ;; CHECK-NEXT:   (struct.new_default $"{i32}")
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -412,7 +412,7 @@
  ;; CHECK:      (func $"get_null_{i32_i64}" (type $16) (result (ref null ${i32_i64}))
  ;; CHECK-NEXT:  (select (result (ref null ${i32_i64}))
  ;; CHECK-NEXT:   (ref.null none)
- ;; CHECK-NEXT:   (struct.new_default ${i32_i64})
+ ;; CHECK-NEXT:   (struct.new_default $"{i32_i64}")
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -427,7 +427,7 @@
  ;; CHECK:      (func $"get_null_{i32_f32}" (type $17) (result (ref null ${i32_f32}))
  ;; CHECK-NEXT:  (select (result (ref null ${i32_f32}))
  ;; CHECK-NEXT:   (ref.null none)
- ;; CHECK-NEXT:   (struct.new_default ${i32_f32})
+ ;; CHECK-NEXT:   (struct.new_default $"{i32_f32}")
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -310,13 +310,13 @@
 
  ;; Show that we can optimize the return type of a function that does a tail
  ;; call.
- ;; CHECK:      (func $tail-callee (type $return_{}) (result (ref ${}))
+ ;; CHECK:      (func $tail-callee (type $"return_{}") (result (ref ${}))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $tail-callee (result (ref $"{}"))
   (unreachable)
  )
- ;; CHECK:      (func $tail-caller-yes (type $return_{}) (result (ref ${}))
+ ;; CHECK:      (func $tail-caller-yes (type $"return_{}") (result (ref ${}))
  ;; CHECK-NEXT:  (return_call $tail-callee)
  ;; CHECK-NEXT: )
  (func $tail-caller-yes (result anyref)
@@ -367,14 +367,14 @@
  )
 
  ;; As above, but with an indirect tail call.
- ;; CHECK:      (func $tail-callee-indirect (type $return_{}) (result (ref ${}))
+ ;; CHECK:      (func $tail-callee-indirect (type $"return_{}") (result (ref ${}))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $tail-callee-indirect (result (ref $"{}"))
   (unreachable)
  )
- ;; CHECK:      (func $tail-caller-indirect-yes (type $return_{}) (result (ref ${}))
- ;; CHECK-NEXT:  (return_call_indirect $0 (type $return_{})
+ ;; CHECK:      (func $tail-caller-indirect-yes (type $"return_{}") (result (ref ${}))
+ ;; CHECK-NEXT:  (return_call_indirect $0 (type $"return_{}")
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -391,7 +391,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (return_call_indirect $0 (type $return_{})
+ ;; CHECK-NEXT:  (return_call_indirect $0 (type $"return_{}")
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -423,15 +423,15 @@
  )
 
  ;; As above, but with a tail call by function reference.
- ;; CHECK:      (func $tail-callee-call_ref (type $return_{}) (result (ref ${}))
+ ;; CHECK:      (func $tail-callee-call_ref (type $"return_{}") (result (ref ${}))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $tail-callee-call_ref (result (ref $"{}"))
   (unreachable)
  )
- ;; CHECK:      (func $tail-caller-call_ref-yes (type $return_{}) (result (ref ${}))
+ ;; CHECK:      (func $tail-caller-call_ref-yes (type $"return_{}") (result (ref ${}))
  ;; CHECK-NEXT:  (local $"return_{}" (ref null $return_{}))
- ;; CHECK-NEXT:  (return_call_ref $return_{}
+ ;; CHECK-NEXT:  (return_call_ref $"return_{}"
  ;; CHECK-NEXT:   (local.get $"return_{}")
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -451,7 +451,7 @@
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (return_call_ref $return_{}
+ ;; CHECK-NEXT:  (return_call_ref $"return_{}"
  ;; CHECK-NEXT:   (local.get $"return_{}")
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -510,7 +510,7 @@
  ;; CHECK-NEXT:     (local.get $y)
  ;; CHECK-NEXT:     (then
  ;; CHECK-NEXT:      (return
- ;; CHECK-NEXT:       (struct.new_default ${i32_f32})
+ ;; CHECK-NEXT:       (struct.new_default $"{i32_f32}")
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (else
@@ -522,7 +522,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (else
  ;; CHECK-NEXT:    (return
- ;; CHECK-NEXT:     (struct.new_default ${i32_i64})
+ ;; CHECK-NEXT:     (struct.new_default $"{i32_i64}")
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/merge-similar-functions_all-features.wast
+++ b/test/lit/passes/merge-similar-functions_all-features.wast
@@ -51,7 +51,7 @@
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (call $take-ref-null-array
-  ;; CHECK-NEXT:   (array.new_fixed $[i8] 0)
+  ;; CHECK-NEXT:   (array.new_fixed $"[i8]" 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $no-call-subtyping-same-operand-0
@@ -82,7 +82,7 @@
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT:  (call $take-ref-eq
-  ;; CHECK-NEXT:   (array.new_fixed $[i8] 0)
+  ;; CHECK-NEXT:   (array.new_fixed $"[i8]" 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $no-call-subtyping-same-operand-1

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -884,7 +884,7 @@
 
  ;; CHECK:      (func $0 (type $2)
  ;; CHECK-NEXT:  (call $1
- ;; CHECK-NEXT:   (array.new_fixed $[i8] 0)
+ ;; CHECK-NEXT:   (array.new_fixed $"[i8]" 0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $0


### PR DESCRIPTION
There were a few places in Print.cpp where we were printing names directly (e.g.
`o << '$' << name`) without proper escaping. Fix those places and update the
test output.