### PR TITLE
Fix build error on riscv64

### DIFF
--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -29,7 +29,7 @@
 
 namespace wasm {
 
-// We don't understand this warning, only here and only on aarch64,
+// We don't understand this warning, only here and only on aarch64 and riscv64,
 // we suspect it's spurious so disabling for now.
 //
 // For context: https://github.com/WebAssembly/binaryen/issues/6311
@@ -37,6 +37,12 @@ namespace wasm {
 #if defined(__aarch64__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+// https://github.com/WebAssembly/binaryen/issues/6410
+#if defined(__riscv) && __riscv_xlen == 64
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuninitialized"
 #endif
 
 template<typename T, size_t N> class SmallVector {
@@ -48,6 +54,10 @@ template<typename T, size_t N> class SmallVector {
   std::vector<T> flexible;
 
 #if defined(__aarch64__)
+#pragma GCC diagnostic pop
+#endif
+
+#if defined(__riscv) && __riscv_xlen == 64
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Similar issue as: https://github.com/WebAssembly/binaryen/pull/6330

```
FAILED: src/passes/CMakeFiles/passes.dir/Precompute.cpp.o 
/usr/bin/c++  -I/build/binaryen/src/binaryen-version_117/src -I/build/binaryen/src/binaryen-version_117/third_party/llvm-project/include -I/build/binaryen/src/binaryen-version_117/build -march=rv64gc -mabi=lp64d -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/binaryen/src=/usr/src/debug/binaryen -DBUILD_LLVM_DWARF -Wall -Werror -Wextra -Wno-unused-parameter -Wno-dangling-pointer -fno-omit-frame-pointer -fno-rtti -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wswitch -Wimplicit-fallthrough -Wnon-virtual-dtor -fPIC -fdiagnostics-color=always -O3 -DNDEBUG -UNDEBUG -std=c++17 -MD -MT src/passes/CMakeFiles/passes.dir/Precompute.cpp.o -MF src/passes/CMakeFiles/passes.dir/Precompute.cpp.o.d -o src/passes/CMakeFiles/passes.dir/Precompute.cpp.o -c /build/binaryen/src/binaryen-version_117/src/passes/Precompute.cpp
In file included from /build/binaryen/src/binaryen-version_117/src/wasm-traversal.h:30,
                 from /build/binaryen/src/binaryen-version_117/src/pass.h:24,
                 from /build/binaryen/src/binaryen-version_117/src/ir/intrinsics.h:20,
                 from /build/binaryen/src/binaryen-version_117/src/ir/effects.h:20,
                 from /build/binaryen/src/binaryen-version_117/src/passes/Precompute.cpp:30:
In copy constructor ‘wasm::SmallVector<wasm::Expression*, 10>::SmallVector(const wasm::SmallVector<wasm::Expression*, 10>&)’,
    inlined from ‘constexpr std::pair<_T1, _T2>::pair(const _T1&, const _T2&) [with _U1 = wasm::Select* const; _U2 = wasm::SmallVector<wasm::Expression*, 10>; typename std::enable_if<(std::_PCC<true, _T1, _T2>::_ConstructiblePair<_U1, _U2>() && std::_PCC<true, _T1, _T2>::_ImplicitlyConvertiblePair<_U1, _U2>()), bool>::type <anonymous> = true; _T1 = wasm::Select* const; _T2 = wasm::SmallVector<wasm::Expression*, 10>]’ at /usr/include/c++/13.2.1/bits/stl_pair.h:559:21,
    inlined from ‘T& wasm::InsertOrderedMap<Key, T>::operator[](const Key&) [with Key = wasm::Select*; T = wasm::SmallVector<wasm::Expression*, 10>]’ at /build/binaryen/src/binaryen-version_117/src/support/insert_ordered.h:112:29:
/build/binaryen/src/binaryen-version_117/src/support/small_vector.h:42:38: error: ‘<unnamed>.wasm::SmallVector<wasm::Expression*, 10>::fixed’ is used uninitialized [-Werror=uninitialized]
   42 | template<typename T, size_t N> class SmallVector {
      |                                      ^~~~~~~~~~~
In file included from /build/binaryen/src/binaryen-version_117/src/passes/Precompute.cpp:38:
/build/binaryen/src/binaryen-version_117/src/support/insert_ordered.h: In function ‘T& wasm::InsertOrderedMap<Key, T>::operator[](const Key&) [with Key = wasm::Select*; T = wasm::SmallVector<wasm::Expression*, 10>]’:
/build/binaryen/src/binaryen-version_117/src/support/insert_ordered.h:112:29: note: ‘<anonymous>’ declared here
  112 |     std::pair<const Key, T> kv = {k, {}};
      |                             ^~
```

Full log at [here](https://[archriscv.felixc.at/.status/log.htm?url=logs/binaryen/binaryen-1:117-1.log](https://archriscv.felixc.at/.status/log.htm?url=logs/binaryen/binaryen-1:117-1.log))

- binaryen: version_117
- OS: Arch Linux
- Arch: RISC-V 64