### PR TITLE
[Parser] Parse annotations, including source map comments

### DIFF
--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -739,8 +739,8 @@ def instruction_parser(new_parser=False):
 
     def print_leaf(expr, inst):
         if new_parser:
-            expr = expr.replace("()", "(ctx, pos)")
-            expr = expr.replace("(s", "(ctx, pos")
+            expr = expr.replace("()", "(ctx, pos, annotations)")
+            expr = expr.replace("(s", "(ctx, pos, annotations")
             printer.print_line("if (op == \"{inst}\"sv) {{".format(inst=inst))
             with printer.indent():
                 printer.print_line("CHECK_ERR({expr});".format(expr=expr))

--- a/src/gen-s-parser.inc
+++ b/src/gen-s-parser.inc
@@ -3632,13 +3632,13 @@ switch (buf[0]) {
         switch (buf[6]) {
           case 'c':
             if (op == "array.copy"sv) {
-              CHECK_ERR(makeArrayCopy(ctx, pos));
+              CHECK_ERR(makeArrayCopy(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 'f':
             if (op == "array.fill"sv) {
-              CHECK_ERR(makeArrayFill(ctx, pos));
+              CHECK_ERR(makeArrayFill(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -3646,7 +3646,7 @@ switch (buf[0]) {
             switch (buf[9]) {
               case '\0':
                 if (op == "array.get"sv) {
-                  CHECK_ERR(makeArrayGet(ctx, pos));
+                  CHECK_ERR(makeArrayGet(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -3654,13 +3654,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "array.get_s"sv) {
-                      CHECK_ERR(makeArrayGet(ctx, pos, true));
+                      CHECK_ERR(makeArrayGet(ctx, pos, annotations, true));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "array.get_u"sv) {
-                      CHECK_ERR(makeArrayGet(ctx, pos, false));
+                      CHECK_ERR(makeArrayGet(ctx, pos, annotations, false));
                       return Ok{};
                     }
                     goto parse_error;
@@ -3674,13 +3674,13 @@ switch (buf[0]) {
             switch (buf[11]) {
               case 'd':
                 if (op == "array.init_data"sv) {
-                  CHECK_ERR(makeArrayInitData(ctx, pos));
+                  CHECK_ERR(makeArrayInitData(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
               case 'e':
                 if (op == "array.init_elem"sv) {
-                  CHECK_ERR(makeArrayInitElem(ctx, pos));
+                  CHECK_ERR(makeArrayInitElem(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -3689,7 +3689,7 @@ switch (buf[0]) {
           }
           case 'l':
             if (op == "array.len"sv) {
-              CHECK_ERR(makeArrayLen(ctx, pos));
+              CHECK_ERR(makeArrayLen(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -3697,7 +3697,7 @@ switch (buf[0]) {
             switch (buf[9]) {
               case '\0':
                 if (op == "array.new"sv) {
-                  CHECK_ERR(makeArrayNew(ctx, pos, false));
+                  CHECK_ERR(makeArrayNew(ctx, pos, annotations, false));
                   return Ok{};
                 }
                 goto parse_error;
@@ -3707,13 +3707,13 @@ switch (buf[0]) {
                     switch (buf[11]) {
                       case 'a':
                         if (op == "array.new_data"sv) {
-                          CHECK_ERR(makeArrayNewData(ctx, pos));
+                          CHECK_ERR(makeArrayNewData(ctx, pos, annotations));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'e':
                         if (op == "array.new_default"sv) {
-                          CHECK_ERR(makeArrayNew(ctx, pos, true));
+                          CHECK_ERR(makeArrayNew(ctx, pos, annotations, true));
                           return Ok{};
                         }
                         goto parse_error;
@@ -3722,13 +3722,13 @@ switch (buf[0]) {
                   }
                   case 'e':
                     if (op == "array.new_elem"sv) {
-                      CHECK_ERR(makeArrayNewElem(ctx, pos));
+                      CHECK_ERR(makeArrayNewElem(ctx, pos, annotations));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'f':
                     if (op == "array.new_fixed"sv) {
-                      CHECK_ERR(makeArrayNewFixed(ctx, pos));
+                      CHECK_ERR(makeArrayNewFixed(ctx, pos, annotations));
                       return Ok{};
                     }
                     goto parse_error;
@@ -3740,7 +3740,7 @@ switch (buf[0]) {
           }
           case 's':
             if (op == "array.set"sv) {
-              CHECK_ERR(makeArraySet(ctx, pos));
+              CHECK_ERR(makeArraySet(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -3749,7 +3749,7 @@ switch (buf[0]) {
       }
       case 't':
         if (op == "atomic.fence"sv) {
-          CHECK_ERR(makeAtomicFence(ctx, pos));
+          CHECK_ERR(makeAtomicFence(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -3760,7 +3760,7 @@ switch (buf[0]) {
     switch (buf[2]) {
       case '\0':
         if (op == "br"sv) {
-          CHECK_ERR(makeBreak(ctx, pos, false));
+          CHECK_ERR(makeBreak(ctx, pos, annotations, false));
           return Ok{};
         }
         goto parse_error;
@@ -3768,7 +3768,7 @@ switch (buf[0]) {
         switch (buf[3]) {
           case 'i':
             if (op == "br_if"sv) {
-              CHECK_ERR(makeBreak(ctx, pos, true));
+              CHECK_ERR(makeBreak(ctx, pos, annotations, true));
               return Ok{};
             }
             goto parse_error;
@@ -3778,13 +3778,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case '\0':
                     if (op == "br_on_cast"sv) {
-                      CHECK_ERR(makeBrOnCast(ctx, pos));
+                      CHECK_ERR(makeBrOnCast(ctx, pos, annotations));
                       return Ok{};
                     }
                     goto parse_error;
                   case '_':
                     if (op == "br_on_cast_fail"sv) {
-                      CHECK_ERR(makeBrOnCast(ctx, pos, true));
+                      CHECK_ERR(makeBrOnCast(ctx, pos, annotations, true));
                       return Ok{};
                     }
                     goto parse_error;
@@ -3795,13 +3795,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'o':
                     if (op == "br_on_non_null"sv) {
-                      CHECK_ERR(makeBrOnNull(ctx, pos, true));
+                      CHECK_ERR(makeBrOnNull(ctx, pos, annotations, true));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "br_on_null"sv) {
-                      CHECK_ERR(makeBrOnNull(ctx, pos));
+                      CHECK_ERR(makeBrOnNull(ctx, pos, annotations));
                       return Ok{};
                     }
                     goto parse_error;
@@ -3813,7 +3813,7 @@ switch (buf[0]) {
           }
           case 't':
             if (op == "br_table"sv) {
-              CHECK_ERR(makeBreakTable(ctx, pos));
+              CHECK_ERR(makeBreakTable(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -3829,7 +3829,7 @@ switch (buf[0]) {
         switch (buf[4]) {
           case '\0':
             if (op == "call"sv) {
-              CHECK_ERR(makeCall(ctx, pos, /*isReturn=*/false));
+              CHECK_ERR(makeCall(ctx, pos, annotations, /*isReturn=*/false));
               return Ok{};
             }
             goto parse_error;
@@ -3837,13 +3837,13 @@ switch (buf[0]) {
             switch (buf[5]) {
               case 'i':
                 if (op == "call_indirect"sv) {
-                  CHECK_ERR(makeCallIndirect(ctx, pos, /*isReturn=*/false));
+                  CHECK_ERR(makeCallIndirect(ctx, pos, annotations, /*isReturn=*/false));
                   return Ok{};
                 }
                 goto parse_error;
               case 'r':
                 if (op == "call_ref"sv) {
-                  CHECK_ERR(makeCallRef(ctx, pos, /*isReturn=*/false));
+                  CHECK_ERR(makeCallRef(ctx, pos, annotations, /*isReturn=*/false));
                   return Ok{};
                 }
                 goto parse_error;
@@ -3855,7 +3855,7 @@ switch (buf[0]) {
       }
       case 'o':
         if (op == "cont.new"sv) {
-          CHECK_ERR(makeContNew(ctx, pos));
+          CHECK_ERR(makeContNew(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -3866,13 +3866,13 @@ switch (buf[0]) {
     switch (buf[1]) {
       case 'a':
         if (op == "data.drop"sv) {
-          CHECK_ERR(makeDataDrop(ctx, pos));
+          CHECK_ERR(makeDataDrop(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 'r':
         if (op == "drop"sv) {
-          CHECK_ERR(makeDrop(ctx, pos));
+          CHECK_ERR(makeDrop(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -3883,13 +3883,13 @@ switch (buf[0]) {
     switch (buf[7]) {
       case 'e':
         if (op == "extern.externalize"sv) {
-          CHECK_ERR(makeRefAs(ctx, pos, ExternExternalize));
+          CHECK_ERR(makeRefAs(ctx, pos, annotations, ExternExternalize));
           return Ok{};
         }
         goto parse_error;
       case 'i':
         if (op == "extern.internalize"sv) {
-          CHECK_ERR(makeRefAs(ctx, pos, ExternInternalize));
+          CHECK_ERR(makeRefAs(ctx, pos, annotations, ExternInternalize));
           return Ok{};
         }
         goto parse_error;
@@ -3906,13 +3906,13 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'b':
                     if (op == "f32.abs"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsFloat32));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f32.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -3923,7 +3923,7 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.ceil"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilFloat32));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::CeilFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -3933,7 +3933,7 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "f32.const"sv) {
-                              CHECK_ERR(makeConst(ctx, pos, Type::f32));
+                              CHECK_ERR(makeConst(ctx, pos, annotations, Type::f32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -3943,13 +3943,13 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f32.convert_i32_s"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt32ToFloat32));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertSInt32ToFloat32));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f32.convert_i32_u"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt32ToFloat32));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertUInt32ToFloat32));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -3960,13 +3960,13 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f32.convert_i64_s"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt64ToFloat32));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertSInt64ToFloat32));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f32.convert_i64_u"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt64ToFloat32));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertUInt64ToFloat32));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -3981,7 +3981,7 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "f32.copysign"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::CopySignFloat32));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::CopySignFloat32));
                           return Ok{};
                         }
                         goto parse_error;
@@ -3995,13 +3995,13 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.demote_f64"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::DemoteFloat64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::DemoteFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32.div"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4010,13 +4010,13 @@ switch (buf[0]) {
               }
               case 'e':
                 if (op == "f32.eq"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqFloat32));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqFloat32));
                   return Ok{};
                 }
                 goto parse_error;
               case 'f':
                 if (op == "f32.floor"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorFloat32));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::FloorFloat32));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4024,13 +4024,13 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.ge"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32.gt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4041,19 +4041,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f32.le"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "f32.load"sv) {
-                      CHECK_ERR(makeLoad(ctx, pos, Type::f32, /*signed=*/false, 4, /*isAtomic=*/false));
+                      CHECK_ERR(makeLoad(ctx, pos, annotations, Type::f32, /*signed=*/false, 4, /*isAtomic=*/false));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32.lt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4064,19 +4064,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'a':
                     if (op == "f32.max"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32.min"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32.mul"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4087,19 +4087,19 @@ switch (buf[0]) {
                 switch (buf[6]) {
                   case '\0':
                     if (op == "f32.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f32.nearest"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestFloat32));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NearestFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f32.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegFloat32));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4108,7 +4108,7 @@ switch (buf[0]) {
               }
               case 'r':
                 if (op == "f32.reinterpret_i32"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretInt32));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ReinterpretInt32));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4116,19 +4116,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'q':
                     if (op == "f32.sqrt"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtFloat32));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SqrtFloat32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32.store"sv) {
-                      CHECK_ERR(makeStore(ctx, pos, Type::f32, 4, /*isAtomic=*/false));
+                      CHECK_ERR(makeStore(ctx, pos, annotations, Type::f32, 4, /*isAtomic=*/false));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubFloat32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubFloat32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4137,7 +4137,7 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f32.trunc"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncFloat32));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncFloat32));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4150,13 +4150,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'b':
                     if (op == "f32x4.abs"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f32x4.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4167,7 +4167,7 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.ceil"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::CeilVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4175,13 +4175,13 @@ switch (buf[0]) {
                     switch (buf[20]) {
                       case 's':
                         if (op == "f32x4.convert_i32x4_s"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSVecI32x4ToVecF32x4));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertSVecI32x4ToVecF32x4));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "f32x4.convert_i32x4_u"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUVecI32x4ToVecF32x4));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertUVecI32x4ToVecF32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -4195,13 +4195,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.demote_f64x2_zero"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::DemoteZeroVecF64x2ToVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::DemoteZeroVecF64x2ToVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32x4.div"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4212,13 +4212,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'q':
                     if (op == "f32x4.eq"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'x':
                     if (op == "f32x4.extract_lane"sv) {
-                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecF32x4, 4));
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneVecF32x4, 4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4227,7 +4227,7 @@ switch (buf[0]) {
               }
               case 'f':
                 if (op == "f32x4.floor"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorVecF32x4));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::FloorVecF32x4));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4235,13 +4235,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.ge"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32x4.gt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4252,13 +4252,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f32x4.le"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f32x4.lt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4269,19 +4269,19 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'a':
                     if (op == "f32x4.max"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32x4.min"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32x4.mul"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4292,19 +4292,19 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "f32x4.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f32x4.nearest"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NearestVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f32x4.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4315,13 +4315,13 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 'a':
                     if (op == "f32x4.pmax"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMaxVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::PMaxVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f32x4.pmin"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMinVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::PMinVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4336,13 +4336,13 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case 'a':
                             if (op == "f32x4.relaxed_fma"sv) {
-                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmaVecF32x4));
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::RelaxedFmaVecF32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "f32x4.relaxed_fms"sv) {
-                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmsVecF32x4));
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::RelaxedFmsVecF32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -4353,13 +4353,13 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case 'a':
                             if (op == "f32x4.relaxed_max"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMaxVecF32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RelaxedMaxVecF32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'i':
                             if (op == "f32x4.relaxed_min"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMinVecF32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RelaxedMinVecF32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -4371,7 +4371,7 @@ switch (buf[0]) {
                   }
                   case 'p':
                     if (op == "f32x4.replace_lane"sv) {
-                      CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecF32x4, 4));
+                      CHECK_ERR(makeSIMDReplace(ctx, pos, annotations, SIMDReplaceOp::ReplaceLaneVecF32x4, 4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4382,19 +4382,19 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'p':
                     if (op == "f32x4.splat"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SplatVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'q':
                     if (op == "f32x4.sqrt"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtVecF32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SqrtVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f32x4.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecF32x4));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubVecF32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4403,7 +4403,7 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f32x4.trunc"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncVecF32x4));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncVecF32x4));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4421,13 +4421,13 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'b':
                     if (op == "f64.abs"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsFloat64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f64.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4438,7 +4438,7 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f64.ceil"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilFloat64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::CeilFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4448,7 +4448,7 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "f64.const"sv) {
-                              CHECK_ERR(makeConst(ctx, pos, Type::f64));
+                              CHECK_ERR(makeConst(ctx, pos, annotations, Type::f64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -4458,13 +4458,13 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f64.convert_i32_s"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt32ToFloat64));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertSInt32ToFloat64));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f64.convert_i32_u"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt32ToFloat64));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertUInt32ToFloat64));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -4475,13 +4475,13 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 's':
                                     if (op == "f64.convert_i64_s"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertSInt64ToFloat64));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertSInt64ToFloat64));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "f64.convert_i64_u"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertUInt64ToFloat64));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertUInt64ToFloat64));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -4496,7 +4496,7 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "f64.copysign"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::CopySignFloat64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::CopySignFloat64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -4508,19 +4508,19 @@ switch (buf[0]) {
               }
               case 'd':
                 if (op == "f64.div"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivFloat64));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivFloat64));
                   return Ok{};
                 }
                 goto parse_error;
               case 'e':
                 if (op == "f64.eq"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqFloat64));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqFloat64));
                   return Ok{};
                 }
                 goto parse_error;
               case 'f':
                 if (op == "f64.floor"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorFloat64));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::FloorFloat64));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4528,13 +4528,13 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f64.ge"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64.gt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4545,19 +4545,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'e':
                     if (op == "f64.le"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "f64.load"sv) {
-                      CHECK_ERR(makeLoad(ctx, pos, Type::f64, /*signed=*/false, 8, /*isAtomic=*/false));
+                      CHECK_ERR(makeLoad(ctx, pos, annotations, Type::f64, /*signed=*/false, 8, /*isAtomic=*/false));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64.lt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4568,19 +4568,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'a':
                     if (op == "f64.max"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f64.min"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64.mul"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4591,19 +4591,19 @@ switch (buf[0]) {
                 switch (buf[6]) {
                   case '\0':
                     if (op == "f64.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f64.nearest"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestFloat64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NearestFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f64.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegFloat64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4612,13 +4612,13 @@ switch (buf[0]) {
               }
               case 'p':
                 if (op == "f64.promote_f32"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PromoteFloat32));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::PromoteFloat32));
                   return Ok{};
                 }
                 goto parse_error;
               case 'r':
                 if (op == "f64.reinterpret_i64"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretInt64));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ReinterpretInt64));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4626,19 +4626,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'q':
                     if (op == "f64.sqrt"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtFloat64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SqrtFloat64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64.store"sv) {
-                      CHECK_ERR(makeStore(ctx, pos, Type::f64, 8, /*isAtomic=*/false));
+                      CHECK_ERR(makeStore(ctx, pos, annotations, Type::f64, 8, /*isAtomic=*/false));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubFloat64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubFloat64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4647,7 +4647,7 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f64.trunc"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncFloat64));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncFloat64));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4660,13 +4660,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'b':
                     if (op == "f64x2.abs"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "f64x2.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4677,7 +4677,7 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f64x2.ceil"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CeilVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::CeilVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4685,13 +4685,13 @@ switch (buf[0]) {
                     switch (buf[24]) {
                       case 's':
                         if (op == "f64x2.convert_low_i32x4_s"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertLowSVecI32x4ToVecF64x2));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertLowSVecI32x4ToVecF64x2));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "f64x2.convert_low_i32x4_u"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ConvertLowUVecI32x4ToVecF64x2));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ConvertLowUVecI32x4ToVecF64x2));
                           return Ok{};
                         }
                         goto parse_error;
@@ -4703,7 +4703,7 @@ switch (buf[0]) {
               }
               case 'd':
                 if (op == "f64x2.div"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivVecF64x2));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivVecF64x2));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4711,13 +4711,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'q':
                     if (op == "f64x2.eq"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'x':
                     if (op == "f64x2.extract_lane"sv) {
-                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecF64x2, 2));
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneVecF64x2, 2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4726,7 +4726,7 @@ switch (buf[0]) {
               }
               case 'f':
                 if (op == "f64x2.floor"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::FloorVecF64x2));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::FloorVecF64x2));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4734,13 +4734,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f64x2.ge"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64x2.gt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4751,13 +4751,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "f64x2.le"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "f64x2.lt"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4768,19 +4768,19 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'a':
                     if (op == "f64x2.max"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "f64x2.min"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64x2.mul"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4791,19 +4791,19 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "f64x2.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'a':
                     if (op == "f64x2.nearest"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NearestVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NearestVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "f64x2.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4816,13 +4816,13 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case 'a':
                         if (op == "f64x2.pmax"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMaxVecF64x2));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::PMaxVecF64x2));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'i':
                         if (op == "f64x2.pmin"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::PMinVecF64x2));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::PMinVecF64x2));
                           return Ok{};
                         }
                         goto parse_error;
@@ -4831,7 +4831,7 @@ switch (buf[0]) {
                   }
                   case 'r':
                     if (op == "f64x2.promote_low_f32x4"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PromoteLowVecF32x4ToVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::PromoteLowVecF32x4ToVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4846,13 +4846,13 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case 'a':
                             if (op == "f64x2.relaxed_fma"sv) {
-                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmaVecF64x2));
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::RelaxedFmaVecF64x2));
                               return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "f64x2.relaxed_fms"sv) {
-                              CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::RelaxedFmsVecF64x2));
+                              CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::RelaxedFmsVecF64x2));
                               return Ok{};
                             }
                             goto parse_error;
@@ -4863,13 +4863,13 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case 'a':
                             if (op == "f64x2.relaxed_max"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMaxVecF64x2));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RelaxedMaxVecF64x2));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'i':
                             if (op == "f64x2.relaxed_min"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedMinVecF64x2));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RelaxedMinVecF64x2));
                               return Ok{};
                             }
                             goto parse_error;
@@ -4881,7 +4881,7 @@ switch (buf[0]) {
                   }
                   case 'p':
                     if (op == "f64x2.replace_lane"sv) {
-                      CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecF64x2, 2));
+                      CHECK_ERR(makeSIMDReplace(ctx, pos, annotations, SIMDReplaceOp::ReplaceLaneVecF64x2, 2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4892,19 +4892,19 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'p':
                     if (op == "f64x2.splat"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SplatVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'q':
                     if (op == "f64x2.sqrt"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SqrtVecF64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SqrtVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "f64x2.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecF64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubVecF64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4913,7 +4913,7 @@ switch (buf[0]) {
               }
               case 't':
                 if (op == "f64x2.trunc"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncVecF64x2));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncVecF64x2));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4930,13 +4930,13 @@ switch (buf[0]) {
     switch (buf[7]) {
       case 'g':
         if (op == "global.get"sv) {
-          CHECK_ERR(makeGlobalGet(ctx, pos));
+          CHECK_ERR(makeGlobalGet(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 's':
         if (op == "global.set"sv) {
-          CHECK_ERR(makeGlobalSet(ctx, pos));
+          CHECK_ERR(makeGlobalSet(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -4951,7 +4951,7 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'b':
                 if (op == "i16x8.abs"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI16x8));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -4959,7 +4959,7 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i16x8.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -4967,13 +4967,13 @@ switch (buf[0]) {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i16x8.add_sat_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatSVecI16x8));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddSatSVecI16x8));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.add_sat_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatUVecI16x8));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddSatUVecI16x8));
                           return Ok{};
                         }
                         goto parse_error;
@@ -4985,13 +4985,13 @@ switch (buf[0]) {
               }
               case 'l':
                 if (op == "i16x8.all_true"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI16x8));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AllTrueVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
               case 'v':
                 if (op == "i16x8.avgr_u"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AvgrUVecI16x8));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AvgrUVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5000,13 +5000,13 @@ switch (buf[0]) {
           }
           case 'b':
             if (op == "i16x8.bitmask"sv) {
-              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI16x8));
+              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::BitmaskVecI16x8));
               return Ok{};
             }
             goto parse_error;
           case 'd':
             if (op == "i16x8.dot_i8x16_i7x16_s"sv) {
-              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DotI8x16I7x16SToVecI16x8));
+              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DotI8x16I7x16SToVecI16x8));
               return Ok{};
             }
             goto parse_error;
@@ -5014,7 +5014,7 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'q':
                 if (op == "i16x8.eq"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI16x8));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5024,13 +5024,13 @@ switch (buf[0]) {
                     switch (buf[28]) {
                       case 's':
                         if (op == "i16x8.extadd_pairwise_i8x16_s"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseSVecI8x16ToI16x8));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtAddPairwiseSVecI8x16ToI16x8));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.extadd_pairwise_i8x16_u"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseUVecI8x16ToI16x8));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtAddPairwiseUVecI8x16ToI16x8));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5043,13 +5043,13 @@ switch (buf[0]) {
                         switch (buf[24]) {
                           case 's':
                             if (op == "i16x8.extend_high_i8x16_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI8x16ToVecI16x8));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendHighSVecI8x16ToVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extend_high_i8x16_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI8x16ToVecI16x8));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendHighUVecI8x16ToVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5060,13 +5060,13 @@ switch (buf[0]) {
                         switch (buf[23]) {
                           case 's':
                             if (op == "i16x8.extend_low_i8x16_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI8x16ToVecI16x8));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendLowSVecI8x16ToVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extend_low_i8x16_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI8x16ToVecI16x8));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendLowUVecI8x16ToVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5082,13 +5082,13 @@ switch (buf[0]) {
                         switch (buf[24]) {
                           case 's':
                             if (op == "i16x8.extmul_high_i8x16_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI16x8));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulHighSVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extmul_high_i8x16_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI16x8));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulHighUVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5099,13 +5099,13 @@ switch (buf[0]) {
                         switch (buf[23]) {
                           case 's':
                             if (op == "i16x8.extmul_low_i8x16_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI16x8));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulLowSVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i16x8.extmul_low_i8x16_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI16x8));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulLowUVecI16x8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5119,13 +5119,13 @@ switch (buf[0]) {
                     switch (buf[19]) {
                       case 's':
                         if (op == "i16x8.extract_lane_s"sv) {
-                          CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneSVecI16x8, 8));
+                          CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneSVecI16x8, 8));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.extract_lane_u"sv) {
-                          CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneUVecI16x8, 8));
+                          CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneUVecI16x8, 8));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5144,13 +5144,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.ge_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeSVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.ge_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeUVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5161,13 +5161,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.gt_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtSVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.gt_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtUVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5181,7 +5181,7 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'a':
                 if (op == "i16x8.laneselect"sv) {
-                  CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI16x8));
+                  CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::LaneselectI16x8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5189,13 +5189,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.le_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeSVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.le_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeUVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5206,13 +5206,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i16x8.lt_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtSVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.lt_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtUVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5228,13 +5228,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i16x8.max_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxSVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxSVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.max_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxUVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxUVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5245,13 +5245,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i16x8.min_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinSVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinSVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.min_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinUVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinUVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5260,7 +5260,7 @@ switch (buf[0]) {
               }
               case 'u':
                 if (op == "i16x8.mul"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecI16x8));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5273,13 +5273,13 @@ switch (buf[0]) {
                 switch (buf[19]) {
                   case 's':
                     if (op == "i16x8.narrow_i32x4_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowSVecI32x4ToVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NarrowSVecI32x4ToVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i16x8.narrow_i32x4_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowUVecI32x4ToVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NarrowUVecI32x4ToVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5290,13 +5290,13 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "i16x8.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "i16x8.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI16x8));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5308,7 +5308,7 @@ switch (buf[0]) {
           }
           case 'q':
             if (op == "i16x8.q15mulr_sat_s"sv) {
-              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::Q15MulrSatSVecI16x8));
+              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::Q15MulrSatSVecI16x8));
               return Ok{};
             }
             goto parse_error;
@@ -5316,13 +5316,13 @@ switch (buf[0]) {
             switch (buf[8]) {
               case 'l':
                 if (op == "i16x8.relaxed_q15mulr_s"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedQ15MulrSVecI16x8));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RelaxedQ15MulrSVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
               case 'p':
                 if (op == "i16x8.replace_lane"sv) {
-                  CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI16x8, 8));
+                  CHECK_ERR(makeSIMDReplace(ctx, pos, annotations, SIMDReplaceOp::ReplaceLaneVecI16x8, 8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5335,7 +5335,7 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 'l':
                     if (op == "i16x8.shl"sv) {
-                      CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI16x8));
+                      CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShlVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5343,13 +5343,13 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case 's':
                         if (op == "i16x8.shr_s"sv) {
-                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI16x8));
+                          CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrSVecI16x8));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.shr_u"sv) {
-                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI16x8));
+                          CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrUVecI16x8));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5361,7 +5361,7 @@ switch (buf[0]) {
               }
               case 'p':
                 if (op == "i16x8.splat"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI16x8));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SplatVecI16x8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5369,7 +5369,7 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i16x8.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI16x8));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubVecI16x8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5377,13 +5377,13 @@ switch (buf[0]) {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i16x8.sub_sat_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatSVecI16x8));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubSatSVecI16x8));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i16x8.sub_sat_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatUVecI16x8));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubSatUVecI16x8));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5407,13 +5407,13 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 's':
                     if (op == "i31.get_s"sv) {
-                      CHECK_ERR(makeI31Get(ctx, pos, true));
+                      CHECK_ERR(makeI31Get(ctx, pos, annotations, true));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i31.get_u"sv) {
-                      CHECK_ERR(makeI31Get(ctx, pos, false));
+                      CHECK_ERR(makeI31Get(ctx, pos, annotations, false));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5422,7 +5422,7 @@ switch (buf[0]) {
               }
               case 'n':
                 if (op == "i31.new"sv) {
-                  CHECK_ERR(makeRefI31(ctx, pos));
+                  CHECK_ERR(makeRefI31(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -5437,13 +5437,13 @@ switch (buf[0]) {
                     switch (buf[5]) {
                       case 'd':
                         if (op == "i32.add"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddInt32));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddInt32));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'n':
                         if (op == "i32.and"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndInt32));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AndInt32));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5453,19 +5453,19 @@ switch (buf[0]) {
                             switch (buf[15]) {
                               case '\0':
                                 if (op == "i32.atomic.load"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 4, /*isAtomic=*/true));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/false, 4, /*isAtomic=*/true));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '1':
                                 if (op == "i32.atomic.load16_u"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 2, /*isAtomic=*/true));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/false, 2, /*isAtomic=*/true));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '8':
                                 if (op == "i32.atomic.load8_u"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 1, /*isAtomic=*/true));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/false, 1, /*isAtomic=*/true));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -5480,13 +5480,13 @@ switch (buf[0]) {
                                     switch (buf[16]) {
                                       case 'd':
                                         if (op == "i32.atomic.rmw.add"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 4));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i32, 4));
                                           return Ok{};
                                         }
                                         goto parse_error;
                                       case 'n':
                                         if (op == "i32.atomic.rmw.and"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 4));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i32, 4));
                                           return Ok{};
                                         }
                                         goto parse_error;
