### PR TITLE
[Parser] Use unreachables to fulfill tuple requirements

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -175,6 +175,8 @@ Result<Expression*> IRBuilder::pop(size_t size) {
   CHECK_ERR(packageHoistedValue(*hoisted, size));
 
   auto* ret = scope.exprStack.back();
+  // If the top value has the correct size, we can pop it and be done.
+  // Unreachable values satisfy any size.
   if (ret->type.size() == size || ret->type == Type::unreachable) {
     scope.exprStack.pop_back();
     return ret;

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -175,7 +175,7 @@ Result<Expression*> IRBuilder::pop(size_t size) {
   CHECK_ERR(packageHoistedValue(*hoisted, size));
 
   auto* ret = scope.exprStack.back();
-  if (ret->type.size() == size) {
+  if (ret->type.size() == size || ret->type == Type::unreachable) {
     scope.exprStack.pop_back();
     return ret;
   }

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -3652,10 +3652,7 @@
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (return
- ;; CHECK-NEXT:   (tuple.make 2
- ;; CHECK-NEXT:    (unreachable)
- ;; CHECK-NEXT:    (unreachable)
- ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $return-two-second-unreachable (param i32) (result i32 i64)


### PR DESCRIPTION
When we need to pop a tuple and the top value on the stack is unreachable, just
pop the unreachable rather than producing a tuple.make. This always produces
valid IR since an unreachable is always valid where a tuple would otherwise be
expected. It also avoids bloating the parsed IR, since we would previously parse
a `tuple.make` where all the children were unreachable in this case.