### PR TITLE
Fuzzer: Match the logging of i31ref between JS and C++

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -561,6 +561,10 @@ def fix_output(out):
     # change that index, so ignore it
     out = re.sub(r'funcref\([\d\w$+-_:]+\)', 'funcref()', out)
 
+    # JS prints i31 as just a number, so change "funcref(N)" (which C++ emits)
+    # to "N".
+    out = re.sub(r'i31ref\((\d+)\)', r'\1', out)
+
     lines = out.splitlines()
     for i in range(len(lines)):
         line = lines[i]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -561,7 +561,7 @@ def fix_output(out):
     # change that index, so ignore it
     out = re.sub(r'funcref\([\d\w$+-_:]+\)', 'funcref()', out)
 
-    # JS prints i31 as just a number, so change "funcref(N)" (which C++ emits)
+    # JS prints i31 as just a number, so change "i31ref(N)" (which C++ emits)
     # to "N".
     out = re.sub(r'i31ref\((\d+)\)', r'\1', out)
 

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -115,27 +115,8 @@ struct ExecutionResults {
           // ignore the result if we hit an unreachable and returned no value
           if (values->size() > 0) {
             std::cout << "[fuzz-exec] note result: " << exp->name << " => ";
-            auto resultType = func->getResults();
-            if (resultType.isRef() && !resultType.isString()) {
-              // Don't print reference values, as funcref(N) contains an index
-              // for example, which is not guaranteed to remain identical after
-              // optimizations. Do not print the type in detail (as even that
-              // may change due to closed-world optimizations); just print a
-              // simple type like JS does, 'object' or 'function', but also
-              // print null for a null (so a null function does not get
-              // printed as object, as in JS we have typeof null == 'object').
-              if (values->size() == 1 && (*values)[0].isNull()) {
-                std::cout << "null\n";
-              } else if (resultType.isFunction()) {
-                std::cout << "function\n";
-              } else {
-                std::cout << "object\n";
-              }
-            } else {
-              // Non-references can be printed in full. So can strings, since we
-              // always know how to print them and there is just one string
-              // type.
-              std::cout << *values << '\n';
+            for (auto value : *values) {
+              printValue(value);
             }
           }
         }
@@ -148,6 +129,37 @@ struct ExecutionResults {
       // change whether a host limit is reached.
       ignore = true;
     }
+  }
+
+  void printValue(Literal value) {
+    // Unwrap an externalized value to get the actual value.
+    if (Type::isSubType(value.type, Type(HeapType::ext, Nullable))) {
+      value = value.internalize();
+    }
+
+    auto type = value.type;
+    if (type.isRef() && !type.isString()) {
+      // Don't print reference values, as funcref(N) contains an index
+      // for example, which is not guaranteed to remain identical after
+      // optimizations. Do not print the type in detail (as even that
+      // may change due to closed-world optimizations); just print a
+      // simple type like JS does, 'object' or 'function', but also
+      // print null for a null (so a null function does not get
+      // printed as object, as in JS we have typeof null == 'object').
+      if (value.isNull()) {
+        std::cout << "null\n";
+      } else if (type.isFunction()) {
+        std::cout << "function\n";
+      } else {
+        std::cout << "object\n";
+      }
+      return;
+    }
+
+    // Non-references can be printed in full. So can strings, since we
+    // always know how to print them and there is just one string
+    // type.
+    std::cout << value << '\n';
   }
 
   // get current results and check them against previous ones

--- a/test/lit/exec/i31.wast
+++ b/test/lit/exec/i31.wast
@@ -76,6 +76,23 @@
       (ref.null i31)
     )
   )
+
+  (func $return-i31 (result i31ref)
+    ;; An i31 should be logged out using its integer value, unlike a struct or
+    ;; array which ends up as only "object".
+    (ref.i31
+      (i32.const 42)
+    )
+  )
+
+  (func $return-exted-i31 (result i31ref)
+    ;; Even an externalized i31 is logged out using its integer value.
+    (extern.externalize
+      (ref.i31
+        (i32.const 42)
+      )
+    )
+  )
 )
 ;; CHECK:      [fuzz-exec] calling null-local
 ;; CHECK-NEXT: [fuzz-exec] note result: null-local => 1

--- a/test/lit/exec/i31.wast
+++ b/test/lit/exec/i31.wast
@@ -77,7 +77,9 @@
     )
   )
 
-  (func $return-i31 (result i31ref)
+  ;; CHECK:      [fuzz-exec] calling return-i31
+  ;; CHECK-NEXT: [fuzz-exec] note result: return-i31 => i31ref(42)
+  (func $return-i31 (export "return-i31") (result i31ref)
     ;; An i31 should be logged out using its integer value, unlike a struct or
     ;; array which ends up as only "object".
     (ref.i31
@@ -85,7 +87,9 @@
     )
   )
 
-  (func $return-exted-i31 (result i31ref)
+  ;; CHECK:      [fuzz-exec] calling return-exted-i31
+  ;; CHECK-NEXT: [fuzz-exec] note result: return-exted-i31 => i31ref(42)
+  (func $return-exted-i31 (export "return-exted-i31") (result externref)
     ;; Even an externalized i31 is logged out using its integer value.
     (extern.externalize
       (ref.i31
@@ -114,10 +118,18 @@
 
 ;; CHECK:      [fuzz-exec] calling trap
 ;; CHECK-NEXT: [trap null ref]
+
+;; CHECK:      [fuzz-exec] calling return-i31
+;; CHECK-NEXT: [fuzz-exec] note result: return-i31 => i31ref(42)
+
+;; CHECK:      [fuzz-exec] calling return-exted-i31
+;; CHECK-NEXT: [fuzz-exec] note result: return-exted-i31 => i31ref(42)
 ;; CHECK-NEXT: [fuzz-exec] comparing nn-s
 ;; CHECK-NEXT: [fuzz-exec] comparing nn-u
 ;; CHECK-NEXT: [fuzz-exec] comparing non-null
 ;; CHECK-NEXT: [fuzz-exec] comparing null-immediate
 ;; CHECK-NEXT: [fuzz-exec] comparing null-local
+;; CHECK-NEXT: [fuzz-exec] comparing return-exted-i31
+;; CHECK-NEXT: [fuzz-exec] comparing return-i31
 ;; CHECK-NEXT: [fuzz-exec] comparing trap
 ;; CHECK-NEXT: [fuzz-exec] comparing zero-is-not-null


### PR DESCRIPTION
JS engines print i31ref as just a number, so we need a small regex to
standardize the representation (similar to what we do for funcrefs on
the code above).

On the C++ side, make it actually print the i31ref rather than treat it
like a generic reference (for whom we only print `"object"`). To do that
we must unwrap an externalized i31 as necessary, and add a case for
i31 in the printing logic.

Also move that printing logic to its own function, as it was starting to
get quite long.