### PR TITLE
Mark non-closed types as requiring GC

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -933,7 +933,7 @@ FeatureSet Type::getFeatures() const {
 
           if (heapType->isStruct() || heapType->isArray() ||
               heapType->getRecGroup().size() > 1 ||
-              heapType->getDeclaredSuperType()) {
+              heapType->getDeclaredSuperType() || heapType->isOpen()) {
             feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
           } else if (heapType->isSignature()) {
             // This is a function reference, which requires reference types and

--- a/test/lit/validation/open-types-no-gc.wast
+++ b/test/lit/validation/open-types-no-gc.wast
@@ -1,0 +1,13 @@
+;; Test that declaring non-final types without GC is a validation error.
+
+;; RUN:  not wasm-opt %s -all --disable-gc 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+  (type $f1 (sub (func)))
+
+  (func $test (type $f1)
+    (unreachable)
+  )
+)


### PR DESCRIPTION
This omission was able to cause a problem with text round-tripping.