### PR TITLE
Debug location parser: accept arbitrary paths

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1736,30 +1736,29 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
       return;
     }
 
-    auto contents = lexer.takeKeyword();
-    if (!contents || !lexer.empty()) {
-      return;
-    }
+    auto contents = lexer.next();
 
-    auto fileSize = contents->find(':');
-    if (fileSize == contents->npos) {
+    auto fileSize = contents.find(':');
+    if (fileSize == 0 || fileSize == contents.npos) {
       return;
     }
-    auto file = contents->substr(0, fileSize);
-    contents = contents->substr(fileSize + 1);
+    auto file = contents.substr(0, fileSize);
+    contents = contents.substr(fileSize + 1);
 
-    auto lineSize = contents->find(':');
-    if (fileSize == contents->npos) {
+    auto lineSize = contents.find(':');
+    if (lineSize == contents.npos) {
       return;
     }
-    auto line = Lexer(contents->substr(0, lineSize)).takeU32();
-    if (!line) {
+    lexer = Lexer(contents.substr(0, lineSize));
+    auto line = lexer.takeU32();
+    if (!line || !lexer.empty()) {
       return;
     }
-    contents = contents->substr(lineSize + 1);
+    contents = contents.substr(lineSize + 1);
 
-    auto col = Lexer(*contents).takeU32();
-    if (!col) {
+    lexer = Lexer(contents);
+    auto col = lexer.takeU32();
+    if (!col || !lexer.empty()) {
       return;
     }
 

--- a/test/lit/source-map.wast
+++ b/test/lit/source-map.wast
@@ -90,10 +90,13 @@
   )
 
   ;; CHECK:      (func $paths
+  ;; CHECK-NEXT:  ;;@ /tmp/src.cpp:1:1
   ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  ;;@ ../src.cpp:2:2
   ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  ;;@ café.cpp:2:2
   ;; CHECK-NEXT:  (nop)
-  ;; CHECK-NEXT:  ;;@ src.cpp:3:3
+  ;; CHECK-NEXT:  ;;@ café.cpp:2:2
   ;; CHECK-NEXT:  (nop)
   ;; CHECK-NEXT: )
   (func $paths

--- a/test/lit/source-map.wast
+++ b/test/lit/source-map.wast
@@ -10,9 +10,9 @@
 
 (module
   ;;@ src.cpp:0:1
-  ;; CHECK:      (type $0 (func (param i32 i32)))
+  ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (type $1 (func))
+  ;; CHECK:      (type $1 (func (param i32 i32)))
 
   ;; CHECK:      (func $foo (param $x i32) (param $y i32)
   ;; CHECK-NEXT:  ;;@ src.cpp:10:1
@@ -87,5 +87,24 @@
     )
     ;;@ src.cpp:3:1
     (return)
+  )
+
+  ;; CHECK:      (func $paths
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT:  ;;@ src.cpp:3:3
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $paths
+    ;;@ /tmp/src.cpp:1:1
+    (nop)
+    ;;@ ../src.cpp:2:2
+    (nop)
+    ;;@ café.cpp:2:2
+    (nop)
+    ;; This annotation is invalid (missing column)
+    ;;@ src.cpp:3
+    (nop)
   )
 )


### PR DESCRIPTION
The whole annotation was parsed as a keyword, which prevented file paths with non-ascii characters or paths starting with `/` or `.`.

Also, there was a typo: one was comparing `fileSize` rather than `lineSize` to `contents->npos`.