### PR TITLE
binaryen.js: Avoid catching exit/rejection which confuses Node error reporting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,10 +500,9 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_wasm optimized "-Wno-error=closure")
   target_link_libraries(binaryen_wasm optimized "-flto")
   target_link_libraries(binaryen_wasm debug "--profiling")
-  # Avoid catching exit/rejection as that can confuse error reporting in Node,
+  # Avoid catching exit as that can confuse error reporting in Node,
   # see https://github.com/emscripten-core/emscripten/issues/17228
   target_link_libraries(binaryen_wasm "-sNODEJS_CATCH_EXIT=0")
-  target_link_libraries(binaryen_wasm "-sNODEJS_CATCH_REJECTION=0")
   install(TARGETS binaryen_wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   # binaryen.js JavaScript variant
@@ -554,10 +553,9 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_js optimized "-flto")
   target_link_libraries(binaryen_js debug "--profiling")
   target_link_libraries(binaryen_js debug "-sASSERTIONS")
-  # Avoid catching exit/rejection as that can confuse error reporting in Node,
+  # Avoid catching exit as that can confuse error reporting in Node,
   # see https://github.com/emscripten-core/emscripten/issues/17228
   target_link_libraries(binaryen_js "-sNODEJS_CATCH_EXIT=0")
-  target_link_libraries(binaryen_js "-sNODEJS_CATCH_REJECTION=0")
   install(TARGETS binaryen_js DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,6 +500,10 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_wasm optimized "-Wno-error=closure")
   target_link_libraries(binaryen_wasm optimized "-flto")
   target_link_libraries(binaryen_wasm debug "--profiling")
+  # Avoid catching exit/rejection as that can confuse error reporting in Node,
+  # see https://github.com/emscripten-core/emscripten/issues/17228
+  target_link_libraries(binaryen_wasm "-sNODEJS_CATCH_EXIT=0")
+  target_link_libraries(binaryen_wasm "-sNODEJS_CATCH_REJECTION=0")
   install(TARGETS binaryen_wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
 
   # binaryen.js JavaScript variant
@@ -550,6 +554,10 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_js optimized "-flto")
   target_link_libraries(binaryen_js debug "--profiling")
   target_link_libraries(binaryen_js debug "-sASSERTIONS")
+  # Avoid catching exit/rejection as that can confuse error reporting in Node,
+  # see https://github.com/emscripten-core/emscripten/issues/17228
+  target_link_libraries(binaryen_js "-sNODEJS_CATCH_EXIT=0")
+  target_link_libraries(binaryen_js "-sNODEJS_CATCH_REJECTION=0")
   install(TARGETS binaryen_js DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 


### PR DESCRIPTION
Fixes https://github.com/emscripten-core/emscripten/issues/17228

This seems the right default in binaryen.js which is used as a library through
npm mostly. We aren't a main program that wants to control node exclusively.

I verified manually that this does not interfere with our binaryen.js tests here,
just to be safe (that is, I added an error in a test and I saw the test then failed).