### PR TITLE
Revert "[threads] Allow i31refs of mixed shareability to compare equal (#6752)"

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -412,14 +412,6 @@ void Literal::getBits(uint8_t (&buf)[16]) const {
 }
 
 bool Literal::operator==(const Literal& other) const {
-  // As a special case, shared and unshared i31 can compare equal even if their
-  // types are different (because one is shared and the other is not).
-  if (type.isRef() && other.type.isRef() && type.getHeapType().isBasic() &&
-      other.type.getHeapType().isBasic() &&
-      type.getHeapType().getBasic(Unshared) == HeapType::i31 &&
-      other.type.getHeapType().getBasic(Unshared) == HeapType::i31) {
-    return i32 == other.i32;
-  }
   if (type != other.type) {
     return false;
   }
@@ -453,7 +445,9 @@ bool Literal::operator==(const Literal& other) const {
     if (type.isData()) {
       return gcData == other.gcData;
     }
-    // i31 already handled.
+    if (type.getHeapType() == HeapType::i31) {
+      return i32 == other.i32;
+    }
     WASM_UNREACHABLE("unexpected type");
   }
   WASM_UNREACHABLE("unexpected type");

--- a/test/spec/shared-polymorphism.wast
+++ b/test/spec/shared-polymorphism.wast
@@ -23,14 +23,3 @@
     (extern.convert_any (local.get 0))
   )
 )
-
-(module
-  (func (export "eq") (param i32 i32) (result i32)
-    (ref.eq (ref.i31 (local.get 0)) (ref.i31_shared (local.get 1)))
-  )
-)
-
-(assert_return (invoke "eq" (i32.const 0) (i32.const 0)) (i32.const 1))
-(assert_return (invoke "eq" (i32.const 0) (i32.const 1)) (i32.const 0))
-(assert_return (invoke "eq" (i32.const 1) (i32.const 0)) (i32.const 0))
-(assert_return (invoke "eq" (i32.const 1) (i32.const 1)) (i32.const 1))


### PR DESCRIPTION
Allowing Literals with different types to compare equal causes problems
for passes that want equality to mean real equality, e.g. because they
are using literals as map keys or because they otherwise need to use
them interchangeably.

At a minimum, we would need to differentiate a `refEq` operation where
mixed-shareability i31refs can compare equal from physical equality on
Literals, but there is also appetite to disallow mixed-shareability
ref.eq at the spec level. See
https://github.com/WebAssembly/shared-everything-threads/issues/76.
