### PR TITLE
SafeHeap: Handle overflows when adding the pointer and the size

### DIFF
--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -294,17 +294,10 @@ struct SafeHeap : public Pass {
       builder.makeBinary(memory->is64() ? AddInt64 : AddInt32,
                          builder.makeLocalGet(0, indexType),
                          builder.makeLocalGet(1, indexType))));
-    // check for an overflow when adding the pointer and the size, using the
-    // rule that for any unsigned x and y,
-    //    x + y < x    <=>   x + y overflows
-    block->list.push_back(
-      builder.makeIf(builder.makeBinary(memory->is64() ? LtUInt64 : LtUInt32,
-                                        builder.makeLocalGet(2, indexType),
-                                        builder.makeLocalGet(0, indexType)),
-                     builder.makeCall(segfault, {}, Type::none)));
     // check for reading past valid memory: if pointer + offset + bytes
     block->list.push_back(makeBoundsCheck(style.type,
                                           builder,
+                                          0,
                                           2,
                                           style.bytes,
                                           module,
@@ -355,6 +348,7 @@ struct SafeHeap : public Pass {
     // check for reading past valid memory: if pointer + offset + bytes
     block->list.push_back(makeBoundsCheck(style.valueType,
                                           builder,
+                                          0,
                                           3,
                                           style.bytes,
                                           module,
@@ -395,9 +389,14 @@ struct SafeHeap : public Pass {
       builder.makeCall(alignfault, {}, Type::none));
   }
 
+  // Constructs a bounds check. This receives the indexes of two locals: the
+  // pointer local, which contains the pointer we are checking, and the sum
+  // local which contains the pointer added to the number of bytes being
+  // accessed.
   Expression* makeBoundsCheck(Type type,
                               Builder& builder,
-                              Index local,
+                              Index ptrLocal,
+                              Index sumLocal,
                               Index bytes,
                               Module* module,
                               Type indexType,
@@ -424,18 +423,33 @@ struct SafeHeap : public Pass {
     }
     auto gtuOp = is64 ? GtUInt64 : GtUInt32;
     auto addOp = is64 ? AddInt64 : AddInt32;
+    auto* upperCheck =           builder.makeBinary(upperOp,
+                             builder.makeLocalGet(sumLocal, indexType),
+                             builder.makeConstPtr(upperBound, indexType));
+    auto* lowerCheck =           builder.makeBinary(
+            gtuOp,
+            builder.makeBinary(addOp,
+                               builder.makeLocalGet(sumLocal, indexType),
+                               builder.makeConstPtr(bytes, indexType)),
+            brkLocation);
+    // Check for an overflow when adding the pointer and the size, using the
+    // rule that for any unsigned x and y,
+    //    x + y < x    <=>   x + y overflows
+    auto* overflowCheck = 
+        builder.makeBinary(
+          is64 ? LtUInt64 : LtUInt32,
+          builder.makeLocalGet(sumLocal, indexType),
+          builder.makeLocalGet(ptrLocal, indexType)
+        );
+
     return builder.makeIf(
       builder.makeBinary(
         OrInt32,
-        builder.makeBinary(upperOp,
-                           builder.makeLocalGet(local, indexType),
-                           builder.makeConstPtr(upperBound, indexType)),
+        upperCheck,
         builder.makeBinary(
-          gtuOp,
-          builder.makeBinary(addOp,
-                             builder.makeLocalGet(local, indexType),
-                             builder.makeConstPtr(bytes, indexType)),
-          brkLocation)),
+          OrInt32,
+          lowerCheck,
+          overflowCheck)),
       builder.makeCall(segfault, {}, Type::none));
   }
 };

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -448,9 +448,8 @@ struct SafeHeap : public Pass {
         OrInt32,
         upperCheck,
         builder.makeBinary(OrInt32, lowerCheck, overflowCheck)),
-      builder.makeSequence(
-        builder.makeCall(segfault, {}, Type::none),
-        builder.makeUnreachable()));
+      builder.makeSequence(builder.makeCall(segfault, {}, Type::none),
+                           builder.makeUnreachable()));
   }
 };
 

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -297,11 +297,11 @@ struct SafeHeap : public Pass {
     // check for an overflow when adding the pointer and the size, using the
     // rule that for any unsigned x and y,
     //    x + y < x    <=>   x + y overflows
-    block->list.push_back(builder.makeIf(
-      builder.makeBinary(memory->is64() ? LtUInt64 : LtUInt32,
-                         builder.makeLocalGet(2, indexType),
-                         builder.makeLocalGet(0, indexType)),
-      builder.makeCall(segfault, {}, Type::none)));
+    block->list.push_back(
+      builder.makeIf(builder.makeBinary(memory->is64() ? LtUInt64 : LtUInt32,
+                                        builder.makeLocalGet(2, indexType),
+                                        builder.makeLocalGet(0, indexType)),
+                     builder.makeCall(segfault, {}, Type::none)));
     // check for reading past valid memory: if pointer + offset + bytes
     block->list.push_back(makeBoundsCheck(style.type,
                                           builder,

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -423,33 +423,29 @@ struct SafeHeap : public Pass {
     }
     auto gtuOp = is64 ? GtUInt64 : GtUInt32;
     auto addOp = is64 ? AddInt64 : AddInt32;
-    auto* upperCheck =           builder.makeBinary(upperOp,
-                             builder.makeLocalGet(sumLocal, indexType),
-                             builder.makeConstPtr(upperBound, indexType));
-    auto* lowerCheck =           builder.makeBinary(
-            gtuOp,
-            builder.makeBinary(addOp,
-                               builder.makeLocalGet(sumLocal, indexType),
-                               builder.makeConstPtr(bytes, indexType)),
-            brkLocation);
+    auto* upperCheck =
+      builder.makeBinary(upperOp,
+                         builder.makeLocalGet(sumLocal, indexType),
+                         builder.makeConstPtr(upperBound, indexType));
+    auto* lowerCheck = builder.makeBinary(
+      gtuOp,
+      builder.makeBinary(addOp,
+                         builder.makeLocalGet(sumLocal, indexType),
+                         builder.makeConstPtr(bytes, indexType)),
+      brkLocation);
     // Check for an overflow when adding the pointer and the size, using the
     // rule that for any unsigned x and y,
     //    x + y < x    <=>   x + y overflows
-    auto* overflowCheck = 
-        builder.makeBinary(
-          is64 ? LtUInt64 : LtUInt32,
-          builder.makeLocalGet(sumLocal, indexType),
-          builder.makeLocalGet(ptrLocal, indexType)
-        );
+    auto* overflowCheck =
+      builder.makeBinary(is64 ? LtUInt64 : LtUInt32,
+                         builder.makeLocalGet(sumLocal, indexType),
+                         builder.makeLocalGet(ptrLocal, indexType));
 
     return builder.makeIf(
       builder.makeBinary(
         OrInt32,
         upperCheck,
-        builder.makeBinary(
-          OrInt32,
-          lowerCheck,
-          overflowCheck)),
+        builder.makeBinary(OrInt32, lowerCheck, overflowCheck)),
       builder.makeCall(segfault, {}, Type::none));
   }
 };

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -440,13 +440,17 @@ struct SafeHeap : public Pass {
       builder.makeBinary(is64 ? LtUInt64 : LtUInt32,
                          builder.makeLocalGet(sumLocal, indexType),
                          builder.makeLocalGet(ptrLocal, indexType));
-
+    // Add an unreachable right after the call to segfault for performance
+    // reasons: the call never returns, and this helps optimizations benefit
+    // from that.
     return builder.makeIf(
       builder.makeBinary(
         OrInt32,
         upperCheck,
         builder.makeBinary(OrInt32, lowerCheck, overflowCheck)),
-      builder.makeCall(segfault, {}, Type::none));
+      builder.makeSequence(
+        builder.makeCall(segfault, {}, Type::none),
+        builder.makeUnreachable()));
   }
 };
 

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -22,6 +22,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -51,6 +60,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -86,6 +104,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -115,6 +142,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -159,6 +195,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -188,6 +233,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -232,6 +286,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -261,6 +324,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -305,6 +377,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -346,6 +427,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -375,6 +465,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -410,6 +509,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -439,6 +547,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -483,6 +600,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -512,6 +638,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -556,6 +691,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -585,6 +729,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -629,6 +782,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -670,6 +832,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -699,6 +870,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -743,6 +923,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -784,6 +973,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -813,6 +1011,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -857,6 +1064,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -895,6 +1111,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -939,6 +1164,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -968,6 +1202,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1012,6 +1255,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1053,6 +1305,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1082,6 +1343,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1126,6 +1396,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1164,6 +1443,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2109,6 +2397,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2138,6 +2435,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2173,6 +2479,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2202,6 +2517,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2246,6 +2570,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2275,6 +2608,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2319,6 +2661,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2348,6 +2699,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2392,6 +2752,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2433,6 +2802,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2462,6 +2840,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2497,6 +2884,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2526,6 +2922,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2570,6 +2975,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2599,6 +3013,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2643,6 +3066,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2672,6 +3104,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2716,6 +3157,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2757,6 +3207,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2786,6 +3245,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2830,6 +3298,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2871,6 +3348,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2900,6 +3386,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -2944,6 +3439,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2982,6 +3486,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3026,6 +3539,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3055,6 +3577,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3099,6 +3630,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3140,6 +3680,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3169,6 +3718,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3213,6 +3771,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3251,6 +3818,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4204,6 +4780,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4233,6 +4818,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4268,6 +4862,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4297,6 +4900,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4341,6 +4953,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4370,6 +4991,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4414,6 +5044,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4443,6 +5082,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4487,6 +5135,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4528,6 +5185,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4557,6 +5223,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4592,6 +5267,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4621,6 +5305,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4665,6 +5358,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4694,6 +5396,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4738,6 +5449,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4767,6 +5487,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4811,6 +5540,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4852,6 +5590,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4881,6 +5628,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4925,6 +5681,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4966,6 +5731,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4995,6 +5769,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -5039,6 +5822,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -5077,6 +5869,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -5121,6 +5922,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -5150,6 +5960,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -5194,6 +6013,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -5235,6 +6063,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -5264,6 +6101,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -5308,6 +6154,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -5346,6 +6201,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -22,27 +22,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -63,27 +60,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -104,27 +98,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -145,27 +136,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -195,27 +183,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -236,27 +221,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -286,27 +268,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -327,27 +306,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -377,27 +353,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -427,27 +400,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -468,27 +438,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -509,27 +476,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -550,27 +514,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -600,27 +561,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -641,27 +599,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -691,27 +646,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -732,27 +684,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -782,27 +731,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -832,27 +778,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -873,27 +816,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -923,27 +863,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -973,27 +910,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1014,27 +948,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1064,27 +995,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1114,27 +1042,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1164,27 +1089,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1205,27 +1127,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1255,27 +1174,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1305,27 +1221,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1346,27 +1259,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1396,27 +1306,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1446,27 +1353,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1501,13 +1405,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1534,13 +1444,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1567,13 +1483,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1609,13 +1531,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1642,13 +1570,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1684,13 +1618,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1726,13 +1666,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1759,13 +1705,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1792,13 +1744,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1834,13 +1792,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1867,13 +1831,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1909,13 +1879,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1951,13 +1927,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1984,13 +1966,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2026,13 +2014,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2068,13 +2062,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2110,13 +2110,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2143,13 +2149,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2185,13 +2197,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2227,13 +2245,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2260,13 +2284,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2302,13 +2332,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2344,13 +2380,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2397,27 +2439,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2438,27 +2477,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2479,27 +2515,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2520,27 +2553,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2570,27 +2600,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2611,27 +2638,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2661,27 +2685,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2702,27 +2723,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2752,27 +2770,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2802,27 +2817,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2843,27 +2855,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2884,27 +2893,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2925,27 +2931,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2975,27 +2978,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3016,27 +3016,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3066,27 +3063,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3107,27 +3101,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3157,27 +3148,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3207,27 +3195,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3248,27 +3233,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3298,27 +3280,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3348,27 +3327,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3389,27 +3365,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3439,27 +3412,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3489,27 +3459,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3539,27 +3506,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3580,27 +3544,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3630,27 +3591,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3680,27 +3638,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3721,27 +3676,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3771,27 +3723,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3821,27 +3770,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3876,13 +3822,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3909,13 +3861,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3942,13 +3900,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3984,13 +3948,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4017,13 +3987,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4059,13 +4035,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4101,13 +4083,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4134,13 +4122,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4167,13 +4161,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4209,13 +4209,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4242,13 +4248,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4284,13 +4296,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4326,13 +4344,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4359,13 +4383,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4401,13 +4431,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4443,13 +4479,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4485,13 +4527,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4518,13 +4566,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4560,13 +4614,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4602,13 +4662,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4635,13 +4701,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4677,13 +4749,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4719,13 +4797,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -4780,27 +4864,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4821,27 +4902,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4862,27 +4940,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4903,27 +4978,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4953,27 +5025,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4994,27 +5063,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5044,27 +5110,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5085,27 +5148,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5135,27 +5195,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5185,27 +5242,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5226,27 +5280,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5267,27 +5318,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5308,27 +5356,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5358,27 +5403,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5399,27 +5441,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5449,27 +5488,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5490,27 +5526,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5540,27 +5573,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5590,27 +5620,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5631,27 +5658,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5681,27 +5705,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5731,27 +5752,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5772,27 +5790,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5822,27 +5837,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5872,27 +5884,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5922,27 +5931,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5963,27 +5969,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6013,27 +6016,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6063,27 +6063,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6104,27 +6101,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6154,27 +6148,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6204,27 +6195,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6259,13 +6247,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6292,13 +6286,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6325,13 +6325,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6367,13 +6373,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6400,13 +6412,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6442,13 +6460,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6484,13 +6508,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6517,13 +6547,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6550,13 +6586,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6592,13 +6634,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6625,13 +6673,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6667,13 +6721,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6709,13 +6769,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6742,13 +6808,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6784,13 +6856,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6826,13 +6904,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6868,13 +6952,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6901,13 +6991,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6943,13 +7039,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6985,13 +7087,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -7018,13 +7126,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -7060,13 +7174,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -7102,13 +7222,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )

