### PR TITLE
StringLowering: Properly handle nullable inputs to StringAs

### DIFF
--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -468,6 +468,9 @@ struct StringLowering : public StringGathering {
     Replacer replacer(*this);
     replacer.run(getPassRunner(), module);
     replacer.walkModuleCode(module);
+
+    // ReFinalize to apply changes to parents.
+    ReFinalize().run(getPassRunner(), module);
   }
 };
 

--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -35,6 +35,7 @@
 #include "ir/module-utils.h"
 #include "ir/names.h"
 #include "ir/type-updating.h"
+#include "ir/utils.h"
 #include "pass.h"
 #include "support/json.h"
 #include "wasm-builder.h"

--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -361,7 +361,13 @@ struct StringLowering : public StringGathering {
       void visitStringAs(StringAs* curr) {
         // There is no difference between strings and views with imported
         // strings: they are all just JS strings, so no conversion is needed.
-        replaceCurrent(curr->ref);
+        // However, we must keep the same nullability: the output of StringAs
+        // must be non-nullable.
+        auto* ref = curr->ref;
+        if (ref->type.isNullable()) {
+          ref = Builder(*getModule()).makeRefAs(RefAsNonNull, ref);
+        }
+        replaceCurrent(ref);
       }
 
       void visitStringEncode(StringEncode* curr) {

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -49,7 +49,7 @@
 
   ;; CHECK:       (type $17 (func (param (ref $0))))
 
-  ;; CHECK:       (type $18 (func (param externref externref externref externref (ref extern))))
+  ;; CHECK:       (type $18 (func (param externref (ref extern) externref externref externref (ref extern))))
 
   ;; CHECK:      (type $19 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
@@ -90,7 +90,7 @@
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $18) (param $a externref) (param $b externref) (param $c externref) (param $d externref) (param $nn (ref extern))
+  ;; CHECK:      (func $string.as (type $18) (param $a externref) (param $a_nn (ref extern)) (param $b externref) (param $c externref) (param $d externref) (param $nn_view (ref extern))
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (ref.as_non_null
   ;; CHECK-NEXT:    (local.get $a)
@@ -106,18 +106,22 @@
   ;; CHECK-NEXT:    (local.get $a)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $nn
+  ;; CHECK-NEXT:  (local.set $nn_view
   ;; CHECK-NEXT:   (ref.as_non_null
   ;; CHECK-NEXT:    (local.get $a)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $nn_view
+  ;; CHECK-NEXT:   (local.get $a_nn)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $string.as
     (param $a stringref)
+    (param $a_nn (ref string))
     (param $b stringview_wtf8)
     (param $c stringview_wtf16)
     (param $d stringview_iter)
-    (param $nn (ref stringview_wtf16))
+    (param $nn_view (ref stringview_wtf16))
     ;; These operations all vanish in the lowering, as they all become extref
     ;; (JS strings).
     (local.set $b
@@ -137,11 +141,17 @@
     )
     ;; The input is nullable, and string.as casts to non-null, so we will need
     ;; to keep a cast here in order to validate. (We also add a cast in all the
-    ;; above for simplicity, and other opts can remove them there, but not
-    ;; here.)
-    (local.set $nn
+    ;; above as the inputs are nullable, but this is the only one that will
+    ;; fail to validate. Other opts can remove the above ones.)
+    (local.set $nn_view
       (string.as_wtf16
         (local.get $a)
+      )
+    )
+    ;; The input is already non-nullable here, so no cast is needed.
+    (local.set $nn_view
+      (string.as_wtf16
+        (local.get $a_nn)
       )
     )
   )

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -49,7 +49,7 @@
 
   ;; CHECK:       (type $17 (func (param (ref $0))))
 
-  ;; CHECK:       (type $18 (func (param externref externref externref externref)))
+  ;; CHECK:       (type $18 (func (param externref externref externref externref (ref extern))))
 
   ;; CHECK:      (type $19 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
@@ -90,15 +90,26 @@
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $18) (param $a externref) (param $b externref) (param $c externref) (param $d externref)
+  ;; CHECK:      (func $string.as (type $18) (param $a externref) (param $b externref) (param $c externref) (param $d externref) (param $nn (ref extern))
   ;; CHECK-NEXT:  (local.set $b
-  ;; CHECK-NEXT:   (local.get $a)
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $c
-  ;; CHECK-NEXT:   (local.get $a)
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $d
-  ;; CHECK-NEXT:   (local.get $a)
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $nn
+  ;; CHECK-NEXT:   (ref.as_non_null
+  ;; CHECK-NEXT:    (local.get $a)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $string.as
@@ -106,6 +117,7 @@
     (param $b stringview_wtf8)
     (param $c stringview_wtf16)
     (param $d stringview_iter)
+    (param $nn (ref stringview_wtf16))
     ;; These operations all vanish in the lowering, as they all become extref
     ;; (JS strings).
     (local.set $b
@@ -120,6 +132,15 @@
     )
     (local.set $d
       (string.as_iter
+        (local.get $a)
+      )
+    )
+    ;; The input is nullable, and string.as casts to non-null, so we will need
+    ;; to keep a cast here in order to validate. (We also add a cast in all the
+    ;; above for simplicity, and other opts can remove them there, but not
+    ;; here.)
+    (local.set $nn
+      (string.as_wtf16
         (local.get $a)
       )
     )


### PR DESCRIPTION
StringAs's output must be non-nullable, so add a cast.