### PR TITLE
GUFA: Fix nondeterminism in roots

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -2122,7 +2122,10 @@ Flower::Flower(Module& wasm, const PassOptions& options)
   // The merged roots. (Note that all other forms of merged data are declared at
   // the class level, since we need them during the flow, but the roots are only
   // needed to start the flow, so we can declare them here.)
-  std::unordered_map<Location, PossibleContents> roots;
+  //
+  // This must be insert-ordered for the same reason as |workQueue| is, see
+  // above.
+  InsertOrderedMap<Location, PossibleContents> roots;
 
   for (auto& [func, info] : analysis.map) {
     for (auto& link : info.links) {


### PR DESCRIPTION
Found by the fuzzer. We already processed the work queue in a deterministic
order, but the roots were unordered. The work queue's initial state is filled by
the roots, so we must process the roots deterministically as well.