### PR TITLE
[SetGlobals] fix segfault

### DIFF
--- a/src/passes/SetGlobals.cpp
+++ b/src/passes/SetGlobals.cpp
@@ -41,7 +41,7 @@ struct SetGlobals : public Pass {
       auto value = nameAndValue[1];
       auto* glob = module->getGlobalOrNull(name);
       if (!glob) {
-        std::cerr << "warning: could not find global: " << name << '\n';
+        Fatal() << "Could not find global: " << name;
       }
       // Parse the input.
       Literal lit;


### PR DESCRIPTION
For now if global isn't found, the warning is issued and then the pass segfaults on "if (glob->type == Type::i32)" line because glob is null here (also it is an UB).

This patch replaces warning with Fatal(), preventing segfault and raising an error if global is not found.

I think that the fatal error when the specified global is not found is the preferred (and the current, via segfault) behavior for this pass because it is much safer to break the build than skip SetGlobals without actually setting the variable.