### PR TITLE
Update lit tests to parse with the new parser

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1323,7 +1323,7 @@ Result<> IRBuilder::makePop(Type type) {
       "pop instructions may only appear at the beginning of catch blocks"};
   }
   auto expectedType = scope.exprStack[0]->type;
-  if (type != expectedType) {
+  if (!Type::isSubType(expectedType, type)) {
     return Err{std::string("Expected pop of type ") + expectedType.toString()};
   }
   return Ok{};

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3253,55 +3253,28 @@ Expression* SExpressionWasmBuilder::makeRefAs(Element& s, RefAsOp op) {
 
 Expression*
 SExpressionWasmBuilder::makeStringNew(Element& s, StringNewOp op, bool try_) {
-  size_t i = 1;
   Expression* length = nullptr;
   if (op == StringNewWTF8) {
-    if (s[i]->isStr()) {
-      // legacy syntax
-      std::string_view str = s[i++]->str().str;
-      if (str == "utf8") {
-        op = StringNewUTF8;
-      } else if (str == "wtf8") {
-        op = StringNewWTF8;
-      } else if (str == "replace") {
-        op = StringNewLossyUTF8;
-      } else {
-        throw SParseException("bad string.new op", s);
-      }
-    }
-    length = parseExpression(s[i + 1]);
-    return Builder(wasm).makeStringNew(op, parseExpression(s[i]), length, try_);
+    length = parseExpression(s[2]);
+    return Builder(wasm).makeStringNew(op, parseExpression(s[1]), length, try_);
   } else if (op == StringNewUTF8 || op == StringNewLossyUTF8 ||
              op == StringNewWTF16) {
-    length = parseExpression(s[i + 1]);
-    return Builder(wasm).makeStringNew(op, parseExpression(s[i]), length, try_);
+    length = parseExpression(s[2]);
+    return Builder(wasm).makeStringNew(op, parseExpression(s[1]), length, try_);
   } else if (op == StringNewWTF8Array) {
-    if (s[i]->isStr()) {
-      // legacy syntax
-      std::string_view str = s[i++]->str().str;
-      if (str == "utf8") {
-        op = StringNewUTF8Array;
-      } else if (str == "wtf8") {
-        op = StringNewWTF8Array;
-      } else if (str == "replace") {
-        op = StringNewLossyUTF8Array;
-      } else {
-        throw SParseException("bad string.new op", s);
-      }
-    }
-    auto* start = parseExpression(s[i + 1]);
-    auto* end = parseExpression(s[i + 2]);
+    auto* start = parseExpression(s[2]);
+    auto* end = parseExpression(s[3]);
     return Builder(wasm).makeStringNew(
-      op, parseExpression(s[i]), start, end, try_);
+      op, parseExpression(s[1]), start, end, try_);
   } else if (op == StringNewUTF8Array || op == StringNewLossyUTF8Array ||
              op == StringNewWTF16Array) {
-    auto* start = parseExpression(s[i + 1]);
-    auto* end = parseExpression(s[i + 2]);
+    auto* start = parseExpression(s[2]);
+    auto* end = parseExpression(s[3]);
     return Builder(wasm).makeStringNew(
-      op, parseExpression(s[i]), start, end, try_);
+      op, parseExpression(s[1]), start, end, try_);
   } else if (op == StringNewFromCodePoint) {
     return Builder(wasm).makeStringNew(
-      op, parseExpression(s[i]), nullptr, try_);
+      op, parseExpression(s[1]), nullptr, try_);
   } else {
     throw SParseException("bad string.new op", s);
   }
