### PR TITLE
Remove unused options from wasm-shell

### DIFF
--- a/test/lit/help/wasm-shell.test
+++ b/test/lit/help/wasm-shell.test
@@ -6,14 +6,6 @@
 ;; CHECK-NEXT: ================================================================================
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:
-;; CHECK-NEXT: wasm-shell options:
-;; CHECK-NEXT: -------------------
-;; CHECK-NEXT:
-;; CHECK-NEXT:   --entry,-e Call the entry point after parsing the module
-;; CHECK-NEXT:
-;; CHECK-NEXT:   --skip,-s  Skip input on certain lines (comma-separated-list)
-;; CHECK-NEXT:
-;; CHECK-NEXT:
 ;; CHECK-NEXT: General options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:


### PR DESCRIPTION
None of our tests exercised the --entry or --skip options in wasm-shell, and
since wasm-shell is probably not used for anything outside our testing, there's
no reason to keep them. Remove them.