--- a/test/passes/safe-heap_disable-simd.txt
+++ b/test/passes/safe-heap_disable-simd.txt
@@ -45,6 +45,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -83,6 +84,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -121,6 +123,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -159,6 +162,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -206,6 +210,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -244,6 +249,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -291,6 +297,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -329,6 +336,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -376,6 +384,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -423,6 +432,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -461,6 +471,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -499,6 +510,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -537,6 +549,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -584,6 +597,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -622,6 +636,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -669,6 +684,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -707,6 +723,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -754,6 +771,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -801,6 +819,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -839,6 +858,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -886,6 +906,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -933,6 +954,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -971,6 +993,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1018,6 +1041,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1065,6 +1089,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1112,6 +1137,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -1150,6 +1176,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1197,6 +1224,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1244,6 +1272,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -1282,6 +1311,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1329,6 +1359,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1376,6 +1407,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1423,6 +1455,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -1462,6 +1495,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -1501,6 +1535,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1549,6 +1584,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -1588,6 +1624,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1636,6 +1673,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1684,6 +1722,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -1723,6 +1762,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -1762,6 +1802,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1810,6 +1851,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -1849,6 +1891,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1897,6 +1940,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1945,6 +1989,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -1984,6 +2029,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2032,6 +2078,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2080,6 +2127,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2128,6 +2176,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -2167,6 +2216,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2215,6 +2265,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2263,6 +2314,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -2302,6 +2354,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2350,6 +2403,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2398,6 +2452,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2462,6 +2517,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -2500,6 +2556,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -2538,6 +2595,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -2576,6 +2634,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2623,6 +2682,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -2661,6 +2721,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2708,6 +2769,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -2746,6 +2808,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2793,6 +2856,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2840,6 +2904,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -2878,6 +2943,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -2916,6 +2982,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -2954,6 +3021,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3001,6 +3069,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -3039,6 +3108,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3086,6 +3156,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -3124,6 +3195,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3171,6 +3243,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3218,6 +3291,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -3256,6 +3330,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3303,6 +3378,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3350,6 +3426,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -3388,6 +3465,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3435,6 +3513,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3482,6 +3561,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3529,6 +3609,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -3567,6 +3648,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3614,6 +3696,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3661,6 +3744,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -3699,6 +3783,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3746,6 +3831,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3793,6 +3879,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3840,6 +3927,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -3879,6 +3967,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -3918,6 +4007,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3966,6 +4056,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -4005,6 +4096,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4053,6 +4145,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4101,6 +4194,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -4140,6 +4234,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -4179,6 +4274,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4227,6 +4323,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -4266,6 +4363,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4314,6 +4412,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4362,6 +4461,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -4401,6 +4501,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4449,6 +4550,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4497,6 +4599,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4545,6 +4648,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -4584,6 +4688,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4632,6 +4737,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4680,6 +4786,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -4719,6 +4826,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4767,6 +4875,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4815,6 +4924,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4887,6 +4997,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -4925,6 +5036,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -4963,6 +5075,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -5001,6 +5114,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5048,6 +5162,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -5086,6 +5201,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5133,6 +5249,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -5171,6 +5288,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5218,6 +5336,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5265,6 +5384,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -5303,6 +5423,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -5341,6 +5462,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -5379,6 +5501,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5426,6 +5549,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -5464,6 +5588,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5511,6 +5636,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -5549,6 +5675,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5596,6 +5723,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5643,6 +5771,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -5681,6 +5810,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5728,6 +5858,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5775,6 +5906,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -5813,6 +5945,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5860,6 +5993,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5907,6 +6041,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5954,6 +6089,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -5992,6 +6128,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6039,6 +6176,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6086,6 +6224,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -6124,6 +6263,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6171,6 +6311,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6218,6 +6359,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6265,6 +6407,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -6304,6 +6447,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -6343,6 +6487,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6391,6 +6536,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -6430,6 +6576,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6478,6 +6625,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6526,6 +6674,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -6565,6 +6714,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -6604,6 +6754,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6652,6 +6803,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -6691,6 +6843,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6739,6 +6892,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6787,6 +6941,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -6826,6 +6981,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6874,6 +7030,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6922,6 +7079,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6970,6 +7128,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -7009,6 +7168,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7057,6 +7217,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7105,6 +7266,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -7144,6 +7306,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7192,6 +7355,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7240,6 +7404,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if

