### PR TITLE
StringLowering: Use an array16 type in its own rec group

### DIFF
--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -254,7 +254,8 @@ struct StringLowering : public StringGathering {
     auto array16 = nullArray16.getHeapType();
     auto array16Element = array16.getArray().element;
     for (auto type : allTypes) {
-      if (type.isArray()) {
+      // Match an array type with no super and that is closed.
+      if (type.isArray() && !type.getDeclaredSuperType() && !type.isOpen()) {
         if (type.getArray().element == array16Element) {
           updates[type] = array16;
         }

--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -249,7 +249,7 @@ struct StringLowering : public StringGathering {
     // imported strings expects that type in its own rec group as part of the
     // ABI. Fix that up here. (This is valid to do as this type has no sub- or
     // super-types anyhow; it is "plain old data" for communicating with the
-    // outside anyhow.)
+    // outside.)
     auto allTypes = ModuleUtils::collectHeapTypes(*module);
     auto array16 = nullArray16.getHeapType();
     auto array16Element = array16.getArray().element;

--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -255,10 +255,9 @@ struct StringLowering : public StringGathering {
     auto array16Element = array16.getArray().element;
     for (auto type : allTypes) {
       // Match an array type with no super and that is closed.
-      if (type.isArray() && !type.getDeclaredSuperType() && !type.isOpen()) {
-        if (type.getArray().element == array16Element) {
-          updates[type] = array16;
-        }
+      if (type.isArray() && !type.getDeclaredSuperType() && !type.isOpen() &&
+          type.getArray().element == array16Element) {
+        updates[type] = array16;
       }
     }
 

--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -189,11 +189,11 @@ struct StringLowering : public StringGathering {
     // First, run the gathering operation so all string.consts are in one place.
     StringGathering::run(module);
 
-    // Lower the string.const globals into imports.
-    makeImports(module);
-
     // Remove all HeapType::string etc. in favor of externref.
     updateTypes(module);
+
+    // Lower the string.const globals into imports.
+    makeImports(module);
 
     // Replace string.* etc. operations with imported ones.
     replaceInstructions(module);

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -3,68 +3,75 @@
 ;; RUN: foreach %s %t wasm-opt --string-lowering  -all -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $array16 (array (mut i16)))
-  (type $array16 (array (mut i16)))
+  (rec
+    ;; CHECK:      (type $0 (array (mut i16)))
 
-  ;; CHECK:      (type $1 (func (param externref externref) (result i32)))
+    ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $2 (func (param externref i32 externref)))
+    ;; CHECK:      (type $2 (func (param externref externref) (result i32)))
 
-  ;; CHECK:       (type $3 (func (result externref)))
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $3 (func (param externref i32 externref)))
 
-  ;; CHECK:       (type $4 (func (param externref) (result externref)))
+    ;; CHECK:       (type $4 (func (result externref)))
 
-  ;; CHECK:       (type $5 (func (param externref) (result i32)))
+    ;; CHECK:       (type $struct-of-array (struct (field (ref $0))))
+    (type $struct-of-array (struct (field (ref $array16))))
 
-  ;; CHECK:       (type $6 (func (param externref externref) (result i32)))
+    ;; CHECK:       (type $array16 (array (mut i16)))
+    (type $array16 (array (mut i16)))
+  )
 
-  ;; CHECK:       (type $7 (func (param externref (ref $array16)) (result i32)))
+  ;; CHECK:       (type $7 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $8 (func (param (ref $array16))))
+  ;; CHECK:       (type $8 (func (param externref) (result i32)))
 
-  ;; CHECK:       (type $9 (func (param externref externref externref externref)))
+  ;; CHECK:       (type $9 (func (param externref externref) (result i32)))
 
-  ;; CHECK:      (type $10 (func))
+  ;; CHECK:       (type $10 (func (param externref (ref $0)) (result i32)))
 
-  ;; CHECK:      (type $11 (func (param (ref null $array16) i32 i32) (result (ref extern))))
+  ;; CHECK:       (type $11 (func (param (ref $0))))
 
-  ;; CHECK:      (type $12 (func (param i32) (result (ref extern))))
+  ;; CHECK:       (type $12 (func (param externref externref externref externref)))
 
-  ;; CHECK:      (type $13 (func (param externref (ref null $array16) i32) (result i32)))
+  ;; CHECK:      (type $13 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (type $14 (func (param externref) (result i32)))
+  ;; CHECK:      (type $14 (func (param i32) (result (ref extern))))
 
-  ;; CHECK:      (type $15 (func (param externref i32) (result i32)))
+  ;; CHECK:      (type $15 (func (param externref (ref null $0) i32) (result i32)))
 
-  ;; CHECK:      (type $16 (func (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (type $16 (func (param externref) (result i32)))
+
+  ;; CHECK:      (type $17 (func (param externref i32) (result i32)))
+
+  ;; CHECK:      (type $18 (func (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (import "string.const" "0" (global $string.const_exported (ref extern)))
 
-  ;; CHECK:      (import "colliding" "name" (func $fromCodePoint (type $10)))
+  ;; CHECK:      (import "colliding" "name" (func $fromCodePoint (type $1)))
   (import "colliding" "name" (func $fromCodePoint))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $11) (param (ref null $array16) i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $13) (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_13 (type $12) (param i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_14 (type $14) (param i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $13) (param externref (ref null $array16) i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $15) (param externref (ref null $0) i32) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "equals" (func $equals (type $1) (param externref externref) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "equals" (func $equals (type $2) (param externref externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "compare" (func $compare (type $1) (param externref externref) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "compare" (func $compare (type $2) (param externref externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $14) (param externref) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $16) (param externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $15) (param externref i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $17) (param externref i32) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $16) (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $18) (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (export "export.1" (func $exported-string-returner))
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $9) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
+  ;; CHECK:      (func $string.as (type $12) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:  )
@@ -99,7 +106,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.new.gc (type $8) (param $array16 (ref $array16))
+  ;; CHECK:      (func $string.new.gc (type $11) (param $array16 (ref $0))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (call $fromCharCodeArray
   ;; CHECK-NEXT:    (local.get $array16)
@@ -118,8 +125,8 @@
     )
   )
 
-  ;; CHECK:      (func $string.from_code_point (type $3) (result externref)
-  ;; CHECK-NEXT:  (call $fromCodePoint_13
+  ;; CHECK:      (func $string.from_code_point (type $4) (result externref)
+  ;; CHECK-NEXT:  (call $fromCodePoint_14
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -129,7 +136,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.encode (type $7) (param $ref externref) (param $array16 (ref $array16)) (result i32)
+  ;; CHECK:      (func $string.encode (type $10) (param $ref externref) (param $array16 (ref $0)) (result i32)
   ;; CHECK-NEXT:  (call $intoCharCodeArray
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (local.get $array16)
@@ -144,7 +151,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.eq (type $6) (param $a externref) (param $b externref) (result i32)
+  ;; CHECK:      (func $string.eq (type $9) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $equals
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -157,7 +164,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.compare (type $6) (param $a externref) (param $b externref) (result i32)
+  ;; CHECK:      (func $string.compare (type $9) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $compare
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -170,7 +177,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.length (type $5) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.length (type $8) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $length
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:  )
@@ -181,7 +188,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.get_codeunit (type $5) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.get_codeunit (type $8) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $codePointAt
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -194,7 +201,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.slice (type $4) (param $ref externref) (result externref)
+  ;; CHECK:      (func $string.slice (type $7) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (call $substring
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -209,7 +216,7 @@
     )
   )
 
-  ;; CHECK:      (func $exported-string-returner (type $3) (result externref)
+  ;; CHECK:      (func $exported-string-returner (type $4) (result externref)
   ;; CHECK-NEXT:  (global.get $string.const_exported)
   ;; CHECK-NEXT: )
   (func $exported-string-returner (export "export.1") (result stringref)
@@ -218,7 +225,7 @@
     (string.const "exported")
   )
 
-  ;; CHECK:      (func $exported-string-receiver (type $2) (param $x externref) (param $y i32) (param $z externref)
+  ;; CHECK:      (func $exported-string-receiver (type $3) (param $x externref) (param $y i32) (param $z externref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:  )
@@ -240,6 +247,42 @@
     )
     (drop
       (local.get $z)
+    )
+  )
+
+  ;; CHECK:      (func $use-struct-of-array (type $1)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (call $fromCharCodeArray
+  ;; CHECK-NEXT:    (struct.get $struct-of-array 0
+  ;; CHECK-NEXT:     (struct.new $struct-of-array
+  ;; CHECK-NEXT:      (array.new_fixed $0 2
+  ;; CHECK-NEXT:       (i32.const 10)
+  ;; CHECK-NEXT:       (i32.const 20)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $use-struct-of-array
+    ;; The array type here should switch to the new 16-bit array type that we
+    ;; use for the new imports, so that it is compatible with them. Without
+    ;; that, calling the import as we do here will fail.
+    (drop
+      (string.new_wtf16_array
+        (struct.get $struct-of-array 0
+          (struct.new $struct-of-array
+            (array.new_fixed $array16 2
+              (i32.const 10)
+              (i32.const 20)
+            )
+          )
+        )
+        (i32.const 0)
+        (i32.const 1)
+      )
     )
   )
 )

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -15,58 +15,65 @@
 
     ;; CHECK:       (type $4 (func (result externref)))
 
-  ;; CHECK:       (type $5 (func (param externref) (result externref)))
+    ;; CHECK:       (type $struct-of-array (struct (field (ref $0))))
+    (type $struct-of-array (struct (field (ref $array16))))
 
-  ;; CHECK:       (type $6 (func (param externref) (result i32)))
+    ;; CHECK:       (type $array16 (array (mut i16)))
+    (type $array16 (array (mut i16)))
+  )
 
-  ;; CHECK:       (type $7 (func (param externref externref) (result i32)))
+  ;; CHECK:       (type $7 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $8 (func (param externref (ref $array16)) (result i32)))
+  ;; CHECK:       (type $8 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $9 (func (param (ref $array16))))
+  ;; CHECK:       (type $9 (func (param externref) (result i32)))
 
-  ;; CHECK:       (type $10 (func (param externref externref externref externref)))
+  ;; CHECK:       (type $10 (func (param externref externref) (result i32)))
 
-  ;; CHECK:      (type $11 (func))
+  ;; CHECK:       (type $11 (func (param externref (ref $0)) (result i32)))
 
-  ;; CHECK:      (type $12 (func (param (ref null $array16) i32 i32) (result (ref extern))))
+  ;; CHECK:       (type $12 (func (param (ref $0))))
 
-  ;; CHECK:      (type $13 (func (param i32) (result (ref extern))))
+  ;; CHECK:       (type $13 (func (param externref externref externref externref)))
 
-  ;; CHECK:      (type $14 (func (param externref (ref null $array16) i32) (result i32)))
+  ;; CHECK:      (type $14 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (type $15 (func (param externref) (result i32)))
+  ;; CHECK:      (type $15 (func (param i32) (result (ref extern))))
 
-  ;; CHECK:      (type $16 (func (param externref i32) (result i32)))
+  ;; CHECK:      (type $16 (func (param externref (ref null $0) i32) (result i32)))
 
-  ;; CHECK:      (type $17 (func (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (type $17 (func (param externref) (result i32)))
+
+  ;; CHECK:      (type $18 (func (param externref i32) (result i32)))
+
+  ;; CHECK:      (type $19 (func (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (import "string.const" "0" (global $string.const_exported (ref extern)))
 
-  ;; CHECK:      (import "colliding" "name" (func $fromCodePoint (type $11)))
+  ;; CHECK:      (import "colliding" "name" (func $fromCodePoint (type $1)))
   (import "colliding" "name" (func $fromCodePoint))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $12) (param (ref null $array16) i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $14) (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_15 (type $13) (param i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_16 (type $15) (param i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $14) (param externref (ref null $array16) i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $16) (param externref (ref null $0) i32) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "equals" (func $equals (type $2) (param externref externref) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "compare" (func $compare (type $2) (param externref externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $15) (param externref) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $17) (param externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $16) (param externref i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $18) (param externref i32) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $17) (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $19) (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (export "export.1" (func $exported-string-returner))
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $10) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
+  ;; CHECK:      (func $string.as (type $13) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:  )
@@ -101,6 +108,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.new.gc (type $12) (param $array16 (ref $0))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (call $fromCharCodeArray
   ;; CHECK-NEXT:    (local.get $array16)
@@ -119,6 +127,8 @@
     )
   )
 
+  ;; CHECK:      (func $string.from_code_point (type $4) (result externref)
+  ;; CHECK-NEXT:  (call $fromCodePoint_16
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -128,6 +138,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.encode (type $11) (param $ref externref) (param $array16 (ref $0)) (result i32)
   ;; CHECK-NEXT:  (call $intoCharCodeArray
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (local.get $array16)
@@ -142,6 +153,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.eq (type $10) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $equals
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -154,6 +166,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.compare (type $10) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $compare
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -166,6 +179,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.length (type $9) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $length
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:  )
@@ -176,6 +190,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.get_codeunit (type $9) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $codePointAt
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -188,6 +203,7 @@
     )
   )
 
+  ;; CHECK:      (func $string.slice (type $8) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (call $substring
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -202,7 +218,7 @@
     )
   )
 
-  ;; CHECK:      (func $if.string (type $4) (param $ref externref) (result externref)
+  ;; CHECK:      (func $if.string (type $7) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (if (result externref)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -225,7 +241,7 @@
     )
   )
 
-  ;; CHECK:      (func $if.string.flip (type $4) (param $ref externref) (result externref)
+  ;; CHECK:      (func $if.string.flip (type $7) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (if (result externref)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -249,6 +265,7 @@
     )
   )
 
+  ;; CHECK:      (func $exported-string-returner (type $4) (result externref)
   ;; CHECK-NEXT:  (global.get $string.const_exported)
   ;; CHECK-NEXT: )
   (func $exported-string-returner (export "export.1") (result stringref)

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -27,62 +27,65 @@
     ;; CHECK:       (type $array16-open (sub (array (mut i16))))
     (type $array16-open (sub (array (mut i16))))
 
+    ;; CHECK:       (type $array16-child (sub $array16-open (array (mut i16))))
+    (type $array16-child (sub $array16-open (array (mut i16))))
+
     ;; CHECK:       (type $array16 (array (mut i16)))
     (type $array16 (array (mut i16)))
   )
 
-  ;; CHECK:       (type $10 (func (param externref) (result externref)))
-
   ;; CHECK:       (type $11 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $12 (func (param externref) (result i32)))
+  ;; CHECK:       (type $12 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $13 (func (param externref externref) (result i32)))
+  ;; CHECK:       (type $13 (func (param externref) (result i32)))
 
-  ;; CHECK:       (type $14 (func (param externref (ref $0)) (result i32)))
+  ;; CHECK:       (type $14 (func (param externref externref) (result i32)))
 
-  ;; CHECK:       (type $15 (func (param (ref $0))))
+  ;; CHECK:       (type $15 (func (param externref (ref $0)) (result i32)))
 
-  ;; CHECK:       (type $16 (func (param externref externref externref externref)))
+  ;; CHECK:       (type $16 (func (param (ref $0))))
 
-  ;; CHECK:      (type $17 (func (param (ref null $0) i32 i32) (result (ref extern))))
+  ;; CHECK:       (type $17 (func (param externref externref externref externref)))
 
-  ;; CHECK:      (type $18 (func (param i32) (result (ref extern))))
+  ;; CHECK:      (type $18 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (type $19 (func (param externref (ref null $0) i32) (result i32)))
+  ;; CHECK:      (type $19 (func (param i32) (result (ref extern))))
 
-  ;; CHECK:      (type $20 (func (param externref) (result i32)))
+  ;; CHECK:      (type $20 (func (param externref (ref null $0) i32) (result i32)))
 
-  ;; CHECK:      (type $21 (func (param externref i32) (result i32)))
+  ;; CHECK:      (type $21 (func (param externref) (result i32)))
 
-  ;; CHECK:      (type $22 (func (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (type $22 (func (param externref i32) (result i32)))
+
+  ;; CHECK:      (type $23 (func (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (import "string.const" "0" (global $string.const_exported (ref extern)))
 
   ;; CHECK:      (import "colliding" "name" (func $fromCodePoint (type $1)))
   (import "colliding" "name" (func $fromCodePoint))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $17) (param (ref null $0) i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $18) (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_16 (type $18) (param i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_16 (type $19) (param i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $19) (param externref (ref null $0) i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $20) (param externref (ref null $0) i32) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "equals" (func $equals (type $2) (param externref externref) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "compare" (func $compare (type $2) (param externref externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $20) (param externref) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $21) (param externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $21) (param externref i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $22) (param externref i32) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $22) (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $23) (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (export "export.1" (func $exported-string-returner))
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $16) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
+  ;; CHECK:      (func $string.as (type $17) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:  )
@@ -117,7 +120,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.new.gc (type $15) (param $array16 (ref $0))
+  ;; CHECK:      (func $string.new.gc (type $16) (param $array16 (ref $0))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (call $fromCharCodeArray
   ;; CHECK-NEXT:    (local.get $array16)
@@ -147,7 +150,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.encode (type $14) (param $ref externref) (param $array16 (ref $0)) (result i32)
+  ;; CHECK:      (func $string.encode (type $15) (param $ref externref) (param $array16 (ref $0)) (result i32)
   ;; CHECK-NEXT:  (call $intoCharCodeArray
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (local.get $array16)
@@ -162,7 +165,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.eq (type $13) (param $a externref) (param $b externref) (result i32)
+  ;; CHECK:      (func $string.eq (type $14) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $equals
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -175,7 +178,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.compare (type $13) (param $a externref) (param $b externref) (result i32)
+  ;; CHECK:      (func $string.compare (type $14) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $compare
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -188,7 +191,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.length (type $12) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.length (type $13) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $length
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:  )
@@ -199,7 +202,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.get_codeunit (type $12) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.get_codeunit (type $13) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $codePointAt
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -212,7 +215,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.slice (type $11) (param $ref externref) (result externref)
+  ;; CHECK:      (func $string.slice (type $12) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (call $substring
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -227,7 +230,7 @@
     )
   )
 
-  ;; CHECK:      (func $if.string (type $10) (param $ref externref) (result externref)
+  ;; CHECK:      (func $if.string (type $11) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (if (result externref)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -250,7 +253,7 @@
     )
   )
 
-  ;; CHECK:      (func $if.string.flip (type $10) (param $ref externref) (result externref)
+  ;; CHECK:      (func $if.string.flip (type $11) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (if (result externref)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -311,6 +314,7 @@
   ;; CHECK:      (func $use-struct-of-array (type $1)
   ;; CHECK-NEXT:  (local $array16 (ref $0))
   ;; CHECK-NEXT:  (local $open (ref $array16-open))
+  ;; CHECK-NEXT:  (local $child (ref $array16-child))
   ;; CHECK-NEXT:  (local $32 (ref $array32))
   ;; CHECK-NEXT:  (local $imm (ref $array16-imm))
   ;; CHECK-NEXT:  (drop
@@ -337,6 +341,9 @@
     ;; In comparison, the array16-open param should remain as it is: it is an
     ;; open type which is different then the one we care about.
     (local $open (ref $array16-open))
+
+    ;; Likewise a child of that open type is also ignored.
+    (local $child (ref $array16-child))
 
     ;; Another array size is also ignored.
     (local $32 (ref $array32))

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -19,19 +19,16 @@
     (type $struct-of-array (struct (field (ref $array16))))
 
     ;; CHECK:       (type $array16-imm (array i32))
+    (type $array16-imm (array i32))
 
     ;; CHECK:       (type $array32 (array (mut i32)))
+    (type $array32 (array (mut i32)))
 
     ;; CHECK:       (type $array16-open (sub (array (mut i16))))
+    (type $array16-open (sub (array (mut i16))))
 
     ;; CHECK:       (type $array16 (array (mut i16)))
     (type $array16 (array (mut i16)))
-
-    (type $array16-open (sub (array (mut i16))))
-
-    (type $array32 (array (mut i32)))
-
-    (type $array16-imm (array i32))
   )
 
   ;; CHECK:       (type $10 (func (param externref) (result externref)))

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -312,7 +312,7 @@
   )
 
   ;; CHECK:      (func $use-struct-of-array (type $1)
-  ;; CHECK-NEXT:  (local $closed (ref $0))
+  ;; CHECK-NEXT:  (local $array16 (ref $0))
   ;; CHECK-NEXT:  (local $open (ref $array16-open))
   ;; CHECK-NEXT:  (local $32 (ref $array32))
   ;; CHECK-NEXT:  (local $imm (ref $array16-imm))
@@ -335,7 +335,7 @@
     ;; The array type here should switch to the new 16-bit array type that we
     ;; use for the new imports, so that it is compatible with them. Without
     ;; that, calling the import as we do below will fail.
-    (local $closed (ref $array16))
+    (local $array16 (ref $array16))
 
     ;; In comparison, the array16-open param should remain as it is: it is an
     ;; open type which is different then the one we care about.

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -18,62 +18,74 @@
     ;; CHECK:       (type $struct-of-array (struct (field (ref $0))))
     (type $struct-of-array (struct (field (ref $array16))))
 
+    ;; CHECK:       (type $array16-imm (array i32))
+
+    ;; CHECK:       (type $array32 (array (mut i32)))
+
+    ;; CHECK:       (type $array16-open (sub (array (mut i16))))
+
     ;; CHECK:       (type $array16 (array (mut i16)))
     (type $array16 (array (mut i16)))
+
+    (type $array16-open (sub (array (mut i16))))
+
+    (type $array32 (array (mut i32)))
+
+    (type $array16-imm (array i32))
   )
 
-  ;; CHECK:       (type $7 (func (param externref) (result externref)))
+  ;; CHECK:       (type $10 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $8 (func (param externref) (result externref)))
+  ;; CHECK:       (type $11 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $9 (func (param externref) (result i32)))
+  ;; CHECK:       (type $12 (func (param externref) (result i32)))
 
-  ;; CHECK:       (type $10 (func (param externref externref) (result i32)))
+  ;; CHECK:       (type $13 (func (param externref externref) (result i32)))
 
-  ;; CHECK:       (type $11 (func (param externref (ref $0)) (result i32)))
+  ;; CHECK:       (type $14 (func (param externref (ref $0)) (result i32)))
 
-  ;; CHECK:       (type $12 (func (param (ref $0))))
+  ;; CHECK:       (type $15 (func (param (ref $0))))
 
-  ;; CHECK:       (type $13 (func (param externref externref externref externref)))
+  ;; CHECK:       (type $16 (func (param externref externref externref externref)))
 
-  ;; CHECK:      (type $14 (func (param (ref null $0) i32 i32) (result (ref extern))))
+  ;; CHECK:      (type $17 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (type $15 (func (param i32) (result (ref extern))))
+  ;; CHECK:      (type $18 (func (param i32) (result (ref extern))))
 
-  ;; CHECK:      (type $16 (func (param externref (ref null $0) i32) (result i32)))
+  ;; CHECK:      (type $19 (func (param externref (ref null $0) i32) (result i32)))
 
-  ;; CHECK:      (type $17 (func (param externref) (result i32)))
+  ;; CHECK:      (type $20 (func (param externref) (result i32)))
 
-  ;; CHECK:      (type $18 (func (param externref i32) (result i32)))
+  ;; CHECK:      (type $21 (func (param externref i32) (result i32)))
 
-  ;; CHECK:      (type $19 (func (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (type $22 (func (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (import "string.const" "0" (global $string.const_exported (ref extern)))
 
   ;; CHECK:      (import "colliding" "name" (func $fromCodePoint (type $1)))
   (import "colliding" "name" (func $fromCodePoint))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $14) (param (ref null $0) i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $17) (param (ref null $0) i32 i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_16 (type $15) (param i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "fromCodePoint" (func $fromCodePoint_16 (type $18) (param i32) (result (ref extern))))
 
-  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $16) (param externref (ref null $0) i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "intoCharCodeArray" (func $intoCharCodeArray (type $19) (param externref (ref null $0) i32) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "equals" (func $equals (type $2) (param externref externref) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "compare" (func $compare (type $2) (param externref externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $17) (param externref) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $20) (param externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $18) (param externref i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $21) (param externref i32) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $19) (param externref i32 i32) (result (ref extern))))
+  ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $22) (param externref i32 i32) (result (ref extern))))
 
   ;; CHECK:      (export "export.1" (func $exported-string-returner))
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $13) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
+  ;; CHECK:      (func $string.as (type $16) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:  )
@@ -108,7 +120,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.new.gc (type $12) (param $array16 (ref $0))
+  ;; CHECK:      (func $string.new.gc (type $15) (param $array16 (ref $0))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (call $fromCharCodeArray
   ;; CHECK-NEXT:    (local.get $array16)
@@ -138,7 +150,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.encode (type $11) (param $ref externref) (param $array16 (ref $0)) (result i32)
+  ;; CHECK:      (func $string.encode (type $14) (param $ref externref) (param $array16 (ref $0)) (result i32)
   ;; CHECK-NEXT:  (call $intoCharCodeArray
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (local.get $array16)
@@ -153,7 +165,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.eq (type $10) (param $a externref) (param $b externref) (result i32)
+  ;; CHECK:      (func $string.eq (type $13) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $equals
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -166,7 +178,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.compare (type $10) (param $a externref) (param $b externref) (result i32)
+  ;; CHECK:      (func $string.compare (type $13) (param $a externref) (param $b externref) (result i32)
   ;; CHECK-NEXT:  (call $compare
   ;; CHECK-NEXT:   (local.get $a)
   ;; CHECK-NEXT:   (local.get $b)
@@ -179,7 +191,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.length (type $9) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.length (type $12) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $length
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:  )
@@ -190,7 +202,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.get_codeunit (type $9) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.get_codeunit (type $12) (param $ref externref) (result i32)
   ;; CHECK-NEXT:  (call $codePointAt
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -203,7 +215,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.slice (type $8) (param $ref externref) (result externref)
+  ;; CHECK:      (func $string.slice (type $11) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (call $substring
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -218,7 +230,7 @@
     )
   )
 
-  ;; CHECK:      (func $if.string (type $7) (param $ref externref) (result externref)
+  ;; CHECK:      (func $if.string (type $10) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (if (result externref)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -241,7 +253,7 @@
     )
   )
 
-  ;; CHECK:      (func $if.string.flip (type $7) (param $ref externref) (result externref)
+  ;; CHECK:      (func $if.string.flip (type $10) (param $ref externref) (result externref)
   ;; CHECK-NEXT:  (if (result externref)
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:   (then
@@ -300,6 +312,10 @@
   )
 
   ;; CHECK:      (func $use-struct-of-array (type $1)
+  ;; CHECK-NEXT:  (local $closed (ref $0))
+  ;; CHECK-NEXT:  (local $open (ref $array16-open))
+  ;; CHECK-NEXT:  (local $32 (ref $array32))
+  ;; CHECK-NEXT:  (local $imm (ref $array16-imm))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (call $fromCharCodeArray
   ;; CHECK-NEXT:    (struct.get $struct-of-array 0
@@ -318,7 +334,19 @@
   (func $use-struct-of-array
     ;; The array type here should switch to the new 16-bit array type that we
     ;; use for the new imports, so that it is compatible with them. Without
-    ;; that, calling the import as we do here will fail.
+    ;; that, calling the import as we do below will fail.
+    (local $closed (ref $array16))
+
+    ;; In comparison, the array16-open param should remain as it is: it is an
+    ;; open type which is different then the one we care about.
+    (local $open (ref $array16-open))
+
+    ;; Another array size is also ignored.
+    (local $32 (ref $array32))
+
+    ;; An immutable array is also ignored.
+    (local $imm (ref $array16-imm))
+
     (drop
       (string.new_wtf16_array
         (struct.get $struct-of-array 0


### PR DESCRIPTION
The input module might use an array of 16-bit elements type that is somewhere in a
giant rec group, but that is not valid for imported strings: that array type is now on an
import and must match the expected ABI, which is to be in its own personal rec group.

The old array16 type remains in the module after this transformation, but all uses of it
are replaced with uses of the new array16 type.

Also move makeImports to after updateTypes: there are no types to update in the new
imports. That does not matter but it can make debugging less pleasant, so improve it.