### PR TITLE
C API: Add support for clearing up interned objects

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -6490,6 +6490,14 @@ void BinaryenSetColorsEnabled(bool enabled) { Colors::setEnabled(enabled); }
 
 bool BinaryenAreColorsEnabled() { return Colors::isEnabled(); }
 
+void BinaryenDangerClearInternedTypes() {
+  destroyAllTypesForTestingPurposesOnly();
+}
+
+void BinaryenDangerClearInternedStrings() {
+  destroyAllStringsForTestingPurposesOnly();
+}
+
 #ifdef __EMSCRIPTEN__
 // Internal binaryen.js APIs
 

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -3626,6 +3626,13 @@ BINARYEN_API void BinaryenSetColorsEnabled(bool enabled);
 
 // Query whether color is enable for the Wasm printer
 BINARYEN_API bool BinaryenAreColorsEnabled();
+
+// Clear up all interned types (dangerous)
+BINARYEN_API void BinaryenDangerClearInternedTypes();
+
+// Clear up all interned strings (dangerous)
+BINARYEN_API void BinaryenDangerClearInternedStrings();
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/support/istring.h
+++ b/src/support/istring.h
@@ -91,6 +91,10 @@ public:
   size_t size() const { return str.size(); }
 };
 
+// Dangerous! Frees all interned strings that have ever been created.
+// This is only really meant to be used for tests.
+void destroyAllStringsForTestingPurposesOnly();
+
 } // namespace wasm
 
 namespace std {

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -2047,6 +2047,11 @@ void test_color_status() {
   BinaryenSetColorsEnabled(old_state);
 }
 
+void test_clear_interned() {
+  BinaryenDangerClearInternedTypes();
+  BinaryenDangerClearInternedStrings();
+}
+
 void test_for_each() {
   BinaryenIndex i;
 
@@ -2373,6 +2378,7 @@ int main() {
   test_for_each();
   test_func_opt();
   test_typebuilder();
+  test_clear_interned();
 
   return 0;
 }


### PR DESCRIPTION
Hey developers, sorry about the late response for issue #6239, I've been struggling with the "static initialization order fiasco" problem when trying to move static variables like `globalStrings` outside the function. The source code in the PR may not be the best solution but that's my best effort.

If there are any problems, please feel free to leave some comments and let me know.