### PR TITLE
Fuzzer: Update the typeLocals data structure before mutation

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -150,6 +150,14 @@ private:
     }
 
     ~FunctionCreationContext();
+
+    // Fill in the typeLocals data structure.
+    void computeTypeLocals() {
+      typeLocals.clear();
+      for (Index i = 0; i < func->getNumLocals(); i++) {
+        typeLocals[func->getLocalType(i)].push_back(i);
+      }
+    }
   };
 
   FunctionCreationContext* funcContext = nullptr;


### PR DESCRIPTION
Rather than compute the map of type to locals of that type once, at the
start, also update it when relevant, as we can add more locals in some
cases. This allows us to `local.get` from those late-added locals too.