### PR TITLE
[Strings] Fuzz and interpret all relevant StringNew methods

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,3 @@ BinPackParameters: false
 Language: JavaScript
 DisableFormat: true
 ---
-Language: Json
-BasedOnStyle: LLVM
----

--- a/.clang-format
+++ b/.clang-format
@@ -15,4 +15,3 @@ DisableFormat: true
 Language: Json
 BasedOnStyle: LLVM
 ---
-

--- a/.clang-format
+++ b/.clang-format
@@ -12,3 +12,7 @@ BinPackParameters: false
 Language: JavaScript
 DisableFormat: true
 ---
+Language: Json
+BasedOnStyle: LLVM
+---
+

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -315,6 +315,8 @@ private:
   Expression* makeBasicRef(Type type);
   Expression* makeCompoundRef(Type type);
 
+  Expression* makeString();
+
   // Similar to makeBasic/CompoundRef, but indicates that this value will be
   // used in a place that will trap on null. For example, the reference of a
   // struct.get or array.set would use this.

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -380,6 +380,7 @@ private:
   Type getLoggableType();
   bool isLoggableType(Type type);
   Nullability getNullability();
+  Mutability getMutability();
   Nullability getSubType(Nullability nullability);
   HeapType getSubType(HeapType type);
   Type getSubType(Type type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2721,9 +2721,11 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeString() {
-  auto arrayHeapType = HeapType(Array(Field(Type::i32, Field::PackedType::i16)));
+  // Fuzz with JS-style strings.
+  auto mutability = getMutability();
+  auto arrayHeapType = HeapType(Array(Field(Field::PackedType::i16, mutability)));
   auto nullability = getNullability();
-  auto arrayType = Type(arrayType, nullability);
+  auto arrayType = Type(arrayHeapType, nullability);
   switch (upTo(3)) {
     case 0: {
       // Make a string from an array.
@@ -2734,7 +2736,7 @@ Expression* TranslateToFuzzReader::makeString() {
     }
     case 1: {
       // Make a string from a code point.
-      autoCodePoint = make(Type::i32);
+      auto codePoint = make(Type::i32);
       return builder.makeStringNew(StringNewFromCodePoint, codePoint, nullptr, false);
     }
     case 2: {
@@ -4092,6 +4094,10 @@ Nullability TranslateToFuzzReader::getNullability() {
     return NonNullable;
   }
   return Nullable;
+}
+
+Mutability TranslateToFuzzReader::getMutability() {
+  return oneIn(2) ? Mutable : Immutable;
 }
 
 Nullability TranslateToFuzzReader::getSubType(Nullability nullability) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2737,7 +2737,7 @@ Expression* TranslateToFuzzReader::makeString() {
         return builder.makeStringNew(
           StringNewWTF16Array, array, start, end, false);
       }
-      [[fallthrough]]
+      [[fallthrough]];
     }
     case 1: {
       // Make a string from a code point. We can only do this in functions.
@@ -2746,7 +2746,7 @@ Expression* TranslateToFuzzReader::makeString() {
         return builder.makeStringNew(
           StringNewFromCodePoint, codePoint, nullptr, false);
       }
-      [[fallthrough]]
+      [[fallthrough]];
     }
     case 2: {
       // Construct an interesting WTF-8 string from parts and use string.const.

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2723,7 +2723,8 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
 Expression* TranslateToFuzzReader::makeString() {
   // Fuzz with JS-style strings.
   auto mutability = getMutability();
-  auto arrayHeapType = HeapType(Array(Field(Field::PackedType::i16, mutability)));
+  auto arrayHeapType =
+    HeapType(Array(Field(Field::PackedType::i16, mutability)));
   auto nullability = getNullability();
   auto arrayType = Type(arrayHeapType, nullability);
   switch (upTo(3)) {
@@ -2732,12 +2733,14 @@ Expression* TranslateToFuzzReader::makeString() {
       auto array = make(arrayType);
       auto* start = make(Type::i32);
       auto* end = make(Type::i32);
-      return builder.makeStringNew(StringNewWTF16Array, array, start, end, false);
+      return builder.makeStringNew(
+        StringNewWTF16Array, array, start, end, false);
     }
     case 1: {
       // Make a string from a code point.
       auto codePoint = make(Type::i32);
-      return builder.makeStringNew(StringNewFromCodePoint, codePoint, nullptr, false);
+      return builder.makeStringNew(
+        StringNewFromCodePoint, codePoint, nullptr, false);
     }
     case 2: {
       // Construct an interesting WTF-8 string from parts and use string.const.

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2729,18 +2729,24 @@ Expression* TranslateToFuzzReader::makeString() {
   auto arrayType = Type(arrayHeapType, nullability);
   switch (upTo(3)) {
     case 0: {
-      // Make a string from an array.
-      auto array = make(arrayType);
-      auto* start = make(Type::i32);
-      auto* end = make(Type::i32);
-      return builder.makeStringNew(
-        StringNewWTF16Array, array, start, end, false);
+      // Make a string from an array. We can only do this in functions.
+      if (funcContext) {
+        auto array = make(arrayType);
+        auto* start = make(Type::i32);
+        auto* end = make(Type::i32);
+        return builder.makeStringNew(
+          StringNewWTF16Array, array, start, end, false);
+      }
+      [[fallthrough]]
     }
     case 1: {
-      // Make a string from a code point.
-      auto codePoint = make(Type::i32);
-      return builder.makeStringNew(
-        StringNewFromCodePoint, codePoint, nullptr, false);
+      // Make a string from a code point. We can only do this in functions.
+      if (funcContext) {
+        auto codePoint = make(Type::i32);
+        return builder.makeStringNew(
+          StringNewFromCodePoint, codePoint, nullptr, false);
+      }
+      [[fallthrough]]
     }
     case 2: {
       // Construct an interesting WTF-8 string from parts and use string.const.

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2783,6 +2783,7 @@ Expression* TranslateToFuzzReader::makeString() {
       return builder.makeStringConst(wtf16.str());
     }
   }
+  WASM_UNREACHABLE("bad switch");
 }
 
 Expression* TranslateToFuzzReader::makeTrappingRefUse(HeapType type) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1898,6 +1898,12 @@ public:
         }
         return makeGCData(contents, curr->type);
       }
+      case StringNewFromCodePoint: {
+        auto codePoint = ptr.getSingleValue().geti32();
+        Literals contents;
+        contents.push_back(Literal(int32_t(codePoint)));
+        return makeGCData(contents, curr->type);
+      }
       default:
         // TODO: others
         return Flow(NONCONSTANT_FLOW);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1900,21 +1900,14 @@ public:
         return makeGCData(contents, curr->type);
       }
       case StringNewFromCodePoint: {
-        uint32_t codePoint = ptr.getSingleValue().geti32();
+        uint32_t codePoint = ptr.getSingleValue().getUnsigned();
         if (codePoint > 0x10FFFF) {
           trap("invalid code point");
         }
         std::stringstream wtf16;
         String::writeWTF16CodePoint(wtf16, codePoint);
         std::string str = wtf16.str();
-        Literals contents;
-        // The output contains a code point and a null terminator, so it is not
-        // empty. Write it all out but the null terminator.
-        assert(!str.empty());
-        for (size_t i = 0; i < str.size() - 1; i++) {
-          contents.push_back(Literal(int32_t(str[i])));
-        }
-        return makeGCData(contents, curr->type);
+        return Literal(str);
       }
       default:
         // TODO: others

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -424,7 +424,7 @@
   )
 
   ;; CHECK:      [fuzz-exec] calling weird_code_point
-  ;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\u03e8")
+  ;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\uffe8")
   (func $weird_code_point (export "weird_code_point") (result stringref)
     (string.from_code_point
       (i32.const 1000)
@@ -432,7 +432,7 @@
   )
 
   ;; CHECK:      [fuzz-exec] calling invalid_code_point
-  ;; CHECK-NEXT: [fuzz-exec] note result: invalid_code_point => string("\uffad")
+  ;; CHECK-NEXT: [trap invalid code point]
   (func $invalid_code_point (export "invalid_code_point") (result stringref)
     (string.from_code_point
       (i32.const -83)
@@ -547,10 +547,10 @@
 ;; CHECK-NEXT: [fuzz-exec] note result: string.from_code_point => string("A")
 
 ;; CHECK:      [fuzz-exec] calling weird_code_point
-;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\u03e8")
+;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\uffe8")
 
 ;; CHECK:      [fuzz-exec] calling invalid_code_point
-;; CHECK-NEXT: [fuzz-exec] note result: invalid_code_point => string("\uffad")
+;; CHECK-NEXT: [trap invalid code point]
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.1
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.10
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.2

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -414,6 +414,14 @@
     ;; Concatenating these surrogates creates '𐍈'.
     (string.concat (string.const "\ED\A0\80") (string.const "\ED\BD\88"))
   )
+
+  ;; CHECK:      [fuzz-exec] calling string.from_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: string.from_code_point => string("A")
+  (func $string.from_code_point (export "string.from_code_point") (result stringref)
+    (string.from_code_point
+      (i32.const 65)
+    )
+  )
 )
 ;; CHECK:      [fuzz-exec] calling new_wtf16_array
 ;; CHECK-NEXT: [fuzz-exec] note result: new_wtf16_array => string("ello")
@@ -518,6 +526,9 @@
 
 ;; CHECK:      [fuzz-exec] calling concat-surrogates
 ;; CHECK-NEXT: [fuzz-exec] note result: concat-surrogates => string("\ud800\udf48")
+
+;; CHECK:      [fuzz-exec] calling string.from_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: string.from_code_point => string("A")
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.1
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.10
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.2
@@ -551,3 +562,4 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing slice
 ;; CHECK-NEXT: [fuzz-exec] comparing slice-big
 ;; CHECK-NEXT: [fuzz-exec] comparing slice-unicode
+;; CHECK-NEXT: [fuzz-exec] comparing string.from_code_point

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -422,6 +422,22 @@
       (i32.const 65)
     )
   )
+
+  ;; CHECK:      [fuzz-exec] calling weird_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\u03e8")
+  (func $weird_code_point (export "weird_code_point") (result stringref)
+    (string.from_code_point
+      (i32.const 1000)
+    )
+  )
+
+  ;; CHECK:      [fuzz-exec] calling invalid_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: invalid_code_point => string("\uffad")
+  (func $invalid_code_point (export "invalid_code_point") (result stringref)
+    (string.from_code_point
+      (i32.const -83)
+    )
+  )
 )
 ;; CHECK:      [fuzz-exec] calling new_wtf16_array
 ;; CHECK-NEXT: [fuzz-exec] note result: new_wtf16_array => string("ello")
@@ -529,6 +545,12 @@
 
 ;; CHECK:      [fuzz-exec] calling string.from_code_point
 ;; CHECK-NEXT: [fuzz-exec] note result: string.from_code_point => string("A")
+
+;; CHECK:      [fuzz-exec] calling weird_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\u03e8")
+
+;; CHECK:      [fuzz-exec] calling invalid_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: invalid_code_point => string("\uffad")
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.1
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.10
 ;; CHECK-NEXT: [fuzz-exec] comparing compare.2
@@ -551,6 +573,7 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing eq.5
 ;; CHECK-NEXT: [fuzz-exec] comparing get_codeunit
 ;; CHECK-NEXT: [fuzz-exec] comparing get_length
+;; CHECK-NEXT: [fuzz-exec] comparing invalid_code_point
 ;; CHECK-NEXT: [fuzz-exec] comparing new_2
 ;; CHECK-NEXT: [fuzz-exec] comparing new_4
 ;; CHECK-NEXT: [fuzz-exec] comparing new_empty
@@ -563,3 +586,4 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing slice-big
 ;; CHECK-NEXT: [fuzz-exec] comparing slice-unicode
 ;; CHECK-NEXT: [fuzz-exec] comparing string.from_code_point
+;; CHECK-NEXT: [fuzz-exec] comparing weird_code_point

--- a/test/lit/exec/strings.wast
+++ b/test/lit/exec/strings.wast
@@ -423,11 +423,45 @@
     )
   )
 
