### PR TITLE
Set hasExplicitName for thunks generated in FuncCastEmulation. NFC

### DIFF
--- a/src/passes/FuncCastEmulation.cpp
+++ b/src/passes/FuncCastEmulation.cpp
@@ -206,6 +206,7 @@ private:
                            Signature(Type(thunkParams), Type::i64),
                            {}, // no vars
                            toABI(call, module));
+    thunkFunc->hasExplicitName = true;
     module->addFunction(std::move(thunkFunc));
     return thunk;
   }


### PR DESCRIPTION
Without this all the newly created thunks lack names in the name section.