### PR TITLE
[Parser][NFC] Remove `Token` from lexer interface

### DIFF
--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -168,33 +168,32 @@ public:
     advance();
   }
 
-  std::optional<Token> peek() const { return curr; }
-
   bool takeLParen() {
-    auto t = peek();
-    if (!t || !t->isLParen()) {
+    if (!curr || !curr->isLParen()) {
       return false;
     }
     advance();
     return true;
   }
+
+  bool peekLParen() { return Lexer(*this).takeLParen(); }
 
   bool takeRParen() {
-    auto t = peek();
-    if (!t || !t->isRParen()) {
+    if (!curr || !curr->isRParen()) {
       return false;
     }
     advance();
     return true;
   }
+
+  bool peekRParen() { return Lexer(*this).takeRParen(); }
 
   bool takeUntilParen() {
     while (true) {
-      auto t = peek();
-      if (!t) {
+      if (!curr) {
         return false;
       }
-      if (t->isLParen() || t->isRParen()) {
+      if (curr->isLParen() || curr->isRParen()) {
         return true;
       }
       advance();
@@ -202,8 +201,8 @@ public:
   }
 
   std::optional<Name> takeID() {
-    if (auto t = peek()) {
-      if (auto id = t->getID()) {
+    if (curr) {
+      if (auto id = curr->getID()) {
         advance();
         // See comment on takeName.
         return Name(std::string(*id));
@@ -213,8 +212,8 @@ public:
   }
 
   std::optional<std::string_view> takeKeyword() {
-    if (auto t = peek()) {
-      if (auto keyword = t->getKeyword()) {
+    if (curr) {
+      if (auto keyword = curr->getKeyword()) {
         advance();
         return *keyword;
       }
@@ -222,9 +221,13 @@ public:
     return {};
   }
 
+  std::optional<std::string_view> peekKeyword() {
+    return Lexer(*this).takeKeyword();
+  }
+
   bool takeKeyword(std::string_view expected) {
-    if (auto t = peek()) {
-      if (auto keyword = t->getKeyword()) {
+    if (curr) {
+      if (auto keyword = curr->getKeyword()) {
         if (*keyword == expected) {
           advance();
           return true;
@@ -236,8 +239,8 @@ public:
 
   std::optional<uint64_t> takeOffset() {
     using namespace std::string_view_literals;
-    if (auto t = peek()) {
-      if (auto keyword = t->getKeyword()) {
+    if (curr) {
+      if (auto keyword = curr->getKeyword()) {
         if (keyword->substr(0, 7) != "offset="sv) {
           return {};
         }
@@ -245,7 +248,7 @@ public:
         if (subLexer.empty()) {
           return {};
         }
-        if (auto o = subLexer.peek()->getU<uint64_t>()) {
+        if (auto o = subLexer.curr->getU<uint64_t>()) {
           subLexer.advance();
           if (subLexer.empty()) {
             advance();
@@ -259,8 +262,8 @@ public:
 
   std::optional<uint32_t> takeAlign() {
     using namespace std::string_view_literals;
-    if (auto t = peek()) {
-      if (auto keyword = t->getKeyword()) {
+    if (curr) {
+      if (auto keyword = curr->getKeyword()) {
         if (keyword->substr(0, 6) != "align="sv) {
           return {};
         }
@@ -268,7 +271,7 @@ public:
         if (subLexer.empty()) {
           return {};
         }
-        if (auto a = subLexer.peek()->getU<uint32_t>()) {
+        if (auto a = subLexer.curr->getU<uint32_t>()) {
           subLexer.advance();
           if (subLexer.empty()) {
             advance();
@@ -281,8 +284,8 @@ public:
   }
 
   template<typename T> std::optional<T> takeU() {
-    if (auto t = peek()) {
-      if (auto n = t->getU<T>()) {
+    if (curr) {
+      if (auto n = curr->getU<T>()) {
         advance();
         return n;
       }
@@ -291,8 +294,8 @@ public:
   }
 
   template<typename T> std::optional<T> takeI() {
-    if (auto t = peek()) {
-      if (auto n = t->getI<T>()) {
+    if (curr) {
+      if (auto n = curr->getI<T>()) {
         advance();
         return n;
       }
@@ -315,8 +318,8 @@ public:
   std::optional<uint8_t> takeI8() { return takeI<uint8_t>(); }
 
   std::optional<double> takeF64() {
-    if (auto t = peek()) {
-      if (auto d = t->getF64()) {
+    if (curr) {
+      if (auto d = curr->getF64()) {
         advance();
         return d;
       }
@@ -325,8 +328,8 @@ public:
   }
 
   std::optional<float> takeF32() {
-    if (auto t = peek()) {
-      if (auto f = t->getF32()) {
+    if (curr) {
+      if (auto f = curr->getF32()) {
         advance();
         return f;
       }
@@ -335,10 +338,11 @@ public:
   }
 
   std::optional<std::string> takeString() {
-    if (auto t = peek()) {
-      if (auto s = t->getString()) {
+    if (curr) {
+      if (auto s = curr->getString()) {
+        std::string ret(*s);
         advance();
-        return std::string(*s);
+        return ret;
       }
     }
     return {};
@@ -392,8 +396,8 @@ public:
   TextPos position() const { return position(getPos()); }
 
   size_t getPos() const {
-    if (auto t = peek()) {
-      return getIndex() - t->span.size();
+    if (curr) {
+      return getIndex() - curr->span.size();
     }
     return getIndex();
   }

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -549,7 +549,7 @@ template<typename Ctx> Result<typename Ctx::FieldT> fieldtype(Ctx& ctx) {
 template<typename Ctx> Result<typename Ctx::FieldsT> fields(Ctx& ctx) {
   auto res = ctx.makeFields();
   while (true) {
-    if (auto t = ctx.in.peek(); !t || t->isRParen()) {
+    if (ctx.in.empty() || ctx.in.peekRParen()) {
       return res;
     }
     if (ctx.in.takeSExprStart("field")) {
@@ -754,13 +754,11 @@ template<typename Ctx> MaybeResult<> plaininstr(Ctx& ctx) {
 // instr ::= plaininstr | blockinstr
 template<typename Ctx> MaybeResult<> instr(Ctx& ctx) {
   // Check for valid strings that are not instructions.
-  if (auto tok = ctx.in.peek()) {
-    if (auto keyword = tok->getKeyword()) {
-      if (keyword == "end"sv || keyword == "then"sv || keyword == "else"sv ||
-          keyword == "catch"sv || keyword == "catch_all"sv ||
-          keyword == "delegate"sv || keyword == "ref"sv) {
-        return {};
-      }
+  if (auto keyword = ctx.in.peekKeyword()) {
+    if (keyword == "end"sv || keyword == "then"sv || keyword == "else"sv ||
+        keyword == "catch"sv || keyword == "catch_all"sv ||
+        keyword == "delegate"sv || keyword == "ref"sv) {
+      return {};
     }
   }
   if (auto inst = blockinstr(ctx)) {
@@ -775,7 +773,7 @@ template<typename Ctx> MaybeResult<> instr(Ctx& ctx) {
 
 template<typename Ctx> MaybeResult<> foldedinstr(Ctx& ctx) {
   // We must have an '(' to start a folded instruction.
-  if (auto tok = ctx.in.peek(); !tok || !tok->isLParen()) {
+  if (!ctx.in.peekLParen()) {
     return {};
   }
 
@@ -2965,7 +2963,7 @@ template<typename Ctx> MaybeResult<> tag(Ctx& ctx) {
 //               | data
 //               | tag
 template<typename Ctx> MaybeResult<> modulefield(Ctx& ctx) {
-  if (auto t = ctx.in.peek(); !t || t->isRParen()) {
+  if (ctx.in.empty() || ctx.in.peekRParen()) {
     return {};
   }
   if (auto res = deftype(ctx)) {


### PR DESCRIPTION
Replace the general `peek` method that returned a `Token` with specific peek
methods that look for (but do not consume) specific kinds of tokens. This change
is a prerequisite for simplifying the lexer implementation by removing `Token`
entirely.