--- a/test/passes/safe-heap_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd.txt
@@ -193,27 +193,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -240,27 +237,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -281,27 +275,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -322,27 +313,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -363,27 +351,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -404,27 +389,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -460,27 +442,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -510,27 +489,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -551,27 +527,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -601,27 +574,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -651,27 +621,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -692,27 +659,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -742,27 +706,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -792,27 +753,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -842,27 +800,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -889,27 +844,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -930,27 +882,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -971,27 +920,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1012,27 +958,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1053,27 +996,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1109,27 +1049,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1159,27 +1096,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1200,27 +1134,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1250,27 +1181,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1300,27 +1228,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1341,27 +1266,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1391,27 +1313,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1447,27 +1366,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1497,27 +1413,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1538,27 +1451,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1588,27 +1498,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1638,27 +1545,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1688,27 +1592,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1729,27 +1630,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1779,27 +1677,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1829,27 +1724,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1879,27 +1771,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1929,27 +1818,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1970,27 +1856,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2020,27 +1903,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2070,27 +1950,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2111,27 +1988,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2161,27 +2035,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2211,27 +2082,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2261,27 +2129,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2302,27 +2167,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2352,27 +2214,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2402,27 +2261,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2452,27 +2308,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2507,13 +2360,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2540,13 +2399,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2573,13 +2438,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2606,13 +2477,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2648,13 +2525,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2690,13 +2573,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2723,13 +2612,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2765,13 +2660,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2807,13 +2708,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2849,13 +2756,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2882,13 +2795,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2915,13 +2834,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2948,13 +2873,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2990,13 +2921,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3032,13 +2969,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3065,13 +3008,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3107,13 +3056,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3149,13 +3104,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3191,13 +3152,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3224,13 +3191,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3266,13 +3239,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3308,13 +3287,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3350,13 +3335,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3392,13 +3383,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3425,13 +3422,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3467,13 +3470,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3509,13 +3518,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3542,13 +3557,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3584,13 +3605,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3626,13 +3653,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3668,13 +3701,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3701,13 +3740,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3743,13 +3788,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3785,13 +3836,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3827,13 +3884,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3890,27 +3953,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3931,27 +3991,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3972,27 +4029,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4013,27 +4067,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4063,27 +4114,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4104,27 +4152,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4154,27 +4199,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4195,27 +4237,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4245,27 +4284,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4295,27 +4331,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4336,27 +4369,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4377,27 +4407,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4418,27 +4445,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4468,27 +4492,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4509,27 +4530,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4559,27 +4577,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4600,27 +4615,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4650,27 +4662,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4700,27 +4709,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4741,27 +4747,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4791,27 +4794,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4841,27 +4841,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4882,27 +4879,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4932,27 +4926,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4982,27 +4973,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5032,27 +5020,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5073,27 +5058,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5123,27 +5105,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5173,27 +5152,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5214,27 +5190,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5264,27 +5237,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5314,27 +5284,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5364,27 +5331,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5405,27 +5369,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5455,27 +5416,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5505,27 +5463,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5555,27 +5510,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5610,13 +5562,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5643,13 +5601,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5676,13 +5640,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5718,13 +5688,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5751,13 +5727,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5793,13 +5775,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5835,13 +5823,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5868,13 +5862,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5901,13 +5901,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5943,13 +5949,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5976,13 +5988,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6018,13 +6036,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6060,13 +6084,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6093,13 +6123,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6135,13 +6171,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6177,13 +6219,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6219,13 +6267,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6252,13 +6306,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6294,13 +6354,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6336,13 +6402,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6369,13 +6441,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6411,13 +6489,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6453,13 +6537,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6495,13 +6585,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6528,13 +6624,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6570,13 +6672,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6612,13 +6720,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6654,13 +6768,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6722,27 +6842,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6769,27 +6886,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6810,27 +6924,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6851,27 +6962,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6892,27 +7000,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6933,27 +7038,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6989,27 +7091,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7039,27 +7138,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7080,27 +7176,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7130,27 +7223,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7180,27 +7270,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7221,27 +7308,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7271,27 +7355,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7321,27 +7402,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7371,27 +7449,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7418,27 +7493,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7459,27 +7531,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7500,27 +7569,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7541,27 +7607,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7582,27 +7645,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7638,27 +7698,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7688,27 +7745,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7729,27 +7783,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7779,27 +7830,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7829,27 +7877,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7870,27 +7915,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7920,27 +7962,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7976,27 +8015,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8026,27 +8062,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8067,27 +8100,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8117,27 +8147,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8167,27 +8194,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8217,27 +8241,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8258,27 +8279,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8308,27 +8326,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8358,27 +8373,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8408,27 +8420,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8458,27 +8467,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8499,27 +8505,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8549,27 +8552,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8599,27 +8599,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8640,27 +8637,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8690,27 +8684,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8740,27 +8731,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8790,27 +8778,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8831,27 +8816,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8881,27 +8863,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8931,27 +8910,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8981,27 +8957,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9036,13 +9009,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9069,13 +9048,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9102,13 +9087,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9135,13 +9126,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9177,13 +9174,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9219,13 +9222,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9252,13 +9261,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9294,13 +9309,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9336,13 +9357,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9378,13 +9405,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9411,13 +9444,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9444,13 +9483,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9477,13 +9522,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9519,13 +9570,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9561,13 +9618,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9594,13 +9657,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9636,13 +9705,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9678,13 +9753,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9720,13 +9801,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9753,13 +9840,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9795,13 +9888,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9837,13 +9936,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9879,13 +9984,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9921,13 +10032,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9954,13 +10071,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9996,13 +10119,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10038,13 +10167,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10071,13 +10206,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10113,13 +10254,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10155,13 +10302,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10197,13 +10350,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10230,13 +10389,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10272,13 +10437,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10314,13 +10485,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10356,13 +10533,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )

--- a/test/passes/safe-heap_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd.txt
@@ -193,6 +193,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -231,6 +240,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -260,6 +278,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -295,6 +322,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -327,6 +363,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -356,6 +401,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -406,6 +460,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -447,6 +510,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -476,6 +548,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -520,6 +601,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -561,6 +651,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -590,6 +689,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -634,6 +742,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -672,6 +789,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -716,6 +842,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -754,6 +889,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -783,6 +927,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -818,6 +971,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -850,6 +1012,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -879,6 +1050,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -929,6 +1109,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -970,6 +1159,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -999,6 +1197,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1043,6 +1250,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1084,6 +1300,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1113,6 +1338,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1154,6 +1388,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1204,6 +1447,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1245,6 +1497,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1274,6 +1535,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1318,6 +1588,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1356,6 +1635,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1400,6 +1688,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1429,6 +1726,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1473,6 +1779,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1511,6 +1826,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1555,6 +1879,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1596,6 +1929,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1625,6 +1967,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1669,6 +2020,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1710,6 +2070,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1739,6 +2108,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1783,6 +2161,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1821,6 +2208,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1865,6 +2261,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1894,6 +2299,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1938,6 +2352,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1979,6 +2402,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -2017,6 +2449,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3449,6 +3890,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3478,6 +3928,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3513,6 +3972,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3542,6 +4010,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3586,6 +4063,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3615,6 +4101,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3659,6 +4154,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3688,6 +4192,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3732,6 +4245,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3773,6 +4295,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3802,6 +4333,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3837,6 +4377,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3866,6 +4415,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3910,6 +4468,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -3939,6 +4506,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3983,6 +4559,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4012,6 +4597,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4056,6 +4650,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4097,6 +4700,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4126,6 +4738,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4170,6 +4791,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4211,6 +4841,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4240,6 +4879,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4284,6 +4932,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4322,6 +4979,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4366,6 +5032,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4395,6 +5070,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4439,6 +5123,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4480,6 +5173,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4509,6 +5211,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4553,6 +5264,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4591,6 +5311,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4635,6 +5364,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4664,6 +5402,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4708,6 +5455,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4749,6 +5505,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -4787,6 +5552,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -5948,6 +6722,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -5986,6 +6769,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6015,6 +6807,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6050,6 +6851,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6082,6 +6892,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6111,6 +6930,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6161,6 +6989,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6202,6 +7039,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6231,6 +7077,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6275,6 +7130,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6316,6 +7180,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6345,6 +7218,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6389,6 +7271,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6427,6 +7318,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6471,6 +7371,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6509,6 +7418,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6538,6 +7456,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6573,6 +7500,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6605,6 +7541,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6634,6 +7579,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6684,6 +7638,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6725,6 +7688,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6754,6 +7726,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6798,6 +7779,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6839,6 +7829,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -6868,6 +7867,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6909,6 +7917,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6959,6 +7976,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7000,6 +8026,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7029,6 +8064,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7073,6 +8117,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7111,6 +8164,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7155,6 +8217,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7184,6 +8255,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7228,6 +8308,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7266,6 +8355,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7310,6 +8408,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7351,6 +8458,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7380,6 +8496,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7424,6 +8549,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7465,6 +8599,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7494,6 +8637,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7538,6 +8690,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7576,6 +8737,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7620,6 +8790,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7649,6 +8828,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7693,6 +8881,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7734,6 +8931,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -7772,6 +8978,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if

