### PR TITLE
[Parser][NFC] Do less work when parsing function types

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -173,6 +173,8 @@ struct NullTypeParserCtx {
   BlockTypeT getBlockTypeFromResult(size_t results) { return Ok{}; }
 
   Result<> getBlockTypeFromTypeUse(Index, TypeUseT) { return Ok{}; }
+
+  bool skipFunctionBody() { return false; }
 };
 
 template<typename Ctx> struct TypeParserCtx {
@@ -310,6 +312,8 @@ template<typename Ctx> struct TypeParserCtx {
     assert(results.size() == 1);
     return HeapType(Signature(Type::none, results[0]));
   }
+
+  bool skipFunctionBody() { return false; }
 };
 
 struct NullInstrParserCtx {
@@ -1197,6 +1201,8 @@ struct ParseModuleTypesCtx : TypeParserCtx<ParseModuleTypesCtx>,
     : TypeParserCtx<ParseModuleTypesCtx>(typeIndices), in(in), wasm(wasm),
       types(types), implicitTypes(implicitTypes),
       implicitElemIndices(implicitElemIndices) {}
+
+  bool skipFunctionBody() { return true; }
 
   Result<HeapTypeT> getHeapTypeFromIdx(Index idx) {
     if (idx >= types.size()) {

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -3028,11 +3028,13 @@ template<typename Ctx> MaybeResult<> func(Ctx& ctx) {
       CHECK_ERR(l);
       localVars = *l;
     }
-    CHECK_ERR(instrs(ctx));
-    ctx.setSrcLoc(ctx.in.takeAnnotations());
+    if (!ctx.skipFunctionBody()) {
+      CHECK_ERR(instrs(ctx));
+      ctx.setSrcLoc(ctx.in.takeAnnotations());
+    }
   }
 
-  if (!ctx.in.takeRParen()) {
+  if (!ctx.skipFunctionBody() && !ctx.in.takeRParen()) {
     return ctx.in.err("expected end of function");
   }
 


### PR DESCRIPTION
After the initial parsing pass to find the locations of all the module elements
and after the type definitions have been parsed, the next phase of parsing is to
visit all of the module elements and parse their types. This phase does not
require parsing function bodies, but it previously parsed entire functions
anyway for simplicity. To improve performance, skip that useless work.