### PR TITLE
Do not abbreviate items in element segments

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3089,8 +3089,9 @@ void PrintSExpression::visitElementSegment(ElementSegment* curr) {
     }
   } else {
     for (auto* entry : curr->data) {
-      o << ' ';
+      o << " (item ";
       visit(entry);
+      o << ')';
     }
   }
   o << ')' << maybeNewLine;

--- a/test/lit/basic/multi-table.wast
+++ b/test/lit/basic/multi-table.wast
@@ -57,21 +57,21 @@
   ;; CHECK-BIN:      (elem $activeNonZeroOffset (table $t2) (i32.const 1) func $f $g)
   (elem $activeNonZeroOffset (table $t2) (offset (i32.const 1)) func $f $g)
 
-  ;; CHECK-TEXT:      (elem $e3-1 (table $t3) (global.get $g2) funcref (ref.func $f) (ref.null nofunc))
-  ;; CHECK-BIN:      (elem $e3-1 (table $t3) (global.get $g2) funcref (ref.func $f) (ref.null nofunc))
+  ;; CHECK-TEXT:      (elem $e3-1 (table $t3) (global.get $g2) funcref (item (ref.func $f)) (item (ref.null nofunc)))
+  ;; CHECK-BIN:      (elem $e3-1 (table $t3) (global.get $g2) funcref (item (ref.func $f)) (item (ref.null nofunc)))
   (elem $e3-1 (table $t3) (global.get $g2) funcref (ref.func $f) (ref.null func))
-  ;; CHECK-TEXT:      (elem $e3-2 (table $t3) (i32.const 2) (ref null $none_=>_none) (ref.func $f) (ref.func $g))
-  ;; CHECK-BIN:      (elem $e3-2 (table $t3) (i32.const 2) (ref null $none_=>_none) (ref.func $f) (ref.func $g))
+  ;; CHECK-TEXT:      (elem $e3-2 (table $t3) (i32.const 2) (ref null $none_=>_none) (item (ref.func $f)) (item (ref.func $g)))
+  ;; CHECK-BIN:      (elem $e3-2 (table $t3) (i32.const 2) (ref null $none_=>_none) (item (ref.func $f)) (item (ref.func $g)))
   (elem $e3-2 (table $t3) (offset (i32.const 2)) (ref null $none_=>_none) (item ref.func $f) (item (ref.func $g)))
 
   ;; CHECK-TEXT:      (elem $passive-1 func $f $g)
   ;; CHECK-BIN:      (elem $passive-1 func $f $g)
   (elem $passive-1 func $f $g)
-  ;; CHECK-TEXT:      (elem $passive-2 funcref (ref.func $f) (ref.func $g) (ref.null nofunc))
-  ;; CHECK-BIN:      (elem $passive-2 funcref (ref.func $f) (ref.func $g) (ref.null nofunc))
+  ;; CHECK-TEXT:      (elem $passive-2 funcref (item (ref.func $f)) (item (ref.func $g)) (item (ref.null nofunc)))
+  ;; CHECK-BIN:      (elem $passive-2 funcref (item (ref.func $f)) (item (ref.func $g)) (item (ref.null nofunc)))
   (elem $passive-2 funcref (item ref.func $f) (item (ref.func $g)) (ref.null func))
-  ;; CHECK-TEXT:      (elem $passive-3 (ref null $none_=>_none) (ref.func $f) (ref.func $g) (ref.null nofunc) (global.get $g1))
-  ;; CHECK-BIN:      (elem $passive-3 (ref null $none_=>_none) (ref.func $f) (ref.func $g) (ref.null nofunc) (global.get $g1))
+  ;; CHECK-TEXT:      (elem $passive-3 (ref null $none_=>_none) (item (ref.func $f)) (item (ref.func $g)) (item (ref.null nofunc)) (item (global.get $g1)))
+  ;; CHECK-BIN:      (elem $passive-3 (ref null $none_=>_none) (item (ref.func $f)) (item (ref.func $g)) (item (ref.null nofunc)) (item (global.get $g1)))
   (elem $passive-3 (ref null $none_=>_none) (item ref.func $f) (item (ref.func $g)) (ref.null $none_=>_none) (global.get $g1))
   ;; CHECK-TEXT:      (elem $empty func)
   ;; CHECK-BIN:      (elem $empty func)
@@ -80,8 +80,8 @@
 
   ;; This elem will be emitted as usesExpressions because of the type of the
   ;; table.
