### PR TITLE
Typed continuations: update syntax of handler clauses

### DIFF
--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -2426,7 +2426,7 @@ makeContNew(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   return ctx.makeContNew(pos, annotations, *type);
 }
 
-// resume ::= 'resume' typeidx ('(' 'tag' tagidx labelidx ')')*
+// resume ::= 'resume' typeidx ('(' 'on' tagidx labelidx ')')*
 template<typename Ctx>
 Result<>
 makeResume(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
@@ -2434,7 +2434,7 @@ makeResume(Ctx& ctx, Index pos, const std::vector<Annotation>& annotations) {
   CHECK_ERR(type);
 
   auto tagLabels = ctx.makeTagLabelList();
-  while (ctx.in.takeSExprStart("tag"sv)) {
+  while (ctx.in.takeSExprStart("on"sv)) {
     auto tag = tagidx(ctx);
     CHECK_ERR(tag);
     auto label = labelidx(ctx);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2347,11 +2347,9 @@ struct PrintExpressionContents
     o << ' ';
     printHeapType(curr->contType);
 
-    // We deliberate keep all (tag ...) clauses on the same line as the resume
-    // itself to work around a quirk in update_lit_checks.py
     for (Index i = 0; i < curr->handlerTags.size(); i++) {
       o << " (";
-      printMedium(o, "tag ");
+      printMedium(o, "on ");
       curr->handlerTags[i].print(o);
       o << ' ';
       curr->handlerBlocks[i].print(o);

--- a/test/lit/basic/typed_continuations_resume.wast
+++ b/test/lit/basic/typed_continuations_resume.wast
@@ -39,7 +39,7 @@
  ;; CHECK-BINARY-NEXT:  (drop
  ;; CHECK-BINARY-NEXT:   (block $label$1 (result (ref $ct))
  ;; CHECK-BINARY-NEXT:    (return
- ;; CHECK-BINARY-NEXT:     (resume $ct (tag $t $label$1)
+ ;; CHECK-BINARY-NEXT:     (resume $ct (on $t $label$1)
  ;; CHECK-BINARY-NEXT:      (i32.const 123)
  ;; CHECK-BINARY-NEXT:      (local.get $x)
  ;; CHECK-BINARY-NEXT:     )
@@ -52,7 +52,7 @@
  ;; CHECK-TEXT-NEXT:  (tuple.extract 2 0
  ;; CHECK-TEXT-NEXT:   (block $handler (type $2) (result i32 (ref $ct))
  ;; CHECK-TEXT-NEXT:    (return
- ;; CHECK-TEXT-NEXT:     (resume $ct (tag $t $handler)
+ ;; CHECK-TEXT-NEXT:     (resume $ct (on $t $handler)
  ;; CHECK-TEXT-NEXT:      (i32.const 123)
  ;; CHECK-TEXT-NEXT:      (local.get $x)
  ;; CHECK-TEXT-NEXT:     )
@@ -66,7 +66,7 @@
  ;; CHECK-BIN-NEXT:  (local.set $1
  ;; CHECK-BIN-NEXT:   (block $label$1 (type $2) (result i32 (ref $ct))
  ;; CHECK-BIN-NEXT:    (return
- ;; CHECK-BIN-NEXT:     (resume $ct (tag $t $label$1)
+ ;; CHECK-BIN-NEXT:     (resume $ct (on $t $label$1)
  ;; CHECK-BIN-NEXT:      (i32.const 123)
  ;; CHECK-BIN-NEXT:      (local.get $x)
  ;; CHECK-BIN-NEXT:     )
@@ -92,7 +92,7 @@
    (block $handler (result i32 (ref $ct))
     (return
      (resume $ct
-      (tag $t $handler)
+      (on $t $handler)
       (i32.const 123)
       (local.get $x)
      )
@@ -115,7 +115,7 @@
 ;; CHECK-NODEBUG-NEXT:  (drop
 ;; CHECK-NODEBUG-NEXT:   (block $label$1 (result (ref $1))
 ;; CHECK-NODEBUG-NEXT:    (return
-;; CHECK-NODEBUG-NEXT:     (resume $1 (tag $tag$0 $label$1)
+;; CHECK-NODEBUG-NEXT:     (resume $1 (on $tag$0 $label$1)
 ;; CHECK-NODEBUG-NEXT:      (i32.const 123)
 ;; CHECK-NODEBUG-NEXT:      (local.get $0)
 ;; CHECK-NODEBUG-NEXT:     )
@@ -140,7 +140,7 @@
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $1
 ;; CHECK-BIN-NODEBUG-NEXT:   (block $label$1 (type $2) (result i32 (ref $1))
 ;; CHECK-BIN-NODEBUG-NEXT:    (return
-;; CHECK-BIN-NODEBUG-NEXT:     (resume $1 (tag $tag$0 $label$1)
+;; CHECK-BIN-NODEBUG-NEXT:     (resume $1 (on $tag$0 $label$1)
 ;; CHECK-BIN-NODEBUG-NEXT:      (i32.const 123)
 ;; CHECK-BIN-NODEBUG-NEXT:      (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:     )

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -4868,7 +4868,7 @@
  ;; CHECK-NEXT:     (tuple.drop 3
  ;; CHECK-NEXT:      (block $block0 (type $36) (result i32 i64 (ref null $simple-cont))
  ;; CHECK-NEXT:       (local.set $f
- ;; CHECK-NEXT:        (resume $simple-cont (tag $empty $block) (tag $tag-pair-to-pair $block0)
+ ;; CHECK-NEXT:        (resume $simple-cont (on $empty $block) (on $tag-pair-to-pair $block0)
  ;; CHECK-NEXT:         (i32.const 0)
  ;; CHECK-NEXT:         (i64.const 1)
  ;; CHECK-NEXT:         (local.get $ct)
@@ -4890,7 +4890,7 @@
     i32.const 0
     i64.const 1
     local.get $ct
-    resume $simple-cont (tag $empty 1) (tag $tag-pair-to-pair 0)
+    resume $simple-cont (on $empty 1) (on $tag-pair-to-pair 0)
     local.set $f
     unreachable
    end


### PR DESCRIPTION
The syntax for handler clauses in `resume` instructions has recently changed, using `on` instead of `tag` now.

Instead of 
```
(resume $ct (tag $tag0 $block0) ...  (tag $tagn $blockn))
```

we now have

```
(resume $ct (on $tag0 $block0) ...  (on $tagn $blockn))
```

This PR adapts parsing, printing, and some tests accordingly.

(Note that this PR deliberately makes none of the other changes that will arise from implementing the new, combined stack switching proposal, yet.)
