### PR TITLE
Reject invalid section IDs

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -408,7 +408,6 @@ SPEC_TESTS_TO_SKIP = [
     'utf8-invalid-encoding.wast',
     'const.wast',
     'address.wast',
-    'custom.wast',  # invalid section ID accepted as Custom, triggering UBSan
 
     # Unlinkable module accepted
     'linking.wast',

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1453,7 +1453,7 @@ class WasmBinaryReader {
   Index startIndex = -1;
   std::set<Function::DebugLocation> debugLocation;
   size_t codeSectionLocation;
-  std::set<BinaryConsts::Section> seenSections;
+  std::unordered_set<uint8_t> seenSections;
 
   // All types defined in the type section
   std::vector<HeapType> types;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1783,9 +1783,8 @@ void WasmBinaryReader::read() {
 
     // note the section in the list of seen sections, as almost no sections can
     // appear more than once, and verify those that shouldn't do not.
-    if (sectionCode != BinaryConsts::Section::Custom &&
-        sectionCode != BinaryConsts::Section::Code) {
-      if (!seenSections.insert(BinaryConsts::Section(sectionCode)).second) {
+    if (sectionCode != BinaryConsts::Section::Custom) {
+      if (!seenSections.insert(sectionCode).second) {
         throwError("section seen more than once: " +
                    std::to_string(sectionCode));
       }
@@ -1837,7 +1836,7 @@ void WasmBinaryReader::read() {
       case BinaryConsts::Section::Tag:
         readTags();
         break;
-      default: {
+      case BinaryConsts::Section::Custom: {
         readCustomSection(payloadLen);
         if (pos > oldPos + payloadLen) {
           throwError("bad user section size, started at " +
@@ -1846,7 +1845,11 @@ void WasmBinaryReader::read() {
                      " not being equal to new position " + std::to_string(pos));
         }
         pos = oldPos + payloadLen;
+        break;
       }
+      default:
+        throwError(std::string("unrecognized section ID: ") +
+                   std::to_string(sectionCode));
     }
 
     // make sure we advanced exactly past this section

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1783,11 +1783,9 @@ void WasmBinaryReader::read() {
 
     // note the section in the list of seen sections, as almost no sections can
     // appear more than once, and verify those that shouldn't do not.
-    if (sectionCode != BinaryConsts::Section::Custom) {
-      if (!seenSections.insert(sectionCode).second) {
-        throwError("section seen more than once: " +
-                   std::to_string(sectionCode));
-      }
+    if (sectionCode != BinaryConsts::Section::Custom &&
+        !seenSections.insert(sectionCode).second) {
+      throwError("section seen more than once: " + std::to_string(sectionCode));
     }
 
     switch (sectionCode) {


### PR DESCRIPTION
Rather than treating them as custom sections. Also fix UB where invalid
`Section` enum values could be used as keys in a map. Use the raw `uint8_t`
section IDs as keys instead. Re-enable a disabled spec test that was failing
because of this bug and UB.