### PR TITLE
Fuzzer: Separate arguments used to make the fuzz wasm from the opts we run on it

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -176,6 +176,7 @@ def update_feature_opts(wasm):
 def randomize_fuzz_settings():
     # a list of the arguments to pass to wasm-opt -ttf when generating the wasm
     global GEN_ARGS
+    GEN_ARGS = []
 
     # a list of the optimizations to run on the wasm
     global FUZZ_OPTS
@@ -190,7 +191,6 @@ def randomize_fuzz_settings():
     # a boolean whether we legalize the wasm for JS
     global LEGALIZE
 
-    GEN_ARGS = []
     if random.random() < 0.5:
         NANS = True
     else:
@@ -217,7 +217,6 @@ def randomize_fuzz_settings():
 
         # Add --dce not only when generating the original wasm but to the
         # optimizations we use to create any other wasm file.
-        FUZZ_OPTS = []
         FUZZ_OPTS += ['--dce']
 
     print('randomized settings (NaNs, OOB, legalize):', NANS, OOB, LEGALIZE)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -179,6 +179,7 @@ def randomize_fuzz_settings():
 
     # a list of the optimizations to run on the wasm
     global FUZZ_OPTS
+    FUZZ_OPTS = []
 
     # a boolean whether NaN values are allowed, or we de-NaN them
     global NANS

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -215,6 +215,8 @@ def randomize_fuzz_settings():
     if '--disable-gc' not in FEATURE_OPTS:
         GEN_ARGS += ['--dce']
 
+        # Add --dce not only when generating the original wasm but to the
+        # optimizations we use to create any other wasm file.
         FUZZ_OPTS = []
         FUZZ_OPTS += ['--dce']
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -195,15 +195,14 @@ def randomize_fuzz_settings():
     else:
         NANS = False
         GEN_ARGS += ['--denan']
-    FUZZ_OPTS = []
     if random.random() < 0.5:
         OOB = True
     else:
         OOB = False
-        FUZZ_OPTS += ['--no-fuzz-oob']
+        GEN_ARGS += ['--no-fuzz-oob']
     if random.random() < 0.5:
         LEGALIZE = True
-        FUZZ_OPTS += ['--legalize-and-prune-js-interface']
+        GEN_ARGS += ['--legalize-and-prune-js-interface']
     else:
         LEGALIZE = False
 
@@ -213,6 +212,9 @@ def randomize_fuzz_settings():
     #   https://github.com/WebAssembly/binaryen/pull/5665
     #   https://github.com/WebAssembly/binaryen/issues/5599
     if '--disable-gc' not in FEATURE_OPTS:
+        GEN_ARGS += ['--dce']
+
+        FUZZ_OPTS = []
         FUZZ_OPTS += ['--dce']
 
     print('randomized settings (NaNs, OOB, legalize):', NANS, OOB, LEGALIZE)

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -50,6 +50,10 @@ function printed(x, y) {
   } else if (typeof x === 'string') {
     // Emit a string in the same format as the binaryen interpreter.
     return 'string("' + x + '")';
+  } else if (typeof x === 'bigint') {
+    // Print bigints in legalized form, which is two 32-bit numbers of the low
+    // and high bits.
+    return (Number(x) | 0) + ' ' + (Number(x >> 32n) | 0)
   } else if (typeof x !== 'number') {
     // Something that is not a number or string, like a reference. We can't
     // print a reference because it could look different after opts - imagine


### PR DESCRIPTION
Before `FUZZ_OPTS` was used both when doing `--translate-to-fuzz/-ttf` to generate the
wasm from the random bytes and also when later running optimizations to generate
a second wasm file for comparison. That is, we ended up doing this, if the opts were `-O3`:

```
wasm-opt random.input -ttf -o a.wasm -O3
wasm-opt a.wasm -O3 -o b.wasm
```

Now we have a pair `a.wasm,b.wasm` which we can test. However, we have run `-O3`
on both which is a little silly - the second `-O3` might not actually have anything left
to do, which would mean we compare the same wasm to itself.

Worse, this is incorrect, as there are things we need to do *only* during the
generation phase, like `--denan`. We need that in order to generate a valid wasm to
test on, but it is "destructive" in itself: when removing NaNs (to avoid nondeterminism)
if replaces them with `0`, which is different. As a result, running `--denan` when
generating the second wasm from the first could lead to different execution in them.
This was always a problem, but became more noticable recently now that DeNaN
modifies SIMD operations, as one optimization we do is to replace a `memory.copy`
with `v128.load + v128.store`, and `--denan` will make sure the loaded value has no
NaNs...

To fix this, separate the generation and optimization phase. Instead of

```
wasm-opt random.input -ttf -o a.wasm --denan -O3
wasm-opt a.wasm --denan -O3 -o b.wasm
```

(note how `--denan -O3` appears twice), do this:

```
wasm-opt random.input -ttf -o a.wasm --denan
wasm-opt a.wasm -O3 -o b.wasm
```

(note how `--denan` appears in generation, and `-O3` in optimization.