### PR TITLE
Remove extra space printed in empty structs

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2109,10 +2109,6 @@ TypePrinter::print(const Struct& struct_,
     print(struct_.fields[i]);
     os << ')';
   }
-  // TODO: Remove this extra space kept to minimize test diffs.
-  if (struct_.fields.size() == 0) {
-    os << ' ';
-  }
   return os << ")";
 }
 

--- a/test/example/typeinfo.txt
+++ b/test/example/typeinfo.txt
@@ -12,7 +12,7 @@ i31
 i31ref
 (ref i31)
 (func)
-(type $struct.0 (struct ))
+(type $struct.0 (struct))
 (type $array.0 (array i32))
 
 ;; Signature
@@ -24,7 +24,7 @@ i31ref
 (ref null $func.0)
 
 ;; Struct
-(type $struct.0 (struct ))
+(type $struct.0 (struct))
 (ref $struct.0)
 (ref null $struct.0)
 (type $struct.0 (struct (field i32) (field i64) (field (mut f32)) (field (mut f64))))

--- a/test/lit/basic/shared-types.wast
+++ b/test/lit/basic/shared-types.wast
@@ -8,9 +8,9 @@
     ;; CHECK:      (type $0 (func))
 
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $final (shared (struct )))
+    ;; CHECK-NEXT:  (type $final (shared (struct)))
     (type $final (shared (struct)))
-    ;; CHECK:       (type $top (sub (shared (struct ))))
+    ;; CHECK:       (type $top (sub (shared (struct))))
     (type $top (sub (shared (struct))))
     ;; CHECK:       (type $mid (sub $top (shared (struct (field i32)))))
     (type $mid (sub $top (shared (struct i32))))

--- a/test/lit/cast-and-recast-tuple.wast
+++ b/test/lit/cast-and-recast-tuple.wast
@@ -10,9 +10,9 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $A (sub (struct )))
+    ;; CHECK-NEXT:  (type $A (sub (struct)))
     (type $A (sub (struct)))
-    ;; CHECK:       (type $B (sub $A (struct )))
+    ;; CHECK:       (type $B (sub $A (struct)))
     (type $B (sub $A (struct)))
   )
 

--- a/test/lit/cast-and-recast.wast
+++ b/test/lit/cast-and-recast.wast
@@ -10,11 +10,11 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $A (sub (struct )))
+    ;; CHECK-NEXT:  (type $A (sub (struct)))
     (type $A (sub (struct)))
-    ;; CHECK:       (type $B (sub $A (struct )))
+    ;; CHECK:       (type $B (sub $A (struct)))
     (type $B (sub $A (struct)))
-    ;; CHECK:       (type $C (sub $B (struct )))
+    ;; CHECK:       (type $C (sub $B (struct)))
     (type $C (sub $B (struct)))
   )
 

--- a/test/lit/ctor-eval/ctor_after_serialization.wat
+++ b/test/lit/ctor-eval/ctor_after_serialization.wat
@@ -7,7 +7,7 @@
 ;; contains the serialization of the struct.new instruction).
 
 (module
- ;; CHECK:      (type $A (struct ))
+ ;; CHECK:      (type $A (struct))
  (type $A (struct))
 
  (export "new" (func $new))
@@ -43,7 +43,7 @@
  ;; As above, but now there is an existing global with the name that we want to
  ;; use. We should not collide.
 
- ;; CHECK:      (type $A (struct ))
+ ;; CHECK:      (type $A (struct))
  (type $A (struct))
 
  ;; CHECK:      (type $1 (func (result (ref any))))

--- a/test/lit/empty-elem.wast
+++ b/test/lit/empty-elem.wast
@@ -6,7 +6,7 @@
 ;; type, resulting in invalid modules.
 
 (module
- ;; CHECK:      (type $struct (sub (struct )))
+ ;; CHECK:      (type $struct (sub (struct)))
  (type $struct (sub (struct)))
 
  ;; CHECK:      (type $array (sub (array (mut (ref null $struct)))))

--- a/test/lit/fuzz-types.test
+++ b/test/lit/fuzz-types.test
@@ -6,7 +6,7 @@
 ;; CHECK-NEXT:  (type $0 (sub (struct (field (mut i16)) (field (mut (ref $2))) (field (mut (ref null $2))))))
 ;; CHECK-NEXT:  (type $1 (sub (func (param (ref $1)) (result f64 (ref $0) f32 (ref null (shared eq))))))
 ;; CHECK-NEXT:  (type $2 (sub (shared (struct (field (mut (ref null (shared extern)))) (field (mut (ref null $2)))))))
-;; CHECK-NEXT:  (type $3 (sub (shared (struct ))))
+;; CHECK-NEXT:  (type $3 (sub (shared (struct))))
 ;; CHECK-NEXT: )
 ;; CHECK-NEXT: (rec
 ;; CHECK-NEXT:  (type $4 (sub (array i32)))
@@ -36,7 +36,7 @@
 ;; CHECK-NEXT:  (type $0 (sub (struct (field (mut i16)) (field (mut (ref $2))) (field (mut (ref null $2))))))
 ;; CHECK-NEXT:  (type $1 (sub (func (param (ref $1)) (result f64 (ref $0) f32 (ref null (shared eq))))))
 ;; CHECK-NEXT:  (type $2 (sub (shared (struct (field (mut (ref null (shared extern)))) (field (mut (ref null $2)))))))
-;; CHECK-NEXT:  (type $3 (sub (shared (struct ))))
+;; CHECK-NEXT:  (type $3 (sub (shared (struct)))
 ;; CHECK-NEXT: )
 ;; CHECK-NEXT: (rec
 ;; CHECK-NEXT:  (type $4 (sub (array i32)))

--- a/test/lit/global-only.wast
+++ b/test/lit/global-only.wast
@@ -6,7 +6,7 @@
 ;; RUN: wasm-opt -all %s -S -o - | filecheck %s
 
 (module $parse
-  ;; CHECK:      (type $t (struct ))
+  ;; CHECK:      (type $t (struct))
   (type $t (struct))
   ;; CHECK:      (global $g (ref null $t) (ref.null none))
   (global $g (ref null $t) (ref.null $t))

--- a/test/lit/isorecursive-good.wast
+++ b/test/lit/isorecursive-good.wast
@@ -34,7 +34,7 @@
     (type $final-func (sub final $sub-func (func (param (ref $super-array)) (result (ref $final-array)))))
   )
 
-  ;; CHECK:      (type $final-root (struct ))
+  ;; CHECK:      (type $final-root (struct))
   (type $final-root (sub final (struct)))
 
   ;; CHECK:      (func $make-super-struct (type $6) (result (ref $super-struct))

--- a/test/lit/isorecursive-output-ordering.wast
+++ b/test/lit/isorecursive-output-ordering.wast
@@ -9,22 +9,22 @@
 
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $unused-6 (sub (struct )))
+  ;; CHECK-NEXT:  (type $unused-6 (sub (struct)))
 
-  ;; CHECK:       (type $used-a-bit (sub (struct )))
+  ;; CHECK:       (type $used-a-bit (sub (struct)))
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $unused-1 (sub (struct )))
+  ;; CHECK-NEXT:  (type $unused-1 (sub (struct)))
   (type $unused-1 (sub (struct)))
-  ;; CHECK:       (type $unused-2 (sub (struct )))
+  ;; CHECK:       (type $unused-2 (sub (struct)))
   (type $unused-2 (sub (struct)))
-  ;; CHECK:       (type $unused-3 (sub (struct )))
+  ;; CHECK:       (type $unused-3 (sub (struct)))
   (type $unused-3 (sub (struct)))
-  ;; CHECK:       (type $unused-4 (sub (struct )))
+  ;; CHECK:       (type $unused-4 (sub (struct)))
   (type $unused-4 (sub (struct)))
-  ;; CHECK:       (type $used-a-lot (sub (struct )))
+  ;; CHECK:       (type $used-a-lot (sub (struct)))
   (type $used-a-lot (sub (struct)))
-  ;; CHECK:       (type $unused-5 (sub (struct )))
+  ;; CHECK:       (type $unused-5 (sub (struct)))
   (type $unused-5 (sub (struct)))
  )
 
@@ -47,20 +47,20 @@
 
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $leaf (sub (struct )))
+  ;; CHECK-NEXT:  (type $leaf (sub (struct)))
   (type $leaf (sub (struct)))
