### PR TITLE
Add "interposition" to the fuzzer's mutate() method

### DIFF
--- a/src/ir/localize.h
+++ b/src/ir/localize.h
@@ -110,7 +110,7 @@ struct ChildLocalizer {
         // Move the child out, and put an unreachable in its place (note that we
         // don't need an actual set here, as there is no value to set to a
         // local).
-        movedChildren.push_back(child);
+        sets.push_back(child);
         *childp = builder.makeUnreachable();
         hasUnreachableChild = true;
         continue;
@@ -121,7 +121,7 @@ struct ChildLocalizer {
         // (The only reason we still need them is that they may be needed for
         // validation, e.g. if one contains a break to a block that is the only
         // reason the block has type none.)
-        movedChildren.push_back(builder.makeDrop(child));
+        sets.push_back(builder.makeDrop(child));
         *childp = builder.makeUnreachable();
         continue;
       }
@@ -139,23 +139,23 @@ struct ChildLocalizer {
       }
       if (needLocal) {
         auto local = builder.addVar(func, child->type);
-        movedChildren.push_back(builder.makeLocalSet(local, child));
+        sets.push_back(builder.makeLocalSet(local, child));
         *childp = builder.makeLocalGet(local, child->type);
       }
     }
   }
 
   // Helper that gets a replacement for the parent: a block containing the
