### PR TITLE
Fix GlobalRefining's handling of gets in module code and add missing validation

### DIFF
--- a/src/passes/GlobalRefining.cpp
+++ b/src/passes/GlobalRefining.cpp
@@ -143,8 +143,9 @@ struct GlobalRefining : public Pass {
           ReFinalize().walkFunctionInModule(curr, &wasm);
         }
       }
-    };
-    GetUpdater(*this, *module).run(getPassRunner(), module);
+    } updater(*this, *module);
+    updater.run(getPassRunner(), module);
+    updater.runOnModuleCode(getPassRunner(), module);
   }
 };
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1004,9 +1004,15 @@ void FunctionValidator::visitGlobalGet(GlobalGet* curr) {
   if (!info.validateGlobally) {
     return;
   }
-  shouldBeTrue(getModule()->getGlobalOrNull(curr->name),
-               curr,
-               "global.get name must be valid");
+  auto* global = getModule()->getGlobalOrNull(curr->name);
+  if (shouldBeTrue(global,
+                   curr,
+                   "global.get name must be valid")) {
+    shouldBeEqual(curr->type,
+                  global->type,
+                  curr,
+                  "global.get must have right type");
+  }
 }
 
 void FunctionValidator::visitGlobalSet(GlobalSet* curr) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1005,13 +1005,9 @@ void FunctionValidator::visitGlobalGet(GlobalGet* curr) {
     return;
   }
   auto* global = getModule()->getGlobalOrNull(curr->name);
-  if (shouldBeTrue(global,
-                   curr,
-                   "global.get name must be valid")) {
-    shouldBeEqual(curr->type,
-                  global->type,
-                  curr,
-                  "global.get must have right type");
+  if (shouldBeTrue(global, curr, "global.get name must be valid")) {
+    shouldBeEqual(
+      curr->type, global->type, curr, "global.get must have right type");
   }
 }
 

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -1176,7 +1176,7 @@ void test_core() {
                       makeInt32(module, 0)),
     BinaryenStringNew(module,
                       BinaryenStringNewWTF16Array(),
-                      BinaryenGlobalGet(module, "i16Array-global", i8Array),
+                      BinaryenGlobalGet(module, "i16Array-global", i16Array),
                       makeInt32(module, 0),
                       makeInt32(module, 0)),
     BinaryenStringNew(

--- a/test/lit/passes/global-refining.wast
+++ b/test/lit/passes/global-refining.wast
@@ -193,3 +193,30 @@
     (nop)
   )
 )
+
+;; We can refine $a, after which we should update the global.get in the other
+;; global, or else we'd error on validation.
+(module
+  ;; CHECK:      (type $super (sub (func)))
+  ;; CLOSD:      (type $super (sub (func)))
+  (type $super (sub (func)))
+  ;; CHECK:      (type $sub (sub $super (func)))
+  ;; CLOSD:      (type $sub (sub $super (func)))
+  (type $sub (sub $super (func)))
+
+  ;; CHECK:      (global $a (ref $sub) (ref.func $func))
+  ;; CLOSD:      (global $a (ref $sub) (ref.func $func))
+  (global $a (ref $super) (ref.func $func))
+  ;; CHECK:      (global $b (ref $super) (global.get $a))
+  ;; CLOSD:      (global $b (ref $super) (global.get $a))
+  (global $b (ref $super) (global.get $a))
+
+  ;; CHECK:      (func $func (type $sub)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  ;; CLOSD:      (func $func (type $sub)
+  ;; CLOSD-NEXT:  (nop)
+  ;; CLOSD-NEXT: )
+  (func $func (type $sub)
+  )
+)

--- a/test/lit/passes/global-refining.wast
+++ b/test/lit/passes/global-refining.wast
@@ -196,6 +196,7 @@
 
 ;; We can refine $a, after which we should update the global.get in the other
 ;; global, or else we'd error on validation.
+;; TODO: we could optimize further here and refine the type of the global $b.
 (module
   ;; CHECK:      (type $super (sub (func)))
   ;; CLOSD:      (type $super (sub (func)))


### PR DESCRIPTION
GlobalRefining did not traverse module code, so it did not update `global.get`s
in other globals.

Add missing validation that actually errors on that: We did not check `global.get`
types.

These could be separate PRs but it would be difficult to test them separately.