### PR TITLE
fix(#6639): fix stack-use-after-scope on windows

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -858,7 +858,8 @@ private:
     }
 
     auto* child = stack[index];
-    for (auto** currChild : ChildIterator(stack[index - 1]).children) {
+    auto childIterator = ChildIterator(stack[index - 1]);
+    for (auto** currChild : childIterator.children) {
       if (*currChild == child) {
         return currChild;
       }


### PR DESCRIPTION
This PR addresses #6639, moving `ChildIterator(stack[index - 1])` into a local variable to avoid use after free.
Tested manually on Windows and Linux, same result as expected.  