### PR TITLE
wasm2js: Fix the names of temp vars with named reference types

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -217,7 +217,7 @@ public:
                      std::to_string(index))
                       .c_str(),
                     false);
-//      ret = fromName(ret, NameScope::Local);
+      ret = fromName(ret, NameScope::Local);
     }
     if (func->localIndices.find(ret) == func->localIndices.end()) {
       Builder::addVar(func, ret, type);

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -217,6 +217,7 @@ public:
                      std::to_string(index))
                       .c_str(),
                     false);
+//      ret = fromName(ret, NameScope::Local);
     }
     if (func->localIndices.find(ret) == func->localIndices.end()) {
       Builder::addVar(func, ret, type);

--- a/test/wasm2js/refs.2asm.js
+++ b/test/wasm2js/refs.2asm.js
@@ -61,6 +61,12 @@ function asmFunc(imports) {
   funcref_temps(funcref_temps, +(+((wasm2js_funcref$0 = $2, wasm2js_funcref$1 = $3 || wasm2js_trap(), wasm2js_i32$0 = 0, wasm2js_i32$0 ? wasm2js_funcref$0 : wasm2js_funcref$1) == null | 0)));
  }
  
+ function named_type_temps() {
+  var $0 = null, wasm2js__ref_null_$func_0_$0 = null, wasm2js__ref_null_$func_0_$1 = null, wasm2js_i32$0 = 0;
+  $0 = named_type_temps;
+  return wasm2js_(ref null $func.0)$0 = null, wasm2js_(ref null $func.0)$1 = $0 || wasm2js_trap(), wasm2js_i32$0 = 0, wasm2js_i32$0 ? wasm2js_(ref null $func.0)$0 : wasm2js_(ref null $func.0)$1;
+ }
+ 
  return {
   "null_": null_, 
   "is_null": is_null, 
@@ -69,7 +75,8 @@ function asmFunc(imports) {
   "ref_as": ref_as, 
   "use_global": use_global, 
   "use_global_ref": use_global_ref, 
-  "funcref_temps": funcref_temps
+  "funcref_temps": funcref_temps, 
+  "named_type_temps": named_type_temps
  };
 }
 
@@ -83,3 +90,4 @@ export var ref_as = retasmFunc.ref_as;
 export var use_global = retasmFunc.use_global;
 export var use_global_ref = retasmFunc.use_global_ref;
 export var funcref_temps = retasmFunc.funcref_temps;
+export var named_type_temps = retasmFunc.named_type_temps;

--- a/test/wasm2js/refs.2asm.js
+++ b/test/wasm2js/refs.2asm.js
@@ -62,9 +62,9 @@ function asmFunc(imports) {
  }
  
  function named_type_temps() {
-  var $0 = null, wasm2js__ref_null_$func_0_$0 = null, wasm2js__ref_null_$func_0_$1 = null, wasm2js_i32$0 = 0;
+  var $0 = null, wasm2js__ref_null_$func_0_$0_1 = null, wasm2js__ref_null_$func_0_$1_1 = null, wasm2js_i32$0 = 0;
   $0 = named_type_temps;
-  return wasm2js_(ref null $func.0)$0 = null, wasm2js_(ref null $func.0)$1 = $0 || wasm2js_trap(), wasm2js_i32$0 = 0, wasm2js_i32$0 ? wasm2js_(ref null $func.0)$0 : wasm2js_(ref null $func.0)$1;
+  return wasm2js__ref_null_$func_0_$0 = null, wasm2js__ref_null_$func_0_$1 = $0 || wasm2js_trap(), wasm2js_i32$0 = 0, wasm2js_i32$0 ? wasm2js__ref_null_$func_0_$0 : wasm2js__ref_null_$func_0_$1;
  }
  
  return {

--- a/test/wasm2js/refs.2asm.js.opt
+++ b/test/wasm2js/refs.2asm.js.opt
@@ -53,6 +53,10 @@ function asmFunc(imports) {
   funcref_temps(funcref_temps, 0.0);
  }
  
+ function named_type_temps() {
+  return named_type_temps;
+ }
+ 
  return {
   "null_": null_, 
   "is_null": is_null, 
@@ -61,7 +65,8 @@ function asmFunc(imports) {
   "ref_as": ref_as, 
   "use_global": use_global, 
   "use_global_ref": use_global_ref, 
-  "funcref_temps": funcref_temps
+  "funcref_temps": funcref_temps, 
+  "named_type_temps": named_type_temps
  };
 }
 
@@ -75,3 +80,4 @@ export var ref_as = retasmFunc.ref_as;
 export var use_global = retasmFunc.use_global;
 export var use_global_ref = retasmFunc.use_global_ref;
 export var funcref_temps = retasmFunc.funcref_temps;
+export var named_type_temps = retasmFunc.named_type_temps;

--- a/test/wasm2js/refs.wast
+++ b/test/wasm2js/refs.wast
@@ -1,4 +1,6 @@
 (module
+  (type $func (func (result funcref)))
+
   (global $global (mut anyref) (ref.null any))
 
   (global $global-ref (mut funcref) (ref.func $use-global-ref))
@@ -79,6 +81,26 @@
           )
         )
       )
+    )
+  )
+
+  (func $named_type_temps (export "named_type_temps") (result funcref)
+    ;; This nested expression ends up needing to use temp vars, and one such
+    ;; name contains the type $func. We should emit that in form that is
+    ;; mangled for JS, without '(' which appears in the stringified name of the
+    ;; type, "(ref null $func)".
+    (select (result (ref null $func))
+      (ref.null nofunc)
+      (if (result (ref $func))
+        (i32.const 1)
+        (then
+          (ref.func $named_type_temps)
+        )
+        (else
+          (unreachable)
+        )
+      )
+      (i32.const 0)
     )
   )
 )


### PR DESCRIPTION
We were missing code to mangle such names for JS. Without that, the name
of a temp var for the type `(ref $foo)` would end up with `(`, `)` in the name, which
is not valid in JS.

(See last commit for the effect of the one-line change.)