### PR TITLE
[Strings] Fix finalize() of StringNew on arrays

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1249,7 +1249,9 @@ void RefAs::finalize() {
 
 void StringNew::finalize() {
   if (ptr->type == Type::unreachable ||
-      (length && length->type == Type::unreachable)) {
+      (length && length->type == Type::unreachable) ||
+      (start && start->type == Type::unreachable) ||
+      (end && end->type == Type::unreachable)) {
     type = Type::unreachable;
   } else {
     type = Type(HeapType::string, try_ ? Nullable : NonNullable);


### PR DESCRIPTION
We added two fields to StringNew at some point but forgot to update the finalize method.