### PR TITLE
GUFA: Handle bottom types in filterDataContents()

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -2616,7 +2616,13 @@ void Flower::filterGlobalContents(PossibleContents& contents,
 void Flower::filterDataContents(PossibleContents& contents,
                                 const DataLocation& dataLoc) {
   auto field = GCTypeUtils::getField(dataLoc.type, dataLoc.index);
-  assert(field);
+  if (!field) {
+    // This is a bottom type; nothing will be written here.
+    assert(dataLoc.type.isBottom());
+    contents = PossibleContents::none();
+    return;
+  }
+
   if (field->isPacked()) {
     // We must handle packed fields carefully.
     if (contents.isLiteral()) {

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -6056,3 +6056,41 @@
     )
   )
 )
+
+(module
+  ;; CHECK:      (type $array (sub (array (mut i8))))
+  (type $array (sub (array (mut i8))))
+
+  ;; CHECK:      (type $1 (func))
+
+  ;; CHECK:      (global $global (ref null $array) (array.new_fixed $array 0))
+  (global $global (ref null $array) (array.new_fixed $array 0))
+
+  ;; CHECK:      (func $test (type $1)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable ArraySet we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (ref.cast nullref
+  ;; CHECK-NEXT:     (global.get $global)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    ;; We should not error on sets to bottom types, even if they are cast from
+    ;; valid values.
+    (array.set $array
+     (ref.cast nullref
+       (global.get $global)
+     )
+     (i32.const 0)
+     (i32.const 0)
+   )
+  )
+)


### PR DESCRIPTION
Normally a bottom type cannot reach there, as we ignore unreachable GC
operations early on. However, we can infer a bottom type later during the
flow, so we need to handle that (just not error on it, and for clarity during
debugging we also clear the contents).