### PR TITLE
[parser] Fix bug when printing type builder errors

### DIFF
--- a/src/parser/parse-2-typedefs.cpp
+++ b/src/parser/parse-2-typedefs.cpp
@@ -34,7 +34,7 @@ Result<> parseTypeDefs(
   if (auto* err = built.getError()) {
     std::stringstream msg;
     msg << "invalid type: " << err->reason;
-    return ctx.in.err(decls.typeDefs[err->index].pos, msg.str());
+    return ctx.in.err(decls.subtypeDefs[err->index].pos, msg.str());
   }
   types = *built;
   // Record type names on the module and in typeNames.

--- a/test/lit/parse-bad-supertype-8616.wast
+++ b/test/lit/parse-bad-supertype-8616.wast
@@ -1,0 +1,11 @@
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s
+
+;; CHECK: Fatal: 9:2: error: invalid type: Heap type has an undeclared supertype
+
+;; Regression test for a parser bug that caused an assertion failure in this case.
+(module
+ (rec
+  (type $A (sub (struct (field i32))))
+  (type $B (sub $B (struct (field i32) (field i32))))
+ )
+)


### PR DESCRIPTION
The type index from the TypeBuilder error was mapped to a file location
incorrectly, resulting in an assertion failure.

Fixes #6816.
