### PR TITLE
[Outlining] Fixes break reconstruction

### DIFF
--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -132,7 +132,15 @@ struct ReconstructStringifyWalker
                          : state == NotInSeq ? &existingBuilder
                                              : nullptr;
     if (builder) {
-      ASSERT_OK(builder->visit(curr));
+      if (auto* expr = curr->dynCast<Break>()) {
+        Type type = expr->value ? expr->value->type : Type::none;
+        ASSERT_OK(builder->visitBreakWithType(expr, type));
+      } else if (auto* expr = curr->dynCast<Switch>()) {
+        Type type = expr->value ? expr->value->type : Type::none;
+        ASSERT_OK(builder->visitSwitchWithType(expr, type));
+      } else {
+        ASSERT_OK(builder->visit(curr));
+      }
     }
     DBG(printVisitExpression(curr));
 

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -138,10 +138,11 @@ struct ReconstructStringifyWalker
       } else if (auto* expr = curr->dynCast<Switch>()) {
         Type type = expr->value ? expr->value->type : Type::none;
         ASSERT_OK(builder->visitSwitchWithType(expr, type));
-      } else if (curr->dynCast<BrOn>()) {
-        ASSERT_OK(builder->visit(curr));
       } else {
-        assert(!Properties::isBranch(curr));
+        // Assert ensures new unhandled branch instructions
+        // will quickly cause an error. Serves as a reminder to
+        // implement a new special-case visit*WithType.
+        assert(curr->is<BrOn> || !Properties::isBranch(curr));
         ASSERT_OK(builder->visit(curr));
       }
     }

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -142,7 +142,7 @@ struct ReconstructStringifyWalker
         // Assert ensures new unhandled branch instructions
         // will quickly cause an error. Serves as a reminder to
         // implement a new special-case visit*WithType.
-        assert(curr->is<BrOn> || !Properties::isBranch(curr));
+        assert(curr->is<BrOn>() || !Properties::isBranch(curr));
         ASSERT_OK(builder->visit(curr));
       }
     }

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -138,7 +138,10 @@ struct ReconstructStringifyWalker
       } else if (auto* expr = curr->dynCast<Switch>()) {
         Type type = expr->value ? expr->value->type : Type::none;
         ASSERT_OK(builder->visitSwitchWithType(expr, type));
+      } else if (curr->dynCast<BrOn>()) {
+        ASSERT_OK(builder->visit(curr));
       } else {
+        assert(!Properties::isBranch(curr));
         ASSERT_OK(builder->visit(curr));
       }
     }

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -222,23 +222,23 @@ public:
   [[nodiscard]] Result<> visitArrayNewFixed(ArrayNewFixed*);
   // Used to visit break exprs when traversing the module in the fully nested
   // format. Break label destinations are assumed to have already been visited,
-  // with a corresponding push onto the scope stack. As a result, an exception
-  // will occur if a corresponding scope is not found for the break.
+  // with a corresponding push onto the scope stack. As a result, an error will
+  // return if a corresponding scope is not found for the break.
   [[nodiscard]] Result<> visitBreak(Break*,
                                     std::optional<Index> label = std::nullopt);
-  // Used to visit break nodes when traversing the module in the stacky format.
-  // The type indicates how many values need to be popped from the stack and
-  // consumed by the break.
+  // Used to visit break nodes when traversing a single block without its
+  // context. The type indicates how many values the break carries to its
+  // destination.
   [[nodiscard]] Result<> visitBreakWithType(Break*, Type);
   [[nodiscard]] Result<>
   // Used to visit switch exprs when traversing the module in the fully nested
   // format. Switch label destinations are assumed to have already been visited,
-  // with a corresponding push onto the scope stack. As a result, an exception
-  // will occur if a corresponding scope is not found for the switch.
+  // with a corresponding push onto the scope stack. As a result, an error will
+  // return if a corresponding scope is not found for the switch.
   visitSwitch(Switch*, std::optional<Index> defaultLabel = std::nullopt);
