### PR TITLE
Update effects.h to handle return calls correctly

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -519,7 +519,9 @@ private:
         // target function throws and we know that will be caught anyhow, the
         // same as the code below for the general path. We can always filter out
         // throws for return calls because they are already more precisely
-        // captured by `hasReturnCallThrow` and `branchesOut`.
+        // captured by `branchesOut`, which models the return, and
+        // `hasReturnCallThrow`, which models the throw that will happen after
+        // the return.
         if (targetEffects->throws_ && (parent.tryDepth > 0 || curr->isReturn)) {
           auto filteredEffects = *targetEffects;
           filteredEffects.throws_ = false;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -795,7 +795,7 @@ private:
 
       parent.calls = true;
       if (parent.features.hasExceptionHandling() &&
-          (parent.tryDepth == 0 || curr->isReturn)) {
+          (parent.tryDepth == 0 && !curr->isReturn)) {
         parent.throws_ = true;
       }
     }

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -518,7 +518,7 @@ private:
         // target function throws and we know that will be caught anyhow, the
         // same as the code below for the general path. We can always filter out
         // throws for return calls because they are already more precisely
-        // captured by `hasReturnCallThrow`.
+        // captured by `hasReturnCallThrow` and `branchesOut`.
         if (targetEffects->throws_ && (parent.tryDepth > 0 || curr->isReturn)) {
           auto filteredEffects = *targetEffects;
           filteredEffects.throws_ = false;
@@ -532,8 +532,8 @@ private:
 
       parent.calls = true;
       // When EH is enabled, any call can throw. Skip this for return calls
-      // because the throw is already more precisely captured by
-      // `hasReturnCallThrow`.
+      // because the throw is already more precisely captured by the combination
+      // of `hasReturnCallThrow` and `branchesOut`.
       if (parent.features.hasExceptionHandling() && parent.tryDepth == 0 &&
           !curr->isReturn) {
         parent.throws_ = true;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -166,10 +166,11 @@ public:
   // body.
   //
   // We currently do this stashing only for the throw effect, but in principle
-  // we could do it for all effects if it made a difference. (Only throw is noticeable
-  // now because the only thing that can change between doing the call here
-  // and doing it outside at the function exit is the scoping of try-catch blocks.
-  // If future wasm scoping additions are added, we may need more here.)
+  // we could do it for all effects if it made a difference. (Only throw is
+  // noticeable now because the only thing that can change between doing the
+  // call here and doing it outside at the function exit is the scoping of
+  // try-catch blocks. If future wasm scoping additions are added, we may need
+  // more here.)
   bool hasReturnCallThrow = false;
 
   // Helper functions to check for various effect types

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -66,8 +66,16 @@ public:
   // Walk an entire function body. This will ignore effects that are not
   // noticeable from the perspective of the caller, that is, effects that are
   // only noticeable during the call, but "vanish" when the call stack is
-  // unwound. Unlike walking just the body, walking the function will also
-  // include the effects of any return calls the function makes.
+  // unwound.
+  //
+  // Unlike walking just the body, walking the function will also
+  // include the effects of any return calls the function makes. For that
+  // reason, it is a bug if a user of this code calls walk(Expression*) and not
+  // walk(Function*) if their intention is to scan an entire function body.
+  // Putting it another way, a return_call is syntax sugar for a return and a
+  // call, where the call executes at the function scope, so there is a
+  // meaningful difference between scanning an expression and scanning
+  // the entire function body.
   void walk(Function* func) {
     walk(func->body);
 
@@ -158,7 +166,10 @@ public:
   // body.
   //
   // We currently do this stashing only for the throw effect, but in principle
-  // we could do it for all effects if it made a difference.
+  // we could do it for all effects if it made a difference. (Only throw is noticeable
+  // now because the only thing that can change between doing the call here
+  // and doing it outside at the function exit is the scoping of try-catch blocks.
+  // If future wasm scoping additions are added, we may need more here.)
   bool hasReturnCallThrow = false;
 
   // Helper functions to check for various effect types

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -23,12 +23,66 @@
 
 namespace wasm {
 
-// Track various possible effects.
-struct EffectSet {
-  // Options that affect effect tracking
-  bool trapsNeverHappen;
+// Analyze various possible effects.
 
-  EffectSet(bool trapsNeverHappen) : trapsNeverHappen(trapsNeverHappen) {}
+class EffectAnalyzer {
+public:
+  EffectAnalyzer(const PassOptions& passOptions, Module& module)
+    : ignoreImplicitTraps(passOptions.ignoreImplicitTraps),
+      trapsNeverHappen(passOptions.trapsNeverHappen),
+      funcEffectsMap(passOptions.funcEffectsMap), module(module),
+      features(module.features) {}
+
+  EffectAnalyzer(const PassOptions& passOptions,
+                 Module& module,
+                 Expression* ast)
+    : EffectAnalyzer(passOptions, module) {
+    walk(ast);
+  }
+
+  EffectAnalyzer(const PassOptions& passOptions, Module& module, Function* func)
+    : EffectAnalyzer(passOptions, module) {
+    walk(func);
+  }
+
+  bool ignoreImplicitTraps;
+  bool trapsNeverHappen;
+  std::shared_ptr<FuncEffectsMap> funcEffectsMap;
+  Module& module;
+  FeatureSet features;
+
+  // Walk an expression and all its children.
+  void walk(Expression* ast) {
+    InternalAnalyzer(*this).walk(ast);
+    post();
+  }
+
+  // Visit an expression, without any children.
+  void visit(Expression* ast) {
+    InternalAnalyzer(*this).visit(ast);
+    post();
+  }
+
+  // Walk an entire function body. This will ignore effects that are not
+  // noticeable from the perspective of the caller, that is, effects that are
+  // only noticeable during the call, but "vanish" when the call stack is
+  // unwound.
+  void walk(Function* func) {
+    walk(func->body);
+
+    // Effects of return-called functions will be visible to the caller.
+    if (hasReturnCallThrow) {
+      throws_ = true;
+    }
+
+    // We can ignore branching out of the function body - this can only be
+    // a return, and that is only noticeable in the function, not outside.
+    branchesOut = false;
+
+    // When the function exits, changes to locals cannot be noticed any more.
+    localsWritten.clear();
+    localsRead.clear();
+  }
 
   // Core effect tracking
 
@@ -94,8 +148,15 @@ struct EffectSet {
   // or a continuation that is never continued, are examples of that.
   bool mayNotReturn = false;
 
-  std::set<Name> breakTargets;
-  std::set<Name> delegateTargets;
+  // Return calls are indistinguishable from normal returns from the perspective
+  // of their surrounding code, and the return-callee's effects only become
+  // visible when considering the effects of the whole function containing the
+  // return call. To model this correctly, stash the callee's effects on the
+  // side and only merge them in after walking a full function body.
+  //
+  // We currently do this stashing only for the throw effect, but in principle
+  // we could do it for all effects if it made a difference.
+  bool hasReturnCallThrow = false;
 
   // Helper functions to check for various effect types
 
@@ -204,7 +265,7 @@ struct EffectSet {
   // example we can't reorder A and B if B traps, but in the first example we
   // can reorder them even if B traps (even if A has a global effect like a
   // global.set, since we assume B does not trap in traps-never-happen).
-  bool invalidates(const EffectSet& other) {
+  bool invalidates(const EffectAnalyzer& other) {
     if ((transfersControlFlow() && other.hasSideEffects()) ||
         (other.transfersControlFlow() && hasSideEffects()) ||
         ((writesMemory || calls) && other.accessesMemory()) ||
@@ -271,7 +332,7 @@ struct EffectSet {
     return false;
   }
 
-  void mergeIn(const EffectSet& other) {
+  void mergeIn(const EffectAnalyzer& other) {
     branchesOut = branchesOut || other.branchesOut;
     calls = calls || other.calls;
     readsMemory = readsMemory || other.readsMemory;
@@ -307,70 +368,6 @@ struct EffectSet {
       delegateTargets.insert(i);
     }
   }
-};
-
-// Analyze various possible effects.
-
-struct EffectAnalyzer : EffectSet {
-  EffectAnalyzer(const PassOptions& passOptions, Module& module)
-    : EffectSet(passOptions.trapsNeverHappen),
-      ignoreImplicitTraps(passOptions.ignoreImplicitTraps),
-      funcEffectsMap(passOptions.funcEffectsMap), module(module),
-      features(module.features), returnCallEffects(*this) {}
-
-  EffectAnalyzer(const PassOptions& passOptions,
-                 Module& module,
-                 Expression* ast)
-    : EffectAnalyzer(passOptions, module) {
-    walk(ast);
-  }
-
-  EffectAnalyzer(const PassOptions& passOptions, Module& module, Function* func)
-    : EffectAnalyzer(passOptions, module) {
-    walk(func);
-  }
-
-  bool ignoreImplicitTraps;
-  std::shared_ptr<FuncEffectsMap> funcEffectsMap;
-  Module& module;
-  FeatureSet features;
-
-  // Return calls appear no different than normal returns to local surrounding
-  // code, but the effects of the return-called functions are visible to
-  // callers. Collect effects of return-called functions here and merge them in
-  // only when analyzing an entire function.
-  EffectSet returnCallEffects;
-
-  // Walk an expression and all its children.
-  void walk(Expression* ast) {
-    InternalAnalyzer(*this).walk(ast);
-    post();
-  }
-
-  // Visit an expression, without any children.
-  void visit(Expression* ast) {
-    InternalAnalyzer(*this).visit(ast);
-    post();
-  }
-
-  // Walk an entire function body. This will ignore effects that are not
-  // noticeable from the perspective of the caller, that is, effects that are
-  // only noticeable during the call, but "vanish" when the call stack is
-  // unwound.
-  void walk(Function* func) {
-    walk(func->body);
-
-    // Effects of return-called functions will be visible to the caller.
-    mergeIn(returnCallEffects);
-
-    // We can ignore branching out of the function body - this can only be
-    // a return, and that is only noticeable in the function, not outside.
-    branchesOut = false;
-
-    // When the function exits, changes to locals cannot be noticed any more.
-    localsWritten.clear();
-    localsRead.clear();
-  }
 
   // the checks above happen after the node's children were processed, in the
   // order of execution we must also check for control flow that happens before
@@ -390,6 +387,9 @@ struct EffectAnalyzer : EffectSet {
     }
     return hasAnything();
   }
+
+  std::set<Name> breakTargets;
+  std::set<Name> delegateTargets;
 
 private:
   struct InternalAnalyzer
@@ -491,44 +491,51 @@ private:
 
       if (curr->isReturn) {
         parent.branchesOut = true;
+        // When EH is enabled, any call can throw.
+        if (parent.features.hasExceptionHandling() &&
+            (!targetEffects || targetEffects->throws())) {
+          parent.hasReturnCallThrow = true;
+        }
       }
-
-      auto& effects = curr->isReturn ? parent.returnCallEffects : parent;
 
       if (targetEffects) {
         // We have effect information for this call target, and can just use
-        // that. The one change we may want to make is to remove throws_, if
-        // the target function throws and we know that will be caught anyhow,
-        // the same as the code below for the general path. We can't filter
-        // out throws on return calls because they will return out of the
-        // handlers before making the call.
-        if (targetEffects->throws_ && parent.tryDepth > 0 && !curr->isReturn) {
+        // that. The one change we may want to make is to remove throws_, if the
+        // target function throws and we know that will be caught anyhow, the
+        // same as the code below for the general path. We can always filter out
+        // throws for return calls because they are already more precisely
+        // captured by `hasReturnCallThrow`.
+        if (targetEffects->throws_ && (parent.tryDepth > 0 || curr->isReturn)) {
           auto filteredEffects = *targetEffects;
           filteredEffects.throws_ = false;
-          effects.mergeIn(filteredEffects);
+          parent.mergeIn(filteredEffects);
         } else {
           // Just merge in all the effects.
-          effects.mergeIn(*targetEffects);
+          parent.mergeIn(*targetEffects);
         }
         return;
       }
 
-      effects.calls = true;
-      // When EH is enabled, any call can throw.
-      if (parent.features.hasExceptionHandling() &&
-          (parent.tryDepth == 0 || curr->isReturn)) {
-        effects.throws_ = true;
+      parent.calls = true;
+      // When EH is enabled, any call can throw. Skip this for return calls
+      // because the throw is already more precisely captured by
+      // `hasReturnCallThrow`.
+      if (parent.features.hasExceptionHandling() && parent.tryDepth == 0 &&
+          !curr->isReturn) {
+        parent.throws_ = true;
       }
     }
     void visitCallIndirect(CallIndirect* curr) {
+      parent.calls = true;
       if (curr->isReturn) {
         parent.branchesOut = true;
+        if (parent.features.hasExceptionHandling()) {
+          parent.hasReturnCallThrow = true;
+        }
       }
-      auto& effects = curr->isReturn ? parent.returnCallEffects : parent;
-      effects.calls = true;
       if (parent.features.hasExceptionHandling() &&
-          (parent.tryDepth == 0 || curr->isReturn)) {
-        effects.throws_ = true;
+          (parent.tryDepth == 0 && !curr->isReturn)) {
+        parent.throws_ = true;
       }
     }
     void visitLocalGet(LocalGet* curr) {
@@ -773,6 +780,9 @@ private:
     void visitCallRef(CallRef* curr) {
       if (curr->isReturn) {
         parent.branchesOut = true;
+        if (parent.features.hasExceptionHandling()) {
+          parent.hasReturnCallThrow = true;
+        }
       }
       if (curr->target->type.isNull()) {
         parent.trap = true;
@@ -783,11 +793,10 @@ private:
         parent.implicitTrap = true;
       }
 
-      auto& effects = curr->isReturn ? parent.returnCallEffects : parent;
-      effects.calls = true;
+      parent.calls = true;
       if (parent.features.hasExceptionHandling() &&
           (parent.tryDepth == 0 || curr->isReturn)) {
-        effects.throws_ = true;
+        parent.throws_ = true;
       }
     }
     void visitRefTest(RefTest* curr) {}

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -66,7 +66,8 @@ public:
   // Walk an entire function body. This will ignore effects that are not
   // noticeable from the perspective of the caller, that is, effects that are
   // only noticeable during the call, but "vanish" when the call stack is
-  // unwound.
+  // unwound. Unlike walking just the body, walking the function will also
+  // include the effects of any return calls the function makes.
   void walk(Function* func) {
     walk(func->body);
 
@@ -148,11 +149,13 @@ public:
   // or a continuation that is never continued, are examples of that.
   bool mayNotReturn = false;
 
-  // Return calls are indistinguishable from normal returns from the perspective
-  // of their surrounding code, and the return-callee's effects only become
-  // visible when considering the effects of the whole function containing the
-  // return call. To model this correctly, stash the callee's effects on the
-  // side and only merge them in after walking a full function body.
+  // Since return calls return out of the body of the function before performing
+  // their call, they are indistinguishable from normal returns from the
+  // perspective of their surrounding code, and the return-callee's effects only
+  // become visible when considering the effects of the whole function
+  // containing the return call. To model this correctly, stash the callee's
+  // effects on the side and only merge them in after walking a full function
+  // body.
   //
   // We currently do this stashing only for the throw effect, but in principle
   // we could do it for all effects if it made a difference.

--- a/src/pass.h
+++ b/src/pass.h
@@ -98,7 +98,7 @@ struct InliningOptions {
 };
 
 // Forward declaration for FuncEffectsMap.
-struct EffectAnalyzer;
+class EffectAnalyzer;
 
 using FuncEffectsMap = std::unordered_map<Name, EffectAnalyzer>;
 

--- a/src/pass.h
+++ b/src/pass.h
@@ -98,7 +98,7 @@ struct InliningOptions {
 };
 
 // Forward declaration for FuncEffectsMap.
-class EffectAnalyzer;
+struct EffectAnalyzer;
 
 using FuncEffectsMap = std::unordered_map<Name, EffectAnalyzer>;
 

--- a/test/lit/passes/global-effects.wast
+++ b/test/lit/passes/global-effects.wast
@@ -8,27 +8,36 @@
 ;; RUN: foreach %s %t wasm-opt -all --generate-global-effects --discard-global-effects --vacuum -S -o - | filecheck %s --check-prefix WITHOUT
 
 (module
-  ;; WITHOUT:      (type $0 (func))
+
+  ;; WITHOUT:      (type $void (func))
+  ;; INCLUDE:      (type $void (func))
+  (type $void (func))
 
   ;; WITHOUT:      (type $1 (func (result i32)))
 
   ;; WITHOUT:      (type $2 (func (param i32)))
 
-  ;; WITHOUT:      (import "a" "b" (func $import (type $0)))
-  ;; INCLUDE:      (type $0 (func))
-
+  ;; WITHOUT:      (import "a" "b" (func $import (type $void)))
   ;; INCLUDE:      (type $1 (func (result i32)))
 
   ;; INCLUDE:      (type $2 (func (param i32)))
 
-  ;; INCLUDE:      (import "a" "b" (func $import (type $0)))
+  ;; INCLUDE:      (import "a" "b" (func $import (type $void)))
   (import "a" "b" (func $import))
 
+  ;; WITHOUT:      (table $t 0 funcref)
+  ;; INCLUDE:      (table $t 0 funcref)
+  (table $t funcref 0)
+
+  ;; WITHOUT:      (elem declare func $throw)
+
   ;; WITHOUT:      (tag $tag)
+  ;; INCLUDE:      (elem declare func $throw)
+
   ;; INCLUDE:      (tag $tag)
   (tag $tag)
 
-  ;; WITHOUT:      (func $main (type $0)
+  ;; WITHOUT:      (func $main (type $void)
   ;; WITHOUT-NEXT:  (call $nop)
   ;; WITHOUT-NEXT:  (call $unreachable)
   ;; WITHOUT-NEXT:  (call $call-nop)
@@ -39,7 +48,7 @@
   ;; WITHOUT-NEXT:  (call $throw)
   ;; WITHOUT-NEXT:  (call $throw-and-import)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $main (type $0)
+  ;; INCLUDE:      (func $main (type $void)
   ;; INCLUDE-NEXT:  (call $unreachable)
   ;; INCLUDE-NEXT:  (call $call-unreachable)
   ;; INCLUDE-NEXT:  (call $throw)
@@ -67,10 +76,10 @@
     (call $throw-and-import)
   )
 
-  ;; WITHOUT:      (func $cycle (type $0)
+  ;; WITHOUT:      (func $cycle (type $void)
   ;; WITHOUT-NEXT:  (call $cycle)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $cycle (type $0)
+  ;; INCLUDE:      (func $cycle (type $void)
   ;; INCLUDE-NEXT:  (call $cycle)
   ;; INCLUDE-NEXT: )
   (func $cycle
@@ -79,10 +88,10 @@
     (call $cycle)
   )
 
-  ;; WITHOUT:      (func $cycle-1 (type $0)
+  ;; WITHOUT:      (func $cycle-1 (type $void)
   ;; WITHOUT-NEXT:  (call $cycle-2)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $cycle-1 (type $0)
+  ;; INCLUDE:      (func $cycle-1 (type $void)
   ;; INCLUDE-NEXT:  (call $cycle-2)
   ;; INCLUDE-NEXT: )
   (func $cycle-1
@@ -90,40 +99,40 @@
     (call $cycle-2)
   )
 
-  ;; WITHOUT:      (func $cycle-2 (type $0)
+  ;; WITHOUT:      (func $cycle-2 (type $void)
   ;; WITHOUT-NEXT:  (call $cycle-1)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $cycle-2 (type $0)
+  ;; INCLUDE:      (func $cycle-2 (type $void)
   ;; INCLUDE-NEXT:  (call $cycle-1)
   ;; INCLUDE-NEXT: )
   (func $cycle-2
     (call $cycle-1)
   )
 
-  ;; WITHOUT:      (func $nop (type $0)
+  ;; WITHOUT:      (func $nop (type $void)
   ;; WITHOUT-NEXT:  (nop)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $nop (type $0)
+  ;; INCLUDE:      (func $nop (type $void)
   ;; INCLUDE-NEXT:  (nop)
   ;; INCLUDE-NEXT: )
   (func $nop
     (nop)
   )
 
-  ;; WITHOUT:      (func $unreachable (type $0)
+  ;; WITHOUT:      (func $unreachable (type $void)
   ;; WITHOUT-NEXT:  (unreachable)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $unreachable (type $0)
+  ;; INCLUDE:      (func $unreachable (type $void)
   ;; INCLUDE-NEXT:  (unreachable)
   ;; INCLUDE-NEXT: )
   (func $unreachable
     (unreachable)
   )
 
-  ;; WITHOUT:      (func $call-nop (type $0)
+  ;; WITHOUT:      (func $call-nop (type $void)
   ;; WITHOUT-NEXT:  (call $nop)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $call-nop (type $0)
+  ;; INCLUDE:      (func $call-nop (type $void)
   ;; INCLUDE-NEXT:  (nop)
   ;; INCLUDE-NEXT: )
   (func $call-nop
@@ -131,10 +140,10 @@
     (call $nop)
   )
 
-  ;; WITHOUT:      (func $call-unreachable (type $0)
+  ;; WITHOUT:      (func $call-unreachable (type $void)
   ;; WITHOUT-NEXT:  (call $unreachable)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $call-unreachable (type $0)
+  ;; INCLUDE:      (func $call-unreachable (type $void)
   ;; INCLUDE-NEXT:  (call $unreachable)
   ;; INCLUDE-NEXT: )
   (func $call-unreachable
@@ -172,7 +181,7 @@
     )
   )
 
-  ;; WITHOUT:      (func $call-throw-and-catch (type $0)
+  ;; WITHOUT:      (func $call-throw-and-catch (type $void)
   ;; WITHOUT-NEXT:  (try $try
   ;; WITHOUT-NEXT:   (do
   ;; WITHOUT-NEXT:    (call $throw)
@@ -190,7 +199,7 @@
   ;; WITHOUT-NEXT:   )
   ;; WITHOUT-NEXT:  )
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $call-throw-and-catch (type $0)
+  ;; INCLUDE:      (func $call-throw-and-catch (type $void)
   ;; INCLUDE-NEXT:  (try $try0
   ;; INCLUDE-NEXT:   (do
   ;; INCLUDE-NEXT:    (call $throw-and-import)
@@ -219,10 +228,10 @@
     )
   )
 
-  ;; WITHOUT:      (func $return-call-throw-and-catch (type $0)
+  ;; WITHOUT:      (func $return-call-throw-and-catch (type $void)
   ;; WITHOUT-NEXT:  (return_call $throw)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $return-call-throw-and-catch (type $0)
+  ;; INCLUDE:      (func $return-call-throw-and-catch (type $void)
   ;; INCLUDE-NEXT:  (return_call $throw)
   ;; INCLUDE-NEXT: )
   (func $return-call-throw-and-catch
@@ -238,7 +247,57 @@
     )
   )
 
-  ;; WITHOUT:      (func $call-return-call-throw-and-catch (type $0)
+  ;; WITHOUT:      (func $return-call-indirect-throw-and-catch (type $void)
+  ;; WITHOUT-NEXT:  (return_call_indirect $t (type $void)
+  ;; WITHOUT-NEXT:   (i32.const 0)
+  ;; WITHOUT-NEXT:  )
+  ;; WITHOUT-NEXT: )
+  ;; INCLUDE:      (func $return-call-indirect-throw-and-catch (type $void)
+  ;; INCLUDE-NEXT:  (return_call_indirect $t (type $void)
+  ;; INCLUDE-NEXT:   (i32.const 0)
+  ;; INCLUDE-NEXT:  )
+  ;; INCLUDE-NEXT: )
+  (func $return-call-indirect-throw-and-catch
+    (try
+      (do
+        ;; This call cannot be optimized out, as the target may throw. However,
+        ;; the surrounding try-catch can be removed even without global effects
+        ;; because the throw from the return_call is never observed by this
+        ;; try-catch.
+        (return_call_indirect
+          (i32.const 0)
+        )
+      )
+      (catch_all)
+    )
+  )
+
+  ;; WITHOUT:      (func $return-call-ref-throw-and-catch (type $void)
+  ;; WITHOUT-NEXT:  (return_call_ref $void
+  ;; WITHOUT-NEXT:   (ref.func $throw)
+  ;; WITHOUT-NEXT:  )
+  ;; WITHOUT-NEXT: )
+  ;; INCLUDE:      (func $return-call-ref-throw-and-catch (type $void)
+  ;; INCLUDE-NEXT:  (return_call_ref $void
+  ;; INCLUDE-NEXT:   (ref.func $throw)
+  ;; INCLUDE-NEXT:  )
+  ;; INCLUDE-NEXT: )
+  (func $return-call-ref-throw-and-catch
+    (try
+      (do
+        ;; This call cannot be optimized out, as the target may throw. However,
+        ;; the surrounding try-catch can be removed even without global effects
+        ;; because the throw from the return_call is never observed by this
+        ;; try-catch.
+        (return_call_ref $void
+          (ref.func $throw)
+        )
+      )
+      (catch_all)
+    )
+  )
+
+  ;; WITHOUT:      (func $call-return-call-throw-and-catch (type $void)
   ;; WITHOUT-NEXT:  (try $try
   ;; WITHOUT-NEXT:   (do
   ;; WITHOUT-NEXT:    (call $return-call-throw-and-catch)
@@ -247,10 +306,46 @@
   ;; WITHOUT-NEXT:    (nop)
   ;; WITHOUT-NEXT:   )
   ;; WITHOUT-NEXT:  )
+  ;; WITHOUT-NEXT:  (try $try1
+  ;; WITHOUT-NEXT:   (do
+  ;; WITHOUT-NEXT:    (call $return-call-indirect-throw-and-catch)
+  ;; WITHOUT-NEXT:   )
+  ;; WITHOUT-NEXT:   (catch_all
+  ;; WITHOUT-NEXT:    (nop)
+  ;; WITHOUT-NEXT:   )
+  ;; WITHOUT-NEXT:  )
+  ;; WITHOUT-NEXT:  (try $try2
+  ;; WITHOUT-NEXT:   (do
+  ;; WITHOUT-NEXT:    (call $return-call-ref-throw-and-catch)
+  ;; WITHOUT-NEXT:   )
+  ;; WITHOUT-NEXT:   (catch_all
+  ;; WITHOUT-NEXT:    (nop)
+  ;; WITHOUT-NEXT:   )
+  ;; WITHOUT-NEXT:  )
   ;; WITHOUT-NEXT:  (call $return-call-throw-and-catch)
+  ;; WITHOUT-NEXT:  (call $return-call-indirect-throw-and-catch)
+  ;; WITHOUT-NEXT:  (call $return-call-ref-throw-and-catch)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $call-return-call-throw-and-catch (type $0)
+  ;; INCLUDE:      (func $call-return-call-throw-and-catch (type $void)
+  ;; INCLUDE-NEXT:  (try $try1
+  ;; INCLUDE-NEXT:   (do
+  ;; INCLUDE-NEXT:    (call $return-call-indirect-throw-and-catch)
+  ;; INCLUDE-NEXT:   )
+  ;; INCLUDE-NEXT:   (catch_all
+  ;; INCLUDE-NEXT:    (nop)
+  ;; INCLUDE-NEXT:   )
+  ;; INCLUDE-NEXT:  )
+  ;; INCLUDE-NEXT:  (try $try2
+  ;; INCLUDE-NEXT:   (do
+  ;; INCLUDE-NEXT:    (call $return-call-ref-throw-and-catch)
+  ;; INCLUDE-NEXT:   )
+  ;; INCLUDE-NEXT:   (catch_all
+  ;; INCLUDE-NEXT:    (nop)
+  ;; INCLUDE-NEXT:   )
+  ;; INCLUDE-NEXT:  )
   ;; INCLUDE-NEXT:  (call $return-call-throw-and-catch)
+  ;; INCLUDE-NEXT:  (call $return-call-indirect-throw-and-catch)
+  ;; INCLUDE-NEXT:  (call $return-call-ref-throw-and-catch)
   ;; INCLUDE-NEXT: )
   (func $call-return-call-throw-and-catch
     (try
@@ -262,11 +357,29 @@
       )
       (catch_all)
     )
-    ;; This cannot be optimized out at all.
+    (try
+      (do
+        ;; This would be the same, except since it performs an indirect call, we
+        ;; conservatively assume it could have any effect, so we can't optimize.
+        (call $return-call-indirect-throw-and-catch)
+      )
+      (catch_all)
+    )
+    (try
+      (do
+        ;; Same here.
+        (call $return-call-ref-throw-and-catch)
+      )
+      (catch_all)
+    )
+
+    ;; These cannot be optimized out at all.
     (call $return-call-throw-and-catch)
+    (call $return-call-indirect-throw-and-catch)
+    (call $return-call-ref-throw-and-catch)
   )
 
-  ;; WITHOUT:      (func $call-unreachable-and-catch (type $0)
+  ;; WITHOUT:      (func $call-unreachable-and-catch (type $void)
   ;; WITHOUT-NEXT:  (try $try
   ;; WITHOUT-NEXT:   (do
   ;; WITHOUT-NEXT:    (call $unreachable)
@@ -276,7 +389,7 @@
   ;; WITHOUT-NEXT:   )
   ;; WITHOUT-NEXT:  )
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $call-unreachable-and-catch (type $0)
+  ;; INCLUDE:      (func $call-unreachable-and-catch (type $void)
   ;; INCLUDE-NEXT:  (call $unreachable)
   ;; INCLUDE-NEXT: )
   (func $call-unreachable-and-catch
@@ -346,20 +459,20 @@
     )
   )
 
-  ;; WITHOUT:      (func $throw (type $0)
+  ;; WITHOUT:      (func $throw (type $void)
   ;; WITHOUT-NEXT:  (throw $tag)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $throw (type $0)
+  ;; INCLUDE:      (func $throw (type $void)
   ;; INCLUDE-NEXT:  (throw $tag)
   ;; INCLUDE-NEXT: )
   (func $throw
     (throw $tag)
   )
 
-  ;; WITHOUT:      (func $throw-and-import (type $0)
+  ;; WITHOUT:      (func $throw-and-import (type $void)
   ;; WITHOUT-NEXT:  (throw $tag)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $throw-and-import (type $0)
+  ;; INCLUDE:      (func $throw-and-import (type $void)
   ;; INCLUDE-NEXT:  (throw $tag)
   ;; INCLUDE-NEXT: )
   (func $throw-and-import
@@ -374,11 +487,11 @@
     )
   )
 
-  ;; WITHOUT:      (func $cycle-with-unknown-call (type $0)
+  ;; WITHOUT:      (func $cycle-with-unknown-call (type $void)
   ;; WITHOUT-NEXT:  (call $cycle-with-unknown-call)
   ;; WITHOUT-NEXT:  (call $import)
   ;; WITHOUT-NEXT: )
-  ;; INCLUDE:      (func $cycle-with-unknown-call (type $0)
+  ;; INCLUDE:      (func $cycle-with-unknown-call (type $void)
   ;; INCLUDE-NEXT:  (call $cycle-with-unknown-call)
   ;; INCLUDE-NEXT:  (call $import)
   ;; INCLUDE-NEXT: )

--- a/test/lit/passes/global-effects.wast
+++ b/test/lit/passes/global-effects.wast
@@ -219,6 +219,53 @@
     )
   )
 
+  ;; WITHOUT:      (func $return-call-throw-and-catch (type $0)
+  ;; WITHOUT-NEXT:  (return_call $throw)
+  ;; WITHOUT-NEXT: )
+  ;; INCLUDE:      (func $return-call-throw-and-catch (type $0)
+  ;; INCLUDE-NEXT:  (return_call $throw)
+  ;; INCLUDE-NEXT: )
+  (func $return-call-throw-and-catch
+    (try
+      (do
+        ;; This call cannot be optimized out, as the target throws. However, the
+        ;; surrounding try-catch can be removed even without global effects
+        ;; because the throw from the return_call is never observed by this
+        ;; try-catch.
+        (return_call $throw)
+      )
+      (catch_all)
+    )
+  )
+
+  ;; WITHOUT:      (func $call-return-call-throw-and-catch (type $0)
+  ;; WITHOUT-NEXT:  (try $try
+  ;; WITHOUT-NEXT:   (do
+  ;; WITHOUT-NEXT:    (call $return-call-throw-and-catch)
+  ;; WITHOUT-NEXT:   )
+  ;; WITHOUT-NEXT:   (catch_all
+  ;; WITHOUT-NEXT:    (nop)
+  ;; WITHOUT-NEXT:   )
+  ;; WITHOUT-NEXT:  )
+  ;; WITHOUT-NEXT:  (call $return-call-throw-and-catch)
+  ;; WITHOUT-NEXT: )
+  ;; INCLUDE:      (func $call-return-call-throw-and-catch (type $0)
+  ;; INCLUDE-NEXT:  (call $return-call-throw-and-catch)
+  ;; INCLUDE-NEXT: )
+  (func $call-return-call-throw-and-catch
+    (try
+      (do
+        ;; Even though the body of the previous function is a try-catch_all, the
+        ;; function still throws because of its return_call, so this cannot be
+        ;; optimized out, but once again the entire try-catch can be.
+        (call $return-call-throw-and-catch)
+      )
+      (catch_all)
+    )
+    ;; This cannot be optimized out at all.
+    (call $return-call-throw-and-catch)
+  )
+
   ;; WITHOUT:      (func $call-unreachable-and-catch (type $0)
   ;; WITHOUT-NEXT:  (try $try
   ;; WITHOUT-NEXT:   (do

--- a/test/lit/passes/simplify-locals-eh-old.wast
+++ b/test/lit/passes/simplify-locals-eh-old.wast
@@ -152,6 +152,57 @@
     )
   )
 
+  ;; CHECK:      (func $return-call-can-be-sinked-into-try (type $3) (result i32)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (try $try (result i32)
+  ;; CHECK-NEXT:   (do
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (if (result i32)
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (return_call $return-call-can-be-sinked-into-try)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (else
+  ;; CHECK-NEXT:       (i32.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (catch $e-i32
+  ;; CHECK-NEXT:    (pop i32)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $return-call-can-be-sinked-into-try (result i32)
+    (local $0 i32)
+    (drop
+      ;; This cannot throw either, so it can be sunk. Wrap the return_call in an
+      ;; if so the whole expression does not return unconditionally.
+      (local.tee $0
+        (if (result i32)
+          (i32.const 0)
+          (then
+            (return_call $return-call-can-be-sinked-into-try)
+          )
+          (else
+            (i32.const 1)
+          )
+        )
+      )
+    )
+    (try (result i32)
+      (do
+        (drop (local.get $0))
+        (i32.const 0)
+      )
+      (catch $e-i32
+        (pop i32)
+      )
+    )
+  )
+
   ;; CHECK:      (func $equivalent-set-removal-call (type $1) (param $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (nop)


### PR DESCRIPTION
As far as their surrounding code is concerned return calls are no different from
normal returns. It's only from a caller's perspective that a function containing
a return call also has the effects of the return-callee. To model this more
precisely in EffectAnalyzer, stash the effects of return-callees on the side and
only merge them in at the end when analyzing the effects of a full function
body.