### PR TITLE
Report timeout in interpretation of AtomicWait

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3431,7 +3431,7 @@ public:
     if (timeout.getSingleValue().getInteger() != 0) {
       hostLimit("threads support");
     }
-    return Literal(int32_t(0)); // equal
+    return Literal(int32_t(2)); // Timed out
   }
   Flow visitAtomicNotify(AtomicNotify* curr) {
     NOTE_ENTER("AtomicNotify");

--- a/test/lit/exec/atomic.wast
+++ b/test/lit/exec/atomic.wast
@@ -8,7 +8,7 @@
  (memory $0 23 256 shared)
 
  ;; CHECK:      [fuzz-exec] calling wait_and_log
- ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
+ ;; CHECK-NEXT: [LoggingExternalInterface logging 2]
  (func $wait_and_log (export "wait_and_log")
   (call $log
    (memory.atomic.wait64


### PR DESCRIPTION
To avoid slow-running fuzz cases, we report a host limit when interpreting
atomic.wait with any non-zero timeout. However, in the allowed case where the
timeout is zero, we were incorrectly interpreting the wait as returning 0,
meaning that it was woken up, instead of 2, meaning that the timeout expired.
Fix it to return 2.