### PR TITLE
[NFC] Avoid a temp local

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -2702,8 +2702,9 @@ Literal Literal::externalize() const {
 
 Literal Literal::internalize() const {
   auto share = type.getHeapType().getShared();
-  assert(Type::isSubType(type, Type(HeapTypes::ext.getBasic(share), Nullable)) &&
-         "can only internalize external references");
+  assert(
+    Type::isSubType(type, Type(HeapTypes::ext.getBasic(share), Nullable)) &&
+    "can only internalize external references");
   if (isNull()) {
     return Literal(std::shared_ptr<GCData>{}, HeapTypes::none.getBasic(share));
   }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -2702,8 +2702,7 @@ Literal Literal::externalize() const {
 
 Literal Literal::internalize() const {
   auto share = type.getHeapType().getShared();
-  auto extType = HeapTypes::ext.getBasic(share);
-  assert(Type::isSubType(type, Type(extType, Nullable)) &&
+  assert(Type::isSubType(type, Type(HeapTypes::ext.getBasic(share), Nullable)) &&
          "can only internalize external references");
   if (isNull()) {
     return Literal(std::shared_ptr<GCData>{}, HeapTypes::none.getBasic(share));


### PR DESCRIPTION
The local was only used once, so it didn't really add much. And, it was causing some
compilers to error on "unused variable" (when building without assertions, the use
was removed).