### PR TITLE
Fuzz shell: Add a j2wasm import

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -172,6 +172,10 @@ var imports = {
     'setTempRet0': function(x) { tempRet0 = x },
     'getTempRet0': function() { return tempRet0 },
   },
+  'imports': {
+    'j2wasm.ExceptionUtils.tag':
+      new WebAssembly.Tag({parameters: ['externref']}),
+  },
 };
 
 imports = Asyncify.instrumentImports(imports);

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -177,8 +177,9 @@ var imports = {
 // If Tags are available, add the import j2wasm expects.
 if (typeof WebAssembly.Tag !== 'undefined') {
   imports['imports'] = {
-    'j2wasm.ExceptionUtils.tag':
-      new WebAssembly.Tag({parameters: ['externref']}),
+    'j2wasm.ExceptionUtils.tag': new WebAssembly.Tag({
+      'parameters': ['externref']
+    }),
   };
 }
 

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -172,11 +172,15 @@ var imports = {
     'setTempRet0': function(x) { tempRet0 = x },
     'getTempRet0': function() { return tempRet0 },
   },
-  'imports': {
+};
+
+// If Tags are available, add the import j2wasm expects.
+if (typeof WebAssembly.Tag !== 'undefined') {
+  imports['imports'] = {
     'j2wasm.ExceptionUtils.tag':
       new WebAssembly.Tag({parameters: ['externref']}),
-  },
-};
+  };
+}
 
 imports = Asyncify.instrumentImports(imports);
 


### PR DESCRIPTION
With this, the fuzz shell can run a hello world Java file compiled by j2wasm.