### PR TITLE
SignaturePruning: Properly handle public types

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,3 @@ BinPackParameters: false
 Language: JavaScript
 DisableFormat: true
 ---
-Language: Json
-BasedOnStyle: LLVM
----

--- a/.clang-format
+++ b/.clang-format
@@ -12,3 +12,6 @@ BinPackParameters: false
 Language: JavaScript
 DisableFormat: true
 ---
+Language: Json
+BasedOnStyle: LLVM
+---

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -39,9 +39,22 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   // come before their subtypes.
   Index i = 0;
   auto privateTypes = ModuleUtils::getPrivateHeapTypes(wasm);
+  std::unordered_set<HeapType> privateTypesSet(privateTypes.begin(), privateTypes.end());
+
+for (auto t : privateTypes) {
+std::cout << "P: " << t << " and " << privateTypesSet.count(t) << '\n';
+}
+for (auto t : additionalPrivateTypes) {
+std::cout << "ADDp: " << t << " and " << privateTypesSet.count(t) << '\n';
+}
 
   for (auto t : additionalPrivateTypes) {
-    privateTypes.push_back(t);
+    // Only add additional private types that are not already in the list.
+    if (!privateTypesSet.count(t)) {
+std::cout << "actually add " << t << " and " << privateTypesSet.count(t) << '\n';
+      privateTypes.push_back(t);
+      privateTypesSet.insert(t);
+    }
   }
 
   // Topological sort to have supertypes first, but we have to account for the
