### PR TITLE
Tests/Fuzzing: Remove some obsolete experimental V8 flags

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -256,12 +256,8 @@ def has_shell_timeout():
 V8_OPTS = [
     '--wasm-staging',
     '--experimental-wasm-compilation-hints',
-    '--experimental-wasm-gc',
-    '--experimental-wasm-typed-funcref',
     '--experimental-wasm-memory64',
-    '--experimental-wasm-extended-const',
     '--experimental-wasm-stringref',
-    '--wasm-final-types',
 ]
 
 # external tools


### PR DESCRIPTION
Those flags were removed in V8 as the features are no longer experimental. This
PR removes this noise from our logs:
```
Warning: unknown flag --experimental-wasm-gc.                                                                                                                                                 
Try --help for options                                                                                                                                                                        
Warning: unknown flag --experimental-wasm-typed-funcref.                                                                                                                                      
Try --help for options                                                                         
Warning: unknown flag --experimental-wasm-extended-const.                                                                                                                                     
Try --help for options                                                                         
Warning: unknown flag --wasm-final-types.                                                      
Try --help for options                                                                         
```
However, older versions of V8 may not work any more without those flags. I
always test on a recent one, and I'm not sure if we have a use for anything
else?