### PR TITLE
CodeFolding: Fix up old EH when we fold away an If

### DIFF
--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -58,8 +58,8 @@
 #include <iterator>
 
 #include "ir/branch-utils.h"
-#include "ir/eh-utils.h"
 #include "ir/effects.h"
+#include "ir/eh-utils.h"
 #include "ir/find_all.h"
 #include "ir/label-utils.h"
 #include "ir/utils.h"

--- a/test/lit/passes/code-folding-eh-old.wast
+++ b/test/lit/passes/code-folding-eh-old.wast
@@ -72,7 +72,7 @@
   ;; CHECK-NEXT: )
   (func $foo)
 
-  ;; CHECK:      (func $try-call-optimize-terminating-tails (type $2) (result i32)
+  ;; CHECK:      (func $try-call-optimize-terminating-tails (type $1) (result i32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (call $foo)
@@ -153,6 +153,62 @@
         )
       )
       (unreachable)
+    )
+  )
+
+  ;; CHECK:      (func $if-arms-in-catch (type $1) (result i32)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (try
+  ;; CHECK-NEXT:   (do
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (catch $e-i32
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (pop i32)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block
+  ;; CHECK-NEXT:     (block
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (i32.eqz
+  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-arms-in-catch (result i32)
+    (try
+      (do
+        (unreachable)
+      )
+      (catch $e-i32
+        ;; These if arms can be folded, after which the if is replaced by a
+        ;; block, so we need a fixup for the pop.
+        (if
+          (pop i32)
+          (then
+            (drop
+              (i32.eqz
+                (i32.const 1)
+              )
+            )
+          )
+          (else
+            (drop
+              (i32.eqz
+                (i32.const 1)
+              )
+            )
+          )
+        )
+        (unreachable)
+      )
     )
   )
 )


### PR DESCRIPTION
Context: The pass does (among other things) this:
```wat
(if
  condition
  X
  X
)

=>

(block
  (drop
    condition
  )
  X ;; deduplicated
)
```
After that the condition is now nested in a block, so we may need EH fixups
if it contains a pop.