### PR TITLE
Source map fixes

### DIFF
--- a/src/passes/DebugLocationPropagation.cpp
+++ b/src/passes/DebugLocationPropagation.cpp
@@ -64,6 +64,10 @@ struct DebugLocationPropagation
         if (auto it = locs.find(previous); it != locs.end()) {
           locs[curr] = it->second;
         }
+      } else if (self->getFunction()->prologLocation.size()) {
+        // The first instruction may inherit its location from the
+        // function prolog
+        locs[curr] = *self->getFunction()->prologLocation.begin();
       }
     }
     expressionStack.push_back(curr);

--- a/src/passes/DebugLocationPropagation.cpp
+++ b/src/passes/DebugLocationPropagation.cpp
@@ -65,8 +65,8 @@ struct DebugLocationPropagation
           locs[curr] = it->second;
         }
       } else if (self->getFunction()->prologLocation.size()) {
-        // The first instruction may inherit its location from the
-        // function prolog
+        // Instructions may inherit their locations from the function
+        // prolog.
         locs[curr] = *self->getFunction()->prologLocation.begin();
       }
     }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3025,8 +3025,7 @@ void PrintSExpression::visitDefinedFunction(Function* curr) {
     // Print the stack IR.
     printStackIR(curr->stackIR.get(), *this);
   }
