### PR TITLE
Heap2Local: Properly handle failing array casts

### DIFF
--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -1050,9 +1050,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
     }
 
     // When we ref.test an array allocation, we cannot simply turn the array
-    // into a struct, as then the test will behave different. (Note that this is
-    // not a problem for ref.*cast*, as the cast simply goes away when the value
-    // flows through, and we verify it will do so in the escape analysis.) To
+    // into a struct, as then the test will behave differently. To properly
     // handle this, check if the test succeeds or not, and write out the outcome
     // here (similar to Struct2Local::visitRefTest). Note that we test on
     // |originalType| here and not |allocation->type|, as the allocation has

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -1069,13 +1069,16 @@ struct Array2Struct : PostWalker<Array2Struct> {
 
     // As with RefTest, we need to check if the cast succeeds with the array
     // type before we turn it into a struct type (as after that change, the
-    // outcome of the cast will look different). If we fail here, ensure that we
-    // trap with an unreachable.
+    // outcome of the cast will look different).
     if (!Type::isSubType(originalType, curr->type)) {
+      // The cast fails, ensure we trap with an unreachable.
       replaceCurrent(builder.makeSequence(builder.makeDrop(curr),
                                           builder.makeUnreachable()));
     } else {
-      // The cast succeeds. Update the type.
+      // The cast succeeds. Update the type. (It is ok to use the non-nullable
+      // type here unconditionally, since we know the allocation flows through
+      // here, and anyhow we will be removing the reference during Struct2Local,
+      // later.)
       curr->type = nonNullStruct;
     }
 

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -4417,7 +4417,7 @@
   (func $array.cast.struct.set
     (local $eq (ref eq))
     (local $struct (ref struct))
-    ;; As above, but now the cast fails and is stored to struct. We do not
+    ;; As above, but now the cast fails and is stored to a struct local. We do not
     ;; escape and we emit an unreachable for the cast.
     (local.set $struct
       (ref.cast (ref struct)

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -4310,7 +4310,9 @@
 
  ;; CHECK:      (type $0 (func (result (ref struct))))
  (type $0 (func (result (ref struct))))
- ;; CHECK:      (type $3 (func (result (ref array))))
+ ;; CHECK:      (type $3 (func (result structref)))
+
+ ;; CHECK:      (type $4 (func (result (ref array))))
 
  ;; CHECK:      (type $array (array i8))
  (type $array (array i8))
@@ -4337,7 +4339,26 @@
     )
   )
 
-  ;; CHECK:      (func $array.cast.array (type $3) (result (ref array))
+  ;; CHECK:      (func $array.cast.struct.null (type $3) (result structref)
+  ;; CHECK-NEXT:  (local $eq (ref eq))
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result nullref)
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $array.cast.struct.null (result (ref null struct))
+    (local $eq (ref eq))
+    ;; As above but the cast is to a nullable type, which changes nothing.
+    (ref.cast (ref null struct)
+      (local.tee $eq
+        (array.new_fixed $array 0)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $array.cast.array (type $4) (result (ref array))
   ;; CHECK-NEXT:  (local $eq (ref eq))
   ;; CHECK-NEXT:  (ref.cast (ref array)
   ;; CHECK-NEXT:   (local.tee $eq

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -3345,12 +3345,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (block
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (unreachable)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (local.set $2
   ;; CHECK-NEXT:    (i32.const 100)
@@ -4365,13 +4360,8 @@
   ;; CHECK-NEXT:  (local $eq (ref eq))
   ;; CHECK-NEXT:  (local $array (ref array))
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result nullref)
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   (block (result nullref)
+  ;; CHECK-NEXT:    (ref.null none)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )


### PR DESCRIPTION
Followup to #6727 which added support for failing casts in Struct2Local, but it
turns out that it required Array2Struct changes as well. Specifically, when we
turn an array into a struct then casts can look like they behave differently
(what used to be an array input, becomes a struct), so like with RefTest that we
already handled, check if the cast succeeds in the original form and handle
that.

Found by the fuzzer.
