### PR TITLE
Fix shareability handling in TypeSSA collision logic

### DIFF
--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -111,6 +111,7 @@ std::vector<HeapType> ensureTypesAreInNewRecGroup(RecGroup recGroup,
           builder[i].subTypeOf(*super);
         }
         builder[i].setOpen(type.isOpen());
+        builder[i].setShared(type.getShared());
       }
 
       // Implement the hash as a struct with "random" fields, and add it.


### PR DESCRIPTION
@tlively This makes me wonder if we should consider adding a "copy" method on
TypeBuilder, to avoid needing to remember to do both setOpen/setShared in each
such place?