-  if (currFunction->epilogLocation.size() &&
-      lastPrintedLocation != *currFunction->epilogLocation.begin()) {
+  if (currFunction->epilogLocation.size()) {
     // Print last debug location: mix of decIndent and printDebugLocation
     // logic.
     doIndent(o, indent);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1348,6 +1348,7 @@ public:
   void writeSourceMapProlog();
   void writeSourceMapEpilog();
   void writeDebugLocation(const Function::DebugLocation& loc);
+  void writeNoDebugLocation();
   void writeDebugLocation(Expression* curr, Function* func);
   void writeDebugLocationEnd(Expression* curr, Function* func);
   void writeExtraDebugLocation(Expression* curr, Function* func, size_t id);

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -443,9 +443,12 @@ public:
   void emitDelegate(Try* curr) { writer.emitDelegate(curr); }
   void emitScopeEnd(Expression* curr) { writer.emitScopeEnd(curr); }
   void emitFunctionEnd() {
+    // Indicate the debug location corresponding to the end opcode
+    // that terminates the function code.
     if (func->epilogLocation.size()) {
       parent.writeDebugLocation(*func->epilogLocation.begin());
     } else {
+      // The end opcode has no debug location.
       parent.writeNoDebugLocation();
     }
     writer.emitFunctionEnd();

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -445,6 +445,8 @@ public:
   void emitFunctionEnd() {
     if (func->epilogLocation.size()) {
       parent.writeDebugLocation(*func->epilogLocation.begin());
+    } else {
+      parent.writeNoDebugLocation();
     }
     writer.emitFunctionEnd();
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2687,12 +2687,11 @@ void WasmBinaryReader::readFunctions() {
 
     readVars();
 
-    std::swap(func->prologLocation, debugLocation);
+    func->prologLocation = debugLocation;
     {
       // process the function body
       BYN_TRACE("processing function: " << i << std::endl);
       nextLabel = 0;
-      debugLocation.clear();
       willBeIgnored = false;
       // process body
       assert(breakStack.empty());

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2930,7 +2930,6 @@ void WasmBinaryReader::readNextDebugLocation() {
 
   if (nextDebugPos == 0) {
     // We reached the end of the source map; nothing left to read.
-    debugLocation.clear();
     return;
   }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -399,7 +399,7 @@ void WasmBinaryWriter::writeFunctions() {
   ModuleUtils::iterDefinedFunctions(*wasm, [&](Function* func) {
     assert(binaryLocationTrackedExpressionsForFunc.empty());
     BYN_TRACE("write one at" << o.size() << std::endl);
-    // Do not smear any debug location from the previous function
+    // Do not smear any debug location from the previous function.
     writeNoDebugLocation();
     size_t sourceMapLocationsSizeAtFunctionStart = sourceMapLocations.size();
     size_t sizePos = writeU32LEBPlaceholder();

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2839,8 +2839,13 @@ void StackIRToBinaryWriter::write() {
         WASM_UNREACHABLE("unexpected op");
     }
   }
+  // Indicate the debug location corresponding to the end opcode that
+  // terminates the function code.
   if (func->epilogLocation.size()) {
     parent.writeDebugLocation(*func->epilogLocation.begin());
+  } else {
+    // The end opcode has no debug location.
+    parent.writeNoDebugLocation();
   }
   writer.emitFunctionEnd();
 }

--- a/test/binaryen.js/sourcemap.js.txt
+++ b/test/binaryen.js/sourcemap.js.txt
@@ -5,4 +5,4 @@ module.c
 020: u  r  c  e  M  a  p  p  i  n  g  U  R  L  0f m  
 030: o  d  u  l  e  .  w  a  s  m  .  m  a  p 
 
-{"version":3,"sources":["module.c"],"names":[],"mappings":"wBAAE"}
+{"version":3,"sources":["module.c"],"names":[],"mappings":"wBAAE,E"}

--- a/test/fib-dbg.wasm.fromBinary
+++ b/test/fib-dbg.wasm.fromBinary
@@ -214,6 +214,7 @@
     (local.get $4)
    )
   )
+  ;;@ fib.c:8:0
  )
  (func $runPostSets
   (local $0 i32)

--- a/test/fib-dbg.wasm.fromBinary
+++ b/test/fib-dbg.wasm.fromBinary
@@ -209,8 +209,8 @@
      (br $label$4)
     )
    )
+   ;;@ fib.c:8:0
    (return
-    ;;@ fib.c:8:0
     (local.get $4)
    )
   )

--- a/test/lit/debug/source-map-smearing.wast
+++ b/test/lit/debug/source-map-smearing.wast
@@ -2,6 +2,12 @@
 ;; RUN: echo >> %t.wasm.map
 ;; RUN: cat %t.wasm.map | filecheck %s
 
+;; Also test with StackIR, which should have identical results.
+;;
+;; RUN: wasm-opt %s --generate-stack-ir -o %t.wasm -osm %t.map -g -q
+;; RUN: echo >> %t.wasm.map
+;; RUN: cat %t.wasm.map | filecheck %s
+
 ;; Check that the debug locations do not smear beyond a function
 ;; epilogue to the next function. The encoded segment 'C' means that
 ;; the previous segment is indeed one-byte long.

--- a/test/lit/debug/source-map-smearing.wast
+++ b/test/lit/debug/source-map-smearing.wast
@@ -1,0 +1,16 @@
+;; RUN: wasm-opt %s -g -o %t.wasm -osm %t.wasm.map
+;; RUN: echo >> %t.wasm.map
+;; RUN: cat %t.wasm.map | filecheck %s
+
+;; Check that the debug locations do not smear beyond a function
+;; epilogue to the next function. The encoded segment 'C' means that
+;; the previous segment is indeed one-byte long.
+;; CHECK: {"version":3,"sources":["foo"],"names":[],"mappings":"yBAAC,C,GACC"}
+(module
+  (func $0
+    ;;@ foo:1:1
+  )
+  (func $1
+    ;;@ foo:2:2
+  )
+)

--- a/test/lit/debug/source-map-stop.wast
+++ b/test/lit/debug/source-map-stop.wast
@@ -3,6 +3,11 @@
 ;; RUN: wasm-opt %s -g -o %t.wasm -osm %t.wasm.map
 ;; RUN: wasm-opt %t.wasm -ism %t.wasm.map -S -o - | filecheck %s
 
+;; Also test with StackIR, which should have identical results.
+;;
+;; RUN: wasm-opt %s --generate-stack-ir -o %t.wasm -osm %t.map -g -q
+;; RUN: wasm-opt %t.wasm -ism %t.map -q -o - -S | filecheck %s
+
 ;; Verify that writing to a source map and reading it back does not "smear"
 ;; debug info across adjacent instructions. The debug info in the output should
 ;; be identical to the input.


### PR DESCRIPTION
Some debug locations could be dropped at the beginning and end of functions:
- if a source map segment starts before the beginning of the code, it was not taken into account except for the function prologue;
- the last segment of the source map was ignored after one instruction;
- for coherence with the text printer, the text parser should propagate the debug location of the function prologue to its first instruction.
- the text printer should always print the debug location of the function epilogue if there is one (for coherence, since one repeats a debug location at the same indentation level for readability, and for round-tripping since the test parser does not propagate debug locations to the function epilogue).

Also, the binary writer was smearing the debug location of the last instruction to the function epilogue, and the debug location of a previous function could smear to the prologue of the next function.