### PR TITLE
[NFC][parser] Rename deftype and subtype

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -885,8 +885,8 @@ struct ParseDeclsCtx : NullTypeParserCtx, NullInstrParserCtx {
   Module& wasm;
 
   // The module element definitions we are parsing in this phase.
+  std::vector<DefPos> recTypeDefs;
   std::vector<DefPos> typeDefs;
-  std::vector<DefPos> subtypeDefs;
   std::vector<DefPos> funcDefs;
   std::vector<DefPos> tableDefs;
   std::vector<DefPos> memoryDefs;
@@ -939,15 +939,15 @@ struct ParseDeclsCtx : NullTypeParserCtx, NullInstrParserCtx {
   void setOpen() {}
   void setShared() {}
   Result<> addSubtype(HeapTypeT) { return Ok{}; }
-  void finishSubtype(Name name, Index pos) {
+  void finishTypeDef(Name name, Index pos) {
     // TODO: type annotations
-    subtypeDefs.push_back({name, pos, Index(subtypeDefs.size()), {}});
+    typeDefs.push_back({name, pos, Index(typeDefs.size()), {}});
   }
   size_t getRecGroupStartIndex() { return 0; }
   void addRecGroup(Index, size_t) {}
-  void finishDeftype(Index pos) {
+  void finishRectype(Index pos) {
     // TODO: type annotations
-    typeDefs.push_back({{}, pos, Index(typeDefs.size()), {}});
+    recTypeDefs.push_back({{}, pos, Index(recTypeDefs.size()), {}});
   }
 
   Limits makeLimits(uint64_t n, std::optional<uint64_t> m) {
@@ -1115,7 +1115,7 @@ struct ParseTypeDefsCtx : TypeParserCtx<ParseTypeDefsCtx> {
     return Ok{};
   }
 
-  void finishSubtype(Name name, Index pos) { names[index++].name = name; }
+  void finishTypeDef(Name name, Index pos) { names[index++].name = name; }
 
   size_t getRecGroupStartIndex() { return index; }
 
@@ -1123,7 +1123,7 @@ struct ParseTypeDefsCtx : TypeParserCtx<ParseTypeDefsCtx> {
     builder.createRecGroup(start, len);
   }
 
-  void finishDeftype(Index) {}
+  void finishRectype(Index) {}
 };
 
 // Phase 3: Parse type uses to find implicitly defined types.

--- a/src/parser/parse-2-typedefs.cpp
+++ b/src/parser/parse-2-typedefs.cpp
@@ -24,17 +24,17 @@ Result<> parseTypeDefs(
   IndexMap& typeIndices,
   std::vector<HeapType>& types,
   std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames) {
-  TypeBuilder builder(decls.subtypeDefs.size());
+  TypeBuilder builder(decls.typeDefs.size());
   ParseTypeDefsCtx ctx(input, builder, typeIndices);
-  for (auto& typeDef : decls.typeDefs) {
-    WithPosition with(ctx, typeDef.pos);
-    CHECK_ERR(deftype(ctx));
+  for (auto& recType : decls.recTypeDefs) {
+    WithPosition with(ctx, recType.pos);
+    CHECK_ERR(rectype(ctx));
   }
   auto built = builder.build();
   if (auto* err = built.getError()) {
     std::stringstream msg;
     msg << "invalid type: " << err->reason;
-    return ctx.in.err(decls.subtypeDefs[err->index].pos, msg.str());
+    return ctx.in.err(decls.typeDefs[err->index].pos, msg.str());
   }
   types = *built;
   // Record type names on the module and in typeNames.

--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -338,8 +338,9 @@ MaybeResult<ImportNames> inlineImport(Lexer&);
 Result<std::vector<Name>> inlineExports(Lexer&);
 template<typename Ctx> Result<> comptype(Ctx&);
 template<typename Ctx> Result<> sharecomptype(Ctx&);
-template<typename Ctx> MaybeResult<typename Ctx::ModuleNameT> subtype(Ctx&);
-template<typename Ctx> MaybeResult<> deftype(Ctx&);
+template<typename Ctx> Result<> subtype(Ctx&);
+template<typename Ctx> MaybeResult<> typedef_(Ctx&);
+template<typename Ctx> MaybeResult<> rectype(Ctx&);
 template<typename Ctx> MaybeResult<typename Ctx::LocalsT> locals(Ctx&);
 template<typename Ctx> MaybeResult<> import_(Ctx&);
 template<typename Ctx> MaybeResult<> func(Ctx&);
@@ -2780,20 +2781,8 @@ template<typename Ctx> Result<> sharecomptype(Ctx& ctx) {
   return Ok{};
 }
 
-// subtype ::= '(' 'type' id? '(' 'sub' typeidx? sharecomptype ')' ')'
-//           | '(' 'type' id? sharecomptype ')'
-template<typename Ctx> MaybeResult<> subtype(Ctx& ctx) {
-  auto pos = ctx.in.getPos();
-
-  if (!ctx.in.takeSExprStart("type"sv)) {
-    return {};
-  }
-
-  Name name;
-  if (auto id = ctx.in.takeID()) {
-    name = *id;
-  }
-
+// subtype ::= '(' 'sub' typeidx? sharecomptype ')'  | sharecomptype
+template<typename Ctx> Result<> subtype(Ctx& ctx) {
   if (ctx.in.takeSExprStart("sub"sv)) {
     if (!ctx.in.takeKeyword("final"sv)) {
       ctx.setOpen();
@@ -2811,24 +2800,42 @@ template<typename Ctx> MaybeResult<> subtype(Ctx& ctx) {
   } else {
     CHECK_ERR(sharecomptype(ctx));
   }
+  return Ok{};
+}
+
+// typedef ::= '(' 'type' id? subtype ')'
+template<typename Ctx> MaybeResult<> typedef_(Ctx& ctx) {
+  auto pos = ctx.in.getPos();
+
+  if (!ctx.in.takeSExprStart("type"sv)) {
+    return {};
+  }
+
+  Name name;
+  if (auto id = ctx.in.takeID()) {
+    name = *id;
+  }
+
+  auto sub = subtype(ctx);
+  CHECK_ERR(sub);
 
   if (!ctx.in.takeRParen()) {
     return ctx.in.err("expected end of type definition");
   }
 
-  ctx.finishSubtype(name, pos);
+  ctx.finishTypeDef(name, pos);
   return Ok{};
 }
 
-// deftype ::= '(' 'rec' subtype* ')'
+// rectype ::= '(' 'rec' subtype* ')'
 //           | subtype
-template<typename Ctx> MaybeResult<> deftype(Ctx& ctx) {
+template<typename Ctx> MaybeResult<> rectype(Ctx& ctx) {
   auto pos = ctx.in.getPos();
 
   if (ctx.in.takeSExprStart("rec"sv)) {
     size_t startIndex = ctx.getRecGroupStartIndex();
     size_t groupLen = 0;
-    while (auto type = subtype(ctx)) {
+    while (auto type = typedef_(ctx)) {
       CHECK_ERR(type);
       ++groupLen;
     }
@@ -2836,13 +2843,13 @@ template<typename Ctx> MaybeResult<> deftype(Ctx& ctx) {
       return ctx.in.err("expected type definition or end of recursion group");
     }
     ctx.addRecGroup(startIndex, groupLen);
-  } else if (auto type = subtype(ctx)) {
+  } else if (auto type = typedef_(ctx)) {
     CHECK_ERR(type);
   } else {
     return {};
   }
 
-  ctx.finishDeftype(pos);
+  ctx.finishRectype(pos);
   return Ok{};
 }
 
@@ -3464,7 +3471,7 @@ template<typename Ctx> MaybeResult<> modulefield(Ctx& ctx) {
   if (ctx.in.empty() || ctx.in.peekRParen()) {
     return {};
   }
-  if (auto res = deftype(ctx)) {
+  if (auto res = rectype(ctx)) {
     CHECK_ERR(res);
     return Ok{};
   }

--- a/src/parser/wat-parser.cpp
+++ b/src/parser/wat-parser.cpp
@@ -97,7 +97,7 @@ Result<> doParseModule(Module& wasm, Lexer& input, bool allowExtra) {
     return decls.in.err("Unexpected tokens after module");
   }
 
-  auto typeIndices = createIndexMap(decls.in, decls.subtypeDefs);
+  auto typeIndices = createIndexMap(decls.in, decls.typeDefs);
   CHECK_ERR(typeIndices);
 
   std::vector<HeapType> types;


### PR DESCRIPTION
Match the current spec and clarify terminology by renaming the old `deftype` to
`rectype` and renaming the old `subtype` to `typedef`. Also split the parser for
actual `subtype` out of the parser for the newly named `typedef`.
