### PR TITLE
[Parser] Support references to struct fields by name

### DIFF
--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -13,9 +13,9 @@
  (type $ret2 (func (result i32 i32)))
 
  (rec
-  ;; CHECK:      (type $3 (func (result i32 i64)))
+  ;; CHECK:      (type $pair (struct (field $first (mut i32)) (field $second (mut i64))))
 
-  ;; CHECK:      (type $pair (struct (field (mut i32)) (field (mut i64))))
+  ;; CHECK:      (type $4 (func (result i32 i64)))
 
   ;; CHECK:      (type $5 (func (param i32 i64)))
 
@@ -110,71 +110,75 @@
 
  ;; CHECK:      (type $48 (func (param (ref $pair)) (result i64)))
 
- ;; CHECK:      (type $49 (func (param (ref $pair) i32)))
+ ;; CHECK:      (type $49 (func (param (ref null $pair)) (result i32)))
 
- ;; CHECK:      (type $50 (func (param (ref $pair) i64)))
+ ;; CHECK:      (type $50 (func (param (ref $pair) i32)))
 
- ;; CHECK:      (type $51 (func (param i64 i32) (result (ref $a1))))
+ ;; CHECK:      (type $51 (func (param (ref $pair) i64)))
 
- ;; CHECK:      (type $52 (func (param i32) (result (ref $a1))))
+ ;; CHECK:      (type $52 (func (param (ref null $pair) i64)))
 
- ;; CHECK:      (type $53 (func (param i32 i32) (result (ref $a1))))
+ ;; CHECK:      (type $53 (func (param i64 i32) (result (ref $a1))))
 
- ;; CHECK:      (type $54 (func (param (ref $a1) i32) (result i64)))
+ ;; CHECK:      (type $54 (func (param i32) (result (ref $a1))))
 
- ;; CHECK:      (type $55 (func (param (ref $packed-i8) i32) (result i32)))
+ ;; CHECK:      (type $55 (func (param i32 i32) (result (ref $a1))))
 
- ;; CHECK:      (type $56 (func (param (ref $packed-i16) i32) (result i32)))
+ ;; CHECK:      (type $56 (func (param (ref $a1) i32) (result i64)))
 
- ;; CHECK:      (type $57 (func (param (ref $a2) i32 f32)))
+ ;; CHECK:      (type $57 (func (param (ref $packed-i8) i32) (result i32)))
 
- ;; CHECK:      (type $58 (func (param arrayref) (result i32)))
+ ;; CHECK:      (type $58 (func (param (ref $packed-i16) i32) (result i32)))
 
- ;; CHECK:      (type $59 (func (param (ref $a2) i32 (ref $a2) i32 i32)))
+ ;; CHECK:      (type $59 (func (param (ref $a2) i32 f32)))
 
- ;; CHECK:      (type $60 (func (param (ref $a2) i32 f32 i32)))
+ ;; CHECK:      (type $60 (func (param arrayref) (result i32)))
 
- ;; CHECK:      (type $61 (func (param (ref $a2) i32 i32 i32)))
+ ;; CHECK:      (type $61 (func (param (ref $a2) i32 (ref $a2) i32 i32)))
 
- ;; CHECK:      (type $62 (func (param (ref $any-array) i32 i32 i32)))
+ ;; CHECK:      (type $62 (func (param (ref $a2) i32 f32 i32)))
 
- ;; CHECK:      (type $63 (func (param externref)))
+ ;; CHECK:      (type $63 (func (param (ref $a2) i32 i32 i32)))
 
- ;; CHECK:      (type $64 (func (param i32 i32) (result stringref)))
+ ;; CHECK:      (type $64 (func (param (ref $any-array) i32 i32 i32)))
 
- ;; CHECK:      (type $65 (func (param (ref $packed-i8) i32 i32) (result stringref)))
+ ;; CHECK:      (type $65 (func (param externref)))
 
- ;; CHECK:      (type $66 (func (param i32) (result stringref)))
+ ;; CHECK:      (type $66 (func (param i32 i32) (result stringref)))
 
- ;; CHECK:      (type $67 (func (result (ref string))))
+ ;; CHECK:      (type $67 (func (param (ref $packed-i8) i32 i32) (result stringref)))
 
- ;; CHECK:      (type $68 (func (param stringref) (result i32)))
+ ;; CHECK:      (type $68 (func (param i32) (result stringref)))
 
- ;; CHECK:      (type $69 (func (param stringview_wtf16) (result i32)))
+ ;; CHECK:      (type $69 (func (result (ref string))))
 
- ;; CHECK:      (type $70 (func (param stringref (ref $packed-i8) i32) (result i32)))
+ ;; CHECK:      (type $70 (func (param stringref) (result i32)))
 
- ;; CHECK:      (type $71 (func (param stringref stringref) (result (ref string))))
+ ;; CHECK:      (type $71 (func (param stringview_wtf16) (result i32)))
 
- ;; CHECK:      (type $72 (func (param stringref) (result stringview_wtf8)))
+ ;; CHECK:      (type $72 (func (param stringref (ref $packed-i8) i32) (result i32)))
 
- ;; CHECK:      (type $73 (func (param stringref) (result (ref stringview_wtf16))))
+ ;; CHECK:      (type $73 (func (param stringref stringref) (result (ref string))))
 
- ;; CHECK:      (type $74 (func (param stringref) (result stringview_iter)))
+ ;; CHECK:      (type $74 (func (param stringref) (result stringview_wtf8)))
 
- ;; CHECK:      (type $75 (func (param (ref stringview_wtf8) i32 i32) (result i32)))
+ ;; CHECK:      (type $75 (func (param stringref) (result (ref stringview_wtf16))))
 
- ;; CHECK:      (type $76 (func (param stringview_wtf16 i32) (result i32)))
+ ;; CHECK:      (type $76 (func (param stringref) (result stringview_iter)))
 
- ;; CHECK:      (type $77 (func (param stringview_iter) (result i32)))
+ ;; CHECK:      (type $77 (func (param (ref stringview_wtf8) i32 i32) (result i32)))
 
- ;; CHECK:      (type $78 (func (param stringview_iter i32) (result i32)))
+ ;; CHECK:      (type $78 (func (param stringview_wtf16 i32) (result i32)))
 
- ;; CHECK:      (type $79 (func (param (ref stringview_iter) i32) (result i32)))
+ ;; CHECK:      (type $79 (func (param stringview_iter) (result i32)))
 
- ;; CHECK:      (type $80 (func (param stringview_wtf8 stringview_wtf16 i32 i32)))
+ ;; CHECK:      (type $80 (func (param stringview_iter i32) (result i32)))
 
- ;; CHECK:      (type $81 (func (param stringview_iter i32) (result (ref string))))
+ ;; CHECK:      (type $81 (func (param (ref stringview_iter) i32) (result i32)))
+
+ ;; CHECK:      (type $82 (func (param stringview_wtf8 stringview_wtf16 i32 i32)))
+
+ ;; CHECK:      (type $83 (func (param stringview_iter i32) (result (ref string))))
 
  ;; CHECK:      (type $s2 (struct (field i32)))
  (type $s2 (struct i32))
@@ -197,7 +201,7 @@
  ;; CHECK:      (type $a3 (array (mut f64)))
  (type $a3 (array (field $x (mut f64))))
 
- (type $pair (struct (mut i32) (mut i64)))
+ (type $pair (struct (field $first (mut i32)) (field $second (mut i64))))
 
  (type $packed-i8 (array (mut i8)))
 
@@ -238,7 +242,7 @@
 
  ;; imported memories
  (memory (export "mem") (export "mem2") (import "" "mem") 0)
- ;; CHECK:      (type $93 (func (param (ref $s0) (ref $s1) (ref $s2) (ref $s3) (ref $s4) (ref $s5) (ref $s6) (ref $s7) (ref $s8) (ref $a0) (ref $a1) (ref $a2) (ref $a3) (ref $subvoid) (ref $submany) (ref $all-types))))
+ ;; CHECK:      (type $95 (func (param (ref $s0) (ref $s1) (ref $s2) (ref $s3) (ref $s4) (ref $s5) (ref $s6) (ref $s7) (ref $s8) (ref $a0) (ref $a1) (ref $a2) (ref $a3) (ref $subvoid) (ref $submany) (ref $all-types))))
 
  ;; CHECK:      (import "" "mem" (memory $mimport$0 0))
 
@@ -283,7 +287,7 @@
 
  ;; CHECK:      (import "mod" "f5" (func $fimport$0 (type $void)))
 
- ;; CHECK:      (import "mod" "imported-f" (func $fimport$1 (type $3) (result i32 i64)))
+ ;; CHECK:      (import "mod" "imported-f" (func $fimport$1 (type $4) (result i32 i64)))
 
  ;; CHECK:      (import "mod" "t0" (tag $imported (param i32 i64)))
 
@@ -1824,8 +1828,8 @@
   end
  )
 
