### PR TITLE
Validate features for types used in tables

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -363,6 +363,7 @@ INITIAL_CONTENTS_IGNORE = [
     'shared-ref_eq.wast',
     'shared-types-no-gc.wast',
     'shared-ref-i31.wast',
+    'table-type.wast',
 ]
 
 

--- a/test/lit/validation/table-type.wast
+++ b/test/lit/validation/table-type.wast
@@ -1,0 +1,12 @@
+;; Test that the features required by table types are checked
+
+;; RUN: not wasm-opt %s -all --disable-shared-everything 2>&1 | filecheck %s --check-prefix NO-SHARED
+;; RUN: wasm-opt %s -all -S -o - | filecheck %s --check-prefix SHARED
+
+;; NO-SHARED: table type requires additional features
+;; NO-SHARED: [--enable-shared-everything]
+;; SHARED: (table $t 0 0 (ref null (shared func)))
+
+(module
+  (table $t 0 0 (ref null (shared func)))
+)


### PR DESCRIPTION
We previously special-cased things like GC types, but switch to a more
general solution of detecting what features a table's type requires.
