### PR TITLE
Validate memarg offsets

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -399,9 +399,8 @@ os.chdir(options.out_dir)
 # delete the old file, make sure you rename the corresponding .wast.log file in
 # expected-output/ if any.
 SPEC_TESTS_TO_SKIP = [
-    # Malformed module accepted
+    # Requires us to write our own floating point parser
     'const.wast',
-    'address.wast',
 
     # Unlinkable module accepted
     'linking.wast',

--- a/src/support/string.cpp
+++ b/src/support/string.cpp
@@ -318,6 +318,9 @@ std::ostream& writeWTF16CodePoint(std::ostream& os, uint32_t u) {
   return os;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 bool convertWTF8ToWTF16(std::ostream& os, std::string_view str) {
   bool valid = true;
   bool lastWasLeadingSurrogate = false;
@@ -342,6 +345,8 @@ bool convertWTF8ToWTF16(std::ostream& os, std::string_view str) {
 
   return valid;
 }
+
+#pragma GCC diagnostic pop
 
 bool convertWTF16ToWTF8(std::ostream& os, std::string_view str) {
   return doConvertWTF16ToWTF8(os, str, true);

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -526,6 +526,7 @@ private:
     return info.shouldBeSubType(left, right, curr, text, getFunction());
   }
 
+  void validateOffset(Address offset, Memory* mem, Expression* curr);
   void validateAlignment(
     size_t align, Type type, Index bytes, bool isAtomic, Expression* curr);
   void validateMemBytes(uint8_t bytes, Type type, Expression* curr);
@@ -1046,6 +1047,7 @@ void FunctionValidator::visitLoad(Load* curr) {
                  "SIMD operations require SIMD [--enable-simd]");
   }
   validateMemBytes(curr->bytes, curr->type, curr);
+  validateOffset(curr->offset, memory, curr);
   validateAlignment(curr->align, curr->type, curr->bytes, curr->isAtomic, curr);
   shouldBeEqualOrFirstIsUnreachable(
     curr->ptr->type,
@@ -1077,6 +1079,7 @@ void FunctionValidator::visitStore(Store* curr) {
                  "SIMD operations require SIMD [--enable-simd]");
   }
   validateMemBytes(curr->bytes, curr->valueType, curr);
+  validateOffset(curr->offset, memory, curr);
   validateAlignment(
     curr->align, curr->valueType, curr->bytes, curr->isAtomic, curr);
   shouldBeEqualOrFirstIsUnreachable(
@@ -1370,6 +1373,7 @@ void FunctionValidator::visitSIMDLoad(SIMDLoad* curr) {
       break;
   }
   Index bytes = curr->getMemBytes();
+  validateOffset(curr->offset, memory, curr);
   validateAlignment(curr->align, memAlignType, bytes, /*isAtomic=*/false, curr);
 }
 
@@ -1423,6 +1427,7 @@ void FunctionValidator::visitSIMDLoadStoreLane(SIMDLoadStoreLane* curr) {
       WASM_UNREACHABLE("Unexpected SIMDLoadStoreLane op");
   }
   Index bytes = curr->getMemBytes();
+  validateOffset(curr->offset, memory, curr);
   validateAlignment(curr->align, memAlignType, bytes, /*isAtomic=*/false, curr);
   shouldBeTrue(curr->index < lanes, curr, "invalid lane index");
 }
@@ -3455,6 +3460,13 @@ void FunctionValidator::visitFunction(Function* curr) {
     assert(rethrowTargetNames.empty());
     labelNames.clear();
   }
+}
+
+void FunctionValidator::validateOffset(Address offset,
+                                       Memory* mem,
+                                       Expression* curr) {
+  shouldBeTrue(
+    mem->is64() || offset < (1ull << 32), curr, "offset must be u32");
 }
 
 void FunctionValidator::validateAlignment(

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3465,8 +3465,9 @@ void FunctionValidator::visitFunction(Function* curr) {
 void FunctionValidator::validateOffset(Address offset,
                                        Memory* mem,
                                        Expression* curr) {
-  shouldBeTrue(
-    mem->is64() || offset < (1ull << 32), curr, "offset must be u32");
+  shouldBeTrue(mem->is64() || offset <= std::numeric_limits<uint32_t>::max(),
+               curr,
+               "offset must be u32");
 }
 
 void FunctionValidator::validateAlignment(

--- a/test/spec/address.wast
+++ b/test/spec/address.wast
@@ -203,7 +203,7 @@
 (assert_trap (invoke "16s_bad" (i32.const 1)) "out of bounds memory access")
 (assert_trap (invoke "32_bad" (i32.const 1)) "out of bounds memory access")
 
-(assert_malformed
+(assert_invalid
   (module quote
     "(memory 1)"
     "(func (drop (i32.load offset=4294967296 (i32.const 0))))"


### PR DESCRIPTION
For 32-bit memories, the offset value must be in the u32 range. Update
the address.wast spec test to assert that a module with an overlarge
offset value is invalid rather than malformed.