- ;; CHECK:      (func $try-catch-params (type $3) (result i32 i64)
- ;; CHECK-NEXT:  (try (type $3) (result i32 i64)
+ ;; CHECK:      (func $try-catch-params (type $4) (result i32 i64)
+ ;; CHECK-NEXT:  (try (type $4) (result i32 i64)
  ;; CHECK-NEXT:   (do
  ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 0)
@@ -1845,8 +1849,8 @@
   end
  )
 
- ;; CHECK:      (func $try-catch-pop (type $3) (result i32 i64)
- ;; CHECK-NEXT:  (try (type $3) (result i32 i64)
+ ;; CHECK:      (func $try-catch-pop (type $4) (result i32 i64)
+ ;; CHECK-NEXT:  (try (type $4) (result i32 i64)
  ;; CHECK-NEXT:   (do
  ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 0)
@@ -2704,8 +2708,8 @@
   br 0
  )
 
- ;; CHECK:      (func $br-multivalue (type $3) (result i32 i64)
- ;; CHECK-NEXT:  (block $label (type $3) (result i32 i64)
+ ;; CHECK:      (func $br-multivalue (type $4) (result i32 i64)
+ ;; CHECK-NEXT:  (block $label (type $4) (result i32 i64)
  ;; CHECK-NEXT:   (br $label
  ;; CHECK-NEXT:    (tuple.make 2
  ;; CHECK-NEXT:     (i32.const 0)
@@ -2720,9 +2724,9 @@
   br 0
  )
 
- ;; CHECK:      (func $br-multivalue-drop (type $3) (result i32 i64)
- ;; CHECK-NEXT:  (block $label (type $3) (result i32 i64)
- ;; CHECK-NEXT:   (block (type $3) (result i32 i64)
+ ;; CHECK:      (func $br-multivalue-drop (type $4) (result i32 i64)
+ ;; CHECK-NEXT:  (block $label (type $4) (result i32 i64)
+ ;; CHECK-NEXT:   (block (type $4) (result i32 i64)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (f32.const 0)
  ;; CHECK-NEXT:    )
@@ -2922,9 +2926,9 @@
   end
  )
 
- ;; CHECK:      (func $br-table-multivalue (type $3) (result i32 i64)
- ;; CHECK-NEXT:  (block $a (type $3) (result i32 i64)
- ;; CHECK-NEXT:   (block $b (type $3) (result i32 i64)
+ ;; CHECK:      (func $br-table-multivalue (type $4) (result i32 i64)
+ ;; CHECK-NEXT:  (block $a (type $4) (result i32 i64)
+ ;; CHECK-NEXT:   (block $b (type $4) (result i32 i64)
  ;; CHECK-NEXT:    (br_table $a $b
  ;; CHECK-NEXT:     (tuple.make 2
  ;; CHECK-NEXT:      (i32.const 42)
@@ -4082,7 +4086,7 @@
  )
 
  ;; CHECK:      (func $struct-get-0 (type $47) (param $0 (ref $pair)) (result i32)
- ;; CHECK-NEXT:  (struct.get $pair 0
+ ;; CHECK-NEXT:  (struct.get $pair $first
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -4092,7 +4096,7 @@
  )
 
  ;; CHECK:      (func $struct-get-1 (type $48) (param $0 (ref $pair)) (result i64)
- ;; CHECK-NEXT:  (struct.get $pair 1
+ ;; CHECK-NEXT:  (struct.get $pair $second
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -4101,8 +4105,18 @@
   struct.get $pair 1
  )
 
- ;; CHECK:      (func $struct-set-0 (type $49) (param $0 (ref $pair)) (param $1 i32)
- ;; CHECK-NEXT:  (struct.set $pair 0
+ ;; CHECK:      (func $struct-get-named (type $49) (param $0 (ref null $pair)) (result i32)
+ ;; CHECK-NEXT:  (struct.get $pair $first
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $struct-get-named (param (ref null $pair)) (result i32)
+  local.get 0
+  struct.get $pair $first
+ )
+
+ ;; CHECK:      (func $struct-set-0 (type $50) (param $0 (ref $pair)) (param $1 i32)
+ ;; CHECK-NEXT:  (struct.set $pair $first
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
  ;; CHECK-NEXT:  )
@@ -4113,8 +4127,8 @@
   struct.set $pair 0
  )
 
- ;; CHECK:      (func $struct-set-1 (type $50) (param $0 (ref $pair)) (param $1 i64)
- ;; CHECK-NEXT:  (struct.set $pair 1
+ ;; CHECK:      (func $struct-set-1 (type $51) (param $0 (ref $pair)) (param $1 i64)
+ ;; CHECK-NEXT:  (struct.set $pair $second
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
  ;; CHECK-NEXT:  )
@@ -4125,7 +4139,19 @@
   struct.set 14 1
  )
 
- ;; CHECK:      (func $array-new (type $51) (param $0 i64) (param $1 i32) (result (ref $a1))
+ ;; CHECK:      (func $struct-set-named (type $52) (param $0 (ref null $pair)) (param $1 i64)
+ ;; CHECK-NEXT:  (struct.set $pair $second
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:   (local.get $1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $struct-set-named (param (ref null $pair) i64)
+  local.get 0
+  local.get 1
+  struct.set 14 $second
+ )
+
+ ;; CHECK:      (func $array-new (type $53) (param $0 i64) (param $1 i32) (result (ref $a1))
  ;; CHECK-NEXT:  (array.new $a1
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4137,7 +4163,7 @@
   array.new $a1
  )
 
- ;; CHECK:      (func $array-new-default (type $52) (param $0 i32) (result (ref $a1))
+ ;; CHECK:      (func $array-new-default (type $54) (param $0 i32) (result (ref $a1))
  ;; CHECK-NEXT:  (array.new_default $a1
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4147,7 +4173,7 @@
   array.new_default 11
  )
 
- ;; CHECK:      (func $array-new-data (type $53) (param $0 i32) (param $1 i32) (result (ref $a1))
+ ;; CHECK:      (func $array-new-data (type $55) (param $0 i32) (param $1 i32) (result (ref $a1))
  ;; CHECK-NEXT:  (array.new_data $a1 $implicit-data
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4181,7 +4207,7 @@
   drop
  )
 
- ;; CHECK:      (func $array-get (type $54) (param $0 (ref $a1)) (param $1 i32) (result i64)
+ ;; CHECK:      (func $array-get (type $56) (param $0 (ref $a1)) (param $1 i32) (result i64)
  ;; CHECK-NEXT:  (array.get $a1
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4193,7 +4219,7 @@
   array.get $a1
  )
 
- ;; CHECK:      (func $array-get-s (type $55) (param $0 (ref $packed-i8)) (param $1 i32) (result i32)
+ ;; CHECK:      (func $array-get-s (type $57) (param $0 (ref $packed-i8)) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (array.get_s $packed-i8
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4205,7 +4231,7 @@
   array.get_s 15
  )
 
- ;; CHECK:      (func $array-get-u (type $56) (param $0 (ref $packed-i16)) (param $1 i32) (result i32)
+ ;; CHECK:      (func $array-get-u (type $58) (param $0 (ref $packed-i16)) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (array.get_u $packed-i16
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4217,7 +4243,7 @@
   array.get_u $packed-i16
  )
 
- ;; CHECK:      (func $array-set (type $57) (param $0 (ref $a2)) (param $1 i32) (param $2 f32)
+ ;; CHECK:      (func $array-set (type $59) (param $0 (ref $a2)) (param $1 i32) (param $2 f32)
  ;; CHECK-NEXT:  (array.set $a2
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4231,7 +4257,7 @@
   array.set $a2
  )
 
- ;; CHECK:      (func $array-len (type $58) (param $0 arrayref) (result i32)
+ ;; CHECK:      (func $array-len (type $60) (param $0 arrayref) (result i32)
  ;; CHECK-NEXT:  (array.len
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4241,7 +4267,7 @@
   array.len
  )
 
- ;; CHECK:      (func $array-copy (type $59) (param $0 (ref $a2)) (param $1 i32) (param $2 (ref $a2)) (param $3 i32) (param $4 i32)
+ ;; CHECK:      (func $array-copy (type $61) (param $0 (ref $a2)) (param $1 i32) (param $2 (ref $a2)) (param $3 i32) (param $4 i32)
  ;; CHECK-NEXT:  (array.copy $a2 $a2
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4259,7 +4285,7 @@
   array.copy $a2 $a2
  )
 
- ;; CHECK:      (func $array-fill (type $60) (param $0 (ref $a2)) (param $1 i32) (param $2 f32) (param $3 i32)
+ ;; CHECK:      (func $array-fill (type $62) (param $0 (ref $a2)) (param $1 i32) (param $2 f32) (param $3 i32)
  ;; CHECK-NEXT:  (array.fill $a2
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4275,7 +4301,7 @@
   array.fill $a2
  )
 
- ;; CHECK:      (func $array-init-data (type $61) (param $0 (ref $a2)) (param $1 i32) (param $2 i32) (param $3 i32)
+ ;; CHECK:      (func $array-init-data (type $63) (param $0 (ref $a2)) (param $1 i32) (param $2 i32) (param $3 i32)
  ;; CHECK-NEXT:  (array.init_data $a2 $implicit-data
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4291,7 +4317,7 @@
   array.init_data $a2 0
  )
 
- ;; CHECK:      (func $array-init-elem (type $62) (param $0 (ref $any-array)) (param $1 i32) (param $2 i32) (param $3 i32)
+ ;; CHECK:      (func $array-init-elem (type $64) (param $0 (ref $any-array)) (param $1 i32) (param $2 i32) (param $3 i32)
  ;; CHECK-NEXT:  (array.init_elem $any-array $passive-2
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4320,7 +4346,7 @@
   drop
  )
 
- ;; CHECK:      (func $any-convert-extern (type $63) (param $0 externref)
+ ;; CHECK:      (func $any-convert-extern (type $65) (param $0 externref)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (extern.internalize
  ;; CHECK-NEXT:    (local.get $0)
@@ -4346,7 +4372,7 @@
   drop
  )
 
- ;; CHECK:      (func $string-new (type $64) (param $0 i32) (param $1 i32) (result stringref)
+ ;; CHECK:      (func $string-new (type $66) (param $0 i32) (param $1 i32) (result stringref)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (string.new_utf8_try
  ;; CHECK-NEXT:    (local.get $0)
@@ -4388,7 +4414,7 @@
   string.new_wtf16
  )
 
- ;; CHECK:      (func $string-new-gc (type $65) (param $0 (ref $packed-i8)) (param $1 i32) (param $2 i32) (result stringref)
+ ;; CHECK:      (func $string-new-gc (type $67) (param $0 (ref $packed-i8)) (param $1 i32) (param $2 i32) (result stringref)
  ;; CHECK-NEXT:  (string.new_utf8_array
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4402,7 +4428,7 @@
   string.new_utf8_array
  )
 
- ;; CHECK:      (func $string-new-code-point (type $66) (param $0 i32) (result stringref)
+ ;; CHECK:      (func $string-new-code-point (type $68) (param $0 i32) (result stringref)
  ;; CHECK-NEXT:  (string.from_code_point
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4412,7 +4438,7 @@
   string.from_code_point
  )
 
- ;; CHECK:      (func $string-const (type $67) (result (ref string))
+ ;; CHECK:      (func $string-const (type $69) (result (ref string))
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (string.const "foobar")
  ;; CHECK-NEXT:  )
@@ -4461,7 +4487,7 @@
   drop
  )
 
- ;; CHECK:      (func $string-hash (type $68) (param $0 stringref) (result i32)
+ ;; CHECK:      (func $string-hash (type $70) (param $0 stringref) (result i32)
  ;; CHECK-NEXT:  (string.hash
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4471,7 +4497,7 @@
   string.hash
  )
 
- ;; CHECK:      (func $stringview-length (type $69) (param $0 stringview_wtf16) (result i32)
+ ;; CHECK:      (func $stringview-length (type $71) (param $0 stringview_wtf16) (result i32)
  ;; CHECK-NEXT:  (stringview_wtf16.length
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4526,7 +4552,7 @@
   drop
  )
 
- ;; CHECK:      (func $string-encode-gc (type $70) (param $0 stringref) (param $1 (ref $packed-i8)) (param $2 i32) (result i32)
+ ;; CHECK:      (func $string-encode-gc (type $72) (param $0 stringref) (param $1 (ref $packed-i8)) (param $2 i32) (result i32)
  ;; CHECK-NEXT:  (string.encode_wtf8_array
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4540,7 +4566,7 @@
   string.encode_wtf8_array
  )
 
- ;; CHECK:      (func $string-concat (type $71) (param $0 stringref) (param $1 stringref) (result (ref string))
+ ;; CHECK:      (func $string-concat (type $73) (param $0 stringref) (param $1 stringref) (result (ref string))
  ;; CHECK-NEXT:  (string.concat
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4576,7 +4602,7 @@
   string.compare
  )
 
- ;; CHECK:      (func $string-as-wtf8 (type $72) (param $0 stringref) (result stringview_wtf8)
+ ;; CHECK:      (func $string-as-wtf8 (type $74) (param $0 stringref) (result stringview_wtf8)
  ;; CHECK-NEXT:  (string.as_wtf8
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4586,7 +4612,7 @@
   string.as_wtf8
  )
 
- ;; CHECK:      (func $string-as-wtf16 (type $73) (param $0 stringref) (result (ref stringview_wtf16))
+ ;; CHECK:      (func $string-as-wtf16 (type $75) (param $0 stringref) (result (ref stringview_wtf16))
  ;; CHECK-NEXT:  (string.as_wtf16
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4596,7 +4622,7 @@
   string.as_wtf16
  )
 
- ;; CHECK:      (func $string-as-iter (type $74) (param $0 stringref) (result stringview_iter)
+ ;; CHECK:      (func $string-as-iter (type $76) (param $0 stringref) (result stringview_iter)
  ;; CHECK-NEXT:  (string.as_iter
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4606,7 +4632,7 @@
   string.as_iter
  )
 
- ;; CHECK:      (func $string-advance (type $75) (param $0 (ref stringview_wtf8)) (param $1 i32) (param $2 i32) (result i32)
+ ;; CHECK:      (func $string-advance (type $77) (param $0 (ref stringview_wtf8)) (param $1 i32) (param $2 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_wtf8.advance
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4620,7 +4646,7 @@
   stringview_wtf8.advance
  )
 
- ;; CHECK:      (func $string-get (type $76) (param $0 stringview_wtf16) (param $1 i32) (result i32)
+ ;; CHECK:      (func $string-get (type $78) (param $0 stringview_wtf16) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_wtf16.get_codeunit
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4632,7 +4658,7 @@
   stringview_wtf16.get_codeunit
  )
 
- ;; CHECK:      (func $string-iter-next (type $77) (param $0 stringview_iter) (result i32)
+ ;; CHECK:      (func $string-iter-next (type $79) (param $0 stringview_iter) (result i32)
  ;; CHECK-NEXT:  (stringview_iter.next
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4642,7 +4668,7 @@
   stringview_iter.next
  )
 
- ;; CHECK:      (func $string-iter-advance (type $78) (param $0 stringview_iter) (param $1 i32) (result i32)
+ ;; CHECK:      (func $string-iter-advance (type $80) (param $0 stringview_iter) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_iter.advance
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4654,7 +4680,7 @@
   stringview_iter.advance
  )
 
- ;; CHECK:      (func $string-iter-rewind (type $79) (param $0 (ref stringview_iter)) (param $1 i32) (result i32)
+ ;; CHECK:      (func $string-iter-rewind (type $81) (param $0 (ref stringview_iter)) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_iter.rewind
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4666,7 +4692,7 @@
   stringview_iter.rewind
  )
 
- ;; CHECK:      (func $string-slice (type $80) (param $0 stringview_wtf8) (param $1 stringview_wtf16) (param $2 i32) (param $3 i32)
+ ;; CHECK:      (func $string-slice (type $82) (param $0 stringview_wtf8) (param $1 stringview_wtf16) (param $2 i32) (param $3 i32)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (stringview_wtf8.slice
  ;; CHECK-NEXT:    (local.get $0)
@@ -4695,7 +4721,7 @@
   drop
  )
 
- ;; CHECK:      (func $string-iter-slice (type $81) (param $0 stringview_iter) (param $1 i32) (result (ref string))
+ ;; CHECK:      (func $string-iter-slice (type $83) (param $0 stringview_iter) (param $1 i32) (result (ref string))
  ;; CHECK-NEXT:  (stringview_iter.slice
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4994,7 +5020,7 @@
   )
  )
 
- ;; CHECK:      (func $use-types (type $93) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany)) (param $15 (ref $all-types))
+ ;; CHECK:      (func $use-types (type $95) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany)) (param $15 (ref $all-types))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT: )
  (func $use-types


### PR DESCRIPTION
Construct a mapping from heap type and field name to field index, then use it while parsing instructions.