### PR TITLE
Validator: ArrayNew|InitData require Bulk Memory

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2909,6 +2909,10 @@ void FunctionValidator::visitArrayNew(ArrayNew* curr) {
 void FunctionValidator::visitArrayNewData(ArrayNewData* curr) {
   visitArrayNew(curr);
 
+  shouldBeTrue(
+    getModule()->features.hasBulkMemory(),
+    curr,
+    "Data segment operations require bulk memory [--enable-bulk-memory]");
   if (!shouldBeTrue(getModule()->getDataSegment(curr->segment),
                     curr,
                     "array.new_data segment should exist")) {
@@ -3175,6 +3179,10 @@ void FunctionValidator::visitArrayInit(ArrayInit* curr) {
 void FunctionValidator::visitArrayInitData(ArrayInitData* curr) {
   visitArrayInit(curr);
 
+  shouldBeTrue(
+    getModule()->features.hasBulkMemory(),
+    curr,
+    "Data segment operations require bulk memory [--enable-bulk-memory]");
   shouldBeTrue(getModule()->getDataSegmentOrNull(curr->segment),
                curr,
                "array.init_data segment must exist");

--- a/test/lit/validation/array-init-data.wast
+++ b/test/lit/validation/array-init-data.wast
@@ -4,16 +4,16 @@
 
 ;; RUN: not wasm-opt --enable-reference-types --enable-gc %s 2>&1 | filecheck %s
 
-;; CHECK: all used types should be allowed
+;; CHECK: Data segment operations require bulk memory
 
 (module
  (type $0 (array i8))
 
- (memory $0 16 17 shared)
+ (memory $0 16 17)
 
  (data $0 (i32.const 0) "")
 
- (func $0 (result (ref $0))
+ (func $0
   (array.init_data $0 $0
    (ref.null $0)
    (i32.const 0)

--- a/test/lit/validation/array-init-data.wast
+++ b/test/lit/validation/array-init-data.wast
@@ -1,0 +1,27 @@
+;; array.init_data refers to a data segment and therefore requires the datacount
+;; section be emitted (so it can be validated, per the spec, using only previous
+;; sections), which means bulk memory must be enabled.
+
+;; RUN: not wasm-opt --enable-reference-types --enable-gc %s 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+ (type $0 (array i8))
+
+ (memory $0 16 17 shared)
+
+ (data $0 (i32.const 0) "")
+
+ (func $0 (result (ref $0))
+  (array.init_data $0 $0
+   (ref.null $0)
+   (i32.const 0)
+   (i32.const 0)
+   (i32.const 0)
+  )
+ )
+)
+
+;; But it passes with the feature enabled.
+;; RUN: wasm-opt --enable-reference-types --enable-gc --enable-bulk-memory %s

--- a/test/lit/validation/array-new-data.wast
+++ b/test/lit/validation/array-new-data.wast
@@ -4,12 +4,12 @@
 
 ;; RUN: not wasm-opt --enable-reference-types --enable-gc %s 2>&1 | filecheck %s
 
-;; CHECK: all used types should be allowed
+;; CHECK: Data segment operations require bulk memory
 
 (module
  (type $0 (array i8))
 
- (memory $0 16 17 shared)
+ (memory $0 16 17)
 
  (data $0 (i32.const 0) "")
 

--- a/test/lit/validation/array-new-data.wast
+++ b/test/lit/validation/array-new-data.wast
@@ -1,0 +1,25 @@
+;; array.new_data refers to a data segment and therefore requires the datacount
+;; section be emitted (so it can be validated, per the spec, using only previous
+;; sections), which means bulk memory must be enabled.
+
+;; RUN: not wasm-opt --enable-reference-types --enable-gc %s 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+ (type $0 (array i8))
+
+ (memory $0 16 17 shared)
+
+ (data $0 (i32.const 0) "")
+
+ (func $0 (result (ref $0))
+  (array.new_data $0 $0
+   (i32.const 0)
+   (i32.const 0)
+  )
+ )
+)
+
+;; But it passes with the feature enabled.
+;; RUN: wasm-opt --enable-reference-types --enable-gc --enable-bulk-memory %s


### PR DESCRIPTION
Those instructions refer to a data segment, which mean the DataCount section
must be emitted before them (so that, per the [spec](https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md#datacount-section), they can be validated by
looking only at previous sections), which implies bulk-memory is needed.

Indeed V8 errors without it, as found by the fuzzer.