### PR TITLE
Update file name in INITIAL_CONTENTS_IGNORE

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -331,7 +331,7 @@ INITIAL_CONTENTS_IGNORE = [
     'typed_continuations_suspend.wast',
     # New EH implementation is in progress
     'exception-handling.wast',
-    'translate-eh-old-to-new.wast',
+    'translate-to-new-eh.wast',
     'rse-eh.wast',
     # Non-UTF8 strings trap in V8, and have limitations in our interpreter
     'string-lowering.wast',


### PR DESCRIPTION
The test file was renamed, but the fuzzer still used the old name in
INITIAL_CONTENTS_IGNORE.