@@ -3316,60 +3289,18 @@ Expression* SExpressionWasmBuilder::makeStringConst(Element& s) {
 
 Expression* SExpressionWasmBuilder::makeStringMeasure(Element& s,
                                                       StringMeasureOp op) {
-  size_t i = 1;
-  if (op == StringMeasureWTF8 && s[i]->isStr()) {
-    // legacy syntax
-    std::string_view str = s[i++]->str().str;
-    if (str == "utf8") {
-      op = StringMeasureUTF8;
-    } else if (str == "wtf8") {
-      op = StringMeasureWTF8;
-    } else {
-      throw SParseException("bad string.measure op", s);
-    }
-  }
-  return Builder(wasm).makeStringMeasure(op, parseExpression(s[i]));
+  return Builder(wasm).makeStringMeasure(op, parseExpression(s[1]));
 }
 
 Expression* SExpressionWasmBuilder::makeStringEncode(Element& s,
                                                      StringEncodeOp op) {
-  size_t i = 1;
   Expression* start = nullptr;
-  if (op == StringEncodeWTF8) {
-    if (s[i]->isStr()) {
-      // legacy syntax
-      std::string_view str = s[i++]->str().str;
-      if (str == "utf8") {
-        op = StringEncodeUTF8;
-      } else if (str == "replace") {
-        op = StringEncodeLossyUTF8;
-      } else if (str == "wtf8") {
-        op = StringEncodeWTF8;
-      } else {
-        throw SParseException("bad string.new op", s);
-      }
-    }
-  } else if (op == StringEncodeWTF8Array) {
-    if (s[i]->isStr()) {
-      // legacy syntax
-      std::string_view str = s[i++]->str().str;
-      if (str == "utf8") {
-        op = StringEncodeUTF8Array;
-      } else if (str == "replace") {
-        op = StringEncodeLossyUTF8Array;
-      } else if (str == "wtf8") {
-        op = StringEncodeWTF8Array;
-      } else {
-        throw SParseException("bad string.new op", s);
-      }
-    }
-    start = parseExpression(s[i + 2]);
-  } else if (op == StringEncodeUTF8Array || op == StringEncodeLossyUTF8Array ||
-             op == StringEncodeWTF16Array) {
-    start = parseExpression(s[i + 2]);
+  if (op == StringEncodeWTF8Array || op == StringEncodeUTF8Array ||
+      op == StringEncodeLossyUTF8Array || op == StringEncodeWTF16Array) {
+    start = parseExpression(s[3]);
   }
   return Builder(wasm).makeStringEncode(
-    op, parseExpression(s[i]), parseExpression(s[i + 1]), start);
+    op, parseExpression(s[1]), parseExpression(s[2]), start);
 }
 
 Expression* SExpressionWasmBuilder::makeStringConcat(Element& s) {

--- a/test/lit/basic/multi-table.wast
+++ b/test/lit/basic/multi-table.wast
@@ -15,17 +15,16 @@
   (type $none_=>_none (func))
   (type $A (struct))
   ;; CHECK-TEXT:      (import "a" "b" (table $t1 1 10 funcref))
+  ;; CHECK-BIN:      (import "a" "b" (table $t1 1 10 funcref))
+  (import "a" "b" (table $t1 1 10 funcref))
 
   ;; CHECK-TEXT:      (global $g1 (ref null $none_=>_none) (ref.func $f))
-  ;; CHECK-BIN:      (import "a" "b" (table $t1 1 10 funcref))
-
   ;; CHECK-BIN:      (global $g1 (ref null $none_=>_none) (ref.func $f))
   (global $g1 (ref null $none_=>_none) (ref.func $f))
   ;; CHECK-TEXT:      (global $g2 i32 (i32.const 0))
   ;; CHECK-BIN:      (global $g2 i32 (i32.const 0))
   (global $g2 i32 (i32.const 0))
 
-  (import "a" "b" (table $t1 1 10 funcref))
   ;; CHECK-TEXT:      (table $t2 3 3 funcref)
   ;; CHECK-BIN:      (table $t2 3 3 funcref)
   (table $t2 3 3 funcref)

--- a/test/lit/basic/reference-types.wast
+++ b/test/lit/basic/reference-types.wast
@@ -43,6 +43,19 @@
   ;; CHECK-TEXT:      (import "env" "import_global" (global $import_global eqref))
 
   ;; CHECK-TEXT:      (import "env" "import_func" (func $import_func (type $8) (param eqref) (result funcref)))
+  ;; CHECK-BIN:      (type $5 (func))
+
+  ;; CHECK-BIN:      (type $6 (func (result eqref)))
+
+  ;; CHECK-BIN:      (type $7 (func (param i32)))
+
+  ;; CHECK-BIN:      (type $8 (func (param eqref) (result funcref)))
+
+  ;; CHECK-BIN:      (import "env" "import_global" (global $import_global eqref))
+
+  ;; CHECK-BIN:      (import "env" "import_func" (func $import_func (type $8) (param eqref) (result funcref)))
+  (import "env" "import_func" (func $import_func (param eqref) (result funcref)))
+  (import "env" "import_global" (global $import_global eqref))
 
   ;; CHECK-TEXT:      (global $global_eqref (mut eqref) (ref.null none))
 
@@ -69,18 +82,6 @@
   ;; CHECK-TEXT:      (func $take_eqref (type $sig_eqref) (param $0 eqref)
   ;; CHECK-TEXT-NEXT:  (nop)
   ;; CHECK-TEXT-NEXT: )
-  ;; CHECK-BIN:      (type $5 (func))
-
-  ;; CHECK-BIN:      (type $6 (func (result eqref)))
-
-  ;; CHECK-BIN:      (type $7 (func (param i32)))
-
-  ;; CHECK-BIN:      (type $8 (func (param eqref) (result funcref)))
-
-  ;; CHECK-BIN:      (import "env" "import_global" (global $import_global eqref))
-
-  ;; CHECK-BIN:      (import "env" "import_func" (func $import_func (type $8) (param eqref) (result funcref)))
-
   ;; CHECK-BIN:      (global $global_eqref (mut eqref) (ref.null none))
 
   ;; CHECK-BIN:      (global $global_funcref (mut funcref) (ref.null nofunc))
@@ -172,8 +173,6 @@
   ;; CHECK-BIN-NODEBUG:      (elem declare func $23 $3)
   (elem declare func $ref-taken-but-not-in-table)
 
-  (import "env" "import_func" (func $import_func (param eqref) (result funcref)))
-  (import "env" "import_global" (global $import_global eqref))
   (export "export_func" (func $import_func))
   (export "export_global" (global $import_global))
 

--- a/test/lit/basic/tags.wast
+++ b/test/lit/basic/tags.wast
@@ -12,7 +12,11 @@
 ;; Test tags
 
 (module
+  (tag $e-import (import "env" "im0") (param i32))
+  (import "env" "im1" (tag (param i32 f32)))
+
   (tag (param i32))
+
   ;; CHECK-TEXT:      (type $0 (func (param i32 f32)))
 
   ;; CHECK-TEXT:      (type $1 (func (param i32)))
@@ -54,9 +58,7 @@
   ;; CHECK-TEXT:      (tag $e-export (param i32))
   ;; CHECK-BIN:      (tag $e-export (param i32))
   (tag $e-export (export "ex0") (param i32))
-  (tag $e-import (import "env" "im0") (param i32))
 
-  (import "env" "im1" (tag (param i32 f32)))
   ;; CHECK-TEXT:      (export "ex0" (tag $e-export))
 
   ;; CHECK-TEXT:      (export "ex1" (tag $e))

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -4,6 +4,7 @@
 
 (module
   (type $array16 (array (mut i16)))
+  (memory 1 1)
 
   ;; CHECK:      [fuzz-exec] calling new_wtf16_array
   ;; CHECK-NEXT: [fuzz-exec] note result: new_wtf16_array => string("ello")

--- a/test/lit/merge/fusing.wat.second
+++ b/test/lit/merge/fusing.wat.second
@@ -6,6 +6,10 @@
   ;; Use a different prefix than in first ($main instead of $other).
   (import "first" "bar" (func $main.bar))
 
+  (import "first" "mem" (memory $other.mem 1))
+
+  (import "first" "exn" (tag $exn))
+
   (memory $second.mem 2)
 
   (export "mem" (memory $second.mem))
@@ -26,8 +30,6 @@
     )
   )
 
-  (import "first" "mem" (memory $other.mem 1))
-
   (func $keepalive2 (export "keepalive2") (result i32)
     ;; Load from the memory imported from the second module.
     (i32.load $other.mem
@@ -35,6 +37,5 @@
     )
   )
 
-  (import "first" "exn" (tag $exn))
   (func $keepalive3 (export "keepalive3") (throw $exn))
 )

--- a/test/lit/merge/memory_data.wat.second
+++ b/test/lit/merge/memory_data.wat.second
@@ -1,10 +1,10 @@
 (module
+  ;; Test that the import remains
+  (import "import" "mem" (memory $imported 10000))
+
   (memory $other 100)
 
   (memory $bar 1000)
-
-  ;; Test that the import remains
-  (import "import" "mem" (memory $imported 10000))
 
   (data $a (memory $other) (i32.const 0) "a2")
 

--- a/test/lit/merge/renamings.wat.second
+++ b/test/lit/merge/renamings.wat.second
@@ -1,12 +1,12 @@
 (module
   (type $array (array (mut (ref null func))))
 
+  ;; Test that the import remains
+  (import "elsewhere" "some.tag" (tag $imported (param f64)))
+
   (tag $foo (param f32))
 
   (tag $other (param f64))
-
-  ;; Test that the import remains
-  (import "elsewhere" "some.tag" (tag $imported (param f64)))
 
   (memory $foo 50 60)
 

--- a/test/lit/passes/asyncify-wasm64.wast
+++ b/test/lit/passes/asyncify-wasm64.wast
@@ -7,7 +7,6 @@
 
   ;; CHECK:      (type $f (func (param i32)))
   (type $f (func (param i32)))
-  (memory i64 1 2)
   ;; CHECK:      (type $2 (func))
 
   ;; CHECK:      (type $3 (func (param i64)))
@@ -18,6 +17,9 @@
   (import "env" "import" (func $import))
   ;; CHECK:      (import "env" "import2" (func $import2 (param i32)))
   (import "env" "import2" (func $import2 (param i32)))
+
+  (memory i64 1 2)
+
   (table funcref (elem $liveness2 $liveness2))
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 

--- a/test/lit/passes/asyncify-wasm64_pass-arg=in-secondary-memory.wast
+++ b/test/lit/passes/asyncify-wasm64_pass-arg=in-secondary-memory.wast
@@ -3,7 +3,6 @@
 ;; RUN: wasm-opt --enable-memory64 --enable-multimemory --asyncify --pass-arg=asyncify-in-secondary-memory %s -S -o - | filecheck %s
 
 (module
-  (memory i64 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -14,6 +13,9 @@
 
   ;; CHECK:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory i64 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify.wast
+++ b/test/lit/passes/asyncify.wast
@@ -6,7 +6,6 @@
 (module
   ;; CHECK:      (type $f (func (param i32)))
   (type $f (func (param i32)))
-  (memory 1 2)
   ;; CHECK:      (type $1 (func (param i32 i32)))
 
   ;; CHECK:      (type $2 (func))
@@ -17,15 +16,16 @@
   (import "env" "import" (func $import))
   ;; CHECK:      (import "env" "import2" (func $import2 (param i32)))
   (import "env" "import2" (func $import2 (param i32)))
-  (table funcref (elem $liveness2 $liveness2))
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))
 
-  ;; CHECK:      (memory $0 1 2)
+  ;; CHECK:      (memory $m 1 2)
+  (memory $m 1 2)
 
-  ;; CHECK:      (table $0 2 2 funcref)
-
+  ;; CHECK:      (table $t 2 2 funcref)
+  (table $t funcref (elem $liveness2 $liveness2))
   ;; CHECK:      (elem $0 (i32.const 0) $liveness2 $liveness2)
 
   ;; CHECK:      (export "asyncify_start_unwind" (func $asyncify_start_unwind))

--- a/test/lit/passes/asyncify_enable-multivalue.wast
+++ b/test/lit/passes/asyncify_enable-multivalue.wast
@@ -5,11 +5,12 @@
 
 ;; Pre-existing imports that the pass turns into the implementations.
 (module
-  (memory 1 2)
   (import "asyncify" "start_unwind" (func $asyncify_start_unwind (param i32)))
   (import "asyncify" "stop_unwind" (func $asyncify_stop_unwind))
   (import "asyncify" "start_rewind" (func $asyncify_start_rewind (param i32)))
   (import "asyncify" "stop_rewind" (func $asyncify_stop_rewind))
+
+  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -404,7 +405,6 @@
 ;; CHECK-NEXT:  (global.get $__asyncify_state)
 ;; CHECK-NEXT: )
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -423,6 +423,8 @@
   (import "env" "import3" (func $import3 (param i32)))
   ;; CHECK:      (import "env" "import-mv" (func $import-mv (result i32 i64)))
   (import "env" "import-mv" (func $import-mv (result i32 i64)))
+
+  (memory 1 2)
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --mod-asyncify-always-and-only-unwind -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (result i32)))
@@ -17,6 +16,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-always-and-only-unwind_O.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --mod-asyncify-always-and-only-unwind -O -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -15,6 +14,10 @@
   (import "env" "import" (func $import))
   (import "env" "import2" (func $import2 (result i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_mod-asyncify-never-unwind.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-never-unwind.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --mod-asyncify-never-unwind -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (result i32)))
@@ -17,6 +16,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_mod-asyncify-never-unwind_O.wast
+++ b/test/lit/passes/asyncify_mod-asyncify-never-unwind_O.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --mod-asyncify-never-unwind -O -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -15,6 +14,9 @@
   (import "env" "import" (func $import))
   (import "env" "import2" (func $import2 (result i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_optimize-level=1.wast
+++ b/test/lit/passes/asyncify_optimize-level=1.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --optimize-level=1 -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -19,6 +18,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-addlist@foo.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-addlist@foo.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --pass-arg=asyncify-addlist@foo -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -13,6 +12,9 @@
 
   ;; CHECK:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-addlist@foo_pass-arg=asyncify-ignore-indirect.wast
@@ -6,15 +6,17 @@
 (module
   ;; CHECK:      (type $t (func))
   (type $t (func))
-  (memory 1 2)
-  (table 1 funcref)
-  (elem (i32.const 0))
   ;; CHECK:      (type $1 (func (param i32)))
 
   ;; CHECK:      (type $2 (func (result i32)))
 
   ;; CHECK:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory 1 2)
+  (table 1 funcref)
+  (elem (i32.const 0))
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-onlylist@waka.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-asserts_pass-arg=asyncify-onlylist@waka.wast
@@ -9,7 +9,6 @@
 ;; state.
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $f (func))
   (type $f (func))
   ;; CHECK:      (type $1 (func (param i32)))
@@ -22,6 +21,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   (table funcref (elem $calls-import2-drop $calls-import2-drop))
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 

--- a/test/lit/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-blacklist@foo,bar.wast
@@ -5,7 +5,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --pass-arg=asyncify-blacklist@@%S/asyncify-foo,bar-nl.txt -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -14,6 +13,8 @@
 
   ;; CHECK:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory 1 2)
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-ignore-imports.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-ignore-imports.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --pass-arg=asyncify-ignore-imports -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $f (func))
   (type $f (func))
   ;; CHECK:      (type $1 (func (param i32)))
@@ -17,6 +16,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   (table funcref (elem $calls-import2-drop $calls-import2-drop))
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 

--- a/test/lit/passes/asyncify_pass-arg=asyncify-ignore-indirect.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-ignore-indirect.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --pass-arg=asyncify-ignore-indirect -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $f (func))
   (type $f (func))
   ;; CHECK:      (type $1 (func (param i32)))
@@ -17,6 +16,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   (table funcref (elem $calls-import2-drop $calls-import2-drop))
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 

--- a/test/lit/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-imports@env.import,env.import2.wast
@@ -5,10 +5,12 @@
 
 ;; Pre-existing imports that the pass turns into the implementations.
 (module
-  (memory 1 2)
   (import "asyncify" "start_unwind" (func $asyncify_start_unwind (param i32)))
   (import "asyncify" "start_rewind" (func $asyncify_start_rewind (param i32)))
   (import "asyncify" "stop_rewind" (func $asyncify_stop_rewind))
+
+  (memory 1 2)
+
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -400,7 +402,6 @@
 ;; CHECK-NEXT:  (global.get $__asyncify_state)
 ;; CHECK-NEXT: )
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -415,6 +416,9 @@
   (import "env" "import2" (func $import2 (result i32)))
   ;; CHECK:      (import "env" "import3" (func $import3 (param i32)))
   (import "env" "import3" (func $import3 (param i32)))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-onlylist@foo,bar.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-onlylist@foo,bar.wast
@@ -5,7 +5,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --pass-arg=asyncify-onlylist@@%S/asyncify-foo,bar-nl.txt -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -14,6 +13,8 @@
 
   ;; CHECK:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory 1 2)
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=asyncify-verbose.wast
+++ b/test/lit/passes/asyncify_pass-arg=asyncify-verbose.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --asyncify --pass-arg=asyncify-verbose -S -o - | filecheck %s
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -13,6 +12,9 @@
 
   ;; CHECK:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/asyncify_pass-arg=in-secondary-memory.wast
+++ b/test/lit/passes/asyncify_pass-arg=in-secondary-memory.wast
@@ -4,7 +4,6 @@
 ;; RUN: wasm-opt --enable-multimemory --asyncify --pass-arg=asyncify-in-secondary-memory --pass-arg=asyncify-secondary-memory-size@3 %s -S -o - | filecheck %s --check-prefix SIZE
 
 (module
-  (memory 1 2)
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (type $1 (func (param i32)))
@@ -24,6 +23,9 @@
 
   ;; SIZE:      (import "env" "import" (func $import))
   (import "env" "import" (func $import))
+
+  (memory 1 2)
+
   ;; CHECK:      (global $__asyncify_state (mut i32) (i32.const 0))
 
   ;; CHECK:      (global $__asyncify_data (mut i32) (i32.const 0))

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -1461,7 +1461,6 @@
     (struct.set $struct2 0
       (local.get $struct2)
       (i32.const 9999) ;; use a different value here
-      (f64.const 0)
     )
     (drop
       (struct.new $struct3

--- a/test/lit/passes/coalesce-locals-learning.wast
+++ b/test/lit/passes/coalesce-locals-learning.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --coalesce-locals-learning -S -o - | filecheck %s
 
 (module
-  (memory 10)
   ;; CHECK:      (type $2 (func))
 
   ;; CHECK:      (type $FUNCSIG$iii (func (param i32 i32) (result i32)))
@@ -18,8 +17,12 @@
   (type $3 (func (param i32 f32)))
   ;; CHECK:      (type $4 (func (param i32)))
   (type $4 (func (param i32)))
+
   ;; CHECK:      (import "env" "_emscripten_autodebug_i32" (func $_emscripten_autodebug_i32 (param i32 i32) (result i32)))
   (import "env" "_emscripten_autodebug_i32" (func $_emscripten_autodebug_i32 (param i32 i32) (result i32)))
+
+  (memory 10)
+
   ;; CHECK:      (memory $0 10)
 
   ;; CHECK:      (func $nothing-to-do

--- a/test/lit/passes/coalesce-locals.wast
+++ b/test/lit/passes/coalesce-locals.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt --coalesce-locals -S -o - | filecheck %s
 
 (module
-  (memory 10)
   ;; CHECK:      (type $2 (func))
 
   ;; CHECK:      (type $1 (func (result i32)))
@@ -35,6 +34,9 @@
   (import "env" "get" (func $get (result i32)))
   ;; CHECK:      (import "env" "set" (func $set (param i32)))
   (import "env" "set" (func $set (param i32)))
+
+  (memory 10)
+
   ;; CHECK:      (memory $0 10)
 
   ;; CHECK:      (func $nothing-to-do

--- a/test/lit/passes/directize_all-features.wast
+++ b/test/lit/passes/directize_all-features.wast
@@ -372,6 +372,8 @@
  ;; CHECK:      (type $ii (func (param i32 i32)))
  ;; IMMUT:      (type $ii (func (param i32 i32)))
  (type $ii (func (param i32 i32)))
+ (global $g (import "env" "g") i32)
+
  ;; CHECK:      (import "env" "g" (global $g i32))
 
  ;; CHECK:      (table $0 5 5 funcref)
@@ -379,7 +381,7 @@
 
  ;; IMMUT:      (table $0 5 5 funcref)
  (table $0 5 5 funcref)
- (global $g (import "env" "g") i32)
+
  (elem (global.get $g) $foo)
  ;; CHECK:      (elem $0 (global.get $g) $foo)
 
@@ -421,6 +423,8 @@
  ;; CHECK:      (type $ii (func (param i32 i32)))
  ;; IMMUT:      (type $ii (func (param i32 i32)))
  (type $ii (func (param i32 i32)))
+ (global $g (import "env" "g") i32)
+
  ;; CHECK:      (import "env" "g" (global $g i32))
 
  ;; CHECK:      (table $0 5 5 funcref)
@@ -431,7 +435,7 @@
  ;; CHECK:      (table $1 5 5 funcref)
  ;; IMMUT:      (table $1 5 5 funcref)
  (table $1 5 5 funcref)
- (global $g (import "env" "g") i32)
+
  (elem (table $1) (global.get $g) func $foo)
  ;; CHECK:      (elem $0 (table $1) (global.get $g) func $foo)
 

--- a/test/lit/passes/flatten_i64-to-i32-lowering.wast
+++ b/test/lit/passes/flatten_i64-to-i32-lowering.wast
@@ -4,7 +4,6 @@
 ;; RUN: foreach %s %t wasm-opt -all --flatten --i64-to-i32-lowering -S -o - | filecheck %s
 
 (module
- (memory 1 1)
  ;; CHECK:      (type $0 (func (result i32)))
 
  ;; CHECK:      (type $1 (func (result i64)))
@@ -13,6 +12,8 @@
 
  ;; CHECK:      (import "env" "func" (func $import (type $1) (result i64)))
  (import "env" "func" (func $import (result i64)))
+
+ (memory 1 1)
  ;; CHECK:      (global $i64toi32_i32$HIGH_BITS (mut i32) (i32.const 0))
 
  ;; CHECK:      (memory $0 1 1)

--- a/test/lit/passes/global-effects.wast
+++ b/test/lit/passes/global-effects.wast
@@ -16,8 +16,6 @@
   ;; WITHOUT:      (type $2 (func (param i32)))
 
   ;; WITHOUT:      (import "a" "b" (func $import (type $0)))
-
-  ;; WITHOUT:      (tag $tag)
   ;; INCLUDE:      (type $0 (func))
 
   ;; INCLUDE:      (type $1 (func (result i32)))
@@ -25,8 +23,6 @@
   ;; INCLUDE:      (type $2 (func (param i32)))
 
   ;; INCLUDE:      (import "a" "b" (func $import (type $0)))
-
-  ;; INCLUDE:      (tag $tag)
   ;; DISCARD:      (type $0 (func))
 
   ;; DISCARD:      (type $1 (func (result i32)))
@@ -34,11 +30,12 @@
   ;; DISCARD:      (type $2 (func (param i32)))
 
   ;; DISCARD:      (import "a" "b" (func $import (type $0)))
+  (import "a" "b" (func $import))
 
+  ;; WITHOUT:      (tag $tag)
+  ;; INCLUDE:      (tag $tag)
   ;; DISCARD:      (tag $tag)
   (tag $tag)
-
-  (import "a" "b" (func $import))
 
   ;; WITHOUT:      (func $main (type $0)
   ;; WITHOUT-NEXT:  (call $nop)

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -850,7 +850,7 @@
   (func $unreachable-set-2 (param $"{mut:i8}" (ref null $"{mut:i8}"))
     ;; As above, but the side effects now are a br. Again, the br must happen
     ;; before the trap (in fact, the br will skip the trap here).
-    (block
+    (block $block
       (struct.set $"{mut:i8}" 0
         (local.get $"{mut:i8}")
         (br $block)

--- a/test/lit/passes/memory-packing_all-features.wast
+++ b/test/lit/passes/memory-packing_all-features.wast
@@ -5,19 +5,17 @@
 
 (module
   ;; CHECK:      (import "env" "memoryBase" (global $memoryBase i32))
-
+  (import "env" "memoryBase" (global $memoryBase i32))
   ;; CHECK:      (memory $0 2048 2048)
   (memory $0 2048 2048)
-  (import "env" "memoryBase" (global $memoryBase i32))
   ;; nothing
 )
 
 (module
   ;; CHECK:      (import "env" "memoryBase" (global $memoryBase i32))
-
+  (import "env" "memoryBase" (global $memoryBase i32))
   ;; CHECK:      (memory $0 2048 2048)
   (memory $0 2048 2048)
-  (import "env" "memoryBase" (global $memoryBase i32))
   (data (i32.const 4066) "") ;; empty; leave it as is
                              ;; (remove-unused-module-elements handles such
                              ;; things, taking into account possible traps etc.)
@@ -26,10 +24,10 @@
 ;; CHECK:      (data $0 (i32.const 4066) "")
 (module
   ;; CHECK:      (import "env" "memoryBase" (global $memoryBase i32))
+  (import "env" "memoryBase" (global $memoryBase i32))
 
   ;; CHECK:      (memory $0 2048 2048)
   (memory $0 2048 2048)
-  (import "env" "memoryBase" (global $memoryBase i32))
 
   (data (global.get $memoryBase) "waka this cannot be optimized\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00we don't know where it will go")
 )
@@ -681,6 +679,7 @@
   ;; CHECK:      (type $0 (func))
 
   ;; CHECK:      (import "env" "param" (global $param i32))
+  (import "env" "param" (global $param i32))
 
   ;; CHECK:      (global $__mem_segment_drop_state (mut i32) (i32.const 0))
 
@@ -700,7 +699,6 @@
 
   ;; CHECK:      (memory $0 2048 2048)
   (memory $0 2048 2048)
-  (import "env" "param" (global $param i32))
 
   (data "\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00even\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00more\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00zeroes\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00") ;; 0
 
@@ -2232,10 +2230,11 @@
 ;; CHECK:      (data $2 (i32.const 4096) "\00")
 (module
  ;; CHECK:      (import "env" "memoryBase" (global $memoryBase i32))
+ (import "env" "memoryBase" (global $memoryBase i32))
 
  ;; CHECK:      (memory $0 1 1)
  (memory $0 1 1)
- (import "env" "memoryBase" (global $memoryBase i32))
+
  (data (i32.const 1024) "x")
  (data (global.get $memoryBase) "\00") ;; this could trample, or not
 )
@@ -2244,10 +2243,11 @@
 ;; CHECK:      (data $1 (global.get $memoryBase) "\00")
 (module
  ;; CHECK:      (import "env" "memoryBase" (global $memoryBase i32))
+ (import "env" "memoryBase" (global $memoryBase i32))
 
  ;; CHECK:      (memory $0 1 1)
  (memory $0 1 1)
- (import "env" "memoryBase" (global $memoryBase i32))
+
  (data (i32.const 1024) "\00") ;; this could trample, or not
  (data (global.get $memoryBase) "x")
 )

--- a/test/lit/passes/monomorphize.wast
+++ b/test/lit/passes/monomorphize.wast
@@ -342,8 +342,6 @@
   ;; ALWAYS:      (type $4 (func (param (ref $A))))
 
   ;; ALWAYS:      (import "a" "b" (func $import (type $2) (param (ref $B))))
-
-  ;; ALWAYS:      (global $global (mut i32) (i32.const 1))
   ;; CAREFUL:      (type $2 (func (param (ref $B))))
 
   ;; CAREFUL:      (type $3 (func))
@@ -351,11 +349,11 @@
   ;; CAREFUL:      (type $4 (func (param (ref $A))))
 
   ;; CAREFUL:      (import "a" "b" (func $import (type $2) (param (ref $B))))
+  (import "a" "b" (func $import (param (ref $B))))
 
+  ;; ALWAYS:      (global $global (mut i32) (i32.const 1))
   ;; CAREFUL:      (global $global (mut i32) (i32.const 1))
   (global $global (mut i32) (i32.const 1))
-
-  (import "a" "b" (func $import (param (ref $B))))
 
   ;; ALWAYS:      (func $calls (type $3)
   ;; ALWAYS-NEXT:  (call $refinable

--- a/test/lit/passes/optimize-instructions-ignore-traps.wast
+++ b/test/lit/passes/optimize-instructions-ignore-traps.wast
@@ -6,11 +6,10 @@
   ;; CHECK:      (type $0 (func (param i32 i32) (result i32)))
   (type $0 (func (param i32 i32) (result i32)))
   ;; CHECK:      (import "a" "b" (func $get-i32 (type $2) (result i32)))
+  (import "a" "b" (func $get-i32 (result i32)))
 
   ;; CHECK:      (memory $0 0)
   (memory $0 0)
-
-  (import "a" "b" (func $get-i32 (result i32)))
 
   ;; CHECK:      (func $conditionals (type $0) (param $0 i32) (param $1 i32) (result i32)
   ;; CHECK-NEXT:  (local $2 i32)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -2,7 +2,6 @@
 ;; RUN: wasm-opt %s --optimize-instructions --mvp-features -S -o - | filecheck %s
 
 (module
-  (memory 0)
   ;; CHECK:      (type $0 (func (result i32)))
   (type $0 (func (param i32 i64)))
 
@@ -10,6 +9,8 @@
 
   ;; CHECK:      (import "a" "b" (func $get-f64 (result f64)))
   (import "a" "b" (func $get-f64 (result f64)))
+
+  (memory 0)
 
   ;; CHECK:      (func $and-and (param $i1 i32) (result i32)
   ;; CHECK-NEXT:  (i32.and

--- a/test/lit/passes/remove-unused-module-elements-eh-old.wast
+++ b/test/lit/passes/remove-unused-module-elements-eh-old.wast
@@ -4,6 +4,8 @@
 (module
   (type $0 (func (param i32)))
 
+  (import "env" "e" (tag $e-import (param i32)))
+
   ;; CHECK-NOT: (tag $e-remove
   ;; CHECK: (tag $e-export
   ;; CHECK: (tag $e-throw
@@ -14,7 +16,6 @@
   (tag $e-catch (type $0))    ;; cannot be removed (used in catch)
 
   (export "e-export" (tag $e-export))
-  (import "env" "e" (tag $e-import (param i32)))
 
   (start $start)
   (func $start

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -24,9 +24,6 @@
 
   ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_5 (type $5) (param i32) (result (ref extern))))
 
-  ;; CHECK:      (memory $m 1)
-  (memory $m 1)
-
   ;; CHECK:      (func $string.as (type $3) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (local.get $a)

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -24,6 +24,9 @@
 
   ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_5 (type $5) (param i32) (result (ref extern))))
 
+  ;; CHECK:      (memory $m 1)
+  (memory $m 1)
+
   ;; CHECK:      (func $string.as (type $3) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (local.get $a)

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -48,24 +48,6 @@
 
   ;; CHECK:      (func $string.new (type $5) (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter) (param $e stringref) (param $f stringview_wtf8) (param $g stringview_wtf16) (param $h stringview_iter) (param $i (ref string)) (param $j (ref stringview_wtf8)) (param $k (ref stringview_wtf16)) (param $l (ref stringview_iter))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.new_utf8
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.new_wtf8
-  ;; CHECK-NEXT:    (i32.const 3)
-  ;; CHECK-NEXT:    (i32.const 4)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.new_lossy_utf8
-  ;; CHECK-NEXT:    (i32.const 5)
-  ;; CHECK-NEXT:    (i32.const 6)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.new_wtf16
   ;; CHECK-NEXT:    (i32.const 7)
   ;; CHECK-NEXT:    (i32.const 8)
@@ -103,24 +85,6 @@
     (param $j (ref stringview_wtf8))
     (param $k (ref stringview_wtf16))
     (param $l (ref stringview_iter))
-    (drop
-      (string.new_wtf8 utf8
-        (i32.const 1)
-        (i32.const 2)
-      )
-    )
-    (drop
-      (string.new_wtf8 wtf8
-        (i32.const 3)
-        (i32.const 4)
-      )
-    )
-    (drop
-      (string.new_wtf8 replace
-        (i32.const 5)
-        (i32.const 6)
-      )
-    )
     (drop
       (string.new_wtf16
         (i32.const 7)
@@ -180,17 +144,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.measure_utf8
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.measure_wtf16
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.measure_wtf8
   ;; CHECK-NEXT:    (local.get $ref)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -203,23 +157,13 @@
   (func $string.measure (param $ref stringref)
     (drop
       (i32.eqz ;; validate the output is i32
-        (string.measure_wtf8 wtf8
+        (string.measure_wtf8
           (local.get $ref)
         )
       )
     )
     (drop
-      (string.measure_wtf8 utf8
-        (local.get $ref)
-      )
-    )
-    (drop
       (string.measure_wtf16
-        (local.get $ref)
-      )
-    )
-    (drop
-      (string.measure_wtf8
         (local.get $ref)
       )
     )
@@ -248,27 +192,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.encode_utf8
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:    (i32.const 20)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.encode_wtf16
   ;; CHECK-NEXT:    (local.get $ref)
   ;; CHECK-NEXT:    (i32.const 30)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.encode_wtf8
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:    (i32.const 10)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.encode_lossy_utf8
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:    (i32.const 10)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -281,7 +207,7 @@
   (func $string.encode (param $ref stringref)
     (drop
       (i32.eqz ;; validate the output is i32
-        (string.encode_wtf8 wtf8
+        (string.encode_wtf8
           (local.get $ref)
           (i32.const 10)
         )
@@ -289,34 +215,16 @@
     )
     (drop
       (i32.eqz ;; validate the output is i32
-        (string.encode_wtf8 replace
+        (string.encode_lossy_utf8
           (local.get $ref)
           (i32.const 10)
         )
       )
     )
     (drop
-      (string.encode_wtf8 utf8
-        (local.get $ref)
-        (i32.const 20)
-      )
-    )
-    (drop
       (string.encode_wtf16
         (local.get $ref)
         (i32.const 30)
-      )
-    )
-    (drop
-      (string.encode_wtf8
-        (local.get $ref)
-        (i32.const 10)
-      )
-    )
-    (drop
-      (string.encode_lossy_utf8
-        (local.get $ref)
-        (i32.const 10)
       )
     )
     (drop
@@ -584,27 +492,6 @@
 
   ;; CHECK:      (func $string.new.gc (type $8) (param $array (ref $array)) (param $array16 (ref $array16))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.new_utf8_array
-  ;; CHECK-NEXT:    (local.get $array)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.new_wtf8_array
-  ;; CHECK-NEXT:    (local.get $array)
-  ;; CHECK-NEXT:    (i32.const 3)
-  ;; CHECK-NEXT:    (i32.const 4)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.new_lossy_utf8_array
-  ;; CHECK-NEXT:    (local.get $array)
-  ;; CHECK-NEXT:    (i32.const 5)
-  ;; CHECK-NEXT:    (i32.const 6)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.new_wtf16_array
   ;; CHECK-NEXT:    (local.get $array16)
   ;; CHECK-NEXT:    (i32.const 7)
@@ -634,27 +521,6 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $string.new.gc (param $array (ref $array)) (param $array16 (ref $array16))
-    (drop
-      (string.new_wtf8_array utf8
-        (local.get $array)
-        (i32.const 1)
-        (i32.const 2)
-      )
-    )
-    (drop
-      (string.new_wtf8_array wtf8
-        (local.get $array)
-        (i32.const 3)
-        (i32.const 4)
-      )
-    )
-    (drop
-      (string.new_wtf8_array replace
-        (local.get $array)
-        (i32.const 5)
-        (i32.const 6)
-      )
-    )
     (drop
       (string.new_wtf16_array
         (local.get $array16)
@@ -688,34 +554,11 @@
   ;; CHECK:      (func $string.encode.gc (type $9) (param $ref stringref) (param $array (ref $array)) (param $array16 (ref $array16))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (string.encode_wtf8_array
+  ;; CHECK-NEXT:    (string.encode_wtf16_array
   ;; CHECK-NEXT:     (local.get $ref)
-  ;; CHECK-NEXT:     (local.get $array)
-  ;; CHECK-NEXT:     (i32.const 10)
+  ;; CHECK-NEXT:     (local.get $array16)
+  ;; CHECK-NEXT:     (i32.const 30)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.eqz
-  ;; CHECK-NEXT:    (string.encode_lossy_utf8_array
-  ;; CHECK-NEXT:     (local.get $ref)
-  ;; CHECK-NEXT:     (local.get $array)
-  ;; CHECK-NEXT:     (i32.const 10)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.encode_utf8_array
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:    (local.get $array)
-  ;; CHECK-NEXT:    (i32.const 20)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.encode_wtf16_array
-  ;; CHECK-NEXT:    (local.get $ref)
-  ;; CHECK-NEXT:    (local.get $array16)
-  ;; CHECK-NEXT:    (i32.const 30)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -743,34 +586,11 @@
   (func $string.encode.gc (param $ref stringref) (param $array (ref $array)) (param $array16 (ref $array16))
     (drop
       (i32.eqz ;; validate the output is i32
-        (string.encode_wtf8_array wtf8
+        (string.encode_wtf16_array
           (local.get $ref)
-          (local.get $array)
-          (i32.const 10)
+          (local.get $array16)
+          (i32.const 30)
         )
-      )
-    )
-    (drop
-      (i32.eqz ;; validate the output is i32
-        (string.encode_wtf8_array replace
-          (local.get $ref)
-          (local.get $array)
-          (i32.const 10)
-        )
-      )
-    )
-    (drop
-      (string.encode_wtf8_array utf8
-        (local.get $ref)
-        (local.get $array)
-        (i32.const 20)
-      )
-    )
-    (drop
-      (string.encode_wtf16_array
-        (local.get $ref)
-        (local.get $array16)
-        (i32.const 30)
       )
     )
     (drop


### PR DESCRIPTION
Get as many of the lit tests as possible to parse with the new parser, mostly by
moving declared module items to be after imports. Also fix a bug in the new
parser's pop validation to allow supertypes of the expected type.

The two big issues that still prevent some lit tests from working correctly
under the new parser are missing support for symbolic field names and missing
support for source map annotations.