### PR TITLE
Remove the TRAVERSE_CALLS option in the ConstantExpressionRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Current Trunk
    to configure which features to enable in the parser.
  - The build-time option to use legacy WasmGC opcodes is removed.
  - The strings in `string.const` instructions must now be valid WTF-8.
+ - The `TraverseCalls` flag for `ExpressionRunner` is removed.
 
 v117
 ----

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -6322,10 +6322,6 @@ ExpressionRunnerFlags ExpressionRunnerFlagsPreserveSideeffects() {
   return CExpressionRunner::FlagValues::PRESERVE_SIDEEFFECTS;
 }
 
-ExpressionRunnerFlags ExpressionRunnerFlagsTraverseCalls() {
-  return CExpressionRunner::FlagValues::TRAVERSE_CALLS;
-}
-
 ExpressionRunnerRef ExpressionRunnerCreate(BinaryenModuleRef module,
                                            ExpressionRunnerFlags flags,
                                            BinaryenIndex maxDepth,

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -3495,12 +3495,6 @@ BINARYEN_API ExpressionRunnerFlags ExpressionRunnerFlagsDefault();
 // so subsequent code keeps functioning.
 BINARYEN_API ExpressionRunnerFlags ExpressionRunnerFlagsPreserveSideeffects();
 
-// Traverse through function calls, attempting to compute their concrete value.
-// Must not be used in function-parallel scenarios, where the called function
-// might be concurrently modified, leading to undefined behavior. Traversing
-// another function reuses all of this runner's flags.
-BINARYEN_API ExpressionRunnerFlags ExpressionRunnerFlagsTraverseCalls();
-
 // Creates an ExpressionRunner instance
 BINARYEN_API ExpressionRunnerRef
 ExpressionRunnerCreate(BinaryenModuleRef module,

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -638,7 +638,6 @@ function initializeConstants() {
   Module['ExpressionRunner']['Flags'] = {
     'Default': Module['_ExpressionRunnerFlagsDefault'](),
     'PreserveSideeffects': Module['_ExpressionRunnerFlagsPreserveSideeffects'](),
-    'TraverseCalls': Module['_ExpressionRunnerFlagsTraverseCalls']()
   };
 }
 

--- a/test/binaryen.js/expressionrunner.js
+++ b/test/binaryen.js/expressionrunner.js
@@ -1,7 +1,6 @@
 var Flags = binaryen.ExpressionRunner.Flags;
 console.log("// ExpressionRunner.Flags.Default = " + Flags.Default);
 console.log("// ExpressionRunner.Flags.PreserveSideeffects = " + Flags.PreserveSideeffects);
-console.log("// ExpressionRunner.Flags.TraverseCalls = " + Flags.TraverseCalls);
 
 function assertDeepEqual(x, y) {
   if (typeof x === "object") {
@@ -139,39 +138,7 @@ assertDeepEqual(
   }
 );
 
-// Should traverse into (simple) functions if requested
-runner = new binaryen.ExpressionRunner(module, Flags.TraverseCalls);
-module.addFunction("add", binaryen.createType([ binaryen.i32, binaryen.i32 ]), binaryen.i32, [],
-  module.block(null, [
-    module.i32.add(
-      module.local.get(0, binaryen.i32),
-      module.local.get(1, binaryen.i32)
-    )
-  ], binaryen.i32)
-);
-assert(runner.setLocalValue(0, module.i32.const(1)));
-expr = runner.runAndDispose(
-  module.i32.add(
-    module.i32.add(
-      module.local.get(0, binaryen.i32),
-      module.call("add", [
-        module.i32.const(2),
-        module.i32.const(4)
-      ], binaryen.i32)
-    ),
-    module.local.get(0, binaryen.i32)
-  )
-);
-assertDeepEqual(
-  binaryen.getExpressionInfo(expr),
-  {
-    id: binaryen.ExpressionIds.Const,
-    type: binaryen.i32,
-    value: 8
-  }
-);
-
-// Should not attempt to traverse into functions if not explicitly set
+// Should not attempt to traverse into functions
 runner = new binaryen.ExpressionRunner(module);
 expr = runner.runAndDispose(
   module.i32.add(

--- a/test/binaryen.js/expressionrunner.js.txt
+++ b/test/binaryen.js/expressionrunner.js.txt
@@ -1,3 +1,2 @@
 // ExpressionRunner.Flags.Default = 0
 // ExpressionRunner.Flags.PreserveSideeffects = 1
-// ExpressionRunner.Flags.TraverseCalls = 2


### PR DESCRIPTION
The implementation of calls with this option was incorrect because it cleared
the locals before evaluating the call arguments. The likely explanation for why
this was never noticed is that there are no users of this option, especially
since it is exposed in the C and JS APIs but not used internally.

Rather than try to fix the implementation, just remove the option.