### PR TITLE
Add a proper error for bad select results

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -6865,7 +6865,11 @@ void WasmBinaryReader::visitSelect(Select* curr, uint8_t code) {
     size_t numTypes = getU32LEB();
     std::vector<Type> types;
     for (size_t i = 0; i < numTypes; i++) {
-      types.push_back(getType());
+      auto t = getType();
+      if (!t.isConcrete()) {
+        throwError("bad select type");
+      }
+      types.push_back(t);
     }
     curr->type = Type(types);
   }


### PR DESCRIPTION
The result cannot be `none` or `unreachable` etc.

Fixes #6694