--- a/test/passes/safe-heap_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd.txt
@@ -216,6 +216,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.shr_s
@@ -260,6 +261,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -298,6 +300,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.load8_u
@@ -336,6 +339,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -374,6 +378,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -412,6 +417,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -465,6 +471,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -512,6 +519,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -550,6 +558,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -597,6 +606,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -644,6 +654,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -682,6 +693,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -729,6 +741,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -776,6 +789,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -823,6 +837,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.shr_s
@@ -867,6 +882,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -905,6 +921,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.load8_u
@@ -943,6 +960,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -981,6 +999,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -1019,6 +1038,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1072,6 +1092,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1119,6 +1140,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -1157,6 +1179,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1204,6 +1227,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1251,6 +1275,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -1289,6 +1314,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1336,6 +1362,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1389,6 +1416,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1436,6 +1464,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -1474,6 +1503,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1521,6 +1551,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1568,6 +1599,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1615,6 +1647,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -1653,6 +1686,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1700,6 +1734,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1747,6 +1782,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1794,6 +1830,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1841,6 +1878,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -1879,6 +1917,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1926,6 +1965,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1973,6 +2013,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -2011,6 +2052,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2058,6 +2100,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2105,6 +2148,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2152,6 +2196,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -2190,6 +2235,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2237,6 +2283,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2284,6 +2331,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2331,6 +2379,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2378,6 +2427,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.store8
@@ -2417,6 +2467,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -2456,6 +2507,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -2495,6 +2547,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2543,6 +2596,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2591,6 +2645,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -2630,6 +2685,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2678,6 +2734,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2726,6 +2783,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2774,6 +2832,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.store8
@@ -2813,6 +2872,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -2852,6 +2912,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -2891,6 +2952,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2939,6 +3001,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2987,6 +3050,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -3026,6 +3090,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3074,6 +3139,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3122,6 +3188,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3170,6 +3237,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -3209,6 +3277,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3257,6 +3326,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3305,6 +3375,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3353,6 +3424,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3401,6 +3473,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -3440,6 +3513,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3488,6 +3562,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3536,6 +3611,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -3575,6 +3651,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3623,6 +3700,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3671,6 +3749,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3719,6 +3798,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -3758,6 +3838,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3806,6 +3887,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3854,6 +3936,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3902,6 +3985,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3976,6 +4060,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -4014,6 +4099,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -4052,6 +4138,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -4090,6 +4177,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4137,6 +4225,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -4175,6 +4264,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4222,6 +4312,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -4260,6 +4351,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4307,6 +4399,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4354,6 +4447,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -4392,6 +4486,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -4430,6 +4525,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -4468,6 +4564,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4515,6 +4612,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -4553,6 +4651,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4600,6 +4699,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -4638,6 +4738,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4685,6 +4786,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4732,6 +4834,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -4770,6 +4873,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4817,6 +4921,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4864,6 +4969,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -4902,6 +5008,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4949,6 +5056,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4996,6 +5104,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5043,6 +5152,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -5081,6 +5191,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5128,6 +5239,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5175,6 +5287,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -5213,6 +5326,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5260,6 +5374,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5307,6 +5422,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5354,6 +5470,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -5392,6 +5509,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5439,6 +5557,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5486,6 +5605,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5533,6 +5653,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5580,6 +5701,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -5619,6 +5741,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -5658,6 +5781,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5706,6 +5830,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -5745,6 +5870,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5793,6 +5919,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5841,6 +5968,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -5880,6 +6008,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -5919,6 +6048,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5967,6 +6097,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -6006,6 +6137,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6054,6 +6186,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6102,6 +6235,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -6141,6 +6275,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6189,6 +6324,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6237,6 +6373,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6285,6 +6422,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -6324,6 +6462,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6372,6 +6511,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6420,6 +6560,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -6459,6 +6600,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6507,6 +6649,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6555,6 +6698,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6603,6 +6747,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -6642,6 +6787,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6690,6 +6836,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6738,6 +6885,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6786,6 +6934,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6865,6 +7014,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.shr_s
@@ -6909,6 +7059,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -6947,6 +7098,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.load8_u
@@ -6985,6 +7137,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -7023,6 +7176,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -7061,6 +7215,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7114,6 +7269,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7161,6 +7317,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -7199,6 +7356,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7246,6 +7404,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7293,6 +7452,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -7331,6 +7491,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7378,6 +7539,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7425,6 +7587,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7472,6 +7635,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.shr_s
@@ -7516,6 +7680,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -7554,6 +7719,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.load8_u
@@ -7592,6 +7758,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -7630,6 +7797,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -7668,6 +7836,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7721,6 +7890,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7768,6 +7938,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -7806,6 +7977,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7853,6 +8025,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7900,6 +8073,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -7938,6 +8112,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7985,6 +8160,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8038,6 +8214,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8085,6 +8262,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -8123,6 +8301,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8170,6 +8349,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8217,6 +8397,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8264,6 +8445,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -8302,6 +8484,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8349,6 +8532,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8396,6 +8580,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8443,6 +8628,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8490,6 +8676,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -8528,6 +8715,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8575,6 +8763,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8622,6 +8811,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -8660,6 +8850,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8707,6 +8898,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8754,6 +8946,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8801,6 +8994,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -8839,6 +9033,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8886,6 +9081,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8933,6 +9129,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8980,6 +9177,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9027,6 +9225,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.store8
@@ -9066,6 +9265,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -9105,6 +9305,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -9144,6 +9345,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9192,6 +9394,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9240,6 +9443,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -9279,6 +9483,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9327,6 +9532,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9375,6 +9581,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9423,6 +9630,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.store8
@@ -9462,6 +9670,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -9501,6 +9710,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -9540,6 +9750,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9588,6 +9799,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9636,6 +9848,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -9675,6 +9888,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9723,6 +9937,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9771,6 +9986,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9819,6 +10035,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -9858,6 +10075,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9906,6 +10124,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9954,6 +10173,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10002,6 +10222,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10050,6 +10271,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -10089,6 +10311,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10137,6 +10360,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10185,6 +10409,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -10224,6 +10449,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10272,6 +10498,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10320,6 +10547,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10368,6 +10596,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -10407,6 +10636,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10455,6 +10685,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10503,6 +10734,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10551,6 +10783,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if

