### PR TITLE
Use explicit names for elements creating using `Builder::make_` methods

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4968,7 +4968,6 @@ BinaryenTableRef BinaryenAddTable(BinaryenModuleRef module,
                                   BinaryenIndex maximum,
                                   BinaryenType tableType) {
   auto table = Builder::makeTable(name, Type(tableType), initial, maximum);
-  table->hasExplicitName = true;
   return ((Module*)module)->addTable(std::move(table));
 }
 void BinaryenRemoveTable(BinaryenModuleRef module, const char* table) {

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -701,9 +701,9 @@ void ModuleSplitter::setupTablePatching() {
       auto placeholder = std::make_unique<Function>();
       placeholder->module = config.placeholderNamespace;
       placeholder->base = std::to_string(index);
-      placeholder->name = Names::getValidFunctionName(
+      auto name = Names::getValidFunctionName(
         primary, std::string("placeholder_") + placeholder->base.toString());
-      placeholder->hasExplicitName = true;
+      placeholder->setExplicitName(name);
       placeholder->type = secondaryFunc->type;
       elem = placeholder->name;
       primary.addFunction(std::move(placeholder));
@@ -804,8 +804,7 @@ void ModuleSplitter::shareImportableItems() {
                               Importable& secondaryItem,
                               const std::string& genericExportName,
                               ExternalKind kind) {
-    secondaryItem.name = primaryItem.name;
-    secondaryItem.hasExplicitName = primaryItem.hasExplicitName;
+    secondaryItem.setName(primaryItem.name, primaryItem.hasExplicitName);
     secondaryItem.module = config.importNamespace;
     auto exportIt = exports.find(std::make_pair(kind, primaryItem.name));
     if (exportIt != exports.end()) {

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -158,7 +158,6 @@ void GenerateDynCalls::generateDynCallThunk(HeapType funcType) {
   }
   auto f = builder.makeFunction(
     name, std::move(namedParams), Signature(Type(params), sig.results), {});
-  f->hasExplicitName = true;
   Expression* fptr = builder.makeLocalGet(0, table->indexType);
   std::vector<Expression*> args;
   Index i = 0;

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -227,8 +227,7 @@ private:
 
     Builder builder(*module);
     auto* legal = new Function();
-    legal->name = legalName;
-    legal->hasExplicitName = true;
+    legal->setExplicitName(legalName);
 
     auto* call = module->allocator.alloc<Call>();
     call->target = func->name;
@@ -272,14 +271,12 @@ private:
   Name makeLegalStubForCalledImport(Function* im, Module* module) {
     Builder builder(*module);
     auto legalIm = std::make_unique<Function>();
-    legalIm->name = Name(std::string("legalimport$") + im->name.toString());
+    legalIm->setExplicitName(Name(std::string("legalimport$") + im->name.toString()));
     legalIm->module = im->module;
     legalIm->base = im->base;
-    legalIm->hasExplicitName = true;
     auto stub = std::make_unique<Function>();
-    stub->name = Name(std::string("legalfunc$") + im->name.toString());
+    stub->setExplicitName(Name(std::string("legalfunc$") + im->name.toString()));
     stub->type = im->type;
-    stub->hasExplicitName = true;
 
     auto* call = module->allocator.alloc<Call>();
     call->target = legalIm->name;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -343,7 +343,6 @@ void TranslateToFuzzReader::setupTables() {
   } else {
     auto tablePtr = builder.makeTable(
       Names::getValidTableName(wasm, "fuzzing_table"), funcref, 0, 0);
-    tablePtr->hasExplicitName = true;
     table = wasm.addTable(std::move(tablePtr));
   }
   funcrefTableName = table->name;

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -59,7 +59,6 @@ void Instrumenter::addGlobals(size_t numFuncs) {
       Type::i32,
       Builder(*wasm).makeConst(Literal::makeZero(Type::i32)),
       Builder::Mutable);
-    global->hasExplicitName = true;
     wasm->addGlobal(std::move(global));
   };
   addGlobal(counterGlobal);
@@ -204,7 +203,6 @@ void Instrumenter::addProfileExport(size_t numFuncs) {
   auto name = Names::getValidFunctionName(*wasm, config.profileExport);
   auto writeProfile =
     Builder::makeFunction(name, Signature({ptrType, Type::i32}, Type::i32), {});
-  writeProfile->hasExplicitName = true;
   writeProfile->setLocalName(0, "addr");
   writeProfile->setLocalName(1, "size");
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -49,7 +49,7 @@ public:
                                                 Expression* body = nullptr) {
     assert(type.isSignature());
     auto func = std::make_unique<Function>();
-    func->name = name;
+    func->setExplicitName(name);
     func->type = type;
     func->body = body;
     func->vars.swap(vars);
@@ -63,7 +63,7 @@ public:
                                                 Expression* body = nullptr) {
     assert(type.isSignature());
     auto func = std::make_unique<Function>();
-    func->name = name;
+    func->setExplicitName(name);
     func->type = type;
     func->body = body;
     for (size_t i = 0; i < params.size(); ++i) {
@@ -89,7 +89,7 @@ public:
                                           Address max = Table::kMaxSize,
                                           Type indexType = Type::i32) {
     auto table = std::make_unique<Table>();
-    table->name = name;
+    table->setExplicitName(name);
     table->type = type;
     table->indexType = indexType;
     table->initial = initial;
@@ -103,7 +103,7 @@ public:
                      Expression* offset = nullptr,
                      Type type = Type(HeapType::func, Nullable)) {
     auto seg = std::make_unique<ElementSegment>();
-    seg->name = name;
+    seg->setExplicitName(name);
     seg->table = table;
     seg->offset = offset;
     seg->type = type;
@@ -116,7 +116,7 @@ public:
                                             bool shared = false,
                                             Type indexType = Type::i32) {
     auto memory = std::make_unique<Memory>();
-    memory->name = name;
+    memory->setExplicitName(name);
     memory->initial = initial;
     memory->max = max;
     memory->shared = shared;
@@ -132,7 +132,7 @@ public:
                   const char* init = "",
                   Address size = 0) {
     auto seg = std::make_unique<DataSegment>();
-    seg->name = name;
+    seg->setExplicitName(name);
     seg->memory = memory;
     seg->isPassive = isPassive;
     seg->offset = offset;
@@ -155,7 +155,7 @@ public:
   static std::unique_ptr<Global>
   makeGlobal(Name name, Type type, Expression* init, Mutability mutable_) {
     auto glob = std::make_unique<Global>();
-    glob->name = name;
+    glob->setExplicitName(name);
     glob->type = type;
     glob->init = init;
     glob->mutable_ = mutable_ == Mutable;
@@ -164,7 +164,7 @@ public:
 
   static std::unique_ptr<Tag> makeTag(Name name, Signature sig) {
     auto tag = std::make_unique<Tag>();
-    tag->name = name;
+    tag->setExplicitName(name);
     tag->sig = sig;
     return tag;
   }


### PR DESCRIPTION
In all the cases I could find the `make_xx` helper method were called with meaningful names that are useful in the name section.

See #6496 and #6806