-  ;; CHECK:       (type $unused (sub (struct )))
+  ;; CHECK:       (type $unused (sub (struct)))
   (type $unused (sub (struct)))
  )
 
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $shrub (sub $leaf (struct )))
+  ;; CHECK-NEXT:  (type $shrub (sub $leaf (struct)))
 
-  ;; CHECK:       (type $used-a-ton (sub (struct )))
+  ;; CHECK:       (type $used-a-ton (sub (struct)))
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $twig (sub (struct )))
+  ;; CHECK-NEXT:  (type $twig (sub (struct)))
   (type $twig (sub (struct)))
   ;; CHECK:       (type $used-a-bit (sub (struct (field (ref $leaf)))))
   (type $used-a-bit (sub (struct (ref $leaf))))
@@ -73,9 +73,9 @@
 
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $root (sub (struct )))
+  ;; CHECK-NEXT:  (type $root (sub (struct)))
   (type $root (sub (struct)))
-  ;; CHECK:       (type $used-a-lot (sub $twig (struct )))
+  ;; CHECK:       (type $used-a-lot (sub $twig (struct)))
   (type $used-a-lot (sub $twig (struct)))
  )
 

--- a/test/lit/isorecursive-singleton-group.wast
+++ b/test/lit/isorecursive-singleton-group.wast
@@ -10,7 +10,7 @@
 
 
  (rec
-  ;; CHECK:      (type $singleton (sub (struct )))
+  ;; CHECK:      (type $singleton (sub (struct)))
   (type $singleton (sub (struct)))
  )
 

--- a/test/lit/isorecursive-whole-group.wast
+++ b/test/lit/isorecursive-whole-group.wast
@@ -9,9 +9,9 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $used (sub (struct )))
+  ;; CHECK-NEXT:  (type $used (sub (struct)))
   (type $used (sub (struct)))
-  ;; CHECK:       (type $unused (sub (struct )))
+  ;; CHECK:       (type $unused (sub (struct)))
   (type $unused (sub (struct)))
  )
 