--- a/test/passes/safe-heap_enable-threads_enable-simd64.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd64.txt
@@ -193,6 +193,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -231,6 +240,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -260,6 +278,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -295,6 +322,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -327,6 +363,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -356,6 +401,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -408,6 +462,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -451,6 +514,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -480,6 +552,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -526,6 +607,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -569,6 +659,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -598,6 +697,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -644,6 +752,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -684,6 +801,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -730,6 +856,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -768,6 +903,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -797,6 +941,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -832,6 +985,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -864,6 +1026,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -893,6 +1064,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -945,6 +1125,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -988,6 +1177,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1017,6 +1215,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1063,6 +1270,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1106,6 +1322,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1135,6 +1360,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1178,6 +1412,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1230,6 +1473,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1273,6 +1525,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1302,6 +1563,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1348,6 +1618,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1388,6 +1667,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1434,6 +1722,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1463,6 +1760,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1509,6 +1815,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1549,6 +1864,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1595,6 +1919,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1638,6 +1971,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1667,6 +2009,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1713,6 +2064,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1756,6 +2116,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1785,6 +2154,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1831,6 +2209,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1871,6 +2258,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1917,6 +2313,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -1946,6 +2351,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1992,6 +2406,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -2035,6 +2458,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -2075,6 +2507,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3555,6 +3996,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3584,6 +4034,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3619,6 +4078,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3648,6 +4116,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3694,6 +4171,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3723,6 +4209,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3769,6 +4264,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3798,6 +4302,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3844,6 +4357,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3887,6 +4409,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3916,6 +4447,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3951,6 +4491,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -3980,6 +4529,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4026,6 +4584,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4055,6 +4622,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4101,6 +4677,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4130,6 +4715,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4176,6 +4770,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4219,6 +4822,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4248,6 +4860,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4294,6 +4915,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4337,6 +4967,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4366,6 +5005,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4412,6 +5060,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4452,6 +5109,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4498,6 +5164,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4527,6 +5202,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4573,6 +5257,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4616,6 +5309,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4645,6 +5347,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4691,6 +5402,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4731,6 +5451,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4777,6 +5506,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4806,6 +5544,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4852,6 +5599,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4895,6 +5651,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -4935,6 +5700,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6134,6 +6908,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6172,6 +6955,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6201,6 +6993,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6236,6 +7037,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6268,6 +7078,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6297,6 +7116,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6349,6 +7177,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6392,6 +7229,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6421,6 +7267,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6467,6 +7322,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6510,6 +7374,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6539,6 +7412,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6585,6 +7467,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6625,6 +7516,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6671,6 +7571,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6709,6 +7618,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6738,6 +7656,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6773,6 +7700,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6805,6 +7741,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6834,6 +7779,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6886,6 +7840,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6929,6 +7892,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -6958,6 +7930,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7004,6 +7985,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7047,6 +8037,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7076,6 +8075,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7119,6 +8127,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7171,6 +8188,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7214,6 +8240,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7243,6 +8278,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7289,6 +8333,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7329,6 +8382,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7375,6 +8437,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7404,6 +8475,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7450,6 +8530,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7490,6 +8579,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7536,6 +8634,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7579,6 +8686,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7608,6 +8724,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7654,6 +8779,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7697,6 +8831,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7726,6 +8869,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7772,6 +8924,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7812,6 +8973,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7858,6 +9028,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7887,6 +9066,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7933,6 +9121,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -7976,6 +9173,15 @@
    )
   )
   (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i64.eq
      (local.get $2)
@@ -8016,6 +9222,15 @@
    (i64.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i64.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if

--- a/test/passes/safe-heap_enable-threads_enable-simd64.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd64.txt
@@ -193,27 +193,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -240,27 +237,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -281,27 +275,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -322,27 +313,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -363,27 +351,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -404,27 +389,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -462,27 +444,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -514,27 +493,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -555,27 +531,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -607,27 +580,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -659,27 +629,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -700,27 +667,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -752,27 +716,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -804,27 +765,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -856,27 +814,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -903,27 +858,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -944,27 +896,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -985,27 +934,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1026,27 +972,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1067,27 +1010,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1125,27 +1065,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1177,27 +1114,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1218,27 +1152,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1270,27 +1201,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1322,27 +1250,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1363,27 +1288,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1415,27 +1337,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1473,27 +1392,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1525,27 +1441,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1566,27 +1479,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1618,27 +1528,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1670,27 +1577,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1722,27 +1626,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1763,27 +1664,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1815,27 +1713,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1867,27 +1762,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1919,27 +1811,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1971,27 +1860,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2012,27 +1898,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2064,27 +1947,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2116,27 +1996,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2157,27 +2034,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2209,27 +2083,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2261,27 +2132,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2313,27 +2181,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2354,27 +2219,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2406,27 +2268,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2458,27 +2317,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2510,27 +2366,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2567,13 +2420,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2600,13 +2459,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2633,13 +2498,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2666,13 +2537,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2710,13 +2587,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2754,13 +2637,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2787,13 +2676,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2831,13 +2726,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2875,13 +2776,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2919,13 +2826,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2952,13 +2865,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2985,13 +2904,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3018,13 +2943,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3062,13 +2993,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3106,13 +3043,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3139,13 +3082,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3183,13 +3132,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3227,13 +3182,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3271,13 +3232,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3304,13 +3271,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3348,13 +3321,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3392,13 +3371,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3436,13 +3421,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3480,13 +3471,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3513,13 +3510,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3557,13 +3560,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3601,13 +3610,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3634,13 +3649,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3678,13 +3699,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3722,13 +3749,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3766,13 +3799,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3799,13 +3838,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3843,13 +3888,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3887,13 +3938,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3931,13 +3988,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3996,27 +4059,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4037,27 +4097,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4078,27 +4135,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4119,27 +4173,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4171,27 +4222,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4212,27 +4260,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4264,27 +4309,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4305,27 +4347,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4357,27 +4396,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4409,27 +4445,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4450,27 +4483,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4491,27 +4521,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4532,27 +4559,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4584,27 +4608,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4625,27 +4646,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4677,27 +4695,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4718,27 +4733,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4770,27 +4782,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4822,27 +4831,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4863,27 +4869,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4915,27 +4918,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4967,27 +4967,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5008,27 +5005,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5060,27 +5054,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5112,27 +5103,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5164,27 +5152,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5205,27 +5190,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5257,27 +5239,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5309,27 +5288,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5350,27 +5326,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5402,27 +5375,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5454,27 +5424,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5506,27 +5473,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5547,27 +5511,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5599,27 +5560,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5651,27 +5609,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5703,27 +5658,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5760,13 +5712,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5793,13 +5751,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5826,13 +5790,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5870,13 +5840,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5903,13 +5879,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5947,13 +5929,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5991,13 +5979,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6024,13 +6018,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6057,13 +6057,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6101,13 +6107,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6134,13 +6146,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6178,13 +6196,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6222,13 +6246,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6255,13 +6285,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6299,13 +6335,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6343,13 +6385,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6387,13 +6435,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6420,13 +6474,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6464,13 +6524,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6508,13 +6574,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6541,13 +6613,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6585,13 +6663,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6629,13 +6713,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6673,13 +6763,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6706,13 +6802,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6750,13 +6852,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6794,13 +6902,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6838,13 +6952,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i64.load
-      (call $emscripten_get_sbrk_ptr)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6908,27 +7028,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6955,27 +7072,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6996,27 +7110,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7037,27 +7148,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7078,27 +7186,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7119,27 +7224,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7177,27 +7279,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7229,27 +7328,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7270,27 +7366,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7322,27 +7415,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7374,27 +7464,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7415,27 +7502,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7467,27 +7551,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7519,27 +7600,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7571,27 +7649,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7618,27 +7693,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7659,27 +7731,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7700,27 +7769,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7741,27 +7807,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7782,27 +7845,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7840,27 +7900,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7892,27 +7949,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7933,27 +7987,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7985,27 +8036,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8037,27 +8085,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8078,27 +8123,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8130,27 +8172,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8188,27 +8227,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8240,27 +8276,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8281,27 +8314,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8333,27 +8363,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8385,27 +8412,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8437,27 +8461,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8478,27 +8499,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8530,27 +8548,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8582,27 +8597,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8634,27 +8646,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8686,27 +8695,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8727,27 +8733,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8779,27 +8782,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8831,27 +8831,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8872,27 +8869,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8924,27 +8918,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8976,27 +8967,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9028,27 +9016,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9069,27 +9054,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9121,27 +9103,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9173,27 +9152,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9225,27 +9201,24 @@
    )
   )
   (if
-   (i64.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i64.eq
      (local.get $2)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $2)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $2)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9282,13 +9255,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9315,13 +9294,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9348,13 +9333,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9381,13 +9372,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9425,13 +9422,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9469,13 +9472,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9502,13 +9511,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9546,13 +9561,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9590,13 +9611,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9634,13 +9661,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9667,13 +9700,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 1)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 1)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9700,13 +9739,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9733,13 +9778,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9777,13 +9828,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 2)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 2)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9821,13 +9878,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9854,13 +9917,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9898,13 +9967,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9942,13 +10017,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9986,13 +10067,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10019,13 +10106,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10063,13 +10156,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10107,13 +10206,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10151,13 +10256,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10195,13 +10306,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10228,13 +10345,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10272,13 +10395,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 4)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 4)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10316,13 +10445,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10349,13 +10484,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10393,13 +10534,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10437,13 +10584,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 8)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 8)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10481,13 +10634,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10514,13 +10673,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10558,13 +10723,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10602,13 +10773,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10646,13 +10823,19 @@
      (local.get $3)
      (i64.const 0)
     )
