### PR TITLE
Build and release on aarch64

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -106,6 +106,9 @@ jobs:
   build-alpine:
     name: alpine
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker_platform: [amd64, arm64]
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -113,40 +116,44 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
     - name: start docker
       run: |
-        docker run -w /src -dit --name alpine -v $PWD:/src node:lts-alpine
-        echo 'docker exec alpine "$@";' > ./alpine.sh
-        chmod +x ./alpine.sh
+        docker run -w /src -dit --platform=linux/${{ matrix.docker_platform }} --name alpine-${{ matrix.docker_platform }} -v $PWD:/src node:lts-alpine
+        echo 'docker exec alpine-${{ matrix.docker_platform }} "$@";' > ./alpine-${{ matrix.docker_platform }}.sh
+        chmod +x ./alpine-${{ matrix.docker_platform }}.sh
+
 
     - name: install packages
       run: |
-        ./alpine.sh apk update
-        ./alpine.sh apk add build-base cmake git python3 clang ninja py3-pip
+        ./alpine-${{ matrix.docker_platform }}.sh apk update
+        ./alpine-${{ matrix.docker_platform }}.sh apk add build-base cmake git python3 clang ninja py3-pip
 
     - name: install python dev dependencies
-      run: ./alpine.sh pip3 install -r requirements-dev.txt
+      run: ./alpine-${{ matrix.docker_platform }}.sh pip3 install --break-system-packages -r requirements-dev.txt
 
     - name: cmake
       run: |
-        ./alpine.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON -DCMAKE_INSTALL_PREFIX=install
+        ./alpine-${{ matrix.docker_platform }}.sh cmake . -G Ninja -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON -DCMAKE_INSTALL_PREFIX=install-${{ matrix.docker_platform }}
 
     - name: build
       run: |
-        ./alpine.sh ninja install
+        ./alpine-${{ matrix.docker_platform }}.sh ninja install
 
     - name: test
-      run: ./alpine.sh python3 ./check.py
+      run: ./alpine-${{ matrix.docker_platform }}.sh python3 ./check.py
 
     - name: archive
       id: archive
       run: |
         VERSION=$GITHUB_REF_NAME
-        PKGNAME="binaryen-$VERSION-x86_64-linux"
+        ARCH=$(./alpine-${{ matrix.docker_platform }}.sh uname -m)
+        PKGNAME="binaryen-$VERSION-$ARCH-linux"
         TARBALL=$PKGNAME.tar.gz
         SHASUM=$PKGNAME.tar.gz.sha256
-        ./alpine.sh find install/ -type f -perm -u=x -exec strip {} +
-        mv install binaryen-$VERSION
+        ./alpine-${{ matrix.docker_platform }}.sh find install-${{ matrix.docker_platform }}/ -type f -perm -u=x -exec strip {} +
+        mv install-${{ matrix.docker_platform }} binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "::set-output name=tarball::$TARBALL"


### PR DESCRIPTION
Closes #6311 

Build aarch64 as well as x86_64 on linux using qemu in the release step. Being emulated this is of course pretty slow - ~90m to build, ~45m to test - so it's not practical to run on every push during CI. Some options which may be available in future to improve this:

* Hosted arm runners are in [private preview](https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/) at the moment, if these are ever available to public repos then they would be ideal
* If Apple Silicon based MacOS runners ever support nested virtualisation - which they [do not currently](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#limitations-for-macos-larger-runners) - then we run could these builds in that environment instead (this is how I iterated on this PR and the previous aarch64 build issues)

I tested this on my fork by removing the `tags` push condition, and it [worked as intended](https://github.com/DazWorrall/binaryen/releases/tag/untagged-a297036b571a22a41753).