### PR TITLE
Fuzzer: Add another stringview subtyping error message to ignore

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -671,6 +671,7 @@ def run_vm(cmd):
             # V8 does not accept nullable stringviews
             # (https://github.com/WebAssembly/binaryen/pull/6574)
             'expected (ref stringview_wtf16), got nullref',
+            'expected type (ref stringview_wtf16), found ref.null of type nullref',
         ]
         for issue in known_issues:
             if issue in output:

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -465,12 +465,6 @@ struct HeapTypeGeneratorImpl {
       case HeapType::stringview_iter:
         break;
       case HeapType::none:
-        if (features.hasStrings() && rand.oneIn(10)) {
-          candidates.push_back(HeapType::stringview_wtf8);
-          candidates.push_back(HeapType::stringview_wtf16);
-          candidates.push_back(HeapType::stringview_iter);
-          break;
-        }
         return pickSubAny();
       case HeapType::nofunc:
         return pickSubFunc();

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -465,6 +465,12 @@ struct HeapTypeGeneratorImpl {
       case HeapType::stringview_iter:
         break;
       case HeapType::none:
+        if (features.hasStrings() && rand.oneIn(10)) {
+          candidates.push_back(HeapType::stringview_wtf8);
+          candidates.push_back(HeapType::stringview_wtf16);
+          candidates.push_back(HeapType::stringview_iter);
+          break;
+        }
         return pickSubAny();
       case HeapType::nofunc:
         return pickSubFunc();


### PR DESCRIPTION
Original text:

V8 errors on this, e.g. this was created:
```wat
 (rec
  (type $0 (sub (func (param nullref i32) (result (ref null $3)))))
  (type $1 (sub final $0 (func (param stringview_iter i32) (result (ref null $3)))))
 )
```
V8 says that subtyping is invalid.

Later PR focuses on ignoring a related message.