+  ;; CHECK:      [fuzz-exec] calling unsigned_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: unsigned_code_point => string("\u0093")
+  (func $unsigned_code_point (export "unsigned_code_point") (result stringref)
+    (string.from_code_point
+      ;; This must be interpreted as unsigned, that is, in the escaped output
+      ;; the top byte is 0.
+      (i32.const 147)
+    )
+  )
+
   ;; CHECK:      [fuzz-exec] calling weird_code_point
-  ;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\uffe8")
+  ;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\u03e8")
   (func $weird_code_point (export "weird_code_point") (result stringref)
     (string.from_code_point
-      (i32.const 1000)
+      (i32.const 0x3e8)
+    )
+  )
+
+  ;; CHECK:      [fuzz-exec] calling isolated_high_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: isolated_high_code_point => string("\ud800")
+  (func $isolated_high_code_point (export "isolated_high_code_point") (result stringref)
+    (string.from_code_point
+      (i32.const 0xD800)
+    )
+  )
+
+  ;; CHECK:      [fuzz-exec] calling isolated_low_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: isolated_low_code_point => string("\udc00")
+  (func $isolated_low_code_point (export "isolated_low_code_point") (result stringref)
+    (string.from_code_point
+      (i32.const 0xDC00)
+    )
+  )
+
+  ;; CHECK:      [fuzz-exec] calling surrogate_pair_code_point
+  ;; CHECK-NEXT: [fuzz-exec] note result: surrogate_pair_code_point => string("\u286c")
+  (func $surrogate_pair_code_point (export "surrogate_pair_code_point") (result stringref)
+    (string.from_code_point
+      (i32.const 0x286c) ;; 𐍈
     )
   )
 
