### PR TITLE
[Strings] Fix StringSlice end computation

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2174,7 +2174,7 @@ public:
     auto& refValues = refData->values;
     auto startVal = start.getSingleValue().getUnsigned();
     auto endVal = end.getSingleValue().getUnsigned();
-    endVal = std::min<Index>(endVal, refValues.size());
+    endVal = std::min<size_t>(endVal, refValues.size());
     if (hasNonAsciiUpTo(refValues, endVal)) {
       return Flow(NONCONSTANT_FLOW);
     }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1986,6 +1986,7 @@ public:
     if (ref.breaking()) {
       return ref;
     }
+    // TODO: "WTF-16 position treatment", as in stringview_wtf16.slice?
     Flow ptr = visit(curr->ptr);
     if (ptr.breaking()) {
       return ptr;
@@ -2173,9 +2174,7 @@ public:
     auto& refValues = refData->values;
     auto startVal = start.getSingleValue().getUnsigned();
     auto endVal = end.getSingleValue().getUnsigned();
-    if (endVal > refValues.size()) {
-      trap("array oob");
-    }
+    endVal = std::min(endVal, refValues.size());
     if (hasNonAsciiUpTo(refValues, endVal)) {
       return Flow(NONCONSTANT_FLOW);
     }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2174,7 +2174,7 @@ public:
     auto& refValues = refData->values;
     auto startVal = start.getSingleValue().getUnsigned();
     auto endVal = end.getSingleValue().getUnsigned();
-    endVal = std::min(endVal, refValues.size());
+    endVal = std::min<Index>(endVal, refValues.size());
     if (hasNonAsciiUpTo(refValues, endVal)) {
       return Flow(NONCONSTANT_FLOW);
     }

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -255,6 +255,17 @@
       (i32.const 6)
     )
   )
+
+  ;; CHECK:      [fuzz-exec] calling slice-big
+  ;; CHECK-NEXT: [fuzz-exec] note result: slice-big => string("defgh")
+  (func $slice-big (export "slice-big") (result (ref string))
+    ;; Slicing [3:huge unsigned value] leads to slicing til the end: "defgh".
+    (stringview_wtf16.slice
+      (string.const "abcdefgh")
+      (i32.const 3)
+      (i32.const -1)
+    )
+  )
 )
 ;; CHECK:      [fuzz-exec] calling new_wtf16_array
 ;; CHECK-NEXT: [fuzz-exec] note result: new_wtf16_array => string("ello")
@@ -323,6 +334,9 @@
 
 ;; CHECK:      [fuzz-exec] calling slice
 ;; CHECK-NEXT: [fuzz-exec] note result: slice => string("def")
+
+;; CHECK:      [fuzz-exec] calling slice-big
+;; CHECK-NEXT: [fuzz-exec] note result: slice-big => string("defgh")
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.1
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.10
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.2
@@ -344,3 +358,4 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing get_length
 ;; CHECK-NEXT: [fuzz-exec] comparing new_wtf16_array
 ;; CHECK-NEXT: [fuzz-exec] comparing slice
+;; CHECK-NEXT: [fuzz-exec] comparing slice-big


### PR DESCRIPTION
The [spec](https://github.com/WebAssembly/stringref/blob/main/proposals/stringref/Overview.md#stringview_wtf16) says

```
If pos is greater than the number of WTF-16 code units in view, it is as if it were instead given as the code unit length. This transformation is the "WTF-16 position treatment".

(stringview_wtf16.slice view:stringview_wtf16 start:i32 end:i32)
  -> str:stringref

Return a substring of view, for the WTF-16 code units starting at offset start and continuing to but not including end. start and end receive the "WTF-16 position treatment", as for stringview_wtf16.encode.
```

My understanding is that that means if the end is larger than the size, it is shrunk to the size. That is,
```
end = min(end, actual size)
```
That appears to match what V8 does, thereby fixing a fuzz bug, and also matches what JS strings do. Before, we used to trap on out of bounds here.