### PR TITLE
Do not write assertions to split.wast for spec tests

### DIFF
--- a/check.py
+++ b/check.py
@@ -242,9 +242,9 @@ def run_spec_tests():
                 for module, asserts in support.split_wast(wast):
                     print('        testing split module', split_num)
                     split_num += 1
-                    support.write_wast('split.wast', module, asserts)
+                    support.write_wast('split.wast', module)
                     run_opt_test('split.wast')    # also that our optimizer doesn't break on it
-                    result_wast_file = shared.binary_format_check('split.wast', verify_final_result=False, original_wast=wast)
+                    result_wast_file = shared.binary_format_check('split.wast', verify_final_result=False)
                     with open(result_wast_file) as f:
                         result_wast = f.read()
                         # add the asserts, and verify that the test still passes

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -457,7 +457,7 @@ options.spec_tests = [t for t in options.spec_tests if os.path.basename(t) not
 # check utilities
 
 def binary_format_check(wast, verify_final_result=True, wasm_as_args=['-g'],
-                        binary_suffix='.fromBinary', original_wast=None):
+                        binary_suffix='.fromBinary'):
     # checks we can convert the wast to binary and back
 
     print('         (binary format check)')


### PR DESCRIPTION
As part of our running of spec tests, we split out each module in a test script
into a separate text file for processing with wasm-opt. We previously included
the test assertions corresponding to the module into that text file, where they
were ignored by the legacy text parser. The new parser errors out due to the
extra tokens after the module, though, so to avoid problems once we switch to
the new parser, stop including the assertions in those text files.

Also remove a nearby unused argument as a drive-by cleanup.