### PR TITLE
[Strings] Limit string allocations like we do arrays

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1620,7 +1620,7 @@ public:
   // vector that takes around 1-2GB of memory then we are likely to hit memory
   // limits on 32-bit machines, and in particular on wasm32 VMs that do not
   // have 4GB support, so give up there.
-  static const Index ArrayLimit = (1 << 30) / sizeof(Literal);
+  static const Index DataLimit = (1 << 30) / sizeof(Literal);
 
   Flow visitArrayNew(ArrayNew* curr) {
     NOTE_ENTER("ArrayNew");
@@ -1645,7 +1645,7 @@ public:
     auto heapType = curr->type.getHeapType();
     const auto& element = heapType.getArray().element;
     Index num = size.getSingleValue().geti32();
-    if (num >= ArrayLimit) {
+    if (num >= DataLimit) {
       hostLimit("allocation failure");
     }
     Literals data(num);
@@ -1668,7 +1668,7 @@ public:
   Flow visitArrayNewFixed(ArrayNewFixed* curr) {
     NOTE_ENTER("ArrayNewFixed");
     Index num = curr->values.size();
-    if (num >= ArrayLimit) {
+    if (num >= DataLimit) {
       hostLimit("allocation failure");
     }
     if (curr->type == Type::unreachable) {
@@ -1951,6 +1951,11 @@ public:
     auto rightData = right.getGCData();
     if (!leftData || !rightData) {
       trap("null ref");
+    }
+
+    auto totalSize = leftData->values.size() + rightData->values.size();
+    if (totalSize >= DataLimit) {
+      hostLimit("allocation failure");
     }
 
     Literals contents;


### PR DESCRIPTION
When we concat strings, check if their length exceeds a reasonable
limit. (We do not need to do this for `string.new` as that reads from an
array, which is already properly limited.)

This avoids very slow pauses in the fuzzer (that sometimes OOM).
