### PR TITLE
Check for unreachable in `Select::finalize(Type)`

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -762,7 +762,8 @@ void Binary::finalize() {
 
 void Select::finalize(Type type_) {
   assert(ifTrue && ifFalse);
-  if (ifTrue->type == Type::unreachable || ifFalse->type == Type::unreachable) {
+  if (ifTrue->type == Type::unreachable || ifFalse->type == Type::unreachable ||
+      condition->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
     type = type_;

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -760,7 +760,14 @@ void Binary::finalize() {
   }
 }
 
-void Select::finalize(Type type_) { type = type_; }
+void Select::finalize(Type type_) {
+  assert(ifTrue && ifFalse);
+  if (ifTrue->type == Type::unreachable || ifFalse->type == Type::unreachable) {
+    type = Type::unreachable;
+  } else {
+    type = type_;
+  }
+}
 
 void Select::finalize() {
   assert(ifTrue && ifFalse);


### PR DESCRIPTION
Previously selects finalized with explicit types would never be marked
unreachable, even when they should have been.