### PR TITLE
[threads] Validate all features required by ref.null

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -357,6 +357,8 @@ INITIAL_CONTENTS_IGNORE = [
     'shared-struct.wast',
     'shared-array.wast',
     'shared-i31.wast',
+    'shared-null.wast',
+    'shared-absheaptype.wast',
     'type-ssa-shared.wast',
 ]
 

--- a/test/lit/validation/shared-absheaptype.wast
+++ b/test/lit/validation/shared-absheaptype.wast
@@ -1,4 +1,4 @@
-;; Test that shared structs require shared-everything threads
+;; Test that shared basic heap types require shared-everything threads
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s --check-prefix NO-SHARED
 ;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED

--- a/test/lit/validation/shared-null.wast
+++ b/test/lit/validation/shared-null.wast
@@ -1,0 +1,12 @@
+;; Test that shared nulls require shared-everything threads
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s --check-prefix NO-SHARED
+;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED
+
+;; NO-SHARED: ref.null requires additional features
+;; NO-SHARED: [--enable-reference-types --enable-shared-everything]
+;; SHARED: (ref.null (shared none))
+
+(module
+  (func (drop (ref.null (shared none))))
+)


### PR DESCRIPTION
`ref.null` of shared types should only be allowed when shared-everything
is enabled, but we were previously checking only that reference types
were enabled when validating `ref.null`. Update the code to check all
features required by the null type and factor out shared logic for
printing lists of missing feature options in error messages.
