### PR TITLE
fix(build with MSVC): enable `bigobj` support for parser

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -1,3 +1,6 @@
+if(MSVC)
+	add_compile_options(/bigobj)
+endif()
 FILE(GLOB parser_HEADERS *.h)
 set(parser_SOURCES
  context-decls.cpp
@@ -8,3 +11,4 @@ set(parser_SOURCES
  ${parser_HEADERS}
 )
 add_library(parser OBJECT ${parser_SOURCES})
+


### PR DESCRIPTION
I faced the following error when building with MSVC : `\binaryen\src\parser\wat-parser.cpp(1,1): error C1128: number of sections exceeded object file format limit`.

According to documentation this is related to the default allowable sections in obj files. (https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/fatal-error-c1128?view=msvc-170)

On the another side of things, adding this flag might leads to slower compile time and also probbaly hides high usage of templates in source code.

I added the flag only for parser.