### PR TITLE
Fix fuzzer generation of a DataSegment + add validation that would have caught it

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -225,12 +225,12 @@ void TranslateToFuzzReader::setupMemory() {
     segment->memory = memory->name;
     segment->offset = builder.makeConst(int32_t(0));
     segment->setName(Name::fromInt(0), false);
-    wasm.dataSegments.push_back(std::move(segment));
     auto num = upTo(USABLE_MEMORY * 2);
     for (size_t i = 0; i < num; i++) {
       auto value = upTo(512);
-      wasm.dataSegments[0]->data.push_back(value >= 256 ? 0 : (value & 0xff));
+      segment->data.push_back(value >= 256 ? 0 : (value & 0xff));
     }
+    wasm.addDataSegment(std::move(segment));
   }
 }
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -224,7 +224,8 @@ void TranslateToFuzzReader::setupMemory() {
     auto segment = builder.makeDataSegment();
     segment->memory = memory->name;
     segment->offset = builder.makeConst(int32_t(0));
-    segment->setName(Name::fromInt(0), false);
+    segment->setName(Names::getValidDataSegmentName(wasm, Name::fromInt(0)),
+                     false);
     auto num = upTo(USABLE_MEMORY * 2);
     for (size_t i = 0; i < num; i++) {
       auto value = upTo(512);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3929,13 +3929,21 @@ template<typename T, typename U>
 void validateModuleMap(Module& module,
                        ValidationInfo& info,
                        T& list,
-                       U method,
+                       U getter,
                        const std::string& kind) {
-  // The things in the list should be accessible using the get* APIs, which uses
-  // the lookup maps.
+  // Given a list of module elements (like exports or globals), see that we can
+  // get the items using the getter (getExportorNull, etc.). The getter uses the
+  // lookup map internally, so this validates that they contain all items in
+  // the list.
   for (auto& item : list) {
-    if (!((module.*method)(item->name))) {
+    auto* ptr = (module.*getter)(item->name);
+    if (!ptr) {
       info.fail(kind + " must be found (use updateMaps)", item->name, nullptr);
+    } else {
+      info.shouldBeEqual(item->name,
+                         ptr->name,
+                         item,
+                         "getter must return the correct item");
     }
   }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3960,7 +3960,7 @@ static void validateModuleMaps(Module& module, ValidationInfo& info) {
     module, info, module.functions, &Module::getFunctionOrNull, "Function");
   validateModuleMap(
     module, info, module.globals, &Module::getGlobalOrNull, "Global");
-  validateModuleMap(module, info, module.tags, &Module::getTagOrNull, "tag");
+  validateModuleMap(module, info, module.tags, &Module::getTagOrNull, "Tag");
   validateModuleMap(module,
                     info,
                     module.elementSegments,

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3942,7 +3942,7 @@ void validateModuleMap(Module& module,
     } else {
       info.shouldBeEqual(item->name,
                          ptr->name,
-                         item,
+                         item->name,
                          "getter must return the correct item");
     }
   }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3965,7 +3965,7 @@ static void validateModuleMaps(Module& module, ValidationInfo& info) {
                     info,
                     module.elementSegments,
                     &Module::getElementSegmentOrNull,
-                    "elementSegment");
+                    "ElementSegment");
   validateModuleMap(
     module, info, module.memories, &Module::getMemoryOrNull, "Memory");
   validateModuleMap(module,

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3926,14 +3926,16 @@ static void validateStart(Module& module, ValidationInfo& info) {
 
 namespace {
 template<typename T, typename U>
-void validateModuleMap(Module& module, ValidationInfo& info, T& list, U method, const std::string& kind) {
+void validateModuleMap(Module& module,
+                       ValidationInfo& info,
+                       T& list,
+                       U method,
+                       const std::string& kind) {
   // The things in the list should be accessible using the get* APIs, which uses
   // the lookup maps.
   for (auto& item : list) {
     if (!((module.*method)(item->name))) {
-      info.fail(kind + " must be found (use updateMaps)",
-                item->name,
-                nullptr);
+      info.fail(kind + " must be found (use updateMaps)", item->name, nullptr);
     }
   }
 
@@ -3944,14 +3946,27 @@ void validateModuleMap(Module& module, ValidationInfo& info, T& list, U method, 
 
 static void validateModuleMaps(Module& module, ValidationInfo& info) {
   // Module maps should be up to date.
-  validateModuleMap(module, info, module.exports, &Module::getExportOrNull, "Export");
-  validateModuleMap(module, info, module.functions, &Module::getFunctionOrNull, "Function");
-  validateModuleMap(module, info, module.globals, &Module::getGlobalOrNull, "Global");
+  validateModuleMap(
+    module, info, module.exports, &Module::getExportOrNull, "Export");
+  validateModuleMap(
+    module, info, module.functions, &Module::getFunctionOrNull, "Function");
+  validateModuleMap(
+    module, info, module.globals, &Module::getGlobalOrNull, "Global");
   validateModuleMap(module, info, module.tags, &Module::getTagOrNull, "tag");
-  validateModuleMap(module, info, module.elementSegments, &Module::getElementSegmentOrNull, "elementSegment");
-  validateModuleMap(module, info, module.memories, &Module::getMemoryOrNull, "Memory");
-  validateModuleMap(module, info, module.dataSegments, &Module::getDataSegmentOrNull, "DataSegment");
-  validateModuleMap(module, info, module.tables, &Module::getTableOrNull, "Table");
+  validateModuleMap(module,
+                    info,
+                    module.elementSegments,
+                    &Module::getElementSegmentOrNull,
+                    "elementSegment");
+  validateModuleMap(
+    module, info, module.memories, &Module::getMemoryOrNull, "Memory");
+  validateModuleMap(module,
+                    info,
+                    module.dataSegments,
+                    &Module::getDataSegmentOrNull,
+                    "DataSegment");
+  validateModuleMap(
+    module, info, module.tables, &Module::getTableOrNull, "Table");
 }
 
 static void validateFeatures(Module& module, ValidationInfo& info) {


### PR DESCRIPTION
The DataSegment was manually added to `.dataSegments`, but we need to add it
using `addDataSegment` so the maps are updated and `getDataSegment(name)`
works.

Ideally `.dataSegments` would be private, but a lot of code finds it useful to
iterate on it, so we've left it accessible.

Also add validation that would have caught this earlier: check that each item in
the item lists can be fetched by name.

The reason this was noticed is that #6620 happened to run into it by pure luck.