-  // movedChildren + the parent. This will not contain the parent if we don't
-  // need it (if it was never reached).
+  // sets + the parent. This will not contain the parent if we don't need it
+  // (if it was never reached).
   Expression* getReplacement() {
-    if (movedChildren.empty()) {
+    if (sets.empty()) {
       // Nothing to add.
       return parent;
     }
 
     auto* block = Builder(wasm).makeBlock();
-    block->list.set(movedChildren);
+    block->list.set(sets);
     if (hasUnreachableChild) {
       // If there is an unreachable child then we do not need the parent at all,
       // and we know the type is unreachable.
@@ -168,14 +168,11 @@ struct ChildLocalizer {
     return block;
   }
 
-  // The vector of moved children may be useful to some users directly, e.g. if
-  // all they care about are the children and not the parent.
-  std::vector<Expression*> movedChildren;
-
 private:
   Expression* parent;
   Module& wasm;
 
+  std::vector<Expression*> sets;
   bool hasUnreachableChild = false;
 };
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -908,7 +908,9 @@ void TranslateToFuzzReader::recombine(Function* func) {
 // existing content there. Returns true if we found a place.
 static bool replaceChildWith(Expression* expr, Expression* with) {
   for (auto*& child : ChildIterator(expr)) {
-    if (Type::isSubType(with->type, child->type)) {
+    // To replace, we must have an appropriate type, and we cannot replace a
+    // Pop under any circumstances.
+    if (Type::isSubType(with->type, child->type) && !child->is<Pop>()) {
       child = with;
       return true;
     }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -17,8 +17,8 @@
 #include "tools/fuzzing.h"
 #include "ir/gc-type-utils.h"
 #include "ir/iteration.h"
-#include "ir/localize.h"
 #include "ir/local-structural-dominance.h"
+#include "ir/localize.h"
 #include "ir/module-utils.h"
 #include "ir/subtypes.h"
 #include "ir/type-updating.h"
@@ -988,19 +988,18 @@ void TranslateToFuzzReader::mutate(Function* func) {
           //       child, though if so we should still keep a decent chance to
           //       just drop this expression (as a drop enables passes to think
           //       they can remove more code, by marking the output "unused").
-          rep = parent.builder.makeSequence(parent.builder.makeDrop(curr),
-                                            rep);
-        } else if (mode >= 66 &&
-                   !Properties::isControlFlowStructure(curr) &&
+          rep = parent.builder.makeSequence(parent.builder.makeDrop(curr), rep);
+        } else if (mode >= 66 && !Properties::isControlFlowStructure(curr) &&
                    ChildIterator(curr).getNumChildren() > 0) {
           // This is a normal (non-control-flow) expression with at least one
           // child. "Interpose" between the children and this expression by
           // keeping them and replacing the parent |curr|. We do this by
           // generating sets of the children to locals, and keeping those.
           auto sets = ChildLocalizer(curr,
-                                 getFunction(),
-                                 *getModule(),
-                                 PassOptions::getWithoutOptimization()).movedChildren;
+                                     getFunction(),
+                                     *getModule(),
+                                     PassOptions::getWithoutOptimization())
+                        .movedChildren;
           auto* block = parent.builder.makeBlock(sets);
           // TODO: Ideally the new expression |rep| could consume the children:
           //       all we need is for it to do local.get of the temp locals.

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -910,7 +910,8 @@ static bool replaceChildWith(Expression* expr, Expression* with) {
   for (auto*& child : ChildIterator(expr)) {
     // To replace, we must have an appropriate type, and we cannot replace a
     // Pop under any circumstances.
-    if (Type::isSubType(with->type, child->type) && !child->is<Pop>()) {
+    if (Type::isSubType(with->type, child->type) &&
+        FindAll<Pop>(child).list.empty()) {
       child = with;
       return true;
     }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1039,8 +1039,8 @@ void TranslateToFuzzReader::mutate(Function* func) {
             // nothing more to do.
           } else {
             // Drop curr and append.
-            rep = parent.builder.makeSequence(parent.builder.makeDrop(curr),
-                                              rep);
+            rep =
+              parent.builder.makeSequence(parent.builder.makeDrop(curr), rep);
           }
         } else if (mode >= 66 && !Properties::isControlFlowStructure(curr)) {
           ChildIterator children(curr);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -900,6 +900,9 @@ void TranslateToFuzzReader::recombine(Function* func) {
   };
   Modder modder(wasm, scanner, *this);
   modder.walk(func->body);
+  // TODO: A specific form of recombination we should perhaps do more often is
+  //       to recombine among an expression's children, and in particular to
+  //       reorder them.
 }
 
 // Given two expressions, try to replace one of the children of the first with
@@ -1200,6 +1203,10 @@ void TranslateToFuzzReader::modifyInitialFunctions() {
       recombine(func);
       mutate(func);
       fixAfterChanges(func);
+      // TODO: This triad of functions appears in another place as well, and
+      //       could be handled by a single function. That function could also
+      //       decide to reorder recombine and mutate or even run more cycles of
+      //       them.
     }
   }
   // Remove a start function - the fuzzing harness expects code to run only

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1045,7 +1045,7 @@ void TranslateToFuzzReader::mutate(Function* func) {
         } else if (mode >= 66 && !Properties::isControlFlowStructure(curr)) {
           ChildIterator children(curr);
           auto numChildren = children.getNumChildren();
-          if (numChildren > 0 numChildren < 5) {
+          if (numChildren > 0 && numChildren < 5) {
             // This is a normal (non-control-flow) expression with at least one
             // child (and not an excessive amount of them; see the processing
             // below). "Interpose" between the children and this expression by
@@ -1068,7 +1068,8 @@ void TranslateToFuzzReader::mutate(Function* func) {
             auto* block = parent.builder.makeBlock();
             for (auto* child : children) {
               // Only drop the child if we can't replace it as one of NEW's
-              // children.
+              // children. This does a linear scan of |rep| which is the reason
+              // for the above limit on the number of children.
               if (!replaceChildWith(rep, child)) {
                 block->list.push_back(parent.builder.makeDrop(child));
               }

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,34 +1,34 @@
 total
- [exports]      : 29      
- [funcs]        : 39      
+ [exports]      : 18      
+ [funcs]        : 21      
  [globals]      : 9       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 2       
- [table-data]   : 6       
+ [table-data]   : 7       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 5494    
- [vars]         : 119     
- Binary         : 400     
- Block          : 892     
- Break          : 210     
- Call           : 232     
- CallIndirect   : 12      
- Const          : 898     
- Drop           : 49      
- GlobalGet      : 421     
- GlobalSet      : 333     
- If             : 289     
- Load           : 113     
- LocalGet       : 434     
- LocalSet       : 306     
- Loop           : 118     
- Nop            : 85      
- RefFunc        : 6       
- Return         : 62      
- Select         : 52      
- Store          : 45      
- Switch         : 1       
- Unary          : 380     
- Unreachable    : 156     
+ [total]        : 12378   
+ [vars]         : 79      
+ Binary         : 892     
+ Block          : 1963    
+ Break          : 478     
+ Call           : 288     
+ CallIndirect   : 131     
+ Const          : 2052    
+ Drop           : 89      
+ GlobalGet      : 899     
+ GlobalSet      : 714     
+ If             : 657     
+ Load           : 246     
+ LocalGet       : 1115    
+ LocalSet       : 841     
+ Loop           : 317     
+ Nop            : 155     
+ RefFunc        : 7       
+ Return         : 107     
+ Select         : 85      
+ Store          : 113     
+ Switch         : 3       
+ Unary          : 883     
+ Unreachable    : 343     

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -8,27 +8,27 @@ total
  [table-data]   : 7       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 12398   
+ [total]        : 11685   
  [vars]         : 64      
- Binary         : 893     
- Block          : 1965    
- Break          : 478     
- Call           : 288     
- CallIndirect   : 131     
- Const          : 2058    
- Drop           : 111     
- GlobalGet      : 901     
- GlobalSet      : 714     
- If             : 657     
- Load           : 247     
- LocalGet       : 1115    
- LocalSet       : 827     
- Loop           : 317     
- Nop            : 155     
+ Binary         : 848     
+ Block          : 1846    
+ Break          : 456     
+ Call           : 275     
+ CallIndirect   : 117     
+ Const          : 1952    
+ Drop           : 86      
+ GlobalGet      : 844     
+ GlobalSet      : 679     
+ If             : 625     
+ Load           : 236     
+ LocalGet       : 1050    
+ LocalSet       : 764     
+ Loop           : 301     
+ Nop            : 143     
  RefFunc        : 7       
- Return         : 107     
- Select         : 85      
- Store          : 113     
+ Return         : 103     
+ Select         : 77      
+ Store          : 111     
  Switch         : 3       
- Unary          : 883     
- Unreachable    : 343     
+ Unary          : 835     
+ Unreachable    : 327     

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -8,21 +8,21 @@ total
  [table-data]   : 7       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 12378   
- [vars]         : 79      
- Binary         : 892     
- Block          : 1963    
+ [total]        : 12398   
+ [vars]         : 64      
+ Binary         : 893     
+ Block          : 1965    
  Break          : 478     
  Call           : 288     
  CallIndirect   : 131     
- Const          : 2052    
- Drop           : 89      
- GlobalGet      : 899     
+ Const          : 2058    
+ Drop           : 111     
+ GlobalGet      : 901     
  GlobalSet      : 714     
  If             : 657     
- Load           : 246     
+ Load           : 247     
  LocalGet       : 1115    
- LocalSet       : 841     
+ LocalSet       : 827     
  Loop           : 317     
  Nop            : 155     
  RefFunc        : 7       

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,6 +1,6 @@
 total
  [exports]      : 3       
- [funcs]        : 6       
+ [funcs]        : 5       
  [globals]      : 1       
  [imports]      : 5       
  [memories]     : 1       
@@ -8,35 +8,49 @@ total
  [table-data]   : 1       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 314     
- [vars]         : 38      
- ArrayNew       : 2       
- ArrayNewFixed  : 1       
+ [total]        : 661     
+ [vars]         : 21      
+ ArrayGet       : 1       
+ ArrayLen       : 1       
+ ArrayNew       : 4       
+ ArrayNewFixed  : 6       
  AtomicFence    : 1       
- Binary         : 58      
- Block          : 28      
- Break          : 6       
- Call           : 10      
- Const          : 72      
- Drop           : 3       
- GlobalGet      : 10      
- GlobalSet      : 10      
+ AtomicRMW      : 1       
+ Binary         : 87      
+ Block          : 78      
+ Break          : 17      
+ Call           : 11      
+ Const          : 125     
+ DataDrop       : 1       
+ Drop           : 7       
+ GlobalGet      : 26      
+ GlobalSet      : 26      
  I31Get         : 1       
- If             : 7       
- Load           : 18      
- LocalGet       : 36      
- LocalSet       : 21      
- Loop           : 1       
- Nop            : 2       
- RefEq          : 1       
- RefFunc        : 2       
- RefI31         : 2       
- RefNull        : 1       
- Return         : 2       
- Select         : 1       
- Store          : 1       
- StructGet      : 1       
+ If             : 24      
+ Load           : 22      
+ LocalGet       : 65      
+ LocalSet       : 38      
+ Loop           : 9       
+ MemoryCopy     : 1       
+ Nop            : 9       
+ RefAs          : 8       
+ RefCast        : 1       
+ RefEq          : 2       
+ RefFunc        : 1       
+ RefI31         : 3       
+ RefIsNull      : 2       
+ RefNull        : 13      
+ RefTest        : 1       
+ Return         : 4       
+ SIMDExtract    : 3       
+ SIMDLoad       : 1       
+ Select         : 2       
+ Store          : 4       
+ StructGet      : 2       
  StructNew      : 3       
- TupleMake      : 2       
- Unary          : 6       
- Unreachable    : 5       
+ Throw          : 1       
+ Try            : 1       
+ TupleExtract   : 2       
+ TupleMake      : 5       
+ Unary          : 28      
+ Unreachable    : 13      


### PR DESCRIPTION
Before this PR we only mutated by replacing an expression with another, which
replaced all the children. With this PR we also do these two patterns:
```
(A
  (B)
  (C)
)

=> ;; keep children, replace A

(block
  (drop (B))
  (drop (C))
  (NEW)
)

,

(D
  (A
    (B)
    (C)
  )
)

=> ;; keep A, replace it in the parent

(D
  (block
    (drop
      (A
        (B)
        (C)
      )
    )
    (NEW)
  )
)
```

Even better would be to reuse the children by the new (`(NEW)`) expression,
but that would take significantly more work.