-    (i64.gt_u
-     (i64.add
-      (local.get $3)
-      (i64.const 16)
+    (i32.or
+     (i64.gt_u
+      (i64.add
+       (local.get $3)
+       (i64.const 16)
+      )
+      (i64.load
+       (call $foo)
+      )
      )
-     (i64.load
-      (call $foo)
+     (i64.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )

--- a/test/passes/safe-heap_enable-threads_enable-simd64.txt
+++ b/test/passes/safe-heap_enable-threads_enable-simd64.txt
@@ -216,6 +216,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.shr_s
@@ -260,6 +261,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -298,6 +300,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.load8_u
@@ -336,6 +339,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -374,6 +378,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -412,6 +417,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -467,6 +473,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -516,6 +523,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -554,6 +562,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -603,6 +612,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -652,6 +662,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -690,6 +701,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -739,6 +751,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -788,6 +801,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -837,6 +851,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.shr_s
@@ -881,6 +896,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -919,6 +935,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.load8_u
@@ -957,6 +974,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -995,6 +1013,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -1033,6 +1052,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1088,6 +1108,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1137,6 +1158,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -1175,6 +1197,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1224,6 +1247,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1273,6 +1297,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -1311,6 +1336,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1360,6 +1386,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1415,6 +1442,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1464,6 +1492,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -1502,6 +1531,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1551,6 +1581,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1600,6 +1631,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1649,6 +1681,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -1687,6 +1720,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1736,6 +1770,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1785,6 +1820,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1834,6 +1870,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1883,6 +1920,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -1921,6 +1959,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1970,6 +2009,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2019,6 +2059,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -2057,6 +2098,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2106,6 +2148,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2155,6 +2198,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2204,6 +2248,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -2242,6 +2287,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2291,6 +2337,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2340,6 +2387,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2389,6 +2437,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2438,6 +2487,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.store8
@@ -2477,6 +2527,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -2516,6 +2567,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -2555,6 +2607,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2605,6 +2658,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2655,6 +2709,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -2694,6 +2749,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2744,6 +2800,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2794,6 +2851,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2844,6 +2902,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.store8
@@ -2883,6 +2942,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -2922,6 +2982,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -2961,6 +3022,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3011,6 +3073,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3061,6 +3124,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -3100,6 +3164,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3150,6 +3215,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3200,6 +3266,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3250,6 +3317,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -3289,6 +3357,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3339,6 +3408,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3389,6 +3459,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3439,6 +3510,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3489,6 +3561,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -3528,6 +3601,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3578,6 +3652,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3628,6 +3703,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -3667,6 +3743,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3717,6 +3794,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3767,6 +3845,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3817,6 +3896,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -3856,6 +3936,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3906,6 +3987,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3956,6 +4038,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4006,6 +4089,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4082,6 +4166,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -4120,6 +4205,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -4158,6 +4244,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -4196,6 +4283,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4245,6 +4333,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -4283,6 +4372,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4332,6 +4422,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -4370,6 +4461,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4419,6 +4511,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4468,6 +4561,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -4506,6 +4600,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -4544,6 +4639,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -4582,6 +4678,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4631,6 +4728,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -4669,6 +4767,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4718,6 +4817,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -4756,6 +4856,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4805,6 +4906,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4854,6 +4956,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -4892,6 +4995,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4941,6 +5045,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4990,6 +5095,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -5028,6 +5134,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5077,6 +5184,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5126,6 +5234,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5175,6 +5284,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -5213,6 +5323,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5262,6 +5373,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5311,6 +5423,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -5349,6 +5462,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5398,6 +5512,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5447,6 +5562,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5496,6 +5612,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -5534,6 +5651,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5583,6 +5701,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5632,6 +5751,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5681,6 +5801,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5730,6 +5851,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -5769,6 +5891,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -5808,6 +5931,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5858,6 +5982,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -5897,6 +6022,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5947,6 +6073,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5997,6 +6124,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -6036,6 +6164,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -6075,6 +6204,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6125,6 +6255,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -6164,6 +6295,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6214,6 +6346,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6264,6 +6397,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -6303,6 +6437,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6353,6 +6488,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6403,6 +6539,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6453,6 +6590,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -6492,6 +6630,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6542,6 +6681,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6592,6 +6732,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -6631,6 +6772,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6681,6 +6823,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6731,6 +6874,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6781,6 +6925,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -6820,6 +6965,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6870,6 +7016,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6920,6 +7067,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6970,6 +7118,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7051,6 +7200,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.shr_s
@@ -7095,6 +7245,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -7133,6 +7284,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.load8_u
@@ -7171,6 +7323,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -7209,6 +7362,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -7247,6 +7401,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7302,6 +7457,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7351,6 +7507,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -7389,6 +7546,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7438,6 +7596,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7487,6 +7646,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -7525,6 +7685,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7574,6 +7735,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7623,6 +7785,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7672,6 +7835,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.shr_s
@@ -7716,6 +7880,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -7754,6 +7919,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.load8_u
@@ -7792,6 +7958,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -7830,6 +7997,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -7868,6 +8036,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7923,6 +8092,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7972,6 +8142,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -8010,6 +8181,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8059,6 +8231,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8108,6 +8281,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -8146,6 +8320,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8195,6 +8370,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8250,6 +8426,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8299,6 +8476,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -8337,6 +8515,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8386,6 +8565,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8435,6 +8615,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8484,6 +8665,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -8522,6 +8704,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8571,6 +8754,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8620,6 +8804,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8669,6 +8854,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8718,6 +8904,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -8756,6 +8943,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8805,6 +8993,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8854,6 +9043,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -8892,6 +9082,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8941,6 +9132,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8990,6 +9182,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9039,6 +9232,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -9077,6 +9271,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9126,6 +9321,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9175,6 +9371,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9224,6 +9421,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9273,6 +9471,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.store8
@@ -9312,6 +9511,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -9351,6 +9551,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -9390,6 +9591,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9440,6 +9642,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9490,6 +9693,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -9529,6 +9733,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9579,6 +9784,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9629,6 +9835,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9679,6 +9886,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.store8
@@ -9718,6 +9926,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -9757,6 +9966,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -9796,6 +10006,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9846,6 +10057,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9896,6 +10108,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -9935,6 +10148,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9985,6 +10199,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10035,6 +10250,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10085,6 +10301,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -10124,6 +10341,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10174,6 +10392,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10224,6 +10443,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10274,6 +10494,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10324,6 +10545,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -10363,6 +10585,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10413,6 +10636,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10463,6 +10687,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -10502,6 +10727,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10552,6 +10778,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10602,6 +10829,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10652,6 +10880,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -10691,6 +10920,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10741,6 +10971,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10791,6 +11022,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10841,6 +11073,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if

--- a/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
@@ -193,27 +193,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -240,27 +237,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -281,27 +275,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -322,27 +313,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -363,27 +351,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -404,27 +389,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -460,27 +442,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -510,27 +489,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -551,27 +527,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -601,27 +574,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -651,27 +621,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -692,27 +659,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -742,27 +706,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -792,27 +753,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -842,27 +800,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -889,27 +844,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -930,27 +882,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -971,27 +920,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1012,27 +958,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1053,27 +996,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1109,27 +1049,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1159,27 +1096,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1200,27 +1134,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1250,27 +1181,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1300,27 +1228,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1341,27 +1266,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1391,27 +1313,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1447,27 +1366,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1497,27 +1413,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1538,27 +1451,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1588,27 +1498,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1638,27 +1545,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1688,27 +1592,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1729,27 +1630,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1779,27 +1677,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1829,27 +1724,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1879,27 +1771,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1929,27 +1818,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1970,27 +1856,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2020,27 +1903,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2070,27 +1950,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2111,27 +1988,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2161,27 +2035,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2211,27 +2082,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2261,27 +2129,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2302,27 +2167,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2352,27 +2214,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2402,27 +2261,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2452,27 +2308,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -2507,13 +2360,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2540,13 +2399,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2573,13 +2438,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2606,13 +2477,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2648,13 +2525,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2690,13 +2573,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2723,13 +2612,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2765,13 +2660,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2807,13 +2708,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2849,13 +2756,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2882,13 +2795,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2915,13 +2834,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2948,13 +2873,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2990,13 +2921,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3032,13 +2969,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3065,13 +3008,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3107,13 +3056,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3149,13 +3104,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3191,13 +3152,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3224,13 +3191,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3266,13 +3239,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3308,13 +3287,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3350,13 +3335,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3392,13 +3383,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3425,13 +3422,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3467,13 +3470,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3509,13 +3518,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3542,13 +3557,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3584,13 +3605,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3626,13 +3653,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3668,13 +3701,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3701,13 +3740,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3743,13 +3788,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3785,13 +3836,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3827,13 +3884,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -3890,27 +3953,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3931,27 +3991,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -3972,27 +4029,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4013,27 +4067,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4063,27 +4114,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4104,27 +4152,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4154,27 +4199,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4195,27 +4237,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4245,27 +4284,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4295,27 +4331,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4336,27 +4369,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4377,27 +4407,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4418,27 +4445,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4468,27 +4492,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4509,27 +4530,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4559,27 +4577,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4600,27 +4615,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4650,27 +4662,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4700,27 +4709,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4741,27 +4747,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4791,27 +4794,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4841,27 +4841,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4882,27 +4879,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4932,27 +4926,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -4982,27 +4973,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5032,27 +5020,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5073,27 +5058,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5123,27 +5105,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5173,27 +5152,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5214,27 +5190,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5264,27 +5237,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5314,27 +5284,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5364,27 +5331,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5405,27 +5369,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5455,27 +5416,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5505,27 +5463,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5555,27 +5510,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -5610,13 +5562,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5643,13 +5601,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5676,13 +5640,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5718,13 +5688,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5751,13 +5727,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5793,13 +5775,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5835,13 +5823,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5868,13 +5862,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5901,13 +5901,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5943,13 +5949,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -5976,13 +5988,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6018,13 +6036,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6060,13 +6084,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6093,13 +6123,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6135,13 +6171,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6177,13 +6219,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6219,13 +6267,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6252,13 +6306,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6294,13 +6354,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6336,13 +6402,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6369,13 +6441,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6411,13 +6489,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6453,13 +6537,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6495,13 +6585,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6528,13 +6624,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6570,13 +6672,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6612,13 +6720,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6654,13 +6768,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -6722,27 +6842,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6769,27 +6886,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6810,27 +6924,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6851,27 +6962,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6892,27 +7000,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6933,27 +7038,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -6989,27 +7091,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7039,27 +7138,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7080,27 +7176,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7130,27 +7223,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7180,27 +7270,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7221,27 +7308,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7271,27 +7355,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7321,27 +7402,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7371,27 +7449,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7418,27 +7493,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7459,27 +7531,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7500,27 +7569,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7541,27 +7607,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7582,27 +7645,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7638,27 +7698,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7688,27 +7745,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7729,27 +7783,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7779,27 +7830,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7829,27 +7877,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7870,27 +7915,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7920,27 +7962,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -7976,27 +8015,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8026,27 +8062,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8067,27 +8100,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8117,27 +8147,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8167,27 +8194,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8217,27 +8241,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8258,27 +8279,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8308,27 +8326,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8358,27 +8373,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8408,27 +8420,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8458,27 +8467,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8499,27 +8505,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8549,27 +8552,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8599,27 +8599,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8640,27 +8637,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8690,27 +8684,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8740,27 +8731,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8790,27 +8778,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8831,27 +8816,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8881,27 +8863,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8931,27 +8910,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -8981,27 +8957,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -9036,13 +9009,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9069,13 +9048,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9102,13 +9087,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9135,13 +9126,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9177,13 +9174,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9219,13 +9222,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9252,13 +9261,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9294,13 +9309,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9336,13 +9357,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9378,13 +9405,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9411,13 +9444,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9444,13 +9483,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9477,13 +9522,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9519,13 +9570,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9561,13 +9618,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9594,13 +9657,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9636,13 +9705,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9678,13 +9753,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9720,13 +9801,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9753,13 +9840,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9795,13 +9888,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9837,13 +9936,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9879,13 +9984,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9921,13 +10032,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9954,13 +10071,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -9996,13 +10119,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10038,13 +10167,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10071,13 +10206,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10113,13 +10254,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10155,13 +10302,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10197,13 +10350,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10230,13 +10389,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10272,13 +10437,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10314,13 +10485,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -10356,13 +10533,19 @@
      (local.get $3)
      (i32.const 1024)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 16)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 16)
+      )
+      (i32.load
+       (call $foo)
+      )
      )
