### PR TITLE
LocalCSE: Check effects/generativity early

### DIFF
--- a/src/ir/properties.cpp
+++ b/src/ir/properties.cpp
@@ -19,24 +19,37 @@
 
 namespace wasm::Properties {
 
-bool isGenerative(Expression* curr, FeatureSet features) {
-  struct Scanner : public PostWalker<Scanner> {
-    bool generative = false;
+namespace {
 
-    void visitCall(Call* curr) {
-      // TODO: We could in principle look at the called function to see if it is
-      //       generative. To do that we'd need to compute generativity like we
-      //       compute global effects (we can't just peek from here, as the
-      //       other function might be modified in parallel).
-      generative = true;
-    }
-    void visitCallIndirect(CallIndirect* curr) { generative = true; }
-    void visitCallRef(CallRef* curr) { generative = true; }
-    void visitStructNew(StructNew* curr) { generative = true; }
-    void visitArrayNew(ArrayNew* curr) { generative = true; }
-    void visitArrayNewFixed(ArrayNewFixed* curr) { generative = true; }
-  } scanner;
+struct GenerativityScanner : public PostWalker<GenerativityScanner> {
+  bool generative = false;
+
+  void visitCall(Call* curr) {
+    // TODO: We could in principle look at the called function to see if it is
+    //       generative. To do that we'd need to compute generativity like we
+    //       compute global effects (we can't just peek from here, as the
+    //       other function might be modified in parallel).
+    generative = true;
+  }
+  void visitCallIndirect(CallIndirect* curr) { generative = true; }
+  void visitCallRef(CallRef* curr) { generative = true; }
+  void visitStructNew(StructNew* curr) { generative = true; }
+  void visitArrayNew(ArrayNew* curr) { generative = true; }
+  void visitArrayNewFixed(ArrayNewFixed* curr) { generative = true; }
+};
+
+} // anonymous namespace
+
+bool isGenerative(Expression* curr) {
+  GenerativityScanner scanner;
   scanner.walk(curr);
+  return scanner.generative;
+}
+
+// As above, but only checks |curr| and not children.
+bool isShallowlyGenerative(Expression* curr) {
+  GenerativityScanner scanner;
+  scanner.visit(curr);
   return scanner.generative;
 }
 

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -527,7 +527,10 @@ inline bool canEmitSelectWithArms(Expression* ifTrue, Expression* ifFalse) {
 //    the latter because calls are already handled best in other manners (using
 //    EffectAnalyzer).
 //
-bool isGenerative(Expression* curr, FeatureSet features);
+bool isGenerative(Expression* curr);
+
+// As above, but only checks |curr| and not children.
+bool isShallowlyGenerative(Expression* curr);
 
 // Whether this expression is valid in a context where WebAssembly requires a
 // constant expression, such as a global initializer.

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -346,7 +346,7 @@ struct Scanner
     // checking effects here we could perhaps add backtracking, but that sounds
     // more complex.)
     //
-    // We can ignore traps here because if a trap occurs the optimization
+    // We use |hasNonTrapSideEffects| because if a trap occurs the optimization
     // remains valid: both this and the copy of it would trap, which means the
     // first traps and the second isn't reached anyhow.
     //
@@ -447,10 +447,6 @@ struct Checker
           requestInfos.erase(original);
         }
 
-        // Note that we've already checked above that this has no side effects
-        // or generativity: if we got here, then it is good to go from the
-        // perspective of this expression itself (but may be invalidated by
-        // other code in between, see above).
         activeOriginals.erase(original);
       }
     }
@@ -476,6 +472,10 @@ struct Checker
       // none of them.)
       effects.trap = false;
 
+      // Note that we've already checked above that this has no side effects or
+      // generativity: if we got here, then it is good to go from the
+      // perspective of this expression itself (but may be invalidated by other
+      // code in between, see above).
       activeOriginals.emplace(
         curr, ActiveOriginalInfo{info.requests, std::move(effects)});
     } else if (info.original) {

--- a/src/passes/LocalCSE.cpp
+++ b/src/passes/LocalCSE.cpp
@@ -352,7 +352,8 @@ struct Scanner
     //
     // (We don't stash these effects because we may compute many of them here,
     // and only need the few for those patterns that repeat.)
-    if (ShallowEffectAnalyzer(options, *getModule(), curr).hasNonTrapSideEffects()) {
+    if (ShallowEffectAnalyzer(options, *getModule(), curr)
+          .hasNonTrapSideEffects()) {
       return false;
     }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2508,7 +2508,7 @@ private:
 
     // To be equal, they must also be known to return the same result
     // deterministically.
-    return !Properties::isGenerative(left, getModule()->features);
+    return !Properties::isGenerative(left);
   }
 
   // Similar to areConsecutiveInputsEqual() but also checks if we can remove

--- a/test/lit/passes/local-cse.wast
+++ b/test/lit/passes/local-cse.wast
@@ -9,7 +9,9 @@
 
   ;; CHECK:      (type $1 (func (param i32) (result i32)))
 
-  ;; CHECK:      (type $2 (func (result i64)))
+  ;; CHECK:      (type $2 (func (param i32)))
+
+  ;; CHECK:      (type $3 (func (result i64)))
 
   ;; CHECK:      (memory $0 100 100)
 
@@ -313,6 +315,45 @@
       (call $calls (i32.const 10))
     )
     (i32.const 10)
+  )
+
+  ;; CHECK:      (func $in-calls (param $x i32)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (call $calls
+  ;; CHECK-NEXT:    (local.tee $1
+  ;; CHECK-NEXT:     (i32.add
+  ;; CHECK-NEXT:      (i32.const 10)
+  ;; CHECK-NEXT:      (i32.const 20)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (call $calls
+  ;; CHECK-NEXT:    (local.get $1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $in-calls (param $x i32)
+    ;; The side effects of calls prevent optimization, but expressions nested in
+    ;; calls can be optimized.
+    (drop
+      (call $calls
+        (i32.add
+          (i32.const 10)
+          (i32.const 20)
+        )
+      )
+    )
+    (drop
+      (call $calls
+        (i32.add
+          (i32.const 10)
+          (i32.const 20)
+        )
+      )
+    )
   )
 
   ;; CHECK:      (func $many-sets (result i64)


### PR DESCRIPTION
Previously we checked late, and as a result might end up failing to optimize when
a sub-pattern could have worked. E.g.
```wat
(call
  (A)
)
(call
  (A)
)
```
The `call` cannot be optimized, but the `A` pattern repeats. Before this PR we'd
greedily focus on the entire `call` and then fail. After this PR we skip the call
before we commit to which patterns to try to optimize, so we succeed.

Add a `isShallowlyGenerative` helper here as we compute this step by step as
we go. Also remove a parameter to the generativity code (it did not use the
features it was passed).