@@ -5495,19 +5495,19 @@ switch (buf[0]) {
                                   }
                                   case 'c':
                                     if (op == "i32.atomic.rmw.cmpxchg"sv) {
-                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i32, 4));
+                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i32, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i32.atomic.rmw.or"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 4));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i32, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 's':
                                     if (op == "i32.atomic.rmw.sub"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 4));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i32, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -5515,13 +5515,13 @@ switch (buf[0]) {
                                     switch (buf[16]) {
                                       case 'c':
                                         if (op == "i32.atomic.rmw.xchg"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 4));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i32, 4));
                                           return Ok{};
                                         }
                                         goto parse_error;
                                       case 'o':
                                         if (op == "i32.atomic.rmw.xor"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 4));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i32, 4));
                                           return Ok{};
                                         }
                                         goto parse_error;
@@ -5537,13 +5537,13 @@ switch (buf[0]) {
                                     switch (buf[18]) {
                                       case 'd':
                                         if (op == "i32.atomic.rmw16.add_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 2));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i32, 2));
                                           return Ok{};
                                         }
                                         goto parse_error;
                                       case 'n':
                                         if (op == "i32.atomic.rmw16.and_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 2));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i32, 2));
                                           return Ok{};
                                         }
                                         goto parse_error;
@@ -5552,19 +5552,19 @@ switch (buf[0]) {
                                   }
                                   case 'c':
                                     if (op == "i32.atomic.rmw16.cmpxchg_u"sv) {
-                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i32, 2));
+                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i32, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i32.atomic.rmw16.or_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 2));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i32, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 's':
                                     if (op == "i32.atomic.rmw16.sub_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 2));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i32, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -5572,13 +5572,13 @@ switch (buf[0]) {
                                     switch (buf[18]) {
                                       case 'c':
                                         if (op == "i32.atomic.rmw16.xchg_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 2));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i32, 2));
                                           return Ok{};
                                         }
                                         goto parse_error;
                                       case 'o':
                                         if (op == "i32.atomic.rmw16.xor_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 2));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i32, 2));
                                           return Ok{};
                                         }
                                         goto parse_error;
@@ -5594,13 +5594,13 @@ switch (buf[0]) {
                                     switch (buf[17]) {
                                       case 'd':
                                         if (op == "i32.atomic.rmw8.add_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i32, 1));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i32, 1));
                                           return Ok{};
                                         }
                                         goto parse_error;
                                       case 'n':
                                         if (op == "i32.atomic.rmw8.and_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i32, 1));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i32, 1));
                                           return Ok{};
                                         }
                                         goto parse_error;
@@ -5609,19 +5609,19 @@ switch (buf[0]) {
                                   }
                                   case 'c':
                                     if (op == "i32.atomic.rmw8.cmpxchg_u"sv) {
-                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i32, 1));
+                                      CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i32, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i32.atomic.rmw8.or_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i32, 1));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i32, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 's':
                                     if (op == "i32.atomic.rmw8.sub_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i32, 1));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i32, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -5629,13 +5629,13 @@ switch (buf[0]) {
                                     switch (buf[17]) {
                                       case 'c':
                                         if (op == "i32.atomic.rmw8.xchg_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i32, 1));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i32, 1));
                                           return Ok{};
                                         }
                                         goto parse_error;
                                       case 'o':
                                         if (op == "i32.atomic.rmw8.xor_u"sv) {
-                                          CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i32, 1));
+                                          CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i32, 1));
                                           return Ok{};
                                         }
                                         goto parse_error;
@@ -5652,19 +5652,19 @@ switch (buf[0]) {
                             switch (buf[16]) {
                               case '\0':
                                 if (op == "i32.atomic.store"sv) {
-                                  CHECK_ERR(makeStore(ctx, pos, Type::i32, 4, /*isAtomic=*/true));
+                                  CHECK_ERR(makeStore(ctx, pos, annotations, Type::i32, 4, /*isAtomic=*/true));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '1':
                                 if (op == "i32.atomic.store16"sv) {
-                                  CHECK_ERR(makeStore(ctx, pos, Type::i32, 2, /*isAtomic=*/true));
+                                  CHECK_ERR(makeStore(ctx, pos, annotations, Type::i32, 2, /*isAtomic=*/true));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '8':
                                 if (op == "i32.atomic.store8"sv) {
-                                  CHECK_ERR(makeStore(ctx, pos, Type::i32, 1, /*isAtomic=*/true));
+                                  CHECK_ERR(makeStore(ctx, pos, annotations, Type::i32, 1, /*isAtomic=*/true));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -5681,19 +5681,19 @@ switch (buf[0]) {
                     switch (buf[5]) {
                       case 'l':
                         if (op == "i32.clz"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ClzInt32));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ClzInt32));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'o':
                         if (op == "i32.const"sv) {
-                          CHECK_ERR(makeConst(ctx, pos, Type::i32));
+                          CHECK_ERR(makeConst(ctx, pos, annotations, Type::i32));
                           return Ok{};
                         }
                         goto parse_error;
                       case 't':
                         if (op == "i32.ctz"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CtzInt32));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::CtzInt32));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5704,13 +5704,13 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case 's':
                         if (op == "i32.div_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivSInt32));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivSInt32));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i32.div_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivUInt32));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivUInt32));
                           return Ok{};
                         }
                         goto parse_error;
@@ -5723,13 +5723,13 @@ switch (buf[0]) {
                         switch (buf[6]) {
                           case '\0':
                             if (op == "i32.eq"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'z':
                             if (op == "i32.eqz"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::EqZInt32));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::EqZInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5740,13 +5740,13 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case '1':
                             if (op == "i32.extend16_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS16Int32));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendS16Int32));
                               return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i32.extend8_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS8Int32));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendS8Int32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5762,13 +5762,13 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.ge_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeSInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.ge_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeUInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5779,13 +5779,13 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.gt_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtSInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.gt_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtUInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5801,13 +5801,13 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.le_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeSInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.le_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeUInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5818,7 +5818,7 @@ switch (buf[0]) {
                         switch (buf[8]) {
                           case '\0':
                             if (op == "i32.load"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 4, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/false, 4, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5826,13 +5826,13 @@ switch (buf[0]) {
                             switch (buf[11]) {
                               case 's':
                                 if (op == "i32.load16_s"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/true, 2, /*isAtomic=*/false));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/true, 2, /*isAtomic=*/false));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.load16_u"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 2, /*isAtomic=*/false));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/false, 2, /*isAtomic=*/false));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -5843,13 +5843,13 @@ switch (buf[0]) {
                             switch (buf[10]) {
                               case 's':
                                 if (op == "i32.load8_s"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/true, 1, /*isAtomic=*/false));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/true, 1, /*isAtomic=*/false));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.load8_u"sv) {
-                                  CHECK_ERR(makeLoad(ctx, pos, Type::i32, /*signed=*/false, 1, /*isAtomic=*/false));
+                                  CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i32, /*signed=*/false, 1, /*isAtomic=*/false));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -5863,13 +5863,13 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 's':
                             if (op == "i32.lt_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtSInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32.lt_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtUInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5881,25 +5881,25 @@ switch (buf[0]) {
                   }
                   case 'm':
                     if (op == "i32.mul"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulInt32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulInt32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'n':
                     if (op == "i32.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeInt32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeInt32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "i32.or"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::OrInt32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::OrInt32));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'p':
                     if (op == "i32.popcnt"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PopcntInt32));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::PopcntInt32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -5909,7 +5909,7 @@ switch (buf[0]) {
                         switch (buf[6]) {
                           case 'i':
                             if (op == "i32.reinterpret_f32"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretFloat32));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ReinterpretFloat32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5917,13 +5917,13 @@ switch (buf[0]) {
                             switch (buf[8]) {
                               case 's':
                                 if (op == "i32.rem_s"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemSInt32));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RemSInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.rem_u"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemUInt32));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RemUInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -5937,13 +5937,13 @@ switch (buf[0]) {
                         switch (buf[7]) {
                           case 'l':
                             if (op == "i32.rotl"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotLInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RotLInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'r':
                             if (op == "i32.rotr"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotRInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RotRInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5959,7 +5959,7 @@ switch (buf[0]) {
                         switch (buf[6]) {
                           case 'l':
                             if (op == "i32.shl"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShlInt32));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ShlInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -5967,13 +5967,13 @@ switch (buf[0]) {
                             switch (buf[8]) {
                               case 's':
                                 if (op == "i32.shr_s"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrSInt32));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ShrSInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.shr_u"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrUInt32));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ShrUInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -5987,19 +5987,19 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case '\0':
                             if (op == "i32.store"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i32, 4, /*isAtomic=*/false));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i32, 4, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
                           case '1':
                             if (op == "i32.store16"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i32, 2, /*isAtomic=*/false));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i32, 2, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i32.store8"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i32, 1, /*isAtomic=*/false));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i32, 1, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6008,7 +6008,7 @@ switch (buf[0]) {
                       }
                       case 'u':
                         if (op == "i32.sub"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubInt32));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubInt32));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6023,13 +6023,13 @@ switch (buf[0]) {
                             switch (buf[14]) {
                               case 's':
                                 if (op == "i32.trunc_f32_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat32ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSFloat32ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_f32_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat32ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncUFloat32ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6040,13 +6040,13 @@ switch (buf[0]) {
                             switch (buf[14]) {
                               case 's':
                                 if (op == "i32.trunc_f64_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat64ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSFloat64ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_f64_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat64ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncUFloat64ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6062,13 +6062,13 @@ switch (buf[0]) {
                             switch (buf[18]) {
                               case 's':
                                 if (op == "i32.trunc_sat_f32_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat32ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatSFloat32ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_sat_f32_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat32ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatUFloat32ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6079,13 +6079,13 @@ switch (buf[0]) {
                             switch (buf[18]) {
                               case 's':
                                 if (op == "i32.trunc_sat_f64_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat64ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatSFloat64ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32.trunc_sat_f64_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat64ToInt32));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatUFloat64ToInt32));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6100,13 +6100,13 @@ switch (buf[0]) {
                   }
                   case 'w':
                     if (op == "i32.wrap_i64"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::WrapInt64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::WrapInt64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'x':
                     if (op == "i32.xor"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::XorInt32));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::XorInt32));
                       return Ok{};
                     }
                     goto parse_error;
@@ -6119,19 +6119,19 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'b':
                         if (op == "i32x4.abs"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI32x4));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'd':
                         if (op == "i32x4.add"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI32x4));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'l':
                         if (op == "i32x4.all_true"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI32x4));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AllTrueVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6140,7 +6140,7 @@ switch (buf[0]) {
                   }
                   case 'b':
                     if (op == "i32x4.bitmask"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI32x4));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::BitmaskVecI32x4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -6148,13 +6148,13 @@ switch (buf[0]) {
                     switch (buf[11]) {
                       case '1':
                         if (op == "i32x4.dot_i16x8_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DotSVecI16x8ToVecI32x4));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DotSVecI16x8ToVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
                       case '8':
                         if (op == "i32x4.dot_i8x16_i7x16_add_s"sv) {
-                          CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::DotI8x16I7x16AddSToVecI32x4));
+                          CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::DotI8x16I7x16AddSToVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6165,7 +6165,7 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'q':
                         if (op == "i32x4.eq"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI32x4));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6175,13 +6175,13 @@ switch (buf[0]) {
                             switch (buf[28]) {
                               case 's':
                                 if (op == "i32x4.extadd_pairwise_i16x8_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseSVecI16x8ToI32x4));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtAddPairwiseSVecI16x8ToI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.extadd_pairwise_i16x8_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtAddPairwiseUVecI16x8ToI32x4));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtAddPairwiseUVecI16x8ToI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6194,13 +6194,13 @@ switch (buf[0]) {
                                 switch (buf[24]) {
                                   case 's':
                                     if (op == "i32x4.extend_high_i16x8_s"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI16x8ToVecI32x4));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendHighSVecI16x8ToVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extend_high_i16x8_u"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI16x8ToVecI32x4));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendHighUVecI16x8ToVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6211,13 +6211,13 @@ switch (buf[0]) {
                                 switch (buf[23]) {
                                   case 's':
                                     if (op == "i32x4.extend_low_i16x8_s"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI16x8ToVecI32x4));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendLowSVecI16x8ToVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extend_low_i16x8_u"sv) {
-                                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI16x8ToVecI32x4));
+                                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendLowUVecI16x8ToVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6233,13 +6233,13 @@ switch (buf[0]) {
                                 switch (buf[24]) {
                                   case 's':
                                     if (op == "i32x4.extmul_high_i16x8_s"sv) {
-                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI32x4));
+                                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulHighSVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extmul_high_i16x8_u"sv) {
-                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI32x4));
+                                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulHighUVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6250,13 +6250,13 @@ switch (buf[0]) {
                                 switch (buf[23]) {
                                   case 's':
                                     if (op == "i32x4.extmul_low_i16x8_s"sv) {
-                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI32x4));
+                                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulLowSVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'u':
                                     if (op == "i32x4.extmul_low_i16x8_u"sv) {
-                                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI32x4));
+                                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulLowUVecI32x4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6268,7 +6268,7 @@ switch (buf[0]) {
                           }
                           case 'r':
                             if (op == "i32x4.extract_lane"sv) {
-                              CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecI32x4, 4));
+                              CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneVecI32x4, 4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6284,13 +6284,13 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.ge_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeSVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.ge_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeUVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6301,13 +6301,13 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.gt_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtSVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.gt_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtUVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6321,7 +6321,7 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'a':
                         if (op == "i32x4.laneselect"sv) {
-                          CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI32x4));
+                          CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::LaneselectI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6329,13 +6329,13 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.le_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeSVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.le_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeUVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6346,13 +6346,13 @@ switch (buf[0]) {
                         switch (buf[9]) {
                           case 's':
                             if (op == "i32x4.lt_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtSVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.lt_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtUVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6368,13 +6368,13 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i32x4.max_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxSVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxSVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.max_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxUVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxUVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6385,13 +6385,13 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i32x4.min_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinSVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinSVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.min_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinUVecI32x4));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinUVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6400,7 +6400,7 @@ switch (buf[0]) {
                       }
                       case 'u':
                         if (op == "i32x4.mul"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecI32x4));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6411,13 +6411,13 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case '\0':
                         if (op == "i32x4.ne"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI32x4));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'g':
                         if (op == "i32x4.neg"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI32x4));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6432,13 +6432,13 @@ switch (buf[0]) {
                             switch (buf[26]) {
                               case 's':
                                 if (op == "i32x4.relaxed_trunc_f32x4_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncSVecF32x4ToVecI32x4));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::RelaxedTruncSVecF32x4ToVecI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.relaxed_trunc_f32x4_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncUVecF32x4ToVecI32x4));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::RelaxedTruncUVecF32x4ToVecI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6449,13 +6449,13 @@ switch (buf[0]) {
                             switch (buf[26]) {
                               case 's':
                                 if (op == "i32x4.relaxed_trunc_f64x2_s_zero"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncZeroSVecF64x2ToVecI32x4));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::RelaxedTruncZeroSVecF64x2ToVecI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.relaxed_trunc_f64x2_u_zero"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::RelaxedTruncZeroUVecF64x2ToVecI32x4));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::RelaxedTruncZeroUVecF64x2ToVecI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6467,7 +6467,7 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "i32x4.replace_lane"sv) {
-                          CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI32x4, 4));
+                          CHECK_ERR(makeSIMDReplace(ctx, pos, annotations, SIMDReplaceOp::ReplaceLaneVecI32x4, 4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6480,7 +6480,7 @@ switch (buf[0]) {
                         switch (buf[8]) {
                           case 'l':
                             if (op == "i32x4.shl"sv) {
-                              CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI32x4));
+                              CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShlVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6488,13 +6488,13 @@ switch (buf[0]) {
                             switch (buf[10]) {
                               case 's':
                                 if (op == "i32x4.shr_s"sv) {
-                                  CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI32x4));
+                                  CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrSVecI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i32x4.shr_u"sv) {
-                                  CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI32x4));
+                                  CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrUVecI32x4));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6506,13 +6506,13 @@ switch (buf[0]) {
                       }
                       case 'p':
                         if (op == "i32x4.splat"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI32x4));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SplatVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i32x4.sub"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI32x4));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubVecI32x4));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6525,13 +6525,13 @@ switch (buf[0]) {
                         switch (buf[22]) {
                           case 's':
                             if (op == "i32x4.trunc_sat_f32x4_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSVecF32x4ToVecI32x4));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatSVecF32x4ToVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.trunc_sat_f32x4_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUVecF32x4ToVecI32x4));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatUVecF32x4ToVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6542,13 +6542,13 @@ switch (buf[0]) {
                         switch (buf[22]) {
                           case 's':
                             if (op == "i32x4.trunc_sat_f64x2_s_zero"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatZeroSVecF64x2ToVecI32x4));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatZeroSVecF64x2ToVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i32x4.trunc_sat_f64x2_u_zero"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatZeroUVecF64x2ToVecI32x4));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatZeroUVecF64x2ToVecI32x4));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6575,13 +6575,13 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'd':
                     if (op == "i64.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddInt64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddInt64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'n':
                     if (op == "i64.and"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndInt64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AndInt64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -6591,25 +6591,25 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case '\0':
                             if (op == "i64.atomic.load"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 8, /*isAtomic=*/true));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 8, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
                           case '1':
                             if (op == "i64.atomic.load16_u"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 2, /*isAtomic=*/true));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 2, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
                           case '3':
                             if (op == "i64.atomic.load32_u"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 4, /*isAtomic=*/true));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 4, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i64.atomic.load8_u"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 1, /*isAtomic=*/true));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 1, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6624,13 +6624,13 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw.add"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 8));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i64, 8));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw.and"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 8));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i64, 8));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6639,19 +6639,19 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw.cmpxchg"sv) {
-                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 8));
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i64, 8));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw.or"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 8));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i64, 8));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw.sub"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 8));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i64, 8));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6659,13 +6659,13 @@ switch (buf[0]) {
                                 switch (buf[16]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw.xchg"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 8));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i64, 8));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw.xor"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 8));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i64, 8));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6681,13 +6681,13 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw16.add_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 2));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i64, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw16.and_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 2));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i64, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6696,19 +6696,19 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw16.cmpxchg_u"sv) {
-                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 2));
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i64, 2));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw16.or_u"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 2));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i64, 2));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw16.sub_u"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 2));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i64, 2));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6716,13 +6716,13 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw16.xchg_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 2));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i64, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw16.xor_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 2));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i64, 2));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6738,13 +6738,13 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw32.add_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 4));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i64, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw32.and_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 4));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i64, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6753,19 +6753,19 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw32.cmpxchg_u"sv) {
-                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 4));
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i64, 4));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw32.or_u"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 4));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i64, 4));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw32.sub_u"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 4));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i64, 4));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6773,13 +6773,13 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw32.xchg_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 4));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i64, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw32.xor_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 4));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i64, 4));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6795,13 +6795,13 @@ switch (buf[0]) {
                                 switch (buf[17]) {
                                   case 'd':
                                     if (op == "i64.atomic.rmw8.add_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAdd, Type::i64, 1));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAdd, Type::i64, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'n':
                                     if (op == "i64.atomic.rmw8.and_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWAnd, Type::i64, 1));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWAnd, Type::i64, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6810,19 +6810,19 @@ switch (buf[0]) {
                               }
                               case 'c':
                                 if (op == "i64.atomic.rmw8.cmpxchg_u"sv) {
-                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, Type::i64, 1));
+                                  CHECK_ERR(makeAtomicCmpxchg(ctx, pos, annotations, Type::i64, 1));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'o':
                                 if (op == "i64.atomic.rmw8.or_u"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWOr, Type::i64, 1));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWOr, Type::i64, 1));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 's':
                                 if (op == "i64.atomic.rmw8.sub_u"sv) {
-                                  CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWSub, Type::i64, 1));
+                                  CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWSub, Type::i64, 1));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -6830,13 +6830,13 @@ switch (buf[0]) {
                                 switch (buf[17]) {
                                   case 'c':
                                     if (op == "i64.atomic.rmw8.xchg_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXchg, Type::i64, 1));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXchg, Type::i64, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case 'o':
                                     if (op == "i64.atomic.rmw8.xor_u"sv) {
-                                      CHECK_ERR(makeAtomicRMW(ctx, pos, AtomicRMWOp::RMWXor, Type::i64, 1));
+                                      CHECK_ERR(makeAtomicRMW(ctx, pos, annotations, AtomicRMWOp::RMWXor, Type::i64, 1));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -6853,25 +6853,25 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case '\0':
                             if (op == "i64.atomic.store"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 8, /*isAtomic=*/true));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 8, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
                           case '1':
                             if (op == "i64.atomic.store16"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 2, /*isAtomic=*/true));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 2, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
                           case '3':
                             if (op == "i64.atomic.store32"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 4, /*isAtomic=*/true));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 4, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "i64.atomic.store8"sv) {
-                              CHECK_ERR(makeStore(ctx, pos, Type::i64, 1, /*isAtomic=*/true));
+                              CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 1, /*isAtomic=*/true));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6888,19 +6888,19 @@ switch (buf[0]) {
                 switch (buf[5]) {
                   case 'l':
                     if (op == "i64.clz"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ClzInt64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ClzInt64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'o':
                     if (op == "i64.const"sv) {
-                      CHECK_ERR(makeConst(ctx, pos, Type::i64));
+                      CHECK_ERR(makeConst(ctx, pos, annotations, Type::i64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "i64.ctz"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::CtzInt64));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::CtzInt64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -6911,13 +6911,13 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 's':
                     if (op == "i64.div_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivSInt64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivSInt64));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i64.div_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::DivUInt64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::DivUInt64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -6930,13 +6930,13 @@ switch (buf[0]) {
                     switch (buf[6]) {
                       case '\0':
                         if (op == "i64.eq"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqInt64));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'z':
                         if (op == "i64.eqz"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::EqZInt64));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::EqZInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6947,19 +6947,19 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case '1':
                         if (op == "i64.extend16_s"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS16Int64));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendS16Int64));
                           return Ok{};
                         }
                         goto parse_error;
                       case '3':
                         if (op == "i64.extend32_s"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS32Int64));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendS32Int64));
                           return Ok{};
                         }
                         goto parse_error;
                       case '8':
                         if (op == "i64.extend8_s"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendS8Int64));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendS8Int64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -6967,13 +6967,13 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case 's':
                             if (op == "i64.extend_i32_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendSInt32));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendSInt32));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.extend_i32_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendUInt32));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendUInt32));
                               return Ok{};
                             }
                             goto parse_error;
