### PR TITLE
Remove the typed variant of `Select::finalize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Current Trunk
    the `else` branch itself.
  - Add a new `BinaryenModuleReadWithFeatures` function to the C API that allows
    to configure which features to enable in the parser.
+ - `BinaryenSelect` no longer takes a `BinaryenType` parameter.
 
 v117
 ----

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1320,17 +1320,12 @@ BinaryenExpressionRef BinaryenBinary(BinaryenModuleRef module,
 BinaryenExpressionRef BinaryenSelect(BinaryenModuleRef module,
                                      BinaryenExpressionRef condition,
                                      BinaryenExpressionRef ifTrue,
-                                     BinaryenExpressionRef ifFalse,
-                                     BinaryenType type) {
+                                     BinaryenExpressionRef ifFalse) {
   auto* ret = ((Module*)module)->allocator.alloc<Select>();
   ret->condition = (Expression*)condition;
   ret->ifTrue = (Expression*)ifTrue;
   ret->ifFalse = (Expression*)ifFalse;
-  if (type != BinaryenTypeAuto()) {
-    ret->finalize(Type(type));
-  } else {
-    ret->finalize();
-  }
+  ret->finalize();
   return static_cast<Expression*>(ret);
 }
 BinaryenExpressionRef BinaryenDrop(BinaryenModuleRef module,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -847,8 +847,7 @@ BINARYEN_API BinaryenExpressionRef
 BinaryenSelect(BinaryenModuleRef module,
                BinaryenExpressionRef condition,
                BinaryenExpressionRef ifTrue,
-               BinaryenExpressionRef ifFalse,
-               BinaryenType type);
+               BinaryenExpressionRef ifFalse);
 BINARYEN_API BinaryenExpressionRef BinaryenDrop(BinaryenModuleRef module,
                                                 BinaryenExpressionRef value);
 // Return: value can be NULL

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2378,8 +2378,8 @@ function wrapModule(module, self = {}) {
     }
   };
 
-  self['select'] = function(condition, ifTrue, ifFalse, type) {
-    return Module['_BinaryenSelect'](module, condition, ifTrue, ifFalse, typeof type !== 'undefined' ? type : Module['auto']);
+  self['select'] = function(condition, ifTrue, ifFalse) {
+    return Module['_BinaryenSelect'](module, condition, ifTrue, ifFalse);
   };
   self['drop'] = function(value) {
     return Module['_BinaryenDrop'](module, value);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -5133,7 +5133,7 @@ private:
         curr->ifTrue = updateArm(curr->ifTrue);
         curr->ifFalse = updateArm(curr->ifFalse);
         un->value = curr;
-        curr->finalize(newType);
+        curr->finalize();
         return replaceCurrent(un);
       }
     }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1311,7 +1311,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           return nullptr;
         }
         return Builder(*getModule())
-          .makeSelect(iff->condition, iff->ifTrue, iff->ifFalse, iff->type);
+          .makeSelect(iff->condition, iff->ifTrue, iff->ifFalse);
       }
 
       void visitLocalSet(LocalSet* curr) {

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -324,7 +324,7 @@ private:
   Expression* makeUnary(Type type);
   Expression* buildBinary(const BinaryArgs& args);
   Expression* makeBinary(Type type);
-  Expression* buildSelect(const ThreeArgs& args, Type type);
+  Expression* buildSelect(const ThreeArgs& args);
   Expression* makeSelect(Type type);
   Expression* makeSwitch(Type type);
   Expression* makeDrop(Type type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3041,15 +3041,14 @@ Expression* TranslateToFuzzReader::makeBinary(Type type) {
   WASM_UNREACHABLE("invalid type");
 }
 
-Expression* TranslateToFuzzReader::buildSelect(const ThreeArgs& args,
-                                               Type type) {
-  return builder.makeSelect(args.a, args.b, args.c, type);
+Expression* TranslateToFuzzReader::buildSelect(const ThreeArgs& args) {
+  return builder.makeSelect(args.a, args.b, args.c);
 }
 
 Expression* TranslateToFuzzReader::makeSelect(Type type) {
   Type subType1 = getSubType(type);
   Type subType2 = getSubType(type);
-  return buildSelect({make(Type::i32), make(subType1), make(subType2)}, type);
+  return buildSelect({make(Type::i32), make(subType1), make(subType2)});
 }
 
 Expression* TranslateToFuzzReader::makeSwitch(Type type) {

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -630,17 +630,6 @@ public:
     ret->finalize();
     return ret;
   }
-  Select* makeSelect(Expression* condition,
-                     Expression* ifTrue,
-                     Expression* ifFalse,
-                     Type type) {
-    auto* ret = wasm.allocator.alloc<Select>();
-    ret->condition = condition;
-    ret->ifTrue = ifTrue;
-    ret->ifFalse = ifFalse;
-    ret->finalize(type);
-    return ret;
-  }
   Return* makeReturn(Expression* value = nullptr) {
     auto* ret = wasm.allocator.alloc<Return>();
     ret->value = value;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1278,7 +1278,6 @@ public:
   Expression* condition;
 
   void finalize();
-  void finalize(Type type_);
 };
 
 class Drop : public SpecificExpression<Expression::DropId> {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6790,11 +6790,7 @@ void WasmBinaryReader::visitSelect(Select* curr, uint8_t code) {
   curr->condition = popNonVoidExpression();
   curr->ifFalse = popNonVoidExpression();
   curr->ifTrue = popNonVoidExpression();
-  if (code == BinaryConsts::SelectWithType) {
-    curr->finalize(curr->type);
-  } else {
-    curr->finalize();
-  }
+  curr->finalize();
 }
 
 void WasmBinaryReader::visitReturn(Return* curr) {

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1372,9 +1372,7 @@ Result<> IRBuilder::makeBinary(BinaryOp op) {
 Result<> IRBuilder::makeSelect(std::optional<Type> type) {
   Select curr;
   CHECK_ERR(visitSelect(&curr));
-  auto* built =
-    type ? builder.makeSelect(curr.condition, curr.ifTrue, curr.ifFalse, *type)
-         : builder.makeSelect(curr.condition, curr.ifTrue, curr.ifFalse);
+  auto* built = builder.makeSelect(curr.condition, curr.ifTrue, curr.ifFalse);
   if (type && !Type::isSubType(built->type, *type)) {
     return Err{"select type does not match expected type"};
   }

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1491,10 +1491,9 @@ Expression* SExpressionWasmBuilder::makeSelect(Element& s) {
   ret->ifTrue = parseExpression(s[i++]);
   ret->ifFalse = parseExpression(s[i++]);
   ret->condition = parseExpression(s[i]);
-  if (type.isConcrete()) {
-    ret->finalize(type);
-  } else {
-    ret->finalize();
+  ret->finalize();
+  if (type != Type::none && !Type::isSubType(ret->type, type)) {
+    throw SParseException("select type does not match annotation", s);
   }
   return ret;
 }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -760,8 +760,6 @@ void Binary::finalize() {
   }
 }
 
-void Select::finalize(Type type_) { type = type_; }
-
 void Select::finalize() {
   assert(ifTrue && ifFalse);
   if (ifTrue->type == Type::unreachable || ifFalse->type == Type::unreachable ||

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -603,7 +603,7 @@ function test_core() {
     module.ref.is_null(module.ref.null(binaryen.externref)),
     module.ref.is_null(module.ref.null(binaryen.funcref)),
     module.ref.is_null(module.ref.func("kitchen()sinker", binaryen.funcref)),
-    module.select(temp10, module.ref.null(binaryen.funcref), module.ref.func("kitchen()sinker", binaryen.funcref), binaryen.funcref),
+    module.select(temp10, module.ref.null(binaryen.funcref), module.ref.func("kitchen()sinker", binaryen.funcref)),
 
     // GC
     module.ref.eq(module.ref.null(binaryen.eqref), module.ref.null(binaryen.eqref)),

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -1045,7 +1045,7 @@ void test_core() {
       module, 8, 0, 2, 8, BinaryenTypeFloat64(), makeInt32(module, 9), "0"),
     BinaryenStore(module, 4, 0, 0, temp13, temp14, BinaryenTypeInt32(), "0"),
     BinaryenStore(module, 8, 2, 4, temp15, temp16, BinaryenTypeInt64(), "0"),
-    BinaryenSelect(module, temp10, temp11, temp12, BinaryenTypeAuto()),
+    BinaryenSelect(module, temp10, temp11, temp12),
     BinaryenReturn(module, makeInt32(module, 1337)),
     // Tail call
     BinaryenReturnCall(
@@ -1064,8 +1064,7 @@ void test_core() {
       module,
       temp10,
       BinaryenRefNull(module, BinaryenTypeNullFuncref()),
-      BinaryenRefFunc(module, "kitchen()sinker", BinaryenTypeFuncref()),
-      BinaryenTypeFuncref()),
+      BinaryenRefFunc(module, "kitchen()sinker", BinaryenTypeFuncref())),
     // GC
     BinaryenRefEq(module,
                   BinaryenRefNull(module, BinaryenTypeNullref()),

--- a/test/lit/basic/reference-types.wast
+++ b/test/lit/basic/reference-types.wast
@@ -663,7 +663,7 @@
   ;; CHECK-TEXT-NEXT:   )
   ;; CHECK-TEXT-NEXT:  )
   ;; CHECK-TEXT-NEXT:  (drop
-  ;; CHECK-TEXT-NEXT:   (select (result anyref)
+  ;; CHECK-TEXT-NEXT:   (select (result eqref)
   ;; CHECK-TEXT-NEXT:    (local.get $local_eqref)
   ;; CHECK-TEXT-NEXT:    (ref.i31
   ;; CHECK-TEXT-NEXT:     (i32.const 0)
@@ -1198,7 +1198,7 @@
   ;; CHECK-BIN-NEXT:   )
   ;; CHECK-BIN-NEXT:  )
   ;; CHECK-BIN-NEXT:  (drop
-  ;; CHECK-BIN-NEXT:   (select (result anyref)
+  ;; CHECK-BIN-NEXT:   (select (result eqref)
   ;; CHECK-BIN-NEXT:    (local.get $local_eqref)
   ;; CHECK-BIN-NEXT:    (ref.i31
   ;; CHECK-BIN-NEXT:     (i32.const 0)
@@ -2411,7 +2411,7 @@
 ;; CHECK-BIN-NODEBUG-NEXT:   )
 ;; CHECK-BIN-NODEBUG-NEXT:  )
 ;; CHECK-BIN-NODEBUG-NEXT:  (drop
-;; CHECK-BIN-NODEBUG-NEXT:   (select (result anyref)
+;; CHECK-BIN-NODEBUG-NEXT:   (select (result eqref)
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:    (ref.i31
 ;; CHECK-BIN-NODEBUG-NEXT:     (i32.const 0)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2245,14 +2245,12 @@
   ;; CHECK-NEXT:  (local $A (ref $A))
   ;; CHECK-NEXT:  (local $B (ref $B))
   ;; CHECK-NEXT:  (struct.set $A 0
-  ;; CHECK-NEXT:   (select (result (ref null $A))
-  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   (block (result (ref null $A))
   ;; CHECK-NEXT:    (local.tee $B
   ;; CHECK-NEXT:     (struct.new $B
   ;; CHECK-NEXT:      (i32.const 20)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (struct.get $A 0
   ;; CHECK-NEXT:    (struct.new $A
@@ -2273,16 +2271,14 @@
     ;; that we track the copied value even though the copy is on $A but it
     ;; affects $B.
     (struct.set $A 0
-      ;; This select is used to keep the type that reaches the struct.set $A,
+      ;; This block is used to keep the type that reaches the struct.set $A,
       ;; and not $B, so it looks like a perfect copy of $A->$A.
-      (select (result (ref null $A))
-        (ref.null $A)
+      (block (result (ref null $A))
         (local.tee $B
           (struct.new $B
             (i32.const 20)
           )
         )
-        (i32.const 0)
       )
       (struct.get $A 0
         (struct.new $A

--- a/test/lit/passes/optimize-instructions-gc-tnh.wast
+++ b/test/lit/passes/optimize-instructions-gc-tnh.wast
@@ -497,16 +497,13 @@
   )
 
   ;; TNH:      (func $null.arm.null.effects (type $void)
-  ;; TNH-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
+  ;; TNH-NEXT:  (block
   ;; TNH-NEXT:   (drop
   ;; TNH-NEXT:    (select
   ;; TNH-NEXT:     (unreachable)
   ;; TNH-NEXT:     (ref.null none)
   ;; TNH-NEXT:     (call $get-i32)
   ;; TNH-NEXT:    )
-  ;; TNH-NEXT:   )
-  ;; TNH-NEXT:   (drop
-  ;; TNH-NEXT:    (i32.const 1)
   ;; TNH-NEXT:   )
   ;; TNH-NEXT:   (unreachable)
   ;; TNH-NEXT:  )
@@ -523,16 +520,13 @@
   ;; TNH-NEXT:  )
   ;; TNH-NEXT: )
   ;; NO_TNH:      (func $null.arm.null.effects (type $void)
-  ;; NO_TNH-NEXT:  (block ;; (replaces unreachable StructSet we can't emit)
+  ;; NO_TNH-NEXT:  (block
   ;; NO_TNH-NEXT:   (drop
   ;; NO_TNH-NEXT:    (select
   ;; NO_TNH-NEXT:     (unreachable)
   ;; NO_TNH-NEXT:     (ref.null none)
   ;; NO_TNH-NEXT:     (call $get-i32)
   ;; NO_TNH-NEXT:    )
-  ;; NO_TNH-NEXT:   )
-  ;; NO_TNH-NEXT:   (drop
-  ;; NO_TNH-NEXT:    (i32.const 1)
   ;; NO_TNH-NEXT:   )
   ;; NO_TNH-NEXT:   (unreachable)
   ;; NO_TNH-NEXT:  )

--- a/test/lit/passes/remove-unused-brs_all-features.wast
+++ b/test/lit/passes/remove-unused-brs_all-features.wast
@@ -120,14 +120,14 @@
  (func $i32_=>_none (param i32)
  )
  ;; CHECK:      (func $selectify (type $6) (param $x i32) (result funcref)
- ;; CHECK-NEXT:  (select (result funcref)
+ ;; CHECK-NEXT:  (select (result (ref func))
  ;; CHECK-NEXT:   (ref.func $none_=>_i32)
  ;; CHECK-NEXT:   (ref.func $i32_=>_none)
  ;; CHECK-NEXT:   (local.get $x)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $selectify (param $x i32) (result funcref)
-  ;; this if has arms with different function types, for which funcref is the
+  ;; this if has arms with different function types, for which (ref func) is the
   ;; LUB
   (if (result funcref)
    (local.get $x)

--- a/test/lit/select-gc.wat
+++ b/test/lit/select-gc.wat
@@ -6,11 +6,10 @@
 ;; only used in that one place in the whole module.
 
 (module
-  ;; CHECK:      (type $struct (struct ))
   (type $struct (struct))
 
   ;; CHECK:      (func $foo (type $0) (result anyref)
-  ;; CHECK-NEXT:  (select (result (ref null $struct))
+  ;; CHECK-NEXT:  (select (result nullref)
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:   (i32.const 1)


### PR DESCRIPTION
It was not correct because it did not check for unreachability in the select's
children. Rather than fix it, which would have required largely duplicating the
untyped version of `Select::finalize`, simply remove it. This simplifies all the
uses of the old API at the cost of forcing them to compute a LUB, which seems
acceptable.