### PR TITLE
GlobalStructInference: Un-nest struct.news in globals when that is helpful

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,3 @@ BinPackParameters: false
 Language: JavaScript
 DisableFormat: true
 ---
-Language: Json
-BasedOnStyle: LLVM
----

--- a/.clang-format
+++ b/.clang-format
@@ -12,3 +12,6 @@ BinPackParameters: false
 Language: JavaScript
 DisableFormat: true
 ---
+Language: Json
+BasedOnStyle: LLVM
+---

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -254,7 +254,7 @@ struct GlobalStructInference : public Pass {
         return std::get<PossibleConstantValues>(content);
       }
 
-      Expression* getPointer() const {
+      Expression* getExpression() const {
         assert(!isConstant());
         return std::get<Expression*>(content);
       }
@@ -434,7 +434,7 @@ struct GlobalStructInference : public Pass {
           // Create a global.get with temporary name, leaving only the updating
           // of the name to later work.
           auto* get =
-            builder.makeGlobalGet(value.globals[0], value.getPointer()->type);
+            builder.makeGlobalGet(value.globals[0], value.getExpression()->type);
 
           globalsToUnnest.emplace_back(
             GlobalToUnnest{value.globals[0], fieldIndex, get});

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -470,15 +470,19 @@ struct GlobalStructInference : public Pass {
         }
 
         // Excellent, we can optimize here! Emit a select.
-        //
-        // Note that we must trap on null, so add a ref.as_non_null here.
+
         auto checkGlobal = values[0].globals[0];
+        // Compute the left and right values before the next line, as the order
+        // of their execution matters (they may note globals for un-nesting).
+        auto* left = getReadValue(values[0]);
+        auto* right = getReadValue(values[1]);
+        // Note that we must trap on null, so add a ref.as_non_null here.
         replaceCurrent(builder.makeSelect(
           builder.makeRefEq(builder.makeRefAs(RefAsNonNull, curr->ref),
                             builder.makeGlobalGet(
                               checkGlobal, wasm.getGlobal(checkGlobal)->type)),
-          getReadValue(values[0]),
-          getReadValue(values[1])));
+          left,
+          right));
       }
 
       void visitFunction(Function* func) {

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -246,7 +246,9 @@ struct GlobalStructInference : public Pass {
       // TODO: SmallVector?
       std::vector<Name> globals;
 
-      bool isConstant() const { return std::get_if<PossibleConstantValues>(&content); }
+      bool isConstant() const {
+        return std::get_if<PossibleConstantValues>(&content);
+      }
 
       const PossibleConstantValues& getConstant() const {
         assert(isConstant());
@@ -267,7 +269,7 @@ struct GlobalStructInference : public Pass {
     //    (struct.new $T ..)
     //
     // We have a nested struct.new here. That is not a constant value, but we
-    //can turn it into a global.get:
+    // can turn it into a global.get:
     //
     //  (global $g.nested (struct.new $T ..)
     //  (global $g (struct.new $S
@@ -302,7 +304,9 @@ struct GlobalStructInference : public Pass {
       GlobalsToUnnest& globalsToUnnest;
 
     public:
-      FunctionOptimizer(GlobalStructInference& parent, GlobalsToUnnest& globalsToUnnest) : parent(parent), globalsToUnnest(globalsToUnnest) {}
+      FunctionOptimizer(GlobalStructInference& parent,
+                        GlobalsToUnnest& globalsToUnnest)
+        : parent(parent), globalsToUnnest(globalsToUnnest) {}
 
       bool refinalize = false;
 
@@ -433,7 +437,8 @@ struct GlobalStructInference : public Pass {
           auto* get = builder.makeGlobalGet(value.globals[0],
                                             (*value.getPointer())->type);
 
-          globalsToUnnest.emplace_back(GlobalToUnnest{value.globals[0], fieldIndex, get});
+          globalsToUnnest.emplace_back(
+            GlobalToUnnest{value.globals[0], fieldIndex, get});
           return get;
         };
 
@@ -515,8 +520,11 @@ struct GlobalStructInference : public Pass {
           assert(get->type == nestedGet->type);
         } else {
           // Add a new global, initialized to the operand.
-          auto newName = Names::getValidGlobalName(*module, global->name.toString() + ".unnested." + std::to_string(index));
-          module->addGlobal(builder.makeGlobal(newName, get->type, operand, Builder::Immutable));
+          auto newName = Names::getValidGlobalName(
+            *module,
+            global->name.toString() + ".unnested." + std::to_string(index));
+          module->addGlobal(builder.makeGlobal(
+            newName, get->type, operand, Builder::Immutable));
           // Replace the operand with a get of that new global, and update the
           // original get to read the same.
           operand = builder.makeGlobalGet(newName, get->type);

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -433,8 +433,8 @@ struct GlobalStructInference : public Pass {
 
           // Create a global.get with temporary name, leaving only the updating
           // of the name to later work.
-          auto* get = builder.makeGlobalGet(value.globals[0],
-                                            value.getPointer()->type);
+          auto* get =
+            builder.makeGlobalGet(value.globals[0], value.getPointer()->type);
 
           globalsToUnnest.emplace_back(
             GlobalToUnnest{value.globals[0], fieldIndex, get});

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -398,7 +398,7 @@ struct GlobalStructInference : public Pass {
 
         // Helper for optimization: Given a Value, returns what we should read
         // for it.
-        auto getReadValue = [&](const Value& value) {
+        auto getReadValue = [&](const Value& value) -> Expression* {
           if (value.constant.isConstant()) {
             // This is known to be a constant, so simply emit an expression for
             // that constant.

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -512,6 +512,10 @@ struct GlobalStructInference : public Pass {
 
     if (addedGlobals) {
       // Sort the globals so that added ones appear before their uses.
+      PassRunner runner(module);
+      runner.add("reorder-globals-always");
+      runner.setIsNested(true);
+      runner.run();
     }
   }
 };

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -433,8 +433,8 @@ struct GlobalStructInference : public Pass {
 
           // Create a global.get with temporary name, leaving only the updating
           // of the name to later work.
-          auto* get =
-            builder.makeGlobalGet(value.globals[0], value.getExpression()->type);
+          auto* get = builder.makeGlobalGet(value.globals[0],
+                                            value.getExpression()->type);
 
           globalsToUnnest.emplace_back(
             GlobalToUnnest{value.globals[0], fieldIndex, get});

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -275,7 +275,7 @@ struct GlobalStructInference : public Pass {
     //    (global.get $g.nested)
     //
     // After this un-nesting we end up with a global.get of an immutable global,
-    // which is constant. Note that this adds a globalsand may increase code
+    // which is constant. Note that this adds a global and may increase code
     // size slightly, but if it lets us infer constant values that may lead to
     // devirtualization and other large benefits. Later passes can also re-nest.
     //

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -479,7 +479,7 @@ struct GlobalStructInference : public Pass {
         }
 
         FunctionOptimizer optimizer(*this, globalsToUnnest);
-        optimizer.walkFunction(func);
+        optimizer.walkFunctionInModule(func, module);
       });
 
     // Un-nest any globals as needed, using the deterministic order of the

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -385,16 +385,14 @@ struct GlobalStructInference : public Pass {
               value.content = ptr;
             }
           }
-          if (!value.isConstant()) {
-            return; // XXX
-          }
 
           // If the value is constant, it may be grouped as mentioned before.
           // See if it matches anything we've seen before.
           bool grouped = false;
           if (value.isConstant()) {
             for (auto& oldValue : values) {
-              if (value.getConstant() == oldValue.getConstant()) {
+              if (oldValue.isConstant() &&
+                  oldValue.getConstant() == value.getConstant()) {
                 // Add us to this group.
                 oldValue.globals.push_back(global);
                 grouped = true;

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -368,7 +368,7 @@ struct GlobalStructInference : public Pass {
             value.constant.note(*value.ptr, wasm);
           }
           if (!value.constant.isConstant()) {
-            continue; // XXX
+            return; // XXX
           }
 
           // If the value is constant, it may be grouped as mentioned before.

--- a/src/passes/GlobalStructInference.cpp
+++ b/src/passes/GlobalStructInference.cpp
@@ -438,6 +438,7 @@ struct GlobalStructInference : public Pass {
 
           globalsToUnnest.emplace_back(
             GlobalToUnnest{value.globals[0], fieldIndex, get});
+
           return get;
         };
 

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -895,6 +895,59 @@
   )
 )
 
+;; As above, but with the globals flipped. Now the second global has a non-
+;; constant field.
+(module
+  ;; CHECK:      (type $struct (struct (field i32)))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $1 (func (param (ref null $struct))))
+
+  ;; CHECK:      (global $global2.unnested.0 i32 (i32.add
+  ;; CHECK-NEXT:  (i32.const 41)
+  ;; CHECK-NEXT:  (i32.const 1)
+  ;; CHECK-NEXT: ))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.const 1337)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.const 1337)
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (global.get $global2.unnested.0)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 41)
+      (i32.const 1)
+    )
+  ))
+
+  ;; CHECK:      (func $test (type $1) (param $struct (ref null $struct))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (i32.const 1337)
+  ;; CHECK-NEXT:    (global.get $global2.unnested.0)
+  ;; CHECK-NEXT:    (ref.eq
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (global.get $global1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $struct (ref null $struct))
+    (drop
+      (struct.get $struct 0
+        (local.get $struct)
+      )
+    )
+  )
+)
+
 ;; One global each for two subtypes of a common supertype, and one for the
 ;; supertype.
 (module

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -948,6 +948,66 @@
   )
 )
 
+;; As above, but now both globals have non-constant fields. We un-nest both.
+(module
+  ;; CHECK:      (type $struct (struct (field i32)))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $1 (func (param (ref null $struct))))
+
+  ;; CHECK:      (global $global2.unnested.0 i32 (i32.add
+  ;; CHECK-NEXT:  (i32.const 41)
+  ;; CHECK-NEXT:  (i32.const 1)
+  ;; CHECK-NEXT: ))
+
+  ;; CHECK:      (global $global1.unnested.0 i32 (i32.add
+  ;; CHECK-NEXT:  (i32.const 13)
+  ;; CHECK-NEXT:  (i32.const 37)
+  ;; CHECK-NEXT: ))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (global.get $global1.unnested.0)
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 13)
+      (i32.const 37)
+    )
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (global.get $global2.unnested.0)
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 41)
+      (i32.const 1)
+    )
+  ))
+
+  ;; CHECK:      (func $test (type $1) (param $struct (ref null $struct))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select
+  ;; CHECK-NEXT:    (global.get $global1.unnested.0)
+  ;; CHECK-NEXT:    (global.get $global2.unnested.0)
+  ;; CHECK-NEXT:    (ref.eq
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (global.get $global1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $struct (ref null $struct))
+    (drop
+      (struct.get $struct 0
+        (local.get $struct)
+      )
+    )
+  )
+)
+
 ;; One global each for two subtypes of a common supertype, and one for the
 ;; supertype.
 (module

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -1008,6 +1008,69 @@
   )
 )
 
