### PR TITLE
Enable more spec tests

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -408,6 +408,7 @@ SPEC_TESTS_TO_SKIP = [
     'utf8-invalid-encoding.wast',
     'const.wast',
     'address.wast',
+    'custom.wast', # invalid section ID accepted as Custom, triggering UBSan
 
     # Unlinkable module accepted
     'linking.wast',

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -408,7 +408,7 @@ SPEC_TESTS_TO_SKIP = [
     'utf8-invalid-encoding.wast',
     'const.wast',
     'address.wast',
-    'custom.wast', # invalid section ID accepted as Custom, triggering UBSan
+    'custom.wast',  # invalid section ID accepted as Custom, triggering UBSan
 
     # Unlinkable module accepted
     'linking.wast',

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -399,57 +399,32 @@ os.chdir(options.out_dir)
 # delete the old file, make sure you rename the corresponding .wast.log file in
 # expected-output/ if any.
 SPEC_TESTS_TO_SKIP = [
-    # Stacky code / notation
-    'block.wast',
-    'call.wast',
-    'float_exprs.wast',
+    # Malformed module accepted
     'globals.wast',
-    'loop.wast',
-    'nop.wast',
-    'select.wast',
-    'stack.wast',
-    'unwind.wast',
-
-    # Binary module
-    'binary.wast',
     'binary-leb128.wast',
-    'custom.wast',
-
-    # Empty 'then' or 'else' in 'if'
-    'if.wast',
-    'local_set.wast',
-    'store.wast',
-
-    # No module in a file
-    'token.wast',
     'utf8-custom-section-id.wast',
     'utf8-import-field.wast',
     'utf8-import-module.wast',
     'utf8-invalid-encoding.wast',
+    'const.wast',
+    'address.wast',
 
-    # 'register' command
+    # Unlinkable module accepted
     'linking.wast',
 
-    # Misc. unsupported constructs
-    'call_indirect.wast',  # Empty (param) and (result)
-    'const.wast',  # Unparenthesized expression
-    'data.wast',  # Various unsupported (data) notations
-    'elem.wast',  # Unsupported 'offset' syntax in (elem)
-    'exports.wast',  # Multiple inlined exports for a function
-    'func.wast',  # Forward named type reference
-    'skip-stack-guard-page.wast',  # Hexadecimal style (0x..) in memory offset
+    # Invalid module accepted
+    'func.wast',
+    'type.wast',
+    'unreached-invalid.wast',
 
-    # Untriaged: We don't know the cause of the error yet
-    'address.wast',  # wasm2js 'assert_return' failure
-    'br_if.wast',  # Validation error
-    'float_literals.wast',  # 'assert_return' failure
-    'int_literals.wast',  # 'assert_return' failure
-    'local_tee.wast',  # Validation failure
-    'memory_grow.wast',  # 'assert_return' failure
-    'start.wast',  # Assertion failure
-    'type.wast',  # 'assertion_invalid' failure
-    'unreachable.wast',  # Validation failure
-    'unreached-invalid.wast'  # 'assert_invalid' failure
+    # WAT parser error
+    'unwind.wast',
+
+    # WAST parser error
+    'binary.wast',
+
+    # Test invalid
+    'elem.wast',
 ]
 options.spec_tests = [t for t in options.spec_tests if os.path.basename(t) not
                       in SPEC_TESTS_TO_SKIP]

--- a/test/spec/stack.wast
+++ b/test/spec/stack.wast
@@ -34,17 +34,15 @@
         (i64.eq)
         (if
           (then (br $done))
-          (then
-            (else
-              (local.get $i)
-              (local.get $res)
-              (i64.mul)
-              (local.set $res)
-              (local.get $i)
-              (i64.const 1)
-              (i64.sub)
-              (local.set $i)
-            )
+          (else
+            (local.get $i)
+            (local.get $res)
+            (i64.mul)
+            (local.set $res)
+            (local.get $i)
+            (i64.const 1)
+            (i64.sub)
+            (local.set $i)
           )
         )
         (br $loop)
@@ -93,13 +91,11 @@
         (i64.eq (local.get $i) (i64.const 0))
         (if
           (then (br $done))
-          (then
-            (else
-              (i64.mul (local.get $i) (local.get $res))
-              (local.set $res)
-              (i64.sub (local.get $i) (i64.const 1))
-              (local.set $i)
-            )
+          (else
+            (i64.mul (local.get $i) (local.get $res))
+            (local.set $res)
+            (i64.sub (local.get $i) (i64.const 1))
+            (local.set $i)
           )
         )
         (br $loop)
@@ -129,11 +125,30 @@
     end
     local.get $res
   )
+
+  (global $temp (mut i32) (i32.const 0))
+  (func $add_one_to_global (result i32)
+    (local i32)
+    (global.set $temp (i32.add (i32.const 1) (global.get $temp)))
+    (global.get $temp)
+  )
+  (func $add_one_to_global_and_drop
+    (drop (call $add_one_to_global))
+  )
+  (func (export "not-quite-a-tree") (result i32)
+    call $add_one_to_global
+    call $add_one_to_global
+    call $add_one_to_global_and_drop
+    i32.add
+  )
 )
 
 (assert_return (invoke "fac-expr" (i64.const 25)) (i64.const 7034535277573963776))
 (assert_return (invoke "fac-stack" (i64.const 25)) (i64.const 7034535277573963776))
 (assert_return (invoke "fac-mixed" (i64.const 25)) (i64.const 7034535277573963776))
+
+(assert_return (invoke "not-quite-a-tree") (i32.const 3))
+(assert_return (invoke "not-quite-a-tree") (i32.const 9))
 
 
 ;; Syntax of flat call_indirect


### PR DESCRIPTION
Re-triage all the disabled spec tests and re-enable many of them. Improve the module splitting logic to correctly handle (by skipping) quoted modules and their associated assertions.