### PR TITLE
Ensure printed tuple.extract arity is valid

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -18,6 +18,8 @@
 // Print out text in s-expression format
 //
 
+#include <algorithm>
+
 #include <ir/iteration.h>
 #include <ir/module-utils.h>
 #include <ir/table-utils.h>
@@ -2019,9 +2021,7 @@ struct PrintExpressionContents
     // If the tuple is unreachable, its size will be reported as 1, but that's
     // not a valid tuple size. The size we print mostly doesn't matter if the
     // tuple is unreachable, but it does have to be valid.
-    auto arity = curr->tuple->type.size();
-    arity = arity < 2 ? 2 : arity;
-    o << arity << " ";
+    o << std::max(curr->tuple->type.size(), size_t(2)) << " ";
     o << curr->index;
   }
   void visitRefI31(RefI31* curr) { printMedium(o, "ref.i31"); }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2016,7 +2016,12 @@ struct PrintExpressionContents
   }
   void visitTupleExtract(TupleExtract* curr) {
     printMedium(o, "tuple.extract ");
-    o << curr->tuple->type.size() << " ";
+    // If the tuple is unreachable, its size will be reported as 1, but that's
+    // not a valid tuple size. The size we print mostly doesn't matter if the
+    // tuple is unreachable, but it does have to be valid.
+    auto arity = curr->tuple->type.size();
+    arity = arity < 2 ? 2 : arity;
+    o << arity << " ";
     o << curr->index;
   }
   void visitRefI31(RefI31* curr) { printMedium(o, "ref.i31"); }

--- a/test/lit/passes/optimize-instructions-multivalue.wast
+++ b/test/lit/passes/optimize-instructions-multivalue.wast
@@ -103,7 +103,7 @@
   )
 
   ;; CHECK:      (func $extract-make-unreachable (param $x i32) (param $y i32) (result i32)
-  ;; CHECK-NEXT:  (tuple.extract 1 0
+  ;; CHECK-NEXT:  (tuple.extract 2 0
   ;; CHECK-NEXT:   (tuple.make 2
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:    (local.get $y)

--- a/test/lit/passes/tuple-optimization.wast
+++ b/test/lit/passes/tuple-optimization.wast
@@ -580,12 +580,12 @@
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 1 0
+  ;; CHECK-NEXT:   (tuple.extract 2 0
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (tuple.extract 1 1
+  ;; CHECK-NEXT:   (tuple.extract 2 1
   ;; CHECK-NEXT:    (local.tee $tuple
   ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )


### PR DESCRIPTION
We previously printed the size of the tuple operand as the arity, but that
printed `1` when the operand is unreachable. We don't allow our text input to
use `1` as the arity, so don't print it, either. Instead, print the smallest
valid arity, `2`, in this case.