+;; Three globals with non-constant fields. We do not optimize as we cannot pick
+;; between three values with a single comparison.
+(module
+  ;; CHECK:      (type $struct (struct (field i32)))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $1 (func (param (ref null $struct))))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 42)
+      (i32.const 0)
+    )
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (i32.const 1337)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 1337)
+      (i32.const 0)
+    )
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (i32.const 99999)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 99999)
+      (i32.const 0)
+    )
+  ))
+
+  ;; CHECK:      (func $test (type $1) (param $struct (ref null $struct))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $struct 0
+  ;; CHECK-NEXT:    (local.get $struct)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $struct (ref null $struct))
+    (drop
+      (struct.get $struct 0
+        (local.get $struct)
+      )
+    )
+  )
+)
+
 ;; One global each for two subtypes of a common supertype, and one for the
 ;; supertype.
 (module

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -1071,6 +1071,70 @@
   )
 )
 
+;; As above, but now two of the three's non-constant fields are identical. That
+;; does not help us: they are still non-constant, and we do nothing. (But, other
+;; passes might simplify things by un-nesting the identical code.)
+(module
+  ;; CHECK:      (type $struct (struct (field i32)))
+  (type $struct (struct i32))
+
+  ;; CHECK:      (type $1 (func (param (ref null $struct))))
+
+  ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: ))
+  (global $global1 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 42)
+      (i32.const 0)
+    )
+  ))
+
+  ;; CHECK:      (global $global2 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (i32.const 42)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: ))
+  (global $global2 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 42)
+      (i32.const 0)
+    )
+  ))
+
+  ;; CHECK:      (global $global3 (ref $struct) (struct.new $struct
+  ;; CHECK-NEXT:  (i32.add
+  ;; CHECK-NEXT:   (i32.const 99999)
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: ))
+  (global $global3 (ref $struct) (struct.new $struct
+    (i32.add
+      (i32.const 99999)
+      (i32.const 0)
+    )
+  ))
+
+  ;; CHECK:      (func $test (type $1) (param $struct (ref null $struct))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.get $struct 0
+  ;; CHECK-NEXT:    (local.get $struct)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test (param $struct (ref null $struct))
+    (drop
+      (struct.get $struct 0
+        (local.get $struct)
+      )
+    )
+  )
+)
+
 ;; One global each for two subtypes of a common supertype, and one for the
 ;; supertype.
 (module

--- a/test/lit/passes/gsi.wast
+++ b/test/lit/passes/gsi.wast
@@ -955,14 +955,14 @@
 
   ;; CHECK:      (type $1 (func (param (ref null $struct))))
 
-  ;; CHECK:      (global $global2.unnested.0 i32 (i32.add
-  ;; CHECK-NEXT:  (i32.const 41)
-  ;; CHECK-NEXT:  (i32.const 1)
-  ;; CHECK-NEXT: ))
-
   ;; CHECK:      (global $global1.unnested.0 i32 (i32.add
   ;; CHECK-NEXT:  (i32.const 13)
   ;; CHECK-NEXT:  (i32.const 37)
+  ;; CHECK-NEXT: ))
+
+  ;; CHECK:      (global $global2.unnested.0 i32 (i32.add
+  ;; CHECK-NEXT:  (i32.const 41)
+  ;; CHECK-NEXT:  (i32.const 1)
   ;; CHECK-NEXT: ))
 
   ;; CHECK:      (global $global1 (ref $struct) (struct.new $struct
@@ -1020,6 +1020,11 @@
   ;; CHECK-NEXT:  (i32.const 37)
   ;; CHECK-NEXT: ))
 
+  ;; CHECK:      (global $global2.unnested.0 i32 (i32.add
+  ;; CHECK-NEXT:  (i32.const 41)
+  ;; CHECK-NEXT:  (i32.const 1)
+  ;; CHECK-NEXT: ))
+
   ;; CHECK:      (global $global1.unnested.1 i32 (i32.add
   ;; CHECK-NEXT:  (i32.const 99)
   ;; CHECK-NEXT:  (i32.const 1)
@@ -1039,11 +1044,6 @@
       (i32.const 1)
     )
   ))
