### PR TITLE
[Parser][NFC] Split parser into multiple compilation units

### DIFF
--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -3,6 +3,11 @@ set(parser_SOURCES
  context-decls.cpp
  context-defs.cpp
  lexer.cpp
+ parse-1-decls.cpp
+ parse-2-typedefs.cpp
+ parse-3-implicit-types.cpp
+ parse-4-module-types.cpp
+ parse-5-defs.cpp
  wast-parser.cpp
  wat-parser.cpp
  ${parser_HEADERS}

--- a/src/parser/parse-1-decls.cpp
+++ b/src/parser/parse-1-decls.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wat-parser-internal.h"
+
+namespace wasm::WATParser {
+
+Result<> parseDecls(ParseDeclsCtx& decls) { return module(decls); }
+
+} // namespace wasm::WATParser

--- a/src/parser/parse-2-typedefs.cpp
+++ b/src/parser/parse-2-typedefs.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wat-parser-internal.h"
+
+namespace wasm::WATParser {
+
+Result<> parseTypeDefs(
+  ParseDeclsCtx& decls,
+  Lexer& input,
+  IndexMap& typeIndices,
+  std::vector<HeapType>& types,
+  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames) {
+  TypeBuilder builder(decls.subtypeDefs.size());
+  ParseTypeDefsCtx ctx(input, builder, typeIndices);
+  for (auto& typeDef : decls.typeDefs) {
+    WithPosition with(ctx, typeDef.pos);
+    CHECK_ERR(deftype(ctx));
+  }
+  auto built = builder.build();
+  if (auto* err = built.getError()) {
+    std::stringstream msg;
+    msg << "invalid type: " << err->reason;
+    return ctx.in.err(decls.typeDefs[err->index].pos, msg.str());
+  }
+  types = *built;
+  // Record type names on the module and in typeNames.
+  for (size_t i = 0; i < types.size(); ++i) {
+    auto& names = ctx.names[i];
+    auto& fieldNames = names.fieldNames;
+    if (names.name.is() || fieldNames.size()) {
+      decls.wasm.typeNames.insert({types[i], names});
+      auto& fieldIdxMap = typeNames[types[i]];
+      for (auto [idx, name] : fieldNames) {
+        fieldIdxMap.insert({name, idx});
+      }
+    }
+  }
+  return Ok{};
+}
+
+} // namespace wasm::WATParser

--- a/src/parser/parse-3-implicit-types.cpp
+++ b/src/parser/parse-3-implicit-types.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wat-parser-internal.h"
+
+namespace wasm::WATParser {
+
+Result<>
+parseImplicitTypeDefs(ParseDeclsCtx& decls,
+                      Lexer& input,
+                      IndexMap& typeIndices,
+                      std::vector<HeapType>& types,
+                      std::unordered_map<Index, HeapType>& implicitTypes) {
+  ParseImplicitTypeDefsCtx ctx(input, types, implicitTypes, typeIndices);
+  for (Index pos : decls.implicitTypeDefs) {
+    WithPosition with(ctx, pos);
+    CHECK_ERR(typeuse(ctx));
+  }
+  return Ok{};
+}
+
+} // namespace wasm::WATParser

--- a/src/parser/parse-4-module-types.cpp
+++ b/src/parser/parse-4-module-types.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wat-parser-internal.h"
+
+namespace wasm::WATParser {
+
+Result<> parseModuleTypes(ParseDeclsCtx& decls,
+                          Lexer& input,
+                          IndexMap& typeIndices,
+                          std::vector<HeapType>& types,
+                          std::unordered_map<Index, HeapType>& implicitTypes) {
+  ParseModuleTypesCtx ctx(input,
+                          decls.wasm,
+                          types,
+                          implicitTypes,
+                          decls.implicitElemIndices,
+                          typeIndices);
+  CHECK_ERR(parseDefs(ctx, decls.funcDefs, func));
+  CHECK_ERR(parseDefs(ctx, decls.tableDefs, table));
+  CHECK_ERR(parseDefs(ctx, decls.memoryDefs, memory));
+  CHECK_ERR(parseDefs(ctx, decls.globalDefs, global));
+  CHECK_ERR(parseDefs(ctx, decls.elemDefs, elem));
+  CHECK_ERR(parseDefs(ctx, decls.tagDefs, tag));
+  return Ok{};
+}
+
+} // namespace wasm::WATParser

--- a/src/parser/parse-5-defs.cpp
+++ b/src/parser/parse-5-defs.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wat-parser-internal.h"
+
+namespace wasm::WATParser {
+
+Result<> parseDefinitions(
+  ParseDeclsCtx& decls,
+  Lexer& input,
+  IndexMap& typeIndices,
+  std::vector<HeapType>& types,
+  std::unordered_map<Index, HeapType>& implicitTypes,
+  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames) {
+  // Parse definitions.
+  // TODO: Parallelize this.
+  ParseDefsCtx ctx(input,
+                   decls.wasm,
+                   types,
+                   implicitTypes,
+                   typeNames,
+                   decls.implicitElemIndices,
+                   typeIndices);
+  CHECK_ERR(parseDefs(ctx, decls.tableDefs, table));
+  CHECK_ERR(parseDefs(ctx, decls.globalDefs, global));
+  CHECK_ERR(parseDefs(ctx, decls.startDefs, start));
+  CHECK_ERR(parseDefs(ctx, decls.elemDefs, elem));
+  CHECK_ERR(parseDefs(ctx, decls.dataDefs, data));
+
+  for (Index i = 0; i < decls.funcDefs.size(); ++i) {
+    ctx.index = i;
+    auto* f = decls.wasm.functions[i].get();
+    WithPosition with(ctx, decls.funcDefs[i].pos);
+    ctx.setSrcLoc(decls.funcDefs[i].annotations);
+    if (!f->imported()) {
+      CHECK_ERR(ctx.visitFunctionStart(f));
+    }
+    if (auto parsed = func(ctx)) {
+      CHECK_ERR(parsed);
+    } else {
+      auto im = import_(ctx);
+      assert(im);
+      CHECK_ERR(im);
+    }
+    if (!f->imported()) {
+      auto end = ctx.irBuilder.visitEnd();
+      if (auto* err = end.getErr()) {
+        return ctx.in.err(decls.funcDefs[i].pos, err->msg);
+      }
+    }
+  }
+
+  // Parse exports.
+  // TODO: It would be more technically correct to interleave these properly
+  // with the implicit inline exports in other module field definitions.
+  for (auto pos : decls.exportDefs) {
+    WithPosition with(ctx, pos);
+    auto parsed = export_(ctx);
+    CHECK_ERR(parsed);
+    assert(parsed);
+  }
+  return Ok{};
+}
+
+Result<Literal> parseConst(Lexer& lexer) {
+  Module wasm;
+  ParseDefsCtx ctx(lexer, wasm, {}, {}, {}, {}, {});
+  auto inst = foldedinstr(ctx);
+  CHECK_ERR(inst);
+  auto expr = ctx.irBuilder.build();
+  if (auto* err = expr.getErr()) {
+    return lexer.err(err->msg);
+  }
+  auto* e = *expr;
+  if (!e->is<Const>() && !e->is<RefNull>() && !e->is<RefI31>()) {
+    return lexer.err("expected constant");
+  }
+  lexer = ctx.in;
+  return getLiteralFromConstExpression(e);
+}
+
+} // namespace wasm::WATParser

--- a/src/parser/wat-parser-internal.h
+++ b/src/parser/wat-parser-internal.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "contexts.h"
+#include "parsers.h"
+
+#ifndef parser_wat_parser_internal_h
+#define parser_wat_parser_internal_h
+
+namespace wasm::WATParser {
+
+Result<> parseDecls(ParseDeclsCtx& decls);
+
+Result<> parseTypeDefs(
+  ParseDeclsCtx& decls,
+  Lexer& input,
+  IndexMap& typeIndices,
+  std::vector<HeapType>& types,
+  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames);
+
+Result<>
+parseImplicitTypeDefs(ParseDeclsCtx& decls,
+                      Lexer& input,
+                      IndexMap& typeIndices,
+                      std::vector<HeapType>& types,
+                      std::unordered_map<Index, HeapType>& implicitTypes);
+
+Result<> parseModuleTypes(ParseDeclsCtx& decls,
+                          Lexer& input,
+                          IndexMap& typeIndices,
+                          std::vector<HeapType>& types,
+                          std::unordered_map<Index, HeapType>& implicitTypes);
+
+Result<> parseDefinitions(
+  ParseDeclsCtx& decls,
+  Lexer& input,
+  IndexMap& typeIndices,
+  std::vector<HeapType>& types,
+  std::unordered_map<Index, HeapType>& implicitTypes,
+  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames);
+
+// RAII utility for temporarily changing the parsing position of a parsing
+// context.
+template<typename Ctx> struct WithPosition {
+  Ctx& ctx;
+  Index original;
+  std::vector<Annotation> annotations;
+
+  WithPosition(Ctx& ctx, Index pos)
+    : ctx(ctx), original(ctx.in.getPos()),
+      annotations(ctx.in.takeAnnotations()) {
+    ctx.in.setPos(pos);
+  }
+
+  ~WithPosition() {
+    ctx.in.setPos(original);
+    ctx.in.setAnnotations(std::move(annotations));
+  }
+};
+
+template<typename Ctx>
+Result<> parseDefs(Ctx& ctx,
+                   const std::vector<DefPos>& defs,
+                   MaybeResult<> (*parser)(Ctx&)) {
+  for (auto& def : defs) {
+    ctx.index = def.index;
+    WithPosition with(ctx, def.pos);
+    if (auto parsed = parser(ctx)) {
+      CHECK_ERR(parsed);
+    } else {
+      auto im = import_(ctx);
+      assert(im);
+      CHECK_ERR(im);
+    }
+  }
+  return Ok{};
+}
+
+// Deduction guide to satisfy -Wctad-maybe-unsupported.
+template<typename Ctx> WithPosition(Ctx& ctx, Index) -> WithPosition<Ctx>;
+
+} // namespace wasm::WATParser
+
+#endif // parser_wat_parser_internal_h


### PR DESCRIPTION
Because the parser has five stages, it requires instantiating all of the templates in parsers.h with up to five different contexts. Instantiating all those templates in a single compilation unit takes a long time. On my machine, a release build of wat-parser.cpp.o took 32 seconds. To reduce the time of incremental rebuilds on machines with many cores, split the code across several compilation units so that the templates need to be instantiated for just a single context in each unit. On my machine the longest compilation time after this splitting is 17 seconds. The time for a full release build also drops from 42 seconds to 33 seconds. On machines with fewer cores, the benefit may be smaller or even negative, though.