### PR TITLE
[NFC][threads] Ignore type-ssa-shared.wast in fuzzer

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -357,6 +357,7 @@ INITIAL_CONTENTS_IGNORE = [
     'shared-struct.wast',
     'shared-array.wast',
     'shared-i31.wast',
+    'type-ssa-shared.wast',
 ]
 
 


### PR DESCRIPTION
The fuzzer does not yet properly handle initial contents containing
shared types.
