### PR TITLE
Add a WebAssembly build to release

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -173,6 +173,9 @@ jobs:
   build-wasm:
     name: wasm
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/setup-python@v1
       with:
@@ -202,8 +205,13 @@ jobs:
     - name: build
       run: ninja -C out wasm-opt
 
-    # TODO: Add some testing here. The full test suite is overkill as there is a
-    #       0.5 second startup cost to each run of wasm-opt.js
+    # Minimal smoke test: roundtrip a file.
+    # TODO: Add more testing here, but the full test suite is overkill as there
+    #       is a 0.5 second cost to each run of wasm-opt.js
+    - name: test
+      run: |
+        nodejs out/bin/wasm-opt.js test/hello_world.wat --print > out/t.wat
+        diff test/hello_world.wat out/t.wat
 
     - name: archive
       id: archive

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -210,7 +210,7 @@ jobs:
     #       is a 0.5 second cost to each run of wasm-opt.js
     - name: test
       run: |
-        nodejs out/bin/wasm-opt.js test/hello_world.wat --print > out/t.wat
+        node out/bin/wasm-opt.js test/hello_world.wat --print > out/t.wat
         diff test/hello_world.wat out/t.wat
 
     - name: archive

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -168,3 +168,63 @@ jobs:
         files: |
           ${{ steps.archive.outputs.tarball }}
           ${{ steps.archive.outputs.shasum }}
+
+  # Build to WebAssembly using Emscripten.
+  build-wasm:
+    name: wasm
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: install ninja
+      run: sudo apt-get install ninja-build
+    - name: emsdk install
+      run: |
+        mkdir $HOME/emsdk
+        git clone --depth 1 https://github.com/emscripten-core/emsdk.git $HOME/emsdk
+        $HOME/emsdk/emsdk update-tags
+        $HOME/emsdk/emsdk install tot
+        $HOME/emsdk/emsdk activate tot
+    - name: update path
+      run:  echo "PATH=$PATH:$HOME/emsdk" >> $GITHUB_ENV
+
+    # Configure with wasm EH and pthreads for maximal performance
+    # is |source| needed?
+    - name: cmake
+      run: |
+        source $HOME/emsdk/emsdk_env.sh
+        emcmake cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install -DEMSCRIPTEN_ENABLE_WASM_EH=ON -DEMSCRIPTEN_ENABLE_PTHREADS=ON
+
+    # Build wasm-opt for now TODO add other tools as desired
+    - name: build
+      run: ninja -C out wasm-opt
+
+    # TODO: Add some testing here. The full test suite is overkill as there is a
+    #       0.5 second startup cost to each run of wasm-opt.js
+
+    - name: archive
+      id: archive
+      run: |
+        VERSION=$GITHUB_REF_NAME
+        PKGNAME="binaryen-$VERSION-wasm"
+        TARBALL=$PKGNAME.tar.gz
+        SHASUM=$PKGNAME.tar.gz.sha256
+        mkdir install
+        cp out/bin/wasm-opt* install/
+        mv install binaryen-$VERSION
+        tar -czf $TARBALL binaryen-$VERSION
+        cmake -E sha256sum $TARBALL > $SHASUM
+        echo "::set-output name=tarball::$TARBALL"
+        echo "::set-output name=shasum::$SHASUM"
+
+    - name: upload tarball
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        files: |
+          ${{ steps.archive.outputs.tarball }}
+          ${{ steps.archive.outputs.shasum }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -212,9 +212,8 @@ jobs:
         PKGNAME="binaryen-$VERSION-wasm"
         TARBALL=$PKGNAME.tar.gz
         SHASUM=$PKGNAME.tar.gz.sha256
-        mkdir install
-        cp out/bin/wasm-opt* install/
-        mv install binaryen-$VERSION
+        mkdir binaryen-$VERSION
+        cp out/bin/wasm-opt* binaryen-$VERSION/
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "::set-output name=tarball::$TARBALL"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -192,8 +192,7 @@ jobs:
     - name: update path
       run:  echo "PATH=$PATH:$HOME/emsdk" >> $GITHUB_ENV
 
-    # Configure with wasm EH and pthreads for maximal performance
-    # is |source| needed?
+    # Configure with wasm EH and pthreads for maximal performance.
     - name: cmake
       run: |
         source $HOME/emsdk/emsdk_env.sh

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -169,9 +169,9 @@ jobs:
           ${{ steps.archive.outputs.tarball }}
           ${{ steps.archive.outputs.shasum }}
 
-  # Build to WebAssembly using Emscripten.
-  build-wasm:
-    name: wasm
+  # Build using Emscripten to JavaScript+WebAssembly.
+  build-node:
+    name: node
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -217,7 +217,7 @@ jobs:
       id: archive
       run: |
         VERSION=$GITHUB_REF_NAME
-        PKGNAME="binaryen-$VERSION-wasm"
+        PKGNAME="binaryen-$VERSION-node"
         TARBALL=$PKGNAME.tar.gz
         SHASUM=$PKGNAME.tar.gz.sha256
         mkdir binaryen-$VERSION

--- a/README.md
+++ b/README.md
@@ -384,12 +384,12 @@ https://github.com/WebAssembly/binaryen/releases
 
 Currently builds of the following platforms are included:
 
- * Linux-x86_64
- * Linux-arm64
- * MacOS-x86_64
- * MacOS-arm64
- * Windows-x86_64
- * WebAssembly (experimental): A port of `wasm-opt` itself to wasm. Run
+ * `Linux-x86_64`
+ * `Linux-arm64`
+ * `MacOS-x86_64`
+ * `MacOS-arm64`
+ * `Windows-x86_64`
+ * `WebAssembly` (experimental): A port of `wasm-opt` itself to wasm. Run
    `nodejs wasm-opt.js` as a drop-in replacement to a native build of
    `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
    Wasm EH and Wasm Threads).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Toolchains using Binaryen as a **component** (typically running `wasm-opt`) incl
   * [`wasm-pack`](https://github.com/rustwasm/wasm-pack) (Rust)
   * [`J2CL`](https://j2cl.io/) (Java; [`J2Wasm`](https://github.com/google/j2cl/tree/master/samples/wasm))
   * [`Kotlin`](https://kotl.in/wasmgc) (Kotlin/Wasm)
-  * [`Dart`](https://kotl.in/wasmgc)
+  * [`Dart`](https://flutter.dev/wasm) (Flutter)
 
 For more on how some of those work, see the toolchain architecture parts of
 the [V8 WasmGC porting blogpost](https://v8.dev/blog/wasm-gc-porting).

--- a/README.md
+++ b/README.md
@@ -415,7 +415,8 @@ Currently builds of the following platforms are included:
  * `WebAssembly` (experimental): A port of `wasm-opt` itself to wasm. Run
    `nodejs wasm-opt.js` as a drop-in replacement for a native build of
    `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
-   Wasm EH and Wasm Threads).
+   Wasm EH and Wasm Threads). (Note that this build may also run in Deno, Bun,
+   or other JavaScript+WebAssembly environments, but is tested only on Node.js.)
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,18 @@ effective**:
    wasm [minification], similar to minification for JavaScript, CSS, etc., all
    of which are language-specific.
 
