### PR TITLE
Simplify scratch local calculation

### DIFF
--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -146,13 +146,14 @@ private:
   // type => number of locals of that type in the compact form
   std::unordered_map<Type, size_t> numLocalsByType;
 
-  void noteLocalType(Type type);
+  void noteLocalType(Type type, Index count = 1);
 
   // Keeps track of the binary index of the scratch locals used to lower
-  // tuple.extract.
+  // tuple.extract. If there are multiple scratch locals of the same type, they
+  // are contiguous and this map holds the index of the first.
   InsertOrderedMap<Type, Index> scratchLocals;
-  void countScratchLocals();
-  void setScratchLocals();
+  // Return the type and number of required scratch locals.
+  InsertOrderedMap<Type, Index> countScratchLocals();
 
   // local.get, local.tee, and glboal.get expressions that will be followed by
   // tuple.extracts. We can optimize these by getting only the local for the

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2687,10 +2687,6 @@ InsertOrderedMap<Type, Index> BinaryInstWriter::countScratchLocals() {
 
     ScratchLocalFinder(BinaryInstWriter& parent) : parent(parent) {}
 
-    // We need two i32 scratch locals for reach string slice, but they can be
-    // reused.
-    bool hasStringSlice = false;
-
     void visitTupleExtract(TupleExtract* curr) {
       if (curr->type == Type::unreachable) {
         // We will not emit this instruction anyway.

--- a/test/lit/binary/dwarf-multivalue.test
+++ b/test/lit/binary/dwarf-multivalue.test
@@ -75,12 +75,10 @@
 ;;  (local $11 i32) ;; Previous (local $11 (tuple i32 f32))'s first element
 ;;  (local $12 f32) ;; Previous (local $11 (tuple i32 f32))'s second element
 ;;  (local $13 i32) ;; Previous (local $12 i32)
-;;  (local $14 f32) ;; scratch local for f32
 
 ;; We parse this binary again into Binaryen IR, roundtripping the original
-;; binary. Here until (local $14) is the same with the previous list, and $15 is
-;; is added for tuple parsing and $16 is added for stacky IR resolving during
-;; binary reading process.
+;; binary. Locals $14 and $15 are added for stacky IR resolving during binary
+;; reading process.
 ;; RUN: wasm-opt -all -g --roundtrip %s.wasm -S -o - | filecheck %s --check-prefix=ROUNDTRIP
 ;; ROUNDTRIP:      (func $test
 ;; ROUNDTRIP-NEXT:  (local $0 i32)

--- a/test/lit/binary/dwarf-multivalue.test
+++ b/test/lit/binary/dwarf-multivalue.test
@@ -97,9 +97,8 @@
 ;; ROUNDTRIP-NEXT:  (local $11 i32)
 ;; ROUNDTRIP-NEXT:  (local $12 f32)
 ;; ROUNDTRIP-NEXT:  (local $13 i32)
-;; ROUNDTRIP-NEXT:  (local $14 f32)
-;; ROUNDTRIP-NEXT:  (local $15 (tuple i32 f32))
-;; ROUNDTRIP-NEXT:  (local $16 i32)
+;; ROUNDTRIP-NEXT:  (local $14 (tuple i32 f32))
+;; ROUNDTRIP-NEXT:  (local $15 i32)
 
 ;; We can see that we don't reorder the locals during the process and the
 ;; original list of locals, local $0~$10, is untouched, to NOT invalidate DWARF

--- a/test/lit/multivalue.wast
+++ b/test/lit/multivalue.wast
@@ -149,42 +149,40 @@
  ;; CHECK:      (func $reverse (type $4) (result f32 i64 i32)
  ;; CHECK-NEXT:  (local $x i32)
  ;; CHECK-NEXT:  (local $1 i64)
- ;; CHECK-NEXT:  (local $2 i64)
- ;; CHECK-NEXT:  (local $3 f32)
- ;; CHECK-NEXT:  (local $4 f32)
- ;; CHECK-NEXT:  (local $5 (tuple i32 i64 f32))
- ;; CHECK-NEXT:  (local $6 i64)
- ;; CHECK-NEXT:  (local $7 i32)
- ;; CHECK-NEXT:  (local.set $5
+ ;; CHECK-NEXT:  (local $2 f32)
+ ;; CHECK-NEXT:  (local $3 (tuple i32 i64 f32))
+ ;; CHECK-NEXT:  (local $4 i64)
+ ;; CHECK-NEXT:  (local $5 i32)
+ ;; CHECK-NEXT:  (local.set $3
  ;; CHECK-NEXT:   (call $triple)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (local.set $x
  ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (local.set $7
+ ;; CHECK-NEXT:    (local.set $5
  ;; CHECK-NEXT:     (tuple.extract 3 0
- ;; CHECK-NEXT:      (local.get $5)
+ ;; CHECK-NEXT:      (local.get $3)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (local.set $1
  ;; CHECK-NEXT:     (block (result i64)
- ;; CHECK-NEXT:      (local.set $6
+ ;; CHECK-NEXT:      (local.set $4
  ;; CHECK-NEXT:       (tuple.extract 3 1
- ;; CHECK-NEXT:        (local.get $5)
+ ;; CHECK-NEXT:        (local.get $3)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (local.set $3
+ ;; CHECK-NEXT:      (local.set $2
  ;; CHECK-NEXT:       (tuple.extract 3 2
- ;; CHECK-NEXT:        (local.get $5)
+ ;; CHECK-NEXT:        (local.get $3)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (local.get $6)
+ ;; CHECK-NEXT:      (local.get $4)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.get $7)
+ ;; CHECK-NEXT:    (local.get $5)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (tuple.make 3
- ;; CHECK-NEXT:   (local.get $3)
+ ;; CHECK-NEXT:   (local.get $2)
  ;; CHECK-NEXT:   (local.get $1)
  ;; CHECK-NEXT:   (local.get $x)
  ;; CHECK-NEXT:  )
@@ -228,17 +226,16 @@
 
  ;; Test multivalue globals
  ;; CHECK:      (func $global (type $0) (result i32 i64)
- ;; CHECK-NEXT:  (local $0 i64)
- ;; CHECK-NEXT:  (local $1 i32)
+ ;; CHECK-NEXT:  (local $0 i32)
  ;; CHECK-NEXT:  (global.set $g1
  ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (local.set $1
+ ;; CHECK-NEXT:    (local.set $0
  ;; CHECK-NEXT:     (i32.const 42)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:    (global.set $g2
  ;; CHECK-NEXT:     (i64.const 7)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.get $1)
+ ;; CHECK-NEXT:    (local.get $0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (drop


### PR DESCRIPTION
Change `countScratchLocals` to return the count and type of necessary scratch
locals. It used to encode them as keys in the global map from scratch local
types to local indices, which could not handle having more than one scratch
local of a given type and was generally harder to reason about due to its use of
global state. Take the opportunity to avoid emitting unnecessary scratch locals
for `TupleExtract` expressions that will be optimized to not use them.

Also simplify and better document the calculation of the mapping from IR indices
to binary indices for all locals, scratch and non-scratch.