### PR TITLE
[Parser] Improve parsed IR for multivalue returns

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -378,18 +378,10 @@ Result<> IRBuilder::visitReturn(Return* curr) {
   size_t n = func->getResults().size();
   if (n == 0) {
     curr->value = nullptr;
-  } else if (n == 1) {
-    auto val = pop();
+  } else {
+    auto val = pop(n);
     CHECK_ERR(val);
     curr->value = *val;
-  } else {
-    std::vector<Expression*> vals(n);
-    for (size_t i = 0; i < n; ++i) {
-      auto val = pop();
-      CHECK_ERR(val);
-      vals[n - i - 1] = *val;
-    }
-    curr->value = builder.makeTupleMake(vals);
   }
   return Ok{};
 }

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -3662,6 +3662,16 @@
   return
  )
 
+ ;; CHECK:      (func $return-multivalue (type $4) (result i32 i64)
+ ;; CHECK-NEXT:  (return
+ ;; CHECK-NEXT:   (call $return-multivalue)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $return-multivalue (result i32 i64)
+  call $return-multivalue
+  return
+ )
+
  ;; CHECK:      (func $ref-is-null (type $45) (param $0 anyref) (result i32)
  ;; CHECK-NEXT:  (ref.is_null
  ;; CHECK-NEXT:   (local.get $0)
@@ -3683,7 +3693,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 156
+  ref.func 157
   drop
  )
 


### PR DESCRIPTION
Rather than reassembling a tuple from multiple pops, let the pop implementation
assemble the tuple. This produces less code in cases where there is already a
tuple of the proper size on top of the stack. It also simplifies the code.