### PR TITLE
Add a TypeBuilder API for copying a heap type

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -298,11 +298,14 @@ Type GlobalTypeRewriter::getTempType(Type type) {
     return type;
   }
   if (type.isRef()) {
-    auto ht = type.getHeapType();
-    if (auto it = typeIndices.find(ht); it != typeIndices.end()) {
-      ht = typeBuilder[it->second];
+    auto heapType = type.getHeapType();
+    if (auto it = typeIndices.find(heapType); it != typeIndices.end()) {
+      return typeBuilder.getTempRefType(typeBuilder[it->second],
+                                        type.getNullability());
     }
-    return typeBuilder.getTempRefType(ht, type.getNullability());
+    // This type is not one that is eligible for optimizing. That is fine; just
+    // use it unmodified.
+    return type;
   }
   if (type.isTuple()) {
     auto newTuple = type.getTuple();

--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -98,20 +98,7 @@ std::vector<HeapType> ensureTypesAreInNewRecGroup(RecGroup recGroup,
       // Make a builder and add a slot for the hash.
       TypeBuilder builder(num + 1);
       for (Index i = 0; i < num; i++) {
-        auto type = types[i];
-        if (type.isStruct()) {
-          builder[i] = type.getStruct();
-        } else {
-          // Atm this pass only needs struct and array types. If we refactor
-          // this function to be general purpose we'd need to extend that. TODO
-          assert(type.isArray());
-          builder[i] = type.getArray();
-        }
-        if (auto super = type.getDeclaredSuperType()) {
-          builder[i].subTypeOf(*super);
-        }
-        builder[i].setOpen(type.isOpen());
-        builder[i].setShared(type.getShared());
+        builder[i].copy(types[i]);
       }
 
       // Implement the hash as a struct with "random" fields, and add it.

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -709,7 +709,8 @@ struct TypeBuilder {
       case HeapTypeKind::Array: {
         auto elem = type.getArray().element;
         elem.type = copyType(elem.type);
-        setHeapType(i, Array(elem));
+        // MSVC gets confused without this disambiguation.
+        setHeapType(i, wasm::Array(elem));
         return;
       }
       case HeapTypeKind::Cont:

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -660,6 +660,66 @@ struct TypeBuilder {
   void setHeapType(size_t i, Struct&& struct_);
   void setHeapType(size_t i, Array array);
 
+  // Sets the heap type at index `i` to be a copy of the given heap type with
+  // its referenced HeapTypes to be replaced according to the provided mapping
+  // function.
+  template<typename F> void copyHeapType(size_t i, HeapType type, F map) {
+    assert(!type.isBasic());
+    if (auto super = type.getDeclaredSuperType()) {
+      setSubType(i, map(*super));
+    }
+    setOpen(i, type.isOpen());
+    setShared(i, type.getShared());
+
+    auto copySingleType = [&](Type t) -> Type {
+      if (t.isBasic()) {
+        return t;
+      }
+      assert(t.isRef());
+      return getTempRefType(map(t.getHeapType()), t.getNullability());
+    };
+    auto copyType = [&](Type t) -> Type {
+      if (t.isTuple()) {
+        std::vector<Type> elems;
+        elems.reserve(t.size());
+        for (auto elem : t) {
+          elems.push_back(copySingleType(elem));
+        }
+        return getTempTupleType(Tuple(elems));
+      }
+      return copySingleType(t);
+    };
+    switch (type.getKind()) {
+      case HeapTypeKind::Func: {
+        auto sig = type.getSignature();
+        setHeapType(i, Signature(copyType(sig.params), copyType(sig.results)));
+        return;
+      }
+      case HeapTypeKind::Struct: {
+        const auto& struct_ = type.getStruct();
+        std::vector<Field> fields;
+        fields.reserve(struct_.fields.size());
+        for (auto field : struct_.fields) {
+          field.type = copyType(field.type);
+          fields.push_back(field);
+        }
+        setHeapType(i, Struct(fields));
+        return;
+      }
+      case HeapTypeKind::Array: {
+        auto elem = type.getArray().element;
+        elem.type = copyType(elem.type);
+        setHeapType(i, Array(elem));
+        return;
+      }
+      case HeapTypeKind::Cont:
+        setHeapType(i, Continuation(map(type.getContinuation().type)));
+        return;
+      case HeapTypeKind::Basic:
+        WASM_UNREACHABLE("unexpected kind");
+    }
+  }
+
   // Gets the temporary HeapType at index `i`. This HeapType should only be used
   // to construct temporary Types using the methods below.
   HeapType getTempHeapType(size_t i);
@@ -672,7 +732,7 @@ struct TypeBuilder {
 
   // Declare the HeapType being built at index `i` to be an immediate subtype of
   // the given HeapType.
-  void setSubType(size_t i, HeapType super);
+  void setSubType(size_t i, std::optional<HeapType> super);
 
   // Create a new recursion group covering slots [i, i + length). Groups must
   // not overlap or go out of bounds.
@@ -746,7 +806,7 @@ struct TypeBuilder {
       builder.setHeapType(index, array);
       return *this;
     }
-    Entry& subTypeOf(HeapType other) {
+    Entry& subTypeOf(std::optional<HeapType> other) {
       builder.setSubType(index, other);
       return *this;
     }
@@ -756,6 +816,10 @@ struct TypeBuilder {
     }
     Entry& setShared(Shareability share = Shared) {
       builder.setShared(index, share);
+      return *this;
+    }
+    template<typename F> Entry& copy(HeapType type, F map) {
+      builder.copyHeapType(index, type, map);
       return *this;
     }
   };

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -685,7 +685,7 @@ struct TypeBuilder {
         for (auto elem : t) {
           elems.push_back(copySingleType(elem));
         }
-        return getTempTupleType(Tuple(elems));
+        return getTempTupleType(elems);
       }
       return copySingleType(t);
     };

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -822,6 +822,9 @@ struct TypeBuilder {
       builder.copyHeapType(index, type, map);
       return *this;
     }
+    Entry& copy(HeapType type) {
+      return copy(type, [](HeapType t) { return t; });
+    }
   };
 
   Entry operator[](size_t i) { return Entry{*this, i}; }

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2532,10 +2532,10 @@ Type TypeBuilder::getTempRefType(HeapType type, Nullability nullable) {
   return markTemp(impl->typeStore.insert(TypeInfo(type, nullable)));
 }
 
-void TypeBuilder::setSubType(size_t i, HeapType super) {
+void TypeBuilder::setSubType(size_t i, std::optional<HeapType> super) {
   assert(i < size() && "index out of bounds");
   HeapTypeInfo* sub = impl->entries[i].info.get();
-  sub->supertype = getHeapTypeInfo(super);
+  sub->supertype = super ? getHeapTypeInfo(*super) : nullptr;
 }
 
 void TypeBuilder::createRecGroup(size_t index, size_t length) {


### PR DESCRIPTION
Given a function that maps the old child heap types to new child heap
types, the new API takes care of copying the rest of the structure of a
given heap type into a TypeBuilder slot.

Use the new API in GlobalTypeRewriter::rebuildTypes. It will also be
used in an upcoming type optimization. This refactoring also required
adding the ability to clear the supertype of a TypeBuilder slot, which
was previously not possible.
