### PR TITLE
Fix EH fuzz bugs

### DIFF
--- a/src/ir/eh-utils.cpp
+++ b/src/ir/eh-utils.cpp
@@ -84,7 +84,7 @@ getFirstPop(Expression* catchBody, bool& isPopNested, Expression**& popPtr) {
         } else {
           isPopNested = true;
         }
-      } else if (firstChild->is<Try>()) {
+      } else if (firstChild->is<Try>() || firstChild->is<TryTable>()) {
         isPopNested = true;
       } else {
         WASM_UNREACHABLE("Unexpected control flow expression");

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2456,7 +2456,7 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       return builder.makeArrayNewFixed(trivialArray, {});
     }
     case HeapType::exn: {
-      auto null = builder.makeRefNull(HeapType::ext);
+      auto null = builder.makeRefNull(HeapType::exn);
       if (!type.isNullable()) {
         assert(funcContext);
         return builder.makeRefAs(RefAsNonNull, null);


### PR DESCRIPTION
Due to a typo, the fuzzer was making externrefs when it should have been making
exnrefs. Fix that and also let eh-utils.cpp know that TryTable exists to avoid
an assertion failure.