### PR TITLE
Fix validation of unused LEB128 bits

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -400,7 +400,6 @@ os.chdir(options.out_dir)
 # expected-output/ if any.
 SPEC_TESTS_TO_SKIP = [
     # Malformed module accepted
-    'binary-leb128.wast',
     'utf8-custom-section-id.wast',
     'utf8-import-field.wast',
     'utf8-import-module.wast',

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -107,7 +107,7 @@ template<typename T, typename MiniT> struct LEB {
                             : ((mask_type(1) << (sizeof(T) * 8 - shift)) - 1u);
       T significant_payload = payload_mask & payload;
       value |= significant_payload << shift;
-      T unused_bits_mask = ~payload_mask & 0x7F;
+      T unused_bits_mask = ~payload_mask & 127;
       T unused_bits = payload & unused_bits_mask;
       if (std::is_signed_v<T> && value < 0) {
         if (unused_bits != unused_bits_mask) {


### PR DESCRIPTION
The unused bits must be a sign extension of the significant value, but we were
previously only validating that unsigned LEBs had their unused bytes set to
zero. Re-enable the spec test that checks for proper validation.