### PR TITLE
[NFC] Add the type of the Expression when eliding it

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2786,8 +2786,7 @@ void PrintSExpression::maybePrintUnreachableReplacement(Expression* curr,
   // Emit a block with drops of the children.
   o << "(block";
   if (!minify) {
-    o << " ;; (replaces something unreachable we can't emit, for "
-      << getExpressionName(curr) << ')';
+    o << " ;; (replaces unreachable " << getExpressionName(curr) << " we can't emit)";
   }
   incIndent();
   for (auto* child : ChildIterator(curr)) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2786,7 +2786,8 @@ void PrintSExpression::maybePrintUnreachableReplacement(Expression* curr,
   // Emit a block with drops of the children.
   o << "(block";
   if (!minify) {
-    o << " ;; (replaces something unreachable we can't emit)";
+    o << " ;; (replaces something unreachable we can't emit, for "
+      << getExpressionName(curr) << ')';
   }
   incIndent();
   for (auto* child : ChildIterator(curr)) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2786,7 +2786,8 @@ void PrintSExpression::maybePrintUnreachableReplacement(Expression* curr,
   // Emit a block with drops of the children.
   o << "(block";
   if (!minify) {
-    o << " ;; (replaces unreachable " << getExpressionName(curr) << " we can't emit)";
+    o << " ;; (replaces unreachable " << getExpressionName(curr)
+      << " we can't emit)";
   }
   incIndent();
   for (auto* child : ChildIterator(curr)) {

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -508,7 +508,7 @@
 
   ;; CHECK:      (func $test (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -516,14 +516,14 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -508,7 +508,7 @@
 
   ;; CHECK:      (func $test (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -516,14 +516,14 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -472,7 +472,7 @@
   (return_call_ref $"return_{}" (local.get $"return_{}"))
  )
  ;; CHECK:      (func $tail-caller-call_ref-unreachable (type $2) (result anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -472,7 +472,7 @@
   (return_call_ref $"return_{}" (local.get $"return_{}"))
  )
  ;; CHECK:      (func $tail-caller-call_ref-unreachable (type $2) (result anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/dae_all-features.wast
+++ b/test/lit/passes/dae_all-features.wast
@@ -699,7 +699,7 @@
  ;; CHECK:      (type $1 (func))
 
  ;; CHECK:      (func $no-caller (type $A) (result (ref $A))
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (ref.null nofunc)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/dae_all-features.wast
+++ b/test/lit/passes/dae_all-features.wast
@@ -699,7 +699,7 @@
  ;; CHECK:      (type $1 (func))
 
  ;; CHECK:      (func $no-caller (type $A) (result (ref $A))
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (ref.null nofunc)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -1208,7 +1208,7 @@
   ))
 
   ;; CHECK:      (func $func (type $1) (param $ref (ref null $A)) (result i32)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -1208,7 +1208,7 @@
   ))
 
   ;; CHECK:      (func $func (type $1) (param $ref (ref null $A)) (result i32)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -560,7 +560,7 @@
 
   ;; CHECK:      (func $new-unreachable (type $4)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -560,7 +560,7 @@
 
   ;; CHECK:      (func $new-unreachable (type $4)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (i32.const 2)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/gufa-extern.wast
+++ b/test/lit/passes/gufa-extern.wast
@@ -39,7 +39,7 @@
 
   ;; CHECK:      (func $non-exported (type $0) (param $ext externref) (param $any anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (extern.internalize
   ;; CHECK-NEXT:      (unreachable)

--- a/test/lit/passes/gufa-extern.wast
+++ b/test/lit/passes/gufa-extern.wast
@@ -39,7 +39,7 @@
 
   ;; CHECK:      (func $non-exported (type $0) (param $ext externref) (param $any anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable RefCast we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (extern.internalize
   ;; CHECK-NEXT:      (unreachable)

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -4567,7 +4567,7 @@
   )
 
   ;; CHECK:      (func $call_ref-nofunc (type $2)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -4567,7 +4567,7 @@
   )
 
   ;; CHECK:      (func $call_ref-nofunc (type $2)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/gufa-tnh-closed.wast
+++ b/test/lit/passes/gufa-tnh-closed.wast
@@ -38,7 +38,7 @@
   )
 
   ;; CHECK:      (func $caller (type $2) (param $x funcref)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -83,7 +83,7 @@
   )
 
   ;; CHECK:      (func $caller (type $0) (param $x funcref)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -496,7 +496,7 @@
   ;; CHECK-NEXT:    (local.get $func3)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (struct.new_default $Y2)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/gufa-tnh-closed.wast
+++ b/test/lit/passes/gufa-tnh-closed.wast
@@ -38,7 +38,7 @@
   )
 
   ;; CHECK:      (func $caller (type $2) (param $x funcref)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -83,7 +83,7 @@
   )
 
   ;; CHECK:      (func $caller (type $0) (param $x funcref)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -496,7 +496,7 @@
   ;; CHECK-NEXT:    (local.get $func3)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (struct.new_default $Y2)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -459,7 +459,7 @@
 
   ;; CHECK:      (func $test (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (i32.const 10)
   ;; CHECK-NEXT:    )
@@ -469,9 +469,9 @@
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:    (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -459,7 +459,7 @@
 
   ;; CHECK:      (func $test (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (i32.const 10)
   ;; CHECK-NEXT:    )
@@ -469,9 +469,9 @@
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -215,9 +215,9 @@
 
   ;; CHECK:      (func $ignore-unreachable (type $1)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:     (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:      (drop
   ;; CHECK-NEXT:       (i32.const 2)
   ;; CHECK-NEXT:      )

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -215,9 +215,9 @@
 
   ;; CHECK:      (func $ignore-unreachable (type $1)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:     (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:      (drop
   ;; CHECK-NEXT:       (i32.const 2)
   ;; CHECK-NEXT:      )

--- a/test/lit/passes/inlining-optimizing.wast
+++ b/test/lit/passes/inlining-optimizing.wast
@@ -13,7 +13,7 @@
  )
  ;; CHECK:      (func $1 (type $none_=>_none)
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/inlining-optimizing.wast
+++ b/test/lit/passes/inlining-optimizing.wast
@@ -13,7 +13,7 @@
  )
  ;; CHECK:      (func $1 (type $none_=>_none)
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:   (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/inlining_vacuum_optimize-instructions.wast
+++ b/test/lit/passes/inlining_vacuum_optimize-instructions.wast
@@ -19,7 +19,7 @@
 
  ;; CHECK:      (func $target (type $2) (param $0 (ref null $A))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/inlining_vacuum_optimize-instructions.wast
+++ b/test/lit/passes/inlining_vacuum_optimize-instructions.wast
@@ -19,7 +19,7 @@
 
  ;; CHECK:      (func $target (type $2) (param $0 (ref null $A))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
+ ;; CHECK-NEXT:   (block ;; (replaces unreachable RefCast we can't emit)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -276,7 +276,7 @@
   ;; CHECK-NEXT:   (ref.null nofunc)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $f)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -276,7 +276,7 @@
   ;; CHECK-NEXT:   (ref.null nofunc)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (local.get $f)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -158,7 +158,7 @@
  )
 
  ;; CHECK:      (func $fallthrough-bad-type (type $none_=>_i32) (result i32)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block (result (ref nofunc))
  ;; CHECK-NEXT:     (drop
@@ -213,7 +213,7 @@
  )
 
  ;; CHECK:      (func $ignore-unreachable (type $none_=>_none)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -158,7 +158,7 @@
  )
 
  ;; CHECK:      (func $fallthrough-bad-type (type $none_=>_i32) (result i32)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block (result (ref nofunc))
  ;; CHECK-NEXT:     (drop
@@ -213,7 +213,7 @@
  )
 
  ;; CHECK:      (func $ignore-unreachable (type $none_=>_none)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/optimize-instructions-gc-heap.wast
+++ b/test/lit/passes/optimize-instructions-gc-heap.wast
@@ -713,7 +713,7 @@
   ;; CHECK:      (func $unreachable (type $1)
   ;; CHECK-NEXT:  (local $ref (ref null $struct))
   ;; CHECK-NEXT:  (local.tee $ref
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc-heap.wast
+++ b/test/lit/passes/optimize-instructions-gc-heap.wast
@@ -713,7 +713,7 @@
   ;; CHECK:      (func $unreachable (type $1)
   ;; CHECK-NEXT:  (local $ref (ref null $struct))
   ;; CHECK-NEXT:  (local.tee $ref
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -110,7 +110,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -126,7 +126,7 @@
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; TNH-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; TNH-NEXT:    (drop
   ;; TNH-NEXT:     (unreachable)
   ;; TNH-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -110,7 +110,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable RefCast we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -126,7 +126,7 @@
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:  )
   ;; TNH-NEXT:  (drop
-  ;; TNH-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; TNH-NEXT:   (block ;; (replaces unreachable RefCast we can't emit)
   ;; TNH-NEXT:    (drop
   ;; TNH-NEXT:     (unreachable)
   ;; TNH-NEXT:    )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -497,7 +497,7 @@
   )
 
   ;; TNH:      (func $null.arm.null.effects (type $void)
-  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; TNH-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; TNH-NEXT:   (drop
   ;; TNH-NEXT:    (select
   ;; TNH-NEXT:     (unreachable)
@@ -523,7 +523,7 @@
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $null.arm.null.effects (type $void)
-  ;; NO_TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; NO_TNH-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; NO_TNH-NEXT:   (drop
   ;; NO_TNH-NEXT:    (select
   ;; NO_TNH-NEXT:     (unreachable)
@@ -904,7 +904,7 @@
   )
 
   ;; TNH:      (func $select.unreachable.child (type $6) (param $x (ref $struct)) (result (ref $struct))
-  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; TNH-NEXT:  (block ;; (replaces unreachable RefCast we can't emit)
   ;; TNH-NEXT:   (drop
   ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
@@ -912,7 +912,7 @@
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $select.unreachable.child (type $6) (param $x (ref $struct)) (result (ref $struct))
-  ;; NO_TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; NO_TNH-NEXT:  (block ;; (replaces unreachable RefCast we can't emit)
   ;; NO_TNH-NEXT:   (drop
   ;; NO_TNH-NEXT:    (unreachable)
   ;; NO_TNH-NEXT:   )

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -497,7 +497,7 @@
   )
 
   ;; TNH:      (func $null.arm.null.effects (type $void)
-  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; TNH-NEXT:   (drop
   ;; TNH-NEXT:    (select
   ;; TNH-NEXT:     (unreachable)
@@ -523,7 +523,7 @@
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $null.arm.null.effects (type $void)
-  ;; NO_TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; NO_TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; NO_TNH-NEXT:   (drop
   ;; NO_TNH-NEXT:    (select
   ;; NO_TNH-NEXT:     (unreachable)
@@ -904,7 +904,7 @@
   )
 
   ;; TNH:      (func $select.unreachable.child (type $6) (param $x (ref $struct)) (result (ref $struct))
-  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; TNH-NEXT:   (drop
   ;; TNH-NEXT:    (unreachable)
   ;; TNH-NEXT:   )
@@ -912,7 +912,7 @@
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $select.unreachable.child (type $6) (param $x (ref $struct)) (result (ref $struct))
-  ;; NO_TNH-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; NO_TNH-NEXT:  (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; NO_TNH-NEXT:   (drop
   ;; NO_TNH-NEXT:    (unreachable)
   ;; NO_TNH-NEXT:   )

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -286,7 +286,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable RefCast we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -2773,7 +2773,7 @@
 
   ;; CHECK:      (func $struct.set.null.fallthrough (type $5)
   ;; CHECK-NEXT:  (local $temp (ref null $struct))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (local.tee $temp
   ;; CHECK-NEXT:     (unreachable)
@@ -2802,7 +2802,7 @@
 
   ;; CHECK:      (func $set.array.null (type $5)
   ;; CHECK-NEXT:  (local $temp (ref none))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable ArraySet we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (local.tee $temp
   ;; CHECK-NEXT:     (unreachable)

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -286,7 +286,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -2773,7 +2773,7 @@
 
   ;; CHECK:      (func $struct.set.null.fallthrough (type $5)
   ;; CHECK-NEXT:  (local $temp (ref null $struct))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (local.tee $temp
   ;; CHECK-NEXT:     (unreachable)
@@ -2802,7 +2802,7 @@
 
   ;; CHECK:      (func $set.array.null (type $5)
   ;; CHECK-NEXT:  (local $temp (ref none))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (local.tee $temp
   ;; CHECK-NEXT:     (unreachable)

--- a/test/lit/passes/precompute-gc-immutable.wast
+++ b/test/lit/passes/precompute-gc-immutable.wast
@@ -176,7 +176,7 @@
   ;; CHECK:      (func $unreachable (type $2)
   ;; CHECK-NEXT:  (local $ref-imm (ref null $struct-imm))
   ;; CHECK-NEXT:  (local.tee $ref-imm
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -223,7 +223,7 @@
   ;; CHECK:      (func $local-null (type $2)
   ;; CHECK-NEXT:  (local $ref-imm (ref null $struct-imm))
   ;; CHECK-NEXT:  (call $helper
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.null none)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/precompute-gc-immutable.wast
+++ b/test/lit/passes/precompute-gc-immutable.wast
@@ -176,7 +176,7 @@
   ;; CHECK:      (func $unreachable (type $2)
   ;; CHECK-NEXT:  (local $ref-imm (ref null $struct-imm))
   ;; CHECK-NEXT:  (local.tee $ref-imm
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -223,7 +223,7 @@
   ;; CHECK:      (func $local-null (type $2)
   ;; CHECK-NEXT:  (local $ref-imm (ref null $struct-imm))
   ;; CHECK-NEXT:  (call $helper
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (ref.null none)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -750,7 +750,7 @@
  ;; CHECK-NEXT:   (ref.null none)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+ ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (ref.null none)
  ;; CHECK-NEXT:    )
@@ -787,7 +787,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+ ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (ref.null none)
  ;; CHECK-NEXT:    )
@@ -851,7 +851,7 @@
  )
 
  ;; CHECK:      (func $new_block_unreachable (type $8) (result anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructNew)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block
  ;; CHECK-NEXT:     (unreachable)

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -750,7 +750,7 @@
  ;; CHECK-NEXT:   (ref.null none)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (ref.null none)
  ;; CHECK-NEXT:    )
@@ -787,7 +787,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (ref.null none)
  ;; CHECK-NEXT:    )
@@ -851,7 +851,7 @@
  )
 
  ;; CHECK:      (func $new_block_unreachable (type $8) (result anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructNew)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block
  ;; CHECK-NEXT:     (unreachable)

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -602,7 +602,7 @@
  ;; CHECK:      (func $fallthrough-unreachable (type $6) (param $0 i31ref) (result anyref)
  ;; CHECK-NEXT:  (block $outer
  ;; CHECK-NEXT:   (drop
- ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit, for RefCast)
  ;; CHECK-NEXT:     (drop
  ;; CHECK-NEXT:      (block
  ;; CHECK-NEXT:       (drop

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -602,7 +602,7 @@
  ;; CHECK:      (func $fallthrough-unreachable (type $6) (param $0 i31ref) (result anyref)
  ;; CHECK-NEXT:  (block $outer
  ;; CHECK-NEXT:   (drop
- ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit, for RefCast)
+ ;; CHECK-NEXT:    (block ;; (replaces unreachable RefCast we can't emit)
  ;; CHECK-NEXT:     (drop
  ;; CHECK-NEXT:      (block
  ;; CHECK-NEXT:       (drop

--- a/test/lit/passes/remove-unused-module-elements-refs.wast
+++ b/test/lit/passes/remove-unused-module-elements-refs.wast
@@ -50,7 +50,7 @@
   ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (local.get $A)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -80,7 +80,7 @@
   ;; OPEN_WORLD-NEXT:  (call_ref $A
   ;; OPEN_WORLD-NEXT:   (local.get $A)
   ;; OPEN_WORLD-NEXT:  )
-  ;; OPEN_WORLD-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; OPEN_WORLD-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; OPEN_WORLD-NEXT:   (drop
   ;; OPEN_WORLD-NEXT:    (unreachable)
   ;; OPEN_WORLD-NEXT:   )
@@ -810,7 +810,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -871,7 +871,7 @@
   ;; OPEN_WORLD-NEXT:   )
   ;; OPEN_WORLD-NEXT:  )
   ;; OPEN_WORLD-NEXT:  (drop
-  ;; OPEN_WORLD-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; OPEN_WORLD-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; OPEN_WORLD-NEXT:    (drop
   ;; OPEN_WORLD-NEXT:     (unreachable)
   ;; OPEN_WORLD-NEXT:    )

--- a/test/lit/passes/remove-unused-module-elements-refs.wast
+++ b/test/lit/passes/remove-unused-module-elements-refs.wast
@@ -50,7 +50,7 @@
   ;; CHECK-NEXT:  (call_ref $A
   ;; CHECK-NEXT:   (local.get $A)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
@@ -80,7 +80,7 @@
   ;; OPEN_WORLD-NEXT:  (call_ref $A
   ;; OPEN_WORLD-NEXT:   (local.get $A)
   ;; OPEN_WORLD-NEXT:  )
-  ;; OPEN_WORLD-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; OPEN_WORLD-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; OPEN_WORLD-NEXT:   (drop
   ;; OPEN_WORLD-NEXT:    (unreachable)
   ;; OPEN_WORLD-NEXT:   )
@@ -810,7 +810,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
@@ -871,7 +871,7 @@
   ;; OPEN_WORLD-NEXT:   )
   ;; OPEN_WORLD-NEXT:  )
   ;; OPEN_WORLD-NEXT:  (drop
-  ;; OPEN_WORLD-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; OPEN_WORLD-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; OPEN_WORLD-NEXT:    (drop
   ;; OPEN_WORLD-NEXT:     (unreachable)
   ;; OPEN_WORLD-NEXT:    )

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -819,7 +819,7 @@
 
   ;; CHECK:      (func $0 (type $0)
   ;; CHECK-NEXT:  (local $0 f32)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for RefCast)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable RefCast we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -819,7 +819,7 @@
 
   ;; CHECK:      (func $0 (type $0)
   ;; CHECK-NEXT:  (local $0 f32)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for RefCast)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -856,7 +856,7 @@
   (type $F (func))
 
   ;; CHECK:      (func $func (type $F)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (ref.null nofunc)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -856,7 +856,7 @@
   (type $F (func))
 
   ;; CHECK:      (func $func (type $F)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (ref.null nofunc)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/simplify-locals-gc.wast
+++ b/test/lit/passes/simplify-locals-gc.wast
@@ -76,7 +76,7 @@
   ;; CHECK:      (func $unreachable-struct.get (type $6) (param $x (ref $struct)) (param $y (ref $struct-immutable)) (result i32)
   ;; CHECK-NEXT:  (local $temp i32)
   ;; CHECK-NEXT:  (local.tee $temp
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/simplify-locals-gc.wast
+++ b/test/lit/passes/simplify-locals-gc.wast
@@ -76,7 +76,7 @@
   ;; CHECK:      (func $unreachable-struct.get (type $6) (param $x (ref $struct)) (param $y (ref $struct-immutable)) (result i32)
   ;; CHECK-NEXT:  (local $temp i32)
   ;; CHECK-NEXT:  (local.tee $temp
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -915,7 +915,7 @@
  ;; CHECK:      (func $call-ref-impossible (type $2) (result eqref)
  ;; CHECK-NEXT:  (local $f nullfuncref)
  ;; CHECK-NEXT:  (local $arg anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $arg)
  ;; CHECK-NEXT:   )
@@ -1044,7 +1044,7 @@
 
  ;; CHECK:      (func $struct-get-impossible (type $0) (result anyref)
  ;; CHECK-NEXT:  (local $var nullref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructGet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $var)
  ;; CHECK-NEXT:   )
@@ -1101,7 +1101,7 @@
  ;; CHECK:      (func $struct-set-impossible (type $3)
  ;; CHECK-NEXT:  (local $ref nullref)
  ;; CHECK-NEXT:  (local $val anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $ref)
  ;; CHECK-NEXT:   )
@@ -1246,7 +1246,7 @@
 
  ;; CHECK:      (func $array-get-impossible (type $3) (result anyref)
  ;; CHECK-NEXT:  (local $val nullref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArrayGet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $val)
  ;; CHECK-NEXT:   )
@@ -1289,7 +1289,7 @@
  ;; CHECK:      (func $array-set-impossible (type $0)
  ;; CHECK-NEXT:  (local $ref nullref)
  ;; CHECK-NEXT:  (local $val anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $ref)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/type-generalizing.wast
+++ b/test/lit/passes/type-generalizing.wast
@@ -915,7 +915,7 @@
  ;; CHECK:      (func $call-ref-impossible (type $2) (result eqref)
  ;; CHECK-NEXT:  (local $f nullfuncref)
  ;; CHECK-NEXT:  (local $arg anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $arg)
  ;; CHECK-NEXT:   )
@@ -1044,7 +1044,7 @@
 
  ;; CHECK:      (func $struct-get-impossible (type $0) (result anyref)
  ;; CHECK-NEXT:  (local $var nullref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructGet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable StructGet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $var)
  ;; CHECK-NEXT:   )
@@ -1101,7 +1101,7 @@
  ;; CHECK:      (func $struct-set-impossible (type $3)
  ;; CHECK-NEXT:  (local $ref nullref)
  ;; CHECK-NEXT:  (local $val anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $ref)
  ;; CHECK-NEXT:   )
@@ -1246,7 +1246,7 @@
 
  ;; CHECK:      (func $array-get-impossible (type $3) (result anyref)
  ;; CHECK-NEXT:  (local $val nullref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArrayGet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable ArrayGet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $val)
  ;; CHECK-NEXT:   )
@@ -1289,7 +1289,7 @@
  ;; CHECK:      (func $array-set-impossible (type $0)
  ;; CHECK-NEXT:  (local $ref nullref)
  ;; CHECK-NEXT:  (local $val anyref)
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable ArraySet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (local.get $ref)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -844,7 +844,7 @@
 
   ;; CHECK:      (func $func (type $6) (param $Leaf1-Outer (ref null $Leaf1-Outer))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block
   ;; CHECK-NEXT:      (drop
@@ -1106,7 +1106,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $struct 0
   ;; CHECK-NEXT:   (local.get $struct)
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (ref.null none)
@@ -1196,9 +1196,9 @@
   ;; CHECK:       (type $2 (func))
 
   ;; CHECK:      (func $0 (type $2)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:    (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (drop
@@ -1352,7 +1352,7 @@
   )
 
   ;; CHECK:      (func $bottom.type (type $1) (param $ref (ref none)) (param $value (ref noextern))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (local.get $ref)
   ;; CHECK-NEXT:   )
@@ -1371,7 +1371,7 @@
   )
 
   ;; CHECK:      (func $unreachable (type $0) (param $value (ref noextern))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -844,7 +844,7 @@
 
   ;; CHECK:      (func $func (type $6) (param $Leaf1-Outer (ref null $Leaf1-Outer))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block
   ;; CHECK-NEXT:      (drop
@@ -1106,7 +1106,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $struct 0
   ;; CHECK-NEXT:   (local.get $struct)
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructGet)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (ref.null none)
@@ -1196,9 +1196,9 @@
   ;; CHECK:       (type $2 (func))
 
   ;; CHECK:      (func $0 (type $2)
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:    (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (drop
@@ -1352,7 +1352,7 @@
   )
 
   ;; CHECK:      (func $bottom.type (type $1) (param $ref (ref none)) (param $value (ref noextern))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (local.get $ref)
   ;; CHECK-NEXT:   )
@@ -1371,7 +1371,7 @@
   )
 
   ;; CHECK:      (func $unreachable (type $0) (param $value (ref noextern))
-  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )

--- a/test/lit/passes/type-ssa.wast
+++ b/test/lit/passes/type-ssa.wast
@@ -165,7 +165,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/type-ssa.wast
+++ b/test/lit/passes/type-ssa.wast
@@ -165,7 +165,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for StructNew)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -936,7 +936,7 @@
  ;; CHECK-NEXT:   (struct.new_default $sub)
  ;; CHECK-NEXT:   (ref.func $call-ref)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (struct.new_default $sub)
  ;; CHECK-NEXT:   )
@@ -945,7 +945,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (struct.new_default $sub)
  ;; CHECK-NEXT:   )
@@ -1122,7 +1122,7 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (struct.new_default $struct)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructNew)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1165,7 +1165,7 @@
  ;; CHECK-NEXT:   (local.get $struct)
  ;; CHECK-NEXT:   (struct.new_default $sub)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1174,7 +1174,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:   )
@@ -1229,7 +1229,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for ArrayNew)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
@@ -1287,7 +1287,7 @@
  ;; CHECK-NEXT:    (i32.const 0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArrayNewElem)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1332,7 +1332,7 @@
  ;; CHECK-NEXT:    (struct.new_default $sub)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArrayNewFixed)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1371,7 +1371,7 @@
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (struct.new_default $sub)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1383,7 +1383,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit)
+ ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:   )

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -936,7 +936,7 @@
  ;; CHECK-NEXT:   (struct.new_default $sub)
  ;; CHECK-NEXT:   (ref.func $call-ref)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (struct.new_default $sub)
  ;; CHECK-NEXT:   )
@@ -945,7 +945,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for CallRef)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable CallRef we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (struct.new_default $sub)
  ;; CHECK-NEXT:   )
@@ -1122,7 +1122,7 @@
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (struct.new_default $struct)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructNew)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1165,7 +1165,7 @@
  ;; CHECK-NEXT:   (local.get $struct)
  ;; CHECK-NEXT:   (struct.new_default $sub)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1174,7 +1174,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for StructSet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:   )
@@ -1229,7 +1229,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block ;; (replaces something unreachable we can't emit, for ArrayNew)
+ ;; CHECK-NEXT:   (block ;; (replaces unreachable ArrayNew we can't emit)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
@@ -1287,7 +1287,7 @@
  ;; CHECK-NEXT:    (i32.const 0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArrayNewElem)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable ArrayNewElem we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1332,7 +1332,7 @@
  ;; CHECK-NEXT:    (struct.new_default $sub)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArrayNewFixed)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable ArrayNewFixed we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1371,7 +1371,7 @@
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (struct.new_default $sub)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable ArraySet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
@@ -1383,7 +1383,7 @@
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block ;; (replaces something unreachable we can't emit, for ArraySet)
+ ;; CHECK-NEXT:  (block ;; (replaces unreachable ArraySet we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (ref.null none)
  ;; CHECK-NEXT:   )


### PR DESCRIPTION
In some cases we don't print an Expression in full if it is unreachable, so
we print something instead as a placeholder. This happens in unreachable
code when the children don't provide enough info to print the parent (e.g.
a StructGet with an unreachable reference doesn't know what struct type
to use).

This PR prints out the name of the Expression type of such things, which
can help debugging sometimes. See updated test text for examples.