@@ -546,8 +580,20 @@
 ;; CHECK:      [fuzz-exec] calling string.from_code_point
 ;; CHECK-NEXT: [fuzz-exec] note result: string.from_code_point => string("A")
 
+;; CHECK:      [fuzz-exec] calling unsigned_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: unsigned_code_point => string("\u0093")
+
 ;; CHECK:      [fuzz-exec] calling weird_code_point
-;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\uffe8")
+;; CHECK-NEXT: [fuzz-exec] note result: weird_code_point => string("\u03e8")
+
+;; CHECK:      [fuzz-exec] calling isolated_high_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: isolated_high_code_point => string("\ud800")
+
+;; CHECK:      [fuzz-exec] calling isolated_low_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: isolated_low_code_point => string("\udc00")
+
+;; CHECK:      [fuzz-exec] calling surrogate_pair_code_point
+;; CHECK-NEXT: [fuzz-exec] note result: surrogate_pair_code_point => string("\u286c")
 
 ;; CHECK:      [fuzz-exec] calling invalid_code_point
 ;; CHECK-NEXT: [trap invalid code point]
@@ -574,6 +620,8 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing get_codeunit
 ;; CHECK-NEXT: [fuzz-exec] comparing get_length
 ;; CHECK-NEXT: [fuzz-exec] comparing invalid_code_point
