### PR TITLE
Fuzzer: Standardize notation for exception prefixes

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -477,7 +477,7 @@ STACK_LIMIT = '[trap stack limit]'
 # and also see the --dce workaround below that also links to those issues.
 V8_UNINITIALIZED_NONDEF_LOCAL = 'uninitialized non-defaultable local'
 
-# JS exceptions are logged as exception: REASON
+# JS exceptions are logged as exception thrown: REASON
 EXCEPTION_PREFIX = 'exception thrown: '
 
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -469,6 +469,9 @@ STACK_LIMIT = '[trap stack limit]'
 # and also see the --dce workaround below that also links to those issues.
 V8_UNINITIALIZED_NONDEF_LOCAL = 'uninitialized non-defaultable local'
 
+# JS exceptions are logged as exception: REASON
+EXCEPTION_PREFIX = 'exception: '
+
 
 # given a call line that includes FUZZ_EXEC_CALL_PREFIX, return the export that
 # is called
@@ -576,7 +579,7 @@ def fix_output(out):
     out = re.sub(r'f64\.const (-?[nanN:abcdefxIity\d+-.]+)', fix_double, out)
 
     # mark traps from wasm-opt as exceptions, even though they didn't run in a vm
-    out = out.replace(TRAP_PREFIX, 'exception: ' + TRAP_PREFIX)
+    out = out.replace(TRAP_PREFIX, EXCEPTION_PREFIX + TRAP_PREFIX)
 
     # funcref(0) has the index of the function in it, and optimizations can
     # change that index, so ignore it
@@ -595,7 +598,7 @@ def fix_output(out):
             # developer can see it.
             print(line)
             lines[i] = None
-        elif 'exception' in line:
+        elif EXCEPTION_PREFIX in line:
             # exceptions may differ when optimizing, but an exception should
             # occur, so ignore their types (also js engines print them out
             # slightly differently)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -478,7 +478,7 @@ STACK_LIMIT = '[trap stack limit]'
 V8_UNINITIALIZED_NONDEF_LOCAL = 'uninitialized non-defaultable local'
 
 # JS exceptions are logged as exception: REASON
-EXCEPTION_PREFIX = 'exception: '
+EXCEPTION_PREFIX = 'exception thrown: '
 
 
 # given a call line that includes FUZZ_EXEC_CALL_PREFIX, return the export that

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -597,6 +597,9 @@ def fix_output(out):
     # to "N".
     out = re.sub(r'i31ref\((-?\d+)\)', r'\1', out)
 
+    # Tag names may change due to opts, so canonicalize them.
+    out = re.sub(r' tag\$\d+', ' tag', out)
+
     lines = out.splitlines()
     for i in range(len(lines)):
         line = lines[i]

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -108,7 +108,7 @@ var instance;
 try {
   instance = new WebAssembly.Instance(module, imports);
 } catch (e) {
-  console.log('exception: failed to instantiate module');
+  console.log('exception thrown: failed to instantiate module');
   quit();
 }
 

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -139,7 +139,7 @@ for (var e in exports) {
       console.log('[fuzz-exec] note result: ' + e + ' => ' + printed(result));
     }
   } catch (e) {
-    console.log('exception!');// + [e, e.stack]);
+    console.log('exception: ' + e);
   }
 }
 

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -143,7 +143,7 @@ for (var e in exports) {
       console.log('[fuzz-exec] note result: ' + e + ' => ' + printed(result));
     }
   } catch (e) {
-    console.log('exception: ' + e);
+    console.log('exception thrown: ' + e);
   }
 }
 


### PR DESCRIPTION
We had `exception:` in one and `exception thrown:` in another. Making those
consistent allows `fuzz_shell.js` to print the exception after that prefix, which
makes debugging easier sometimes.

Also canonicalize tag names. Like funcref names, JS VMs print out the internal
name, which can change after opts, so canonicalize it.