### PR TITLE
[Parser] Do not eagerly lex parens

### DIFF
--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -45,16 +45,6 @@ struct TextPos {
 // Tokens
 // ======
 
-struct LParenTok {
-  bool operator==(const LParenTok&) const { return true; }
-  friend std::ostream& operator<<(std::ostream&, const LParenTok&);
-};
-
-struct RParenTok {
-  bool operator==(const RParenTok&) const { return true; }
-  friend std::ostream& operator<<(std::ostream&, const RParenTok&);
-};
-
 struct IdTok {
   // Whether this ID has `$"..."` format
   bool isStr;
@@ -103,23 +93,13 @@ struct KeywordTok {
 };
 
 struct Token {
-  using Data = std::variant<LParenTok,
-                            RParenTok,
-                            IdTok,
-                            IntTok,
-                            FloatTok,
-                            StringTok,
-                            KeywordTok>;
+  using Data = std::variant<IdTok, IntTok, FloatTok, StringTok, KeywordTok>;
   std::string_view span;
   Data data;
 
   // ====================
   // Token classification
   // ====================
-
-  bool isLParen() const { return std::get_if<LParenTok>(&data); }
-
-  bool isRParen() const { return std::get_if<RParenTok>(&data); }
 
   std::optional<std::string_view> getKeyword() const {
     if (std::get_if<KeywordTok>(&data)) {
@@ -173,32 +153,20 @@ public:
     advance();
   }
 
-  bool takeLParen() {
-    if (!curr || !curr->isLParen()) {
-      return false;
-    }
-    advance();
-    return true;
-  }
+  bool takeLParen();
 
   bool peekLParen() { return Lexer(*this).takeLParen(); }
 
-  bool takeRParen() {
-    if (!curr || !curr->isRParen()) {
-      return false;
-    }
-    advance();
-    return true;
-  }
+  bool takeRParen();
 
   bool peekRParen() { return Lexer(*this).takeRParen(); }
 
   bool takeUntilParen() {
     while (true) {
-      if (!curr) {
+      if (empty()) {
         return false;
       }
-      if (curr->isLParen() || curr->isRParen()) {
+      if (peekLParen() || peekRParen()) {
         return true;
       }
       advance();
@@ -392,7 +360,7 @@ public:
     lexToken();
   }
 
-  bool empty() const { return !curr; }
+  bool empty() const { return !curr && index == buffer.size(); }
 
   TextPos position(const char* c) const;
   TextPos position(size_t i) const { return position(buffer.data() + i); }

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -169,6 +169,9 @@ public:
       if (peekLParen() || peekRParen()) {
         return true;
       }
+      if (!curr) {
+        ++index;
+      }
       advance();
     }
   }

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -129,7 +129,6 @@ void ModuleReader::readStdin(Module& wasm, std::string sourceMapFilename) {
   } else {
     std::ostringstream s;
     s.write(input.data(), input.size());
-    s << '\0';
     std::string input_str = s.str();
     readTextData(input_str, wasm, profile);
   }

--- a/test/gtest/wat-lexer.cpp
+++ b/test/gtest/wat-lexer.cpp
@@ -77,9 +77,6 @@ TEST(LexerTest, LexBlockComment) {
 }
 
 TEST(LexerTest, LexParens) {
-  Token left{"("sv, LParenTok{}};
-  Token right{")"sv, RParenTok{}};
-
   Lexer lexer("(())"sv);
 
   ASSERT_FALSE(lexer.empty());


### PR DESCRIPTION
The lexer currently lexes tokens eagerly and stores them in a `Token` variant
ahead of when they are actually requested by the parser. It is wasteful,
however, to classify tokens before they are requested by the parser because it
is likely that the next token will be precisely the kind the parser requests.
The work of checking and rejecting other possible classifications ahead of time
is not useful.

To make incremental progress toward removing `Token` completely, lex parentheses
on demand instead of eagerly.