-Compilers using Binaryen include:
+Toolchains using Binaryen as a **component** (typically running `wasm-opt`) include:
+
+  * [`Emscripten`](http://emscripten.org) (C/C++)
+  * [`wasm-pack`](https://github.com/rustwasm/wasm-pack) (Rust)
+  * [`J2CL`](https://j2cl.io/) (Java; [`J2Wasm`](https://github.com/google/j2cl/tree/master/samples/wasm))
+  * [`Kotlin`](https://kotl.in/wasmgc) (Kotlin/Wasm)
+  * [`Dart`](https://kotl.in/wasmgc)
+
+For more on how some of those work, see the toolchain architecture parts of
+the [V8 WasmGC porting blogpost](https://v8.dev/blog/wasm-gc-porting).
+
+Compilers using Binaryen as a **library** include:
 
  * [`AssemblyScript`](https://github.com/AssemblyScript/assemblyscript) which compiles a variant of TypeScript to WebAssembly
  * [`wasm2js`](https://github.com/WebAssembly/binaryen/blob/main/src/wasm2js.h) which compiles WebAssembly to JS
@@ -362,6 +373,26 @@ Binaryen.js can be built using Emscripten, which can be installed via [the SDK](
   ```bash
   emcmake cmake -DBUILD_FOR_BROWSER=ON . && emmake make
   ```
+
+## Releases
+
+Builds are distributed by the various toolchains that use Binaryen, like
+Emscripten, `wasm-pack`, etc. There are also official releases on GitHub in this
+repo itself:
+
+https://github.com/WebAssembly/binaryen/releases
+
+Currently builds of the following platforms are included:
+
+ * Linux-x86_64
+ * Linux-arm64
+ * MacOS-x86_64
+ * MacOS-arm64
+ * Windows-x86_64
+ * WebAssembly (experimental): A port of `wasm-opt` itself to wasm. Run
+   `nodejs wasm-opt.js` as a drop-in replacement to a native build of
+   `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
+   Wasm EH and Wasm Threads).
 
 ### Visual C++
 

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Currently builds of the following platforms are included:
  * `MacOS-arm64`
  * `Windows-x86_64`
  * `WebAssembly` (experimental): A port of `wasm-opt` itself to wasm. Run
-   `nodejs wasm-opt.js` as a drop-in replacement to a native build of
+   `nodejs wasm-opt.js` as a drop-in replacement for a native build of
    `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
    Wasm EH and Wasm Threads).
 

--- a/README.md
+++ b/README.md
@@ -412,8 +412,8 @@ Currently builds of the following platforms are included:
  * `MacOS-x86_64`
  * `MacOS-arm64`
  * `Windows-x86_64`
- * `WebAssembly` (experimental): A port of `wasm-opt` itself to wasm. Run
-   `nodejs wasm-opt.js` as a drop-in replacement for a native build of
+ * `Node.js` (experimental): A port of `wasm-opt` to JavaScript+WebAssembly.
+   Run `node wasm-opt.js` as a drop-in replacement for a native build of
    `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
    Wasm EH and Wasm Threads). (Note that this build may also run in Deno, Bun,
    or other JavaScript+WebAssembly environments, but is tested only on Node.js.)

--- a/README.md
+++ b/README.md
@@ -401,8 +401,7 @@ Binaryen.js can be built using Emscripten, which can be installed via [the SDK](
 ## Releases
 
 Builds are distributed by the various toolchains that use Binaryen, like
-Emscripten, `wasm-pack`, etc. There are also official releases on GitHub in this
-repo itself:
+Emscripten, `wasm-pack`, etc. There are also official releases on GitHub:
 
 https://github.com/WebAssembly/binaryen/releases
 

--- a/README.md
+++ b/README.md
@@ -374,26 +374,6 @@ Binaryen.js can be built using Emscripten, which can be installed via [the SDK](
   emcmake cmake -DBUILD_FOR_BROWSER=ON . && emmake make
   ```
 
-## Releases
-
-Builds are distributed by the various toolchains that use Binaryen, like
-Emscripten, `wasm-pack`, etc. There are also official releases on GitHub in this
-repo itself:
-
-https://github.com/WebAssembly/binaryen/releases
-
-Currently builds of the following platforms are included:
-
- * `Linux-x86_64`
- * `Linux-arm64`
- * `MacOS-x86_64`
- * `MacOS-arm64`
- * `Windows-x86_64`
- * `WebAssembly` (experimental): A port of `wasm-opt` itself to wasm. Run
-   `nodejs wasm-opt.js` as a drop-in replacement to a native build of
-   `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
-   Wasm EH and Wasm Threads).
-
 ### Visual C++
 
 1. Using the Microsoft Visual Studio Installer, install the "Visual C++ tools for CMake" component.
@@ -417,6 +397,26 @@ Currently builds of the following platforms are included:
    ```
 
    CMake generates a project named "ALL_BUILD.vcxproj" for conveniently building all the projects.
+
+## Releases
+
+Builds are distributed by the various toolchains that use Binaryen, like
+Emscripten, `wasm-pack`, etc. There are also official releases on GitHub in this
+repo itself:
+
+https://github.com/WebAssembly/binaryen/releases
+
+Currently builds of the following platforms are included:
+
+ * `Linux-x86_64`
+ * `Linux-arm64`
+ * `MacOS-x86_64`
+ * `MacOS-arm64`
+ * `Windows-x86_64`
+ * `WebAssembly` (experimental): A port of `wasm-opt` itself to wasm. Run
+   `nodejs wasm-opt.js` as a drop-in replacement to a native build of
+   `wasm-opt`, on any platform that Node.js runs on. Requires Node.js 18+ (for
+   Wasm EH and Wasm Threads).
 
 ## Running
 

--- a/src/support/threads.cpp
+++ b/src/support/threads.cpp
@@ -139,17 +139,15 @@ void ThreadPool::initialize(size_t num) {
 }
 
 size_t ThreadPool::getNumCores() {
-#if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_PTHREADS__)
-  // In an Emscripten build without pthreads support, avoid the overhead of
-  // including support code for the below runtime checks.
+#ifdef __EMSCRIPTEN__
   return 1;
-#endif
-
+#else
   size_t num = std::max(1U, std::thread::hardware_concurrency());
   if (getenv("BINARYEN_CORES")) {
     num = std::stoi(getenv("BINARYEN_CORES"));
   }
   return num;
+#endif
 }
 
 ThreadPool* ThreadPool::get() {


### PR DESCRIPTION
Simply build `wasm-opt` with Emscripten and bundle that up.

Example build:

https://github.com/kripken/binaryen/releases/tag/wasm-build-1

Specifically

[binaryen-wasm-build-1-wasm.tar.gz](https://github.com/kripken/binaryen/releases/download/wasm-build-1/binaryen-wasm-build-1-wasm.tar.gz.sha256)

Only 1.72 MB, as it's just `wasm-opt` and not any other tool, so it is
much smaller than our other targets. Perhaps we will add more of the
tools later as needed (`wasm-metadce`, `wasm-split`, etc.).

Also update the readme regarding which toolchains use us as a library, that I
noticed while editing it to add the release platforms.