-  ;; CHECK-TEXT:      (elem $especial (table $tspecial) (i32.const 0) (ref null $none_=>_none) (ref.func $f) (ref.func $h))
-  ;; CHECK-BIN:      (elem $especial (table $tspecial) (i32.const 0) (ref null $none_=>_none) (ref.func $f) (ref.func $h))
+  ;; CHECK-TEXT:      (elem $especial (table $tspecial) (i32.const 0) (ref null $none_=>_none) (item (ref.func $f)) (item (ref.func $h)))
+  ;; CHECK-BIN:      (elem $especial (table $tspecial) (i32.const 0) (ref null $none_=>_none) (item (ref.func $f)) (item (ref.func $h)))
   (elem $especial (table $tspecial) (i32.const 0) (ref null $none_=>_none) (ref.func $f) (ref.func $h))
 
   ;; CHECK-TEXT:      (func $f (type $none_=>_none)
@@ -134,19 +134,19 @@
 
 ;; CHECK-BIN-NODEBUG:      (elem $2 (table $0) (i32.const 1) func $0 $1)
 
-;; CHECK-BIN-NODEBUG:      (elem $3 (table $1) (global.get $global$1) funcref (ref.func $0) (ref.null nofunc))
+;; CHECK-BIN-NODEBUG:      (elem $3 (table $1) (global.get $global$1) funcref (item (ref.func $0)) (item (ref.null nofunc)))
 
-;; CHECK-BIN-NODEBUG:      (elem $4 (table $1) (i32.const 2) (ref null $0) (ref.func $0) (ref.func $1))
+;; CHECK-BIN-NODEBUG:      (elem $4 (table $1) (i32.const 2) (ref null $0) (item (ref.func $0)) (item (ref.func $1)))
 
 ;; CHECK-BIN-NODEBUG:      (elem $5 func $0 $1)
 
-;; CHECK-BIN-NODEBUG:      (elem $6 funcref (ref.func $0) (ref.func $1) (ref.null nofunc))
+;; CHECK-BIN-NODEBUG:      (elem $6 funcref (item (ref.func $0)) (item (ref.func $1)) (item (ref.null nofunc)))
 
-;; CHECK-BIN-NODEBUG:      (elem $7 (ref null $0) (ref.func $0) (ref.func $1) (ref.null nofunc) (global.get $global$0))
+;; CHECK-BIN-NODEBUG:      (elem $7 (ref null $0) (item (ref.func $0)) (item (ref.func $1)) (item (ref.null nofunc)) (item (global.get $global$0)))
 
 ;; CHECK-BIN-NODEBUG:      (elem $8 func)
 
-;; CHECK-BIN-NODEBUG:      (elem $9 (table $3) (i32.const 0) (ref null $0) (ref.func $0) (ref.func $2))
+;; CHECK-BIN-NODEBUG:      (elem $9 (table $3) (i32.const 0) (ref null $0) (item (ref.func $0)) (item (ref.func $2)))
 
 ;; CHECK-BIN-NODEBUG:      (func $0 (type $0)
 ;; CHECK-BIN-NODEBUG-NEXT:  (drop

--- a/test/lit/passes/optimize-instructions-call_ref-roundtrip.wast
+++ b/test/lit/passes/optimize-instructions-call_ref-roundtrip.wast
@@ -33,15 +33,15 @@
  ;; CHECK:      (table $table-3 10 (ref null $v3))
  (table $table-3 10 (ref null $v3))
 
- ;; CHECK:      (elem $elem-1 (table $table-1) (i32.const 0) (ref null $v1) (ref.func $helper-1))
+ ;; CHECK:      (elem $elem-1 (table $table-1) (i32.const 0) (ref null $v1) (item (ref.func $helper-1)))
  (elem $elem-1 (table $table-1) (i32.const 0) (ref null $v1)
   (ref.func $helper-1))
 
- ;; CHECK:      (elem $elem-2 (table $table-2) (i32.const 0) (ref null $v2) (ref.func $helper-2))
+ ;; CHECK:      (elem $elem-2 (table $table-2) (i32.const 0) (ref null $v2) (item (ref.func $helper-2)))
  (elem $elem-2 (table $table-2) (i32.const 0) (ref null $v2)
   (ref.func $helper-2))
 
- ;; CHECK:      (elem $elem-3 (table $table-3) (i32.const 0) (ref null $v3) (ref.func $helper-3))
+ ;; CHECK:      (elem $elem-3 (table $table-3) (i32.const 0) (ref null $v3) (item (ref.func $helper-3)))
  (elem $elem-3 (table $table-3) (i32.const 0) (ref null $v3)
   (ref.func $helper-3))
 

--- a/test/lit/passes/optimize-instructions-call_ref.wast
+++ b/test/lit/passes/optimize-instructions-call_ref.wast
@@ -23,7 +23,7 @@
 
  ;; CHECK:      (table $table-1 10 (ref null $i32_i32_=>_none))
  (table $table-1 10 (ref null $i32_i32_=>_none))
- ;; CHECK:      (elem $elem-1 (table $table-1) (i32.const 0) (ref null $i32_i32_=>_none) (ref.func $foo))
+ ;; CHECK:      (elem $elem-1 (table $table-1) (i32.const 0) (ref null $i32_i32_=>_none) (item (ref.func $foo)))
  (elem $elem-1 (table $table-1) (i32.const 0) (ref null $i32_i32_=>_none)
   (ref.func $foo))
 

--- a/test/lit/passes/table64-lowering.wast
+++ b/test/lit/passes/table64-lowering.wast
@@ -12,11 +12,11 @@
 
   ;; CHECK:      (table $t32 10 100 funcref)
 
-  ;; CHECK:      (elem $elem64 (table $t64) (i32.const 0) funcref (ref.null nofunc))
+  ;; CHECK:      (elem $elem64 (table $t64) (i32.const 0) funcref (item (ref.null nofunc)))
   (elem $elem64 (table $t64) (i64.const 0) funcref (ref.null func))
 
   (table $t32 10 100 funcref)
-  ;; CHECK:      (elem $elem32 (table $t32) (i32.const 0) funcref (ref.null nofunc))
+  ;; CHECK:      (elem $elem32 (table $t32) (i32.const 0) funcref (item (ref.null nofunc)))
   (elem $elem32 (table $t32) (i32.const 0) funcref (ref.null func))
 
   ;; CHECK:      (func $test_call_indirect

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -103,7 +103,7 @@
 
  ;; An active element segment requires subtyping. So does an element segment
  ;; element.
- ;; CHECK:      (elem $e (table $t) (i32.const 0) (ref null $sub) (struct.new_default $subsub))
+ ;; CHECK:      (elem $e (table $t) (i32.const 0) (ref null $sub) (item (struct.new_default $subsub)))
  (elem $e (table $t) (offset (i32.const 0)) (ref null $sub) (struct.new $subsub))
 )
 

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -375,13 +375,13 @@
  (table $table-any anyref (elem (item i32.const 0 ref.i31) (ref.null any) (item (ref.i31 (i32.const 0)))))
 
  ;; elems
- ;; CHECK:      (elem $implicit-elem (table $table-any) (i32.const 0) anyref (ref.i31
+ ;; CHECK:      (elem $implicit-elem (table $table-any) (i32.const 0) anyref (item (ref.i31
  ;; CHECK-NEXT:  (i32.const 0)
- ;; CHECK-NEXT: ) (ref.null none) (ref.i31
+ ;; CHECK-NEXT: )) (item (ref.null none)) (item (ref.i31
  ;; CHECK-NEXT:  (i32.const 0)
- ;; CHECK-NEXT: ))
+ ;; CHECK-NEXT: )))
 
- ;; CHECK:      (elem $implicit-table (table $timport$0) (i32.const 0) funcref (ref.null nofunc) (ref.null nofunc) (ref.null nofunc))
+ ;; CHECK:      (elem $implicit-table (table $timport$0) (i32.const 0) funcref (item (ref.null nofunc)) (item (ref.null nofunc)) (item (ref.null nofunc)))
  (elem $implicit-table (offset i32.const 0) funcref (ref.null func) (item ref.null func) (item (ref.null func)))
 
  ;; CHECK:      (elem $implicit-table-2 (table $timport$0) (i32.const 1) func)
@@ -393,16 +393,16 @@
  ;; CHECK:      (elem $implicit-table-legacy-indices (table $timport$0) (i32.const 3) func $fimport$0 $fimport$1 $2 $f1)
  (elem $implicit-table-legacy-indices (i32.const 3) 0 1 2 3)
 
- ;; CHECK:      (elem $explicit-table (table $timport$0) (i32.const 0) funcref (ref.null nofunc))
+ ;; CHECK:      (elem $explicit-table (table $timport$0) (i32.const 0) funcref (item (ref.null nofunc)))
  (elem $explicit-table (table 0) (offset (i32.const 0)) funcref (item ref.null func))
 
  ;; CHECK:      (elem $explicit-table-named (table $table-any) (i32.const 1) anyref)
  (elem $explicit-table-named (table $table-any) (i32.const 1) anyref)
 
- ;; CHECK:      (elem $passive (ref null $s0) (struct.new_default $s0) (struct.new_default $s0))
+ ;; CHECK:      (elem $passive (ref null $s0) (item (struct.new_default $s0)) (item (struct.new_default $s0)))
  (elem $passive (ref null $s0) (item struct.new $s0) (struct.new $s0))
 
- ;; CHECK:      (elem $passive-2 anyref (struct.new_default $s0) (struct.new_default $s0))
+ ;; CHECK:      (elem $passive-2 anyref (item (struct.new_default $s0)) (item (struct.new_default $s0)))
  (elem $passive-2 anyref (item struct.new $s0) (struct.new $s0))
 
  ;; CHECK:      (elem declare func $ref-func $table-fill $table-grow $table-set)


### PR DESCRIPTION
The full syntax for an expression in an element syntax looks like
`(item (ref.null none))`, but we have been printing the abbreviated
version, which omits the `(item ...)`. This abbreviation is only valid
when the item has only a single instruction, so it is not always correct
to use it. Rather than determining whether or not to use the
abbreviation on a case-by-case basis, always print the full syntax.