--- a/test/lit/passes/abstract-type-refining.wast
+++ b/test/lit/passes/abstract-type-refining.wast
@@ -14,25 +14,25 @@
   ;; NO_TNH:      (rec
   ;; NO_TNH-NEXT:  (type $0 (func))
 
-  ;; NO_TNH:       (type $A (sub (struct )))
+  ;; NO_TNH:       (type $A (sub (struct)))
   (type $A (sub (struct)))
 
   ;; YESTNH:      (rec
   ;; YESTNH-NEXT:  (type $0 (func))
 
-  ;; YESTNH:       (type $B (sub (struct )))
-  ;; NO_TNH:       (type $B (sub $A (struct )))
+  ;; YESTNH:       (type $B (sub (struct)))
+  ;; NO_TNH:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
-  ;; YESTNH:       (type $C (sub $B (struct )))
-  ;; NO_TNH:       (type $C (sub $B (struct )))
+  ;; YESTNH:       (type $C (sub $B (struct)))
+  ;; NO_TNH:       (type $C (sub $B (struct)))
   (type $C (sub $B (struct)))
 
-  ;; NO_TNH:       (type $D (sub $C (struct )))
+  ;; NO_TNH:       (type $D (sub $C (struct)))
   (type $D (sub $C (struct)))
 
-  ;; YESTNH:       (type $E (sub $C (struct )))
-  ;; NO_TNH:       (type $E (sub $D (struct )))
+  ;; YESTNH:       (type $E (sub $C (struct)))
+  ;; NO_TNH:       (type $E (sub $D (struct)))
   (type $E (sub $D (struct)))
 
   ;; YESTNH:       (type $4 (func (param anyref)))
@@ -264,21 +264,21 @@
 (module
   (rec
     ;; YESTNH:      (rec
-    ;; YESTNH-NEXT:  (type $A (sub (struct )))
+    ;; YESTNH-NEXT:  (type $A (sub (struct)))
     ;; NO_TNH:      (rec
-    ;; NO_TNH-NEXT:  (type $A (sub (struct )))
+    ;; NO_TNH-NEXT:  (type $A (sub (struct)))
     (type $A (sub (struct)))
 
-    ;; YESTNH:       (type $B1 (sub $A (struct )))
+    ;; YESTNH:       (type $B1 (sub $A (struct)))
 
     ;; YESTNH:       (type $2 (func (param anyref)))
 
-    ;; YESTNH:       (type $B (sub $A (struct )))
-    ;; NO_TNH:       (type $B1 (sub $A (struct )))
+    ;; YESTNH:       (type $B (sub $A (struct)))
+    ;; NO_TNH:       (type $B1 (sub $A (struct)))
 
     ;; NO_TNH:       (type $2 (func (param anyref)))
 
-    ;; NO_TNH:       (type $B (sub $A (struct )))
+    ;; NO_TNH:       (type $B (sub $A (struct)))
     (type $B (sub $A (struct)))
 
     (type $B1 (sub $A (struct))) ;; this is a new type
@@ -362,14 +362,14 @@
 (module
   (rec
     ;; NO_TNH:      (rec
-    ;; NO_TNH-NEXT:  (type $A (sub (struct )))
+    ;; NO_TNH-NEXT:  (type $A (sub (struct)))
     (type $A (sub (struct)))
 
     (type $B (sub $A (struct)))
 
     ;; YESTNH:      (rec
-    ;; YESTNH-NEXT:  (type $B1 (sub (struct )))
-    ;; NO_TNH:       (type $B1 (sub $A (struct )))
+    ;; YESTNH-NEXT:  (type $B1 (sub (struct)))
+    ;; NO_TNH:       (type $B1 (sub $A (struct)))
     (type $B1 (sub $A (struct))) ;; this is a new type
   )
 
@@ -449,15 +449,15 @@
 ;; A chain, $A :> $B :> $C, where we can optimize $A all the way to $C.
 (module
   ;; NO_TNH:      (rec
-  ;; NO_TNH-NEXT:  (type $A (sub (struct )))
+  ;; NO_TNH-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; NO_TNH:       (type $B (sub $A (struct )))
+  ;; NO_TNH:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; YESTNH:      (rec
-  ;; YESTNH-NEXT:  (type $C (sub (struct )))
-  ;; NO_TNH:       (type $C (sub $B (struct )))
+  ;; YESTNH-NEXT:  (type $C (sub (struct)))
+  ;; NO_TNH:       (type $C (sub $B (struct)))
   (type $C (sub $B (struct)))
 
   ;; YESTNH:       (type $1 (func (param anyref)))
@@ -824,17 +824,17 @@
     ;; NO_TNH:      (rec
     ;; NO_TNH-NEXT:  (type $0 (func (param anyref)))
 
-    ;; NO_TNH:       (type $A (sub (struct )))
+    ;; NO_TNH:       (type $A (sub (struct)))
     (type $A (sub (struct)))
 
-    ;; NO_TNH:       (type $B (sub $A (struct )))
+    ;; NO_TNH:       (type $B (sub $A (struct)))
     (type $B (sub $A (struct)))
 
     ;; YESTNH:      (rec
     ;; YESTNH-NEXT:  (type $0 (func (param anyref)))
 
-    ;; YESTNH:       (type $C1 (sub (struct )))
-    ;; NO_TNH:       (type $C1 (sub $B (struct )))
+    ;; YESTNH:       (type $C1 (sub (struct)))
+    ;; NO_TNH:       (type $C1 (sub $B (struct)))
     (type $C1 (sub $B (struct)))
 
     (type $C2 (sub $B (struct)))

--- a/test/lit/passes/dae-gc-refine-params.wast
+++ b/test/lit/passes/dae-gc-refine-params.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s -all --dae -S -o - | filecheck %s
 
 (module
- ;; CHECK:      (type $"{}" (sub (struct )))
+ ;; CHECK:      (type $"{}" (sub (struct)))
  (type $"{}" (sub (struct)))
 
  ;; CHECK:      (type $"{i32}" (sub $"{}" (struct (field i32))))

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s -all --dae -S -o - | filecheck %s
 
 (module
- ;; CHECK:      (type $"{}" (sub (struct )))
+ ;; CHECK:      (type $"{}" (sub (struct)))
  (type $"{}" (sub (struct)))
 
  ;; CHECK:      (type $"return_{}" (func (result (ref $"{}"))))

--- a/test/lit/passes/dae-gc.wast
+++ b/test/lit/passes/dae-gc.wast
@@ -2,7 +2,7 @@
 ;; RUN: foreach %s %t wasm-opt -all --dae -S -o - | filecheck %s
 
 (module
- ;; CHECK:      (type $"{}" (struct ))
+ ;; CHECK:      (type $"{}" (struct))
  (type $"{}" (struct))
 
  ;; CHECK:      (func $foo (type $0)

--- a/test/lit/passes/global-refining.wast
+++ b/test/lit/passes/global-refining.wast
@@ -110,10 +110,10 @@
 
   ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   ;; CLOSD:      (type $0 (func))
 
-  ;; CLOSD:      (type $struct (struct ))
+  ;; CLOSD:      (type $struct (struct))
   (type $struct (struct))
   (type $array (array i8))
 

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -6,7 +6,7 @@
   ;; removed.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (sub (struct )))
+  ;; CHECK-NEXT:  (type $struct (sub (struct)))
   (type $struct (sub (struct (field (mut funcref)))))
 
   ;; CHECK:       (type $1 (func (param (ref $struct))))
@@ -22,7 +22,7 @@
   ;; A write does not keep a field from being removed.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (sub (struct )))
+  ;; CHECK-NEXT:  (type $struct (sub (struct)))
   (type $struct (sub (struct (field (mut funcref)))))
 
   ;; CHECK:       (type $1 (func (param (ref $struct))))
@@ -53,7 +53,7 @@
   ;; A new does not keep a field from being removed.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (sub (struct )))
+  ;; CHECK-NEXT:  (type $struct (sub (struct)))
   (type $struct (sub (struct (field (mut funcref)))))
 
   ;; CHECK:       (type $1 (func (param (ref $struct))))
@@ -77,7 +77,7 @@
   ;; A new_default does not keep a field from being removed.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (sub (struct )))
+  ;; CHECK-NEXT:  (type $struct (sub (struct)))
   (type $struct (sub (struct (field (mut funcref)))))
 
   ;; CHECK:       (type $1 (func (param (ref $struct))))
@@ -770,10 +770,10 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $parent (sub (struct )))
+    ;; CHECK-NEXT:  (type $parent (sub (struct)))
     (type $parent (sub (struct (field i32))))
 
-    ;; CHECK:       (type $child2 (sub $parent (struct )))
+    ;; CHECK:       (type $child2 (sub $parent (struct)))
 
     ;; CHECK:       (type $child1 (sub $parent (struct (field i32))))
     (type $child1 (sub $parent (struct (field i32))))
@@ -802,7 +802,7 @@
 
   ;; CHECK:       (type $2 (func))
 
-  ;; CHECK:       (type $"{mut:i8}" (sub (struct )))
+  ;; CHECK:       (type $"{mut:i8}" (sub (struct)))
   (type $"{mut:i8}" (sub (struct (field (mut i8)))))
 
   ;; CHECK:       (type $4 (func (param (ref null $"{mut:i8}"))))
@@ -928,7 +928,7 @@
 
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (sub (struct )))
+  ;; CHECK-NEXT:  (type $struct (sub (struct)))
   (type $struct (sub (struct (field anyref) (field i32) (field f32) (field f64))))
 
   ;; CHECK:       (type $1 (func (result (ref $struct))))

--- a/test/lit/passes/gufa-cast-all.wast
+++ b/test/lit/passes/gufa-cast-all.wast
@@ -6,10 +6,10 @@
   ;; CHECK:      (type $none_=>_none (func))
   (type $none_=>_none (func))
 
-  ;; CHECK:      (type $A (sub (struct )))
+  ;; CHECK:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:      (type $B (sub $A (struct )))
+  ;; CHECK:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:      (type $3 (func (result i32)))

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -2,7 +2,7 @@
 ;; RUN: foreach %s %t wasm-opt -all --gufa -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
 
@@ -361,7 +361,7 @@
 )
 
 (module
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (type $1 (func))
@@ -459,7 +459,7 @@
 (module
   ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (global $A-null anyref (ref.null none))
@@ -569,7 +569,7 @@
 (module
   ;; CHECK:      (type $0 (func (param (ref any)) (result (ref any))))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (type $2 (func (param i32) (result i32)))
@@ -679,7 +679,7 @@
 
 ;; As above, but using indirect calls.
 (module
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (type $two-params (func (param (ref $struct) (ref $struct))))
@@ -811,7 +811,7 @@
 
 ;; As above, but using call_ref.
 (module
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (type $two-params (func (param (ref $struct) (ref $struct))))
@@ -923,7 +923,7 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $struct (sub (struct )))
+    ;; CHECK-NEXT:  (type $struct (sub (struct)))
     (type $struct (sub (struct)))
 
     ;; CHECK:       (type $parent (sub (struct (field (mut (ref null $struct))))))
@@ -931,7 +931,7 @@
     ;; CHECK:       (type $child (sub $parent (struct (field (mut (ref null $struct))) (field (mut (ref null $struct))))))
     (type $child (sub $parent (struct (field (mut (ref null $struct))) (field (mut (ref null $struct))))))
 
-    ;; CHECK:       (type $unrelated (struct ))
+    ;; CHECK:       (type $unrelated (struct))
     (type $unrelated (struct))
   )
 
@@ -1201,7 +1201,7 @@
 
 ;; Exact types: Writes to the parent class do not confuse us.
 (module
-  ;; CHECK:      (type $struct (sub (struct )))
+  ;; CHECK:      (type $struct (sub (struct)))
   (type $struct (sub (struct)))
   ;; CHECK:      (type $parent (sub (struct (field (mut (ref null $struct))))))
   (type $parent (sub (struct (field (mut (ref null $struct))))))
@@ -1557,7 +1557,7 @@
 
   ;; CHECK:      (type $4 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (func $func (type $4)
@@ -1687,7 +1687,7 @@
 
   ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   (type $storage (struct (field (mut (ref null any)))))
@@ -1831,7 +1831,7 @@
 
   ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   (type $storage (struct (field (mut (ref null any)))))
@@ -1898,7 +1898,7 @@
 
   ;; CHECK:      (type $1 (func (param anyref)))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (tag $nothing (param anyref))
@@ -2132,7 +2132,7 @@
 
   ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (tag $tag (param anyref anyref))
@@ -2207,7 +2207,7 @@
 )
 
 (module
-  ;; CHECK:      (type $"{}" (sub (struct )))
+  ;; CHECK:      (type $"{}" (sub (struct)))
   (type $"{}" (sub (struct)))
 
   ;; CHECK:      (type $1 (func (result (ref $"{}"))))
@@ -2461,7 +2461,7 @@
 
   ;; CHECK:      (type $4 (func (param i32)))
 
-  ;; CHECK:      (type $other (sub (struct )))
+  ;; CHECK:      (type $other (sub (struct)))
   (type $other (sub (struct)))
 
   ;; CHECK:      (type $6 (func (result i32)))
@@ -5922,10 +5922,10 @@
 )
 
 (module
-  ;; CHECK:      (type $A (sub (struct )))
+  ;; CHECK:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:      (type $B (sub $A (struct )))
+  ;; CHECK:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:      (type $2 (func (result (ref $A))))
@@ -6008,7 +6008,7 @@
 )
 
 (module
-  ;; CHECK:      (type $A (struct ))
+  ;; CHECK:      (type $A (struct))
   (type $A (struct))
 
   ;; CHECK:      (type $1 (func))

--- a/test/lit/passes/gufa-tnh-closed.wast
+++ b/test/lit/passes/gufa-tnh-closed.wast
@@ -296,13 +296,13 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $X (sub (struct )))
+    ;; CHECK-NEXT:  (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y1 (sub $X (struct )))
+    ;; CHECK:       (type $Y1 (sub $X (struct)))
     (type $Y1 (sub $X (struct)))
 
-    ;; CHECK:       (type $Y2 (sub $X (struct )))
+    ;; CHECK:       (type $Y2 (sub $X (struct)))
     (type $Y2 (sub $X (struct)))
 
     ;; CHECK:       (type $A (func (param anyref)))
@@ -421,13 +421,13 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $X (sub (struct )))
+    ;; CHECK-NEXT:  (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y1 (sub $X (struct )))
+    ;; CHECK:       (type $Y1 (sub $X (struct)))
     (type $Y1 (sub $X (struct)))
 
-    ;; CHECK:       (type $Y2 (sub $X (struct )))
+    ;; CHECK:       (type $Y2 (sub $X (struct)))
     (type $Y2 (sub $X (struct)))
 
     ;; CHECK:       (type $A (func (param anyref anyref)))
@@ -659,13 +659,13 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $X (sub (struct )))
+    ;; CHECK-NEXT:  (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y1 (sub $X (struct )))
+    ;; CHECK:       (type $Y1 (sub $X (struct)))
     (type $Y1 (sub $X (struct)))
 
-    ;; CHECK:       (type $Y2 (sub $X (struct )))
+    ;; CHECK:       (type $Y2 (sub $X (struct)))
     (type $Y2 (sub $X (struct)))
 
     ;; CHECK:       (type $A (func (param anyref anyref anyref anyref anyref anyref)))
@@ -885,13 +885,13 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $X (sub (struct )))
+    ;; CHECK-NEXT:  (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y1 (sub $X (struct )))
+    ;; CHECK:       (type $Y1 (sub $X (struct)))
     (type $Y1 (sub $X (struct)))
 
-    ;; CHECK:       (type $Y2 (sub $X (struct )))
+    ;; CHECK:       (type $Y2 (sub $X (struct)))
     (type $Y2 (sub $X (struct)))
 
     ;; CHECK:       (type $A (func (param (ref null $X) (ref null $X) (ref null $X))))
@@ -1041,13 +1041,13 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $X (sub (struct )))
+    ;; CHECK-NEXT:  (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y1 (sub $X (struct )))
+    ;; CHECK:       (type $Y1 (sub $X (struct)))
     (type $Y1 (sub $X (struct)))
 
-    ;; CHECK:       (type $Y2 (sub $X (struct )))
+    ;; CHECK:       (type $Y2 (sub $X (struct)))
     (type $Y2 (sub $X (struct)))
 
     ;; CHECK:       (type $A (func (param anyref)))

--- a/test/lit/passes/gufa-tnh.wast
+++ b/test/lit/passes/gufa-tnh.wast
@@ -1980,10 +1980,10 @@
 (module
   ;; CHECK:      (type $0 (func))
 
-  ;; CHECK:      (type $A (sub (struct )))
+  ;; CHECK:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:      (type $B (sub $A (struct )))
+  ;; CHECK:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:      (type $3 (func (param (ref null $A))))

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -2348,7 +2348,7 @@
 )
 
 (module
-  ;; CHECK:      (type $A (struct ))
+  ;; CHECK:      (type $A (struct))
   (type $A (struct))
   (type $B (struct (ref $A)))
 

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -2994,7 +2994,7 @@
 
   ;; CHECK:      (type $7 (struct (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32))))
 
-  ;; CHECK:      (type $8 (struct ))
+  ;; CHECK:      (type $8 (struct))
 
   ;; CHECK:      (type $9 (struct (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32)) (field (mut i32))))
 

--- a/test/lit/passes/inlining_splitting.wast
+++ b/test/lit/passes/inlining_splitting.wast
@@ -11,7 +11,7 @@
 
   ;; CHECK:      (type $3 (func (param anyref)))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (type $5 (func (param i64 i32 f64)))

--- a/test/lit/passes/inlining_vacuum_optimize-instructions.wast
+++ b/test/lit/passes/inlining_vacuum_optimize-instructions.wast
@@ -11,7 +11,7 @@
 ;; which is temporarily inconsistent. We must be careful to avoid confusion
 ;; there.
 (module
- ;; CHECK:      (type $B (sub (struct )))
+ ;; CHECK:      (type $B (sub (struct)))
  (type $B (sub (struct )))
  ;; CHECK:      (type $A (sub (struct (field (ref null $B)))))
  (type $A (sub (struct (field (ref null $B)))))

--- a/test/lit/passes/j2cl.wast
+++ b/test/lit/passes/j2cl.wast
@@ -71,7 +71,7 @@
 
 ;; Fields initialized to a non-default value shouldn't be hoisted.
 (module
-  ;; CHECK:      (type $A (struct ))
+  ;; CHECK:      (type $A (struct))
   (type $A (struct))
   ;; CHECK:      (type $1 (func))
 

--- a/test/lit/passes/monomorphize-types.wast
+++ b/test/lit/passes/monomorphize-types.wast
@@ -7,11 +7,11 @@
 ;; RUN: foreach %s %t wasm-opt --monomorphize        -all -S -o - | filecheck %s --check-prefix CAREFUL
 
 (module
-  ;; ALWAYS:      (type $A (sub (struct )))
-  ;; CAREFUL:      (type $A (sub (struct )))
+  ;; ALWAYS:      (type $A (sub (struct)))
+  ;; CAREFUL:      (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; ALWAYS:      (type $B (sub $A (struct )))
-  ;; CAREFUL:      (type $B (sub $A (struct )))
+  ;; ALWAYS:      (type $B (sub $A (struct)))
+  ;; CAREFUL:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; ALWAYS:      (type $2 (func (param (ref $A))))
@@ -128,13 +128,13 @@
   ;; As above, but now the refinable function uses the local in a way that
   ;; requires a fixup.
 
-  ;; ALWAYS:      (type $A (sub (struct )))
+  ;; ALWAYS:      (type $A (sub (struct)))
   ;; CAREFUL:      (type $0 (func))
 
-  ;; CAREFUL:      (type $A (sub (struct )))
+  ;; CAREFUL:      (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; ALWAYS:      (type $B (sub $A (struct )))
-  ;; CAREFUL:      (type $B (sub $A (struct )))
+  ;; ALWAYS:      (type $B (sub $A (struct)))
+  ;; CAREFUL:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
 
@@ -208,21 +208,21 @@
 (module
   ;; Multiple refinings of the same function, and of different functions.
 
-  ;; ALWAYS:      (type $A (sub (struct )))
+  ;; ALWAYS:      (type $A (sub (struct)))
   ;; CAREFUL:      (type $0 (func))
 
-  ;; CAREFUL:      (type $A (sub (struct )))
+  ;; CAREFUL:      (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; ALWAYS:      (type $B (sub $A (struct )))
-  ;; CAREFUL:      (type $B (sub $A (struct )))
+  ;; ALWAYS:      (type $B (sub $A (struct)))
+  ;; CAREFUL:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; ALWAYS:      (type $2 (func))
 
-  ;; ALWAYS:      (type $C (sub $B (struct )))
+  ;; ALWAYS:      (type $C (sub $B (struct)))
   ;; CAREFUL:      (type $3 (func (param (ref $A))))
 
-  ;; CAREFUL:      (type $C (sub $B (struct )))
+  ;; CAREFUL:      (type $C (sub $B (struct)))
   (type $C (sub $B (struct)))
 
   ;; ALWAYS:      (type $4 (func (param (ref $A))))
@@ -343,12 +343,12 @@
   ;; A case where even CAREFUL mode will monomorphize, as it helps the target
   ;; function get optimized better.
 
-  ;; ALWAYS:      (type $A (sub (struct )))
-  ;; CAREFUL:      (type $A (sub (struct )))
+  ;; ALWAYS:      (type $A (sub (struct)))
+  ;; CAREFUL:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; ALWAYS:      (type $B (sub $A (struct )))
-  ;; CAREFUL:      (type $B (sub $A (struct )))
+  ;; ALWAYS:      (type $B (sub $A (struct)))
+  ;; CAREFUL:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; ALWAYS:      (type $2 (func (param (ref $B))))
@@ -578,15 +578,15 @@
 (module
   ;; Test that we avoid recursive calls.
 
-  ;; ALWAYS:      (type $A (sub (struct )))
-  ;; CAREFUL:      (type $A (sub (struct )))
+  ;; ALWAYS:      (type $A (sub (struct)))
+  ;; CAREFUL:      (type $A (sub (struct)))
   (type $A (sub (struct)))
   ;; ALWAYS:      (type $1 (func (param (ref $A))))
 
-  ;; ALWAYS:      (type $B (sub $A (struct )))
+  ;; ALWAYS:      (type $B (sub $A (struct)))
   ;; CAREFUL:      (type $1 (func (param (ref $A))))
 
-  ;; CAREFUL:      (type $B (sub $A (struct )))
+  ;; CAREFUL:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
 

--- a/test/lit/passes/name-types.wast
+++ b/test/lit/passes/name-types.wast
@@ -6,7 +6,7 @@
  (type $obnoxious-super-long-type-name_____________________________1 (struct))
 
  ;; A reasonable name that will be kept.
- ;; CHECK:      (type $type_1 (struct ))
+ ;; CHECK:      (type $type_1 (struct))
 
  ;; CHECK:      (type $reasonable-name (struct (field i32)))
  (type $reasonable-name (struct (field i32)))

--- a/test/lit/passes/no-inline-monomorphize-inlining.wast
+++ b/test/lit/passes/no-inline-monomorphize-inlining.wast
@@ -11,12 +11,12 @@
 ;; RUN: foreach %s %t wasm-opt                        --monomorphize-always --inlining --optimize-level=3 -all -S -o - | filecheck %s --check-prefix YESINLINE
 
 (module
-  ;; NO_INLINE:      (type $A (sub (struct )))
-  ;; YESINLINE:      (type $A (sub (struct )))
+  ;; NO_INLINE:      (type $A (sub (struct)))
+  ;; YESINLINE:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; NO_INLINE:      (type $B (sub $A (struct )))
-  ;; YESINLINE:      (type $B (sub $A (struct )))
+  ;; NO_INLINE:      (type $B (sub $A (struct)))
+  ;; YESINLINE:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; NO_INLINE:      (type $2 (func))

--- a/test/lit/passes/optimize-casts-noeh.wast
+++ b/test/lit/passes/optimize-casts-noeh.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s --optimize-casts --enable-reference-types --enable-gc --enable-tail-call -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $A (struct ))
+  ;; CHECK:      (type $A (struct))
   (type $A (struct))
 
   ;; CHECK:      (func $yes-past-call (type $1) (param $x (ref struct))

--- a/test/lit/passes/optimize-casts-tnh.wast
+++ b/test/lit/passes/optimize-casts-tnh.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s --optimize-casts -all -tnh -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $A (sub (struct )))
+  ;; CHECK:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
   ;; CHECK:      (global $a (mut i32) (i32.const 0))

--- a/test/lit/passes/optimize-casts.wast
+++ b/test/lit/passes/optimize-casts.wast
@@ -2,10 +2,10 @@
 ;; RUN: wasm-opt %s --optimize-casts -all -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $A (sub (struct )))
+  ;; CHECK:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:      (type $B (sub $A (struct )))
+  ;; CHECK:      (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:      (type $void (func))

--- a/test/lit/passes/optimize-instructions-gc-iit.wast
+++ b/test/lit/passes/optimize-instructions-gc-iit.wast
@@ -200,9 +200,9 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $A (sub (struct )))
+    ;; CHECK-NEXT:  (type $A (sub (struct)))
     ;; TNH:      (rec
-    ;; TNH-NEXT:  (type $A (sub (struct )))
+    ;; TNH-NEXT:  (type $A (sub (struct)))
     (type $A (sub (struct )))
     ;; CHECK:       (type $B (sub $A (struct (field (ref null $A)))))
     ;; TNH:       (type $B (sub $A (struct (field (ref null $A)))))
@@ -210,8 +210,8 @@
     ;; CHECK:       (type $C (sub $B (struct (field (ref null $D)))))
     ;; TNH:       (type $C (sub $B (struct (field (ref null $D)))))
     (type $C (sub $B (struct (field (ref null $D)))))
-    ;; CHECK:       (type $D (sub $A (struct )))
-    ;; TNH:       (type $D (sub $A (struct )))
+    ;; CHECK:       (type $D (sub $A (struct)))
+    ;; TNH:       (type $D (sub $A (struct)))
     (type $D (sub $A (struct )))
   )
 

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -4,7 +4,7 @@
 ;; RUN:   | filecheck %s
 
 (module
- ;; CHECK:      (type $empty (struct ))
+ ;; CHECK:      (type $empty (struct))
  (type $empty (struct))
 
  ;; CHECK:      (type $struct (struct (field (mut i32))))

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -5,11 +5,11 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (sub (struct )))
+  ;; CHECK-NEXT:  (type $struct (sub (struct)))
   (type $struct (sub (struct)))
-  ;; CHECK:       (type $struct2 (struct ))
+  ;; CHECK:       (type $struct2 (struct))
   (type $struct2 (struct))
-  ;; CHECK:       (type $substruct (sub $struct (struct )))
+  ;; CHECK:       (type $substruct (sub $struct (struct)))
   (type $substruct (sub $struct (struct)))
  )
 

--- a/test/lit/passes/remove-unused-types.wast
+++ b/test/lit/passes/remove-unused-types.wast
@@ -7,13 +7,13 @@
   ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $mutually-used-2 (struct (field (ref null $mutually-used-1))))
 
-  ;; CHECK:       (type $indirectly-used (struct ))
+  ;; CHECK:       (type $indirectly-used (struct))
 
   ;; CHECK:       (type $mutually-used-1 (struct (field (ref null $mutually-used-2))))
 
   ;; CHECK:       (type $directly-used (struct (field (ref null $indirectly-used))))
 
-  ;; CHECK:       (type $used (struct ))
+  ;; CHECK:       (type $used (struct))
   (type $used (struct))
   (type $unused (struct))
  )

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -8,7 +8,7 @@
   ;; on the function (which are derived from the heap type).
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:       (type $1 (func))
@@ -38,7 +38,7 @@
   ;; As above, but the call is via call_ref.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:       (type $1 (func))
@@ -74,7 +74,7 @@
   ;; is a nullable eqref.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:       (type $1 (func))
@@ -121,11 +121,11 @@
 
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $struct (sub (struct )))
+    ;; CHECK-NEXT:  (type $struct (sub (struct)))
 
-    ;; CHECK:       (type $struct-sub2 (sub $struct (struct )))
+    ;; CHECK:       (type $struct-sub2 (sub $struct (struct)))
 
-    ;; CHECK:       (type $struct-sub1 (sub $struct (struct )))
+    ;; CHECK:       (type $struct-sub1 (sub $struct (struct)))
 
     ;; CHECK:       (type $3 (func))
 
@@ -174,7 +174,7 @@
   ;; updated, though, as they share a heap type.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
 
   ;; CHECK:       (type $1 (func))
 
@@ -277,7 +277,7 @@
   ;; param to be $struct.
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:       (type $1 (func))
@@ -366,7 +366,7 @@
   ;; Test multiple fields in multiple types.
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $struct (struct ))
+    ;; CHECK-NEXT:  (type $struct (struct))
     (type $struct (struct))
 
     ;; CHECK:       (type $1 (func))
@@ -447,7 +447,7 @@
 
   ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   (table 1 1 anyref)
@@ -477,7 +477,7 @@
   ;; allows us to refine (but the new type must be nullable).
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
 
   ;; CHECK:       (type $1 (func))
 
@@ -519,7 +519,7 @@
 
     ;; CHECK:       (type $sig-cannot-refine (sub (func (result (ref func)))))
 
-    ;; CHECK:       (type $struct (struct ))
+    ;; CHECK:       (type $struct (struct))
     (type $struct (struct))
 
     ;; This signature has a single function using it, which returns a more
@@ -625,7 +625,7 @@
 
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $struct (struct ))
+  ;; CHECK-NEXT:  (type $struct (struct))
   (type $struct (struct))
 
   ;; This signature has multiple functions using it, and some of them have nulls
@@ -684,7 +684,7 @@
 
   ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   (type $sig (sub (func (param anyref))))
@@ -728,7 +728,7 @@
 )
 
 (module
-  ;; CHECK:      (type $"{}" (struct ))
+  ;; CHECK:      (type $"{}" (struct))
   (type $"{}" (struct))
 
   ;; CHECK:      (type $1 (func (param (ref $"{}") i32)))
@@ -780,7 +780,7 @@
 
   ;; CHECK:      (type $1 (func))
 
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (import "a" "b" (func $import (type $0) (param structref)))
@@ -913,13 +913,13 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:       (type $B (sub $A (struct )))
+  ;; CHECK:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
-  ;; CHECK:       (type $C (sub $B (struct )))
+  ;; CHECK:       (type $C (sub $B (struct)))
   (type $C (sub $B (struct)))
 
   ;; CHECK:       (type $return_A_2 (func (result (ref $C))))
@@ -1013,13 +1013,13 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:       (type $B1 (sub $A (struct )))
+  ;; CHECK:       (type $B1 (sub $A (struct)))
   (type $B1 (sub $A (struct)))
 
-  ;; CHECK:       (type $B2 (sub $A (struct )))
+  ;; CHECK:       (type $B2 (sub $A (struct)))
   (type $B2 (sub $A (struct)))
  )
 
@@ -1070,10 +1070,10 @@
   ;; CHECK:      (rec
   ;; CHECK-NEXT:  (type $0 (func (param (ref $B))))
 
-  ;; CHECK:       (type $A (sub (struct )))
+  ;; CHECK:       (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:       (type $B (sub $A (struct )))
+  ;; CHECK:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
  )
 

--- a/test/lit/passes/simplify-globals-gc.wast
+++ b/test/lit/passes/simplify-globals-gc.wast
@@ -32,7 +32,7 @@
 )
 
 (module
- ;; CHECK:      (type $struct (struct ))
+ ;; CHECK:      (type $struct (struct))
  (type $struct (struct ))
 
  ;; CHECK:      (type $1 (func (result anyref)))

--- a/test/lit/passes/ssa.wast
+++ b/test/lit/passes/ssa.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s -all --ssa -S -o - | filecheck %s
 
 (module
- ;; CHECK:      (type $A (struct ))
+ ;; CHECK:      (type $A (struct))
  (type $A (struct ))
 
  ;; CHECK:      (func $foo (type $1)

--- a/test/lit/passes/type-finalizing.wast
+++ b/test/lit/passes/type-finalizing.wast
@@ -58,17 +58,17 @@
 (module
   (rec
     ;; UNFINAL:      (rec
-    ;; UNFINAL-NEXT:  (type $parent (sub (struct )))
+    ;; UNFINAL-NEXT:  (type $parent (sub (struct)))
     ;; DOFINAL:      (rec
-    ;; DOFINAL-NEXT:  (type $parent (sub (struct )))
+    ;; DOFINAL-NEXT:  (type $parent (sub (struct)))
     (type $parent (sub (struct)))
 
-    ;; UNFINAL:       (type $child-open (sub $parent (struct )))
-    ;; DOFINAL:       (type $child-open (sub final $parent (struct )))
+    ;; UNFINAL:       (type $child-open (sub $parent (struct)))
+    ;; DOFINAL:       (type $child-open (sub final $parent (struct)))
     (type $child-open (sub $parent (struct)))
 
-    ;; UNFINAL:       (type $child-final (sub $parent (struct )))
-    ;; DOFINAL:       (type $child-final (sub final $parent (struct )))
+    ;; UNFINAL:       (type $child-final (sub $parent (struct)))
+    ;; DOFINAL:       (type $child-final (sub final $parent (struct)))
     (type $child-final (sub final $parent (struct)))
   )
 

--- a/test/lit/passes/type-merging-shared.wast
+++ b/test/lit/passes/type-merging-shared.wast
@@ -10,9 +10,9 @@
 
  ;; CHECK:       (type $B (array i8))
 
- ;; CHECK:       (type $A' (shared (struct )))
+ ;; CHECK:       (type $A' (shared (struct)))
 
- ;; CHECK:       (type $A (struct ))
+ ;; CHECK:       (type $A (struct))
  (type $A (struct))
  (type $A' (shared (struct)))
  (type $B (array i8))
@@ -47,7 +47,7 @@
 
  ;; CHECK:       (type $B (shared (array i8)))
 
- ;; CHECK:       (type $A (shared (struct )))
+ ;; CHECK:       (type $A (shared (struct)))
  (type $A (shared (struct)))
  (type $A' (shared (struct)))
  (type $B (shared (array i8)))

--- a/test/lit/passes/type-merging-tnh.wast
+++ b/test/lit/passes/type-merging-tnh.wast
@@ -4,7 +4,7 @@
 ;; ref.cast does not inhibit merging if traps never happen.
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
   (type $B (sub $A (struct)))
 
@@ -25,9 +25,9 @@
 ;; Check that a ref.test still inhibits merging with -tnh.
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; CHECK:       (type $B (sub $A (struct )))
+  ;; CHECK:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:       (type $2 (func (param (ref $A)) (result i32)))
@@ -47,9 +47,9 @@
 ;; Check that a br_on_cast still inhibits merging with -tnh.
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; CHECK:       (type $B (sub $A (struct )))
+  ;; CHECK:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:       (type $2 (func (param (ref $A)) (result (ref $B))))

--- a/test/lit/passes/type-merging.wast
+++ b/test/lit/passes/type-merging.wast
@@ -157,7 +157,7 @@
 
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $X (sub (struct )))
+  ;; CHECK-NEXT:  (type $X (sub (struct)))
   (type $X (sub (struct)))
   (type $Y (sub $X (struct)))
   ;; CHECK:       (type $A (sub (struct (field (ref null $X)))))
@@ -580,7 +580,7 @@
 
     ;; CHECK:       (type $D' (sub $C (struct (field (ref $A)) (field i32) (field i32))))
 
-    ;; CHECK:       (type $A (sub (struct )))
+    ;; CHECK:       (type $A (sub (struct)))
     (type $A (sub (struct)))
     (type $A' (sub $A (struct)))
 
@@ -625,7 +625,7 @@
 ;; Check that we refinalize properly.
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
   (type $B (sub $A (struct)))
 
@@ -844,12 +844,12 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
   (type $B (sub $A (struct)))
   ;; CHECK:       (type $X (struct (field (ref $A))))
   (type $X (struct (ref $B)))
-  ;; CHECK:       (type $A' (struct ))
+  ;; CHECK:       (type $A' (struct))
   (type $A' (struct))
  )
  ;; CHECK:       (type $3 (func))
@@ -1022,9 +1022,9 @@
 ;; Check that a ref.test inhibits merging (ref.cast is already checked above).
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; CHECK:       (type $B (sub $A (struct )))
+  ;; CHECK:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:       (type $2 (func (param (ref $A)) (result i32)))
@@ -1044,9 +1044,9 @@
 ;; Check that a br_on_cast inhibits merging.
 (module
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $A (sub (struct )))
+  ;; CHECK-NEXT:  (type $A (sub (struct)))
   (type $A (sub (struct)))
-  ;; CHECK:       (type $B (sub $A (struct )))
+  ;; CHECK:       (type $B (sub $A (struct)))
   (type $B (sub $A (struct)))
 
   ;; CHECK:       (type $2 (func (param (ref $A)) (result (ref $B))))

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -459,10 +459,10 @@
 
     ;; CHECK:       (type $B (sub $A (struct (field (ref $Y)))))
 
-    ;; CHECK:       (type $X (sub (struct )))
+    ;; CHECK:       (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y (sub $X (struct )))
+    ;; CHECK:       (type $Y (sub $X (struct)))
     (type $Y (sub $X (struct)))
 
     (type $A (sub (struct (field (ref $X)))))
@@ -509,10 +509,10 @@
 
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $X (sub (struct )))
+    ;; CHECK-NEXT:  (type $X (sub (struct)))
     (type $X (sub (struct)))
 
-    ;; CHECK:       (type $Y (sub $X (struct )))
+    ;; CHECK:       (type $Y (sub $X (struct)))
     (type $Y (sub $X (struct)))
 
     ;; CHECK:       (type $A (sub (struct (field (ref $X)))))
@@ -542,14 +542,14 @@
 )
 
 (module
-  ;; CHECK:      (type $X (sub (struct )))
+  ;; CHECK:      (type $X (sub (struct)))
   (type $X (sub (struct)))
 
   ;; CHECK:      (type $1 (func))
 
   ;; CHECK:      (type $A (sub (struct (field (ref $X)))))
 
-  ;; CHECK:      (type $Y (sub $X (struct )))
+  ;; CHECK:      (type $Y (sub $X (struct)))
   (type $Y (sub $X (struct)))
 
   (type $A (sub (struct (field (ref $X)))))
@@ -819,7 +819,7 @@
   ;;                        -> Leaf2-Outer[Leaf2-Inner]
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $Root-Inner (sub (struct )))
+  ;; CHECK-NEXT:  (type $Root-Inner (sub (struct)))
   (type $Root-Inner (sub (struct)))
 
   ;; CHECK:       (type $Leaf1-Inner (sub $Root-Inner (struct (field i32))))
@@ -831,7 +831,7 @@
 
   ;; CHECK:       (type $Leaf2-Outer (sub $Root-Outer (struct (field (ref $Leaf2-Inner)))))
 
-  ;; CHECK:       (type $Leaf2-Inner (sub $Root-Inner (struct )))
+  ;; CHECK:       (type $Leaf2-Inner (sub $Root-Inner (struct)))
   (type $Leaf2-Inner (sub $Root-Inner (struct )))
 
   (type $Root-Outer (sub (struct (field (ref $Root-Inner)))))
@@ -1147,7 +1147,7 @@
     ;; CHECK:      (rec
     ;; CHECK-NEXT:  (type $A (struct (field (ref $B))))
     (type $A (struct (field (ref struct))))
-    ;; CHECK:       (type $B (struct ))
+    ;; CHECK:       (type $B (struct))
     (type $B (struct))
   )
 

--- a/test/lit/passes/type-ssa.wast
+++ b/test/lit/passes/type-ssa.wast
@@ -366,10 +366,10 @@
 ;; turn into a simple Literal). (We do optimize $empty and generate $empty$1,
 ;; but that is not important here.)
 (module
-  ;; CHECK:      (type $empty (sub (struct )))
+  ;; CHECK:      (type $empty (sub (struct)))
   (type $empty (sub (struct)))
 
-  ;; CHECK:      (type $empty_1 (sub $empty (struct )))
+  ;; CHECK:      (type $empty_1 (sub $empty (struct)))
 
   ;; CHECK:      (type $2 (func (param anyref)))
 
@@ -452,10 +452,10 @@
 )
 
 (module
-  ;; CHECK:      (type $A (sub (struct )))
+  ;; CHECK:      (type $A (sub (struct)))
   (type $A (sub (struct)))
 
-  ;; CHECK:      (type $A_1 (sub $A (struct )))
+  ;; CHECK:      (type $A_1 (sub $A (struct)))
 
   ;; CHECK:      (type $2 (func (result (ref $A))))
 

--- a/test/lit/passes/type-ssa_and_merging.wast
+++ b/test/lit/passes/type-ssa_and_merging.wast
@@ -16,15 +16,15 @@
   ;; YES:      (rec
   ;; YES-NEXT:  (type $1 (func (param (ref $A))))
 
-  ;; YES:       (type $A (sub (struct )))
+  ;; YES:       (type $A (sub (struct)))
   (type $A (sub (struct (field (mut i32)))))
 
   ;; NOP:      (type $2 (func (result i32)))
 
   ;; NOP:      (import "a" "b" (func $import (type $2) (result i32)))
-  ;; YES:       (type $A_2 (sub $A (struct )))
+  ;; YES:       (type $A_2 (sub $A (struct)))
 
-  ;; YES:       (type $A_1 (sub $A (struct )))
+  ;; YES:       (type $A_1 (sub $A (struct)))
 
   ;; YES:      (import "a" "b" (func $import (type $0) (result i32)))
   (import "a" "b" (func $import (result i32)))

--- a/test/lit/passes/unsubtyping-casts.wast
+++ b/test/lit/passes/unsubtyping-casts.wast
@@ -3,7 +3,7 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $top (sub (struct )))
+ ;; CHECK-NEXT:  (type $top (sub (struct)))
  (type $top (sub (struct)))
  (type $mid (sub $top (struct)))
  (type $bot (sub $mid (struct)))
@@ -31,11 +31,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $top (sub (struct )))
+ ;; CHECK-NEXT:  (type $top (sub (struct)))
  (type $top (sub (struct)))
- ;; CHECK:       (type $mid (sub $top (struct )))
+ ;; CHECK:       (type $mid (sub $top (struct)))
  (type $mid (sub $top (struct)))
- ;; CHECK:       (type $bot (sub $mid (struct )))
+ ;; CHECK:       (type $bot (sub $mid (struct)))
  (type $bot (sub $mid (struct)))
 
  ;; CHECK:       (type $3 (func))
@@ -69,11 +69,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $top (sub (struct )))
+ ;; CHECK-NEXT:  (type $top (sub (struct)))
  (type $top (sub (struct)))
- ;; CHECK:       (type $mid (sub $top (struct )))
+ ;; CHECK:       (type $mid (sub $top (struct)))
  (type $mid (sub $top (struct)))
- ;; CHECK:       (type $bot (sub $mid (struct )))
+ ;; CHECK:       (type $bot (sub $mid (struct)))
  (type $bot (sub $mid (struct)))
 
  ;; CHECK:       (type $3 (func))
@@ -106,11 +106,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $top (sub (struct )))
+ ;; CHECK-NEXT:  (type $top (sub (struct)))
  (type $top (sub (struct)))
- ;; CHECK:       (type $mid (sub $top (struct )))
+ ;; CHECK:       (type $mid (sub $top (struct)))
  (type $mid (sub $top (struct)))
- ;; CHECK:       (type $bot (sub $mid (struct )))
+ ;; CHECK:       (type $bot (sub $mid (struct)))
  (type $bot (sub $mid (struct)))
 
  ;; CHECK:       (type $3 (func))
@@ -153,11 +153,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $top (sub (struct )))
+ ;; CHECK-NEXT:  (type $top (sub (struct)))
  (type $top (sub (struct)))
- ;; CHECK:       (type $mid (sub $top (struct )))
+ ;; CHECK:       (type $mid (sub $top (struct)))
  (type $mid (sub $top (struct)))
- ;; CHECK:       (type $bot (sub $mid (struct )))
+ ;; CHECK:       (type $bot (sub $mid (struct)))
  (type $bot (sub $mid (struct)))
 
  ;; CHECK:       (type $3 (func))
@@ -272,11 +272,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $top (sub (struct )))
+ ;; CHECK-NEXT:  (type $top (sub (struct)))
  (type $top (sub (struct)))
- ;; CHECK:       (type $mid (sub (struct )))
+ ;; CHECK:       (type $mid (sub (struct)))
  (type $mid (sub $top (struct)))
- ;; CHECK:       (type $bot (sub $mid (struct )))
+ ;; CHECK:       (type $bot (sub $mid (struct)))
  (type $bot (sub $mid (struct)))
 
  ;; CHECK:       (type $3 (func))
@@ -312,11 +312,11 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $top (sub (struct )))
+  ;; CHECK-NEXT:  (type $top (sub (struct)))
   (type $top (sub (struct)))
-  ;; CHECK:       (type $mid (sub $top (struct )))
+  ;; CHECK:       (type $mid (sub $top (struct)))
   (type $mid (sub $top (struct)))
-  ;; CHECK:       (type $bot (sub (struct )))
+  ;; CHECK:       (type $bot (sub (struct)))
   (type $bot (sub $mid (struct)))
  )
 
@@ -381,11 +381,11 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $top (sub (struct )))
+  ;; CHECK-NEXT:  (type $top (sub (struct)))
   (type $top (sub (struct)))
-  ;; CHECK:       (type $mid (sub $top (struct )))
+  ;; CHECK:       (type $mid (sub $top (struct)))
   (type $mid (sub $top (struct)))
-  ;; CHECK:       (type $bot (sub (struct )))
+  ;; CHECK:       (type $bot (sub (struct)))
   (type $bot (sub $mid (struct)))
  )
 
@@ -478,11 +478,11 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $topC (sub (struct )))
+  ;; CHECK-NEXT:  (type $topC (sub (struct)))
   (type $topC (sub (struct)))
-  ;; CHECK:       (type $midC (sub $topC (struct )))
+  ;; CHECK:       (type $midC (sub $topC (struct)))
   (type $midC (sub $topC (struct)))
-  ;; CHECK:       (type $botC (sub $midC (struct )))
+  ;; CHECK:       (type $botC (sub $midC (struct)))
   (type $botC (sub $midC (struct)))
 
   ;; CHECK:       (type $topB (sub (struct (field (ref null $topC)))))

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -61,9 +61,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; A function body requires subtyping
@@ -79,9 +79,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; A global initializer requires subtyping
@@ -91,11 +91,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
- ;; CHECK:       (type $subsub (sub $sub (struct )))
+ ;; CHECK:       (type $subsub (sub $sub (struct)))
  (type $subsub (sub $sub (struct)))
 
  ;; CHECK:      (table $t 1 1 (ref null $super))
@@ -109,9 +109,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $X (sub (struct )))
+ ;; CHECK-NEXT:  (type $X (sub (struct)))
  (type $X (sub (struct)))
- ;; CHECK:       (type $Y (sub $X (struct )))
+ ;; CHECK:       (type $Y (sub $X (struct)))
  (type $Y (sub $X (struct)))
 
  ;; CHECK:       (type $A (sub (struct (field (ref null $X)))))
@@ -126,9 +126,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $X (sub (struct )))
+ ;; CHECK-NEXT:  (type $X (sub (struct)))
  (type $X (sub (struct)))
- ;; CHECK:       (type $Y (sub $X (struct )))
+ ;; CHECK:       (type $Y (sub $X (struct)))
  (type $Y (sub $X (struct)))
 
  ;; CHECK:       (type $A (sub (array (ref null $X))))
@@ -146,14 +146,14 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $X (sub (struct )))
+  ;; CHECK-NEXT:  (type $X (sub (struct)))
   (type $X (sub (struct)))
-  ;; CHECK:       (type $Y (sub $X (struct )))
+  ;; CHECK:       (type $Y (sub $X (struct)))
   (type $Y (sub $X (struct)))
 
-  ;; CHECK:       (type $X' (sub (struct )))
+  ;; CHECK:       (type $X' (sub (struct)))
   (type $X' (sub (struct)))
-  ;; CHECK:       (type $Y' (sub $X' (struct )))
+  ;; CHECK:       (type $Y' (sub $X' (struct)))
   (type $Y' (sub $X' (struct)))
 
   ;; CHECK:       (type $A (sub (func (param (ref $Y')) (result (ref $X)))))
@@ -176,9 +176,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -216,9 +216,9 @@
  ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $opt (sub (struct (field i32))))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
  (type $opt (sub $super (struct i32)))
 
@@ -264,9 +264,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -302,9 +302,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -328,9 +328,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -370,9 +370,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -412,9 +412,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func (param (ref $super))))
@@ -434,9 +434,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func (result (ref $sub))))
@@ -461,9 +461,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func (param (ref $super))))
@@ -488,9 +488,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func (result (ref $sub))))
@@ -541,9 +541,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -565,9 +565,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -593,9 +593,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -618,11 +618,11 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
  ;; CHECK:       (type $sub2 (sub $super (struct (field i32))))
 
- ;; CHECK:       (type $sub1 (sub $super (struct )))
+ ;; CHECK:       (type $sub1 (sub $super (struct)))
  (type $sub1 (sub $super (struct)))
  (type $sub2 (sub $super (struct i32)))
 
@@ -651,9 +651,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func (result (ref $super))))
@@ -673,9 +673,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $sub (sub (struct )))
+ ;; CHECK-NEXT:  (type $sub (sub (struct)))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
  (type $sub (sub $super (struct)))
 
@@ -697,14 +697,14 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $super2 (sub (struct )))
+  ;; CHECK-NEXT:  (type $super2 (sub (struct)))
 
-  ;; CHECK:       (type $sub2 (sub $super2 (struct )))
+  ;; CHECK:       (type $sub2 (sub $super2 (struct)))
 
-  ;; CHECK:       (type $super1 (sub (struct )))
+  ;; CHECK:       (type $super1 (sub (struct)))
   (type $super1 (sub (struct)))
   (type $super2 (sub (struct)))
-  ;; CHECK:       (type $sub1 (sub $super1 (struct )))
+  ;; CHECK:       (type $sub1 (sub $super1 (struct)))
   (type $sub1 (sub $super1 (struct)))
   (type $sub2 (sub $super2 (struct)))
  )
