### PR TITLE
Remove `isString` type methods

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -96,7 +96,9 @@ public:
   // Whether this is GC data, that is, something stored on the heap (aside from
   // a null or i31). This includes structs, arrays, and also strings.
   bool isData() const { return type.isData(); }
-  bool isString() const { return type.isString(); }
+  bool isString() const {
+    return type.isRef() && type.getHeapType().isMaybeShared(HeapType::string);
+  }
 
   bool isNull() const { return type.isNull(); }
 
@@ -770,11 +772,11 @@ template<> struct hash<wasm::Literal> {
         wasm::rehash(digest, a.getFunc());
         return digest;
       }
-      if (a.type.getHeapType() == wasm::HeapType::i31) {
+      if (a.type.getHeapType().isMaybeShared(wasm::HeapType::i31)) {
         wasm::rehash(digest, a.geti31(true));
         return digest;
       }
-      if (a.type.isString()) {
+      if (a.type.getHeapType().isMaybeShared(wasm::HeapType::string)) {
         auto& values = a.getGCData()->values;
         wasm::rehash(digest, values.size());
         for (auto c : values) {

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -830,7 +830,6 @@ private:
     }
     // We can emit a StringConst for a string constant.
     if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::string)) {
-      assert(!type.getHeapType().isShared() && "TODO: shared string support");
       return true;
     }
     // All other reference types cannot be precomputed. Even an immutable GC

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -829,7 +829,8 @@ private:
       return true;
     }
     // We can emit a StringConst for a string constant.
-    if (type.isString()) {
+    if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::string)) {
+      assert(!type.getHeapType().isShared() && "TODO: shared string support");
       return true;
     }
     // All other reference types cannot be precomputed. Even an immutable GC

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -148,7 +148,8 @@ struct ExecutionResults {
     // simple and stable internal structures that optimizations will not alter.
     auto type = value.type;
     if (type.isRef()) {
-      if (type.isString() || type.getHeapType() == HeapType::i31) {
+      if (type.getHeapType().isMaybeShared(HeapType::string) ||
+          type.getHeapType().isMaybeShared(HeapType::i31)) {
         std::cout << value << '\n';
       } else if (value.isNull()) {
         std::cout << "null\n";
@@ -189,7 +190,9 @@ struct ExecutionResults {
     // TODO: Once we support optimizing under some form of open-world
     // assumption, we should be able to check that the types and/or structure of
     // GC data passed out of the module does not change.
-    if (a.type.isRef() && !a.type.isString()) {
+    if (a.type.isRef() &&
+        !a.type.getHeapType().isMaybeShared(HeapType::string) &&
+        !a.type.getHeapType().isMaybeShared(HeapType::i31)) {
       return true;
     }
     if (a != b) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2536,7 +2536,8 @@ Expression* TranslateToFuzzReader::makeConst(Type type) {
     if (type.isNullable() && oneIn(8)) {
       return builder.makeRefNull(type.getHeapType());
     }
-    if (type.getHeapType().isString()) {
+    if (type.getHeapType().isMaybeShared(HeapType::string)) {
+      assert(!type.getHeapType().isShared() && "TODO: shared strings");
       return makeStringConst();
     }
     if (type.getHeapType().isBasic()) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -841,7 +841,8 @@ public:
     // externalized i31s) can be handled by the general makeConstantExpression
     // logic (which knows how to handle externalization, for i31s; and it also
     // can handle string constants).
-    if (!value.isData() || value.type.getHeapType().isString()) {
+    if (!value.isData() ||
+        value.type.getHeapType().isMaybeShared(HeapType::string)) {
       return builder.makeConstantExpression(original);
     }
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -170,7 +170,6 @@ public:
   bool isSignature() const;
   bool isStruct() const;
   bool isArray() const;
-  bool isString() const;
   bool isDefaultable() const;
 
   Nullability getNullability() const;
@@ -376,7 +375,6 @@ public:
   bool isContinuation() const;
   bool isStruct() const;
   bool isArray() const;
-  bool isString() const;
   bool isBottom() const;
   bool isOpen() const;
   bool isShared() const { return getShared() == Shared; }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -439,7 +439,7 @@ bool Literal::operator==(const Literal& other) const {
       assert(func.is() && other.func.is());
       return func == other.func;
     }
-    if (type.isString()) {
+    if (type.getHeapType().isMaybeShared(HeapType::string)) {
       return gcData->values == other.gcData->values;
     }
     if (type.isData()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -814,8 +814,6 @@ bool Type::isStruct() const { return isRef() && getHeapType().isStruct(); }
 
 bool Type::isArray() const { return isRef() && getHeapType().isArray(); }
 
-bool Type::isString() const { return isRef() && getHeapType().isString(); }
-
 bool Type::isDefaultable() const {
   // A variable can get a default value if its type is concrete (unreachable
   // and none have no values, hence no default), and if it's a reference, it
@@ -1143,8 +1141,6 @@ bool HeapType::isArray() const {
     return getHeapTypeInfo(*this)->isArray();
   }
 }
-
-bool HeapType::isString() const { return *this == HeapType::string; }
 
 bool HeapType::isBottom() const {
   if (isBasic()) {


### PR DESCRIPTION
Since there is only one unshared string heap type, the `isString()`
method did not do anything that could not be done as well with other,
more fundamental methods. Although using `isString` saved characters
compared with its replacement, that's not enough of a benefit to offset
the advantages of reducing redundant API surface and being more explicit
at callsites.

This would be NFC, but I updated many call sites of `isString` to handle
shared string types as well, or at least error more eagerly on them,
which may have changed observable behavior.
