### PR TITLE
[threads] Add a "shared-everything" feature

### DIFF
--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -94,6 +94,7 @@ struct ToolOptions : public Options {
       .addFeature(FeatureSet::Strings, "strings")
       .addFeature(FeatureSet::MultiMemory, "multimemory")
       .addFeature(FeatureSet::TypedContinuations, "typed continuations")
+      .addFeature(FeatureSet::SharedEverything, "shared-everything threads")
       .add("--enable-typed-function-references",
            "",
            "Deprecated compatibility flag",

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -428,6 +428,7 @@ extern const char* ExtendedConstFeature;
 extern const char* StringsFeature;
 extern const char* MultiMemoryFeature;
 extern const char* TypedContinuationsFeature;
+extern const char* SharedEverythingFeature;
 
 enum Subsection {
   NameModule = 0,

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -45,11 +45,12 @@ struct FeatureSet {
     Strings = 1 << 14,
     MultiMemory = 1 << 15,
     TypedContinuations = 1 << 16,
+    SharedEverything = 1 << 17,
     MVP = None,
     // Keep in sync with llvm default features:
     // https://github.com/llvm/llvm-project/blob/c7576cb89d6c95f03968076e902d3adfd1996577/clang/lib/Basic/Targets/WebAssembly.cpp#L150-L153
     Default = SignExt | MutableGlobals,
-    All = (1 << 17) - 1,
+    All = (1 << 18) - 1,
   };
 
   static std::string toString(Feature f) {
@@ -88,6 +89,8 @@ struct FeatureSet {
         return "multimemory";
       case TypedContinuations:
         return "typed-continuations";
+      case SharedEverything:
+        return "shared-everything";
       default:
         WASM_UNREACHABLE("unexpected feature");
     }
@@ -135,6 +138,9 @@ struct FeatureSet {
   bool hasTypedContinuations() const {
     return (features & TypedContinuations) != 0;
   }
+  bool hasSharedEverything() const {
+    return (features & SharedEverything) != 0;
+  }
   bool hasAll() const { return (features & All) != 0; }
 
   void set(FeatureSet f, bool v = true) {
@@ -157,6 +163,7 @@ struct FeatureSet {
   void setStrings(bool v = true) { set(Strings, v); }
   void setMultiMemory(bool v = true) { set(MultiMemory, v); }
   void setTypedContinuations(bool v = true) { set(TypedContinuations, v); }
+  void setSharedEverything(bool v = true) { set(SharedEverything, v); }
   void setMVP() { features = MVP; }
   void setAll() { features = All; }
 
@@ -184,6 +191,10 @@ struct FeatureSet {
   FeatureSet& operator|=(const FeatureSet& other) {
     features |= other.features;
     return *this;
+  }
+
+  FeatureSet operator-(FeatureSet& other) const {
+    return features & ~other.features;
   }
 
   uint32_t features;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1319,9 +1319,14 @@ void WasmBinaryWriter::writeFeaturesSection() {
         return BinaryConsts::CustomSections::MultiMemoryFeature;
       case FeatureSet::TypedContinuations:
         return BinaryConsts::CustomSections::TypedContinuationsFeature;
-      default:
-        WASM_UNREACHABLE("unexpected feature flag");
+      case FeatureSet::SharedEverything:
+        return BinaryConsts::CustomSections::SharedEverythingFeature;
+      case FeatureSet::None:
+      case FeatureSet::Default:
+      case FeatureSet::All:
+        break;
     }
+    WASM_UNREACHABLE("unexpected feature flag");
   };
 
   std::vector<const char*> features;
@@ -3825,6 +3830,8 @@ void WasmBinaryReader::readFeatures(size_t payloadLen) {
     } else if (name ==
                BinaryConsts::CustomSections::TypedContinuationsFeature) {
       feature = FeatureSet::TypedContinuations;
+    } else if (name == BinaryConsts::CustomSections::SharedEverythingFeature) {
+      feature = FeatureSet::SharedEverything;
     } else {
       // Silently ignore unknown features (this may be and old binaryen running
       // on a new wasm).

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -936,7 +936,13 @@ FeatureSet Type::getFeatures() const {
               heapType->getRecGroup().size() > 1 ||
               heapType->getDeclaredSuperType() || heapType->isOpen()) {
             feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
-          } else if (heapType->isSignature()) {
+          }
+
+          if (heapType->isShared()) {
+            feats |= FeatureSet::SharedEverything;
+          }
+
+          if (heapType->isSignature()) {
             // This is a function reference, which requires reference types and
             // possibly also multivalue (if it has multiple returns). Note that
             // technically typed function references also require GC, however,
@@ -949,7 +955,9 @@ FeatureSet Type::getFeatures() const {
             if (sig.results.isTuple()) {
               feats |= FeatureSet::Multivalue;
             }
-          } else if (heapType->isContinuation()) {
+          }
+
+          if (heapType->isContinuation()) {
             feats |= FeatureSet::TypedContinuations;
           }
 
@@ -969,7 +977,7 @@ FeatureSet Type::getFeatures() const {
       collector.noteChild(&heapType);
       return collector.feats;
     }
-    TODO_SINGLE_COMPOUND(t);
+
     switch (t.getBasic()) {
       case Type::v128:
         return FeatureSet::SIMD;

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -932,8 +932,7 @@ FeatureSet Type::getFeatures() const {
             }
           }
 
-          if (heapType->isStruct() || heapType->isArray() ||
-              heapType->getRecGroup().size() > 1 ||
+          if (heapType->getRecGroup().size() > 1 ||
               heapType->getDeclaredSuperType() || heapType->isOpen()) {
             feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
           }
@@ -942,7 +941,9 @@ FeatureSet Type::getFeatures() const {
             feats |= FeatureSet::SharedEverything;
           }
 
-          if (heapType->isSignature()) {
+          if (heapType->isStruct() || heapType->isArray()) {
+            feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
+          } else if (heapType->isSignature()) {
             // This is a function reference, which requires reference types and
             // possibly also multivalue (if it has multiple returns). Note that
             // technically typed function references also require GC, however,
@@ -955,9 +956,7 @@ FeatureSet Type::getFeatures() const {
             if (sig.results.isTuple()) {
               feats |= FeatureSet::Multivalue;
             }
-          }
-
-          if (heapType->isContinuation()) {
+          } else if (heapType->isContinuation()) {
             feats |= FeatureSet::TypedContinuations;
           }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3701,6 +3701,25 @@ static void validateGlobals(Module& module, ValidationInfo& info) {
       seen.insert(curr);
     }
   });
+
+  // Check that globals have allowed types.
+  for (auto& g : module.globals) {
+    auto globalFeats = g->type.getFeatures();
+    if (!info.shouldBeTrue(globalFeats <= module.features, g->name, "")) {
+      auto& stream = info.getStream(nullptr);
+      stream << "global type requires additional features [";
+      bool first = true;
+      (globalFeats - module.features).iterFeatures([&](FeatureSet feat) {
+        if (first) {
+          first = false;
+        } else {
+          stream << " ";
+        }
+        stream << "--enable-" << feat.toString();
+      });
+      stream << "]\n";
+    }
+  }
 }
 
 static void validateMemories(Module& module, ValidationInfo& info) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -54,6 +54,7 @@ const char* ExtendedConstFeature = "extended-const";
 const char* StringsFeature = "strings";
 const char* MultiMemoryFeature = "multimemory";
 const char* TypedContinuationsFeature = "typed-continuations";
+const char* SharedEverythingFeature = "shared-everything";
 } // namespace CustomSections
 } // namespace BinaryConsts
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -33,7 +33,7 @@ Features.RelaxedSIMD: 4096
 Features.ExtendedConst: 8192
 Features.Strings: 16384
 Features.MultiMemory: 32768
-Features.All: 131071
+Features.All: 262143
 InvalidId: 0
 BlockId: 1
 IfId: 2

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -47,7 +47,7 @@ BinaryenFeatureMemory64: 2048
 BinaryenFeatureRelaxedSIMD: 4096
 BinaryenFeatureExtendedConst: 8192
 BinaryenFeatureStrings: 16384
-BinaryenFeatureAll: 131071
+BinaryenFeatureAll: 262143
 (f32.neg
  (f32.const -33.61199951171875)
 )

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -108,6 +108,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -115,6 +115,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -101,6 +101,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -143,6 +143,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -131,6 +131,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -156,6 +156,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -721,6 +721,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations                 Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything                    Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything                   Disable shared-everything
+;; CHECK-NEXT:                                                 threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -137,6 +137,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -217,6 +217,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations        Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything           Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything          Disable shared-everything threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -675,6 +675,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-continuations                 Disable typed continuations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-shared-everything                    Enable shared-everything threads
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-shared-everything                   Disable shared-everything
+;; CHECK-NEXT:                                                 threads
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/lit/validation/shared-struct.wast
+++ b/test/lit/validation/shared-struct.wast
@@ -1,0 +1,12 @@
+;; Test that shared structs require shared-everything threads
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s --check-prefix NO-SHARED
+;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED
+
+;; NO-SHARED: global type requires additional features [--enable-reference-types --enable-gc --enable-shared-everything]
+;; SHARED: (type $t (shared (struct )))
+
+(module
+  (type $t (shared (struct)))
+  (global (import "" "") (ref null $t))
+)

--- a/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
+++ b/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
@@ -15,6 +15,7 @@
 --enable-strings
 --enable-multimemory
 --enable-typed-continuations
+--enable-shared-everything
 (module
  (type $0 (func (result v128 externref)))
  (func $foo (type $0) (result v128 externref)

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -425,4 +425,5 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
             '--enable-strings',
             '--enable-multimemory',
             '--enable-typed-continuations',
+            '--enable-shared-everything',
         ], p2.stdout.splitlines())


### PR DESCRIPTION
Add the feature and flags to enable and disable it. Require the new feature to
be enabled for shared heap types to validate. To make the test work, update the
validator to actually check features for global types.