### PR TITLE
Fix Emscripten build with -Wno-unused-command-line-argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,7 @@ if(EMSCRIPTEN)
     add_link_flag("-sMODULARIZE")
     add_link_flag("-sEXPORT_ES6")
     add_link_flag("-sFILESYSTEM")
-    add_link_flag("-sFORCE_FILESYSTEM")    
+    add_link_flag("-sFORCE_FILESYSTEM")
   else()
     # On Node.js, make the tools immediately usable.
     add_link_flag("-sNODERAWFS")
@@ -474,6 +474,8 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_wasm "-sFILESYSTEM")
   target_link_libraries(binaryen_wasm "-sEXPORT_NAME=Binaryen")
   target_link_libraries(binaryen_wasm "-sNODERAWFS=0")
+  # Do not error on the repeated NODERAWFS argument
+  target_link_libraries(binaryen_wasm "-Wno-unused-command-line-argument")
   # Emit a single file for convenience of people using binaryen.js as a library,
   # so they only need to distribute a single file.
   target_link_libraries(binaryen_wasm "-sSINGLE_FILE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,6 +511,8 @@ if(EMSCRIPTEN)
     target_link_libraries(binaryen_js "-sFILESYSTEM=1")
   endif()
   target_link_libraries(binaryen_js "-sNODERAWFS=0")
+  # Do not error on the repeated NODERAWFS argument
+  target_link_libraries(binaryen_js "-Wno-unused-command-line-argument")
   target_link_libraries(binaryen_js "-sSINGLE_FILE")
   target_link_libraries(binaryen_js "-sEXPORT_NAME=Binaryen")
   # Currently, js_of_ocaml can only process ES5 code


### PR DESCRIPTION
Emscripten had started complaining about the repeated NODERAWFS arguments in the
link command, but they would be nontrivial to deduplicate.