### PR TITLE
[threads] Fix feature detection for shared basic heap types

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1526,6 +1526,10 @@ FeatureSet HeapType::getFeatures() const {
     FeatureSet feats = FeatureSet::None;
 
     void noteChild(HeapType* heapType) {
+      if (heapType->isShared()) {
+        feats |= FeatureSet::SharedEverything;
+      }
+
       if (heapType->isBasic()) {
         switch (heapType->getBasic(Unshared)) {
           case HeapType::ext:
@@ -1563,10 +1567,6 @@ FeatureSet HeapType::getFeatures() const {
       if (heapType->getRecGroup().size() > 1 ||
           heapType->getDeclaredSuperType() || heapType->isOpen()) {
         feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
-      }
-
-      if (heapType->isShared()) {
-        feats |= FeatureSet::SharedEverything;
       }
 
       if (heapType->isStruct() || heapType->isArray()) {

--- a/test/lit/validation/shared-absheaptype.wast
+++ b/test/lit/validation/shared-absheaptype.wast
@@ -1,0 +1,11 @@
+;; Test that shared structs require shared-everything threads
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s --check-prefix NO-SHARED
+;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED
+
+;; NO-SHARED: global type requires additional features [--enable-reference-types --enable-gc --enable-shared-everything]
+;; SHARED: (import "" "" (global $gimport$0 (ref null (shared any))))
+
+(module
+  (global (import "" "") (ref null (shared any)))
+)


### PR DESCRIPTION
The logic for adding the shared-everything feature was not previously
executed for shared basic heap types.