+;; CHECK-NEXT: [fuzz-exec] comparing isolated_high_code_point
+;; CHECK-NEXT: [fuzz-exec] comparing isolated_low_code_point
 ;; CHECK-NEXT: [fuzz-exec] comparing new_2
 ;; CHECK-NEXT: [fuzz-exec] comparing new_4
 ;; CHECK-NEXT: [fuzz-exec] comparing new_empty
@@ -586,4 +634,6 @@
 ;; CHECK-NEXT: [fuzz-exec] comparing slice-big
 ;; CHECK-NEXT: [fuzz-exec] comparing slice-unicode
 ;; CHECK-NEXT: [fuzz-exec] comparing string.from_code_point
+;; CHECK-NEXT: [fuzz-exec] comparing surrogate_pair_code_point
+;; CHECK-NEXT: [fuzz-exec] comparing unsigned_code_point
 ;; CHECK-NEXT: [fuzz-exec] comparing weird_code_point


### PR DESCRIPTION
This adds fuzzing for `string.new_wtf16_array` and `string.from_code_point`. The
latter was also missing interpreter support, which this adds.

@tlively I seem to get the wrong results for unicode here - am I using the wrong
API or using it incorrectly? The last testcase here traps in V8 on being an invalid
codePoint but `String::convertUTF16ToUTF8` returns that it is valid.

For comparison, related V8 code: https://chromium.googlesource.com/v8/v8/+/a19a2ff2be5b60f6df6c7c7160860ede2cb85e27%5E%21/#F3