### PR TITLE
Monomorphize: Use -O3 over -O1 + tweaks

### DIFF
--- a/test/lit/passes/monomorphize-consts.wast
+++ b/test/lit/passes/monomorphize-consts.wast
@@ -29,6 +29,8 @@
 
   ;; CAREFUL:      (type $3 (func (param i32) (result i32)))
 
+  ;; CAREFUL:      (type $4 (func (result i32)))
+
   ;; CAREFUL:      (import "a" "b" (func $import (type $2) (param i32)))
   (import "a" "b" (func $import (param i32)))
 
@@ -314,16 +316,13 @@
   ;; ALWAYS-NEXT: )
   ;; CAREFUL:      (func $mutual-recursion-b (type $3) (param $0 i32) (result i32)
   ;; CAREFUL-NEXT:  (i32.add
-  ;; CAREFUL-NEXT:   (call $mutual-recursion-a
-  ;; CAREFUL-NEXT:    (i32.const 0)
-  ;; CAREFUL-NEXT:   )
+  ;; CAREFUL-NEXT:   (call $mutual-recursion-a_10)
   ;; CAREFUL-NEXT:   (i32.const 1337)
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT: )
   (func $mutual-recursion-b (param $x i32) (result i32)
     (i32.add
-      ;; This can be optimized (in ALWAYS; to see the benefit in CAREFUL, we
-      ;; need additional cycles, which we do not do yet).
+      ;; This can be optimized (as the constant 0 allows work to happen).
       (call $mutual-recursion-a
         (i32.const 0)
       )
@@ -632,4 +631,8 @@
 ;; CAREFUL-NEXT:  (call $import
 ;; CAREFUL-NEXT:   (local.get $0)
 ;; CAREFUL-NEXT:  )
+;; CAREFUL-NEXT: )
+
+;; CAREFUL:      (func $mutual-recursion-a_10 (type $4) (result i32)
+;; CAREFUL-NEXT:  (i32.const 42)
 ;; CAREFUL-NEXT: )

--- a/test/lit/passes/monomorphize-types.wast
+++ b/test/lit/passes/monomorphize-types.wast
@@ -447,35 +447,35 @@
   ;; ALWAYS-NEXT:  )
   ;; ALWAYS-NEXT: )
   ;; CAREFUL:      (func $refinable (type $4) (param $0 (ref $A))
-  ;; CAREFUL-NEXT:  (local $1 (ref $A))
+  ;; CAREFUL-NEXT:  (local $1 (ref $B))
+  ;; CAREFUL-NEXT:  (local $2 (ref $B))
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast (ref $B)
-  ;; CAREFUL-NEXT:    (local.get $0)
-  ;; CAREFUL-NEXT:   )
-  ;; CAREFUL-NEXT:  )
-  ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast (ref $B)
-  ;; CAREFUL-NEXT:    (local.tee $1
-  ;; CAREFUL-NEXT:     (select (result (ref $A))
-  ;; CAREFUL-NEXT:      (local.get $0)
-  ;; CAREFUL-NEXT:      (struct.new_default $B)
-  ;; CAREFUL-NEXT:      (global.get $global)
-  ;; CAREFUL-NEXT:     )
+  ;; CAREFUL-NEXT:   (local.tee $1
+  ;; CAREFUL-NEXT:    (ref.cast (ref $B)
+  ;; CAREFUL-NEXT:     (local.get $0)
   ;; CAREFUL-NEXT:    )
   ;; CAREFUL-NEXT:   )
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast (ref $B)
-  ;; CAREFUL-NEXT:    (local.get $1)
+  ;; CAREFUL-NEXT:   (local.tee $2
+  ;; CAREFUL-NEXT:    (select (result (ref $B))
+  ;; CAREFUL-NEXT:     (local.get $1)
+  ;; CAREFUL-NEXT:     (struct.new_default $B)
+  ;; CAREFUL-NEXT:     (global.get $global)
+  ;; CAREFUL-NEXT:    )
   ;; CAREFUL-NEXT:   )
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT:  (call $import
-  ;; CAREFUL-NEXT:   (ref.cast (ref $B)
-  ;; CAREFUL-NEXT:    (local.get $0)
-  ;; CAREFUL-NEXT:   )
+  ;; CAREFUL-NEXT:   (local.get $2)
+  ;; CAREFUL-NEXT:  )
+  ;; CAREFUL-NEXT:  (call $import
+  ;; CAREFUL-NEXT:   (local.get $1)
   ;; CAREFUL-NEXT:  )
   ;; CAREFUL-NEXT: )
   (func $refinable (param $ref (ref $A))
+    ;; Note that this large function will end up optimized in CAREFUL mode, as a
+    ;; side effect of our keeping optimizations we run for comparison purposes.
+
     (local $x (ref $A))
     ;; The refined version of this function will not have the cast, since
     ;; optimizations manage to remove it using the more refined type.


### PR DESCRIPTION
Eventually I'll need to do some tuning of compile time speed, but for now it is
going to be simpler to do all the opts, in particular because it makes writing
tests simpler.