### PR TITLE
[Parser] Do not involve IRBuilder for imported functions

### DIFF
--- a/src/parser/context-defs.cpp
+++ b/src/parser/context-defs.cpp
@@ -50,16 +50,6 @@ ParseDefsCtx::makeTypeUse(Index pos,
   return it->second;
 }
 
-Result<> ParseDefsCtx::addFunc(Name,
-                               const std::vector<Name>&,
-                               ImportNames*,
-                               TypeUseT,
-                               std::optional<LocalsT>,
-                               Index pos) {
-  CHECK_ERR(withLoc(pos, irBuilder.visitEnd()));
-  return Ok{};
-}
-
 Result<> ParseDefsCtx::addGlobal(Name,
                                  const std::vector<Name>&,
                                  ImportNames*,

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1324,12 +1324,15 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
                                std::optional<HeapTypeT> type,
                                ParamsT* params,
                                ResultsT* results);
+
   Result<> addFunc(Name,
                    const std::vector<Name>&,
                    ImportNames*,
                    TypeUseT,
                    std::optional<LocalsT>,
-                   Index pos);
+                   Index) {
+    return Ok{};
+  }
 
   Result<>
   addTable(Name, const std::vector<Name>&, ImportNames*, TableTypeT, Index) {

--- a/src/parser/wat-parser.cpp
+++ b/src/parser/wat-parser.cpp
@@ -177,7 +177,10 @@ Result<> parseModule(Module& wasm, std::string_view input) {
 
     for (Index i = 0; i < decls.funcDefs.size(); ++i) {
       ctx.index = i;
-      CHECK_ERR(ctx.visitFunctionStart(wasm.functions[i].get()));
+      auto* f = wasm.functions[i].get();
+      if (!f->imported()) {
+        CHECK_ERR(ctx.visitFunctionStart(f));
+      }
       WithPosition with(ctx, decls.funcDefs[i].pos);
       if (auto parsed = func(ctx)) {
         CHECK_ERR(parsed);
@@ -185,6 +188,9 @@ Result<> parseModule(Module& wasm, std::string_view input) {
         auto im = import_(ctx);
         assert(im);
         CHECK_ERR(im);
+      }
+      if (!f->imported()) {
+        CHECK_ERR(ctx.irBuilder.visitEnd());
       }
     }
 

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -162,7 +162,6 @@ Result<Expression*> IRBuilder::pop(size_t size) {
   // Find the suffix of expressions that do not produce values.
   auto hoisted = hoistLastValue();
   CHECK_ERR(hoisted);
-
   if (!hoisted) {
     // There are no expressions that produce values.
     if (scope.unreachable) {
@@ -700,6 +699,9 @@ Result<Expression*> IRBuilder::finishScope(Block* block) {
     // the top.
     auto hoisted = hoistLastValue();
     CHECK_ERR(hoisted);
+    if (!hoisted) {
+      return Err{"popping from empty stack"};
+    }
   }
 
   Expression* ret = nullptr;

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -271,7 +271,7 @@
 
  ;; imported functions
  (func (export "f5.0") (export "f5.1") (import "mod" "f5"))
- (import "mod" "imported-f" (func (param) (result)))
+ (import "mod" "imported-f" (func (param) (result i32 i64)))
 
  ;; imported tags
  (tag $imported (export "t0.0") (export "t0.1") (import "mod" "t0") (param i32 i64))
@@ -283,7 +283,7 @@
 
  ;; CHECK:      (import "mod" "f5" (func $fimport$0 (type $void)))
 
- ;; CHECK:      (import "mod" "imported-f" (func $fimport$1 (type $void)))
+ ;; CHECK:      (import "mod" "imported-f" (func $fimport$1 (type $3) (result i32 i64)))
 
  ;; CHECK:      (import "mod" "t0" (tag $imported (param i32 i64)))
 


### PR DESCRIPTION
We previously had a bug where we would begin and end an IRBuilder context for
imported functions even though they don't have bodies. For functions that return
results, ending this empty scope should have produced an error except that we
had another bug where we only produced that error for multivalue functions. We
did not previously have imported multivalue functions in wat-kitchen-sink.wast,
so both of these bugs went undetected. Fix both bugs and update the test to
include an imported multivalue function so that it would have failed without
this fix.