### PR TITLE
Improve return validation

### DIFF
--- a/test/gtest/validator.cpp
+++ b/test/gtest/validator.cpp
@@ -48,3 +48,20 @@ TEST(ValidatorTest, MissingCatchTag) {
     WasmValidator::FlagValues::Globally | WasmValidator::FlagValues::Quiet;
   EXPECT_FALSE(validator.validate(&function, module, flags));
 }
+
+TEST(ValidatorTest, ReturnUnreachable) {
+  Module module;
+  Builder builder(module);
+
+  // (return (unreachable)) should be invalid if a function has no return type.
+  auto func =
+    builder.makeFunction("func",
+                         {},
+                         Signature(Type::none, Type::none),
+                         {},
+                         builder.makeReturn(builder.makeUnreachable()));
+
+  auto flags =
+    WasmValidator::FlagValues::Globally | WasmValidator::FlagValues::Quiet;
+  EXPECT_FALSE(WasmValidator{}.validate(func.get(), module, flags));
+}


### PR DESCRIPTION
Disallow returns from having any children, even unreachable children, in
function that do not return any values.