### PR TITLE
Validator: Check subtyping in CallIndirect [DO NOT LAND]

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -543,11 +543,10 @@ private:
     return info.shouldBeSubType(left, right, curr, text, getFunction());
   }
 
-  bool
-  shouldBeSubType(HeapType left,
-                  HeapType right,
-                  Expression* curr,
-                  const char* text) {
+  bool shouldBeSubType(HeapType left,
+                       HeapType right,
+                       Expression* curr,
+                       const char* text) {
     return info.shouldBeSubType(left, right, curr, text, getFunction());
   }
 

--- a/test/lit/validation/call-indirect-subtyping.wast
+++ b/test/lit/validation/call-indirect-subtyping.wast
@@ -1,0 +1,22 @@
+;; Check that we fail to validate a call_indirect whose cast type is not a
+;; subtype of the table type.
+
+;; RUN: not wasm-opt -all %s -o - -S 2>&1 | filecheck %s
+
+;; CHECK: call-indirect cast type must be a subtype of table
+
+(module
+ (rec
+  (type $type-A (sub (func)))
+  (type $type-B (sub (func)))
+ )
+
+ (table $table-A 1 1 (ref null $type-A))
+
+ (func $test
+  (call_indirect $table-A (type $type-B)
+   (i32.const 0)
+  )
+ )
+)
+


### PR DESCRIPTION
V8 requires this, e.g.
```wat
(module
 (rec
  (type $0 (sub (func)))
  (type $1 (sub (func)))
 )
 (type $2 (func))
 (table $0 1 1 (ref null $1))
 (func $0
  (call_indirect (type $0)
   (i32.const 0)
  )
 )
)
```
errors on
```
CompileError: WebAssembly.Module(): Compiling function #0 failed: call_indirect: Immediate signature #0 is not a subtype of immediate table #0 @+46
```

However, @tlively you wrote otherwise in a test, so I am confused:

https://github.com/WebAssembly/binaryen/blob/f6bb943490dc87b16481bfc1604a796edf2acea8/test/lit/passes/unsubtyping.wast#L525-L536

Reading the main spec, it still mentions only funcref, so it is pre-typed-function-references I guess. Reading the typed function references [spec](https://webassembly.github.io/function-references/core/valid/instructions.html#control-instructions) I only see it change the requirement from `funcref` to `ref null func`. I also cannot find anything in the overviews, so I am lost as to what the correct behavior is.

cc @jakobkummerow for the V8 behavior - am I reading that error right, and if so where in the spec is that validation rule added?