### PR TITLE
Fix isGenerative on calls and test via improving OptimizeInstructions::areConsecutiveInputsEqual()

### DIFF
--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -23,7 +23,13 @@ bool isGenerative(Expression* curr, FeatureSet features) {
   struct Scanner : public PostWalker<Scanner> {
     bool generative = false;
 
-    void visitCall(Call* curr) { generative = true; }
+    void visitCall(Call* curr) {
+      // TODO: We could in principle look at the called function to see if it is
+      //       generative. To do that we'd need to compute generativity like we
+      //       compute global effects (we can't just peek from here, as the
+      //       other function might be modified in parallel).
+      generative = true;
+    }
     void visitCallIndirect(CallIndirect* curr) { generative = true; }
     void visitCallRef(CallRef* curr) { generative = true; }
     void visitStructNew(StructNew* curr) { generative = true; }

--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -20,14 +20,12 @@
 namespace wasm::Properties {
 
 bool isGenerative(Expression* curr, FeatureSet features) {
-  // Practically no wasm instructions are generative. Exceptions occur only in
-  // GC atm.
-  if (!features.hasGC()) {
-    return false;
-  }
-
   struct Scanner : public PostWalker<Scanner> {
     bool generative = false;
+
+    void visitCall(Call* curr) { generative = true; }
+    void visitCallIndirect(CallIndirect* curr) { generative = true; }
+    void visitCallRef(CallRef* curr) { generative = true; }
     void visitStructNew(StructNew* curr) { generative = true; }
     void visitArrayNew(ArrayNew* curr) { generative = true; }
     void visitArrayNewFixed(ArrayNewFixed* curr) { generative = true; }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2295,7 +2295,7 @@ private:
   std::vector<LocalInfo> localInfo;
 
   // Checks if the first is a local.tee and the second a local.get of that same
-  // index. This is useful in the methods right before us, as it is a common
+  // index. This is useful in the methods right below us, as it is a common
   // pattern where two consecutive inputs are equal despite being syntactically
   // different.
   bool areMatchingTeeAndGet(Expression* left, Expression* right) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2300,8 +2300,11 @@ private:
   // different.
   bool areMatchingTeeAndGet(Expression* left, Expression* right) {
     auto& passOptions = getPassOptions();
-    left = Properties::getFallthrough(left, passOptions, *getModule(),
-                                      Properties::FallthroughBehavior::NoTeeBrIf);
+    left =
+      Properties::getFallthrough(left,
+                                 passOptions,
+                                 *getModule(),
+                                 Properties::FallthroughBehavior::NoTeeBrIf);
     if (auto* set = left->dynCast<LocalSet>()) {
       right = Properties::getFallthrough(right, passOptions, *getModule());
       if (auto* get = right->dynCast<LocalGet>()) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2294,13 +2294,36 @@ private:
   // Information about our locals
   std::vector<LocalInfo> localInfo;
 
+  // Checks if the first is a local.tee and the second a local.get of that same
+  // index. This is useful in the methods right before us, as it is a common
+  // pattern where two consecutive inputs are equal despite being syntactically
+  // different.
+  bool areMatchingTeeAndGet(Expression* left, Expression* right) {
+    auto& passOptions = getPassOptions();
+    left = Properties::getFallthrough(left, passOptions, *getModule(),
+                                      Properties::FallthroughBehavior::NoTeeBrIf);
+    if (auto* set = left->dynCast<LocalSet>()) {
+      right = Properties::getFallthrough(right, passOptions, *getModule());
+      if (auto* get = right->dynCast<LocalGet>()) {
+        if (set->isTee() && get->index == set->index) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   // Check if two consecutive inputs to an instruction are equal. As they are
   // consecutive, no code can execeute in between them, which simplies the
   // problem here (and which is the case we care about in this pass, which does
   // simple peephole optimizations - all we care about is a single instruction
   // at a time, and its inputs).
   bool areConsecutiveInputsEqual(Expression* left, Expression* right) {
-    // First, ignore extraneous things and compare them syntactically.
+    if (areMatchingTeeAndGet(left, right)) {
+      return true;
+    }
+
+    // Ignore extraneous things and compare them syntactically.
     auto& passOptions = getPassOptions();
     left = Properties::getFallthrough(left, passOptions, *getModule());
     right = Properties::getFallthrough(right, passOptions, *getModule());
@@ -2343,13 +2366,10 @@ private:
   // side effects at all in the middle. For example, a Const in between is ok.
   bool areConsecutiveInputsEqualAndFoldable(Expression* left,
                                             Expression* right) {
-    if (auto* set = left->dynCast<LocalSet>()) {
-      if (auto* get = right->dynCast<LocalGet>()) {
-        if (set->isTee() && get->index == set->index) {
-          return true;
-        }
-      }
+    if (areMatchingTeeAndGet(left, right)) {
+      return true;
     }
+
     // stronger property than we need - we can not only fold
     // them but remove them entirely.
     return areConsecutiveInputsEqualAndRemovable(left, right);

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2316,23 +2316,24 @@ private:
   // at a time, and its inputs).
   bool areConsecutiveInputsEqual(Expression* left, Expression* right) {
     // When we look for a tee/get pair, we can consider the fallthrough values
-    // for both, as we are considering equality and not thinking about whether
-    // we can remove them or not. (However, we must use NoTeeBrIf as we do not
-    // want to look through the tee.)
+    // for the first, as the fallthrough happens last (however, we must use
+    // NoTeeBrIf as we do not want to look through the tee). We cannot do this
+    // on the second, however, as there could be effects in the middle.
+    // TODO: Use effects here perhaps.
     auto& passOptions = getPassOptions();
     left =
       Properties::getFallthrough(left,
                                  passOptions,
                                  *getModule(),
                                  Properties::FallthroughBehavior::NoTeeBrIf);
-    right = Properties::getFallthrough(right, passOptions, *getModule());
     if (areMatchingTeeAndGet(left, right)) {
       return true;
     }
 
     // Ignore extraneous things and compare them syntactically. We can also
-    // look at the full fallthrough for the left side now.
+    // look at the full fallthrough for both sides now.
     left = Properties::getFallthrough(left, passOptions, *getModule());
+    right = Properties::getFallthrough(right, passOptions, *getModule());
     if (!ExpressionAnalyzer::equal(left, right)) {
       return false;
     }

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -14918,6 +14918,38 @@
       )
     ))
   )
+  ;; CHECK:      (func $optimize-float-points-fallthrough-cc (param $x f64) (param $xb f64) (param $y f32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.mul
+  ;; CHECK-NEXT:    (block (result f64)
+  ;; CHECK-NEXT:     (call $set-i32
+  ;; CHECK-NEXT:      (i32.const 42)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.tee $x
+  ;; CHECK-NEXT:      (f64.const 12.34)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $optimize-float-points-fallthrough-cc (param $x f64) (param $xb f64) (param $y f32)
+    ;; Removing the local.set and the block on the right lets us optimize using
+    ;; the tee/get pair.
+    (drop (f64.abs
+      (f64.mul
+        (block (result f64)
+          (call $set-i32
+            (i32.const 42)
+          )
+          (local.tee $x
+            (f64.const 12.34)
+          )
+        )
+        (local.get $x)         ;; this moved out
+      )
+    ))
+  )
   ;; CHECK:      (func $optimize-float-points-fallthrough-d (param $x f64) (param $xb f64) (param $y f32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (f64.abs

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -14873,7 +14873,7 @@
           (call $set-i32
             (i32.const 42)
           )
-          (local.tee $x         ;; this changes
+          (local.tee $x         ;; this changed
             (f64.const 12.34)
           )
         )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -15274,6 +15274,88 @@
       )
     )
   )
+  ;; CHECK:      (func $ternary-identical-arms-tee (param $param i32)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (local.tee $x
+  ;; CHECK-NEXT:     (local.get $param)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (call $send-i32
+  ;; CHECK-NEXT:      (i32.const 42)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (call $send-i32
+  ;; CHECK-NEXT:      (i32.const 1337)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.tee $x
+  ;; CHECK-NEXT:      (local.get $param)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (local.tee $x
+  ;; CHECK-NEXT:    (local.get $param)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $ternary-identical-arms-tee (param $param i32)
+    (local $x i32)
+    ;; The select's ifTrue and condition are equal (as a tee/get pair with
+    ;; only a const in between), but there is a side effect too, that prevents
+    ;; optimization atm TODO
+    (drop
+      (select
+        (local.tee $x
+          (local.get $param)
+        )
+        (i32.const 0)
+        (block (result i32)
+          (call $send-i32
+            (i32.const 42)
+          )
+          (local.get $x)
+        )
+      )
+    )
+    ;; Side effect on the ifTrue - same outcome, we cannot optimize yet.
+    (drop
+      (select
+        (block (result i32)
+          (call $send-i32
+            (i32.const 1337)
+          )
+          (local.tee $x
+            (local.get $param)
+          )
+        )
+        (i32.const 0)
+        (local.get $x)
+      )
+    )
+    ;; When there are no blocks or things and just a local.tee/get, we can
+    ;; optimize.
+    (drop
+      (select
+        (local.tee $x
+          (local.get $param)
+        )
+        (i32.const 0)
+        (local.get $x)
+      )
+    )
+  )
   ;; CHECK:      (func $ternary-identical-arms-and-type-is-none (param $x i32) (param $y i32) (param $z i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -14769,62 +14769,6 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.abs
-  ;; CHECK-NEXT:    (f64.mul
-  ;; CHECK-NEXT:     (block (result f64)
-  ;; CHECK-NEXT:      (call $set-i32
-  ;; CHECK-NEXT:       (i32.const 42)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (call $get-f64)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result f64)
-  ;; CHECK-NEXT:      (call $set-i32
-  ;; CHECK-NEXT:       (i32.const 1337)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (call $get-f64)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.mul
-  ;; CHECK-NEXT:    (block (result f64)
-  ;; CHECK-NEXT:     (call $set-i32
-  ;; CHECK-NEXT:      (i32.const 42)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (local.tee $x
-  ;; CHECK-NEXT:      (f64.const 12.34)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (block (result f64)
-  ;; CHECK-NEXT:     (call $set-i32
-  ;; CHECK-NEXT:      (i32.const 1337)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (f64.abs
-  ;; CHECK-NEXT:    (f64.mul
-  ;; CHECK-NEXT:     (block (result f64)
-  ;; CHECK-NEXT:      (call $set-i32
-  ;; CHECK-NEXT:       (i32.const 42)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.tee $x
-  ;; CHECK-NEXT:       (f64.const 12.34)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result f64)
-  ;; CHECK-NEXT:      (call $set-i32
-  ;; CHECK-NEXT:       (i32.const 1337)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $xb)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $optimize-float-points-fallthrough (param $x f64) (param $xb f64) (param $y f32)
     ;; abs(x * x)   ==>   x * x  , as in the previous function.
@@ -14847,7 +14791,28 @@
         )
       )
     ))
-
+  )
+  ;; CHECK:      (func $optimize-float-points-fallthrough-b (param $x f64) (param $xb f64) (param $y f32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.abs
+  ;; CHECK-NEXT:    (f64.mul
+  ;; CHECK-NEXT:     (block (result f64)
+  ;; CHECK-NEXT:      (call $set-i32
+  ;; CHECK-NEXT:       (i32.const 42)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (call $get-f64)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block (result f64)
+  ;; CHECK-NEXT:      (call $set-i32
+  ;; CHECK-NEXT:       (i32.const 1337)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (call $get-f64)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $optimize-float-points-fallthrough-b (param $x f64) (param $xb f64) (param $y f32)
     ;; But generative effects in the fallthrough values themselves block us.
     (drop (f64.abs
       (f64.mul
@@ -14865,7 +14830,28 @@
         )
       )
     ))
-
+  )
+  ;; CHECK:      (func $optimize-float-points-fallthrough-c (param $x f64) (param $xb f64) (param $y f32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.mul
+  ;; CHECK-NEXT:    (block (result f64)
+  ;; CHECK-NEXT:     (call $set-i32
+  ;; CHECK-NEXT:      (i32.const 42)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.tee $x
+  ;; CHECK-NEXT:      (f64.const 12.34)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result f64)
+  ;; CHECK-NEXT:     (call $set-i32
+  ;; CHECK-NEXT:      (i32.const 1337)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $optimize-float-points-fallthrough-c (param $x f64) (param $xb f64) (param $y f32)
     ;; local.tee/get pairs are ok, though.
     (drop (f64.abs
       (f64.mul
@@ -14885,7 +14871,30 @@
         )
       )
     ))
-
+  )
+  ;; CHECK:      (func $optimize-float-points-fallthrough-d (param $x f64) (param $xb f64) (param $y f32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (f64.abs
+  ;; CHECK-NEXT:    (f64.mul
+  ;; CHECK-NEXT:     (block (result f64)
+  ;; CHECK-NEXT:      (call $set-i32
+  ;; CHECK-NEXT:       (i32.const 42)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.tee $x
+  ;; CHECK-NEXT:       (f64.const 12.34)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (block (result f64)
+  ;; CHECK-NEXT:      (call $set-i32
+  ;; CHECK-NEXT:       (i32.const 1337)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $xb)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $optimize-float-points-fallthrough-d (param $x f64) (param $xb f64) (param $y f32)
     ;; The wrong local index means we fail again.
     (drop (f64.abs
       (f64.mul
@@ -14906,7 +14915,6 @@
       )
     ))
   )
-
   ;; CHECK:      (func $ternary (param $x i32) (param $y i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz


### PR DESCRIPTION
"Generative" is what we call something like a `struct.new` that may be syntactically
identical to another `struct.new`, but each time a new value is generated. The same
is true for calls, which can do anything, including return a different value for
syntactically identical calls.

This was not a bug because the main user of `isGenerative`,
`areConsecutiveInputsEqual()`, was too weak to notice, that is, it gave up sooner,
for other reasons. This PR improves that function to do a much better check,
which makes the fix necessary to prevent regressions.

This is not terribly important for itself, but will help a later PR that will add code
that depends more heavily on `areConsecutiveInputsEqual()`.