-  // Used to visit switch nodes when traversing the module in the stacky format.
-  // The type indicates how many values need to be popped from the stack and
-  // consumed by the switch.
+  // Used to visit switch nodes when traversing a single block without its
+  // context. The type indicates how many values the switch carries to its
+  // destination.
   [[nodiscard]] Result<> visitSwitchWithType(Switch*, Type);
   [[nodiscard]] Result<> visitCall(Call*);
   [[nodiscard]] Result<> visitCallIndirect(CallIndirect*);

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -544,8 +544,8 @@ private:
   [[nodiscard]] Result<> packageHoistedValue(const HoistedVal&,
                                              size_t sizeHint = 1);
 
-  [[nodiscard]] Result<Expression*> getBranchValue(Name labelName,
-                                                   std::optional<Index> label);
+  [[nodiscard]] Result<Expression*>
+  getBranchValue(Expression* curr, Name labelName, std::optional<Index> label);
 
   void dump();
 };

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -220,10 +220,26 @@ public:
   [[nodiscard]] Result<> visitStructNew(StructNew*);
   [[nodiscard]] Result<> visitArrayNew(ArrayNew*);
   [[nodiscard]] Result<> visitArrayNewFixed(ArrayNewFixed*);
+  // Used to visit break exprs when traversing the module in the fully nested
+  // format. Break label destinations are assumed to have already been visited,
+  // with a corresponding push onto the scope stack. As a result, an exception
+  // will occur if a corresponding scope is not found for the break.
   [[nodiscard]] Result<> visitBreak(Break*,
                                     std::optional<Index> label = std::nullopt);
+  // Used to visit break nodes when traversing the module in the stacky format.
+  // The type indicates how many values need to be popped from the stack and
+  // consumed by the break.
+  [[nodiscard]] Result<> visitBreakWithType(Break*, Type);
   [[nodiscard]] Result<>
+  // Used to visit switch exprs when traversing the module in the fully nested
+  // format. Switch label destinations are assumed to have already been visited,
+  // with a corresponding push onto the scope stack. As a result, an exception
+  // will occur if a corresponding scope is not found for the switch.
   visitSwitch(Switch*, std::optional<Index> defaultLabel = std::nullopt);
+  // Used to visit switch nodes when traversing the module in the stacky format.
+  // The type indicates how many values need to be popped from the stack and
+  // consumed by the switch.
+  [[nodiscard]] Result<> visitSwitchWithType(Switch*, Type);
   [[nodiscard]] Result<> visitCall(Call*);
   [[nodiscard]] Result<> visitCallIndirect(CallIndirect*);
   [[nodiscard]] Result<> visitCallRef(CallRef*);

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -439,7 +439,7 @@ Result<> IRBuilder::visitBreakWithType(Break* curr, Type type) {
     CHECK_ERR(cond);
     curr->condition = *cond;
   }