@@ -732,9 +732,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -759,9 +759,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -790,9 +790,9 @@
  ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $0 (func))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:      (table $super 1 1 (ref null $super))
@@ -820,9 +820,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -856,9 +856,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -892,9 +892,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -921,9 +921,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $f (func (param (ref $super))))
@@ -976,9 +976,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $f (func (result (ref $sub))))
@@ -1010,9 +1010,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -1042,9 +1042,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -1072,9 +1072,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $2 (func))
@@ -1104,9 +1104,9 @@
  ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $struct (sub (struct (field (ref null $super)))))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  (type $struct (sub (struct (ref null $super))))
@@ -1151,9 +1151,9 @@
  ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $struct (sub (struct (field (mut (ref null $super))))))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  (type $struct (sub (struct (mut (ref null $super)))))
@@ -1207,9 +1207,9 @@
  ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $array (sub (array (ref null $super))))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  (type $array (sub (array (ref null $super))))
@@ -1270,9 +1270,9 @@
 
  ;; CHECK:       (type $1 (func))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  (type $array (sub (array (ref null $super))))
@@ -1317,9 +1317,9 @@
  ;; CHECK:      (rec
  ;; CHECK-NEXT:  (type $array (sub (array (ref null $super))))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  (type $array (sub (array (ref null $super))))
@@ -1355,9 +1355,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $array (sub (array (mut (ref null $super)))))
@@ -1420,9 +1420,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $sub-array (sub (array (mut (ref null $sub)))))
@@ -1508,9 +1508,9 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  ;; CHECK:       (type $array (sub (array (mut (ref null $super)))))
@@ -1587,9 +1587,9 @@
 
  ;; CHECK:       (type $1 (func))
 
