### PR TITLE
GUFA: Fix hashing of GlobalInfo's type

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -226,9 +226,9 @@ void PossibleContents::intersect(const PossibleContents& other) {
   // Note the global's information, if we started as a global. In that case, the
   // code below will refine our type but we can remain a global, which we will
   // accomplish by restoring our global status at the end.
-  std::optional<Name> globalName;
+  std::optional<Global*> global;
   if (isGlobal()) {
-    globalName = getGlobal();
+    global = getGlobal();
   }
 
   auto newType = Type(newHeapType, nullability);
@@ -267,9 +267,9 @@ void PossibleContents::intersect(const PossibleContents& other) {
     value = ConeType{newType, newDepth};
   }
 
-  if (globalName) {
+  if (global) {
     // Restore the global but keep the new and refined type.
-    value = GlobalInfo{*globalName, getType()};
+    value = GlobalInfo{*global, getType()};
   }
 }
 
@@ -2578,7 +2578,7 @@ void Flower::filterGlobalContents(PossibleContents& contents,
     // a cone/exact type *and* that something is equal to a global, in some
     // cases. See https://github.com/WebAssembly/binaryen/pull/5083
     if (contents.isMany() || contents.isConeType()) {
-      contents = PossibleContents::global(global->name, global->type);
+      contents = PossibleContents::global(global, global->type);
 
       // TODO: We could do better here, to set global->init->type instead of
       //       global->type, or even the contents.getType() - either of those

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -226,9 +226,9 @@ void PossibleContents::intersect(const PossibleContents& other) {
   // Note the global's information, if we started as a global. In that case, the
   // code below will refine our type but we can remain a global, which we will
   // accomplish by restoring our global status at the end.
-  std::optional<Global*> global;
+  std::optional<Name> globalName;
   if (isGlobal()) {
-    global = getGlobal();
+    globalName = getGlobal();
   }
 
   auto newType = Type(newHeapType, nullability);
@@ -267,9 +267,9 @@ void PossibleContents::intersect(const PossibleContents& other) {
     value = ConeType{newType, newDepth};
   }
 
-  if (global) {
+  if (globalName) {
     // Restore the global but keep the new and refined type.
-    value = GlobalInfo{*global, getType()};
+    value = GlobalInfo{*globalName, getType()};
   }
 }
 
@@ -2578,7 +2578,7 @@ void Flower::filterGlobalContents(PossibleContents& contents,
     // a cone/exact type *and* that something is equal to a global, in some
     // cases. See https://github.com/WebAssembly/binaryen/pull/5083
     if (contents.isMany() || contents.isConeType()) {
-      contents = PossibleContents::global(global, global->type);
+      contents = PossibleContents::global(global->name, global->type);
 
       // TODO: We could do better here, to set global->init->type instead of
       //       global->type, or even the contents.getType() - either of those

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -76,6 +76,9 @@ class PossibleContents {
     // The contents flowing out will be a Global, but of a non-nullable type,
     // unlike the original global.
     Type type;
+    // TODO: Consider adding a depth here, or merging this with ConeType in some
+    //       way. In principle, not having depth info can lead to loss of
+    //       precision.
     bool operator==(const GlobalInfo& other) const {
       return name == other.name && type == other.type;
     }
@@ -305,8 +308,9 @@ public:
       // Nothing to add.
     } else if (isLiteral()) {
       rehash(ret, getLiteral());
-    } else if (isGlobal()) {
-      rehash(ret, getGlobal());
+    } else if (auto* global = std::get_if<GlobalInfo>(&value)) {
+      rehash(ret, global->name);
+      rehash(ret, global->type);
     } else if (auto* coneType = std::get_if<ConeType>(&value)) {
       rehash(ret, coneType->type);
       rehash(ret, coneType->depth);

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -65,7 +65,7 @@ class PossibleContents {
   struct None : public std::monostate {};
 
   struct GlobalInfo {
-    Name name;
+    Global* global;
     // The type of contents. Note that this may not match the type of the
     // global, if we were filtered. For example:
     //
@@ -77,7 +77,7 @@ class PossibleContents {
     // unlike the original global.
     Type type;
     bool operator==(const GlobalInfo& other) const {
-      return name == other.name && type == other.type;
+      return global == other.global && type == other.type;
     }
   };
 
@@ -119,8 +119,8 @@ public:
 
   static PossibleContents none() { return PossibleContents{None()}; }
   static PossibleContents literal(Literal c) { return PossibleContents{c}; }
-  static PossibleContents global(Name name, Type type) {
-    return PossibleContents{GlobalInfo{name, type}};
+  static PossibleContents global(Global* global, Type type) {
+    return PossibleContents{GlobalInfo{global, type}};
   }
   // Helper for a cone type with depth 0, i.e., an exact type.
   static PossibleContents exactType(Type type) {
@@ -190,9 +190,9 @@ public:
     return std::get<Literal>(value);
   }
 
-  Name getGlobal() const {
+  Global* getGlobal() const {
     assert(isGlobal());
-    return std::get<GlobalInfo>(value).name;
+    return std::get<GlobalInfo>(value).global;
   }
 
   bool isNull() const { return isLiteral() && getLiteral().isNull(); }
@@ -290,11 +290,11 @@ public:
     if (isLiteral()) {
       return builder.makeConstantExpression(getLiteral());
     } else {
-      auto name = getGlobal();
+      auto* global = getGlobal();
       // Note that we load the type from the module, rather than use the type
       // in the GlobalInfo, as that type may not match the global (see comment
       // in the GlobalInfo declaration above).
-      return builder.makeGlobalGet(name, wasm.getGlobal(name)->type);
+      return builder.makeGlobalGet(global->name, global->type);
     }
   }
 
@@ -306,7 +306,7 @@ public:
     } else if (isLiteral()) {
       rehash(ret, getLiteral());
     } else if (isGlobal()) {
-      rehash(ret, getGlobal());
+      rehash(ret, getGlobal()->name);
     } else if (auto* coneType = std::get_if<ConeType>(&value)) {
       rehash(ret, coneType->type);
       rehash(ret, coneType->depth);
@@ -328,7 +328,7 @@ public:
         o << " HT: " << h;
       }
     } else if (isGlobal()) {
-      o << "GlobalInfo $" << getGlobal() << " T: " << getType();
+      o << "GlobalInfo $" << getGlobal()->name << " T: " << getType();
     } else if (auto* coneType = std::get_if<ConeType>(&value)) {
       auto t = coneType->type;
       o << "ConeType " << t;


### PR DESCRIPTION
See lines 69-70 in that header: For a global we store the name and a type,
and the type may be more precise than the global's type in the wasm. As
a result, when hashing, it is not enough to hash only the name, so hash
the type as well.

Not sure if this caused any significant issues due to more hash collisions,
but I noticed it while reading the code.

Also add a random TODO as a comment.