### PR TITLE
Fuzzer: Ignore V8 errors on uninitialized non-defaultable locals

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -642,6 +642,8 @@ def run_vm(cmd):
             # strings in this list for known issues (to which more need to be
             # added as necessary).
             HOST_LIMIT_PREFIX,
+            # see comment above on this constant
+            V8_UNINITIALIZED_NONDEF_LOCAL,
         ]
         for issue in known_issues:
             if issue in output:
@@ -774,10 +776,7 @@ class CompareVMs(TestCaseHandler):
             name = 'd8'
 
             def run(self, wasm, extra_d8_flags=[]):
-                output = run_vm([shared.V8, FUZZ_SHELL_JS] + shared.V8_OPTS + extra_d8_flags + ['--', wasm])
-                if 'V8_UNINITIALIZED_NONDEF_LOCAL' in output:
-                    output = ignore
-                return output
+                return run_vm([shared.V8, FUZZ_SHELL_JS] + shared.V8_OPTS + extra_d8_flags + ['--', wasm])
 
             def can_run(self, wasm):
                 return True


### PR DESCRIPTION
See #5665 #5599, this is an existing issue and we have a workaround for it
using `--dce`, but it does not always work. I seem to be seeing this in higher
frequency since landing recent fuzzer improvements, so ignore it.

There is some risk of us missing real bugs here (that we validate and V8
does not), but this is a validation error which is not as serious as a difference
in behavior. And this is a long-standing issue that hasn't bitten us yet.