### PR TITLE
Fuzzer: Stop emitting nullable stringviews

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -668,6 +668,9 @@ def run_vm(cmd):
             HOST_LIMIT_PREFIX,
             # see comment above on this constant
             V8_UNINITIALIZED_NONDEF_LOCAL,
+            # V8 does not accept nullable stringviews
+            # (https://github.com/WebAssembly/binaryen/pull/6574)
+            'expected (ref stringview_wtf16), got nullref',
         ]
         for issue in known_issues:
             if issue in output:

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -307,7 +307,7 @@ bool canHandleAsLocal(Type type) {
   if (type.isRef()) {
     // V8 does not accept nullable string views, and so we must avoid putting
     // them in locals (as even a non-nullable one may end up nullable if we see
-    // situations that require fixing in handleNonDefaultableLocals.
+    // situations that require fixing in handleNonDefaultableLocals).
     auto heapType = type.getHeapType();
     return heapType != HeapType::stringview_wtf8 &&
            heapType != HeapType::stringview_wtf16 &&

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -312,7 +312,6 @@ bool canHandleAsLocal(Type type) {
     return heapType != HeapType::stringview_wtf8 &&
            heapType != HeapType::stringview_wtf16 &&
            heapType != HeapType::stringview_iter;
-
   }
   return type.isConcrete();
 }

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -304,6 +304,16 @@ namespace TypeUpdating {
 
 bool canHandleAsLocal(Type type) {
   // TODO: Inline this into its callers.
+  if (type.isRef()) {
+    // V8 does not accept nullable string views, and so we must avoid putting
+    // them in locals (as even a non-nullable one may end up nullable if we see
+    // situations that require fixing in handleNonDefaultableLocals.
+    auto heapType = type.getHeapType();
+    return heapType != HeapType::stringview_wtf8 &&
+           heapType != HeapType::stringview_wtf16 &&
+           heapType != HeapType::stringview_iter;
+
+  }
   return type.isConcrete();
 }
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -30,9 +30,7 @@ namespace wasm {
 namespace {
 
 bool canBeNullable(HeapType type) {
-  // V8 does not accept nullable string views, and so we must avoid putting
-  // them in locals (as even a non-nullable one may end up nullable if we see
-  // situations that require fixing in handleNonDefaultableLocals.
+  // V8 does not accept nullable string views.
   return type != HeapType::stringview_wtf8 &&
          type != HeapType::stringview_wtf16 &&
          type != HeapType::stringview_iter;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -703,6 +703,9 @@ Function* TranslateToFuzzReader::addFunction() {
   Index numVars = upToSquared(MAX_VARS);
   for (Index i = 0; i < numVars; i++) {
     auto type = getConcreteType();
+    if (!TypeUpdating::canHandleAsLocal(type)) {
+      type = Type::i32;
+    }
     func->vars.push_back(type);
   }
   context.computeTypeLocals();
@@ -1858,7 +1861,7 @@ Expression* TranslateToFuzzReader::makeLocalGet(Type type) {
   // the time), or emit a local.get of a new local, or emit a local.tee of a new
   // local.
   auto choice = upTo(3);
-  if (choice == 0) {
+  if (choice == 0 || !TypeUpdating::canHandleAsLocal(type)) {
     return makeConst(type);
   }
   // Otherwise, add a new local. If the type is not non-nullable then we may

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2827,7 +2827,8 @@ Expression* TranslateToFuzzReader::makeStringConcat() {
 }
 
 Expression* TranslateToFuzzReader::makeStringSlice() {
-  auto* ref = makeTrappingRefUse(HeapType::stringview_wtf16);
+  // StringViews cannot be non-nullable.
+  auto* ref = make(Type(HeapType::stringview_wtf16, NonNullable));
   auto* start = make(Type::i32);
   auto* end = make(Type::i32);
   return builder.makeStringSliceWTF(StringSliceWTF16, ref, start, end);
@@ -2858,7 +2859,8 @@ Expression* TranslateToFuzzReader::makeStringMeasure(Type type) {
 Expression* TranslateToFuzzReader::makeStringGet(Type type) {
   assert(type == Type::i32);
 
-  auto* ref = makeTrappingRefUse(HeapType::stringview_wtf16);
+  // StringViews cannot be non-nullable.
+  auto* ref = make(Type(HeapType::stringview_wtf16, NonNullable));
   auto* pos = make(Type::i32);
   return builder.makeStringWTF16Get(ref, pos);
 }


### PR DESCRIPTION
As of

https://chromium-review.googlesource.com/c/v8/v8/+/5471674

V8 requires stringviews to be non-nullable. It might be possible to make that
change in our IR, or to remove views entirely, but for now this PR makes the
fuzzer stop emitting nullable stringviews as a workaround to allow us to fuzz
current V8.

Without this the fuzzer errors after just a few dozen, and after it I've gone
several thousand without issue (though in theory this PR might miss some
path that can emit a nullable stringview).