### PR TITLE
Restore isString type methods

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -96,9 +96,7 @@ public:
   // Whether this is GC data, that is, something stored on the heap (aside from
   // a null or i31). This includes structs, arrays, and also strings.
   bool isData() const { return type.isData(); }
-  bool isString() const {
-    return type.isRef() && type.getHeapType().isMaybeShared(HeapType::string);
-  }
+  bool isString() const { return type.isString(); }
 
   bool isNull() const { return type.isNull(); }
 
@@ -772,11 +770,11 @@ template<> struct hash<wasm::Literal> {
         wasm::rehash(digest, a.getFunc());
         return digest;
       }
-      if (a.type.getHeapType().isMaybeShared(wasm::HeapType::i31)) {
+      if (a.type.getHeapType() == wasm::HeapType::i31) {
         wasm::rehash(digest, a.geti31(true));
         return digest;
       }
-      if (a.type.getHeapType().isMaybeShared(wasm::HeapType::string)) {
+      if (a.type.isString()) {
         auto& values = a.getGCData()->values;
         wasm::rehash(digest, values.size());
         for (auto c : values) {

--- a/src/literal.h
+++ b/src/literal.h
@@ -770,7 +770,7 @@ template<> struct hash<wasm::Literal> {
         wasm::rehash(digest, a.getFunc());
         return digest;
       }
-      if (a.type.getHeapType() == wasm::HeapType::i31) {
+      if (a.type.getHeapType().isMaybeShared(wasm::HeapType::i31)) {
         wasm::rehash(digest, a.geti31(true));
         return digest;
       }

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -829,7 +829,7 @@ private:
       return true;
     }
     // We can emit a StringConst for a string constant.
-    if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::string)) {
+    if (type.isString()) {
       return true;
     }
     // All other reference types cannot be precomputed. Even an immutable GC

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -148,8 +148,7 @@ struct ExecutionResults {
     // simple and stable internal structures that optimizations will not alter.
     auto type = value.type;
     if (type.isRef()) {
-      if (type.getHeapType().isMaybeShared(HeapType::string) ||
-          type.getHeapType().isMaybeShared(HeapType::i31)) {
+      if (type.isString() || type.getHeapType() == HeapType::i31) {
         std::cout << value << '\n';
       } else if (value.isNull()) {
         std::cout << "null\n";
@@ -190,9 +189,7 @@ struct ExecutionResults {
     // TODO: Once we support optimizing under some form of open-world
     // assumption, we should be able to check that the types and/or structure of
     // GC data passed out of the module does not change.
-    if (a.type.isRef() &&
-        !a.type.getHeapType().isMaybeShared(HeapType::string) &&
-        !a.type.getHeapType().isMaybeShared(HeapType::i31)) {
+    if (a.type.isRef() && !a.type.isString()) {
       return true;
     }
     if (a != b) {

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -148,7 +148,7 @@ struct ExecutionResults {
     // simple and stable internal structures that optimizations will not alter.
     auto type = value.type;
     if (type.isRef()) {
-      if (type.isString() || type.getHeapType() == HeapType::i31) {
+      if (type.isString() || type.getHeapType().isMaybeShared(HeapType::i31)) {
         std::cout << value << '\n';
       } else if (value.isNull()) {
         std::cout << "null\n";
@@ -189,7 +189,8 @@ struct ExecutionResults {
     // TODO: Once we support optimizing under some form of open-world
     // assumption, we should be able to check that the types and/or structure of
     // GC data passed out of the module does not change.
-    if (a.type.isRef() && !a.type.isString()) {
+    if (a.type.isRef() && !a.type.isString() &&
+        !a.type.getHeapType().isMaybeShared(HeapType::i31)) {
       return true;
     }
     if (a != b) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2536,8 +2536,7 @@ Expression* TranslateToFuzzReader::makeConst(Type type) {
     if (type.isNullable() && oneIn(8)) {
       return builder.makeRefNull(type.getHeapType());
     }
-    if (type.getHeapType().isMaybeShared(HeapType::string)) {
-      assert(!type.getHeapType().isShared() && "TODO: shared strings");
+    if (type.getHeapType().isString()) {
       return makeStringConst();
     }
     if (type.getHeapType().isBasic()) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -841,7 +841,7 @@ public:
     // externalized i31s) can be handled by the general makeConstantExpression
     // logic (which knows how to handle externalization, for i31s; and it also
     // can handle string constants).
-    if (!value.isData() || value.type.getHeapType().isString()) {
+    if (!value.isData() || value.isString()) {
       return builder.makeConstantExpression(original);
     }
 

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -841,8 +841,7 @@ public:
     // externalized i31s) can be handled by the general makeConstantExpression
     // logic (which knows how to handle externalization, for i31s; and it also
     // can handle string constants).
-    if (!value.isData() ||
-        value.type.getHeapType().isMaybeShared(HeapType::string)) {
+    if (!value.isData() || value.type.getHeapType().isString()) {
       return builder.makeConstantExpression(original);
     }
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1217,28 +1217,26 @@ public:
     if (type.isFunction()) {
       return makeRefFunc(value.getFunc(), type.getHeapType());
     }
-    if (type.isRef()) {
-      if (type.getHeapType().isMaybeShared(HeapType::i31)) {
-        return makeRefI31(makeConst(value.geti31()),
-                          type.getHeapType().getShared());
+    if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::i31)) {
+      return makeRefI31(makeConst(value.geti31()),
+                        type.getHeapType().getShared());
+    }
+    if (type.isString()) {
+      // The string is already WTF-16, but we need to convert from `Literals` to
+      // actual string.
+      std::stringstream wtf16;
+      for (auto c : value.getGCData()->values) {
+        auto u = c.getInteger();
+        assert(u < 0x10000);
+        wtf16 << uint8_t(u & 0xFF);
+        wtf16 << uint8_t(u >> 8);
       }
-      if (type.getHeapType().isMaybeShared(HeapType::string)) {
-        // The string is already WTF-16, but we need to convert from `Literals`
-        // to actual string.
-        std::stringstream wtf16;
-        for (auto c : value.getGCData()->values) {
-          auto u = c.getInteger();
-          assert(u < 0x10000);
-          wtf16 << uint8_t(u & 0xFF);
-          wtf16 << uint8_t(u >> 8);
-        }
-        // TODO: Use wtf16.view() once we have C++20.
-        return makeStringConst(wtf16.str());
-      }
-      if (type.getHeapType().isMaybeShared(HeapType::ext)) {
-        return makeRefAs(ExternConvertAny,
-                         makeConstantExpression(value.internalize()));
-      }
+      // TODO: Use wtf16.view() once we have C++20.
+      return makeStringConst(wtf16.str());
+    }
+    if (type.isRef() && type.getHeapType() == HeapType::ext) {
+      return makeRefAs(ExternConvertAny,
+                       makeConstantExpression(value.internalize()));
     }
     TODO_SINGLE_COMPOUND(type);
     WASM_UNREACHABLE("unsupported constant expression");

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -1234,7 +1234,7 @@ public:
       // TODO: Use wtf16.view() once we have C++20.
       return makeStringConst(wtf16.str());
     }
-    if (type.isRef() && type.getHeapType() == HeapType::ext) {
+    if (type.isRef() && type.getHeapType().isMaybeShared(HeapType::ext)) {
       return makeRefAs(ExternConvertAny,
                        makeConstantExpression(value.internalize()));
     }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -170,6 +170,7 @@ public:
   bool isSignature() const;
   bool isStruct() const;
   bool isArray() const;
+  bool isString() const;
   bool isDefaultable() const;
 
   Nullability getNullability() const;
@@ -387,6 +388,7 @@ public:
   bool isContinuation() const { return getKind() == HeapTypeKind::Cont; }
   bool isStruct() const { return getKind() == HeapTypeKind::Struct; }
   bool isArray() const { return getKind() == HeapTypeKind::Array; }
+  bool isString() const { return isMaybeShared(HeapType::string); }
   bool isBottom() const;
   bool isOpen() const;
   bool isShared() const { return getShared() == Shared; }

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -439,7 +439,7 @@ bool Literal::operator==(const Literal& other) const {
       assert(func.is() && other.func.is());
       return func == other.func;
     }
-    if (type.getHeapType().isMaybeShared(HeapType::string)) {
+    if (type.isString()) {
       return gcData->values == other.gcData->values;
     }
     if (type.isData()) {

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -814,6 +814,8 @@ bool Type::isStruct() const { return isRef() && getHeapType().isStruct(); }
 
 bool Type::isArray() const { return isRef() && getHeapType().isArray(); }
 
+bool Type::isString() const { return isRef() && getHeapType().isString(); }
+
 bool Type::isDefaultable() const {
   // A variable can get a default value if its type is concrete (unreachable
   // and none have no values, hence no default), and if it's a reference, it


### PR DESCRIPTION
PR ##6803 proposed removing Type::isString and HeapType::isString in
favor of more explicit, verbose callsites. There was no consensus to
make this change, but it was accidentally committed as part of #6804.

Revert the accidental change, except for the useful, noncontroversial
parts, such as fixing the `isString` implementation and a few other
locations to correctly handle shared types.