-     (i32.load
-      (call $foo)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )

--- a/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
@@ -193,6 +193,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -231,6 +240,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -260,6 +278,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -295,6 +322,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -327,6 +363,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -356,6 +401,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -406,6 +460,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -447,6 +510,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -476,6 +548,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -520,6 +601,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -561,6 +651,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -590,6 +689,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -634,6 +742,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -672,6 +789,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -716,6 +842,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -754,6 +889,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -783,6 +927,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -818,6 +971,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -850,6 +1012,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -879,6 +1050,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -929,6 +1109,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -970,6 +1159,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -999,6 +1197,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1043,6 +1250,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1084,6 +1300,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1113,6 +1338,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1154,6 +1388,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1204,6 +1447,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1245,6 +1497,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1274,6 +1535,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1318,6 +1588,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1356,6 +1635,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1400,6 +1688,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1429,6 +1726,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1473,6 +1779,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1511,6 +1826,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1555,6 +1879,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1596,6 +1929,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1625,6 +1967,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1669,6 +2020,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1710,6 +2070,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1739,6 +2108,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1783,6 +2161,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1821,6 +2208,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1865,6 +2261,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1894,6 +2299,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1938,6 +2352,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -1979,6 +2402,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -2017,6 +2449,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3449,6 +3890,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3478,6 +3928,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3513,6 +3972,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3542,6 +4010,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3586,6 +4063,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3615,6 +4101,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3659,6 +4154,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3688,6 +4192,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3732,6 +4245,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3773,6 +4295,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3802,6 +4333,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3837,6 +4377,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3866,6 +4415,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3910,6 +4468,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -3939,6 +4506,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -3983,6 +4559,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4012,6 +4597,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4056,6 +4650,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4097,6 +4700,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4126,6 +4738,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4170,6 +4791,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4211,6 +4841,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4240,6 +4879,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4284,6 +4932,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4322,6 +4979,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4366,6 +5032,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4395,6 +5070,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4439,6 +5123,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4480,6 +5173,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4509,6 +5211,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4553,6 +5264,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4591,6 +5311,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4635,6 +5364,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4664,6 +5402,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -4708,6 +5455,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4749,6 +5505,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -4787,6 +5552,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -5948,6 +6722,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -5986,6 +6769,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6015,6 +6807,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6050,6 +6851,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6082,6 +6892,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6111,6 +6930,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6161,6 +6989,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6202,6 +7039,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6231,6 +7077,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6275,6 +7130,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6316,6 +7180,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6345,6 +7218,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6389,6 +7271,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6427,6 +7318,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6471,6 +7371,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6509,6 +7418,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6538,6 +7456,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6573,6 +7500,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6605,6 +7541,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6634,6 +7579,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6684,6 +7638,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6725,6 +7688,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6754,6 +7726,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6798,6 +7779,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6839,6 +7829,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -6868,6 +7867,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6909,6 +7917,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -6959,6 +7976,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7000,6 +8026,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7029,6 +8064,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7073,6 +8117,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7111,6 +8164,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7155,6 +8217,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7184,6 +8255,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7228,6 +8308,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7266,6 +8355,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7310,6 +8408,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7351,6 +8458,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7380,6 +8496,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7424,6 +8549,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7465,6 +8599,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7494,6 +8637,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7538,6 +8690,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7576,6 +8737,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7620,6 +8790,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7649,6 +8828,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -7693,6 +8881,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7734,6 +8931,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.lt_u
      (local.get $2)
@@ -7772,6 +8978,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if

