### PR TITLE
Implement dropping of active Element Segments

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3801,10 +3801,10 @@ public:
     const auto& seg = *wasm.getElementSegment(curr->segment);
     auto end = offset + size;
     if (end > seg.data.size()) {
-      trap("out of bounds segment access in array.init_elem");
+      trap("out of bounds segment access in array.new_elem");
     }
     if (end > 0 && droppedElementSegments.count(curr->segment)) {
-      trap("out of bounds segment access in array.init_elem");
+      trap("out of bounds segment access in array.new_elem");
     }
     contents.reserve(size);
     for (Index i = offset; i < end; ++i) {
@@ -3896,11 +3896,13 @@ public:
     Module& wasm = *self()->getModule();
 
     auto* seg = wasm.getElementSegment(curr->segment);
-    if ((uint64_t)offsetVal + sizeVal > seg->data.size()) {
-      trap("out of bounds segment access in array.init");
+    auto max = (uint64_t)offsetVal + sizeVal;
+    if (max > seg->data.size()) {
+      trap("out of bounds segment access in array.init_elem");
     }
-    // TODO: Check whether the segment has been dropped once we support
-    // dropping element segments.
+    if (max > 0 && droppedElementSegments.count(curr->segment)) {
+      trap("out of bounds segment access in array.init_elem");
+    }
     for (size_t i = 0; i < sizeVal; i++) {
       // TODO: This is not correct because it does not preserve the identity
       // of references in the table! ArrayNew suffers the same problem.

--- a/test/lit/exec/array.wast
+++ b/test/lit/exec/array.wast
@@ -5,6 +5,18 @@
 (module
  (type $array (array (mut i8)))
 
+ (type $array-func (array funcref))
+
+ (memory $mem 10 10)
+
+ (data $data (i32.const 0) "a")
+
+ (table $table 10 10 funcref)
+
+ (elem $active (i32.const 0) $func)
+
+ (elem $passive $func)
+
  ;; CHECK:      [fuzz-exec] calling func
  ;; CHECK-NEXT: [fuzz-exec] note result: func => 1
  (func $func (export "func") (result i32)
@@ -14,7 +26,58 @@
    (return (i32.const 2))
   )
  )
+
+ ;; CHECK:      [fuzz-exec] calling new_active
+ ;; CHECK-NEXT: waka 1 : 1 : 1
+ ;; CHECK-NEXT: [trap out of bounds segment access in array.init_elem]
+ (func $new_active (export "new_active")
+  ;; Even though this is reading 0 items, offset 1 is out of bounds in that
+  ;; dropped element segment, and this traps.
+  (drop
+   (array.new_elem $array-func $active
+    (i32.const 1)
+    (i32.const 0)
+   )
+  )
+ )
+
+ ;; CHECK:      [fuzz-exec] calling new_active_in_bounds
+ ;; CHECK-NEXT: waka 0 : 1 : 1
+ (func $new_active_in_bounds (export "new_active_in_bounds")
+  ;; Even though this is dropped, we read 0 from offset 0, which is ok.
+  (drop
+   (array.new_elem $array-func $active
+    (i32.const 0)
+    (i32.const 0)
+   )
+  )
+ )
+
+ ;; CHECK:      [fuzz-exec] calling new_passive
+ ;; CHECK-NEXT: waka 1 : 1 : 0
+ (func $new_passive (export "new_passive")
+  ;; Using the passive segment here works.
+  (drop
+   (array.new_elem $array-func $passive
+    (i32.const 1)
+    (i32.const 0)
+   )
+  )
+ )
 )
 ;; CHECK:      [fuzz-exec] calling func
 ;; CHECK-NEXT: [fuzz-exec] note result: func => 1
+
+;; CHECK:      [fuzz-exec] calling new_active
+;; CHECK-NEXT: waka 1 : 1 : 1
+;; CHECK-NEXT: [trap out of bounds segment access in array.init_elem]
+
+;; CHECK:      [fuzz-exec] calling new_active_in_bounds
+;; CHECK-NEXT: waka 0 : 1 : 1
+
+;; CHECK:      [fuzz-exec] calling new_passive
+;; CHECK-NEXT: waka 1 : 1 : 0
 ;; CHECK-NEXT: [fuzz-exec] comparing func
+;; CHECK-NEXT: [fuzz-exec] comparing new_active
+;; CHECK-NEXT: [fuzz-exec] comparing new_active_in_bounds
+;; CHECK-NEXT: [fuzz-exec] comparing new_passive

--- a/test/lit/exec/array.wast
+++ b/test/lit/exec/array.wast
@@ -7,10 +7,6 @@
 
  (type $array-func (array (mut funcref)))
 
- (memory $mem 10 10)
-
- (data $data (i32.const 0) "a")
-
  (table $table 10 10 funcref)
 
  (elem $active (i32.const 0) $func)

--- a/test/lit/exec/array.wast
+++ b/test/lit/exec/array.wast
@@ -5,7 +5,7 @@
 (module
  (type $array (array (mut i8)))
 
- (type $array-func (array funcref))
+ (type $array-func (array (mut funcref)))
 
  (memory $mem 10 10)
 
@@ -28,8 +28,7 @@
  )
 
  ;; CHECK:      [fuzz-exec] calling new_active
- ;; CHECK-NEXT: waka 1 : 1 : 1
- ;; CHECK-NEXT: [trap out of bounds segment access in array.init_elem]
+ ;; CHECK-NEXT: [trap out of bounds segment access in array.new_elem]
  (func $new_active (export "new_active")
   ;; Even though this is reading 0 items, offset 1 is out of bounds in that
   ;; dropped element segment, and this traps.
@@ -42,7 +41,6 @@
  )
 
  ;; CHECK:      [fuzz-exec] calling new_active_in_bounds
- ;; CHECK-NEXT: waka 0 : 1 : 1
  (func $new_active_in_bounds (export "new_active_in_bounds")
   ;; Even though this is dropped, we read 0 from offset 0, which is ok.
   (drop
@@ -54,7 +52,6 @@
  )
 
  ;; CHECK:      [fuzz-exec] calling new_passive
- ;; CHECK-NEXT: waka 1 : 1 : 0
  (func $new_passive (export "new_passive")
   ;; Using the passive segment here works.
   (drop
@@ -64,20 +61,68 @@
    )
   )
  )
+
+ ;; CHECK:      [fuzz-exec] calling init_active
+ ;; CHECK-NEXT: [trap out of bounds segment access in array.init_elem]
+ (func $init_active (export "init_active")
+  ;; Even though this is reading 0 items, offset 1 is out of bounds in that
+  ;; dropped element segment, and this traps.
+  (array.init_elem $array-func $active
+   (array.new_default $array-func
+    (i32.const 100)
+   )
+   (i32.const 50)
+   (i32.const 1)
+   (i32.const 0)
+  )
+ )
+
+ ;; CHECK:      [fuzz-exec] calling init_active_in_bounds
+ (func $init_active_in_bounds (export "init_active_in_bounds")
+  ;; Even though this is dropped, we read 0 from offset 0, which is ok.
+  (array.init_elem $array-func $active
+   (array.new_default $array-func
+    (i32.const 100)
+   )
+   (i32.const 50)
+   (i32.const 0)
+   (i32.const 0)
+  )
+ )
+
+ ;; CHECK:      [fuzz-exec] calling init_passive
+ (func $init_passive (export "init_passive")
+  ;; This works ok.
+  (array.init_elem $array-func $passive
+   (array.new_default $array-func
+    (i32.const 100)
+   )
+   (i32.const 50)
+   (i32.const 1)
+   (i32.const 0)
+  )
+ )
 )
 ;; CHECK:      [fuzz-exec] calling func
 ;; CHECK-NEXT: [fuzz-exec] note result: func => 1
 
 ;; CHECK:      [fuzz-exec] calling new_active
-;; CHECK-NEXT: waka 1 : 1 : 1
-;; CHECK-NEXT: [trap out of bounds segment access in array.init_elem]
+;; CHECK-NEXT: [trap out of bounds segment access in array.new_elem]
 
 ;; CHECK:      [fuzz-exec] calling new_active_in_bounds
-;; CHECK-NEXT: waka 0 : 1 : 1
 
 ;; CHECK:      [fuzz-exec] calling new_passive
-;; CHECK-NEXT: waka 1 : 1 : 0
+
+;; CHECK:      [fuzz-exec] calling init_active
+;; CHECK-NEXT: [trap out of bounds segment access in array.init_elem]
+
+;; CHECK:      [fuzz-exec] calling init_active_in_bounds
+
+;; CHECK:      [fuzz-exec] calling init_passive
 ;; CHECK-NEXT: [fuzz-exec] comparing func
+;; CHECK-NEXT: [fuzz-exec] comparing init_active
+;; CHECK-NEXT: [fuzz-exec] comparing init_active_in_bounds
+;; CHECK-NEXT: [fuzz-exec] comparing init_passive
 ;; CHECK-NEXT: [fuzz-exec] comparing new_active
 ;; CHECK-NEXT: [fuzz-exec] comparing new_active_in_bounds
 ;; CHECK-NEXT: [fuzz-exec] comparing new_passive


### PR DESCRIPTION
Also rename the existing `droppedSegments` to `droppedDataSegments` for clarity.