### PR TITLE
When creating `dynCall` and `legalstub` function mark them as hasExplicitName. NFC

### DIFF
--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -149,6 +149,7 @@ void GenerateDynCalls::generateDynCallThunk(HeapType funcType) {
   }
   auto f = builder.makeFunction(
     name, std::move(namedParams), Signature(Type(params), sig.results), {});
+  f->hasExplicitName = true;
   Expression* fptr = builder.makeLocalGet(0, Type::i32);
   std::vector<Expression*> args;
   Index i = 0;

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -229,6 +229,7 @@ private:
     Builder builder(*module);
     auto* legal = new Function();
     legal->name = legalName;
+    legal->hasExplicitName = true;
 
     auto* call = module->allocator.alloc<Call>();
     call->target = func->name;


### PR DESCRIPTION
This is temporary workaround for the current test failures on the emscripten waterfall.  The real fix I believe will be to make `hasExplicitName` the default in these kinds of cases.

See: #6466