### PR TITLE
Validate that names are valid UTF-8

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -400,10 +400,6 @@ os.chdir(options.out_dir)
 # expected-output/ if any.
 SPEC_TESTS_TO_SKIP = [
     # Malformed module accepted
-    'utf8-custom-section-id.wast',
-    'utf8-import-field.wast',
-    'utf8-import-module.wast',
-    'utf8-invalid-encoding.wast',
     'const.wast',
     'address.wast',
 

--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -25,6 +25,7 @@
 
 #include "support/name.h"
 #include "support/result.h"
+#include "support/string.h"
 
 #ifndef parser_lexer_h
 #define parser_lexer_h
@@ -124,11 +125,11 @@ public:
   std::optional<std::string> takeString();
 
   std::optional<Name> takeName() {
-    // TODO: Validate UTF.
-    if (auto str = takeString()) {
-      return Name(*str);
+    auto str = takeString();
+    if (!str || !String::isUTF8(*str)) {
+      return std::nullopt;
     }
-    return std::nullopt;
+    return Name(*str);
   }
 
   bool takeSExprStart(std::string_view expected) {

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -99,6 +99,9 @@ bool convertWTF16ToWTF8(std::ostream& os, std::string_view str);
 // unit. Returns `true` if the input was valid UTF-16.
 bool convertUTF16ToUTF8(std::ostream& os, std::string_view str);
 
+// Whether the string is valid UTF-8.
+bool isUTF8(std::string_view str);
+
 } // namespace wasm::String
 
 #endif // wasm_support_string_h

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1505,7 +1505,7 @@ public:
   HeapType getIndexedHeapType();
 
   Type getConcreteType();
-  Name getInlineString();
+  Name getInlineString(bool requireValid = true);
   void verifyInt8(int8_t x);
   void verifyInt16(int16_t x);
   void verifyInt32(int32_t x);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2201,11 +2201,13 @@ Type WasmBinaryReader::getConcreteType() {
   return type;
 }
 
-Name WasmBinaryReader::getInlineString() {
+Name WasmBinaryReader::getInlineString(bool requireValid) {
   BYN_TRACE("<==\n");
   auto len = getU32LEB();
   auto data = getByteView(len);
-
+  if (requireValid && !String::isUTF8(data)) {
+    throwError("invalid UTF-8 string");
+  }
   BYN_TRACE("getInlineString: " << data << " ==>\n");
   return Name(data);
 }
@@ -3027,7 +3029,7 @@ void WasmBinaryReader::readStrings() {
   }
   size_t num = getU32LEB();
   for (size_t i = 0; i < num; i++) {
-    auto string = getInlineString();
+    auto string = getInlineString(false);
     // Re-encode from WTF-8 to WTF-16.
     std::stringstream wtf16;
     if (!String::convertWTF8ToWTF16(wtf16, string.str)) {


### PR DESCRIPTION
Add an `isUTF8` utility and use it in both the text and binary parsers. Add missing checks for overlong encodings and overlarge code points in our WTF8 reader, which the new utility uses. Re-enable the spec tests that test UTF-8 validation.