### PR TITLE
Make FunctionInfo's assignment operator argument const

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -103,7 +103,7 @@ struct FunctionInfo {
   }
 
   // Provide an explicit = operator as the |refs| field lacks one by default.
-  FunctionInfo& operator=(FunctionInfo& other) {
+  FunctionInfo& operator=(const FunctionInfo& other) {
     refs = other.refs.load();
     size = other.size;
     hasCalls = other.hasCalls;


### PR DESCRIPTION
Aside from the fact that there's no need for this to be non-const and this is the usual way to write an assignment operator, this is also needed because of a recent change to std::pair (https://github.com/llvm/llvm-project/pull/89652). This seems to be forcing pair to want the const version of the assignment operator of its members.