### PR TITLE
[threads] Shared polymorphism for extern conversions

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2222,10 +2222,11 @@ void FunctionValidator::visitRefAs(RefAs* curr) {
       if (curr->type == Type::unreachable) {
         return;
       }
-      shouldBeSubType(curr->value->type,
-                      Type(HeapType::ext, Nullable),
-                      curr->value,
-                      "any.convert_extern value should be an externref");
+      shouldBeSubTypeIgnoringShared(
+        curr->value->type,
+        Type(HeapType::ext, Nullable),
+        curr->value,
+        "any.convert_extern value should be an externref");
       break;
     }
     case ExternConvertAny: {
@@ -2235,10 +2236,11 @@ void FunctionValidator::visitRefAs(RefAs* curr) {
       if (curr->type == Type::unreachable) {
         return;
       }
-      shouldBeSubType(curr->value->type,
-                      Type(HeapType::any, Nullable),
-                      curr->value,
-                      "extern.convert_any value should be an anyref");
+      shouldBeSubTypeIgnoringShared(
+        curr->value->type,
+        Type(HeapType::any, Nullable),
+        curr->value,
+        "extern.convert_any value should be an anyref");
       break;
     }
   }

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1227,15 +1227,18 @@ void RefAs::finalize() {
     type = Type::unreachable;
     return;
   }
+  auto valHeapType = value->type.getHeapType();
   switch (op) {
     case RefAsNonNull:
-      type = Type(value->type.getHeapType(), NonNullable);
+      type = Type(valHeapType, NonNullable);
       break;
     case AnyConvertExtern:
-      type = Type(HeapType::any, value->type.getNullability());
+      type = Type(HeapTypes::any.getBasic(valHeapType.getShared()),
+                  value->type.getNullability());
       break;
     case ExternConvertAny:
-      type = Type(HeapType::ext, value->type.getNullability());
+      type = Type(HeapTypes::ext.getBasic(valHeapType.getShared()),
+                  value->type.getNullability());
       break;
     default:
       WASM_UNREACHABLE("invalid ref.as_*");

--- a/test/spec/shared-polymorphism.wast
+++ b/test/spec/shared-polymorphism.wast
@@ -9,4 +9,17 @@
   (func (param (ref null (shared i31))) (drop (i31.get_u (local.get 0))))
 
   (func (param (ref null (shared array))) (drop (array.len (local.get 0))))
+
+  (func (param (ref null (shared extern))) (result (ref null (shared any)))
+    (any.convert_extern (local.get 0))
+  )
+  (func (param (ref (shared extern))) (result (ref (shared any)))
+    (any.convert_extern (local.get 0))
+  )
+  (func (param (ref null (shared any))) (result (ref null (shared extern)))
+    (extern.convert_any (local.get 0))
+  )
+  (func (param (ref (shared any))) (result (ref (shared extern)))
+    (extern.convert_any (local.get 0))
+  )
 )


### PR DESCRIPTION
`any.convert_extern` and `extern.convert_any` return references to
shared heap types iff their operands are references to shared heap
types.