@@ -6992,13 +6992,13 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.ge_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeSInt64));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.ge_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeUInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7009,13 +7009,13 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.gt_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtSInt64));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.gt_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtUInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7031,13 +7031,13 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.le_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeSInt64));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.le_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeUInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7048,7 +7048,7 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case '\0':
                         if (op == "i64.load"sv) {
-                          CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 8, /*isAtomic=*/false));
+                          CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 8, /*isAtomic=*/false));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7056,13 +7056,13 @@ switch (buf[0]) {
                         switch (buf[11]) {
                           case 's':
                             if (op == "i64.load16_s"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/true, 2, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/true, 2, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.load16_u"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 2, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 2, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7073,13 +7073,13 @@ switch (buf[0]) {
                         switch (buf[11]) {
                           case 's':
                             if (op == "i64.load32_s"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/true, 4, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/true, 4, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.load32_u"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 4, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 4, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7090,13 +7090,13 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i64.load8_s"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/true, 1, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/true, 1, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.load8_u"sv) {
-                              CHECK_ERR(makeLoad(ctx, pos, Type::i64, /*signed=*/false, 1, /*isAtomic=*/false));
+                              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::i64, /*signed=*/false, 1, /*isAtomic=*/false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7110,13 +7110,13 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 's':
                         if (op == "i64.lt_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtSInt64));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i64.lt_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtUInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7128,25 +7128,25 @@ switch (buf[0]) {
               }
               case 'm':
                 if (op == "i64.mul"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulInt64));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulInt64));
                   return Ok{};
                 }
                 goto parse_error;
               case 'n':
                 if (op == "i64.ne"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeInt64));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeInt64));
                   return Ok{};
                 }
                 goto parse_error;
               case 'o':
                 if (op == "i64.or"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::OrInt64));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::OrInt64));
                   return Ok{};
                 }
                 goto parse_error;
               case 'p':
                 if (op == "i64.popcnt"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PopcntInt64));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::PopcntInt64));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7156,7 +7156,7 @@ switch (buf[0]) {
                     switch (buf[6]) {
                       case 'i':
                         if (op == "i64.reinterpret_f64"sv) {
-                          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ReinterpretFloat64));
+                          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ReinterpretFloat64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7164,13 +7164,13 @@ switch (buf[0]) {
                         switch (buf[8]) {
                           case 's':
                             if (op == "i64.rem_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemSInt64));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RemSInt64));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.rem_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RemUInt64));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RemUInt64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7184,13 +7184,13 @@ switch (buf[0]) {
                     switch (buf[7]) {
                       case 'l':
                         if (op == "i64.rotl"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotLInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RotLInt64));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "i64.rotr"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RotRInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RotRInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7206,7 +7206,7 @@ switch (buf[0]) {
                     switch (buf[6]) {
                       case 'l':
                         if (op == "i64.shl"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShlInt64));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ShlInt64));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7214,13 +7214,13 @@ switch (buf[0]) {
                         switch (buf[8]) {
                           case 's':
                             if (op == "i64.shr_s"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrSInt64));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ShrSInt64));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.shr_u"sv) {
-                              CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ShrUInt64));
+                              CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ShrUInt64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7234,25 +7234,25 @@ switch (buf[0]) {
                     switch (buf[9]) {
                       case '\0':
                         if (op == "i64.store"sv) {
-                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 8, /*isAtomic=*/false));
+                          CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 8, /*isAtomic=*/false));
                           return Ok{};
                         }
                         goto parse_error;
                       case '1':
                         if (op == "i64.store16"sv) {
-                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 2, /*isAtomic=*/false));
+                          CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 2, /*isAtomic=*/false));
                           return Ok{};
                         }
                         goto parse_error;
                       case '3':
                         if (op == "i64.store32"sv) {
-                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 4, /*isAtomic=*/false));
+                          CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 4, /*isAtomic=*/false));
                           return Ok{};
                         }
                         goto parse_error;
                       case '8':
                         if (op == "i64.store8"sv) {
-                          CHECK_ERR(makeStore(ctx, pos, Type::i64, 1, /*isAtomic=*/false));
+                          CHECK_ERR(makeStore(ctx, pos, annotations, Type::i64, 1, /*isAtomic=*/false));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7261,7 +7261,7 @@ switch (buf[0]) {
                   }
                   case 'u':
                     if (op == "i64.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubInt64));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubInt64));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7276,13 +7276,13 @@ switch (buf[0]) {
                         switch (buf[14]) {
                           case 's':
                             if (op == "i64.trunc_f32_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat32ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSFloat32ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_f32_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat32ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncUFloat32ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7293,13 +7293,13 @@ switch (buf[0]) {
                         switch (buf[14]) {
                           case 's':
                             if (op == "i64.trunc_f64_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSFloat64ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSFloat64ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_f64_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncUFloat64ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncUFloat64ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7315,13 +7315,13 @@ switch (buf[0]) {
                         switch (buf[18]) {
                           case 's':
                             if (op == "i64.trunc_sat_f32_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat32ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatSFloat32ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_sat_f32_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat32ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatUFloat32ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7332,13 +7332,13 @@ switch (buf[0]) {
                         switch (buf[18]) {
                           case 's':
                             if (op == "i64.trunc_sat_f64_s"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatSFloat64ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatSFloat64ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64.trunc_sat_f64_u"sv) {
-                              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::TruncSatUFloat64ToInt64));
+                              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::TruncSatUFloat64ToInt64));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7353,7 +7353,7 @@ switch (buf[0]) {
               }
               case 'x':
                 if (op == "i64.xor"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::XorInt64));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::XorInt64));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7366,19 +7366,19 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'b':
                     if (op == "i64x2.abs"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'd':
                     if (op == "i64x2.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'l':
                     if (op == "i64x2.all_true"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AllTrueVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7387,7 +7387,7 @@ switch (buf[0]) {
               }
               case 'b':
                 if (op == "i64x2.bitmask"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI64x2));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::BitmaskVecI64x2));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7395,7 +7395,7 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'q':
                     if (op == "i64x2.eq"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7407,13 +7407,13 @@ switch (buf[0]) {
                             switch (buf[24]) {
                               case 's':
                                 if (op == "i64x2.extend_high_i32x4_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighSVecI32x4ToVecI64x2));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendHighSVecI32x4ToVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extend_high_i32x4_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendHighUVecI32x4ToVecI64x2));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendHighUVecI32x4ToVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -7424,13 +7424,13 @@ switch (buf[0]) {
                             switch (buf[23]) {
                               case 's':
                                 if (op == "i64x2.extend_low_i32x4_s"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowSVecI32x4ToVecI64x2));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendLowSVecI32x4ToVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extend_low_i32x4_u"sv) {
-                                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::ExtendLowUVecI32x4ToVecI64x2));
+                                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::ExtendLowUVecI32x4ToVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -7446,13 +7446,13 @@ switch (buf[0]) {
                             switch (buf[24]) {
                               case 's':
                                 if (op == "i64x2.extmul_high_i32x4_s"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighSVecI64x2));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulHighSVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extmul_high_i32x4_u"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulHighUVecI64x2));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulHighUVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -7463,13 +7463,13 @@ switch (buf[0]) {
                             switch (buf[23]) {
                               case 's':
                                 if (op == "i64x2.extmul_low_i32x4_s"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowSVecI64x2));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulLowSVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case 'u':
                                 if (op == "i64x2.extmul_low_i32x4_u"sv) {
-                                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::ExtMulLowUVecI64x2));
+                                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::ExtMulLowUVecI64x2));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -7481,7 +7481,7 @@ switch (buf[0]) {
                       }
                       case 'r':
                         if (op == "i64x2.extract_lane"sv) {
-                          CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneVecI64x2, 2));
+                          CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneVecI64x2, 2));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7495,13 +7495,13 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'e':
                     if (op == "i64x2.ge_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeSVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "i64x2.gt_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtSVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7512,19 +7512,19 @@ switch (buf[0]) {
                 switch (buf[7]) {
                   case 'a':
                     if (op == "i64x2.laneselect"sv) {
-                      CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI64x2));
+                      CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::LaneselectI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'e':
                     if (op == "i64x2.le_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeSVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 't':
                     if (op == "i64x2.lt_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtSVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7533,7 +7533,7 @@ switch (buf[0]) {
               }
               case 'm':
                 if (op == "i64x2.mul"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MulVecI64x2));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MulVecI64x2));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7541,13 +7541,13 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "i64x2.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "i64x2.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7556,7 +7556,7 @@ switch (buf[0]) {
               }
               case 'r':
                 if (op == "i64x2.replace_lane"sv) {
-                  CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI64x2, 2));
+                  CHECK_ERR(makeSIMDReplace(ctx, pos, annotations, SIMDReplaceOp::ReplaceLaneVecI64x2, 2));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7566,7 +7566,7 @@ switch (buf[0]) {
                     switch (buf[8]) {
                       case 'l':
                         if (op == "i64x2.shl"sv) {
-                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI64x2));
+                          CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShlVecI64x2));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7574,13 +7574,13 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 's':
                             if (op == "i64x2.shr_s"sv) {
-                              CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI64x2));
+                              CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrSVecI64x2));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'u':
                             if (op == "i64x2.shr_u"sv) {
-                              CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI64x2));
+                              CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrUVecI64x2));
                               return Ok{};
                             }
                             goto parse_error;
@@ -7592,13 +7592,13 @@ switch (buf[0]) {
                   }
                   case 'p':
                     if (op == "i64x2.splat"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI64x2));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SplatVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i64x2.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI64x2));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubVecI64x2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7617,7 +7617,7 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'b':
                 if (op == "i8x16.abs"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AbsVecI8x16));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AbsVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7625,7 +7625,7 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i8x16.add"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7633,13 +7633,13 @@ switch (buf[0]) {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i8x16.add_sat_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatSVecI8x16));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddSatSVecI8x16));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i8x16.add_sat_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AddSatUVecI8x16));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AddSatUVecI8x16));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7651,13 +7651,13 @@ switch (buf[0]) {
               }
               case 'l':
                 if (op == "i8x16.all_true"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AllTrueVecI8x16));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AllTrueVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
               case 'v':
                 if (op == "i8x16.avgr_u"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AvgrUVecI8x16));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AvgrUVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7666,7 +7666,7 @@ switch (buf[0]) {
           }
           case 'b':
             if (op == "i8x16.bitmask"sv) {
-              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::BitmaskVecI8x16));
+              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::BitmaskVecI8x16));
               return Ok{};
             }
             goto parse_error;
@@ -7674,7 +7674,7 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'q':
                 if (op == "i8x16.eq"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::EqVecI8x16));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::EqVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7682,13 +7682,13 @@ switch (buf[0]) {
                 switch (buf[19]) {
                   case 's':
                     if (op == "i8x16.extract_lane_s"sv) {
-                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneSVecI8x16, 16));
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneSVecI8x16, 16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.extract_lane_u"sv) {
-                      CHECK_ERR(makeSIMDExtract(ctx, pos, SIMDExtractOp::ExtractLaneUVecI8x16, 16));
+                      CHECK_ERR(makeSIMDExtract(ctx, pos, annotations, SIMDExtractOp::ExtractLaneUVecI8x16, 16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7704,13 +7704,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.ge_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeSVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeSVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.ge_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GeUVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GeUVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7721,13 +7721,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.gt_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtSVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtSVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.gt_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::GtUVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::GtUVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7741,7 +7741,7 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'a':
                 if (op == "i8x16.laneselect"sv) {
-                  CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::LaneselectI8x16));
+                  CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::LaneselectI8x16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7749,13 +7749,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.le_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeSVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeSVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.le_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LeUVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LeUVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7766,13 +7766,13 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case 's':
                     if (op == "i8x16.lt_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtSVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtSVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.lt_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::LtUVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::LtUVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7788,13 +7788,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i8x16.max_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxSVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxSVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.max_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MaxUVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MaxUVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7805,13 +7805,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case 's':
                     if (op == "i8x16.min_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinSVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinSVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.min_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::MinUVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::MinUVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7827,13 +7827,13 @@ switch (buf[0]) {
                 switch (buf[19]) {
                   case 's':
                     if (op == "i8x16.narrow_i16x8_s"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowSVecI16x8ToVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NarrowSVecI16x8ToVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "i8x16.narrow_i16x8_u"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NarrowUVecI16x8ToVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NarrowUVecI16x8ToVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7844,13 +7844,13 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case '\0':
                     if (op == "i8x16.ne"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::NeVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::NeVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'g':
                     if (op == "i8x16.neg"sv) {
-                      CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NegVecI8x16));
+                      CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NegVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7862,7 +7862,7 @@ switch (buf[0]) {
           }
           case 'p':
             if (op == "i8x16.popcnt"sv) {
-              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::PopcntVecI8x16));
+              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::PopcntVecI8x16));
               return Ok{};
             }
             goto parse_error;
@@ -7870,13 +7870,13 @@ switch (buf[0]) {
             switch (buf[8]) {
               case 'l':
                 if (op == "i8x16.relaxed_swizzle"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::RelaxedSwizzleVecI8x16));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::RelaxedSwizzleVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
               case 'p':
                 if (op == "i8x16.replace_lane"sv) {
-                  CHECK_ERR(makeSIMDReplace(ctx, pos, SIMDReplaceOp::ReplaceLaneVecI8x16, 16));
+                  CHECK_ERR(makeSIMDReplace(ctx, pos, annotations, SIMDReplaceOp::ReplaceLaneVecI8x16, 16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7889,7 +7889,7 @@ switch (buf[0]) {
                 switch (buf[8]) {
                   case 'l':
                     if (op == "i8x16.shl"sv) {
-                      CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShlVecI8x16));
+                      CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShlVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7897,13 +7897,13 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case 's':
                         if (op == "i8x16.shr_s"sv) {
-                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrSVecI8x16));
+                          CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrSVecI8x16));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i8x16.shr_u"sv) {
-                          CHECK_ERR(makeSIMDShift(ctx, pos, SIMDShiftOp::ShrUVecI8x16));
+                          CHECK_ERR(makeSIMDShift(ctx, pos, annotations, SIMDShiftOp::ShrUVecI8x16));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7912,7 +7912,7 @@ switch (buf[0]) {
                   }
                   case 'u':
                     if (op == "i8x16.shuffle"sv) {
-                      CHECK_ERR(makeSIMDShuffle(ctx, pos));
+                      CHECK_ERR(makeSIMDShuffle(ctx, pos, annotations));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7921,7 +7921,7 @@ switch (buf[0]) {
               }
               case 'p':
                 if (op == "i8x16.splat"sv) {
-                  CHECK_ERR(makeUnary(ctx, pos, UnaryOp::SplatVecI8x16));
+                  CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::SplatVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7929,7 +7929,7 @@ switch (buf[0]) {
                 switch (buf[9]) {
                   case '\0':
                     if (op == "i8x16.sub"sv) {
-                      CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubVecI8x16));
+                      CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubVecI8x16));
                       return Ok{};
                     }
                     goto parse_error;
@@ -7937,13 +7937,13 @@ switch (buf[0]) {
                     switch (buf[14]) {
                       case 's':
                         if (op == "i8x16.sub_sat_s"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatSVecI8x16));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubSatSVecI8x16));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "i8x16.sub_sat_u"sv) {
-                          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SubSatUVecI8x16));
+                          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SubSatUVecI8x16));
                           return Ok{};
                         }
                         goto parse_error;
@@ -7955,7 +7955,7 @@ switch (buf[0]) {
               }
               case 'w':
                 if (op == "i8x16.swizzle"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::SwizzleVecI8x16));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::SwizzleVecI8x16));
                   return Ok{};
                 }
                 goto parse_error;
