### PR TITLE
[StringLowering] Lower `stringview_wtf16.get_codeunit` to `charCodeAt`

### DIFF
--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -295,7 +295,7 @@ struct StringLowering : public StringGathering {
   Name equalsImport;
   Name compareImport;
   Name lengthImport;
-  Name codePointAtImport;
+  Name charCodeAtImport;
   Name substringImport;
 
   // The name of the module to import string functions from.
@@ -334,8 +334,8 @@ struct StringLowering : public StringGathering {
     // string.length: string -> i32
     lengthImport = addImport(module, "length", nullExt, Type::i32);
     // string.codePointAt: string, offset -> i32
-    codePointAtImport =
-      addImport(module, "codePointAt", {nullExt, Type::i32}, Type::i32);
+    charCodeAtImport =
+      addImport(module, "charCodeAt", {nullExt, Type::i32}, Type::i32);
     // string.substring: string, start, end -> string
     substringImport =
       addImport(module, "substring", {nullExt, Type::i32, Type::i32}, nnExt);
@@ -425,7 +425,7 @@ struct StringLowering : public StringGathering {
       void visitStringWTF16Get(StringWTF16Get* curr) {
         Builder builder(*getModule());
         replaceCurrent(builder.makeCall(
-          lowering.codePointAtImport, {curr->ref, curr->pos}, Type::i32));
+          lowering.charCodeAtImport, {curr->ref, curr->pos}, Type::i32));
       }
 
       void visitStringSliceWTF(StringSliceWTF* curr) {

--- a/test/lit/passes/string-gathering.wast
+++ b/test/lit/passes/string-gathering.wast
@@ -61,7 +61,7 @@
 
   ;; LOWER:      (import "wasm:js-string" "length" (func $length (type $6) (param externref) (result i32)))
 
-  ;; LOWER:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $7) (param externref i32) (result i32)))
+  ;; LOWER:      (import "wasm:js-string" "charCodeAt" (func $charCodeAt (type $7) (param externref i32) (result i32)))
 
   ;; LOWER:      (import "wasm:js-string" "substring" (func $substring (type $8) (param externref i32 i32) (result (ref extern))))
 
@@ -182,7 +182,7 @@
 
   ;; LOWER:      (import "wasm:js-string" "length" (func $length (type $5) (param externref) (result i32)))
 
-  ;; LOWER:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $6) (param externref i32) (result i32)))
+  ;; LOWER:      (import "wasm:js-string" "charCodeAt" (func $charCodeAt (type $6) (param externref i32) (result i32)))
 
   ;; LOWER:      (import "wasm:js-string" "substring" (func $substring (type $7) (param externref i32 i32) (result (ref extern))))
 

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -85,7 +85,7 @@
 
   ;; CHECK:      (import "wasm:js-string" "length" (func $length (type $23) (param externref) (result i32)))
 
-  ;; CHECK:      (import "wasm:js-string" "codePointAt" (func $codePointAt (type $24) (param externref i32) (result i32)))
+  ;; CHECK:      (import "wasm:js-string" "charCodeAt" (func $charCodeAt (type $24) (param externref i32) (result i32)))
 
   ;; CHECK:      (import "wasm:js-string" "substring" (func $substring (type $25) (param externref i32 i32) (result (ref extern))))
 
@@ -245,7 +245,7 @@
   )
 
   ;; CHECK:      (func $string.get_codeunit (type $15) (param $ref externref) (result i32)
-  ;; CHECK-NEXT:  (call $codePointAt
+  ;; CHECK-NEXT:  (call $charCodeAt
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
   ;; CHECK-NEXT:  )


### PR DESCRIPTION
Previously we lowered this to `getCodePointAt`, which has different semantics
around surrogate pairs.