### PR TITLE
Validate function imports

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3334,12 +3334,6 @@ void FunctionValidator::visitFunction(Function* curr) {
   }
 
   if (curr->body) {
-    assert(breakTypes.empty());
-    assert(delegateTargetNames.empty());
-    assert(rethrowTargetNames.empty());
-    returnTypes.clear();
-    labelNames.clear();
-
     if (curr->getResults().isTuple()) {
       shouldBeTrue(getModule()->features.hasMultivalue(),
                    curr->body,
@@ -3374,6 +3368,15 @@ void FunctionValidator::visitFunction(Function* curr) {
         }
       }
     }
+
+    // Assert that we finished with a clean state after processing the body's
+    // expressions, and reset the state for next time. Note that we use some of
+    // this state in the above validations, so this must appear last.
+    assert(breakTypes.empty());
+    assert(delegateTargetNames.empty());
+    assert(rethrowTargetNames.empty());
+    returnTypes.clear();
+    labelNames.clear();
   }
 }
 

--- a/test/lit/validation/imports.wast
+++ b/test/lit/validation/imports.wast
@@ -1,0 +1,9 @@
+;; Test that we validate imported functions.
+
+;; RUN: not wasm-opt %s -all --disable-simd 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+  (import "env" "imported-v128" (func $imported-v128 (result v128)))
+)


### PR DESCRIPTION
We validate functions in parallel, but function-parallel passes do not run on imports,
so we did not issue a validation error on an import using a disallowed type, for example.

All the changes in `visitFunction` are just to group all the parts using `body` to the
end, and putting them behind a check for `body`.

(diff without whitespace is smaller)

Found using #6310 #6312