### PR TITLE
Fuzzer: Mark Roundtrip pass as adding effects

### DIFF
--- a/src/passes/RoundTrip.cpp
+++ b/src/passes/RoundTrip.cpp
@@ -28,6 +28,12 @@
 namespace wasm {
 
 struct RoundTrip : public Pass {
+  // Reloading the wasm may alter function names etc., which means our global
+  // function effect tracking can get confused, and effects may seem to appear.
+  // To avoid that, mark this pass as adding effects, which will clear all
+  // cached effects and such.
+  bool addsEffects() override { return true; }
+
   void run(Module* module) override {
     BufferWithRandomAccess buffer;
     // Save features, which would not otherwise make it through a round trip if


### PR DESCRIPTION
It doesn't literally add them, but roundtripping a file can rename functions
which means our internal map of function name to effects can get out of
date, which has the effect of "adding" effects to passes when they get the
wrong ones.

This pass is just a fuzzer helper, so this hack seems good enough.