### PR TITLE
[Emscripten port] Fix core count logic for Emscripten+pthreads

### DIFF
--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -139,15 +139,17 @@ void ThreadPool::initialize(size_t num) {
 }
 
 size_t ThreadPool::getNumCores() {
-#ifdef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
+  // In an Emscripten build without pthreads support, avoid the overhead of
+  // including support code for the below runtime checks.
   return 1;
-#else
+#endif
+
   size_t num = std::max(1U, std::thread::hardware_concurrency());
   if (getenv("BINARYEN_CORES")) {
     num = std::stoi(getenv("BINARYEN_CORES"));
   }
   return num;
-#endif
 }
 
 ThreadPool* ThreadPool::get() {


### PR DESCRIPTION
Before this all Emscripten builds would use 1 core.