### PR TITLE
Fix parsing of table imports

### DIFF
--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3737,15 +3737,13 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
       table->max = Table::kUnlimitedSize;
     }
 
+    // ends with the table element type
     table->type = elementToType(*inner[j++]);
     if (!table->type.isRef()) {
       throw SParseException("Only reference types are valid for tables", s);
     }
 
     wasm.addTable(std::move(table));
-
-    j++; // funcref
-    // ends with the table element type
   } else if (kind == ExternalKind::Memory) {
     auto memory = std::make_unique<Memory>();
     memory->setName(name, hasExplicitName);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -3737,6 +3737,11 @@ void SExpressionWasmBuilder::parseImport(Element& s) {
       table->max = Table::kUnlimitedSize;
     }
 
+    table->type = elementToType(*inner[j++]);
+    if (!table->type.isRef()) {
+      throw SParseException("Only reference types are valid for tables", s);
+    }
+
     wasm.addTable(std::move(table));
 
     j++; // funcref

--- a/test/lit/basic/table-import.wast
+++ b/test/lit/basic/table-import.wast
@@ -15,24 +15,38 @@
   ;; CHECK-BIN-NODEBUG:      (type $0 (func))
   (type $0 (func))
   (import "env" "table" (table 1 1 funcref))
+  (import "env" "table2" (table 1 1 anyref))
+  (import "env" "table3" (table 1 1 (ref null $0)))
   (elem (i32.const 0) $foo)
   ;; CHECK-TEXT:      (import "env" "table" (table $timport$0 1 1 funcref))
+
+  ;; CHECK-TEXT:      (import "env" "table2" (table $timport$1 1 1 funcref))
+
+  ;; CHECK-TEXT:      (import "env" "table3" (table $timport$2 1 1 funcref))
 
   ;; CHECK-TEXT:      (memory $0 0)
   ;; CHECK-BIN:      (import "env" "table" (table $timport$0 1 1 funcref))
 
+  ;; CHECK-BIN:      (import "env" "table2" (table $timport$1 1 1 funcref))
+
+  ;; CHECK-BIN:      (import "env" "table3" (table $timport$2 1 1 funcref))
+
   ;; CHECK-BIN:      (memory $0 0)
   ;; CHECK-BIN-NODEBUG:      (import "env" "table" (table $timport$0 1 1 funcref))
+
+  ;; CHECK-BIN-NODEBUG:      (import "env" "table2" (table $timport$1 1 1 funcref))
+
+  ;; CHECK-BIN-NODEBUG:      (import "env" "table3" (table $timport$2 1 1 funcref))
 
   ;; CHECK-BIN-NODEBUG:      (memory $0 0)
   (memory $0 0)
 
-  ;; CHECK-TEXT:      (elem $0 (i32.const 0) $foo)
+  ;; CHECK-TEXT:      (elem $0 (table $timport$0) (i32.const 0) func $foo)
 
   ;; CHECK-TEXT:      (func $foo (type $0)
   ;; CHECK-TEXT-NEXT:  (nop)
   ;; CHECK-TEXT-NEXT: )
-  ;; CHECK-BIN:      (elem $0 (i32.const 0) $foo)
+  ;; CHECK-BIN:      (elem $0 (table $timport$0) (i32.const 0) func $foo)
 
   ;; CHECK-BIN:      (func $foo (type $0)
   ;; CHECK-BIN-NEXT:  (nop)
@@ -40,8 +54,9 @@
   (func $foo (type $0)
     (nop)
   )
+
 )
-;; CHECK-BIN-NODEBUG:      (elem $0 (i32.const 0) $0)
+;; CHECK-BIN-NODEBUG:      (elem $0 (table $timport$0) (i32.const 0) func $0)
 
 ;; CHECK-BIN-NODEBUG:      (func $0 (type $0)
 ;; CHECK-BIN-NODEBUG-NEXT:  (nop)

--- a/test/lit/basic/table-import.wast
+++ b/test/lit/basic/table-import.wast
@@ -20,23 +20,23 @@
   (elem (i32.const 0) $foo)
   ;; CHECK-TEXT:      (import "env" "table" (table $timport$0 1 1 funcref))
 
-  ;; CHECK-TEXT:      (import "env" "table2" (table $timport$1 1 1 funcref))
+  ;; CHECK-TEXT:      (import "env" "table2" (table $timport$1 1 1 anyref))
 
-  ;; CHECK-TEXT:      (import "env" "table3" (table $timport$2 1 1 funcref))
+  ;; CHECK-TEXT:      (import "env" "table3" (table $timport$2 1 1 (ref null $0)))
 
   ;; CHECK-TEXT:      (memory $0 0)
   ;; CHECK-BIN:      (import "env" "table" (table $timport$0 1 1 funcref))
 
-  ;; CHECK-BIN:      (import "env" "table2" (table $timport$1 1 1 funcref))
+  ;; CHECK-BIN:      (import "env" "table2" (table $timport$1 1 1 anyref))
 
-  ;; CHECK-BIN:      (import "env" "table3" (table $timport$2 1 1 funcref))
+  ;; CHECK-BIN:      (import "env" "table3" (table $timport$2 1 1 (ref null $0)))
 
   ;; CHECK-BIN:      (memory $0 0)
   ;; CHECK-BIN-NODEBUG:      (import "env" "table" (table $timport$0 1 1 funcref))
 
-  ;; CHECK-BIN-NODEBUG:      (import "env" "table2" (table $timport$1 1 1 funcref))
+  ;; CHECK-BIN-NODEBUG:      (import "env" "table2" (table $timport$1 1 1 anyref))
 
-  ;; CHECK-BIN-NODEBUG:      (import "env" "table3" (table $timport$2 1 1 funcref))
+  ;; CHECK-BIN-NODEBUG:      (import "env" "table3" (table $timport$2 1 1 (ref null $0)))
 
   ;; CHECK-BIN-NODEBUG:      (memory $0 0)
   (memory $0 0)


### PR DESCRIPTION
The types was ignored and `funcref` was always used instead.