### PR TITLE
Strings: Add some interpreter support

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1975,7 +1975,28 @@ public:
   Flow visitStringWTF8Advance(StringWTF8Advance* curr) {
     WASM_UNREACHABLE("unimp");
   }
-  Flow visitStringWTF16Get(StringWTF16Get* curr) { WASM_UNREACHABLE("unimp"); }
+  Flow visitStringWTF16Get(StringWTF16Get* curr) {
+    NOTE_ENTER("StringEq");
+    Flow ref = visit(curr->ref);
+    if (ref.breaking()) {
+      return ref;
+    }
+    Flow pos = visit(curr->pos);
+    if (pos.breaking()) {
+      return pos;
+    }
+    auto refValue = ref.getSingleValue();
+    auto data = refValue.getGCData();
+    if (!data) {
+      trap("null ref");
+    }
+    auto& values = data->values;
+    Index i = pos.getSingleValue().geti32();
+    if (i >= values.size()) {
+      trap("string oob");
+    }
+    return Literal(values[i].geti32());
+  }
   Flow visitStringIterNext(StringIterNext* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitStringIterMove(StringIterMove* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitStringSliceWTF(StringSliceWTF* curr) { WASM_UNREACHABLE("unimp"); }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1972,7 +1972,22 @@ public:
     return Literal(result);
   }
   Flow visitStringAs(StringAs* curr) {
-    // TODO
+    // For now we only support JS-style strings.
+    assert(curr->op == StringAsWTF16);
+
+    Flow flow = visit(curr->ref);
+    if (flow.breaking()) {
+      return flow;
+    }
+    auto value = flow.getSingleValue();
+    auto data = value.getGCData();
+    if (!data) {
+      trap("null ref");
+    }
+
+    // A JS-style string can be viewed simply as the underlying data. All we
+    // need to do is fix up the type.
+    return Literal(data, curr->type.getHeapType());
   }
   Flow visitStringWTF8Advance(StringWTF8Advance* curr) {
     WASM_UNREACHABLE("unimp");

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1902,7 +1902,21 @@ public:
   Flow visitStringConst(StringConst* curr) {
     return Literal(curr->string.toString());
   }
-  Flow visitStringMeasure(StringMeasure* curr) { WASM_UNREACHABLE("unimp"); }
+  Flow visitStringMeasure(StringMeasure* curr) {
+    // For now we only support JS-style strings.
+    assert(curr->op == StringMeasureWTF16View);
+
+    Flow flow = visit(curr->ref);
+    if (flow.breaking()) {
+      return flow;
+    }
+    auto value = flow.getSingleValue();
+    auto data = value.getGCData();
+    if (!data) {
+      trap("null ref");
+    }
+    return Literal(int32_t(data->values.size()));
+  }
   Flow visitStringEncode(StringEncode* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitStringConcat(StringConcat* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitStringEq(StringEq* curr) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1971,7 +1971,9 @@ public:
     }
     return Literal(result);
   }
-  Flow visitStringAs(StringAs* curr) { WASM_UNREACHABLE("unimp"); }
+  Flow visitStringAs(StringAs* curr) {
+    // TODO
+  }
   Flow visitStringWTF8Advance(StringWTF8Advance* curr) {
     WASM_UNREACHABLE("unimp");
   }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1163,7 +1163,6 @@ bool HeapType::isFunction() const {
 
 bool HeapType::isData() const {
   if (isBasic()) {
-    // TODO comment about stringview JS like
     return id == struct_ || id == array || id == string ||
            id == stringview_wtf16;
   } else {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1163,7 +1163,9 @@ bool HeapType::isFunction() const {
 
 bool HeapType::isData() const {
   if (isBasic()) {
-    return id == struct_ || id == array || id == string;
+    // TODO comment about stringview JS like
+    return id == struct_ || id == array || id == string ||
+           id == stringview_wtf16;
   } else {
     return getHeapTypeInfo(*this)->isData();
   }

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -166,12 +166,23 @@
   ;; CHECK:      [fuzz-exec] calling get_codeunit
   ;; CHECK-NEXT: [fuzz-exec] note result: get_codeunit => 99
   (func $get_codeunit (export "get_codeunit") (result i32)
-    ;; Reads 'c' which is code 99
+    ;; Reads 'c' which is code 99.
     (stringview_wtf16.get_codeunit
       (string.as_wtf16
         (string.const "abcdefg")
       )
       (i32.const 2)
+    )
+  )
+
+  ;; CHECK:      [fuzz-exec] calling get_length
+  ;; CHECK-NEXT: [fuzz-exec] note result: get_length => 7
+  (func $get_length (export "get_length") (result i32)
+    ;; This should return 7.
+    (stringview_wtf16.length
+      (string.as_wtf16
+        (string.const "1234567")
+      )
     )
   )
 )
@@ -228,6 +239,9 @@
 
 ;; CHECK:      [fuzz-exec] calling get_codeunit
 ;; CHECK-NEXT: [fuzz-exec] note result: get_codeunit => 99
+
+;; CHECK:      [fuzz-exec] calling get_length
+;; CHECK-NEXT: [fuzz-exec] note result: get_length => 7
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.1
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.10
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.2
@@ -245,4 +259,5 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing eq.4
 ;; CHECK-NEXT: [fuzz-exec] comparing eq.5
 ;; CHECK-NEXT: [fuzz-exec] comparing get_codeunit
+;; CHECK-NEXT: [fuzz-exec] comparing get_length
 ;; CHECK-NEXT: [fuzz-exec] comparing new_wtf16_array

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -163,6 +163,8 @@
     )
   )
 
+  ;; CHECK:      [fuzz-exec] calling get_codeunit
+  ;; CHECK-NEXT: [fuzz-exec] note result: get_codeunit => 99
   (func $get_codeunit (export "get_codeunit") (result i32)
     ;; Reads 'c' which is code 99
     (stringview_wtf16.get_codeunit
@@ -223,6 +225,9 @@
 
 ;; CHECK:      [fuzz-exec] calling compare.10
 ;; CHECK-NEXT: [fuzz-exec] note result: compare.10 => -1
+
+;; CHECK:      [fuzz-exec] calling get_codeunit
+;; CHECK-NEXT: [fuzz-exec] note result: get_codeunit => 99
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.1
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.10
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.2
@@ -239,4 +244,5 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing eq.3
 ;; CHECK-NEXT: [fuzz-exec] comparing eq.4
 ;; CHECK-NEXT: [fuzz-exec] comparing eq.5
+;; CHECK-NEXT: [fuzz-exec] comparing get_codeunit
 ;; CHECK-NEXT: [fuzz-exec] comparing new_wtf16_array

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -162,6 +162,16 @@
       (string.const "hf")
     )
   )
+
+  (func $get_codeunit (export "get_codeunit") (result i32)
+    ;; Reads 'c' which is code 99
+    (stringview_wtf16.get_codeunit
+      (string.as_wtf16
+        (string.const "abcdefg")
+      )
+      (i32.const 2)
+    )
+  )
 )
 ;; CHECK:      [fuzz-exec] calling new_wtf16_array
 ;; CHECK-NEXT: [fuzz-exec] note result: new_wtf16_array => string("ello")


### PR DESCRIPTION
This adds just enough support to be able to `--fuzz-exec` a small but realistic fuzz
testcase from Java.

To that end, just implement the minimal ops we need, which are all related to
JS-style strings. Full Strings support does not make sense to spend time on atm,
but this small PR unblocks fuzzing so it seems worth it.