### PR TITLE
Add local.set/tee local type annotations to BINARYEN_PRINT_FULL 

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -524,7 +524,7 @@ struct PrintExpressionContents
     }
     printLocal(curr->index, currFunction, o);
     if (full && currFunction) {
-      o << "(; local type: ";
+      o << " (; local type: ";
       printType(currFunction->getLocalType(curr->index));
       o << " ;)";
     }

--- a/test/lit/debug/full.wat
+++ b/test/lit/debug/full.wat
@@ -27,21 +27,21 @@
   ;; NRML-NEXT:  )
   ;; NRML-NEXT: )
   ;; FULL:      (func $a
-  ;; FULL-NEXT:  [none] ;;@ src.cpp:1:2
-  ;; FULL-NEXT:  [none](block $block
-  ;; FULL-NEXT:   [none] ;;@ src.cpp:1:2
+  ;; FULL-NEXT:  (; none ;) ;;@ src.cpp:1:2
+  ;; FULL-NEXT:   (;none ;)(block $block
+  ;; FULL-NEXT:   (; none ;) ;;@ src.cpp:1:2
   ;; FULL-NEXT:   (drop
-  ;; FULL-NEXT:    [i32] ;;@ src.cpp:1:2
+  ;; FULL-NEXT:    (; i32 ;) ;;@ src.cpp:1:2
   ;; FULL-NEXT:    (i32.const 0)
   ;; FULL-NEXT:   )
-  ;; FULL-NEXT:   [none] ;;@ src.cpp:3:4
+  ;; FULL-NEXT:   (; none ;) ;;@ src.cpp:3:4
   ;; FULL-NEXT:   (drop
-  ;; FULL-NEXT:    [i32] ;;@ src.cpp:3:4
+  ;; FULL-NEXT:    (; i32 ;) ;;@ src.cpp:3:4
   ;; FULL-NEXT:    (i32.const 1)
   ;; FULL-NEXT:   )
-  ;; FULL-NEXT:   [none] ;;@ src.cpp:3:4
+  ;; FULL-NEXT:   (; none ;) ;;@ src.cpp:3:4
   ;; FULL-NEXT:   (drop
-  ;; FULL-NEXT:    [i32] ;;@ src.cpp:3:4
+  ;; FULL-NEXT:    (; i32 ;) ;;@ src.cpp:3:4
   ;; FULL-NEXT:    (i32.const 2)
   ;; FULL-NEXT:   )
   ;; FULL-NEXT:  ) ;; end block block

--- a/test/lit/debug/replace-keep.wat
+++ b/test/lit/debug/replace-keep.wat
@@ -14,7 +14,7 @@
   ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:200:2
   ;; CHECK-NEXT:   (call $test)
   ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:200:2
-  ;; CHECK-NEXT:   (local.set $temp(; local type: i32 ;)
+  ;; CHECK-NEXT:   (local.set $temp (; local type: i32 ;)
   ;; CHECK-NEXT:    (; i32 ;) ;;@ src.cpp:200:2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
@@ -45,7 +45,7 @@
   ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:400:4
   ;; CHECK-NEXT:   (call $test)
   ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:200:2
-  ;; CHECK-NEXT:   (local.set $temp(; local type: i32 ;)
+  ;; CHECK-NEXT:   (local.set $temp (; local type: i32 ;)
   ;; CHECK-NEXT:    (; i32 ;) ;;@ src.cpp:500:5
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )

--- a/test/lit/debug/replace-keep.wat
+++ b/test/lit/debug/replace-keep.wat
@@ -9,13 +9,13 @@
 (module
   ;; CHECK:      (func $test
   ;; CHECK-NEXT:  (local $temp i32)
-  ;; CHECK-NEXT:  [none] ;;@ src.cpp:200:2
-  ;; CHECK-NEXT:  [none](block
-  ;; CHECK-NEXT:   [none] ;;@ src.cpp:200:2
+  ;; CHECK-NEXT:  (; none ;) ;;@ src.cpp:200:2
+  ;; CHECK-NEXT:   (;none ;)(block
+  ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:200:2
   ;; CHECK-NEXT:   (call $test)
-  ;; CHECK-NEXT:   [none] ;;@ src.cpp:200:2
-  ;; CHECK-NEXT:   (local.set $temp
-  ;; CHECK-NEXT:    [i32] ;;@ src.cpp:200:2
+  ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:200:2
+  ;; CHECK-NEXT:   (local.set $temp(; local type: i32 ;)
+  ;; CHECK-NEXT:    (; i32 ;) ;;@ src.cpp:200:2
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  ) ;; end block
@@ -40,13 +40,13 @@
 
   ;; CHECK:      (func $test-no-trample
   ;; CHECK-NEXT:  (local $temp i32)
-  ;; CHECK-NEXT:  [none] ;;@ src.cpp:300:3
-  ;; CHECK-NEXT:  [none](block
-  ;; CHECK-NEXT:   [none] ;;@ src.cpp:400:4
+  ;; CHECK-NEXT:  (; none ;) ;;@ src.cpp:300:3
+  ;; CHECK-NEXT:   (;none ;)(block
+  ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:400:4
   ;; CHECK-NEXT:   (call $test)
-  ;; CHECK-NEXT:   [none] ;;@ src.cpp:200:2
-  ;; CHECK-NEXT:   (local.set $temp
-  ;; CHECK-NEXT:    [i32] ;;@ src.cpp:500:5
+  ;; CHECK-NEXT:   (; none ;) ;;@ src.cpp:200:2
+  ;; CHECK-NEXT:   (local.set $temp(; local type: i32 ;)
+  ;; CHECK-NEXT:    (; i32 ;) ;;@ src.cpp:500:5
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  ) ;; end block


### PR DESCRIPTION
With this we now print e.g.
```wat
(local.set $temp (; local type: i32 ;)
  ...
```
This can be nice in large functions to avoid needing to scroll up to
see the local type, e.g. when debugging why unsubtyping doesn't
work somewhere.

Also avoid `[ ]` in this mode, in favor of the standard `(; ;)`.