### PR TITLE
Source maps: allow to specify that an expression has no debug info in text parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,33 @@ environment. That will print this for the above `add`:
 (full print mode also adds a `[type]` for each expression, right before the
 debug location).
 
+The debug information is also propagated from an expression to its
+next sibling:
+```wat
+;;@ src.cpp:100:33
+(local.set $x
+ (i32.const 0)
+)
+(local.set $y ;; This receives an annotation of src.cpp:100:33
+ (i32.const 0)
+)
+```
+
+You can prevent the propagation of debug info by explicitly mentioning
+that an expression has not debug info using the annotation `;;@` with
+nothing else:
+```wat
+;;@ src.cpp:100:33
+(local.set $x
+ ;;@
+ (i32.const 0) ;; This does not receive any annotation
+)
+;;@
+(local.set $y ;; This does not receive any annotation
+ (i32.const 0)
+)
+```
+
 There is no shorthand in the binary format. That is, roundtripping (writing and
 reading) through a binary + source map should not change which expressions have
 debug info on them or the contents of that info.

--- a/README.md
+++ b/README.md
@@ -947,9 +947,11 @@ nothing else:
 )
 ;;@
 (local.set $y ;; This does not receive any annotation
- (i32.const 0)
+ (i32.const 7)
 )
 ```
+This stops the propagatation to children and siblings as well. So,
+expression `(i32.const 7)` does not have any debug info either.
 
 There is no shorthand in the binary format. That is, roundtripping (writing and
 reading) through a binary + source map should not change which expressions have

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -60,7 +60,9 @@ Function* copyFunction(Function* func,
   // Update file indices if needed
   if (fileIndexMap) {
     for (auto& iter : ret->debugLocations) {
-      iter.second.fileIndex = (*fileIndexMap)[iter.second.fileIndex];
+      if (iter.second) {
+        iter.second->fileIndex = (*fileIndexMap)[iter.second->fileIndex];
+      }
     }
     updateLocationSet(ret->prologLocation, *fileIndexMap);
     updateLocationSet(ret->epilogLocation, *fileIndexMap);

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1723,7 +1723,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     }
     Lexer lexer(annotation->contents);
     if (lexer.empty()) {
-      irBuilder.setDebugLocation({0, 0, 0});
+      irBuilder.setDebugLocation(std::nullopt);
       return;
     }
 
@@ -1762,7 +1762,8 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
       assert(wasm.debugInfoFileNames.size() == it->second);
       wasm.debugInfoFileNames.push_back(std::string(file));
     }
-    irBuilder.setDebugLocation({it->second, *line, *col});
+    irBuilder.setDebugLocation(
+      Function::DebugLocation({it->second, *line, *col}));
   }
 
   Result<> makeBlock(Index pos,

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1722,6 +1722,11 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
       return;
     }
     Lexer lexer(annotation->contents);
+    if (lexer.empty()) {
+      irBuilder.setDebugLocation({0, 0, 0});
+      return;
+    }
+
     auto contents = lexer.takeKeyword();
     if (!contents || !lexer.empty()) {
       return;

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -120,7 +120,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
   // Keep track of the last printed debug location to avoid printing
   // repeated debug locations for children. nullopt means that we have
   // not yet printed any debug location, or that we last printed an
-  // annotation indicating that the expression had not associated
+  // annotation indicating that the expression had no associated
   // debug location.
   std::optional<Function::DebugLocation> lastPrintedLocation;
   bool debugInfo;

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -117,6 +117,11 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
 
   Module* currModule = nullptr;
   Function* currFunction = nullptr;
+  // Keep track of the last printed debug location to avoid printing
+  // repeated debug locations for children. nullopt means that we have
+  // not yet printed any debug location, or that we last printed an
+  // annotation indicating that the expression had not associated
+  // debug location.
   std::optional<Function::DebugLocation> lastPrintedLocation;
   bool debugInfo;
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2481,9 +2481,14 @@ void PrintSExpression::printDebugLocation(
   }
   lastPrintedLocation = location;
   lastPrintIndent = indent;
-  auto fileName = currModule->debugInfoFileNames[location.fileIndex];
-  o << ";;@ " << fileName << ":" << location.lineNumber << ":"
-    << location.columnNumber << '\n';
+  Function::DebugLocation noLocation = {0, 0, 0};
+  if (location == noLocation) {
+    o << ";;@\n";
+  } else {
+    auto fileName = currModule->debugInfoFileNames[location.fileIndex];
+    o << ";;@ " << fileName << ":" << location.lineNumber << ":"
+      << location.columnNumber << '\n';
+  }
   doIndent(o, indent);
 }
 
@@ -2494,6 +2499,8 @@ void PrintSExpression::printDebugLocation(Expression* curr) {
     auto iter = debugLocations.find(curr);
     if (iter != debugLocations.end()) {
       printDebugLocation(iter->second);
+    } else {
+      printDebugLocation({0, 0, 0});
     }
     // show a binary position, if there is one
     if (debugInfo) {
@@ -2968,6 +2975,7 @@ void PrintSExpression::visitDefinedFunction(Function* curr) {
   doIndent(o, indent);
   currFunction = curr;
   lastPrintedLocation = {0, 0, 0};
+  lastPrintIndent = 0;
   if (currFunction->prologLocation.size()) {
     printDebugLocation(*currFunction->prologLocation.begin());
   }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2475,6 +2475,9 @@ std::ostream& PrintSExpression::printPrefixedTypes(const char* prefix,
 
 void PrintSExpression::printDebugLocation(
   const std::optional<Function::DebugLocation>& location) {
+  if (minify) {
+    return;
+  }
   // Do not skip repeated debug info in full mode, for less-confusing debugging:
   // full mode prints out everything in the most verbose manner.
   if (lastPrintedLocation == location && indent > lastPrintIndent && !full) {

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -238,13 +238,17 @@ private:
   Module& wasm;
   Function* func;
   Builder builder;
-  // We distinguish three cases:
-  // - no debug location has been specified for the next instruction;
-  //   then this instruction may inherit a debug location from its
-  //   parent or a previous sibling;
-  // - we explicitly specified that this instruction has no debug location;
-  // - we provided a debug location for this instruction.
-  std::optional<std::optional<Function::DebugLocation>> debugLoc;
+
+  // The location lacks debug info as it was marked as not having it.
+  struct NoDebug : public std::monostate {};
+  // The location lacks debug info, but was not marked as not having
+  // it, and it can receive it from the parent or its previous sibling
+  // (if it has one).
+  struct CanReceiveDebug : public std::monostate {};
+  using DebugVariant =
+    std::variant<NoDebug, CanReceiveDebug, Function::DebugLocation>;
+
+  DebugVariant debugLoc;
 
   struct ChildPopper;
 

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -58,7 +58,7 @@ public:
 
   // Set the debug location to be attached to the next visited, created, or
   // pushed instruction.
-  void setDebugLocation(const Function::DebugLocation&);
+  void setDebugLocation(const std::optional<Function::DebugLocation>&);
 
   // Handle the boundaries of control flow structures. Users may choose to use
   // the corresponding `makeXYZ` function below instead of `visitXYZStart`, but
@@ -238,7 +238,7 @@ private:
   Module& wasm;
   Function* func;
   Builder builder;
-  std::optional<Function::DebugLocation> debugLoc;
+  std::optional<std::optional<Function::DebugLocation>> debugLoc;
 
   struct ChildPopper;
 

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -238,6 +238,12 @@ private:
   Module& wasm;
   Function* func;
   Builder builder;
+  // We distinguish three cases:
+  // - no debug location has been specified for the next instruction;
+  //   then this instruction may inherit a debug location from its
+  //   parent or a previous sibling;
+  // - we explicitly specified that this instruction has no debug location;
+  // - we provided a debug location for this instruction.
   std::optional<std::optional<Function::DebugLocation>> debugLoc;
 
   struct ChildPopper;

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2185,7 +2185,9 @@ public:
                    : columnNumber < other.columnNumber;
     }
   };
-  std::unordered_map<Expression*, DebugLocation> debugLocations;
+  // One can explicitly set the debug location of an expression to
+  // nullopt to stop the propagation of debug locations.
+  std::unordered_map<Expression*, std::optional<DebugLocation>> debugLocations;
   std::set<DebugLocation> prologLocation;
   std::set<DebugLocation> epilogLocation;
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1401,9 +1401,9 @@ void WasmBinaryWriter::writeDebugLocation(Expression* curr, Function* func) {
   if (sourceMap) {
     auto& debugLocations = func->debugLocations;
     auto iter = debugLocations.find(curr);
-    if (iter != debugLocations.end()) {
+    if (iter != debugLocations.end() && iter->second) {
       // There is debug information here, write it out.
-      writeDebugLocation(iter->second);
+      writeDebugLocation(*(iter->second));
     } else {
       // This expression has no debug location.
       writeNoDebugLocation();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1990,8 +1990,11 @@ Expression* SExpressionWasmBuilder::makeConst(Element& s, Type type) {
   return ret;
 }
 
-static size_t parseMemAttributes(
-  size_t i, Element& s, Address& offset, Address& align, bool memory64) {
+static size_t parseMemAttributes(size_t i,
+                                 Element& s,
+                                 Address& offset,
+                                 Address& align,
+                                 bool memory64) {
   // Parse "align=X" and "offset=X" arguments, bailing out on anything else.
   while (!s[i]->isList()) {
     const char* str = s[i]->str().str.data();

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -219,6 +219,10 @@ void SExpressionParser::parseDebugLocation() {
   while (debugLocEnd[0] && debugLocEnd[0] != '\n') {
     debugLocEnd++;
   }
+  if (debugLocEnd == debugLoc) {
+    loc = nullptr;
+    return;
+  }
   char const* pos = debugLoc;
   while (pos < debugLocEnd && pos[0] != ':') {
     pos++;
@@ -1986,11 +1990,8 @@ Expression* SExpressionWasmBuilder::makeConst(Element& s, Type type) {
   return ret;
 }
 
-static size_t parseMemAttributes(size_t i,
-                                 Element& s,
-                                 Address& offset,
-                                 Address& align,
-                                 bool memory64) {
+static size_t parseMemAttributes(
+  size_t i, Element& s, Address& offset, Address& align, bool memory64) {
   // Parse "align=X" and "offset=X" arguments, bailing out on anything else.
   while (!s[i]->isList()) {
     const char* str = s[i]->str().str.data();

--- a/test/example/debug-location-propagation.cpp
+++ b/test/example/debug-location-propagation.cpp
@@ -33,10 +33,10 @@ int main() {
 
   auto& debugLocations = module->getFunction("adder")->debugLocations;
   assert(debugLocations.size() == 4);
-  assert(debugLocations[x].columnNumber == 13);
-  assert(debugLocations[y].columnNumber == 13);
-  assert(debugLocations[add].columnNumber == 2);
-  assert(debugLocations[drop].columnNumber == 2);
+  assert(debugLocations[x]->columnNumber == 13);
+  assert(debugLocations[y]->columnNumber == 13);
+  assert(debugLocations[add]->columnNumber == 2);
+  assert(debugLocations[drop]->columnNumber == 2);
 
   BinaryenSetDebugInfo(false);
   BinaryenModuleDispose(module);

--- a/test/lit/debug/source-map-stop.wast
+++ b/test/lit/debug/source-map-stop.wast
@@ -124,4 +124,41 @@
     ;;@ waka:200:2
     (i32.const 2)
   )
+
+  ;; CHECK:      (func $foo (param $x i32) (param $y i32)
+  ;; CHECK-NEXT:  ;;@ src.cpp:90:1
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   ;;@
+  ;; CHECK-NEXT:   (i32.add
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    ;;@ src.cpp:100:1
+  ;; CHECK-NEXT:    (return)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (else
+  ;; CHECK-NEXT:    ;;@
+  ;; CHECK-NEXT:    (return)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $foo (param $x i32) (param $y i32)
+    ;;@ src.cpp:90:1
+    (if
+      ;;@
+      (i32.add
+        (local.get $x)
+        (local.get $y)
+      )
+      (then
+        ;;@ src.cpp:100:1
+        (return)
+      )
+      (else
+        ;;@
+        (return)
+      )
+    )
+  )
 )


### PR DESCRIPTION
The comment `;;@` with nothing else can be used to specify that the following expression does not have any debug info associated to it. This can be used to stop the automatic propagation of debug info in the text parsers.

The text printer has also been updated to output this comment when needed.