### PR TITLE
Fuzzer: Improve BigInt printing

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -50,6 +50,10 @@ function printed(x, y) {
   } else if (typeof x === 'string') {
     // Emit a string in the same format as the binaryen interpreter.
     return 'string("' + x + '")';
+  } else if (typeof x === 'bigint') {
+    // Print bigints in legalized form, which is two 32-bit numbers of the low
+    // and high bits.
+    return (Number(x) | 0) + ' ' + (Number(x >> 32n) | 0)
   } else if (typeof x !== 'number') {
     // Something that is not a number or string, like a reference. We can't
     // print a reference because it could look different after opts - imagine


### PR DESCRIPTION
Before this we only printed the type of a BigInt and not the value.