@@ -7972,19 +7972,19 @@ switch (buf[0]) {
     switch (buf[6]) {
       case 'g':
         if (op == "local.get"sv) {
-          CHECK_ERR(makeLocalGet(ctx, pos));
+          CHECK_ERR(makeLocalGet(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 's':
         if (op == "local.set"sv) {
-          CHECK_ERR(makeLocalSet(ctx, pos));
+          CHECK_ERR(makeLocalSet(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 't':
         if (op == "local.tee"sv) {
-          CHECK_ERR(makeLocalTee(ctx, pos));
+          CHECK_ERR(makeLocalTee(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -7997,7 +7997,7 @@ switch (buf[0]) {
         switch (buf[14]) {
           case 'n':
             if (op == "memory.atomic.notify"sv) {
-              CHECK_ERR(makeAtomicNotify(ctx, pos));
+              CHECK_ERR(makeAtomicNotify(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8005,13 +8005,13 @@ switch (buf[0]) {
             switch (buf[18]) {
               case '3':
                 if (op == "memory.atomic.wait32"sv) {
-                  CHECK_ERR(makeAtomicWait(ctx, pos, Type::i32));
+                  CHECK_ERR(makeAtomicWait(ctx, pos, annotations, Type::i32));
                   return Ok{};
                 }
                 goto parse_error;
               case '6':
                 if (op == "memory.atomic.wait64"sv) {
-                  CHECK_ERR(makeAtomicWait(ctx, pos, Type::i64));
+                  CHECK_ERR(makeAtomicWait(ctx, pos, annotations, Type::i64));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8023,31 +8023,31 @@ switch (buf[0]) {
       }
       case 'c':
         if (op == "memory.copy"sv) {
-          CHECK_ERR(makeMemoryCopy(ctx, pos));
+          CHECK_ERR(makeMemoryCopy(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 'f':
         if (op == "memory.fill"sv) {
-          CHECK_ERR(makeMemoryFill(ctx, pos));
+          CHECK_ERR(makeMemoryFill(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 'g':
         if (op == "memory.grow"sv) {
-          CHECK_ERR(makeMemoryGrow(ctx, pos));
+          CHECK_ERR(makeMemoryGrow(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 'i':
         if (op == "memory.init"sv) {
-          CHECK_ERR(makeMemoryInit(ctx, pos));
+          CHECK_ERR(makeMemoryInit(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
       case 's':
         if (op == "memory.size"sv) {
-          CHECK_ERR(makeMemorySize(ctx, pos));
+          CHECK_ERR(makeMemorySize(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -8056,13 +8056,13 @@ switch (buf[0]) {
   }
   case 'n':
     if (op == "nop"sv) {
-      CHECK_ERR(makeNop(ctx, pos));
+      CHECK_ERR(makeNop(ctx, pos, annotations));
       return Ok{};
     }
     goto parse_error;
   case 'p':
     if (op == "pop"sv) {
-      CHECK_ERR(makePop(ctx, pos));
+      CHECK_ERR(makePop(ctx, pos, annotations));
       return Ok{};
     }
     goto parse_error;
@@ -8072,25 +8072,25 @@ switch (buf[0]) {
         switch (buf[4]) {
           case 'a':
             if (op == "ref.as_non_null"sv) {
-              CHECK_ERR(makeRefAs(ctx, pos, RefAsNonNull));
+              CHECK_ERR(makeRefAs(ctx, pos, annotations, RefAsNonNull));
               return Ok{};
             }
             goto parse_error;
           case 'c':
             if (op == "ref.cast"sv) {
-              CHECK_ERR(makeRefCast(ctx, pos));
+              CHECK_ERR(makeRefCast(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 'e':
             if (op == "ref.eq"sv) {
-              CHECK_ERR(makeRefEq(ctx, pos));
+              CHECK_ERR(makeRefEq(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 'f':
             if (op == "ref.func"sv) {
-              CHECK_ERR(makeRefFunc(ctx, pos));
+              CHECK_ERR(makeRefFunc(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8098,13 +8098,13 @@ switch (buf[0]) {
             switch (buf[5]) {
               case '3':
                 if (op == "ref.i31"sv) {
-                  CHECK_ERR(makeRefI31(ctx, pos));
+                  CHECK_ERR(makeRefI31(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
               case 's':
                 if (op == "ref.is_null"sv) {
-                  CHECK_ERR(makeRefIsNull(ctx, pos));
+                  CHECK_ERR(makeRefIsNull(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8113,13 +8113,13 @@ switch (buf[0]) {
           }
           case 'n':
             if (op == "ref.null"sv) {
-              CHECK_ERR(makeRefNull(ctx, pos));
+              CHECK_ERR(makeRefNull(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 't':
             if (op == "ref.test"sv) {
-              CHECK_ERR(makeRefTest(ctx, pos));
+              CHECK_ERR(makeRefTest(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8128,7 +8128,7 @@ switch (buf[0]) {
       }
       case 's':
         if (op == "resume"sv) {
-          CHECK_ERR(makeResume(ctx, pos));
+          CHECK_ERR(makeResume(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -8136,7 +8136,7 @@ switch (buf[0]) {
         switch (buf[3]) {
           case 'h':
             if (op == "rethrow"sv) {
-              CHECK_ERR(makeRethrow(ctx, pos));
+              CHECK_ERR(makeRethrow(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8144,7 +8144,7 @@ switch (buf[0]) {
             switch (buf[6]) {
               case '\0':
                 if (op == "return"sv) {
-                  CHECK_ERR(makeReturn(ctx, pos));
+                  CHECK_ERR(makeReturn(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8152,7 +8152,7 @@ switch (buf[0]) {
                 switch (buf[11]) {
                   case '\0':
                     if (op == "return_call"sv) {
-                      CHECK_ERR(makeCall(ctx, pos, /*isReturn=*/true));
+                      CHECK_ERR(makeCall(ctx, pos, annotations, /*isReturn=*/true));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8160,13 +8160,13 @@ switch (buf[0]) {
                     switch (buf[12]) {
                       case 'i':
                         if (op == "return_call_indirect"sv) {
-                          CHECK_ERR(makeCallIndirect(ctx, pos, /*isReturn=*/true));
+                          CHECK_ERR(makeCallIndirect(ctx, pos, annotations, /*isReturn=*/true));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "return_call_ref"sv) {
-                          CHECK_ERR(makeCallRef(ctx, pos, /*isReturn=*/true));
+                          CHECK_ERR(makeCallRef(ctx, pos, annotations, /*isReturn=*/true));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8189,7 +8189,7 @@ switch (buf[0]) {
     switch (buf[1]) {
       case 'e':
         if (op == "select"sv) {
-          CHECK_ERR(makeSelect(ctx, pos));
+          CHECK_ERR(makeSelect(ctx, pos, annotations));
           return Ok{};
         }
         goto parse_error;
@@ -8203,7 +8203,7 @@ switch (buf[0]) {
                     switch (buf[10]) {
                       case 'i':
                         if (op == "string.as_iter"sv) {
-                          CHECK_ERR(makeStringAs(ctx, pos, StringAsIter));
+                          CHECK_ERR(makeStringAs(ctx, pos, annotations, StringAsIter));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8211,13 +8211,13 @@ switch (buf[0]) {
                         switch (buf[13]) {
                           case '1':
                             if (op == "string.as_wtf16"sv) {
-                              CHECK_ERR(makeStringAs(ctx, pos, StringAsWTF16));
+                              CHECK_ERR(makeStringAs(ctx, pos, annotations, StringAsWTF16));
                               return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "string.as_wtf8"sv) {
-                              CHECK_ERR(makeStringAs(ctx, pos, StringAsWTF8));
+                              CHECK_ERR(makeStringAs(ctx, pos, annotations, StringAsWTF8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8231,7 +8231,7 @@ switch (buf[0]) {
                     switch (buf[9]) {
                       case 'm':
                         if (op == "string.compare"sv) {
-                          CHECK_ERR(makeStringEq(ctx, pos, StringEqCompare));
+                          CHECK_ERR(makeStringEq(ctx, pos, annotations, StringEqCompare));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8239,13 +8239,13 @@ switch (buf[0]) {
                         switch (buf[10]) {
                           case 'c':
                             if (op == "string.concat"sv) {
-                              CHECK_ERR(makeStringConcat(ctx, pos));
+                              CHECK_ERR(makeStringConcat(ctx, pos, annotations));
                               return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "string.const"sv) {
-                              CHECK_ERR(makeStringConst(ctx, pos));
+                              CHECK_ERR(makeStringConst(ctx, pos, annotations));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8263,13 +8263,13 @@ switch (buf[0]) {
                             switch (buf[24]) {
                               case '\0':
                                 if (op == "string.encode_lossy_utf8"sv) {
-                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeLossyUTF8));
+                                  CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeLossyUTF8));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.encode_lossy_utf8_array"sv) {
-                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeLossyUTF8Array));
+                                  CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeLossyUTF8Array));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -8280,13 +8280,13 @@ switch (buf[0]) {
                             switch (buf[18]) {
                               case '\0':
                                 if (op == "string.encode_utf8"sv) {
-                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeUTF8));
+                                  CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeUTF8));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.encode_utf8_array"sv) {
-                                  CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeUTF8Array));
+                                  CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeUTF8Array));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -8299,13 +8299,13 @@ switch (buf[0]) {
                                 switch (buf[19]) {
                                   case '\0':
                                     if (op == "string.encode_wtf16"sv) {
-                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF16));
+                                      CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeWTF16));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case '_':
                                     if (op == "string.encode_wtf16_array"sv) {
-                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF16Array));
+                                      CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeWTF16Array));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -8316,13 +8316,13 @@ switch (buf[0]) {
                                 switch (buf[18]) {
                                   case '\0':
                                     if (op == "string.encode_wtf8"sv) {
-                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF8));
+                                      CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeWTF8));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case '_':
                                     if (op == "string.encode_wtf8_array"sv) {
-                                      CHECK_ERR(makeStringEncode(ctx, pos, StringEncodeWTF8Array));
+                                      CHECK_ERR(makeStringEncode(ctx, pos, annotations, StringEncodeWTF8Array));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -8337,7 +8337,7 @@ switch (buf[0]) {
                       }
                       case 'q':
                         if (op == "string.eq"sv) {
-                          CHECK_ERR(makeStringEq(ctx, pos, StringEqEqual));
+                          CHECK_ERR(makeStringEq(ctx, pos, annotations, StringEqEqual));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8346,19 +8346,19 @@ switch (buf[0]) {
                   }
                   case 'f':
                     if (op == "string.from_code_point"sv) {
-                      CHECK_ERR(makeStringNew(ctx, pos, StringNewFromCodePoint, false));
+                      CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewFromCodePoint, false));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'h':
                     if (op == "string.hash"sv) {
-                      CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureHash));
+                      CHECK_ERR(makeStringMeasure(ctx, pos, annotations, StringMeasureHash));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'i':
                     if (op == "string.is_usv_sequence"sv) {
-                      CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureIsUSV));
+                      CHECK_ERR(makeStringMeasure(ctx, pos, annotations, StringMeasureIsUSV));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8366,7 +8366,7 @@ switch (buf[0]) {
                     switch (buf[15]) {
                       case 'u':
                         if (op == "string.measure_utf8"sv) {
-                          CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureUTF8));
+                          CHECK_ERR(makeStringMeasure(ctx, pos, annotations, StringMeasureUTF8));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8374,13 +8374,13 @@ switch (buf[0]) {
                         switch (buf[18]) {
                           case '1':
                             if (op == "string.measure_wtf16"sv) {
-                              CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureWTF16));
+                              CHECK_ERR(makeStringMeasure(ctx, pos, annotations, StringMeasureWTF16));
                               return Ok{};
                             }
                             goto parse_error;
                           case '8':
                             if (op == "string.measure_wtf8"sv) {
-                              CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureWTF8));
+                              CHECK_ERR(makeStringMeasure(ctx, pos, annotations, StringMeasureWTF8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8396,13 +8396,13 @@ switch (buf[0]) {
                         switch (buf[21]) {
                           case '\0':
                             if (op == "string.new_lossy_utf8"sv) {
-                              CHECK_ERR(makeStringNew(ctx, pos, StringNewLossyUTF8, false));
+                              CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewLossyUTF8, false));
                               return Ok{};
                             }
                             goto parse_error;
                           case '_':
                             if (op == "string.new_lossy_utf8_array"sv) {
-                              CHECK_ERR(makeStringNew(ctx, pos, StringNewLossyUTF8Array, false));
+                              CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewLossyUTF8Array, false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8413,7 +8413,7 @@ switch (buf[0]) {
                         switch (buf[15]) {
                           case '\0':
                             if (op == "string.new_utf8"sv) {
-                              CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8, false));
+                              CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewUTF8, false));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8423,13 +8423,13 @@ switch (buf[0]) {
                                 switch (buf[21]) {
                                   case '\0':
                                     if (op == "string.new_utf8_array"sv) {
-                                      CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8Array, false));
+                                      CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewUTF8Array, false));
                                       return Ok{};
                                     }
                                     goto parse_error;
                                   case '_':
                                     if (op == "string.new_utf8_array_try"sv) {
-                                      CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8Array, true));
+                                      CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewUTF8Array, true));
                                       return Ok{};
                                     }
                                     goto parse_error;
@@ -8438,7 +8438,7 @@ switch (buf[0]) {
                               }
                               case 't':
                                 if (op == "string.new_utf8_try"sv) {
-                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewUTF8, true));
+                                  CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewUTF8, true));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -8454,13 +8454,13 @@ switch (buf[0]) {
                             switch (buf[16]) {
                               case '\0':
                                 if (op == "string.new_wtf16"sv) {
-                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF16, false));
+                                  CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewWTF16, false));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.new_wtf16_array"sv) {
-                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF16Array, false));
+                                  CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewWTF16Array, false));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -8471,13 +8471,13 @@ switch (buf[0]) {
                             switch (buf[15]) {
                               case '\0':
                                 if (op == "string.new_wtf8"sv) {
-                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF8, false));
+                                  CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewWTF8, false));
                                   return Ok{};
                                 }
                                 goto parse_error;
                               case '_':
                                 if (op == "string.new_wtf8_array"sv) {
-                                  CHECK_ERR(makeStringNew(ctx, pos, StringNewWTF8Array, false));
+                                  CHECK_ERR(makeStringNew(ctx, pos, annotations, StringNewWTF8Array, false));
                                   return Ok{};
                                 }
                                 goto parse_error;
@@ -8499,25 +8499,25 @@ switch (buf[0]) {
                     switch (buf[16]) {
                       case 'a':
                         if (op == "stringview_iter.advance"sv) {
-                          CHECK_ERR(makeStringIterMove(ctx, pos, StringIterMoveAdvance));
+                          CHECK_ERR(makeStringIterMove(ctx, pos, annotations, StringIterMoveAdvance));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'n':
                         if (op == "stringview_iter.next"sv) {
-                          CHECK_ERR(makeStringIterNext(ctx, pos));
+                          CHECK_ERR(makeStringIterNext(ctx, pos, annotations));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'r':
                         if (op == "stringview_iter.rewind"sv) {
-                          CHECK_ERR(makeStringIterMove(ctx, pos, StringIterMoveRewind));
+                          CHECK_ERR(makeStringIterMove(ctx, pos, annotations, StringIterMoveRewind));
                           return Ok{};
                         }
                         goto parse_error;
                       case 's':
                         if (op == "stringview_iter.slice"sv) {
-                          CHECK_ERR(makeStringSliceIter(ctx, pos));
+                          CHECK_ERR(makeStringSliceIter(ctx, pos, annotations));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8530,19 +8530,19 @@ switch (buf[0]) {
                         switch (buf[17]) {
                           case 'g':
                             if (op == "stringview_wtf16.get_codeunit"sv) {
-                              CHECK_ERR(makeStringWTF16Get(ctx, pos));
+                              CHECK_ERR(makeStringWTF16Get(ctx, pos, annotations));
                               return Ok{};
                             }
                             goto parse_error;
                           case 'l':
                             if (op == "stringview_wtf16.length"sv) {
-                              CHECK_ERR(makeStringMeasure(ctx, pos, StringMeasureWTF16View));
+                              CHECK_ERR(makeStringMeasure(ctx, pos, annotations, StringMeasureWTF16View));
                               return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "stringview_wtf16.slice"sv) {
-                              CHECK_ERR(makeStringSliceWTF(ctx, pos, StringSliceWTF16));
+                              CHECK_ERR(makeStringSliceWTF(ctx, pos, annotations, StringSliceWTF16));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8553,13 +8553,13 @@ switch (buf[0]) {
                         switch (buf[16]) {
                           case 'a':
                             if (op == "stringview_wtf8.advance"sv) {
-                              CHECK_ERR(makeStringWTF8Advance(ctx, pos));
+                              CHECK_ERR(makeStringWTF8Advance(ctx, pos, annotations));
                               return Ok{};
                             }
                             goto parse_error;
                           case 's':
                             if (op == "stringview_wtf8.slice"sv) {
-                              CHECK_ERR(makeStringSliceWTF(ctx, pos, StringSliceWTF8));
+                              CHECK_ERR(makeStringSliceWTF(ctx, pos, annotations, StringSliceWTF8));
                               return Ok{};
                             }
                             goto parse_error;
@@ -8581,7 +8581,7 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case '\0':
                     if (op == "struct.get"sv) {
-                      CHECK_ERR(makeStructGet(ctx, pos));
+                      CHECK_ERR(makeStructGet(ctx, pos, annotations));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8589,13 +8589,13 @@ switch (buf[0]) {
                     switch (buf[11]) {
                       case 's':
                         if (op == "struct.get_s"sv) {
-                          CHECK_ERR(makeStructGet(ctx, pos, true));
+                          CHECK_ERR(makeStructGet(ctx, pos, annotations, true));
                           return Ok{};
                         }
                         goto parse_error;
                       case 'u':
                         if (op == "struct.get_u"sv) {
-                          CHECK_ERR(makeStructGet(ctx, pos, false));
+                          CHECK_ERR(makeStructGet(ctx, pos, annotations, false));
                           return Ok{};
                         }
                         goto parse_error;
@@ -8609,13 +8609,13 @@ switch (buf[0]) {
                 switch (buf[10]) {
                   case '\0':
                     if (op == "struct.new"sv) {
-                      CHECK_ERR(makeStructNew(ctx, pos, false));
+                      CHECK_ERR(makeStructNew(ctx, pos, annotations, false));
                       return Ok{};
                     }
                     goto parse_error;
                   case '_':
                     if (op == "struct.new_default"sv) {
-                      CHECK_ERR(makeStructNew(ctx, pos, true));
+                      CHECK_ERR(makeStructNew(ctx, pos, annotations, true));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8624,7 +8624,7 @@ switch (buf[0]) {
               }
               case 's':
                 if (op == "struct.set"sv) {
-                  CHECK_ERR(makeStructSet(ctx, pos));
+                  CHECK_ERR(makeStructSet(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8643,13 +8643,13 @@ switch (buf[0]) {
         switch (buf[6]) {
           case 'c':
             if (op == "table.copy"sv) {
-              CHECK_ERR(makeTableCopy(ctx, pos));
+              CHECK_ERR(makeTableCopy(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 'f':
             if (op == "table.fill"sv) {
-              CHECK_ERR(makeTableFill(ctx, pos));
+              CHECK_ERR(makeTableFill(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8657,13 +8657,13 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'e':
                 if (op == "table.get"sv) {
-                  CHECK_ERR(makeTableGet(ctx, pos));
+                  CHECK_ERR(makeTableGet(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
               case 'r':
                 if (op == "table.grow"sv) {
-                  CHECK_ERR(makeTableGrow(ctx, pos));
+                  CHECK_ERR(makeTableGrow(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8674,13 +8674,13 @@ switch (buf[0]) {
             switch (buf[7]) {
               case 'e':
                 if (op == "table.set"sv) {
-                  CHECK_ERR(makeTableSet(ctx, pos));
+                  CHECK_ERR(makeTableSet(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
               case 'i':
                 if (op == "table.size"sv) {
-                  CHECK_ERR(makeTableSize(ctx, pos));
+                  CHECK_ERR(makeTableSize(ctx, pos, annotations));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8694,13 +8694,13 @@ switch (buf[0]) {
         switch (buf[5]) {
           case '\0':
             if (op == "throw"sv) {
-              CHECK_ERR(makeThrow(ctx, pos));
+              CHECK_ERR(makeThrow(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case '_':
             if (op == "throw_ref"sv) {
-              CHECK_ERR(makeThrowRef(ctx, pos));
+              CHECK_ERR(makeThrowRef(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8711,19 +8711,19 @@ switch (buf[0]) {
         switch (buf[6]) {
           case 'd':
             if (op == "tuple.drop"sv) {
-              CHECK_ERR(makeTupleDrop(ctx, pos));
+              CHECK_ERR(makeTupleDrop(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 'e':
             if (op == "tuple.extract"sv) {
-              CHECK_ERR(makeTupleExtract(ctx, pos));
+              CHECK_ERR(makeTupleExtract(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
           case 'm':
             if (op == "tuple.make"sv) {
-              CHECK_ERR(makeTupleMake(ctx, pos));
+              CHECK_ERR(makeTupleMake(ctx, pos, annotations));
               return Ok{};
             }
             goto parse_error;
@@ -8735,7 +8735,7 @@ switch (buf[0]) {
   }
   case 'u':
     if (op == "unreachable"sv) {
-      CHECK_ERR(makeUnreachable(ctx, pos));
+      CHECK_ERR(makeUnreachable(ctx, pos, annotations));
       return Ok{};
     }
     goto parse_error;
@@ -8747,13 +8747,13 @@ switch (buf[0]) {
             switch (buf[8]) {
               case '\0':
                 if (op == "v128.and"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndVec128));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AndVec128));
                   return Ok{};
                 }
                 goto parse_error;
               case 'n':
                 if (op == "v128.andnot"sv) {
-                  CHECK_ERR(makeBinary(ctx, pos, BinaryOp::AndNotVec128));
+                  CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::AndNotVec128));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8762,7 +8762,7 @@ switch (buf[0]) {
           }
           case 'y':
             if (op == "v128.any_true"sv) {
-              CHECK_ERR(makeUnary(ctx, pos, UnaryOp::AnyTrueVec128));
+              CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::AnyTrueVec128));
               return Ok{};
             }
             goto parse_error;
@@ -8771,13 +8771,13 @@ switch (buf[0]) {
       }
       case 'b':
         if (op == "v128.bitselect"sv) {
-          CHECK_ERR(makeSIMDTernary(ctx, pos, SIMDTernaryOp::Bitselect));
+          CHECK_ERR(makeSIMDTernary(ctx, pos, annotations, SIMDTernaryOp::Bitselect));
           return Ok{};
         }
         goto parse_error;
       case 'c':
         if (op == "v128.const"sv) {
-          CHECK_ERR(makeConst(ctx, pos, Type::v128));
+          CHECK_ERR(makeConst(ctx, pos, annotations, Type::v128));
           return Ok{};
         }
         goto parse_error;
@@ -8785,7 +8785,7 @@ switch (buf[0]) {
         switch (buf[9]) {
           case '\0':
             if (op == "v128.load"sv) {
-              CHECK_ERR(makeLoad(ctx, pos, Type::v128, /*signed=*/false, 16, /*isAtomic=*/false));
+              CHECK_ERR(makeLoad(ctx, pos, annotations, Type::v128, /*signed=*/false, 16, /*isAtomic=*/false));
               return Ok{};
             }
             goto parse_error;
@@ -8795,13 +8795,13 @@ switch (buf[0]) {
                 switch (buf[12]) {
                   case 'l':
                     if (op == "v128.load16_lane"sv) {
-                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load16LaneVec128, 2));
+                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Load16LaneVec128, 2));
                       return Ok{};
                     }
                     goto parse_error;
                   case 's':
                     if (op == "v128.load16_splat"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16SplatVec128, 2));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load16SplatVec128, 2));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8812,13 +8812,13 @@ switch (buf[0]) {
                 switch (buf[14]) {
                   case 's':
                     if (op == "v128.load16x4_s"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16x4SVec128, 8));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load16x4SVec128, 8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "v128.load16x4_u"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load16x4UVec128, 8));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load16x4UVec128, 8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8834,19 +8834,19 @@ switch (buf[0]) {
                 switch (buf[12]) {
                   case 'l':
                     if (op == "v128.load32_lane"sv) {
-                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load32LaneVec128, 4));
+                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Load32LaneVec128, 4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 's':
                     if (op == "v128.load32_splat"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32SplatVec128, 4));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load32SplatVec128, 4));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'z':
                     if (op == "v128.load32_zero"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32ZeroVec128, 4));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load32ZeroVec128, 4));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8857,13 +8857,13 @@ switch (buf[0]) {
                 switch (buf[14]) {
                   case 's':
                     if (op == "v128.load32x2_s"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32x2SVec128, 8));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load32x2SVec128, 8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "v128.load32x2_u"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load32x2UVec128, 8));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load32x2UVec128, 8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8877,19 +8877,19 @@ switch (buf[0]) {
             switch (buf[12]) {
               case 'l':
                 if (op == "v128.load64_lane"sv) {
-                  CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load64LaneVec128, 8));
+                  CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Load64LaneVec128, 8));
                   return Ok{};
                 }
                 goto parse_error;
               case 's':
                 if (op == "v128.load64_splat"sv) {
-                  CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load64SplatVec128, 8));
+                  CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load64SplatVec128, 8));
                   return Ok{};
                 }
                 goto parse_error;
               case 'z':
                 if (op == "v128.load64_zero"sv) {
-                  CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load64ZeroVec128, 8));
+                  CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load64ZeroVec128, 8));
                   return Ok{};
                 }
                 goto parse_error;
@@ -8902,13 +8902,13 @@ switch (buf[0]) {
                 switch (buf[11]) {
                   case 'l':
                     if (op == "v128.load8_lane"sv) {
-                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Load8LaneVec128, 1));
+                      CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Load8LaneVec128, 1));
                       return Ok{};
                     }
                     goto parse_error;
                   case 's':
                     if (op == "v128.load8_splat"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8SplatVec128, 1));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load8SplatVec128, 1));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8919,13 +8919,13 @@ switch (buf[0]) {
                 switch (buf[13]) {
                   case 's':
                     if (op == "v128.load8x8_s"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8x8SVec128, 8));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load8x8SVec128, 8));
                       return Ok{};
                     }
                     goto parse_error;
                   case 'u':
                     if (op == "v128.load8x8_u"sv) {
-                      CHECK_ERR(makeSIMDLoad(ctx, pos, SIMDLoadOp::Load8x8UVec128, 8));
+                      CHECK_ERR(makeSIMDLoad(ctx, pos, annotations, SIMDLoadOp::Load8x8UVec128, 8));
                       return Ok{};
                     }
                     goto parse_error;
@@ -8940,13 +8940,13 @@ switch (buf[0]) {
       }
       case 'n':
         if (op == "v128.not"sv) {
-          CHECK_ERR(makeUnary(ctx, pos, UnaryOp::NotVec128));
+          CHECK_ERR(makeUnary(ctx, pos, annotations, UnaryOp::NotVec128));
           return Ok{};
         }
         goto parse_error;
       case 'o':
         if (op == "v128.or"sv) {
-          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::OrVec128));
+          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::OrVec128));
           return Ok{};
         }
         goto parse_error;
@@ -8954,31 +8954,31 @@ switch (buf[0]) {
         switch (buf[10]) {
           case '\0':
             if (op == "v128.store"sv) {
-              CHECK_ERR(makeStore(ctx, pos, Type::v128, 16, /*isAtomic=*/false));
+              CHECK_ERR(makeStore(ctx, pos, annotations, Type::v128, 16, /*isAtomic=*/false));
               return Ok{};
             }
             goto parse_error;
           case '1':
             if (op == "v128.store16_lane"sv) {
-              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store16LaneVec128, 2));
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Store16LaneVec128, 2));
               return Ok{};
             }
             goto parse_error;
           case '3':
             if (op == "v128.store32_lane"sv) {
-              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store32LaneVec128, 4));
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Store32LaneVec128, 4));
               return Ok{};
             }
             goto parse_error;
           case '6':
             if (op == "v128.store64_lane"sv) {
-              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store64LaneVec128, 8));
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Store64LaneVec128, 8));
               return Ok{};
             }
             goto parse_error;
           case '8':
             if (op == "v128.store8_lane"sv) {
-              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, SIMDLoadStoreLaneOp::Store8LaneVec128, 1));
+              CHECK_ERR(makeSIMDLoadStoreLane(ctx, pos, annotations, SIMDLoadStoreLaneOp::Store8LaneVec128, 1));
               return Ok{};
             }
             goto parse_error;
@@ -8987,7 +8987,7 @@ switch (buf[0]) {
       }
       case 'x':
         if (op == "v128.xor"sv) {
-          CHECK_ERR(makeBinary(ctx, pos, BinaryOp::XorVec128));
+          CHECK_ERR(makeBinary(ctx, pos, annotations, BinaryOp::XorVec128));
           return Ok{};
         }
         goto parse_error;

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -2523,7 +2523,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeStringSliceIter());
   }
 
-  Result<> makeContNew(Index pos, const std::vector<Annotation>& annotations, HeapType type) {
+  Result<> makeContNew(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       HeapType type) {
     return withLoc(pos, irBuilder.makeContNew(type));
   }
 

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -355,20 +355,32 @@ struct NullInstrParserCtx {
   MemargT getMemarg(uint64_t, uint32_t) { return Ok{}; }
 
   template<typename BlockTypeT>
-  Result<> makeBlock(Index, std::optional<Name>, BlockTypeT) {
+  Result<> makeBlock(Index,
+                     const std::vector<Annotation>&,
+                     std::optional<Name>,
+                     BlockTypeT) {
     return Ok{};
   }
   template<typename BlockTypeT>
-  Result<> makeIf(Index, std::optional<Name>, BlockTypeT) {
+  Result<> makeIf(Index,
+                  const std::vector<Annotation>&,
+                  std::optional<Name>,
+                  BlockTypeT) {
     return Ok{};
   }
   Result<> visitElse() { return Ok{}; }
   template<typename BlockTypeT>
-  Result<> makeLoop(Index, std::optional<Name>, BlockTypeT) {
+  Result<> makeLoop(Index,
+                    const std::vector<Annotation>&,
+                    std::optional<Name>,
+                    BlockTypeT) {
     return Ok{};
   }
   template<typename BlockTypeT>
-  Result<> makeTry(Index, std::optional<Name>, BlockTypeT) {
+  Result<> makeTry(Index,
+                   const std::vector<Annotation>&,
+                   std::optional<Name>,
+                   BlockTypeT) {
     return Ok{};
   }
   Result<> visitCatch(Index, TagIdxT) { return Ok{}; }
@@ -383,198 +395,427 @@ struct NullInstrParserCtx {
   CatchT makeCatchAll(LabelIdxT) { return Ok{}; }
   CatchT makeCatchAllRef(LabelIdxT) { return Ok{}; }
   template<typename BlockTypeT>
-  Result<> makeTryTable(Index, std::optional<Name>, BlockTypeT, CatchListT) {
+  Result<> makeTryTable(Index,
+                        const std::vector<Annotation>&,
+                        std::optional<Name>,
+                        BlockTypeT,
+                        CatchListT) {
     return Ok{};
   }
 
   TagLabelListT makeTagLabelList() { return Ok{}; }
   void appendTagLabel(TagLabelListT&, TagIdxT, LabelIdxT) {}
 
-  Result<> makeUnreachable(Index) { return Ok{}; }
-  Result<> makeNop(Index) { return Ok{}; }
-  Result<> makeBinary(Index, BinaryOp) { return Ok{}; }
-  Result<> makeUnary(Index, UnaryOp) { return Ok{}; }
-  template<typename ResultsT> Result<> makeSelect(Index, ResultsT*) {
-    return Ok{};
-  }
-  Result<> makeDrop(Index) { return Ok{}; }
-  Result<> makeMemorySize(Index, MemoryIdxT*) { return Ok{}; }
-  Result<> makeMemoryGrow(Index, MemoryIdxT*) { return Ok{}; }
-  Result<> makeLocalGet(Index, LocalIdxT) { return Ok{}; }
-  Result<> makeLocalTee(Index, LocalIdxT) { return Ok{}; }
-  Result<> makeLocalSet(Index, LocalIdxT) { return Ok{}; }
-  Result<> makeGlobalGet(Index, GlobalIdxT) { return Ok{}; }
-  Result<> makeGlobalSet(Index, GlobalIdxT) { return Ok{}; }
+  void setSrcLoc(const Annotation&) {}
 
-  Result<> makeI32Const(Index, uint32_t) { return Ok{}; }
-  Result<> makeI64Const(Index, uint64_t) { return Ok{}; }
-  Result<> makeF32Const(Index, float) { return Ok{}; }
-  Result<> makeF64Const(Index, double) { return Ok{}; }
-  Result<> makeI8x16Const(Index, const std::array<uint8_t, 16>&) {
+  Result<> makeUnreachable(Index, const std::vector<Annotation>&) {
     return Ok{};
   }
-  Result<> makeI16x8Const(Index, const std::array<uint16_t, 8>&) {
+  Result<> makeNop(Index, const std::vector<Annotation>&) { return Ok{}; }
+  Result<> makeBinary(Index, const std::vector<Annotation>&, BinaryOp) {
     return Ok{};
   }
-  Result<> makeI32x4Const(Index, const std::array<uint32_t, 4>&) {
+  Result<> makeUnary(Index, const std::vector<Annotation>&, UnaryOp) {
     return Ok{};
   }
-  Result<> makeI64x2Const(Index, const std::array<uint64_t, 2>&) {
+  template<typename ResultsT>
+  Result<> makeSelect(Index, const std::vector<Annotation>&, ResultsT*) {
     return Ok{};
   }
-  Result<> makeF32x4Const(Index, const std::array<float, 4>&) { return Ok{}; }
-  Result<> makeF64x2Const(Index, const std::array<double, 2>&) { return Ok{}; }
-  Result<> makeLoad(Index, Type, bool, int, bool, MemoryIdxT*, MemargT) {
+  Result<> makeDrop(Index, const std::vector<Annotation>&) { return Ok{}; }
+  Result<> makeMemorySize(Index, const std::vector<Annotation>&, MemoryIdxT*) {
     return Ok{};
   }
-  Result<> makeStore(Index, Type, int, bool, MemoryIdxT*, MemargT) {
+  Result<> makeMemoryGrow(Index, const std::vector<Annotation>&, MemoryIdxT*) {
     return Ok{};
   }
-  Result<> makeAtomicRMW(Index, AtomicRMWOp, Type, int, MemoryIdxT*, MemargT) {
+  Result<> makeLocalGet(Index, const std::vector<Annotation>&, LocalIdxT) {
     return Ok{};
   }
-  Result<> makeAtomicCmpxchg(Index, Type, int, MemoryIdxT*, MemargT) {
+  Result<> makeLocalTee(Index, const std::vector<Annotation>&, LocalIdxT) {
     return Ok{};
   }
-  Result<> makeAtomicWait(Index, Type, MemoryIdxT*, MemargT) { return Ok{}; }
-  Result<> makeAtomicNotify(Index, MemoryIdxT*, MemargT) { return Ok{}; }
-  Result<> makeAtomicFence(Index) { return Ok{}; }
-  Result<> makeSIMDExtract(Index, SIMDExtractOp, uint8_t) { return Ok{}; }
-  Result<> makeSIMDReplace(Index, SIMDReplaceOp, uint8_t) { return Ok{}; }
-  Result<> makeSIMDShuffle(Index, const std::array<uint8_t, 16>&) {
+  Result<> makeLocalSet(Index, const std::vector<Annotation>&, LocalIdxT) {
     return Ok{};
   }
-  Result<> makeSIMDTernary(Index, SIMDTernaryOp) { return Ok{}; }
-  Result<> makeSIMDShift(Index, SIMDShiftOp) { return Ok{}; }
-  Result<> makeSIMDLoad(Index, SIMDLoadOp, MemoryIdxT*, MemargT) {
+  Result<> makeGlobalGet(Index, const std::vector<Annotation>&, GlobalIdxT) {
     return Ok{};
   }
-  Result<> makeSIMDLoadStoreLane(
-    Index, SIMDLoadStoreLaneOp, MemoryIdxT*, MemargT, uint8_t) {
+  Result<> makeGlobalSet(Index, const std::vector<Annotation>&, GlobalIdxT) {
     return Ok{};
   }
-  Result<> makeMemoryInit(Index, MemoryIdxT*, DataIdxT) { return Ok{}; }
-  Result<> makeDataDrop(Index, DataIdxT) { return Ok{}; }
 
-  Result<> makeMemoryCopy(Index, MemoryIdxT*, MemoryIdxT*) { return Ok{}; }
-  Result<> makeMemoryFill(Index, MemoryIdxT*) { return Ok{}; }
-  template<typename TypeT> Result<> makePop(Index, TypeT) { return Ok{}; }
-  Result<> makeCall(Index, FuncIdxT, bool) { return Ok{}; }
+  Result<> makeI32Const(Index, const std::vector<Annotation>&, uint32_t) {
+    return Ok{};
+  }
+  Result<> makeI64Const(Index, const std::vector<Annotation>&, uint64_t) {
+    return Ok{};
+  }
+  Result<> makeF32Const(Index, const std::vector<Annotation>&, float) {
+    return Ok{};
+  }
+  Result<> makeF64Const(Index, const std::vector<Annotation>&, double) {
+    return Ok{};
+  }
+  Result<> makeI8x16Const(Index,
+                          const std::vector<Annotation>&,
+                          const std::array<uint8_t, 16>&) {
+    return Ok{};
+  }
+  Result<> makeI16x8Const(Index,
+                          const std::vector<Annotation>&,
+                          const std::array<uint16_t, 8>&) {
+    return Ok{};
+  }
+  Result<> makeI32x4Const(Index,
+                          const std::vector<Annotation>&,
+                          const std::array<uint32_t, 4>&) {
+    return Ok{};
+  }
+  Result<> makeI64x2Const(Index,
+                          const std::vector<Annotation>&,
+                          const std::array<uint64_t, 2>&) {
+    return Ok{};
+  }
+  Result<> makeF32x4Const(Index,
+                          const std::vector<Annotation>&,
+                          const std::array<float, 4>&) {
+    return Ok{};
+  }
+  Result<> makeF64x2Const(Index,
+                          const std::vector<Annotation>&,
+                          const std::array<double, 2>&) {
+    return Ok{};
+  }
+  Result<> makeLoad(Index,
+                    const std::vector<Annotation>&,
+                    Type,
+                    bool,
+                    int,
+                    bool,
+                    MemoryIdxT*,
+                    MemargT) {
+    return Ok{};
+  }
+  Result<> makeStore(Index,
+                     const std::vector<Annotation>&,
+                     Type,
+                     int,
+                     bool,
+                     MemoryIdxT*,
+                     MemargT) {
+    return Ok{};
+  }
+  Result<> makeAtomicRMW(Index,
+                         const std::vector<Annotation>&,
+                         AtomicRMWOp,
+                         Type,
+                         int,
+                         MemoryIdxT*,
+                         MemargT) {
+    return Ok{};
+  }
+  Result<> makeAtomicCmpxchg(
+    Index, const std::vector<Annotation>&, Type, int, MemoryIdxT*, MemargT) {
+    return Ok{};
+  }
+  Result<> makeAtomicWait(
+    Index, const std::vector<Annotation>&, Type, MemoryIdxT*, MemargT) {
+    return Ok{};
+  }
+  Result<> makeAtomicNotify(Index,
+                            const std::vector<Annotation>&,
+                            MemoryIdxT*,
+                            MemargT) {
+    return Ok{};
+  }
+  Result<> makeAtomicFence(Index, const std::vector<Annotation>&) {
+    return Ok{};
+  }
+  Result<> makeSIMDExtract(Index,
+                           const std::vector<Annotation>&,
+                           SIMDExtractOp,
+                           uint8_t) {
+    return Ok{};
+  }
+  Result<> makeSIMDReplace(Index,
+                           const std::vector<Annotation>&,
+                           SIMDReplaceOp,
+                           uint8_t) {
+    return Ok{};
+  }
+  Result<> makeSIMDShuffle(Index,
+                           const std::vector<Annotation>&,
+                           const std::array<uint8_t, 16>&) {
+    return Ok{};
+  }
+  Result<>
+  makeSIMDTernary(Index, const std::vector<Annotation>&, SIMDTernaryOp) {
+    return Ok{};
+  }
+  Result<> makeSIMDShift(Index, const std::vector<Annotation>&, SIMDShiftOp) {
+    return Ok{};
+  }
+  Result<> makeSIMDLoad(
+    Index, const std::vector<Annotation>&, SIMDLoadOp, MemoryIdxT*, MemargT) {
+    return Ok{};
+  }
+  Result<> makeSIMDLoadStoreLane(Index,
+                                 const std::vector<Annotation>&,
+                                 SIMDLoadStoreLaneOp,
+                                 MemoryIdxT*,
+                                 MemargT,
+                                 uint8_t) {
+    return Ok{};
+  }
+  Result<>
+  makeMemoryInit(Index, const std::vector<Annotation>&, MemoryIdxT*, DataIdxT) {
+    return Ok{};
+  }
+  Result<> makeDataDrop(Index, const std::vector<Annotation>&, DataIdxT) {
+    return Ok{};
+  }
+
+  Result<> makeMemoryCopy(Index,
+                          const std::vector<Annotation>&,
+                          MemoryIdxT*,
+                          MemoryIdxT*) {
+    return Ok{};
+  }
+  Result<> makeMemoryFill(Index, const std::vector<Annotation>&, MemoryIdxT*) {
+    return Ok{};
+  }
+  template<typename TypeT>
+  Result<> makePop(Index, const std::vector<Annotation>&, TypeT) {
+    return Ok{};
+  }
+  Result<> makeCall(Index, const std::vector<Annotation>&, FuncIdxT, bool) {
+    return Ok{};
+  }
   template<typename TypeUseT>
-  Result<> makeCallIndirect(Index, TableIdxT*, TypeUseT, bool) {
+  Result<> makeCallIndirect(
+    Index, const std::vector<Annotation>&, TableIdxT*, TypeUseT, bool) {
     return Ok{};
   }
-  Result<> makeBreak(Index, LabelIdxT, bool) { return Ok{}; }
-  Result<> makeSwitch(Index, const std::vector<LabelIdxT>&, LabelIdxT) {
+  Result<> makeBreak(Index, const std::vector<Annotation>&, LabelIdxT, bool) {
     return Ok{};
   }
-  Result<> makeReturn(Index) { return Ok{}; }
-  template<typename HeapTypeT> Result<> makeRefNull(Index, HeapTypeT) {
+  Result<> makeSwitch(Index,
+                      const std::vector<Annotation>&,
+                      const std::vector<LabelIdxT>&,
+                      LabelIdxT) {
     return Ok{};
   }
-  Result<> makeRefIsNull(Index) { return Ok{}; }
-  Result<> makeRefFunc(Index, FuncIdxT) { return Ok{}; }
-  Result<> makeRefEq(Index) { return Ok{}; }
-  Result<> makeTableGet(Index, TableIdxT*) { return Ok{}; }
-  Result<> makeTableSet(Index, TableIdxT*) { return Ok{}; }
-  Result<> makeTableSize(Index, TableIdxT*) { return Ok{}; }
-  Result<> makeTableGrow(Index, TableIdxT*) { return Ok{}; }
-  Result<> makeTableFill(Index, TableIdxT*) { return Ok{}; }
-  Result<> makeTableCopy(Index, TableIdxT*, TableIdxT*) { return Ok{}; }
-  Result<> makeThrow(Index, TagIdxT) { return Ok{}; }
-  Result<> makeRethrow(Index, LabelIdxT) { return Ok{}; }
-  Result<> makeThrowRef(Index) { return Ok{}; }
-  Result<> makeTupleMake(Index, uint32_t) { return Ok{}; }
-  Result<> makeTupleExtract(Index, uint32_t, uint32_t) { return Ok{}; }
-  Result<> makeTupleDrop(Index, uint32_t) { return Ok{}; }
-  template<typename HeapTypeT> Result<> makeCallRef(Index, HeapTypeT, bool) {
+  Result<> makeReturn(Index, const std::vector<Annotation>&) { return Ok{}; }
+  template<typename HeapTypeT>
+  Result<> makeRefNull(Index, const std::vector<Annotation>&, HeapTypeT) {
     return Ok{};
   }
-  Result<> makeRefI31(Index) { return Ok{}; }
-  Result<> makeI31Get(Index, bool) { return Ok{}; }
-  template<typename TypeT> Result<> makeRefTest(Index, TypeT) { return Ok{}; }
-  template<typename TypeT> Result<> makeRefCast(Index, TypeT) { return Ok{}; }
+  Result<> makeRefIsNull(Index, const std::vector<Annotation>&) { return Ok{}; }
+  Result<> makeRefFunc(Index, const std::vector<Annotation>&, FuncIdxT) {
+    return Ok{};
+  }
+  Result<> makeRefEq(Index, const std::vector<Annotation>&) { return Ok{}; }
+  Result<> makeTableGet(Index, const std::vector<Annotation>&, TableIdxT*) {
+    return Ok{};
+  }
+  Result<> makeTableSet(Index, const std::vector<Annotation>&, TableIdxT*) {
+    return Ok{};
+  }
+  Result<> makeTableSize(Index, const std::vector<Annotation>&, TableIdxT*) {
+    return Ok{};
+  }
+  Result<> makeTableGrow(Index, const std::vector<Annotation>&, TableIdxT*) {
+    return Ok{};
+  }
+  Result<> makeTableFill(Index, const std::vector<Annotation>&, TableIdxT*) {
+    return Ok{};
+  }
+  Result<>
+  makeTableCopy(Index, const std::vector<Annotation>&, TableIdxT*, TableIdxT*) {
+    return Ok{};
+  }
+  Result<> makeThrow(Index, const std::vector<Annotation>&, TagIdxT) {
+    return Ok{};
+  }
+  Result<> makeRethrow(Index, const std::vector<Annotation>&, LabelIdxT) {
+    return Ok{};
+  }
+  Result<> makeThrowRef(Index, const std::vector<Annotation>&) { return Ok{}; }
+  Result<> makeTupleMake(Index, const std::vector<Annotation>&, uint32_t) {
+    return Ok{};
+  }
+  Result<>
+  makeTupleExtract(Index, const std::vector<Annotation>&, uint32_t, uint32_t) {
+    return Ok{};
+  }
+  Result<> makeTupleDrop(Index, const std::vector<Annotation>&, uint32_t) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeCallRef(Index, const std::vector<Annotation>&, HeapTypeT, bool) {
+    return Ok{};
+  }
+  Result<> makeRefI31(Index, const std::vector<Annotation>&) { return Ok{}; }
+  Result<> makeI31Get(Index, const std::vector<Annotation>&, bool) {
+    return Ok{};
+  }
+  template<typename TypeT>
+  Result<> makeRefTest(Index, const std::vector<Annotation>&, TypeT) {
+    return Ok{};
+  }
+  template<typename TypeT>
+  Result<> makeRefCast(Index, const std::vector<Annotation>&, TypeT) {
+    return Ok{};
+  }
 
-  Result<> makeBrOn(Index, LabelIdxT, BrOnOp) { return Ok{}; }
+  Result<> makeBrOn(Index, const std::vector<Annotation>&, LabelIdxT, BrOnOp) {
+    return Ok{};
+  }
 
   template<typename TypeT>
-  Result<> makeBrOn(Index, LabelIdxT, BrOnOp, TypeT, TypeT) {
+  Result<> makeBrOn(
+    Index, const std::vector<Annotation>&, LabelIdxT, BrOnOp, TypeT, TypeT) {
     return Ok{};
   }
 
-  template<typename HeapTypeT> Result<> makeStructNew(Index, HeapTypeT) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> Result<> makeStructNewDefault(Index, HeapTypeT) {
+  template<typename HeapTypeT>
+  Result<> makeStructNew(Index, const std::vector<Annotation>&, HeapTypeT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeStructGet(Index, HeapTypeT, FieldIdxT, bool) {
+  Result<>
+  makeStructNewDefault(Index, const std::vector<Annotation>&, HeapTypeT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeStructSet(Index, HeapTypeT, FieldIdxT) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> Result<> makeArrayNew(Index, HeapTypeT) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> Result<> makeArrayNewDefault(Index, HeapTypeT) {
+  Result<> makeStructGet(
+    Index, const std::vector<Annotation>&, HeapTypeT, FieldIdxT, bool) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeArrayNewData(Index, HeapTypeT, DataIdxT) {
+  Result<>
+  makeStructSet(Index, const std::vector<Annotation>&, HeapTypeT, FieldIdxT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeArrayNewElem(Index, HeapTypeT, ElemIdxT) {
+  Result<> makeArrayNew(Index, const std::vector<Annotation>&, HeapTypeT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeArrayNewFixed(Index, HeapTypeT, uint32_t) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> Result<> makeArrayGet(Index, HeapTypeT, bool) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> Result<> makeArraySet(Index, HeapTypeT) {
-    return Ok{};
-  }
-  Result<> makeArrayLen(Index) { return Ok{}; }
-  template<typename HeapTypeT>
-  Result<> makeArrayCopy(Index, HeapTypeT, HeapTypeT) {
-    return Ok{};
-  }
-  template<typename HeapTypeT> Result<> makeArrayFill(Index, HeapTypeT) {
+  Result<>
+  makeArrayNewDefault(Index, const std::vector<Annotation>&, HeapTypeT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeArrayInitData(Index, HeapTypeT, DataIdxT) {
+  Result<>
+  makeArrayNewData(Index, const std::vector<Annotation>&, HeapTypeT, DataIdxT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeArrayInitElem(Index, HeapTypeT, ElemIdxT) {
-    return Ok{};
-  }
-  Result<> makeRefAs(Index, RefAsOp) { return Ok{}; }
-  Result<> makeStringNew(Index, StringNewOp, bool, MemoryIdxT*) { return Ok{}; }
-  Result<> makeStringConst(Index, std::string_view) { return Ok{}; }
-  Result<> makeStringMeasure(Index, StringMeasureOp) { return Ok{}; }
-  Result<> makeStringEncode(Index, StringEncodeOp, MemoryIdxT*) { return Ok{}; }
-  Result<> makeStringConcat(Index) { return Ok{}; }
-  Result<> makeStringEq(Index, StringEqOp) { return Ok{}; }
-  Result<> makeStringAs(Index, StringAsOp) { return Ok{}; }
-  Result<> makeStringWTF8Advance(Index) { return Ok{}; }
-  Result<> makeStringWTF16Get(Index) { return Ok{}; }
-  Result<> makeStringIterNext(Index) { return Ok{}; }
-  Result<> makeStringIterMove(Index, StringIterMoveOp) { return Ok{}; }
-  Result<> makeStringSliceWTF(Index, StringSliceWTFOp) { return Ok{}; }
-  Result<> makeStringSliceIter(Index) { return Ok{}; }
-  template<typename HeapTypeT> Result<> makeContNew(Index, HeapTypeT) {
+  Result<>
+  makeArrayNewElem(Index, const std::vector<Annotation>&, HeapTypeT, ElemIdxT) {
     return Ok{};
   }
   template<typename HeapTypeT>
-  Result<> makeResume(Index, HeapTypeT, const TagLabelListT&) {
+  Result<> makeArrayNewFixed(Index,
+                             const std::vector<Annotation>&,
+                             HeapTypeT,
+                             uint32_t) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<>
+  makeArrayGet(Index, const std::vector<Annotation>&, HeapTypeT, bool) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeArraySet(Index, const std::vector<Annotation>&, HeapTypeT) {
+    return Ok{};
+  }
+  Result<> makeArrayLen(Index, const std::vector<Annotation>&) { return Ok{}; }
+  template<typename HeapTypeT>
+  Result<>
+  makeArrayCopy(Index, const std::vector<Annotation>&, HeapTypeT, HeapTypeT) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeArrayFill(Index, const std::vector<Annotation>&, HeapTypeT) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeArrayInitData(Index,
+                             const std::vector<Annotation>&,
+                             HeapTypeT,
+                             DataIdxT) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeArrayInitElem(Index,
+                             const std::vector<Annotation>&,
+                             HeapTypeT,
+                             ElemIdxT) {
+    return Ok{};
+  }
+  Result<> makeRefAs(Index, const std::vector<Annotation>&, RefAsOp) {
+    return Ok{};
+  }
+  Result<> makeStringNew(
+    Index, const std::vector<Annotation>&, StringNewOp, bool, MemoryIdxT*) {
+    return Ok{};
+  }
+  Result<>
+  makeStringConst(Index, const std::vector<Annotation>&, std::string_view) {
+    return Ok{};
+  }
+  Result<>
+  makeStringMeasure(Index, const std::vector<Annotation>&, StringMeasureOp) {
+    return Ok{};
+  }
+  Result<> makeStringEncode(Index,
+                            const std::vector<Annotation>&,
+                            StringEncodeOp,
+                            MemoryIdxT*) {
+    return Ok{};
+  }
+  Result<> makeStringConcat(Index, const std::vector<Annotation>&) {
+    return Ok{};
+  }
+  Result<> makeStringEq(Index, const std::vector<Annotation>&, StringEqOp) {
+    return Ok{};
+  }
+  Result<> makeStringAs(Index, const std::vector<Annotation>&, StringAsOp) {
+    return Ok{};
+  }
+  Result<> makeStringWTF8Advance(Index, const std::vector<Annotation>&) {
+    return Ok{};
+  }
+  Result<> makeStringWTF16Get(Index, const std::vector<Annotation>&) {
+    return Ok{};
+  }
+  Result<> makeStringIterNext(Index, const std::vector<Annotation>&) {
+    return Ok{};
+  }
+  Result<>
+  makeStringIterMove(Index, const std::vector<Annotation>&, StringIterMoveOp) {
+    return Ok{};
+  }
+  Result<>
+  makeStringSliceWTF(Index, const std::vector<Annotation>&, StringSliceWTFOp) {
+    return Ok{};
+  }
+  Result<> makeStringSliceIter(Index, const std::vector<Annotation>&) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeContNew(Index, const std::vector<Annotation>&, HeapTypeT) {
+    return Ok{};
+  }
+  template<typename HeapTypeT>
+  Result<> makeResume(Index,
+                      const std::vector<Annotation>&,
+                      HeapTypeT,
+                      const TagLabelListT&) {
     return Ok{};
   }
 };
@@ -1113,6 +1354,8 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     typeNames;
   const std::unordered_map<Index, Index>& implicitElemIndices;
 
+  std::unordered_map<std::string_view, Index> debugFileIndices;
+
   // The index of the current module element.
   Index index = 0;
 
@@ -1444,7 +1687,51 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return wasm.memories[0]->name;
   }
 
-  Result<> makeBlock(Index pos, std::optional<Name> label, HeapType type) {
+  void setSrcLoc(const Annotation& annotation) {
+    assert(annotation.kind == srcAnnotationKind);
+    Lexer lexer(annotation.contents);
+    auto contents = lexer.takeKeyword();
+    if (!contents || !lexer.empty()) {
+      return;
+    }
+
+    auto fileSize = contents->find(':');
+    if (fileSize == contents->npos) {
+      return;
+    }
+    auto file = contents->substr(0, fileSize);
+    contents = contents->substr(fileSize + 1);
+
+    auto lineSize = contents->find(':');
+    if (fileSize == contents->npos) {
+      return;
+    }
+    auto line = Lexer(contents->substr(0, lineSize)).takeU32();
+    if (!line) {
+      return;
+    }
+    contents = contents->substr(lineSize + 1);
+
+    auto col = Lexer(*contents).takeU32();
+    if (!col) {
+      return;
+    }
+
+    // TODO: If we ever parallelize the parse, access to
+    // `wasm.debugInfoFileNames` will have to be protected by a lock.
+    auto [it, inserted] =
+      debugFileIndices.insert({file, debugFileIndices.size()});
+    if (inserted) {
+      assert(wasm.debugInfoFileNames.size() == it->second);
+      wasm.debugInfoFileNames.push_back(std::string(file));
+    }
+    irBuilder.setDebugLocation({it->second, *line, *col});
+  }
+
+  Result<> makeBlock(Index pos,
+                     const std::vector<Annotation>& annotations,
+                     std::optional<Name> label,
+                     HeapType type) {
     // TODO: validate labels?
     // TODO: Move error on input types to here?
     return withLoc(pos,
@@ -1452,7 +1739,10 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
                                        type.getSignature().results));
   }
 
-  Result<> makeIf(Index pos, std::optional<Name> label, HeapType type) {
+  Result<> makeIf(Index pos,
+                  const std::vector<Annotation>& annotations,
+                  std::optional<Name> label,
+                  HeapType type) {
     // TODO: validate labels?
     // TODO: Move error on input types to here?
     return withLoc(
@@ -1462,7 +1752,10 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
 
   Result<> visitElse() { return withLoc(irBuilder.visitElse()); }
 
-  Result<> makeLoop(Index pos, std::optional<Name> label, HeapType type) {
+  Result<> makeLoop(Index pos,
+                    const std::vector<Annotation>& annotations,
+                    std::optional<Name> label,
+                    HeapType type) {
     // TODO: validate labels?
     // TODO: Move error on input types to here?
     return withLoc(
@@ -1470,7 +1763,10 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
       irBuilder.makeLoop(label ? *label : Name{}, type.getSignature().results));
   }
 
-  Result<> makeTry(Index pos, std::optional<Name> label, HeapType type) {
+  Result<> makeTry(Index pos,
+                   const std::vector<Annotation>& annotations,
+                   std::optional<Name> label,
+                   HeapType type) {
     // TODO: validate labels?
     // TODO: Move error on input types to here?
     return withLoc(
@@ -1479,6 +1775,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   }
 
   Result<> makeTryTable(Index pos,
+                        const std::vector<Annotation>& annotations,
                         std::optional<Name> label,
                         HeapType type,
                         const std::vector<CatchInfo>& info) {
@@ -1512,21 +1809,29 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
 
   Result<> visitEnd() { return withLoc(irBuilder.visitEnd()); }
 
-  Result<> makeUnreachable(Index pos) {
+  Result<> makeUnreachable(Index pos,
+                           const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeUnreachable());
   }
 
-  Result<> makeNop(Index pos) { return withLoc(pos, irBuilder.makeNop()); }
+  Result<> makeNop(Index pos, const std::vector<Annotation>& annotations) {
+    return withLoc(pos, irBuilder.makeNop());
+  }
 
-  Result<> makeBinary(Index pos, BinaryOp op) {
+  Result<> makeBinary(Index pos,
+                      const std::vector<Annotation>& annotations,
+                      BinaryOp op) {
     return withLoc(pos, irBuilder.makeBinary(op));
   }
 
-  Result<> makeUnary(Index pos, UnaryOp op) {
+  Result<>
+  makeUnary(Index pos, const std::vector<Annotation>& annotations, UnaryOp op) {
     return withLoc(pos, irBuilder.makeUnary(op));
   }
 
-  Result<> makeSelect(Index pos, std::vector<Type>* res) {
+  Result<> makeSelect(Index pos,
+                      const std::vector<Annotation>& annotations,
+                      std::vector<Type>* res) {
     if (res && res->size()) {
       if (res->size() > 1) {
         return in.err(pos, "select may not have more than one result type");
@@ -1536,58 +1841,83 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeSelect());
   }
 
-  Result<> makeDrop(Index pos) { return withLoc(pos, irBuilder.makeDrop()); }
+  Result<> makeDrop(Index pos, const std::vector<Annotation>& annotations) {
+    return withLoc(pos, irBuilder.makeDrop());
+  }
 
-  Result<> makeMemorySize(Index pos, Name* mem) {
+  Result<> makeMemorySize(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          Name* mem) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeMemorySize(*m));
   }
 
-  Result<> makeMemoryGrow(Index pos, Name* mem) {
+  Result<> makeMemoryGrow(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          Name* mem) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeMemoryGrow(*m));
   }
 
-  Result<> makeLocalGet(Index pos, Index local) {
+  Result<> makeLocalGet(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Index local) {
     return withLoc(pos, irBuilder.makeLocalGet(local));
   }
 
-  Result<> makeLocalTee(Index pos, Index local) {
+  Result<> makeLocalTee(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Index local) {
     return withLoc(pos, irBuilder.makeLocalTee(local));
   }
 
-  Result<> makeLocalSet(Index pos, Index local) {
+  Result<> makeLocalSet(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Index local) {
     return withLoc(pos, irBuilder.makeLocalSet(local));
   }
 
-  Result<> makeGlobalGet(Index pos, Name global) {
+  Result<> makeGlobalGet(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         Name global) {
     return withLoc(pos, irBuilder.makeGlobalGet(global));
   }
 
-  Result<> makeGlobalSet(Index pos, Name global) {
+  Result<> makeGlobalSet(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         Name global) {
     assert(wasm.getGlobalOrNull(global));
     return withLoc(pos, irBuilder.makeGlobalSet(global));
   }
 
-  Result<> makeI32Const(Index pos, uint32_t c) {
+  Result<> makeI32Const(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        uint32_t c) {
     return withLoc(pos, irBuilder.makeConst(Literal(c)));
   }
 
-  Result<> makeI64Const(Index pos, uint64_t c) {
+  Result<> makeI64Const(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        uint64_t c) {
     return withLoc(pos, irBuilder.makeConst(Literal(c)));
   }
 
-  Result<> makeF32Const(Index pos, float c) {
+  Result<>
+  makeF32Const(Index pos, const std::vector<Annotation>& annotations, float c) {
     return withLoc(pos, irBuilder.makeConst(Literal(c)));
   }
 
-  Result<> makeF64Const(Index pos, double c) {
+  Result<> makeF64Const(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        double c) {
     return withLoc(pos, irBuilder.makeConst(Literal(c)));
   }
 
-  Result<> makeI8x16Const(Index pos, const std::array<uint8_t, 16>& vals) {
+  Result<> makeI8x16Const(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          const std::array<uint8_t, 16>& vals) {
     std::array<Literal, 16> lanes;
     for (size_t i = 0; i < 16; ++i) {
       lanes[i] = Literal(uint32_t(vals[i]));
@@ -1595,7 +1925,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeConst(Literal(lanes)));
   }
 
-  Result<> makeI16x8Const(Index pos, const std::array<uint16_t, 8>& vals) {
+  Result<> makeI16x8Const(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          const std::array<uint16_t, 8>& vals) {
     std::array<Literal, 8> lanes;
     for (size_t i = 0; i < 8; ++i) {
       lanes[i] = Literal(uint32_t(vals[i]));
@@ -1603,7 +1935,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeConst(Literal(lanes)));
   }
 
-  Result<> makeI32x4Const(Index pos, const std::array<uint32_t, 4>& vals) {
+  Result<> makeI32x4Const(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          const std::array<uint32_t, 4>& vals) {
     std::array<Literal, 4> lanes;
     for (size_t i = 0; i < 4; ++i) {
       lanes[i] = Literal(vals[i]);
@@ -1611,7 +1945,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeConst(Literal(lanes)));
   }
 
-  Result<> makeI64x2Const(Index pos, const std::array<uint64_t, 2>& vals) {
+  Result<> makeI64x2Const(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          const std::array<uint64_t, 2>& vals) {
     std::array<Literal, 2> lanes;
     for (size_t i = 0; i < 2; ++i) {
       lanes[i] = Literal(vals[i]);
@@ -1619,7 +1955,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeConst(Literal(lanes)));
   }
 
-  Result<> makeF32x4Const(Index pos, const std::array<float, 4>& vals) {
+  Result<> makeF32x4Const(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          const std::array<float, 4>& vals) {
     std::array<Literal, 4> lanes;
     for (size_t i = 0; i < 4; ++i) {
       lanes[i] = Literal(vals[i]);
@@ -1627,7 +1965,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeConst(Literal(lanes)));
   }
 
-  Result<> makeF64x2Const(Index pos, const std::array<double, 2>& vals) {
+  Result<> makeF64x2Const(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          const std::array<double, 2>& vals) {
     std::array<Literal, 2> lanes;
     for (size_t i = 0; i < 2; ++i) {
       lanes[i] = Literal(vals[i]);
@@ -1636,6 +1976,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   }
 
   Result<> makeLoad(Index pos,
+                    const std::vector<Annotation>& annotations,
                     Type type,
                     bool signed_,
                     int bytes,
@@ -1653,8 +1994,13 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
                      bytes, signed_, memarg.offset, memarg.align, type, *m));
   }
 
-  Result<> makeStore(
-    Index pos, Type type, int bytes, bool isAtomic, Name* mem, Memarg memarg) {
+  Result<> makeStore(Index pos,
+                     const std::vector<Annotation>& annotations,
+                     Type type,
+                     int bytes,
+                     bool isAtomic,
+                     Name* mem,
+                     Memarg memarg) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     if (isAtomic) {
@@ -1665,67 +2011,104 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
       pos, irBuilder.makeStore(bytes, memarg.offset, memarg.align, type, *m));
   }
 
-  Result<> makeAtomicRMW(
-    Index pos, AtomicRMWOp op, Type type, int bytes, Name* mem, Memarg memarg) {
+  Result<> makeAtomicRMW(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         AtomicRMWOp op,
+                         Type type,
+                         int bytes,
+                         Name* mem,
+                         Memarg memarg) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos,
                    irBuilder.makeAtomicRMW(op, bytes, memarg.offset, type, *m));
   }
 
-  Result<>
-  makeAtomicCmpxchg(Index pos, Type type, int bytes, Name* mem, Memarg memarg) {
+  Result<> makeAtomicCmpxchg(Index pos,
+                             const std::vector<Annotation>& annotations,
+                             Type type,
+                             int bytes,
+                             Name* mem,
+                             Memarg memarg) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos,
                    irBuilder.makeAtomicCmpxchg(bytes, memarg.offset, type, *m));
   }
 
-  Result<> makeAtomicWait(Index pos, Type type, Name* mem, Memarg memarg) {
+  Result<> makeAtomicWait(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          Type type,
+                          Name* mem,
+                          Memarg memarg) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeAtomicWait(type, memarg.offset, *m));
   }
 
-  Result<> makeAtomicNotify(Index pos, Name* mem, Memarg memarg) {
+  Result<> makeAtomicNotify(Index pos,
+                            const std::vector<Annotation>& annotations,
+                            Name* mem,
+                            Memarg memarg) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeAtomicNotify(memarg.offset, *m));
   }
 
-  Result<> makeAtomicFence(Index pos) {
+  Result<> makeAtomicFence(Index pos,
+                           const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeAtomicFence());
   }
 
-  Result<> makeSIMDExtract(Index pos, SIMDExtractOp op, uint8_t lane) {
+  Result<> makeSIMDExtract(Index pos,
+                           const std::vector<Annotation>& annotations,
+                           SIMDExtractOp op,
+                           uint8_t lane) {
     return withLoc(pos, irBuilder.makeSIMDExtract(op, lane));
   }
 
-  Result<> makeSIMDReplace(Index pos, SIMDReplaceOp op, uint8_t lane) {
+  Result<> makeSIMDReplace(Index pos,
+                           const std::vector<Annotation>& annotations,
+                           SIMDReplaceOp op,
+                           uint8_t lane) {
     return withLoc(pos, irBuilder.makeSIMDReplace(op, lane));
   }
 
-  Result<> makeSIMDShuffle(Index pos, const std::array<uint8_t, 16>& lanes) {
+  Result<> makeSIMDShuffle(Index pos,
+                           const std::vector<Annotation>& annotations,
+                           const std::array<uint8_t, 16>& lanes) {
     return withLoc(pos, irBuilder.makeSIMDShuffle(lanes));
   }
 
-  Result<> makeSIMDTernary(Index pos, SIMDTernaryOp op) {
+  Result<> makeSIMDTernary(Index pos,
+                           const std::vector<Annotation>& annotations,
+                           SIMDTernaryOp op) {
     return withLoc(pos, irBuilder.makeSIMDTernary(op));
   }
 
-  Result<> makeSIMDShift(Index pos, SIMDShiftOp op) {
+  Result<> makeSIMDShift(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         SIMDShiftOp op) {
     return withLoc(pos, irBuilder.makeSIMDShift(op));
   }
 
-  Result<> makeSIMDLoad(Index pos, SIMDLoadOp op, Name* mem, Memarg memarg) {
+  Result<> makeSIMDLoad(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        SIMDLoadOp op,
+                        Name* mem,
+                        Memarg memarg) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos,
                    irBuilder.makeSIMDLoad(op, memarg.offset, memarg.align, *m));
   }
 
-  Result<> makeSIMDLoadStoreLane(
-    Index pos, SIMDLoadStoreLaneOp op, Name* mem, Memarg memarg, uint8_t lane) {
+  Result<> makeSIMDLoadStoreLane(Index pos,
+                                 const std::vector<Annotation>& annotations,
+                                 SIMDLoadStoreLaneOp op,
+                                 Name* mem,
+                                 Memarg memarg,
+                                 uint8_t lane) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos,
@@ -1733,17 +2116,25 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
                      op, memarg.offset, memarg.align, lane, *m));
   }
 
-  Result<> makeMemoryInit(Index pos, Name* mem, Name data) {
+  Result<> makeMemoryInit(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          Name* mem,
+                          Name data) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeMemoryInit(data, *m));
   }
 
-  Result<> makeDataDrop(Index pos, Name data) {
+  Result<> makeDataDrop(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Name data) {
     return withLoc(pos, irBuilder.makeDataDrop(data));
   }
 
-  Result<> makeMemoryCopy(Index pos, Name* destMem, Name* srcMem) {
+  Result<> makeMemoryCopy(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          Name* destMem,
+                          Name* srcMem) {
     auto destMemory = getMemory(pos, destMem);
     CHECK_ERR(destMemory);
     auto srcMemory = getMemory(pos, srcMem);
@@ -1751,85 +2142,119 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeMemoryCopy(*destMemory, *srcMemory));
   }
 
-  Result<> makeMemoryFill(Index pos, Name* mem) {
+  Result<> makeMemoryFill(Index pos,
+                          const std::vector<Annotation>& annotations,
+                          Name* mem) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeMemoryFill(*m));
   }
 
-  Result<> makePop(Index pos, Type type) {
+  Result<>
+  makePop(Index pos, const std::vector<Annotation>& annotations, Type type) {
     return withLoc(pos, irBuilder.makePop(type));
   }
 
-  Result<> makeCall(Index pos, Name func, bool isReturn) {
+  Result<> makeCall(Index pos,
+                    const std::vector<Annotation>& annotations,
+                    Name func,
+                    bool isReturn) {
     return withLoc(pos, irBuilder.makeCall(func, isReturn));
   }
 
-  Result<>
-  makeCallIndirect(Index pos, Name* table, HeapType type, bool isReturn) {
+  Result<> makeCallIndirect(Index pos,
+                            const std::vector<Annotation>& annotations,
+                            Name* table,
+                            HeapType type,
+                            bool isReturn) {
     auto t = getTable(pos, table);
     CHECK_ERR(t);
     return withLoc(pos, irBuilder.makeCallIndirect(*t, type, isReturn));
   }
 
-  Result<> makeBreak(Index pos, Index label, bool isConditional) {
+  Result<> makeBreak(Index pos,
+                     const std::vector<Annotation>& annotations,
+                     Index label,
+                     bool isConditional) {
     return withLoc(pos, irBuilder.makeBreak(label, isConditional));
   }
 
-  Result<>
-  makeSwitch(Index pos, const std::vector<Index> labels, Index defaultLabel) {
+  Result<> makeSwitch(Index pos,
+                      const std::vector<Annotation>& annotations,
+                      const std::vector<Index> labels,
+                      Index defaultLabel) {
     return withLoc(pos, irBuilder.makeSwitch(labels, defaultLabel));
   }
 
-  Result<> makeReturn(Index pos) {
+  Result<> makeReturn(Index pos, const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeReturn());
   }
 
-  Result<> makeRefNull(Index pos, HeapType type) {
+  Result<> makeRefNull(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       HeapType type) {
     return withLoc(pos, irBuilder.makeRefNull(type));
   }
 
-  Result<> makeRefIsNull(Index pos) {
+  Result<> makeRefIsNull(Index pos,
+                         const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeRefIsNull());
   }
 
-  Result<> makeRefFunc(Index pos, Name func) {
+  Result<> makeRefFunc(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       Name func) {
     return withLoc(pos, irBuilder.makeRefFunc(func));
   }
 
-  Result<> makeRefEq(Index pos) { return withLoc(pos, irBuilder.makeRefEq()); }
+  Result<> makeRefEq(Index pos, const std::vector<Annotation>& annotations) {
+    return withLoc(pos, irBuilder.makeRefEq());
+  }
 
-  Result<> makeTableGet(Index pos, Name* table) {
+  Result<> makeTableGet(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Name* table) {
     auto t = getTable(pos, table);
     CHECK_ERR(t);
     return withLoc(pos, irBuilder.makeTableGet(*t));
   }
 
-  Result<> makeTableSet(Index pos, Name* table) {
+  Result<> makeTableSet(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Name* table) {
     auto t = getTable(pos, table);
     CHECK_ERR(t);
     return withLoc(pos, irBuilder.makeTableSet(*t));
   }
 
-  Result<> makeTableSize(Index pos, Name* table) {
+  Result<> makeTableSize(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         Name* table) {
     auto t = getTable(pos, table);
     CHECK_ERR(t);
     return withLoc(pos, irBuilder.makeTableSize(*t));
   }
 
-  Result<> makeTableGrow(Index pos, Name* table) {
+  Result<> makeTableGrow(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         Name* table) {
     auto t = getTable(pos, table);
     CHECK_ERR(t);
     return withLoc(pos, irBuilder.makeTableGrow(*t));
   }
 
-  Result<> makeTableFill(Index pos, Name* table) {
+  Result<> makeTableFill(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         Name* table) {
     auto t = getTable(pos, table);
     CHECK_ERR(t);
     return withLoc(pos, irBuilder.makeTableFill(*t));
   }
 
-  Result<> makeTableCopy(Index pos, Name* destTable, Name* srcTable) {
+  Result<> makeTableCopy(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         Name* destTable,
+                         Name* srcTable) {
     auto dest = getTable(pos, destTable);
     CHECK_ERR(dest);
     auto src = getTable(pos, srcTable);
@@ -1837,51 +2262,71 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeTableCopy(*dest, *src));
   }
 
-  Result<> makeThrow(Index pos, Name tag) {
+  Result<>
+  makeThrow(Index pos, const std::vector<Annotation>& annotations, Name tag) {
     return withLoc(pos, irBuilder.makeThrow(tag));
   }
 
-  Result<> makeRethrow(Index pos, Index label) {
+  Result<> makeRethrow(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       Index label) {
     return withLoc(pos, irBuilder.makeRethrow(label));
   }
 
-  Result<> makeThrowRef(Index pos) {
+  Result<> makeThrowRef(Index pos, const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeThrowRef());
   }
 
-  Result<> makeTupleMake(Index pos, uint32_t arity) {
+  Result<> makeTupleMake(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         uint32_t arity) {
     return withLoc(pos, irBuilder.makeTupleMake(arity));
   }
 
-  Result<> makeTupleExtract(Index pos, uint32_t arity, uint32_t index) {
+  Result<> makeTupleExtract(Index pos,
+                            const std::vector<Annotation>& annotations,
+                            uint32_t arity,
+                            uint32_t index) {
     return withLoc(pos, irBuilder.makeTupleExtract(arity, index));
   }
 
-  Result<> makeTupleDrop(Index pos, uint32_t arity) {
+  Result<> makeTupleDrop(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         uint32_t arity) {
     return withLoc(pos, irBuilder.makeTupleDrop(arity));
   }
 
-  Result<> makeCallRef(Index pos, HeapType type, bool isReturn) {
+  Result<> makeCallRef(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       HeapType type,
+                       bool isReturn) {
     return withLoc(pos, irBuilder.makeCallRef(type, isReturn));
   }
 
-  Result<> makeRefI31(Index pos) {
+  Result<> makeRefI31(Index pos, const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeRefI31());
   }
 
-  Result<> makeI31Get(Index pos, bool signed_) {
+  Result<> makeI31Get(Index pos,
+                      const std::vector<Annotation>& annotations,
+                      bool signed_) {
     return withLoc(pos, irBuilder.makeI31Get(signed_));
   }
 
-  Result<> makeRefTest(Index pos, Type type) {
+  Result<> makeRefTest(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       Type type) {
     return withLoc(pos, irBuilder.makeRefTest(type));
   }
 
-  Result<> makeRefCast(Index pos, Type type) {
+  Result<> makeRefCast(Index pos,
+                       const std::vector<Annotation>& annotations,
+                       Type type) {
     return withLoc(pos, irBuilder.makeRefCast(type));
   }
 
   Result<> makeBrOn(Index pos,
+                    const std::vector<Annotation>& annotations,
                     Index label,
                     BrOnOp op,
                     Type in = Type::none,
@@ -1889,136 +2334,203 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return withLoc(pos, irBuilder.makeBrOn(label, op, in, out));
   }
 
-  Result<> makeStructNew(Index pos, HeapType type) {
+  Result<> makeStructNew(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         HeapType type) {
     return withLoc(pos, irBuilder.makeStructNew(type));
   }
 
-  Result<> makeStructNewDefault(Index pos, HeapType type) {
+  Result<> makeStructNewDefault(Index pos,
+                                const std::vector<Annotation>& annotations,
+                                HeapType type) {
     return withLoc(pos, irBuilder.makeStructNewDefault(type));
   }
 
-  Result<> makeStructGet(Index pos, HeapType type, Index field, bool signed_) {
+  Result<> makeStructGet(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         HeapType type,
+                         Index field,
+                         bool signed_) {
     return withLoc(pos, irBuilder.makeStructGet(type, field, signed_));
   }
 
-  Result<> makeStructSet(Index pos, HeapType type, Index field) {
+  Result<> makeStructSet(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         HeapType type,
+                         Index field) {
     return withLoc(pos, irBuilder.makeStructSet(type, field));
   }
 
-  Result<> makeArrayNew(Index pos, HeapType type) {
+  Result<> makeArrayNew(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        HeapType type) {
     return withLoc(pos, irBuilder.makeArrayNew(type));
   }
 
-  Result<> makeArrayNewDefault(Index pos, HeapType type) {
+  Result<> makeArrayNewDefault(Index pos,
+                               const std::vector<Annotation>& annotations,
+                               HeapType type) {
     return withLoc(pos, irBuilder.makeArrayNewDefault(type));
   }
 
-  Result<> makeArrayNewData(Index pos, HeapType type, Name data) {
+  Result<> makeArrayNewData(Index pos,
+                            const std::vector<Annotation>& annotations,
+                            HeapType type,
+                            Name data) {
     return withLoc(pos, irBuilder.makeArrayNewData(type, data));
   }
 
-  Result<> makeArrayNewElem(Index pos, HeapType type, Name elem) {
+  Result<> makeArrayNewElem(Index pos,
+                            const std::vector<Annotation>& annotations,
+                            HeapType type,
+                            Name elem) {
     return withLoc(pos, irBuilder.makeArrayNewElem(type, elem));
   }
 
-  Result<> makeArrayNewFixed(Index pos, HeapType type, uint32_t arity) {
+  Result<> makeArrayNewFixed(Index pos,
+                             const std::vector<Annotation>& annotations,
+                             HeapType type,
+                             uint32_t arity) {
     return withLoc(pos, irBuilder.makeArrayNewFixed(type, arity));
   }
 
-  Result<> makeArrayGet(Index pos, HeapType type, bool signed_) {
+  Result<> makeArrayGet(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        HeapType type,
+                        bool signed_) {
     return withLoc(pos, irBuilder.makeArrayGet(type, signed_));
   }
 
-  Result<> makeArraySet(Index pos, HeapType type) {
+  Result<> makeArraySet(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        HeapType type) {
     return withLoc(pos, irBuilder.makeArraySet(type));
   }
 
-  Result<> makeArrayLen(Index pos) {
+  Result<> makeArrayLen(Index pos, const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeArrayLen());
   }
 
-  Result<> makeArrayCopy(Index pos, HeapType destType, HeapType srcType) {
+  Result<> makeArrayCopy(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         HeapType destType,
+                         HeapType srcType) {
     return withLoc(pos, irBuilder.makeArrayCopy(destType, srcType));
   }
 
-  Result<> makeArrayFill(Index pos, HeapType type) {
+  Result<> makeArrayFill(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         HeapType type) {
     return withLoc(pos, irBuilder.makeArrayFill(type));
   }
 
-  Result<> makeArrayInitData(Index pos, HeapType type, Name data) {
+  Result<> makeArrayInitData(Index pos,
+                             const std::vector<Annotation>& annotations,
+                             HeapType type,
+                             Name data) {
     return withLoc(pos, irBuilder.makeArrayInitData(type, data));
   }
 
-  Result<> makeArrayInitElem(Index pos, HeapType type, Name elem) {
+  Result<> makeArrayInitElem(Index pos,
+                             const std::vector<Annotation>& annotations,
+                             HeapType type,
+                             Name elem) {
     return withLoc(pos, irBuilder.makeArrayInitElem(type, elem));
   }
 
-  Result<> makeRefAs(Index pos, RefAsOp op) {
+  Result<>
+  makeRefAs(Index pos, const std::vector<Annotation>& annotations, RefAsOp op) {
     return withLoc(pos, irBuilder.makeRefAs(op));
   }
 
-  Result<> makeStringNew(Index pos, StringNewOp op, bool try_, Name* mem) {
+  Result<> makeStringNew(Index pos,
+                         const std::vector<Annotation>& annotations,
+                         StringNewOp op,
+                         bool try_,
+                         Name* mem) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeStringNew(op, try_, *m));
   }
 
-  Result<> makeStringConst(Index pos, std::string_view str) {
+  Result<> makeStringConst(Index pos,
+                           const std::vector<Annotation>& annotations,
+                           std::string_view str) {
     return withLoc(pos, irBuilder.makeStringConst(Name(str)));
   }
 
-  Result<> makeStringMeasure(Index pos, StringMeasureOp op) {
+  Result<> makeStringMeasure(Index pos,
+                             const std::vector<Annotation>& annotations,
+                             StringMeasureOp op) {
     return withLoc(pos, irBuilder.makeStringMeasure(op));
   }
 
-  Result<> makeStringEncode(Index pos, StringEncodeOp op, Name* mem) {
+  Result<> makeStringEncode(Index pos,
+                            const std::vector<Annotation>& annotations,
+                            StringEncodeOp op,
+                            Name* mem) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     return withLoc(pos, irBuilder.makeStringEncode(op, *m));
   }
 
-  Result<> makeStringConcat(Index pos) {
+  Result<> makeStringConcat(Index pos,
+                            const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeStringConcat());
   }
 
-  Result<> makeStringEq(Index pos, StringEqOp op) {
+  Result<> makeStringEq(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        StringEqOp op) {
     return withLoc(pos, irBuilder.makeStringEq(op));
   }
 
-  Result<> makeStringAs(Index pos, StringAsOp op) {
+  Result<> makeStringAs(Index pos,
+                        const std::vector<Annotation>& annotations,
+                        StringAsOp op) {
     return withLoc(pos, irBuilder.makeStringAs(op));
   }
 
-  Result<> makeStringWTF8Advance(Index pos) {
+  Result<> makeStringWTF8Advance(Index pos,
+                                 const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeStringWTF8Advance());
   }
 
-  Result<> makeStringWTF16Get(Index pos) {
+  Result<> makeStringWTF16Get(Index pos,
+                              const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeStringWTF16Get());
   }
 
-  Result<> makeStringIterNext(Index pos) {
+  Result<> makeStringIterNext(Index pos,
+                              const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeStringIterNext());
   }
 
-  Result<> makeStringIterMove(Index pos, StringIterMoveOp op) {
+  Result<> makeStringIterMove(Index pos,
+                              const std::vector<Annotation>& annotations,
+                              StringIterMoveOp op) {
     return withLoc(pos, irBuilder.makeStringIterMove(op));
   }
 
-  Result<> makeStringSliceWTF(Index pos, StringSliceWTFOp op) {
+  Result<> makeStringSliceWTF(Index pos,
+                              const std::vector<Annotation>& annotations,
+                              StringSliceWTFOp op) {
     return withLoc(pos, irBuilder.makeStringSliceWTF(op));
   }
 
-  Result<> makeStringSliceIter(Index pos) {
+  Result<> makeStringSliceIter(Index pos,
+                               const std::vector<Annotation>& annotations) {
     return withLoc(pos, irBuilder.makeStringSliceIter());
   }
 
-  Result<> makeContNew(Index pos, HeapType type) {
+  Result<> makeContNew(Index pos, const std::vector<Annotation>& annotations, HeapType type) {
     return withLoc(pos, irBuilder.makeContNew(type));
   }
 
-  Result<>
-  makeResume(Index pos, HeapType type, const TagLabelListT& tagLabels) {
+  Result<> makeResume(Index pos,
+                      const std::vector<Annotation>& annotations,
+                      HeapType type,
+                      const TagLabelListT& tagLabels) {
     std::vector<Name> tags;
     std::vector<Index> labels;
     tags.reserve(tagLabels.size());

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -46,10 +46,14 @@ template<typename Ctx> Result<typename Ctx::GlobalTypeT> globaltype(Ctx&);
 template<typename Ctx> Result<uint32_t> tupleArity(Ctx&);
 
 // Instructions
-template<typename Ctx> MaybeResult<> foldedBlockinstr(Ctx&);
-template<typename Ctx> MaybeResult<> unfoldedBlockinstr(Ctx&);
-template<typename Ctx> MaybeResult<> blockinstr(Ctx&);
-template<typename Ctx> MaybeResult<> plaininstr(Ctx&);
+template<typename Ctx>
+MaybeResult<> foldedBlockinstr(Ctx&, const std::vector<Annotation>&);
+template<typename Ctx>
+MaybeResult<> unfoldedBlockinstr(Ctx&, const std::vector<Annotation>&);
+template<typename Ctx>
+MaybeResult<> blockinstr(Ctx&, const std::vector<Annotation>&);
+template<typename Ctx>
+MaybeResult<> plaininstr(Ctx&, const std::vector<Annotation>&);
 template<typename Ctx> MaybeResult<> instr(Ctx&);
 template<typename Ctx> MaybeResult<> foldedinstr(Ctx&);
 template<typename Ctx> Result<> instrs(Ctx&);
@@ -57,118 +61,250 @@ template<typename Ctx> Result<> foldedinstrs(Ctx&);
 template<typename Ctx> Result<typename Ctx::ExprT> expr(Ctx&);
 template<typename Ctx> Result<typename Ctx::MemargT> memarg(Ctx&, uint32_t);
 template<typename Ctx> Result<typename Ctx::BlockTypeT> blocktype(Ctx&);
-template<typename Ctx> MaybeResult<> block(Ctx&, bool);
-template<typename Ctx> MaybeResult<> ifelse(Ctx&, bool);
-template<typename Ctx> MaybeResult<> loop(Ctx&, bool);
-template<typename Ctx> MaybeResult<> trycatch(Ctx&, bool);
+template<typename Ctx>
+MaybeResult<> block(Ctx&, const std::vector<Annotation>&, bool);
+template<typename Ctx>
+MaybeResult<> ifelse(Ctx&, const std::vector<Annotation>&, bool);
+template<typename Ctx>
+MaybeResult<> loop(Ctx&, const std::vector<Annotation>&, bool);
+template<typename Ctx>
+MaybeResult<> trycatch(Ctx&, const std::vector<Annotation>&, bool);
 template<typename Ctx> MaybeResult<typename Ctx::CatchT> catchinstr(Ctx&);
-template<typename Ctx> MaybeResult<> trytable(Ctx&, bool);
-template<typename Ctx> Result<> makeUnreachable(Ctx&, Index);
-template<typename Ctx> Result<> makeNop(Ctx&, Index);
-template<typename Ctx> Result<> makeBinary(Ctx&, Index, BinaryOp op);
-template<typename Ctx> Result<> makeUnary(Ctx&, Index, UnaryOp op);
-template<typename Ctx> Result<> makeSelect(Ctx&, Index);
-template<typename Ctx> Result<> makeDrop(Ctx&, Index);
-template<typename Ctx> Result<> makeMemorySize(Ctx&, Index);
-template<typename Ctx> Result<> makeMemoryGrow(Ctx&, Index);
-template<typename Ctx> Result<> makeLocalGet(Ctx&, Index);
-template<typename Ctx> Result<> makeLocalTee(Ctx&, Index);
-template<typename Ctx> Result<> makeLocalSet(Ctx&, Index);
-template<typename Ctx> Result<> makeGlobalGet(Ctx&, Index);
-template<typename Ctx> Result<> makeGlobalSet(Ctx&, Index);
-template<typename Ctx> Result<> makeConst(Ctx&, Index, Type type);
+template<typename Ctx>
+MaybeResult<> trytable(Ctx&, const std::vector<Annotation>&, bool);
+template<typename Ctx>
+Result<> makeUnreachable(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeNop(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeBinary(Ctx&, Index, const std::vector<Annotation>&, BinaryOp op);
+template<typename Ctx>
+Result<> makeUnary(Ctx&, Index, const std::vector<Annotation>&, UnaryOp op);
+template<typename Ctx>
+Result<> makeSelect(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeDrop(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeMemorySize(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeMemoryGrow(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeLocalGet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeLocalTee(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeLocalSet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeGlobalGet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeGlobalSet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeConst(Ctx&, Index, const std::vector<Annotation>&, Type type);
+template<typename Ctx>
+Result<> makeLoad(Ctx&,
+                  Index,
+                  const std::vector<Annotation>&,
+                  Type type,
+                  bool signed_,
+                  int bytes,
+                  bool isAtomic);
+template<typename Ctx>
+Result<> makeStore(Ctx&,
+                   Index,
+                   const std::vector<Annotation>&,
+                   Type type,
+                   int bytes,
+                   bool isAtomic);
+template<typename Ctx>
+Result<> makeAtomicRMW(Ctx&,
+                       Index,
+                       const std::vector<Annotation>&,
+                       AtomicRMWOp op,
+                       Type type,
+                       uint8_t bytes);
+template<typename Ctx>
+Result<> makeAtomicCmpxchg(
+  Ctx&, Index, const std::vector<Annotation>&, Type type, uint8_t bytes);
+template<typename Ctx>
+Result<> makeAtomicWait(Ctx&, Index, const std::vector<Annotation>&, Type type);
+template<typename Ctx>
+Result<> makeAtomicNotify(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeAtomicFence(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeSIMDExtract(
+  Ctx&, Index, const std::vector<Annotation>&, SIMDExtractOp op, size_t lanes);
+template<typename Ctx>
+Result<> makeSIMDReplace(
+  Ctx&, Index, const std::vector<Annotation>&, SIMDReplaceOp op, size_t lanes);
+template<typename Ctx>
+Result<> makeSIMDShuffle(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
 Result<>
-makeLoad(Ctx&, Index, Type type, bool signed_, int bytes, bool isAtomic);
+makeSIMDTernary(Ctx&, Index, const std::vector<Annotation>&, SIMDTernaryOp op);
 template<typename Ctx>
-Result<> makeStore(Ctx&, Index, Type type, int bytes, bool isAtomic);
+Result<>
+makeSIMDShift(Ctx&, Index, const std::vector<Annotation>&, SIMDShiftOp op);
 template<typename Ctx>
-Result<> makeAtomicRMW(Ctx&, Index, AtomicRMWOp op, Type type, uint8_t bytes);
+Result<> makeSIMDLoad(
+  Ctx&, Index, const std::vector<Annotation>&, SIMDLoadOp op, int bytes);
 template<typename Ctx>
-Result<> makeAtomicCmpxchg(Ctx&, Index, Type type, uint8_t bytes);
-template<typename Ctx> Result<> makeAtomicWait(Ctx&, Index, Type type);
-template<typename Ctx> Result<> makeAtomicNotify(Ctx&, Index);
-template<typename Ctx> Result<> makeAtomicFence(Ctx&, Index);
+Result<> makeSIMDLoadStoreLane(Ctx&,
+                               Index,
+                               const std::vector<Annotation>&,
+                               SIMDLoadStoreLaneOp op,
+                               int bytes);
 template<typename Ctx>
-Result<> makeSIMDExtract(Ctx&, Index, SIMDExtractOp op, size_t lanes);
+Result<> makeMemoryInit(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
-Result<> makeSIMDReplace(Ctx&, Index, SIMDReplaceOp op, size_t lanes);
-template<typename Ctx> Result<> makeSIMDShuffle(Ctx&, Index);
-template<typename Ctx> Result<> makeSIMDTernary(Ctx&, Index, SIMDTernaryOp op);
-template<typename Ctx> Result<> makeSIMDShift(Ctx&, Index, SIMDShiftOp op);
+Result<> makeDataDrop(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
-Result<> makeSIMDLoad(Ctx&, Index, SIMDLoadOp op, int bytes);
+Result<> makeMemoryCopy(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
-Result<> makeSIMDLoadStoreLane(Ctx&, Index, SIMDLoadStoreLaneOp op, int bytes);
-template<typename Ctx> Result<> makeMemoryInit(Ctx&, Index);
-template<typename Ctx> Result<> makeDataDrop(Ctx&, Index);
-template<typename Ctx> Result<> makeMemoryCopy(Ctx&, Index);
-template<typename Ctx> Result<> makeMemoryFill(Ctx&, Index);
-template<typename Ctx> Result<> makePop(Ctx&, Index);
-template<typename Ctx> Result<> makeCall(Ctx&, Index, bool isReturn);
-template<typename Ctx> Result<> makeCallIndirect(Ctx&, Index, bool isReturn);
-template<typename Ctx> Result<> makeBreak(Ctx&, Index, bool isConditional);
-template<typename Ctx> Result<> makeBreakTable(Ctx&, Index);
-template<typename Ctx> Result<> makeReturn(Ctx&, Index);
-template<typename Ctx> Result<> makeRefNull(Ctx&, Index);
-template<typename Ctx> Result<> makeRefIsNull(Ctx&, Index);
-template<typename Ctx> Result<> makeRefFunc(Ctx&, Index);
-template<typename Ctx> Result<> makeRefEq(Ctx&, Index);
-template<typename Ctx> Result<> makeTableGet(Ctx&, Index);
-template<typename Ctx> Result<> makeTableSet(Ctx&, Index);
-template<typename Ctx> Result<> makeTableSize(Ctx&, Index);
-template<typename Ctx> Result<> makeTableGrow(Ctx&, Index);
-template<typename Ctx> Result<> makeTableFill(Ctx&, Index);
-template<typename Ctx> Result<> makeTableCopy(Ctx&, Index);
-template<typename Ctx> Result<> makeThrow(Ctx&, Index);
-template<typename Ctx> Result<> makeRethrow(Ctx&, Index);
-template<typename Ctx> Result<> makeThrowRef(Ctx&, Index);
-template<typename Ctx> Result<> makeTupleMake(Ctx&, Index);
-template<typename Ctx> Result<> makeTupleExtract(Ctx&, Index);
-template<typename Ctx> Result<> makeTupleDrop(Ctx&, Index);
-template<typename Ctx> Result<> makeCallRef(Ctx&, Index, bool isReturn);
-template<typename Ctx> Result<> makeRefI31(Ctx&, Index);
-template<typename Ctx> Result<> makeI31Get(Ctx&, Index, bool signed_);
-template<typename Ctx> Result<> makeRefTest(Ctx&, Index);
-template<typename Ctx> Result<> makeRefCast(Ctx&, Index);
-template<typename Ctx> Result<> makeBrOnNull(Ctx&, Index, bool onFail = false);
-template<typename Ctx> Result<> makeBrOnCast(Ctx&, Index, bool onFail = false);
-template<typename Ctx> Result<> makeStructNew(Ctx&, Index, bool default_);
+Result<> makeMemoryFill(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
-Result<> makeStructGet(Ctx&, Index, bool signed_ = false);
-template<typename Ctx> Result<> makeStructSet(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayNew(Ctx&, Index, bool default_);
-template<typename Ctx> Result<> makeArrayNewData(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayNewElem(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayNewFixed(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayGet(Ctx&, Index, bool signed_ = false);
-template<typename Ctx> Result<> makeArraySet(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayLen(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayCopy(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayFill(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayInitData(Ctx&, Index);
-template<typename Ctx> Result<> makeArrayInitElem(Ctx&, Index);
-template<typename Ctx> Result<> makeRefAs(Ctx&, Index, RefAsOp op);
+Result<> makePop(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
-Result<> makeStringNew(Ctx&, Index, StringNewOp op, bool try_);
-template<typename Ctx> Result<> makeStringConst(Ctx&, Index);
+Result<> makeCall(Ctx&, Index, const std::vector<Annotation>&, bool isReturn);
 template<typename Ctx>
-Result<> makeStringMeasure(Ctx&, Index, StringMeasureOp op);
+Result<>
+makeCallIndirect(Ctx&, Index, const std::vector<Annotation>&, bool isReturn);
 template<typename Ctx>
-Result<> makeStringEncode(Ctx&, Index, StringEncodeOp op);
-template<typename Ctx> Result<> makeStringConcat(Ctx&, Index);
-template<typename Ctx> Result<> makeStringEq(Ctx&, Index, StringEqOp);
-template<typename Ctx> Result<> makeStringAs(Ctx&, Index, StringAsOp op);
-template<typename Ctx> Result<> makeStringWTF8Advance(Ctx&, Index);
-template<typename Ctx> Result<> makeStringWTF16Get(Ctx&, Index);
-template<typename Ctx> Result<> makeStringIterNext(Ctx&, Index);
+Result<>
+makeBreak(Ctx&, Index, const std::vector<Annotation>&, bool isConditional);
 template<typename Ctx>
-Result<> makeStringIterMove(Ctx&, Index, StringIterMoveOp op);
+Result<> makeBreakTable(Ctx&, Index, const std::vector<Annotation>&);
 template<typename Ctx>
-Result<> makeStringSliceWTF(Ctx&, Index, StringSliceWTFOp op);
-template<typename Ctx> Result<> makeStringSliceIter(Ctx&, Index);
-template<typename Ctx> Result<> makeContNew(Ctx&, Index);
-template<typename Ctx> Result<> makeResume(Ctx&, Index);
+Result<> makeReturn(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRefNull(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRefIsNull(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRefFunc(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRefEq(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTableGet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTableSet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTableSize(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTableGrow(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTableFill(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTableCopy(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeThrow(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRethrow(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeThrowRef(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTupleMake(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTupleExtract(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeTupleDrop(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<>
+makeCallRef(Ctx&, Index, const std::vector<Annotation>&, bool isReturn);
+template<typename Ctx>
+Result<> makeRefI31(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeI31Get(Ctx&, Index, const std::vector<Annotation>&, bool signed_);
+template<typename Ctx>
+Result<> makeRefTest(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRefCast(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<>
+makeBrOnNull(Ctx&, Index, const std::vector<Annotation>&, bool onFail = false);
+template<typename Ctx>
+Result<>
+makeBrOnCast(Ctx&, Index, const std::vector<Annotation>&, bool onFail = false);
+template<typename Ctx>
+Result<>
+makeStructNew(Ctx&, Index, const std::vector<Annotation>&, bool default_);
+template<typename Ctx>
+Result<> makeStructGet(Ctx&,
+                       Index,
+                       const std::vector<Annotation>&,
+                       bool signed_ = false);
+template<typename Ctx>
+Result<> makeStructSet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<>
+makeArrayNew(Ctx&, Index, const std::vector<Annotation>&, bool default_);
+template<typename Ctx>
+Result<> makeArrayNewData(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayNewElem(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayNewFixed(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<>
+makeArrayGet(Ctx&, Index, const std::vector<Annotation>&, bool signed_ = false);
+template<typename Ctx>
+Result<> makeArraySet(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayLen(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayCopy(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayFill(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayInitData(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeArrayInitElem(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeRefAs(Ctx&, Index, const std::vector<Annotation>&, RefAsOp op);
+template<typename Ctx>
+Result<> makeStringNew(
+  Ctx&, Index, const std::vector<Annotation>&, StringNewOp op, bool try_);
+template<typename Ctx>
+Result<> makeStringConst(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeStringMeasure(Ctx&,
+                           Index,
+                           const std::vector<Annotation>&,
+                           StringMeasureOp op);
+template<typename Ctx>
+Result<> makeStringEncode(Ctx&,
+                          Index,
+                          const std::vector<Annotation>&,
+                          StringEncodeOp op);
+template<typename Ctx>
+Result<> makeStringConcat(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeStringEq(Ctx&, Index, const std::vector<Annotation>&, StringEqOp);
+template<typename Ctx>
+Result<>
+makeStringAs(Ctx&, Index, const std::vector<Annotation>&, StringAsOp op);
+template<typename Ctx>
+Result<> makeStringWTF8Advance(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeStringWTF16Get(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeStringIterNext(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeStringIterMove(Ctx&,
+                            Index,
+                            const std::vector<Annotation>&,
+                            StringIterMoveOp op);
+template<typename Ctx>
+Result<> makeStringSliceWTF(Ctx&,
+                            Index,
+                            const std::vector<Annotation>&,
+                            StringSliceWTFOp op);
+template<typename Ctx>
+Result<> makeStringSliceIter(Ctx&, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeContNew(Ctx*, Index, const std::vector<Annotation>&);
+template<typename Ctx>
+Result<> makeResume(Ctx&, Index, const std::vector<Annotation>&);
 
 // Modules
 template<typename Ctx> MaybeResult<Index> maybeTypeidx(Ctx& ctx);
@@ -222,12 +358,18 @@ template<typename Ctx> Result<> module(Ctx&);
 template<typename Ctx> struct WithPosition {
   Ctx& ctx;
   Index original;
+  std::vector<Annotation> annotations;
 
-  WithPosition(Ctx& ctx, Index pos) : ctx(ctx), original(ctx.in.getPos()) {
+  WithPosition(Ctx& ctx, Index pos)
+    : ctx(ctx), original(ctx.in.getPos()),
+      annotations(ctx.in.takeAnnotations()) {
     ctx.in.setIndex(pos);
   }
 
-  ~WithPosition() { ctx.in.setIndex(original); }
+  ~WithPosition() {
+    ctx.in.setIndex(original);
+    ctx.in.setAnnotations(std::move(annotations));
+  }
 };
 
 // Deduction guide to satisfy -Wctad-maybe-unsupported.
@@ -690,57 +832,75 @@ template<typename Ctx> Result<uint32_t> tupleArity(Ctx& ctx) {
 // Instructions
 // ============
 
+template<typename Ctx>
+void setSrcLoc(Ctx& ctx, const std::vector<Annotation>& annotations) {
+  for (const auto& annotation : annotations) {
+    if (annotation.kind == srcAnnotationKind) {
+      ctx.setSrcLoc(annotation);
+    }
+  }
+}
+
 // blockinstr ::= block | loop | if-else | try-catch | try_table
-template<typename Ctx> MaybeResult<> foldedBlockinstr(Ctx& ctx) {
-  if (auto i = block(ctx, true)) {
+template<typename Ctx>
+MaybeResult<> foldedBlockinstr(Ctx& ctx,
+                               const std::vector<Annotation>& annotations) {
+  setSrcLoc(ctx, annotations);
+  if (auto i = block(ctx, annotations, true)) {
     return i;
   }
-  if (auto i = ifelse(ctx, true)) {
+  if (auto i = ifelse(ctx, annotations, true)) {
     return i;
   }
-  if (auto i = loop(ctx, true)) {
+  if (auto i = loop(ctx, annotations, true)) {
     return i;
   }
-  if (auto i = trycatch(ctx, true)) {
+  if (auto i = trycatch(ctx, annotations, true)) {
     return i;
   }
-  if (auto i = trytable(ctx, true)) {
-    return i;
-  }
-  return {};
-}
-
-template<typename Ctx> MaybeResult<> unfoldedBlockinstr(Ctx& ctx) {
-  if (auto i = block(ctx, false)) {
-    return i;
-  }
-  if (auto i = ifelse(ctx, false)) {
-    return i;
-  }
-  if (auto i = loop(ctx, false)) {
-    return i;
-  }
-  if (auto i = trycatch(ctx, false)) {
-    return i;
-  }
-  if (auto i = trytable(ctx, false)) {
+  if (auto i = trytable(ctx, annotations, true)) {
     return i;
   }
   return {};
 }
 
-template<typename Ctx> MaybeResult<> blockinstr(Ctx& ctx) {
-  if (auto i = foldedBlockinstr(ctx)) {
+template<typename Ctx>
+MaybeResult<> unfoldedBlockinstr(Ctx& ctx,
+                                 const std::vector<Annotation>& annotations) {
+  setSrcLoc(ctx, annotations);
+  if (auto i = block(ctx, annotations, false)) {
     return i;
   }
-  if (auto i = unfoldedBlockinstr(ctx)) {
+  if (auto i = ifelse(ctx, annotations, false)) {
+    return i;
+  }
+  if (auto i = loop(ctx, annotations, false)) {
+    return i;
+  }
+  if (auto i = trycatch(ctx, annotations, false)) {
+    return i;
+  }
+  if (auto i = trytable(ctx, annotations, false)) {
+    return i;
+  }
+  return {};
+}
+
+template<typename Ctx>
+MaybeResult<> blockinstr(Ctx& ctx, const std::vector<Annotation>& annotations) {
+  if (auto i = foldedBlockinstr(ctx, annotations)) {
+    return i;
+  }
+  if (auto i = unfoldedBlockinstr(ctx, annotations)) {
     return i;
   }
   return {};
 }
 
 // plaininstr ::= ... all plain instructions ...
-template<typename Ctx> MaybeResult<> plaininstr(Ctx& ctx) {
+template<typename Ctx>
+MaybeResult<> plaininstr(Ctx& ctx, const std::vector<Annotation>& annotations) {
+  setSrcLoc(ctx, annotations);
   auto pos = ctx.in.getPos();
   auto keyword = ctx.in.takeKeyword();
   if (!keyword) {
@@ -762,10 +922,10 @@ template<typename Ctx> MaybeResult<> instr(Ctx& ctx) {
       return {};
     }
   }
-  if (auto inst = blockinstr(ctx)) {
+  if (auto inst = blockinstr(ctx, ctx.in.getAnnotations())) {
     return inst;
   }
-  if (auto inst = plaininstr(ctx)) {
+  if (auto inst = plaininstr(ctx, ctx.in.getAnnotations())) {
     return inst;
   }
   // TODO: Handle folded plain instructions as well.
@@ -785,28 +945,35 @@ template<typename Ctx> MaybeResult<> foldedinstr(Ctx& ctx) {
 
   // A stack of (start, end) position pairs defining the positions of
   // instructions that need to be parsed after their folded children.
-  std::vector<std::pair<size_t, std::optional<size_t>>> foldedInstrs;
+  struct InstrInfo {
+    size_t start;
+    std::optional<size_t> end;
+    std::vector<Annotation> annotations;
+  };
+  std::vector<InstrInfo> foldedInstrs;
 
   do {
     if (ctx.in.takeRParen()) {
       // We've reached the end of a folded instruction. Parse it for real.
-      auto [start, end] = foldedInstrs.back();
-      if (!end) {
+      auto info = std::move(foldedInstrs.back());
+      if (!info.end) {
         return ctx.in.err("unexpected end of folded instruction");
       }
       foldedInstrs.pop_back();
 
-      WithPosition with(ctx, start);
-      auto inst = plaininstr(ctx);
+      WithPosition with(ctx, info.start);
+      auto inst = plaininstr(ctx, std::move(info.annotations));
       assert(inst && "unexpectedly failed to parse instruction");
       CHECK_ERR(inst);
-      assert(ctx.in.getPos() == *end && "expected end of instruction");
+      assert(ctx.in.getPos() == *info.end && "expected end of instruction");
       continue;
     }
 
+    auto annotations = ctx.in.takeAnnotations();
+
     // We're not ending an instruction, so we must be starting a new one. Maybe
     // it is a block instruction.
-    if (auto blockinst = foldedBlockinstr(ctx)) {
+    if (auto blockinst = foldedBlockinstr(ctx, annotations)) {
       CHECK_ERR(blockinst);
       continue;
     }
@@ -815,13 +982,13 @@ template<typename Ctx> MaybeResult<> foldedinstr(Ctx& ctx) {
     if (!ctx.in.takeLParen()) {
       return ctx.in.err("expected folded instruction");
     }
-    foldedInstrs.push_back({ctx.in.getPos(), {}});
+    foldedInstrs.push_back({ctx.in.getPos(), {}, std::move(annotations)});
 
     // Consume the span for the instruction without meaningfully parsing it yet.
     // It will be parsed for real using the real context after its s-expression
     // children have been found and parsed.
     NullCtx nullCtx(ctx.in);
-    if (auto inst = plaininstr(nullCtx)) {
+    if (auto inst = plaininstr(nullCtx, {})) {
       CHECK_ERR(inst);
       ctx.in = nullCtx.in;
     } else {
@@ -829,8 +996,8 @@ template<typename Ctx> MaybeResult<> foldedinstr(Ctx& ctx) {
     }
 
     // The folded instruction we just started ends here.
-    assert(!foldedInstrs.back().second);
-    foldedInstrs.back().second = ctx.in.getPos();
+    assert(!foldedInstrs.back().end);
+    foldedInstrs.back().end = ctx.in.getPos();
   } while (!foldedInstrs.empty());
 
   return Ok{};
@@ -903,7 +1070,9 @@ template<typename Ctx> Result<typename Ctx::BlockTypeT> blocktype(Ctx& ctx) {
 
 // block ::= 'block' label blocktype instr* 'end' id?   if id = {} or id = label
 //         | '(' 'block' label blocktype instr* ')'
-template<typename Ctx> MaybeResult<> block(Ctx& ctx, bool folded) {
+template<typename Ctx>
+MaybeResult<>
+block(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto pos = ctx.in.getPos();
 
   if ((folded && !ctx.in.takeSExprStart("block"sv)) ||
@@ -916,7 +1085,7 @@ template<typename Ctx> MaybeResult<> block(Ctx& ctx, bool folded) {
   auto type = blocktype(ctx);
   CHECK_ERR(type);
 
-  ctx.makeBlock(pos, label, *type);
+  ctx.makeBlock(pos, annotations, label, *type);
 
   CHECK_ERR(instrs(ctx));
 
@@ -940,7 +1109,9 @@ template<typename Ctx> MaybeResult<> block(Ctx& ctx, bool folded) {
 // if ::= 'if' label blocktype instr1* ('else' id1? instr2*)? 'end' id2?
 //      | '(' 'if' label blocktype foldedinstr* '(' 'then' instr1* ')'
 //            ('(' 'else' instr2* ')')? ')'
-template<typename Ctx> MaybeResult<> ifelse(Ctx& ctx, bool folded) {
+template<typename Ctx>
+MaybeResult<>
+ifelse(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto pos = ctx.in.getPos();
 
   if ((folded && !ctx.in.takeSExprStart("if"sv)) ||
@@ -957,7 +1128,7 @@ template<typename Ctx> MaybeResult<> ifelse(Ctx& ctx, bool folded) {
     CHECK_ERR(foldedinstrs(ctx));
   }
 
-  ctx.makeIf(pos, label, *type);
+  ctx.makeIf(pos, annotations, label, *type);
 
   if (folded && !ctx.in.takeSExprStart("then"sv)) {
     return ctx.in.err("expected 'then' before if instructions");
@@ -1004,7 +1175,9 @@ template<typename Ctx> MaybeResult<> ifelse(Ctx& ctx, bool folded) {
 
 // loop ::= 'loop' label blocktype instr* 'end' id?
 //        | '(' 'loop' label blocktype instr* ')'
-template<typename Ctx> MaybeResult<> loop(Ctx& ctx, bool folded) {
+template<typename Ctx>
+MaybeResult<>
+loop(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto pos = ctx.in.getPos();
 
   if ((folded && !ctx.in.takeSExprStart("loop"sv)) ||
@@ -1017,7 +1190,7 @@ template<typename Ctx> MaybeResult<> loop(Ctx& ctx, bool folded) {
   auto type = blocktype(ctx);
   CHECK_ERR(type);
 
-  ctx.makeLoop(pos, label, *type);
+  ctx.makeLoop(pos, annotations, label, *type);
 
   CHECK_ERR(instrs(ctx));
 
@@ -1045,7 +1218,9 @@ template<typename Ctx> MaybeResult<> loop(Ctx& ctx, bool folded) {
 //            | 'try' label blocktype instr* 'deledate' label
 //            | '(' 'try' label blocktype '(' 'do' instr* ')'
 //                '(' 'delegate' label ')' ')'
-template<typename Ctx> MaybeResult<> trycatch(Ctx& ctx, bool folded) {
+template<typename Ctx>
+MaybeResult<>
+trycatch(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto pos = ctx.in.getPos();
 
   if ((folded && !ctx.in.takeSExprStart("try"sv)) ||
@@ -1058,7 +1233,7 @@ template<typename Ctx> MaybeResult<> trycatch(Ctx& ctx, bool folded) {
   auto type = blocktype(ctx);
   CHECK_ERR(type);
 
-  CHECK_ERR(ctx.makeTry(pos, label, *type));
+  CHECK_ERR(ctx.makeTry(pos, annotations, label, *type));
 
   if (folded) {
     if (!ctx.in.takeSExprStart("do"sv)) {
@@ -1229,7 +1404,9 @@ template<typename Ctx> MaybeResult<typename Ctx::CatchT> catchinstr(Ctx& ctx) {
 
 // trytable ::= 'try_table' label blocktype catchinstr* instr* 'end' id?
 //            | '(' 'try_table' label blocktype catchinstr* instr* ')'
-template<typename Ctx> MaybeResult<> trytable(Ctx& ctx, bool folded) {
+template<typename Ctx>
+MaybeResult<>
+trytable(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto pos = ctx.in.getPos();
 
   if ((folded && !ctx.in.takeSExprStart("try_table"sv)) ||
@@ -1248,7 +1425,7 @@ template<typename Ctx> MaybeResult<> trytable(Ctx& ctx, bool folded) {
     ctx.appendCatch(catches, *c);
   }
 
-  CHECK_ERR(ctx.makeTryTable(pos, label, *type, catches));
+  CHECK_ERR(ctx.makeTryTable(pos, annotations, label, *type, catches));
 
   CHECK_ERR(instrs(ctx));
 
@@ -1269,95 +1446,132 @@ template<typename Ctx> MaybeResult<> trytable(Ctx& ctx, bool folded) {
   return ctx.visitEnd();
 }
 
-template<typename Ctx> Result<> makeUnreachable(Ctx& ctx, Index pos) {
-  return ctx.makeUnreachable(pos);
+template<typename Ctx>
+Result<> makeUnreachable(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations) {
+  return ctx.makeUnreachable(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeNop(Ctx& ctx, Index pos) {
-  return ctx.makeNop(pos);
+template<typename Ctx>
+Result<>
+makeNop(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeNop(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeBinary(Ctx& ctx, Index pos, BinaryOp op) {
-  return ctx.makeBinary(pos, op);
+template<typename Ctx>
+Result<> makeBinary(Ctx& ctx,
+                    Index pos,
+                    const std::vector<Annotation>& annotations,
+                    BinaryOp op) {
+  return ctx.makeBinary(pos, annotations, op);
 }
 
-template<typename Ctx> Result<> makeUnary(Ctx& ctx, Index pos, UnaryOp op) {
-  return ctx.makeUnary(pos, op);
+template<typename Ctx>
+Result<> makeUnary(Ctx& ctx,
+                   Index pos,
+                   const std::vector<Annotation>& annotations,
+                   UnaryOp op) {
+  return ctx.makeUnary(pos, annotations, op);
 }
 
-template<typename Ctx> Result<> makeSelect(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeSelect(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto res = results(ctx);
   CHECK_ERR(res);
-  return ctx.makeSelect(pos, res.getPtr());
+  return ctx.makeSelect(pos, annotations, res.getPtr());
 }
 
-template<typename Ctx> Result<> makeDrop(Ctx& ctx, Index pos) {
-  return ctx.makeDrop(pos);
+template<typename Ctx>
+Result<>
+makeDrop(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeDrop(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeMemorySize(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeMemorySize(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
-  return ctx.makeMemorySize(pos, mem.getPtr());
+  return ctx.makeMemorySize(pos, annotations, mem.getPtr());
 }
 
-template<typename Ctx> Result<> makeMemoryGrow(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeMemoryGrow(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
-  return ctx.makeMemoryGrow(pos, mem.getPtr());
+  return ctx.makeMemoryGrow(pos, annotations, mem.getPtr());
 }
 
-template<typename Ctx> Result<> makeLocalGet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeLocalGet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto local = localidx(ctx);
   CHECK_ERR(local);
-  return ctx.makeLocalGet(pos, *local);
+  return ctx.makeLocalGet(pos, annotations, *local);
 }
 
-template<typename Ctx> Result<> makeLocalTee(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeLocalTee(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto local = localidx(ctx);
   CHECK_ERR(local);
-  return ctx.makeLocalTee(pos, *local);
+  return ctx.makeLocalTee(pos, annotations, *local);
 }
 
-template<typename Ctx> Result<> makeLocalSet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeLocalSet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto local = localidx(ctx);
   CHECK_ERR(local);
-  return ctx.makeLocalSet(pos, *local);
+  return ctx.makeLocalSet(pos, annotations, *local);
 }
 
-template<typename Ctx> Result<> makeGlobalGet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeGlobalGet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto global = globalidx(ctx);
   CHECK_ERR(global);
-  return ctx.makeGlobalGet(pos, *global);
+  return ctx.makeGlobalGet(pos, annotations, *global);
 }
 
-template<typename Ctx> Result<> makeGlobalSet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeGlobalSet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto global = globalidx(ctx);
   CHECK_ERR(global);
-  return ctx.makeGlobalSet(pos, *global);
+  return ctx.makeGlobalSet(pos, annotations, *global);
 }
 
-template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
+template<typename Ctx>
+Result<> makeConst(Ctx& ctx,
+                   Index pos,
+                   const std::vector<Annotation>& annotations,
+                   Type type) {
   assert(type.isBasic());
   switch (type.getBasic()) {
     case Type::i32:
       if (auto c = ctx.in.takeI32()) {
-        return ctx.makeI32Const(pos, *c);
+        return ctx.makeI32Const(pos, annotations, *c);
       }
       return ctx.in.err("expected i32");
     case Type::i64:
       if (auto c = ctx.in.takeI64()) {
-        return ctx.makeI64Const(pos, *c);
+        return ctx.makeI64Const(pos, annotations, *c);
       }
       return ctx.in.err("expected i64");
     case Type::f32:
       if (auto c = ctx.in.takeF32()) {
-        return ctx.makeF32Const(pos, *c);
+        return ctx.makeF32Const(pos, annotations, *c);
       }
       return ctx.in.err("expected f32");
     case Type::f64:
       if (auto c = ctx.in.takeF64()) {
-        return ctx.makeF64Const(pos, *c);
+        return ctx.makeF64Const(pos, annotations, *c);
       }
       return ctx.in.err("expected f64");
     case Type::v128:
@@ -1370,7 +1584,7 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
           }
           vals[i] = *val;
         }
-        return ctx.makeI8x16Const(pos, vals);
+        return ctx.makeI8x16Const(pos, annotations, vals);
       }
       if (ctx.in.takeKeyword("i16x8"sv)) {
         std::array<uint16_t, 8> vals;
@@ -1381,7 +1595,7 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
           }
           vals[i] = *val;
         }
-        return ctx.makeI16x8Const(pos, vals);
+        return ctx.makeI16x8Const(pos, annotations, vals);
       }
       if (ctx.in.takeKeyword("i32x4"sv)) {
         std::array<uint32_t, 4> vals;
@@ -1392,7 +1606,7 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
           }
           vals[i] = *val;
         }
-        return ctx.makeI32x4Const(pos, vals);
+        return ctx.makeI32x4Const(pos, annotations, vals);
       }
       if (ctx.in.takeKeyword("i64x2"sv)) {
         std::array<uint64_t, 2> vals;
@@ -1403,7 +1617,7 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
           }
           vals[i] = *val;
         }
-        return ctx.makeI64x2Const(pos, vals);
+        return ctx.makeI64x2Const(pos, annotations, vals);
       }
       if (ctx.in.takeKeyword("f32x4"sv)) {
         std::array<float, 4> vals;
@@ -1414,7 +1628,7 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
           }
           vals[i] = *val;
         }
-        return ctx.makeF32x4Const(pos, vals);
+        return ctx.makeF32x4Const(pos, annotations, vals);
       }
       if (ctx.in.takeKeyword("f64x2"sv)) {
         std::array<double, 2> vals;
@@ -1425,7 +1639,7 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
           }
           vals[i] = *val;
         }
-        return ctx.makeF64x2Const(pos, vals);
+        return ctx.makeF64x2Const(pos, annotations, vals);
       }
       return ctx.in.err("expected SIMD vector shape");
     case Type::none:
@@ -1436,82 +1650,125 @@ template<typename Ctx> Result<> makeConst(Ctx& ctx, Index pos, Type type) {
 }
 
 template<typename Ctx>
-Result<> makeLoad(
-  Ctx& ctx, Index pos, Type type, bool signed_, int bytes, bool isAtomic) {
+Result<> makeLoad(Ctx& ctx,
+                  Index pos,
+                  const std::vector<Annotation>& annotations,
+                  Type type,
+                  bool signed_,
+                  int bytes,
+                  bool isAtomic) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
   CHECK_ERR(arg);
-  return ctx.makeLoad(pos, type, signed_, bytes, isAtomic, mem.getPtr(), *arg);
+  return ctx.makeLoad(
+    pos, annotations, type, signed_, bytes, isAtomic, mem.getPtr(), *arg);
 }
 
 template<typename Ctx>
-Result<> makeStore(Ctx& ctx, Index pos, Type type, int bytes, bool isAtomic) {
+Result<> makeStore(Ctx& ctx,
+                   Index pos,
+                   const std::vector<Annotation>& annotations,
+                   Type type,
+                   int bytes,
+                   bool isAtomic) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
   CHECK_ERR(arg);
-  return ctx.makeStore(pos, type, bytes, isAtomic, mem.getPtr(), *arg);
+  return ctx.makeStore(
+    pos, annotations, type, bytes, isAtomic, mem.getPtr(), *arg);
 }
 
 template<typename Ctx>
-Result<>
-makeAtomicRMW(Ctx& ctx, Index pos, AtomicRMWOp op, Type type, uint8_t bytes) {
+Result<> makeAtomicRMW(Ctx& ctx,
+                       Index pos,
+                       const std::vector<Annotation>& annotations,
+                       AtomicRMWOp op,
+                       Type type,
+                       uint8_t bytes) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
   CHECK_ERR(arg);
-  return ctx.makeAtomicRMW(pos, op, type, bytes, mem.getPtr(), *arg);
+  return ctx.makeAtomicRMW(
+    pos, annotations, op, type, bytes, mem.getPtr(), *arg);
 }
 
 template<typename Ctx>
-Result<> makeAtomicCmpxchg(Ctx& ctx, Index pos, Type type, uint8_t bytes) {
+Result<> makeAtomicCmpxchg(Ctx& ctx,
+                           Index pos,
+                           const std::vector<Annotation>& annotations,
+                           Type type,
+                           uint8_t bytes) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
   CHECK_ERR(arg);
-  return ctx.makeAtomicCmpxchg(pos, type, bytes, mem.getPtr(), *arg);
+  return ctx.makeAtomicCmpxchg(
+    pos, annotations, type, bytes, mem.getPtr(), *arg);
 }
 
-template<typename Ctx> Result<> makeAtomicWait(Ctx& ctx, Index pos, Type type) {
+template<typename Ctx>
+Result<> makeAtomicWait(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations,
+                        Type type) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, type == Type::i32 ? 4 : 8);
   CHECK_ERR(arg);
-  return ctx.makeAtomicWait(pos, type, mem.getPtr(), *arg);
+  return ctx.makeAtomicWait(pos, annotations, type, mem.getPtr(), *arg);
 }
 
-template<typename Ctx> Result<> makeAtomicNotify(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeAtomicNotify(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, 4);
   CHECK_ERR(arg);
-  return ctx.makeAtomicNotify(pos, mem.getPtr(), *arg);
-}
-
-template<typename Ctx> Result<> makeAtomicFence(Ctx& ctx, Index pos) {
-  return ctx.makeAtomicFence(pos);
+  return ctx.makeAtomicNotify(pos, annotations, mem.getPtr(), *arg);
 }
 
 template<typename Ctx>
-Result<> makeSIMDExtract(Ctx& ctx, Index pos, SIMDExtractOp op, size_t) {
+Result<> makeAtomicFence(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations) {
+  return ctx.makeAtomicFence(pos, annotations);
+}
+
+template<typename Ctx>
+Result<> makeSIMDExtract(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations,
+                         SIMDExtractOp op,
+                         size_t) {
   auto lane = ctx.in.takeU8();
   if (!lane) {
     return ctx.in.err("expected lane index");
   }
-  return ctx.makeSIMDExtract(pos, op, *lane);
+  return ctx.makeSIMDExtract(pos, annotations, op, *lane);
 }
 
 template<typename Ctx>
-Result<> makeSIMDReplace(Ctx& ctx, Index pos, SIMDReplaceOp op, size_t lanes) {
+Result<> makeSIMDReplace(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations,
+                         SIMDReplaceOp op,
+                         size_t lanes) {
   auto lane = ctx.in.takeU8();
   if (!lane) {
     return ctx.in.err("expected lane index");
   }
-  return ctx.makeSIMDReplace(pos, op, *lane);
+  return ctx.makeSIMDReplace(pos, annotations, op, *lane);
 }
 
-template<typename Ctx> Result<> makeSIMDShuffle(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeSIMDShuffle(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations) {
   std::array<uint8_t, 16> lanes;
   for (int i = 0; i < 16; ++i) {
     auto lane = ctx.in.takeU8();
@@ -1520,31 +1777,44 @@ template<typename Ctx> Result<> makeSIMDShuffle(Ctx& ctx, Index pos) {
     }
     lanes[i] = *lane;
   }
-  return ctx.makeSIMDShuffle(pos, lanes);
+  return ctx.makeSIMDShuffle(pos, annotations, lanes);
 }
 
 template<typename Ctx>
-Result<> makeSIMDTernary(Ctx& ctx, Index pos, SIMDTernaryOp op) {
-  return ctx.makeSIMDTernary(pos, op);
+Result<> makeSIMDTernary(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations,
+                         SIMDTernaryOp op) {
+  return ctx.makeSIMDTernary(pos, annotations, op);
 }
 
 template<typename Ctx>
-Result<> makeSIMDShift(Ctx& ctx, Index pos, SIMDShiftOp op) {
-  return ctx.makeSIMDShift(pos, op);
+Result<> makeSIMDShift(Ctx& ctx,
+                       Index pos,
+                       const std::vector<Annotation>& annotations,
+                       SIMDShiftOp op) {
+  return ctx.makeSIMDShift(pos, annotations, op);
 }
 
 template<typename Ctx>
-Result<> makeSIMDLoad(Ctx& ctx, Index pos, SIMDLoadOp op, int bytes) {
+Result<> makeSIMDLoad(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      SIMDLoadOp op,
+                      int bytes) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
   auto arg = memarg(ctx, bytes);
   CHECK_ERR(arg);
-  return ctx.makeSIMDLoad(pos, op, mem.getPtr(), *arg);
+  return ctx.makeSIMDLoad(pos, annotations, op, mem.getPtr(), *arg);
 }
 
 template<typename Ctx>
-Result<>
-makeSIMDLoadStoreLane(Ctx& ctx, Index pos, SIMDLoadStoreLaneOp op, int bytes) {
+Result<> makeSIMDLoadStoreLane(Ctx& ctx,
+                               Index pos,
+                               const std::vector<Annotation>& annotations,
+                               SIMDLoadStoreLaneOp op,
+                               int bytes) {
   auto reset = ctx.in.getPos();
 
   auto retry = [&]() -> Result<> {
@@ -1557,7 +1827,8 @@ makeSIMDLoadStoreLane(Ctx& ctx, Index pos, SIMDLoadStoreLaneOp op, int bytes) {
     if (!lane) {
       return ctx.in.err("expected lane index");
     }
-    return ctx.makeSIMDLoadStoreLane(pos, op, nullptr, *arg, *lane);
+    return ctx.makeSIMDLoadStoreLane(
+      pos, annotations, op, nullptr, *arg, *lane);
   };
 
   auto mem = maybeMemidx(ctx);
@@ -1570,10 +1841,14 @@ makeSIMDLoadStoreLane(Ctx& ctx, Index pos, SIMDLoadStoreLaneOp op, int bytes) {
   if (!lane) {
     return retry();
   }
-  return ctx.makeSIMDLoadStoreLane(pos, op, mem.getPtr(), *arg, *lane);
+  return ctx.makeSIMDLoadStoreLane(
+    pos, annotations, op, mem.getPtr(), *arg, *lane);
 }
 
-template<typename Ctx> Result<> makeMemoryInit(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeMemoryInit(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations) {
   auto reset = ctx.in.getPos();
 
   auto retry = [&]() -> Result<> {
@@ -1582,7 +1857,7 @@ template<typename Ctx> Result<> makeMemoryInit(Ctx& ctx, Index pos) {
     WithPosition with(ctx, reset);
     auto data = dataidx(ctx);
     CHECK_ERR(data);
-    return ctx.makeMemoryInit(pos, nullptr, *data);
+    return ctx.makeMemoryInit(pos, annotations, nullptr, *data);
   };
 
   auto mem = maybeMemidx(ctx);
@@ -1593,16 +1868,21 @@ template<typename Ctx> Result<> makeMemoryInit(Ctx& ctx, Index pos) {
   if (data.getErr()) {
     return retry();
   }
-  return ctx.makeMemoryInit(pos, mem.getPtr(), *data);
+  return ctx.makeMemoryInit(pos, annotations, mem.getPtr(), *data);
 }
 
-template<typename Ctx> Result<> makeDataDrop(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeDataDrop(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto data = dataidx(ctx);
   CHECK_ERR(data);
-  return ctx.makeDataDrop(pos, *data);
+  return ctx.makeDataDrop(pos, annotations, *data);
 }
 
-template<typename Ctx> Result<> makeMemoryCopy(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeMemoryCopy(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations) {
   auto destMem = maybeMemidx(ctx);
   CHECK_ERR(destMem);
   std::optional<typename Ctx::MemoryIdxT> srcMem = std::nullopt;
@@ -1611,44 +1891,64 @@ template<typename Ctx> Result<> makeMemoryCopy(Ctx& ctx, Index pos) {
     CHECK_ERR(mem);
     srcMem = *mem;
   }
-  return ctx.makeMemoryCopy(pos, destMem.getPtr(), srcMem ? &*srcMem : nullptr);
-}
-
-template<typename Ctx> Result<> makeMemoryFill(Ctx& ctx, Index pos) {
-  auto mem = maybeMemidx(ctx);
-  CHECK_ERR(mem);
-  return ctx.makeMemoryFill(pos, mem.getPtr());
-}
-
-template<typename Ctx> Result<> makePop(Ctx& ctx, Index pos) {
-  auto type = valtype(ctx);
-  CHECK_ERR(type);
-  return ctx.makePop(pos, *type);
-}
-
-template<typename Ctx> Result<> makeCall(Ctx& ctx, Index pos, bool isReturn) {
-  auto func = funcidx(ctx);
-  CHECK_ERR(func);
-  return ctx.makeCall(pos, *func, isReturn);
+  return ctx.makeMemoryCopy(
+    pos, annotations, destMem.getPtr(), srcMem ? &*srcMem : nullptr);
 }
 
 template<typename Ctx>
-Result<> makeCallIndirect(Ctx& ctx, Index pos, bool isReturn) {
+Result<> makeMemoryFill(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations) {
+  auto mem = maybeMemidx(ctx);
+  CHECK_ERR(mem);
+  return ctx.makeMemoryFill(pos, annotations, mem.getPtr());
+}
+
+template<typename Ctx>
+Result<>
+makePop(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  auto type = valtype(ctx);
+  CHECK_ERR(type);
+  return ctx.makePop(pos, annotations, *type);
+}
+
+template<typename Ctx>
+Result<> makeCall(Ctx& ctx,
+                  Index pos,
+                  const std::vector<Annotation>& annotations,
+                  bool isReturn) {
+  auto func = funcidx(ctx);
+  CHECK_ERR(func);
+  return ctx.makeCall(pos, annotations, *func, isReturn);
+}
+
+template<typename Ctx>
+Result<> makeCallIndirect(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations,
+                          bool isReturn) {
   auto table = maybeTableidx(ctx);
   CHECK_ERR(table);
   auto type = typeuse(ctx);
   CHECK_ERR(type);
-  return ctx.makeCallIndirect(pos, table.getPtr(), *type, isReturn);
+  return ctx.makeCallIndirect(
+    pos, annotations, table.getPtr(), *type, isReturn);
 }
 
 template<typename Ctx>
-Result<> makeBreak(Ctx& ctx, Index pos, bool isConditional) {
+Result<> makeBreak(Ctx& ctx,
+                   Index pos,
+                   const std::vector<Annotation>& annotations,
+                   bool isConditional) {
   auto label = labelidx(ctx);
   CHECK_ERR(label);
-  return ctx.makeBreak(pos, *label, isConditional);
+  return ctx.makeBreak(pos, annotations, *label, isConditional);
 }
 
-template<typename Ctx> Result<> makeBreakTable(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeBreakTable(Ctx& ctx,
+                        Index pos,
+                        const std::vector<Annotation>& annotations) {
   std::vector<typename Ctx::LabelIdxT> labels;
   while (true) {
     // Parse at least one label; return an error only if we parse none.
@@ -1662,64 +1962,86 @@ template<typename Ctx> Result<> makeBreakTable(Ctx& ctx, Index pos) {
   }
   auto defaultLabel = labels.back();
   labels.pop_back();
-  return ctx.makeSwitch(pos, labels, defaultLabel);
+  return ctx.makeSwitch(pos, annotations, labels, defaultLabel);
 }
 
-template<typename Ctx> Result<> makeReturn(Ctx& ctx, Index pos) {
-  return ctx.makeReturn(pos);
+template<typename Ctx>
+Result<>
+makeReturn(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeReturn(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeRefNull(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeRefNull(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto t = heaptype(ctx);
   CHECK_ERR(t);
-  return ctx.makeRefNull(pos, *t);
+  return ctx.makeRefNull(pos, annotations, *t);
 }
 
-template<typename Ctx> Result<> makeRefIsNull(Ctx& ctx, Index pos) {
-  return ctx.makeRefIsNull(pos);
+template<typename Ctx>
+Result<>
+makeRefIsNull(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeRefIsNull(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeRefFunc(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeRefFunc(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto func = funcidx(ctx);
   CHECK_ERR(func);
-  return ctx.makeRefFunc(pos, *func);
+  return ctx.makeRefFunc(pos, annotations, *func);
 }
 
-template<typename Ctx> Result<> makeRefEq(Ctx& ctx, Index pos) {
-  return ctx.makeRefEq(pos);
+template<typename Ctx>
+Result<>
+makeRefEq(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeRefEq(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeTableGet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTableGet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto table = maybeTableidx(ctx);
   CHECK_ERR(table);
-  return ctx.makeTableGet(pos, table.getPtr());
+  return ctx.makeTableGet(pos, annotations, table.getPtr());
 }
 
-template<typename Ctx> Result<> makeTableSet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTableSet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto table = maybeTableidx(ctx);
   CHECK_ERR(table);
-  return ctx.makeTableSet(pos, table.getPtr());
+  return ctx.makeTableSet(pos, annotations, table.getPtr());
 }
 
-template<typename Ctx> Result<> makeTableSize(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTableSize(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto table = maybeTableidx(ctx);
   CHECK_ERR(table);
-  return ctx.makeTableSize(pos, table.getPtr());
+  return ctx.makeTableSize(pos, annotations, table.getPtr());
 }
 
-template<typename Ctx> Result<> makeTableGrow(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTableGrow(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto table = maybeTableidx(ctx);
   CHECK_ERR(table);
-  return ctx.makeTableGrow(pos, table.getPtr());
+  return ctx.makeTableGrow(pos, annotations, table.getPtr());
 }
 
-template<typename Ctx> Result<> makeTableFill(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTableFill(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto table = maybeTableidx(ctx);
   CHECK_ERR(table);
-  return ctx.makeTableFill(pos, table.getPtr());
+  return ctx.makeTableFill(pos, annotations, table.getPtr());
 }
 
-template<typename Ctx> Result<> makeTableCopy(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTableCopy(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto destTable = maybeTableidx(ctx);
   CHECK_ERR(destTable);
   auto srcTable = maybeTableidx(ctx);
@@ -1727,279 +2049,399 @@ template<typename Ctx> Result<> makeTableCopy(Ctx& ctx, Index pos) {
   if (destTable && !srcTable) {
     return ctx.in.err("expected table index or identifier");
   }
-  return ctx.makeTableCopy(pos, destTable.getPtr(), srcTable.getPtr());
+  return ctx.makeTableCopy(
+    pos, annotations, destTable.getPtr(), srcTable.getPtr());
 }
 
-template<typename Ctx> Result<> makeThrow(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeThrow(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto tag = tagidx(ctx);
   CHECK_ERR(tag);
-  return ctx.makeThrow(pos, *tag);
+  return ctx.makeThrow(pos, annotations, *tag);
 }
 
-template<typename Ctx> Result<> makeRethrow(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeRethrow(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto label = labelidx(ctx);
   CHECK_ERR(label);
-  return ctx.makeRethrow(pos, *label);
+  return ctx.makeRethrow(pos, annotations, *label);
 }
 
-template<typename Ctx> Result<> makeThrowRef(Ctx& ctx, Index pos) {
-  return ctx.makeThrowRef(pos);
+template<typename Ctx>
+Result<>
+makeThrowRef(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeThrowRef(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeTupleMake(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeTupleMake(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto arity = tupleArity(ctx);
   CHECK_ERR(arity);
-  return ctx.makeTupleMake(pos, *arity);
+  return ctx.makeTupleMake(pos, annotations, *arity);
 }
 
-template<typename Ctx> Result<> makeTupleExtract(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeTupleExtract(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations) {
   auto arity = tupleArity(ctx);
   CHECK_ERR(arity);
   auto index = ctx.in.takeU32();
   if (!index) {
     return ctx.in.err("expected tuple index");
   }
-  return ctx.makeTupleExtract(pos, *arity, *index);
-}
-
-template<typename Ctx> Result<> makeTupleDrop(Ctx& ctx, Index pos) {
-  auto arity = tupleArity(ctx);
-  CHECK_ERR(arity);
-  return ctx.makeTupleDrop(pos, *arity);
+  return ctx.makeTupleExtract(pos, annotations, *arity, *index);
 }
 
 template<typename Ctx>
-Result<> makeCallRef(Ctx& ctx, Index pos, bool isReturn) {
+Result<>
+makeTupleDrop(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  auto arity = tupleArity(ctx);
+  CHECK_ERR(arity);
+  return ctx.makeTupleDrop(pos, annotations, *arity);
+}
+
+template<typename Ctx>
+Result<> makeCallRef(Ctx& ctx,
+                     Index pos,
+                     const std::vector<Annotation>& annotations,
+                     bool isReturn) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
-  return ctx.makeCallRef(pos, *type, isReturn);
+  return ctx.makeCallRef(pos, annotations, *type, isReturn);
 }
 
-template<typename Ctx> Result<> makeRefI31(Ctx& ctx, Index pos) {
-  return ctx.makeRefI31(pos);
+template<typename Ctx>
+Result<>
+makeRefI31(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeRefI31(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeI31Get(Ctx& ctx, Index pos, bool signed_) {
-  return ctx.makeI31Get(pos, signed_);
+template<typename Ctx>
+Result<> makeI31Get(Ctx& ctx,
+                    Index pos,
+                    const std::vector<Annotation>& annotations,
+                    bool signed_) {
+  return ctx.makeI31Get(pos, annotations, signed_);
 }
 
-template<typename Ctx> Result<> makeRefTest(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeRefTest(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = reftype(ctx);
   CHECK_ERR(type);
-  return ctx.makeRefTest(pos, *type);
+  return ctx.makeRefTest(pos, annotations, *type);
 }
 
-template<typename Ctx> Result<> makeRefCast(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeRefCast(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = reftype(ctx);
   CHECK_ERR(type);
-  return ctx.makeRefCast(pos, *type);
+  return ctx.makeRefCast(pos, annotations, *type);
 }
 
-template<typename Ctx> Result<> makeBrOnNull(Ctx& ctx, Index pos, bool onFail) {
+template<typename Ctx>
+Result<> makeBrOnNull(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      bool onFail) {
   auto label = labelidx(ctx);
   CHECK_ERR(label);
-  return ctx.makeBrOn(pos, *label, onFail ? BrOnNonNull : BrOnNull);
+  return ctx.makeBrOn(
+    pos, annotations, *label, onFail ? BrOnNonNull : BrOnNull);
 }
 
-template<typename Ctx> Result<> makeBrOnCast(Ctx& ctx, Index pos, bool onFail) {
+template<typename Ctx>
+Result<> makeBrOnCast(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      bool onFail) {
   auto label = labelidx(ctx);
   CHECK_ERR(label);
   auto in = reftype(ctx);
   CHECK_ERR(in);
   auto out = reftype(ctx);
   CHECK_ERR(out);
-  return ctx.makeBrOn(pos, *label, onFail ? BrOnCastFail : BrOnCast, *in, *out);
+  return ctx.makeBrOn(
+    pos, annotations, *label, onFail ? BrOnCastFail : BrOnCast, *in, *out);
 }
 
 template<typename Ctx>
-Result<> makeStructNew(Ctx& ctx, Index pos, bool default_) {
+Result<> makeStructNew(Ctx& ctx,
+                       Index pos,
+                       const std::vector<Annotation>& annotations,
+                       bool default_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   if (default_) {
-    return ctx.makeStructNewDefault(pos, *type);
+    return ctx.makeStructNewDefault(pos, annotations, *type);
   }
-  return ctx.makeStructNew(pos, *type);
+  return ctx.makeStructNew(pos, annotations, *type);
 }
 
 template<typename Ctx>
-Result<> makeStructGet(Ctx& ctx, Index pos, bool signed_) {
+Result<> makeStructGet(Ctx& ctx,
+                       Index pos,
+                       const std::vector<Annotation>& annotations,
+                       bool signed_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto field = fieldidx(ctx, *type);
   CHECK_ERR(field);
-  return ctx.makeStructGet(pos, *type, *field, signed_);
+  return ctx.makeStructGet(pos, annotations, *type, *field, signed_);
 }
 
-template<typename Ctx> Result<> makeStructSet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeStructSet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto field = fieldidx(ctx, *type);
   CHECK_ERR(field);
-  return ctx.makeStructSet(pos, *type, *field);
+  return ctx.makeStructSet(pos, annotations, *type, *field);
 }
 
 template<typename Ctx>
-Result<> makeArrayNew(Ctx& ctx, Index pos, bool default_) {
+Result<> makeArrayNew(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      bool default_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   if (default_) {
-    return ctx.makeArrayNewDefault(pos, *type);
+    return ctx.makeArrayNewDefault(pos, annotations, *type);
   }
-  return ctx.makeArrayNew(pos, *type);
+  return ctx.makeArrayNew(pos, annotations, *type);
 }
 
-template<typename Ctx> Result<> makeArrayNewData(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeArrayNewData(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto data = dataidx(ctx);
   CHECK_ERR(data);
-  return ctx.makeArrayNewData(pos, *type, *data);
+  return ctx.makeArrayNewData(pos, annotations, *type, *data);
 }
 
-template<typename Ctx> Result<> makeArrayNewElem(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeArrayNewElem(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto elem = elemidx(ctx);
   CHECK_ERR(elem);
-  return ctx.makeArrayNewElem(pos, *type, *elem);
+  return ctx.makeArrayNewElem(pos, annotations, *type, *elem);
 }
 
-template<typename Ctx> Result<> makeArrayNewFixed(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeArrayNewFixed(Ctx& ctx,
+                           Index pos,
+                           const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto arity = ctx.in.takeU32();
   if (!arity) {
     return ctx.in.err(pos, "expected array.new_fixed arity");
   }
-  return ctx.makeArrayNewFixed(pos, *type, *arity);
+  return ctx.makeArrayNewFixed(pos, annotations, *type, *arity);
 }
 
 template<typename Ctx>
-Result<> makeArrayGet(Ctx& ctx, Index pos, bool signed_) {
+Result<> makeArrayGet(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      bool signed_) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
-  return ctx.makeArrayGet(pos, *type, signed_);
+  return ctx.makeArrayGet(pos, annotations, *type, signed_);
 }
 
-template<typename Ctx> Result<> makeArraySet(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeArraySet(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
-  return ctx.makeArraySet(pos, *type);
+  return ctx.makeArraySet(pos, annotations, *type);
 }
 
-template<typename Ctx> Result<> makeArrayLen(Ctx& ctx, Index pos) {
-  return ctx.makeArrayLen(pos);
+template<typename Ctx>
+Result<>
+makeArrayLen(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+  return ctx.makeArrayLen(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeArrayCopy(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeArrayCopy(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto destType = typeidx(ctx);
   CHECK_ERR(destType);
   auto srcType = typeidx(ctx);
   CHECK_ERR(srcType);
-  return ctx.makeArrayCopy(pos, *destType, *srcType);
+  return ctx.makeArrayCopy(pos, annotations, *destType, *srcType);
 }
 
-template<typename Ctx> Result<> makeArrayFill(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeArrayFill(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
-  return ctx.makeArrayFill(pos, *type);
+  return ctx.makeArrayFill(pos, annotations, *type);
 }
 
-template<typename Ctx> Result<> makeArrayInitData(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeArrayInitData(Ctx& ctx,
+                           Index pos,
+                           const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto data = dataidx(ctx);
   CHECK_ERR(data);
-  return ctx.makeArrayInitData(pos, *type, *data);
-}
-
-template<typename Ctx> Result<> makeArrayInitElem(Ctx& ctx, Index pos) {
-  auto type = typeidx(ctx);
-  CHECK_ERR(type);
-  auto elem = elemidx(ctx);
-  return ctx.makeArrayInitElem(pos, *type, *elem);
-}
-
-template<typename Ctx> Result<> makeRefAs(Ctx& ctx, Index pos, RefAsOp op) {
-  return ctx.makeRefAs(pos, op);
+  return ctx.makeArrayInitData(pos, annotations, *type, *data);
 }
 
 template<typename Ctx>
-Result<> makeStringNew(Ctx& ctx, Index pos, StringNewOp op, bool try_) {
-  auto mem = maybeMemidx(ctx);
-  CHECK_ERR(mem);
-  return ctx.makeStringNew(pos, op, try_, mem.getPtr());
+Result<> makeArrayInitElem(Ctx& ctx,
+                           Index pos,
+                           const std::vector<Annotation>& annotations) {
+  auto type = typeidx(ctx);
+  CHECK_ERR(type);
+  auto elem = elemidx(ctx);
+  return ctx.makeArrayInitElem(pos, annotations, *type, *elem);
 }
 
-template<typename Ctx> Result<> makeStringConst(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeRefAs(Ctx& ctx,
+                   Index pos,
+                   const std::vector<Annotation>& annotations,
+                   RefAsOp op) {
+  return ctx.makeRefAs(pos, annotations, op);
+}
+
+template<typename Ctx>
+Result<> makeStringNew(Ctx& ctx,
+                       Index pos,
+                       const std::vector<Annotation>& annotations,
+                       StringNewOp op,
+                       bool try_) {
+  auto mem = maybeMemidx(ctx);
+  CHECK_ERR(mem);
+  return ctx.makeStringNew(pos, annotations, op, try_, mem.getPtr());
+}
+
+template<typename Ctx>
+Result<> makeStringConst(Ctx& ctx,
+                         Index pos,
+                         const std::vector<Annotation>& annotations) {
   auto str = ctx.in.takeString();
   if (!str) {
     return ctx.in.err("expected string");
   }
-  return ctx.makeStringConst(pos, *str);
+  return ctx.makeStringConst(pos, annotations, *str);
 }
 
 template<typename Ctx>
-Result<> makeStringMeasure(Ctx& ctx, Index pos, StringMeasureOp op) {
-  return ctx.makeStringMeasure(pos, op);
+Result<> makeStringMeasure(Ctx& ctx,
+                           Index pos,
+                           const std::vector<Annotation>& annotations,
+                           StringMeasureOp op) {
+  return ctx.makeStringMeasure(pos, annotations, op);
 }
 
 template<typename Ctx>
-Result<> makeStringEncode(Ctx& ctx, Index pos, StringEncodeOp op) {
+Result<> makeStringEncode(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations,
+                          StringEncodeOp op) {
   auto mem = maybeMemidx(ctx);
   CHECK_ERR(mem);
-  return ctx.makeStringEncode(pos, op, mem.getPtr());
-}
-
-template<typename Ctx> Result<> makeStringConcat(Ctx& ctx, Index pos) {
-  return ctx.makeStringConcat(pos);
+  return ctx.makeStringEncode(pos, annotations, op, mem.getPtr());
 }
 
 template<typename Ctx>
-Result<> makeStringEq(Ctx& ctx, Index pos, StringEqOp op) {
-  return ctx.makeStringEq(pos, op);
+Result<> makeStringConcat(Ctx& ctx,
+                          Index pos,
+                          const std::vector<Annotation>& annotations) {
+  return ctx.makeStringConcat(pos, annotations);
 }
 
 template<typename Ctx>
-Result<> makeStringAs(Ctx& ctx, Index pos, StringAsOp op) {
-  return ctx.makeStringAs(pos, op);
-}
-
-template<typename Ctx> Result<> makeStringWTF8Advance(Ctx& ctx, Index pos) {
-  return ctx.makeStringWTF8Advance(pos);
-}
-
-template<typename Ctx> Result<> makeStringWTF16Get(Ctx& ctx, Index pos) {
-  return ctx.makeStringWTF16Get(pos);
-}
-
-template<typename Ctx> Result<> makeStringIterNext(Ctx& ctx, Index pos) {
-  return ctx.makeStringIterNext(pos);
+Result<> makeStringEq(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      StringEqOp op) {
+  return ctx.makeStringEq(pos, annotations, op);
 }
 
 template<typename Ctx>
-Result<> makeStringIterMove(Ctx& ctx, Index pos, StringIterMoveOp op) {
-  return ctx.makeStringIterMove(pos, op);
+Result<> makeStringAs(Ctx& ctx,
+                      Index pos,
+                      const std::vector<Annotation>& annotations,
+                      StringAsOp op) {
+  return ctx.makeStringAs(pos, annotations, op);
 }
 
 template<typename Ctx>
-Result<> makeStringSliceWTF(Ctx& ctx, Index pos, StringSliceWTFOp op) {
-  return ctx.makeStringSliceWTF(pos, op);
+Result<> makeStringWTF8Advance(Ctx& ctx,
+                               Index pos,
+                               const std::vector<Annotation>& annotations) {
+  return ctx.makeStringWTF8Advance(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeStringSliceIter(Ctx& ctx, Index pos) {
-  return ctx.makeStringSliceIter(pos);
+template<typename Ctx>
+Result<> makeStringWTF16Get(Ctx& ctx,
+                            Index pos,
+                            const std::vector<Annotation>& annotations) {
+  return ctx.makeStringWTF16Get(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeContNew(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<> makeStringIterNext(Ctx& ctx,
+                            Index pos,
+                            const std::vector<Annotation>& annotations) {
+  return ctx.makeStringIterNext(pos, annotations);
+}
+
+template<typename Ctx>
+Result<> makeStringIterMove(Ctx& ctx,
+                            Index pos,
+                            const std::vector<Annotation>& annotations,
+                            StringIterMoveOp op) {
+  return ctx.makeStringIterMove(pos, annotations, op);
+}
+
+template<typename Ctx>
+Result<> makeStringSliceWTF(Ctx& ctx,
+                            Index pos,
+                            const std::vector<Annotation>& annotations,
+                            StringSliceWTFOp op) {
+  return ctx.makeStringSliceWTF(pos, annotations, op);
+}
+
+template<typename Ctx>
+Result<> makeStringSliceIter(Ctx& ctx,
+                             Index pos,
+                             const std::vector<Annotation>& annotations) {
+  return ctx.makeStringSliceIter(pos, annotations);
+}
+
+template<typename Ctx> Result<> makeContNew(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
 
-  return ctx.makeContNew(pos, *type);
+  return ctx.makeContNew(pos, annotations, *type);
 }
 
 // resume ::= 'resume' typeidx ('(' 'tag' tagidx labelidx ')')*
-template<typename Ctx> Result<> makeResume(Ctx& ctx, Index pos) {
+template<typename Ctx>
+Result<>
+makeResume(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
 
@@ -2015,7 +2457,7 @@ template<typename Ctx> Result<> makeResume(Ctx& ctx, Index pos) {
     }
   }
 
-  return ctx.makeResume(pos, *type, tagLabels);
+  return ctx.makeResume(pos, annotations, *type, tagLabels);
 }
 
 // =======

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -2431,7 +2431,9 @@ Result<> makeStringSliceIter(Ctx& ctx,
   return ctx.makeStringSliceIter(pos, annotations);
 }
 
-template<typename Ctx> Result<> makeContNew(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
+template<typename Ctx>
+Result<>
+makeContNew(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   auto type = typeidx(ctx);
   CHECK_ERR(type);
 

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -56,6 +56,10 @@ public:
   // any children or refinalization.
   void push(Expression*);
 
+  // Set the debug location to be attached to the next visited, created, or
+  // pushed instruction.
+  void setDebugLocation(const Function::DebugLocation&);
+
   // Handle the boundaries of control flow structures. Users may choose to use
   // the corresponding `makeXYZ` function below instead of `visitXYZStart`, but
   // either way must call `visitEnd` and friends at the appropriate times.
@@ -243,6 +247,9 @@ private:
   Module& wasm;
   Function* func;
   Builder builder;
+  std::optional<Function::DebugLocation> debugLoc;
+
+  void applyDebugLoc(Expression* expr);
 
   // The context for a single block scope, including the instructions parsed
   // inside that scope so far and the ultimate result type we expect this block

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -463,6 +463,11 @@
  ;; CHECK:      (start $return-none)
  (start $return-none)
 
+ ;; Annotations
+ (@annotation this is a meaningless (@annotation ) ;; This is still a comment ))
+   it spans multiple lines just fine and can include $ids 0x42 numbers and "strings"
+ )
+
  ;; functions
  (func)
 
@@ -5090,6 +5095,67 @@
  (func $contnew (param $f (ref $simple)) (result (ref $simple-cont))
    local.get $f
    cont.new $simple-cont
+ )
+
+ ;; CHECK:      (func $source-maps (type $void)
+ ;; CHECK-NEXT:  ;;@ src.cpp:40:1
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   ;;@ src.cpp:30:1
+ ;; CHECK-NEXT:   (i32.add
+ ;; CHECK-NEXT:    ;;@ src.cpp:10:1
+ ;; CHECK-NEXT:    (i32.const 0)
+ ;; CHECK-NEXT:    ;;@ src.cpp:20:1
+ ;; CHECK-NEXT:    (i32.const 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  ;;@ src.cpp:90:1
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   ;;@ src.cpp:70:1
+ ;; CHECK-NEXT:   (i32.add
+ ;; CHECK-NEXT:    ;;@ src.cpp:50:1
+ ;; CHECK-NEXT:    (i32.const 2)
+ ;; CHECK-NEXT:    ;;@ src.cpp:60:1
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     ;;@ src.cpp:70:1
+ ;; CHECK-NEXT:     (loop (result i32)
+ ;; CHECK-NEXT:      ;;@ src.cpp:80:1
+ ;; CHECK-NEXT:      (unreachable)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  ;;@ src.cpp:100:1
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $source-maps
+  ;;@ src.cpp:10:1
+  i32.const 0
+  ;;@ src.cpp:20:1
+  i32.const 1
+  (@src src.cpp:30:1)
+  i32.add
+  (@src src.cpp:40:1)
+  drop
+  ;;@ src.cpp:90:1
+  (drop
+   (@src src.cpp:70:1)
+   (i32.add
+    ;;@ src.cpp:50:1
+    (i32.const 2)
+    (@src src.cpp:60:1)
+    (block (result i32)
+     ;;@ src.cpp:70:1
+     (loop (result i32)
+       ;;@ src.cpp:80:1
+       (unreachable)
+     )
+    )
+   )
+  )
+  ;;@ src.cpp:100:1
+  block
+  end
  )
 
  ;; CHECK:      (func $use-types (type $101) (param $0 (ref $s0)) (param $1 (ref $s1)) (param $2 (ref $s2)) (param $3 (ref $s3)) (param $4 (ref $s4)) (param $5 (ref $s5)) (param $6 (ref $s6)) (param $7 (ref $s7)) (param $8 (ref $s8)) (param $9 (ref $a0)) (param $10 (ref $a1)) (param $11 (ref $a2)) (param $12 (ref $a3)) (param $13 (ref $subvoid)) (param $14 (ref $submany)) (param $15 (ref $all-types))


### PR DESCRIPTION
Parse annotations using the standards-track `(@annotation ...)` format as well
as the `;;@ source-map:0:1` format. Have the lexer implicitly collect
annotations while it skips whitespace and add lexer APIs to access the
annotations since the last token was parsed. Collect annotations before parsing
each instruction and pass the annotations explicitly to the parser and parser
context functions for instructions. Add an API to `IRBuilder` to set a debug
location to be attached to the next visited or created instruction and use it
from the parser.