### PR TITLE
Fuzzer: Stop testing with TurboFan

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -856,12 +856,6 @@ class CompareVMs(TestCaseHandler):
             def run(self, wasm):
                 return super(D8Turboshaft, self).run(wasm, extra_d8_flags=['--no-liftoff', '--turboshaft-wasm', '--turboshaft-wasm-instruction-selection-staged'])
 
-        class D8TurboFan(D8):
-            name = 'd8_turbofan'
-
-            def run(self, wasm):
-                return super(D8TurboFan, self).run(wasm, extra_d8_flags=['--no-liftoff'])
-
         class Wasm2C:
             name = 'wasm2c'
 
@@ -960,7 +954,6 @@ class CompareVMs(TestCaseHandler):
                     D8(),
                     D8Liftoff(),
                     D8Turboshaft(),
-                    D8TurboFan(),
                     # FIXME: Temprorary disable. See issue #4741 for more details
                     # Wasm2C(),
                     # Wasm2C2Wasm()


### PR DESCRIPTION
Turboshaft, the replacement, is rolling out, so we no longer need the coverage.

This makes us significantly faster as TurboFan was much slower than Turboshaft
on random fuzzer binaries.