-  if (!curr->value) {
+  if (type == Type::None) {
     curr->value = nullptr;
   } else {
     auto value = pop(type.size());
@@ -466,7 +466,7 @@ Result<> IRBuilder::visitSwitchWithType(Switch* curr, Type type) {
   auto cond = pop();
   CHECK_ERR(cond);
   curr->condition = *cond;
-  if (!curr->value) {
+  if (type == Type::None) {
     curr->value = nullptr;
   } else {
     auto value = pop(type.size());

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -443,7 +443,7 @@ Result<> IRBuilder::visitBreakWithType(Break* curr, Type type) {
     CHECK_ERR(cond);
     curr->condition = *cond;
   }
-  if (type == Type::None) {
+  if (type == Type::none) {
     curr->value = nullptr;
   } else {
     auto value = pop(type.size());
@@ -470,7 +470,7 @@ Result<> IRBuilder::visitSwitchWithType(Switch* curr, Type type) {
   auto cond = pop();
   CHECK_ERR(cond);
   curr->condition = *cond;
-  if (type == Type::None) {
+  if (type == Type::none) {
     curr->value = nullptr;
   } else {
     auto value = pop(type.size());

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -404,8 +404,10 @@ Result<> IRBuilder::visitArrayNewFixed(ArrayNewFixed* curr) {
   return Ok{};
 }
 
-Result<Expression*> IRBuilder::getBranchValue(Name labelName,
+Result<Expression*> IRBuilder::getBranchValue(Expression* curr,
+                                              Name labelName,
                                               std::optional<Index> label) {
+  assert(curr->is<Break>() || curr->is<Switch>());
   if (!label) {
     auto index = getLabelIndex(labelName);
     CHECK_ERR(index);
@@ -425,7 +427,7 @@ Result<> IRBuilder::visitBreak(Break* curr, std::optional<Index> label) {
     CHECK_ERR(cond);
     curr->condition = *cond;
   }
-  auto value = getBranchValue(curr->name, label);
+  auto value = getBranchValue(curr, curr->name, label);
   CHECK_ERR(value);
   curr->value = *value;
   return Ok{};
@@ -454,7 +456,7 @@ Result<> IRBuilder::visitSwitch(Switch* curr,
   auto cond = pop();
   CHECK_ERR(cond);
   curr->condition = *cond;
-  auto value = getBranchValue(curr->default_, defaultLabel);
+  auto value = getBranchValue(curr, curr->default_, defaultLabel);
   CHECK_ERR(value);
   curr->value = *value;
   return Ok{};

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -409,8 +409,8 @@ Result<Expression*> IRBuilder::getBranchValue(Expression* curr,
                                               std::optional<Index> label) {
   // As new branch instructions are added, one of the existing branch visit*
   // functions is likely to be copied, along with its call to getBranchValue().
-  // This assert serves as a reminder to also add an implementation of visit*WithType()
-  // for new branch instructions.
+  // This assert serves as a reminder to also add an implementation of
+  // visit*WithType() for new branch instructions.
   assert(curr->is<Break>() || curr->is<Switch>());
   if (!label) {
     auto index = getLabelIndex(labelName);

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -444,9 +444,7 @@ Result<> IRBuilder::visitBreakWithType(Break* curr, Type type) {
     CHECK_ERR(value)
     curr->value = *value;
   }
-  // TODO: Call more efficient versions of finalize() that take the known type
-  // for other kinds of nodes as well, as done above.
-  ReFinalizeNode{}.visit(curr);
+  curr->finalize();
   push(curr);
   return Ok{};
 }
@@ -473,9 +471,7 @@ Result<> IRBuilder::visitSwitchWithType(Switch* curr, Type type) {
     CHECK_ERR(value)
     curr->value = *value;
   }
-  // TODO: Call more efficient versions of finalize() that take the known type
-  // for other kinds of nodes as well, as done above.
-  ReFinalizeNode{}.visit(curr);
+  curr->finalize();
   push(curr);
   return Ok{};
 }

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -407,6 +407,10 @@ Result<> IRBuilder::visitArrayNewFixed(ArrayNewFixed* curr) {
 Result<Expression*> IRBuilder::getBranchValue(Expression* curr,
                                               Name labelName,
                                               std::optional<Index> label) {
+  // As new branch instructions are added, one of the existing branch visit*
+  // functions is likely to be copied, along with its call to getBranchValue().
+  // This assert serves as a reminder to also add an implementation of visit*WithType()
+  // for new branch instructions.
   assert(curr->is<Break>() || curr->is<Switch>());
   if (!label) {
     auto index = getLabelIndex(labelName);

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -431,6 +431,26 @@ Result<> IRBuilder::visitBreak(Break* curr, std::optional<Index> label) {
   return Ok{};
 }
 
+Result<> IRBuilder::visitBreakWithType(Break* curr, Type type) {
+  if (curr->condition) {
+    auto cond = pop();
+    CHECK_ERR(cond);
+    curr->condition = *cond;
+  }
+  if (!curr->value) {
+    curr->value = nullptr;
+  } else {
+    auto value = pop(type.size());
+    CHECK_ERR(value)
+    curr->value = *value;
+  }
+  // TODO: Call more efficient versions of finalize() that take the known type
+  // for other kinds of nodes as well, as done above.
+  ReFinalizeNode{}.visit(curr);
+  push(curr);
+  return Ok{};
+}
+
 Result<> IRBuilder::visitSwitch(Switch* curr,
                                 std::optional<Index> defaultLabel) {
   auto cond = pop();
@@ -439,6 +459,24 @@ Result<> IRBuilder::visitSwitch(Switch* curr,
   auto value = getBranchValue(curr->default_, defaultLabel);
   CHECK_ERR(value);
   curr->value = *value;
+  return Ok{};
+}
+
+Result<> IRBuilder::visitSwitchWithType(Switch* curr, Type type) {
+  auto cond = pop();
+  CHECK_ERR(cond);
+  curr->condition = *cond;
+  if (!curr->value) {
+    curr->value = nullptr;
+  } else {
+    auto value = pop(type.size());
+    CHECK_ERR(value)
+    curr->value = *value;
+  }
+  // TODO: Call more efficient versions of finalize() that take the known type
+  // for other kinds of nodes as well, as done above.
+  ReFinalizeNode{}.visit(curr);
+  push(curr);
   return Ok{};
 }
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -614,6 +614,48 @@
   )
 )
 
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (func $outline$ (type $0)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
+  ;; CHECK:      (func $a (type $0)
+  ;; CHECK-NEXT:  (block $label1
+  ;; CHECK-NEXT:   (call $outline$)
+  ;; CHECK-NEXT:   (loop $loop-in
+  ;; CHECK-NEXT:    (br $label1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $outline$)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $a
+    (block $label1
+      (drop
+        (i32.const 2)
+      )
+      (drop
+        (i32.const 1)
+      )
+      (loop
+        (br $label1)
+      )
+      (drop
+        (i32.const 2)
+      )
+      (drop
+        (i32.const 1)
+      )
+    )
+  )
+)
+
 ;; Tests return instructions are correctly filtered from being outlined.
 (module
   ;; CHECK:      (type $0 (func (result i32)))

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -614,6 +614,7 @@
   )
 )
 
+;; Tests branch with condition is reconstructed without error.
 (module
   ;; CHECK:      (type $0 (func))
 
@@ -653,6 +654,63 @@
         (i32.const 1)
       )
     )
+  )
+)
+
+;; Tests br_table instruction is reconstructed without error.
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (type $1 (func (param i32) (result i32)))
+
+  ;; CHECK:      (func $outline$ (type $0)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
+  ;; CHECK:      (func $a (type $1) (param $0 i32) (result i32)
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (block $block
+  ;; CHECK-NEXT:   (block $block0
+  ;; CHECK-NEXT:    (br_table $block $block0
+  ;; CHECK-NEXT:     (local.get $0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (return
+  ;; CHECK-NEXT:     (i32.const 21)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (return
+  ;; CHECK-NEXT:    (i32.const 20)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (i32.const 22)
+  ;; CHECK-NEXT: )
+  (func $a (param i32) (result i32)
+    (drop
+      (i32.const 2)
+    )
+    (drop
+      (i32.const 1)
+    )
+    (block
+      (block
+        (br_table 1 0 (local.get $0))
+        (return (i32.const 21))
+      )
+      (return (i32.const 20))
+    )
+    (drop
+      (i32.const 2)
+    )
+    (drop
+      (i32.const 1)
+    )
+    (i32.const 22)
   )
 )
 


### PR DESCRIPTION
Adds new visitBreakWithType and visitSwitchWithType functions to the IRBuilder API. These functions work around an assumption in IRBuilder that the module is being traversed in the fully nested format, i.e., that the destination scope of a break or switch has been visited before visiting the break or switch. Instead, the type of the destination scope is passed to IRBuilder.