### PR TITLE
Handle single-segment source mapping in source map header decoder

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2939,13 +2939,20 @@ void WasmBinaryReader::readSourceMapHeader() {
   //       investigation (if it does, it will assert in readBase64VLQ, so it
   //       would not be a silent error at least).
   uint32_t position = readBase64VLQ(*sourceMap);
-  uint32_t fileIndex = readBase64VLQ(*sourceMap);
-  uint32_t lineNumber =
-    readBase64VLQ(*sourceMap) + 1; // adjust zero-based line number
-  uint32_t columnNumber = readBase64VLQ(*sourceMap);
   nextDebugPos = position;
-  nextDebugLocation = {fileIndex, lineNumber, columnNumber};
-  nextDebugLocationHasDebugInfo = true;
+
+  auto peek = sourceMap->peek();
+  if (peek == ',' || peek == '\"') {
+    // This is a 1-length entry, so the next location has no debug info.
+    nextDebugLocationHasDebugInfo = false;
+  } else {
+    uint32_t fileIndex = readBase64VLQ(*sourceMap);
+    uint32_t lineNumber =
+        readBase64VLQ(*sourceMap) + 1; // adjust zero-based line number
+    uint32_t columnNumber = readBase64VLQ(*sourceMap);
+    nextDebugLocation = {fileIndex, lineNumber, columnNumber};
+    nextDebugLocationHasDebugInfo = true;
+  }
 }
 
 void WasmBinaryReader::readNextDebugLocation() {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2948,7 +2948,7 @@ void WasmBinaryReader::readSourceMapHeader() {
   } else {
     uint32_t fileIndex = readBase64VLQ(*sourceMap);
     uint32_t lineNumber =
-        readBase64VLQ(*sourceMap) + 1; // adjust zero-based line number
+      readBase64VLQ(*sourceMap) + 1; // adjust zero-based line number
     uint32_t columnNumber = readBase64VLQ(*sourceMap);
     nextDebugLocation = {fileIndex, lineNumber, columnNumber};
     nextDebugLocationHasDebugInfo = true;

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(../../third_party/googletest/googletest/include)
 include_directories(../../src/wasm)
 
 set(unittest_SOURCES
+  binary-reader.cpp
   cfg.cpp
   dfa_minimization.cpp
   json.cpp

--- a/test/gtest/binary-reader.cpp
+++ b/test/gtest/binary-reader.cpp
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
-#include "wasm-binary.h"
 #include "gtest/gtest.h"
+#include "parser/wat-parser.h"
+#include "print-test.h"
+#include "wasm-binary.h"
 
 using namespace wasm;
 
+using BinaryReaderTest = PrintTest;
+
 // Check that debug location parsers can handle single-segment mappings.
-TEST(BinaryReaderTest, SourceMappingSingleSegment) {
-  std::vector<char> moduleBytes = {
-    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00};
+TEST_F(BinaryReaderTest, SourceMappingSingleSegment) {
+  auto moduleText = "(module)";
+  Module module;
+  parseWast(module, moduleText);
+
+  BufferWithRandomAccess buffer;
+  WasmBinaryWriter(&module, buffer, PassOptions());
+  auto moduleBytes = buffer.getAsChars();
 
   // A single-segment mapping starting at offset 0.
   std::string sourceMap = R"(

--- a/test/gtest/binary-reader.cpp
+++ b/test/gtest/binary-reader.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wasm-binary.h"
+#include "gtest/gtest.h"
+
+using namespace wasm;
+
+// Check that debug location parsers can handle single-segment mappings.
+TEST(BinaryReaderTest, SourceMappingSingleSegment) {
+  std::vector<char> moduleBytes = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00};
+
+  // A single-segment mapping starting at offset 0.
+  std::string sourceMap = R"(
+      {
+          "version": 3,
+          "sources": [],
+          "names": [],
+          "mappings": "A"
+      }
+  )";
+  std::stringstream sourceMapStream(sourceMap);
+
+  // Test `readSourceMapHeader`.
+  {
+    Module module;
+    WasmBinaryReader binaryReader(module, FeatureSet::All, moduleBytes);
+    binaryReader.setDebugLocations(&sourceMapStream);
+    binaryReader.readSourceMapHeader();
+  }
+
+  // Test `readNextDebugLocation`.
+  {
+    Module module;
+    WasmBinaryReader binaryReader(module, FeatureSet::All, moduleBytes);
+    binaryReader.setDebugLocations(&sourceMapStream);
+    binaryReader.readNextDebugLocation();
+  }
+}

--- a/test/gtest/binary-reader.cpp
+++ b/test/gtest/binary-reader.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "gtest/gtest.h"
 #include "parser/wat-parser.h"
 #include "print-test.h"
 #include "wasm-binary.h"
+#include "gtest/gtest.h"
 
 using namespace wasm;
 

--- a/test/gtest/binary-reader.cpp
+++ b/test/gtest/binary-reader.cpp
@@ -44,7 +44,8 @@ TEST_F(BinaryReaderTest, SourceMappingSingleSegment) {
   )";
   std::stringstream sourceMapStream(sourceMap);
 
-  // Test `readSourceMapHeader`.
+  // Test `readSourceMapHeader` (only check for errors, as there is no mapping
+  // to print).
   {
     Module module;
     WasmBinaryReader binaryReader(module, FeatureSet::All, moduleBytes);


### PR DESCRIPTION
Single-segment mappings were already handled in `readNextDebugLocation`, but not in `readSourceMapHeader`.

Update `readSourceMapHeader` to handle single-segment mappings.

The code to handle single segments is copied from `readNextDebugLocation`.