### PR TITLE
[NFC] Add HeapType::isMaybeShared(BasicHeapType) utility

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -281,7 +281,7 @@ public:
     return i32;
   }
   int32_t geti31(bool signed_ = true) const {
-    assert(type.getHeapType().getBasic(Unshared) == HeapType::i31);
+    assert(type.getHeapType().isMaybeShared(HeapType::i31));
     // Cast to unsigned for the left shift to avoid undefined behavior.
     return signed_ ? int32_t((uint32_t(i32) << 1)) >> 1 : (i32 & 0x7fffffff);
   }

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -759,8 +759,7 @@ void Inhabitator::markExternRefsNullable() {
     auto children = type.getTypeChildren();
     for (size_t i = 0; i < children.size(); ++i) {
       auto child = children[i];
-      if (child.isRef() && child.getHeapType().isBasic() &&
-          child.getHeapType().getBasic(Unshared) == HeapType::ext &&
+      if (child.isRef() && child.getHeapType().isMaybeShared(HeapType::ext) &&
           child.isNonNullable()) {
         markNullable({type, i});
       }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1217,8 +1217,7 @@ public:
     if (type.isFunction()) {
       return makeRefFunc(value.getFunc(), type.getHeapType());
     }
-    if (type.isRef() && type.getHeapType().isBasic() &&
-        type.getHeapType().getBasic(Unshared) == HeapType::i31) {
+    if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::i31)) {
       return makeRefI31(makeConst(value.geti31()),
                         type.getHeapType().getShared());
     }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -385,6 +385,8 @@ public:
 
   Shareability getShared() const;
 
+  // Check if the type is a given basic heap type, while ignoring whether it is
+  // shared or not.
   bool isMaybeShared(BasicHeapType type) {
     return isBasic() && getBasic(Unshared) == type;
   }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -385,6 +385,10 @@ public:
 
   Shareability getShared() const;
 
+  bool isMaybeShared(BasicHeapType type) {
+    return isBasic() && getBasic(Unshared) == type;
+  }
+
   Signature getSignature() const;
   Continuation getContinuation() const;
 

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -57,8 +57,7 @@ Literal::Literal(Type type) : type(type) {
     return;
   }
 
-  if (type.isRef() && type.getHeapType().isBasic() &&
-      type.getHeapType().getBasic(Unshared) == HeapType::i31) {
+  if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::i31)) {
     assert(type.isNonNullable());
     i32 = 0;
     return;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1521,7 +1521,7 @@ void WasmBinaryWriter::writeType(Type type) {
     // those more refined types.
     if (!wasm->features.hasGC()) {
       auto ht = type.getHeapType();
-      if (ht.isBasic() && ht.getBasic(Unshared) == HeapType::string) {
+      if (ht.isMaybeShared(HeapType::string)) {
         // Do not overgeneralize stringref to anyref. We have tests that when a
         // stringref is expected, we actually get a stringref. If we see a
         // string, the stringref feature must be enabled.

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2910,7 +2910,7 @@ void FunctionValidator::visitStructSet(StructSet* curr) {
     return;
   }
   auto type = curr->ref->type.getHeapType();
-  if (type.isBasic() && type.getBasic(Unshared) == HeapType::none) {
+  if (type.isMaybeShared(HeapType::none)) {
     return;
   }
   if (!shouldBeTrue(

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -964,8 +964,7 @@ void RefI31::finalize() {
   if (value->type == Type::unreachable) {
     type = Type::unreachable;
   } else {
-    assert(type.isRef() && type.getHeapType().isBasic() &&
-           type.getHeapType().getBasic(Unshared) == HeapType::i31);
+    assert(type.isRef() && type.getHeapType().isMaybeShared(HeapType::i31));
   }
 }
 


### PR DESCRIPTION
This abbreviates a common pattern where we first had to check whether a
heap type was basic, then if it was, get its unshared version and
compare it to some expected BasicHeapType.

Suggested in
https://github.com/WebAssembly/binaryen/pull/6771#discussion_r1683005495.
