### PR TITLE
Make stringview reference type shorthands non-nullable

### DIFF
--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -488,13 +488,13 @@ template<typename Ctx> MaybeResult<typename Ctx::TypeT> reftype(Ctx& ctx) {
     return ctx.makeRefType(ctx.makeStringType(), Nullable);
   }
   if (ctx.in.takeKeyword("stringview_wtf8"sv)) {
-    return ctx.makeRefType(ctx.makeStringViewWTF8Type(), Nullable);
+    return ctx.makeRefType(ctx.makeStringViewWTF8Type(), NonNullable);
   }
   if (ctx.in.takeKeyword("stringview_wtf16"sv)) {
-    return ctx.makeRefType(ctx.makeStringViewWTF16Type(), Nullable);
+    return ctx.makeRefType(ctx.makeStringViewWTF16Type(), NonNullable);
   }
   if (ctx.in.takeKeyword("stringview_iter"sv)) {
-    return ctx.makeRefType(ctx.makeStringViewIterType(), Nullable);
+    return ctx.makeRefType(ctx.makeStringViewIterType(), NonNullable);
   }
   if (ctx.in.takeKeyword("contref"sv)) {
     return ctx.makeRefType(ctx.makeContType(), Nullable);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1515,62 +1515,73 @@ void WasmBinaryWriter::writeType(Type type) {
       WASM_UNREACHABLE("bad type without GC");
     }
     auto heapType = type.getHeapType();
-    if (heapType.isBasic() && type.isNullable()) {
-      switch (heapType.getBasic()) {
-        case HeapType::ext:
-          o << S32LEB(BinaryConsts::EncodedType::externref);
-          return;
-        case HeapType::any:
-          o << S32LEB(BinaryConsts::EncodedType::anyref);
-          return;
-        case HeapType::func:
-          o << S32LEB(BinaryConsts::EncodedType::funcref);
-          return;
-        case HeapType::cont:
-          o << S32LEB(BinaryConsts::EncodedType::contref);
-          return;
-        case HeapType::eq:
-          o << S32LEB(BinaryConsts::EncodedType::eqref);
-          return;
-        case HeapType::i31:
-          o << S32LEB(BinaryConsts::EncodedType::i31ref);
-          return;
-        case HeapType::struct_:
-          o << S32LEB(BinaryConsts::EncodedType::structref);
-          return;
-        case HeapType::array:
-          o << S32LEB(BinaryConsts::EncodedType::arrayref);
-          return;
-        case HeapType::exn:
-          o << S32LEB(BinaryConsts::EncodedType::exnref);
-          return;
-        case HeapType::string:
-          o << S32LEB(BinaryConsts::EncodedType::stringref);
-          return;
-        case HeapType::stringview_wtf8:
-          o << S32LEB(BinaryConsts::EncodedType::stringview_wtf8);
-          return;
-        case HeapType::stringview_wtf16:
-          o << S32LEB(BinaryConsts::EncodedType::stringview_wtf16);
-          return;
-        case HeapType::stringview_iter:
-          o << S32LEB(BinaryConsts::EncodedType::stringview_iter);
-          return;
-        case HeapType::none:
-          o << S32LEB(BinaryConsts::EncodedType::nullref);
-          return;
-        case HeapType::noext:
-          o << S32LEB(BinaryConsts::EncodedType::nullexternref);
-          return;
-        case HeapType::nofunc:
-          o << S32LEB(BinaryConsts::EncodedType::nullfuncref);
-          return;
-        case HeapType::noexn:
-          o << S32LEB(BinaryConsts::EncodedType::nullexnref);
-          return;
-        case HeapType::nocont:
-          o << S32LEB(BinaryConsts::EncodedType::nullcontref);
-          return;
+    if (heapType.isBasic()) {
+      if (type.isNullable()) {
+        switch (heapType.getBasic()) {
+          case HeapType::ext:
+            o << S32LEB(BinaryConsts::EncodedType::externref);
+            return;
+          case HeapType::any:
+            o << S32LEB(BinaryConsts::EncodedType::anyref);
+            return;
+          case HeapType::func:
+            o << S32LEB(BinaryConsts::EncodedType::funcref);
+            return;
+          case HeapType::cont:
+            o << S32LEB(BinaryConsts::EncodedType::contref);
+            return;
+          case HeapType::eq:
+            o << S32LEB(BinaryConsts::EncodedType::eqref);
+            return;
+          case HeapType::i31:
+            o << S32LEB(BinaryConsts::EncodedType::i31ref);
+            return;
+          case HeapType::struct_:
+            o << S32LEB(BinaryConsts::EncodedType::structref);
+            return;
+          case HeapType::array:
+            o << S32LEB(BinaryConsts::EncodedType::arrayref);
+            return;
+          case HeapType::exn:
+            o << S32LEB(BinaryConsts::EncodedType::exnref);
+            return;
+          case HeapType::string:
+            o << S32LEB(BinaryConsts::EncodedType::stringref);
+            return;
+          case HeapType::stringview_wtf8:
+          case HeapType::stringview_wtf16:
+          case HeapType::stringview_iter:
+            break;
+          case HeapType::none:
+            o << S32LEB(BinaryConsts::EncodedType::nullref);
+            return;
+          case HeapType::noext:
+            o << S32LEB(BinaryConsts::EncodedType::nullexternref);
+            return;
+          case HeapType::nofunc:
+            o << S32LEB(BinaryConsts::EncodedType::nullfuncref);
+            return;
+          case HeapType::noexn:
+            o << S32LEB(BinaryConsts::EncodedType::nullexnref);
+            return;
+          case HeapType::nocont:
+            o << S32LEB(BinaryConsts::EncodedType::nullcontref);
+            return;
+        }
+      } else {
+        switch (heapType.getBasic()) {
+          case HeapType::stringview_wtf8:
+            o << S32LEB(BinaryConsts::EncodedType::stringview_wtf8);
+            return;
+          case HeapType::stringview_wtf16:
+            o << S32LEB(BinaryConsts::EncodedType::stringview_wtf16);
+            return;
+          case HeapType::stringview_iter:
+            o << S32LEB(BinaryConsts::EncodedType::stringview_iter);
+            return;
+          default:
+            break;
+        }
       }
     }
     if (type.isNullable()) {
@@ -2052,13 +2063,13 @@ bool WasmBinaryReader::getBasicType(int32_t code, Type& out) {
       out = Type(HeapType::string, Nullable);
       return true;
     case BinaryConsts::EncodedType::stringview_wtf8:
-      out = Type(HeapType::stringview_wtf8, Nullable);
+      out = Type(HeapType::stringview_wtf8, NonNullable);
       return true;
     case BinaryConsts::EncodedType::stringview_wtf16:
-      out = Type(HeapType::stringview_wtf16, Nullable);
+      out = Type(HeapType::stringview_wtf16, NonNullable);
       return true;
     case BinaryConsts::EncodedType::stringview_iter:
-      out = Type(HeapType::stringview_iter, Nullable);
+      out = Type(HeapType::stringview_iter, NonNullable);
       return true;
     case BinaryConsts::EncodedType::nullref:
       out = Type(HeapType::none, Nullable);

--- a/src/wasm/wasm-s-parser.cpp
+++ b/src/wasm/wasm-s-parser.cpp
@@ -1286,13 +1286,13 @@ Type SExpressionWasmBuilder::stringToType(std::string_view str,
     return Type(HeapType::string, Nullable);
   }
   if (str.substr(0, 15) == "stringview_wtf8" && (prefix || str.size() == 15)) {
-    return Type(HeapType::stringview_wtf8, Nullable);
+    return Type(HeapType::stringview_wtf8, NonNullable);
   }
   if (str.substr(0, 16) == "stringview_wtf16" && (prefix || str.size() == 16)) {
-    return Type(HeapType::stringview_wtf16, Nullable);
+    return Type(HeapType::stringview_wtf16, NonNullable);
   }
   if (str.substr(0, 15) == "stringview_iter" && (prefix || str.size() == 15)) {
-    return Type(HeapType::stringview_iter, Nullable);
+    return Type(HeapType::stringview_iter, NonNullable);
   }
   if (str.substr(0, 7) == "nullref" && (prefix || str.size() == 7)) {
     return Type(HeapType::none, Nullable);

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1906,11 +1906,9 @@ std::ostream& TypePrinter::print(Type type) {
           case HeapType::string:
             return os << "stringref";
           case HeapType::stringview_wtf8:
-            return os << "stringview_wtf8";
           case HeapType::stringview_wtf16:
-            return os << "stringview_wtf16";
           case HeapType::stringview_iter:
-            return os << "stringview_iter";
+            break;
           case HeapType::none:
             return os << "nullref";
           case HeapType::noext:
@@ -1921,6 +1919,17 @@ std::ostream& TypePrinter::print(Type type) {
             return os << "nullcontref";
           case HeapType::noexn:
             return os << "nullexnref";
+        }
+      } else {
+        switch (heapType.getBasic()) {
+          case HeapType::stringview_wtf8:
+            return os << "stringview_wtf8";
+          case HeapType::stringview_wtf16:
+            return os << "stringview_wtf16";
+          case HeapType::stringview_iter:
+            return os << "stringview_iter";
+          default:
+            break;
         }
       }
     }

--- a/test/lit/ctor-eval/string_view.wast
+++ b/test/lit/ctor-eval/string_view.wast
@@ -10,7 +10,7 @@
  (export "test" (func $test))
 
  ;; CHECK:      (func $test (type $0)
- ;; CHECK-NEXT:  (local $temp-view (ref stringview_wtf16))
+ ;; CHECK-NEXT:  (local $temp-view stringview_wtf16)
  ;; CHECK-NEXT:  (local.set $temp-view
  ;; CHECK-NEXT:   (string.as_wtf16
  ;; CHECK-NEXT:    (string.const "test")

--- a/test/lit/passes/j2cl-inline.wast
+++ b/test/lit/passes/j2cl-inline.wast
@@ -6,16 +6,23 @@
 (module
 
   ;; A once function that has become empty
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (global $$class-initialized@Zoo (mut i32) (i32.const 0))
+
+  ;; CHECK:      (func $clinit-trivial-1_<once>_@Foo (type $0)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
   (func $clinit-trivial-1_<once>_@Foo  )
 
   ;; A once function that just calls another
+  ;; CHECK:      (func $clinit-trivial-2_<once>_@Bar (type $0)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
   (func $clinit-trivial-2_<once>_@Bar
     (call $clinit-trivial-1_<once>_@Foo)
   )
 
-  ;; CHECK:      (type $0 (func))
-
-  ;; CHECK:      (global $$class-initialized@Zoo (mut i32) (i32.const 0))
   (global $$class-initialized@Zoo (mut i32) (i32.const 0))
 
   ;; Not hoisted but trivial.

--- a/test/lit/passes/roundtrip.wast
+++ b/test/lit/passes/roundtrip.wast
@@ -43,7 +43,7 @@
   )
  )
 
- ;; CHECK:      (func $string_view_casts (type $2) (param $x stringview_wtf8) (param $y stringview_wtf16) (param $z stringview_iter)
+ ;; CHECK:      (func $string_view_casts (type $2) (param $x (ref null stringview_wtf8)) (param $y (ref null stringview_wtf16)) (param $z (ref null stringview_iter))
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (ref.as_non_null
  ;; CHECK-NEXT:    (local.get $x)

--- a/test/lit/passes/string-lowering-instructions.wast
+++ b/test/lit/passes/string-lowering-instructions.wast
@@ -42,9 +42,9 @@
 
   ;; CHECK:       (type $13 (func (param externref) (result externref)))
 
-  ;; CHECK:       (type $14 (func (param externref) (result externref)))
+  ;; CHECK:       (type $14 (func (param (ref extern)) (result externref)))
 
-  ;; CHECK:       (type $15 (func (param externref) (result i32)))
+  ;; CHECK:       (type $15 (func (param (ref extern)) (result i32)))
 
   ;; CHECK:       (type $16 (func (param externref externref) (result i32)))
 
@@ -54,7 +54,7 @@
 
   ;; CHECK:       (type $19 (func (param (ref $0))))
 
-  ;; CHECK:       (type $20 (func (param externref (ref extern) externref externref externref (ref extern))))
+  ;; CHECK:       (type $20 (func (param externref (ref extern) (ref extern) (ref extern) (ref extern) (ref extern))))
 
   ;; CHECK:      (type $21 (func (param (ref null $0) i32 i32) (result (ref extern))))
 
@@ -103,7 +103,7 @@
 
   ;; CHECK:      (export "export.2" (func $exported-string-receiver))
 
-  ;; CHECK:      (func $string.as (type $20) (param $a externref) (param $a_nn (ref extern)) (param $b externref) (param $c externref) (param $d externref) (param $nn_view (ref extern))
+  ;; CHECK:      (func $string.as (type $20) (param $a externref) (param $a_nn (ref extern)) (param $b (ref extern)) (param $c (ref extern)) (param $d (ref extern)) (param $nn_view (ref extern))
   ;; CHECK-NEXT:  (local.set $b
   ;; CHECK-NEXT:   (ref.as_non_null
   ;; CHECK-NEXT:    (local.get $a)
@@ -253,7 +253,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.length (type $15) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.length (type $15) (param $ref (ref extern)) (result i32)
   ;; CHECK-NEXT:  (call $length
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:  )
@@ -264,7 +264,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.get_codeunit (type $15) (param $ref externref) (result i32)
+  ;; CHECK:      (func $string.get_codeunit (type $15) (param $ref (ref extern)) (result i32)
   ;; CHECK-NEXT:  (call $charCodeAt
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)
@@ -277,7 +277,7 @@
     )
   )
 
-  ;; CHECK:      (func $string.slice (type $14) (param $ref externref) (result externref)
+  ;; CHECK:      (func $string.slice (type $14) (param $ref (ref extern)) (result externref)
   ;; CHECK-NEXT:  (call $substring
   ;; CHECK-NEXT:   (local.get $ref)
   ;; CHECK-NEXT:   (i32.const 2)

--- a/test/lit/strings.wast
+++ b/test/lit/strings.wast
@@ -25,7 +25,7 @@
   ;; CHECK:      (type $array16 (sub (array (mut i16))))
   (type $array16 (sub (array (mut i16))))
 
-  ;; CHECK:      (type $5 (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter stringref stringview_wtf8 stringview_wtf16 stringview_iter (ref string) (ref stringview_wtf8) (ref stringview_wtf16) (ref stringview_iter))))
+  ;; CHECK:      (type $5 (func (param stringref stringview_wtf8 stringview_wtf16 stringview_iter stringref (ref null stringview_wtf8) (ref null stringview_wtf16) (ref null stringview_iter) (ref string) stringview_wtf8 stringview_wtf16 stringview_iter)))
 
   ;; CHECK:      (type $6 (func (param (ref string))))
 
@@ -46,7 +46,7 @@
 
   ;; CHECK:      (memory $0 10 10)
 
-  ;; CHECK:      (func $string.new (type $5) (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter) (param $e stringref) (param $f stringview_wtf8) (param $g stringview_wtf16) (param $h stringview_iter) (param $i (ref string)) (param $j (ref stringview_wtf8)) (param $k (ref stringview_wtf16)) (param $l (ref stringview_iter))
+  ;; CHECK:      (func $string.new (type $5) (param $a stringref) (param $b stringview_wtf8) (param $c stringview_wtf16) (param $d stringview_iter) (param $e stringref) (param $f (ref null stringview_wtf8)) (param $g (ref null stringview_wtf16)) (param $h (ref null stringview_iter)) (param $i (ref string)) (param $j stringview_wtf8) (param $k stringview_wtf16) (param $l stringview_iter)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.new_wtf16
   ;; CHECK-NEXT:    (i32.const 7)

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -176,19 +176,19 @@
 
  ;; CHECK:      (type $81 (func (param stringref) (result stringview_wtf8)))
 
- ;; CHECK:      (type $82 (func (param stringref) (result (ref stringview_wtf16))))
+ ;; CHECK:      (type $82 (func (param stringref) (result stringview_wtf16)))
 
  ;; CHECK:      (type $83 (func (param stringref) (result stringview_iter)))
 
- ;; CHECK:      (type $84 (func (param (ref stringview_wtf8) i32 i32) (result i32)))
+ ;; CHECK:      (type $84 (func (param stringview_wtf8 i32 i32) (result i32)))
 
  ;; CHECK:      (type $85 (func (param stringview_wtf16 i32) (result i32)))
 
  ;; CHECK:      (type $86 (func (param stringview_iter) (result i32)))
 
- ;; CHECK:      (type $87 (func (param stringview_iter i32) (result i32)))
+ ;; CHECK:      (type $87 (func (param (ref null stringview_iter) i32) (result i32)))
 
- ;; CHECK:      (type $88 (func (param (ref stringview_iter) i32) (result i32)))
+ ;; CHECK:      (type $88 (func (param stringview_iter i32) (result i32)))
 
  ;; CHECK:      (type $89 (func (param stringview_wtf8 stringview_wtf16 i32 i32)))
 
@@ -256,7 +256,7 @@
  (type $cont-bind-before-func (func (param i32) (param i64) (param i32) (param i64) (result f32)))
  (type $cont-bind-before (cont $cont-bind-before-func))
 
- ;; CHECK:      (type $all-types (struct (field externref) (field (ref extern)) (field funcref) (field (ref func)) (field anyref) (field (ref any)) (field eqref) (field (ref eq)) (field i31ref) (field (ref i31)) (field structref) (field (ref struct)) (field arrayref) (field (ref array)) (field exnref) (field (ref exn)) (field stringref) (field (ref string)) (field stringview_wtf8) (field (ref stringview_wtf8)) (field stringview_wtf16) (field (ref stringview_wtf16)) (field stringview_iter) (field (ref stringview_iter)) (field contref) (field (ref cont)) (field nullref) (field (ref none)) (field nullexternref) (field (ref noextern)) (field nullfuncref) (field (ref nofunc)) (field nullexnref) (field (ref noexn)) (field nullcontref) (field (ref nocont))))
+ ;; CHECK:      (type $all-types (struct (field externref) (field (ref extern)) (field funcref) (field (ref func)) (field anyref) (field (ref any)) (field eqref) (field (ref eq)) (field i31ref) (field (ref i31)) (field structref) (field (ref struct)) (field arrayref) (field (ref array)) (field exnref) (field (ref exn)) (field stringref) (field (ref string)) (field stringview_wtf8) (field stringview_wtf8) (field stringview_wtf16) (field stringview_wtf16) (field stringview_iter) (field stringview_iter) (field contref) (field (ref cont)) (field nullref) (field (ref none)) (field nullexternref) (field (ref noextern)) (field nullfuncref) (field (ref nofunc)) (field nullexnref) (field (ref noexn)) (field nullcontref) (field (ref nocont))))
  (type $all-types (struct externref (ref extern)
                           funcref (ref func)
                           anyref (ref any)
@@ -4669,7 +4669,7 @@
   string.as_wtf8
  )
 
- ;; CHECK:      (func $string-as-wtf16 (type $82) (param $0 stringref) (result (ref stringview_wtf16))
+ ;; CHECK:      (func $string-as-wtf16 (type $82) (param $0 stringref) (result stringview_wtf16)
  ;; CHECK-NEXT:  (string.as_wtf16
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
@@ -4689,7 +4689,7 @@
   string.as_iter
  )
 
- ;; CHECK:      (func $string-advance (type $84) (param $0 (ref stringview_wtf8)) (param $1 i32) (param $2 i32) (result i32)
+ ;; CHECK:      (func $string-advance (type $84) (param $0 stringview_wtf8) (param $1 i32) (param $2 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_wtf8.advance
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4725,7 +4725,7 @@
   stringview_iter.next
  )
 
- ;; CHECK:      (func $string-iter-advance (type $87) (param $0 stringview_iter) (param $1 i32) (result i32)
+ ;; CHECK:      (func $string-iter-advance (type $87) (param $0 (ref null stringview_iter)) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_iter.advance
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)
@@ -4737,7 +4737,7 @@
   stringview_iter.advance
  )
 
- ;; CHECK:      (func $string-iter-rewind (type $88) (param $0 (ref stringview_iter)) (param $1 i32) (result i32)
+ ;; CHECK:      (func $string-iter-rewind (type $88) (param $0 stringview_iter) (param $1 i32) (result i32)
  ;; CHECK-NEXT:  (stringview_iter.rewind
  ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:   (local.get $1)


### PR DESCRIPTION
This is inconsistent with all other shorthands, but it is the latest behavior in
V8. Fix the text and binary shorthands in both parsers and writers.