-
-  ;; CHECK:      (global $global2.unnested.0 i32 (i32.add
-  ;; CHECK-NEXT:  (i32.const 41)
-  ;; CHECK-NEXT:  (i32.const 1)
-  ;; CHECK-NEXT: ))
 
   ;; CHECK:      (global $global2.unnested.1 i32 (i32.add
   ;; CHECK-NEXT:  (i32.const 100)


### PR DESCRIPTION
If we have
```wat
(global $g (struct.new $S
  (i32.const 1)
  (struct.new $T ..)
  (ref.func $f)
))
```
then before this PR if we wanted to read the middle field we'd stop, as it is non-constant.
However, we can un-nest it, making it constant:
```wat
(global $g.unnested (struct.new $T ..))
(global $g (struct.new $S
  (i32.const 1)
  (global.get $g.unnested)
  (ref.func $f)
))
```
Now the field is a `global.get` of an immutable global, which is constant. Using this
technique we can handle anything in a struct field, constant or not. The cost of adding
a global is likely offset by the benefit of being able to refer to it directly, as that opens
up more opportunities later.

Concretely, this replaces the constant values we look for in GSI with a variant over
constants or expressions (we do still want to group constants, as multiple globals
with the same constant field can be treated as a whole). And we note cases where we
need to un-nest, and handle those at the end.