--- a/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
+++ b/test/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.txt
@@ -216,6 +216,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.shr_s
@@ -260,6 +261,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -298,6 +300,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.load8_u
@@ -336,6 +339,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -374,6 +378,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -412,6 +417,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -465,6 +471,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -512,6 +519,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -550,6 +558,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -597,6 +606,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -644,6 +654,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -682,6 +693,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -729,6 +741,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -776,6 +789,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -823,6 +837,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.shr_s
@@ -867,6 +882,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -905,6 +921,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.load8_u
@@ -943,6 +960,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -981,6 +999,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -1019,6 +1038,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1072,6 +1092,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1119,6 +1140,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -1157,6 +1179,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1204,6 +1227,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1251,6 +1275,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -1289,6 +1314,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1336,6 +1362,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1389,6 +1416,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1436,6 +1464,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -1474,6 +1503,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1521,6 +1551,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1568,6 +1599,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1615,6 +1647,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -1653,6 +1686,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1700,6 +1734,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1747,6 +1782,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1794,6 +1830,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1841,6 +1878,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -1879,6 +1917,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1926,6 +1965,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1973,6 +2013,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -2011,6 +2052,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2058,6 +2100,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2105,6 +2148,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2152,6 +2196,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -2190,6 +2235,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2237,6 +2283,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2284,6 +2331,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2331,6 +2379,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2378,6 +2427,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.store8
@@ -2417,6 +2467,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -2456,6 +2507,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -2495,6 +2547,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2543,6 +2596,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2591,6 +2645,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -2630,6 +2685,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2678,6 +2734,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2726,6 +2783,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2774,6 +2832,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.store8
@@ -2813,6 +2872,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -2852,6 +2912,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -2891,6 +2952,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2939,6 +3001,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2987,6 +3050,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -3026,6 +3090,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3074,6 +3139,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3122,6 +3188,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3170,6 +3237,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -3209,6 +3277,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3257,6 +3326,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3305,6 +3375,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3353,6 +3424,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3401,6 +3473,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -3440,6 +3513,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3488,6 +3562,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3536,6 +3611,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -3575,6 +3651,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3623,6 +3700,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3671,6 +3749,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3719,6 +3798,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -3758,6 +3838,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3806,6 +3887,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3854,6 +3936,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3902,6 +3985,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -3976,6 +4060,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -4014,6 +4099,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -4052,6 +4138,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -4090,6 +4177,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4137,6 +4225,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -4175,6 +4264,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4222,6 +4312,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -4260,6 +4351,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4307,6 +4399,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4354,6 +4447,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -4392,6 +4486,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -4430,6 +4525,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -4468,6 +4564,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4515,6 +4612,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -4553,6 +4651,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4600,6 +4699,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -4638,6 +4738,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4685,6 +4786,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4732,6 +4834,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -4770,6 +4873,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4817,6 +4921,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4864,6 +4969,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -4902,6 +5008,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4949,6 +5056,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -4996,6 +5104,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5043,6 +5152,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -5081,6 +5191,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5128,6 +5239,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5175,6 +5287,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -5213,6 +5326,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5260,6 +5374,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5307,6 +5422,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5354,6 +5470,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -5392,6 +5509,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5439,6 +5557,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5486,6 +5605,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5533,6 +5653,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5580,6 +5701,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -5619,6 +5741,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -5658,6 +5781,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5706,6 +5830,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -5745,6 +5870,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5793,6 +5919,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5841,6 +5968,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -5880,6 +6008,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -5919,6 +6048,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -5967,6 +6097,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -6006,6 +6137,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6054,6 +6186,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6102,6 +6235,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -6141,6 +6275,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6189,6 +6324,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6237,6 +6373,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6285,6 +6422,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -6324,6 +6462,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6372,6 +6511,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6420,6 +6560,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -6459,6 +6600,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6507,6 +6649,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6555,6 +6698,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6603,6 +6747,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -6642,6 +6787,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6690,6 +6836,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6738,6 +6885,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6786,6 +6934,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -6865,6 +7014,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.shr_s
@@ -6909,6 +7059,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -6947,6 +7098,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.load8_u
@@ -6985,6 +7137,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -7023,6 +7176,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -7061,6 +7215,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7114,6 +7269,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7161,6 +7317,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -7199,6 +7356,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7246,6 +7404,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7293,6 +7452,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -7331,6 +7491,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7378,6 +7539,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7425,6 +7587,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7472,6 +7635,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.shr_s
@@ -7516,6 +7680,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -7554,6 +7719,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.load8_u
@@ -7592,6 +7758,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -7630,6 +7797,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -7668,6 +7836,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7721,6 +7890,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7768,6 +7938,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -7806,6 +7977,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7853,6 +8025,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7900,6 +8073,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -7938,6 +8112,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -7985,6 +8160,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8038,6 +8214,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8085,6 +8262,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -8123,6 +8301,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8170,6 +8349,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8217,6 +8397,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8264,6 +8445,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -8302,6 +8484,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8349,6 +8532,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8396,6 +8580,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8443,6 +8628,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8490,6 +8676,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -8528,6 +8715,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8575,6 +8763,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8622,6 +8811,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -8660,6 +8850,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8707,6 +8898,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8754,6 +8946,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8801,6 +8994,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.load align=1
@@ -8839,6 +9033,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8886,6 +9081,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8933,6 +9129,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -8980,6 +9177,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9027,6 +9225,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.atomic.store8
@@ -9066,6 +9265,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -9105,6 +9305,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -9144,6 +9345,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9192,6 +9394,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9240,6 +9443,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -9279,6 +9483,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9327,6 +9532,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9375,6 +9581,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9423,6 +9630,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.atomic.store8
@@ -9462,6 +9670,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -9501,6 +9710,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -9540,6 +9750,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9588,6 +9799,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9636,6 +9848,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -9675,6 +9888,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9723,6 +9937,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9771,6 +9986,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9819,6 +10035,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -9858,6 +10075,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9906,6 +10124,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -9954,6 +10173,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10002,6 +10222,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10050,6 +10271,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -10089,6 +10311,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10137,6 +10360,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10185,6 +10409,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -10224,6 +10449,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10272,6 +10498,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10320,6 +10547,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10368,6 +10596,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (v128.store align=1
@@ -10407,6 +10636,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10455,6 +10685,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10503,6 +10734,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -10551,6 +10783,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if

--- a/test/passes/safe-heap_start-function.txt
+++ b/test/passes/safe-heap_start-function.txt
@@ -59,6 +59,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -88,6 +97,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -123,6 +141,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -152,6 +179,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -196,6 +232,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -225,6 +270,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -269,6 +323,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -298,6 +361,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -342,6 +414,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -383,6 +464,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -412,6 +502,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -447,6 +546,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -476,6 +584,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -520,6 +637,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -549,6 +675,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -593,6 +728,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -622,6 +766,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -666,6 +819,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -707,6 +869,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -736,6 +907,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -780,6 +960,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -821,6 +1010,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -850,6 +1048,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -894,6 +1101,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -932,6 +1148,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -976,6 +1201,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1005,6 +1239,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1049,6 +1292,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1090,6 +1342,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1119,6 +1380,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if
@@ -1163,6 +1433,15 @@
    )
   )
   (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
+   )
+  )
+  (if
    (i32.or
     (i32.eq
      (local.get $2)
@@ -1201,6 +1480,15 @@
    (i32.add
     (local.get $0)
     (local.get $1)
+   )
+  )
+  (if
+   (i32.lt_u
+    (local.get $2)
+    (local.get $0)
+   )
+   (then
+    (call $segfault)
    )
   )
   (if

--- a/test/passes/safe-heap_start-function.txt
+++ b/test/passes/safe-heap_start-function.txt
@@ -59,27 +59,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -100,27 +97,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -141,27 +135,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -182,27 +173,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -232,27 +220,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -273,27 +258,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -323,27 +305,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -364,27 +343,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -414,27 +390,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -464,27 +437,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -505,27 +475,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -546,27 +513,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -587,27 +551,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -637,27 +598,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -678,27 +636,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -728,27 +683,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -769,27 +721,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -819,27 +768,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -869,27 +815,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -910,27 +853,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -960,27 +900,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1010,27 +947,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1051,27 +985,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1101,27 +1032,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1151,27 +1079,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1201,27 +1126,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1242,27 +1164,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1292,27 +1211,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1342,27 +1258,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1383,27 +1296,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1433,27 +1343,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1483,27 +1390,24 @@
    )
   )
   (if
-   (i32.lt_u
-    (local.get $2)
-    (local.get $0)
-   )
-   (then
-    (call $segfault)
-   )
-  )
-  (if
    (i32.or
     (i32.eq
      (local.get $2)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $2)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $2)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $2)
+      (local.get $0)
      )
     )
    )
@@ -1538,13 +1442,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1571,13 +1481,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1604,13 +1520,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1646,13 +1568,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1679,13 +1607,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1721,13 +1655,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1763,13 +1703,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 1)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 1)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1796,13 +1742,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1829,13 +1781,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 2)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 2)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1871,13 +1829,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1904,13 +1868,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1946,13 +1916,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -1988,13 +1964,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2021,13 +2003,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2063,13 +2051,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2105,13 +2099,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2147,13 +2147,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2180,13 +2186,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2222,13 +2234,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 4)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 4)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2264,13 +2282,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2297,13 +2321,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2339,13 +2369,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )
@@ -2381,13 +2417,19 @@
      (local.get $3)
      (i32.const 0)
     )
-    (i32.gt_u
-     (i32.add
-      (local.get $3)
-      (i32.const 8)
+    (i32.or
+     (i32.gt_u
+      (i32.add
+       (local.get $3)
+       (i32.const 8)
+      )
+      (i32.load
+       (call $emscripten_get_sbrk_ptr)
+      )
      )
-     (i32.load
-      (call $emscripten_get_sbrk_ptr)
+     (i32.lt_u
+      (local.get $3)
+      (local.get $0)
      )
     )
    )

--- a/test/passes/safe-heap_start-function.txt
+++ b/test/passes/safe-heap_start-function.txt
@@ -82,6 +82,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_s
@@ -120,6 +121,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load8_u
@@ -158,6 +160,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_s align=1
@@ -196,6 +199,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -243,6 +247,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load16_u align=1
@@ -281,6 +286,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -328,6 +334,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.load align=1
@@ -366,6 +373,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -413,6 +421,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -460,6 +469,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_s
@@ -498,6 +508,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load8_u
@@ -536,6 +547,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_s align=1
@@ -574,6 +586,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -621,6 +634,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load16_u align=1
@@ -659,6 +673,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -706,6 +721,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_s align=1
@@ -744,6 +760,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -791,6 +808,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -838,6 +856,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load32_u align=1
@@ -876,6 +895,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -923,6 +943,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -970,6 +991,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.load align=1
@@ -1008,6 +1030,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1055,6 +1078,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1102,6 +1126,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1149,6 +1174,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.load align=1
@@ -1187,6 +1213,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1234,6 +1261,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1281,6 +1309,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.load align=1
@@ -1319,6 +1348,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1366,6 +1396,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1413,6 +1444,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1460,6 +1492,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store8
@@ -1499,6 +1532,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store16 align=1
@@ -1538,6 +1572,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1586,6 +1621,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i32.store align=1
@@ -1625,6 +1661,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1673,6 +1710,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1721,6 +1759,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store8
@@ -1760,6 +1799,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store16 align=1
@@ -1799,6 +1839,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1847,6 +1888,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store32 align=1
@@ -1886,6 +1928,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1934,6 +1977,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -1982,6 +2026,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (i64.store align=1
@@ -2021,6 +2066,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2069,6 +2115,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2117,6 +2164,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2165,6 +2213,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f32.store align=1
@@ -2204,6 +2253,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2252,6 +2302,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2300,6 +2351,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (f64.store align=1
@@ -2339,6 +2391,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2387,6 +2440,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if
@@ -2435,6 +2489,7 @@
    )
    (then
     (call $segfault)
+    (unreachable)
    )
   )
   (if


### PR DESCRIPTION
E.g. loading `4` bytes from `2^32 - 2` should error: `2` bytes are past the maximum
address. Before this PR we added `2^32 - 2 + 4` and overflowed to `2`, which we
saw as a low and safe address. This PR adds an extra check for an overflow in
that add.

Fixes https://github.com/emscripten-core/emscripten/issues/21557