### PR TITLE
Do not add an extra null character when reading files

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -71,6 +71,7 @@ T wasm::read_file(const std::string& filename, Flags::BinaryOption binary) {
             << "': Input file too large: " << insize
             << " bytes. Try rebuilding in 64-bit mode.";
   }
+  // Zero-initialize the string or vector with the expected size.
   T input(size_t(insize), '\0');
   if (size_t(insize) == 0) {
     return input;

--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -71,7 +71,7 @@ T wasm::read_file(const std::string& filename, Flags::BinaryOption binary) {
             << "': Input file too large: " << insize
             << " bytes. Try rebuilding in 64-bit mode.";
   }
-  T input(size_t(insize) + (binary == Flags::Binary ? 0 : 1), '\0');
+  T input(size_t(insize), '\0');
   if (size_t(insize) == 0) {
     return input;
   }
@@ -82,8 +82,7 @@ T wasm::read_file(const std::string& filename, Flags::BinaryOption binary) {
     // Truncate size to the number of ASCII characters actually read in text
     // mode (which is generally less than the number of bytes on Windows, if
     // \r\n line endings are present)
-    input.resize(chars + 1);
-    input[chars] = '\0';
+    input.resize(chars);
   }
   return input;
 }

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1436,8 +1436,6 @@ int main(int argc, const char* argv[]) {
                     });
   options.parse(argc, argv);
 
-  auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
-
   Module wasm;
   options.applyFeatures(wasm);
 

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -485,8 +485,6 @@ int main(int argc, const char* argv[]) {
     Fatal() << "no graph file provided.";
   }
 
-  auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
-
   Module wasm;
   options.applyFeatures(wasm);
 

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -976,8 +976,7 @@ int main(int argc, const char* argv[]) {
       ModuleReader reader;
       reader.read(input, wasm, "");
     } else {
-      auto input(
-        read_file<std::vector<char>>(options.extra["infile"], Flags::Text));
+      auto input(read_file<std::string>(options.extra["infile"], Flags::Text));
       if (options.debug) {
         std::cerr << "s-parsing..." << std::endl;
       }

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -39,8 +39,7 @@ bool useNewWATParser = false;
 
 static void readTextData(std::string& input, Module& wasm, IRProfile profile) {
   if (useNewWATParser) {
-    std::string_view in(input.c_str());
-    if (auto parsed = WATParser::parseModule(wasm, in);
+    if (auto parsed = WATParser::parseModule(wasm, input);
         auto err = parsed.getErr()) {
       Fatal() << err->msg;
     }


### PR DESCRIPTION
The new wat parser currently considers itself to be at the end of the file
whenever it cannot lex another token. This is not quite right, but fixing it
causes parser errors because of the extra null character we were appending to
files when we read them. This null character is not useful since we can already
read files as `std::string`, which always has an implicit null character, so
remove it. Clean up some users of `read_file` while we're at it.