@@ -145,6 +158,7 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   for (auto& [old, new_] : oldToNewTypes) {
     if (auto it = wasm.typeNames.find(old); it != wasm.typeNames.end()) {
       wasm.typeNames[new_] = it->second;
+      wasm.typeNames[old].name = "old"; // XXX not quite right yet
     }
   }
 

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -28,7 +28,10 @@ namespace wasm {
 
 GlobalTypeRewriter::GlobalTypeRewriter(Module& wasm) : wasm(wasm) {}
 
-void GlobalTypeRewriter::update(const std::vector<HeapType>& additionalPrivateTypes) { mapTypes(rebuildTypes(additionalPrivateTypes)); }
+void GlobalTypeRewriter::update(
+  const std::vector<HeapType>& additionalPrivateTypes) {
+  mapTypes(rebuildTypes(additionalPrivateTypes));
+}
 
 GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   const std::vector<HeapType>& additionalPrivateTypes) {
@@ -39,7 +42,8 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   // come before their subtypes.
   Index i = 0;
   auto privateTypes = ModuleUtils::getPrivateHeapTypes(wasm);
-  std::unordered_set<HeapType> privateTypesSet(privateTypes.begin(), privateTypes.end());
+  std::unordered_set<HeapType> privateTypesSet(privateTypes.begin(),
+                                               privateTypes.end());
 
   for (auto t : additionalPrivateTypes) {
     // Only add additional private types that are not already in the list.

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -28,7 +28,7 @@ namespace wasm {
 
 GlobalTypeRewriter::GlobalTypeRewriter(Module& wasm) : wasm(wasm) {}
 
-void GlobalTypeRewriter::update() { mapTypes(rebuildTypes()); }
+void GlobalTypeRewriter::update(const std::vector<HeapType>& additionalPrivateTypes) { mapTypes(rebuildTypes(additionalPrivateTypes)); }
 
 GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   const std::vector<HeapType>& additionalPrivateTypes) {

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -43,10 +43,10 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
 
   for (auto t : additionalPrivateTypes) {
     // Only add additional private types that are not already in the list.
-//    if (!privateTypesSet.count(t)) {
+    if (!privateTypesSet.count(t)) {
       privateTypes.push_back(t);
-//      privateTypesSet.insert(t);
-//    }
+      privateTypesSet.insert(t);
+    }
   }
 
   // Topological sort to have supertypes first, but we have to account for the

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -43,10 +43,10 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
 
   for (auto t : additionalPrivateTypes) {
     // Only add additional private types that are not already in the list.
-    if (!privateTypesSet.count(t)) {
+//    if (!privateTypesSet.count(t)) {
       privateTypes.push_back(t);
-      privateTypesSet.insert(t);
-    }
+//      privateTypesSet.insert(t);
+//    }
   }
 
   // Topological sort to have supertypes first, but we have to account for the
@@ -150,10 +150,6 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   for (auto& [old, new_] : oldToNewTypes) {
     if (auto it = wasm.typeNames.find(old); it != wasm.typeNames.end()) {
       wasm.typeNames[new_] = it->second;
-      // Erase the old name. This avoids the same name appearing twice if for
-      // some reason the old type is still in use somehow, which can be
-      // confusing during debugging.
-      wasm.typeNames.erase(old);
     }
   }
 

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -41,17 +41,9 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   auto privateTypes = ModuleUtils::getPrivateHeapTypes(wasm);
   std::unordered_set<HeapType> privateTypesSet(privateTypes.begin(), privateTypes.end());
 
-for (auto t : privateTypes) {
-std::cout << "P: " << t << " and " << privateTypesSet.count(t) << '\n';
-}
-for (auto t : additionalPrivateTypes) {
-std::cout << "ADDp: " << t << " and " << privateTypesSet.count(t) << '\n';
-}
-
   for (auto t : additionalPrivateTypes) {
     // Only add additional private types that are not already in the list.
     if (!privateTypesSet.count(t)) {
-std::cout << "actually add " << t << " and " << privateTypesSet.count(t) << '\n';
       privateTypes.push_back(t);
       privateTypesSet.insert(t);
     }
@@ -158,7 +150,10 @@ std::cout << "actually add " << t << " and " << privateTypesSet.count(t) << '\n'
   for (auto& [old, new_] : oldToNewTypes) {
     if (auto it = wasm.typeNames.find(old); it != wasm.typeNames.end()) {
       wasm.typeNames[new_] = it->second;
-      wasm.typeNames[old].name = "old"; // XXX not quite right yet
+      // Erase the old name. This avoids the same name appearing twice if for
+      // some reason the old type is still in use somehow, which can be
+      // confusing during debugging.
+      wasm.typeNames.erase(old);
     }
   }
 

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -42,14 +42,17 @@ GlobalTypeRewriter::TypeMap GlobalTypeRewriter::rebuildTypes(
   // come before their subtypes.
   Index i = 0;
   auto privateTypes = ModuleUtils::getPrivateHeapTypes(wasm);
-  std::unordered_set<HeapType> privateTypesSet(privateTypes.begin(),
-                                               privateTypes.end());
 
-  for (auto t : additionalPrivateTypes) {
+  if (!additionalPrivateTypes.empty()) {
     // Only add additional private types that are not already in the list.
-    if (!privateTypesSet.count(t)) {
-      privateTypes.push_back(t);
-      privateTypesSet.insert(t);
+    std::unordered_set<HeapType> privateTypesSet(privateTypes.begin(),
+                                                 privateTypes.end());
+
+    for (auto t : additionalPrivateTypes) {
+      if (!privateTypesSet.count(t)) {
+        privateTypes.push_back(t);
+        privateTypesSet.insert(t);
+      }
     }
   }
 

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -403,7 +403,10 @@ public:
 
   // Helper for the repeating pattern of just updating Signature types using a
   // map of old heap type => new Signature.
-  static void updateSignatures(const SignatureUpdates& updates, Module& wasm, const std::vector<HeapType>& additionalPrivateTypes = {}) {
+  static void
+  updateSignatures(const SignatureUpdates& updates,
+                   Module& wasm,
+                   const std::vector<HeapType>& additionalPrivateTypes = {}) {
     if (updates.empty()) {
       return;
     }
@@ -412,7 +415,9 @@ public:
       const SignatureUpdates& updates;
 
     public:
-      SignatureRewriter(Module& wasm, const SignatureUpdates& updates, const std::vector<HeapType>& additionalPrivateTypes)
+      SignatureRewriter(Module& wasm,
+                        const SignatureUpdates& updates,
+                        const std::vector<HeapType>& additionalPrivateTypes)
         : GlobalTypeRewriter(wasm), updates(updates) {
         update(additionalPrivateTypes);
       }

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -291,8 +291,15 @@ struct SignaturePruning : public Pass {
       }
     }
 
-    // Rewrite the types.
-    GlobalTypeRewriter::updateSignatures(newSignatures, *module);
+    // Rewrite the types. We pass in all the types we intend to modify as being
+    // "additional private types" because we have proven above that they are
+    // safe to modify, even if they are technically public (e.g. they may be in
+    // a singleton big rec group that is public because one member is public).
+    std::vector<HeapType> additionalPrivateTypes;
+    for (auto& [type, sig] : newSignatures) {
+      additionalPrivateTypes.push_back(type);
+    }
+    GlobalTypeRewriter::updateSignatures(newSignatures, *module, additionalPrivateTypes);
 
     if (callTargetsToLocalize.empty()) {
       return false;

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -45,11 +45,6 @@ namespace wasm {
 namespace {
 
 struct SignaturePruning : public Pass {
-  // Maps each heap type to the possible pruned heap type. We will fill this
-  // during analysis and then use it while doing an update of the types. If a
-  // type has no improvement that we can find, it will not appear in this map.
-  std::unordered_map<HeapType, Signature> newSignatures;
-
   void run(Module* module) override {
     if (!module->features.hasGC()) {
       return;
@@ -181,6 +176,11 @@ struct SignaturePruning : public Pass {
     // TODO We could handle "cycles" where we remove fields from a group of
     //      types with subtyping relations at once.
     SubTypes subTypes(*module);
+
+    // Maps each heap type to the possible pruned heap type. We will fill this
+    // during analysis and then use it while doing an update of the types. If a
+    // type has no improvement that we can find, it will not appear in this map.
+    std::unordered_map<HeapType, Signature> newSignatures;
 
     // Find parameters to prune.
     //

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -177,7 +177,7 @@ struct SignaturePruning : public Pass {
     //      types with subtyping relations at once.
     SubTypes subTypes(*module);
 
-    // Maps each heap type to the possible pruned heap type. We will fill this
+    // Maps each heap type to the possible pruned signature. We will fill this
     // during analysis and then use it while doing an update of the types. If a
     // type has no improvement that we can find, it will not appear in this map.
     std::unordered_map<HeapType, Signature> newSignatures;

--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -299,7 +299,8 @@ struct SignaturePruning : public Pass {
     for (auto& [type, sig] : newSignatures) {
       additionalPrivateTypes.push_back(type);
     }
-    GlobalTypeRewriter::updateSignatures(newSignatures, *module, additionalPrivateTypes);
+    GlobalTypeRewriter::updateSignatures(
+      newSignatures, *module, additionalPrivateTypes);
 
     if (callTargetsToLocalize.empty()) {
       return false;

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -1155,7 +1155,9 @@
 ;; $exported is exported. The entire rec group becomes exported as well, which
 ;; causes $unused-param's type to be public, which means we cannot normally
 ;; modify it. However, in closed world we allow such changes, and we can remove
-;; the unused param there.
+;; the unused param there. What happens is that we keep the original public rec
+;; group as-is, and add a new rec group for private types, put the pruned type
+;; there, and use that pruned type on $unused-param.
 (module
   (rec
    ;; CHECK:      (rec

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -1151,3 +1151,50 @@
     )
   )
 )
+
+;; $exported is exported. The entire rec group becomes exported as well, which
+;; causes $unused-param's type to be public, which means we cannot normally
+;; modify it. However, in closed world we allow such changes, and we can remove
+;; the unused param there.
+(module
+  (rec
+   ;; CHECK:      (rec
+   ;; CHECK-NEXT:  (type $much (func))
+
+   ;; CHECK:       (type $1 (func))
+
+   ;; CHECK:      (rec
+   ;; CHECK-NEXT:  (type $none (func))
+   (type $none (func))
+   ;; CHECK:       (type $much (func (param i32)))
+   (type $much (func (param i32)))
+  )
+
+  ;; CHECK:      (export "exported" (func $exported))
+
+  ;; CHECK:      (func $exported (type $none)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $exported (export "exported") (type $none)
+  )
+
+  ;; CHECK:      (func $unused-param (type $much)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $unused-param (type $much) (param $param i32)
+  )
+
+  ;; CHECK:      (func $caller (type $1)
+  ;; CHECK-NEXT:  (call $unused-param)
+  ;; CHECK-NEXT: )
+  (func $caller
+    (call $unused-param
+      (i32.const 0)
+    )
+  )
+)
+


### PR DESCRIPTION
The SignaturePruning pass optimizes away parameters that it proves are safe to
remove. It turns out that that does not always match the definition of private
types, which is more restrictive. Specifically, if say all the types are in one big
rec group and one of them is used on an exported function then all of them are
considered public (as the rec group is). However, in closed world, it would be ok
to leave that rec group unchanged but to create a pruned version of that type
and use it, in cases where we see it is safe to remove a parameter. (See the
testcase in the PR for a concrete example.)

To put it another way, SignaturePruning already proves that a parameter is
safe to remove in all the ways that matter. Before this PR, however, the testcase
in this PR would error - so this PR is not an optimization but a bugfix, really -
because SignaturePruning would see that a parameter is safe to remove but
then TypeUpdating would see the type is public and so it would leave it alone,
leading to a broken module.

This situation is in fact not that rare, and happens on real-world Java code.
The reason we did not notice it before is that typically there are no remaining
SignaturePruning opportunities late in the process (when other closed world
optimizations have typically led to a single big rec group).

The concrete fix here is to add `additionalPrivateTypes` to a few more places
in TypeUpdating. We already supported that for cases where a pass knew
better than the general logic what can be modified, and this adds that
ability to the signature-rewriting logic there. Then SignaturePruning can
send in all the types it has proven are safe to modify.

* Also necessary here is to only add from `additionalPrivateTypes` if the type
  is not already in our list (or we'd end up with duplicates in the final rec
  group).
* Also move `newSignatures` in SignaturePruning out of the top level, which
  was confusing (the pass has multiple iterations, and we want each to have
  a fresh instance).