- ;; CHECK:       (type $super (sub (struct )))
+ ;; CHECK:       (type $super (sub (struct)))
  (type $super (sub (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $super (struct)))
 
  (type $array (sub (array (mut (ref null $super)))))
@@ -1662,10 +1662,10 @@
 
 (module
  ;; CHECK:      (rec
- ;; CHECK-NEXT:  (type $super (sub (struct )))
+ ;; CHECK-NEXT:  (type $super (sub (struct)))
  (type $super (sub (struct)))
  (type $mid (sub $super (struct)))
- ;; CHECK:       (type $sub (sub $super (struct )))
+ ;; CHECK:       (type $sub (sub $super (struct)))
  (type $sub (sub $mid (struct)))
 
  ;; $sub <: $super, but it no longer needs to be related to $mid.
@@ -1710,9 +1710,9 @@
 (module
  (rec
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $X (sub (struct )))
+  ;; CHECK-NEXT:  (type $X (sub (struct)))
   (type $X (sub (struct)))
-  ;; CHECK:       (type $Y (sub $X (struct )))
+  ;; CHECK:       (type $Y (sub $X (struct)))
   (type $Y (sub $X (struct)))
 
   ;; CHECK:       (type $super (sub (struct (field (ref null $mid)))))

--- a/test/lit/passes/vacuum-gc.wast
+++ b/test/lit/passes/vacuum-gc.wast
@@ -2,7 +2,7 @@
 ;; RUN: wasm-opt %s --vacuum -all -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $"{}" (struct ))
+  ;; CHECK:      (type $"{}" (struct))
 
   ;; CHECK:      (import "binaryen-intrinsics" "call.without.effects" (func $call.without.effects (type $2) (param i32 i32 funcref) (result anyref)))
   (import "binaryen-intrinsics" "call.without.effects" (func $call.without.effects (param i32 i32 funcref) (result (ref null any))))

--- a/test/lit/select-gc.wat
+++ b/test/lit/select-gc.wat
@@ -6,7 +6,7 @@
 ;; only used in that one place in the whole module.
 
 (module
-  ;; CHECK:      (type $struct (struct ))
+  ;; CHECK:      (type $struct (struct))
   (type $struct (struct))
 
   ;; CHECK:      (func $foo (type $0) (result anyref)

--- a/test/lit/subtype-chain.wast
+++ b/test/lit/subtype-chain.wast
@@ -7,7 +7,7 @@
 ;; types.
 
 (module
-  ;; CHECK:      (type $root (sub (struct )))
+  ;; CHECK:      (type $root (sub (struct)))
   (type $root (sub (struct)))
 
   ;; CHECK:      (type $trunk (sub $root (struct (field i32))))

--- a/test/lit/validation/closed-world-interface.wast
+++ b/test/lit/validation/closed-world-interface.wast
@@ -13,7 +13,7 @@
 
 ;; This is referred to by the type of a function export, but is still not allowed.
 ;; CHECK:      publicly exposed type disallowed with a closed world: $struct, on
-;; CHECK-NEXT: (struct )
+;; CHECK-NEXT: (struct)
 
 (module
   (type $struct (struct))

--- a/test/lit/validation/shared-struct.wast
+++ b/test/lit/validation/shared-struct.wast
@@ -4,7 +4,7 @@
 ;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED
 
 ;; NO-SHARED: global type requires additional features [--enable-reference-types --enable-gc --enable-shared-everything]
-;; SHARED: (type $t (shared (struct )))
+;; SHARED: (type $t (shared (struct)))
 
 (module
   (type $t (shared (struct)))

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -34,9 +34,9 @@
   ;; CHECK:      (type $12 (func (param i32 i64 v128)))
 
   ;; CHECK:      (rec
-  ;; CHECK-NEXT:  (type $s0 (struct ))
+  ;; CHECK-NEXT:  (type $s0 (struct))
   (type $s0 (struct))
-  ;; CHECK:       (type $s1 (struct ))
+  ;; CHECK:       (type $s1 (struct))
   (type $s1 (struct (field)))
  )
 

--- a/test/passes/roundtrip_typenames_features.txt
+++ b/test/passes/roundtrip_typenames_features.txt
@@ -1,5 +1,5 @@
 (module
- (type $NamedStruct (struct ))
+ (type $NamedStruct (struct))
  (type $ref?|$NamedStruct|_=>_none (func (param (ref null $NamedStruct))))
  (export "export" (func $0))
  (func $0 (type $ref?|$NamedStruct|_=>_none) (param $0 (ref null $NamedStruct))


### PR DESCRIPTION
When we switched to the new type printing machinery, we inserted this
extra space to minimize the diff in the test output compared with the
previous type printer. Improve the quality of the printed output by
removing it.
