### PR TITLE
Add a missing binary reading check for BrOn's reference child's type

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -7320,6 +7320,9 @@ bool WasmBinaryReader::maybeVisitBrOn(Expression*& out, uint32_t code) {
   }
   auto name = getBreakTarget(getU32LEB()).name;
   auto* ref = popNonVoidExpression();
+  if (!ref->type.isRef() && ref->type != Type::unreachable) {
+    throwError("bad input type for br_on*");
+  }
   if (isCast) {
     auto inputNullability = (flags & 1) ? Nullable : NonNullable;
     auto castNullability = (flags & 2) ? Nullable : NonNullable;


### PR DESCRIPTION
That child must be a reference, as `finalize()` assumes so. To avoid an
assertion, error early.

Fixes #6696