### PR TITLE
GUFA: Fix signed reads of packed GC data

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -2311,7 +2311,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
     if (exprLoc->expr->is<StructGet>() || exprLoc->expr->is<ArrayGet>()) {
       // Packed data reads must be filtered before the combine() operation, as
       // we must only combine the filtered contents (e.g. if 0xff arrives which
-      // as a signed read is truly 0xffffffff then cannot first combine the
+      // as a signed read is truly 0xffffffff then we cannot first combine the
       // existing 0xffffffff with the new 0xff, as they are different, and the
       // result will no longer be a constant).
       filterPackedDataReads(newContents, *exprLoc);

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -446,6 +446,11 @@ struct SignatureResultLocation {
 // The location of contents in a struct or array (i.e., things that can fit in a
 // dataref). Note that this is specific to this type - it does not include data
 // about subtypes or supertypes.
+//
+// We store the truncated bits here when the field is packed. That is, if -1 is
+// written to an i8 then the value here will be 0xff. StructGet/ArrayGet
+// operations that read a signed value must then perform a sign-extend
+// operation.
 struct DataLocation {
   HeapType type;
   // The index of the field in a struct, or 0 for an array (where we do not

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -5622,6 +5622,49 @@
   )
 )
 
+;; Packed fields with signed gets.
+(module
+  ;; CHECK:      (type $struct (struct (field i16)))
+  (type $struct (struct (field i16)))
+
+  ;; CHECK:      (type $1 (func))
+
+  ;; CHECK:      (func $test-struct (type $1)
+  ;; CHECK-NEXT:  (local $x (ref $struct))
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (struct.new $struct
+  ;; CHECK-NEXT:    (i32.const -1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const -1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 65535)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test-struct
+    (local $x (ref $struct))
+    (local.set $x
+      (struct.new $struct
+        (i32.const -1)
+      )
+    )
+    ;; This reads -1.
+    (drop
+      (struct.get_s $struct 0
+        (local.get $x)
+      )
+    )
+    ;; This reads 65535, as the other bits were truncated.
+    (drop
+      (struct.get_u $struct 0
+        (local.get $x)
+      )
+    )
+  )
+)
+
 ;; Test that we do not error on array.init of a bottom type.
 (module
   (type $"[mut:i32]" (array (mut i32)))

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -5624,10 +5624,14 @@
 
 ;; Packed fields with signed gets.
 (module
+  ;; CHECK:      (type $array (array (mut i8)))
+
+  ;; CHECK:      (type $1 (func))
+
   ;; CHECK:      (type $struct (struct (field i16)))
   (type $struct (struct (field i16)))
 
-  ;; CHECK:      (type $1 (func))
+  (type $array (array (mut i8)))
 
   ;; CHECK:      (func $test-struct (type $1)
   ;; CHECK-NEXT:  (local $x (ref $struct))
@@ -5660,6 +5664,59 @@
     (drop
       (struct.get_u $struct 0
         (local.get $x)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $test-array (type $1)
+  ;; CHECK-NEXT:  (local $x (ref $array))
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (array.new_fixed $array 1
+  ;; CHECK-NEXT:    (i32.const -1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (array.get_s $array
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const -1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (array.get_u $array
+  ;; CHECK-NEXT:      (local.get $x)
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 255)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test-array
+    (local $x (ref $array))
+    (local.set $x
+      (array.new_fixed $array 1
+        (i32.const -1)
+      )
+    )
+    ;; This reads -1.
+    (drop
+      (array.get_s $array
+        (local.get $x)
+        (i32.const 0)
+      )
+    )
+    ;; This reads 255, as the other bits were truncated.
+    (drop
+      (array.get_u $array
+        (local.get $x)
+        (i32.const 0)
       )
     )
   )


### PR DESCRIPTION
GUFA already truncated packed fields on write, which is enough for unsigned gets,
but for signed gets we also need to sign them on reads.

Similar to https://github.com/WebAssembly/binaryen/pull/6493 but for GUFA. Also found by https://github.com/WebAssembly/binaryen/pull/6486