### PR TITLE
Heap2Local: Track interactions in detail

### DIFF
--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -619,8 +619,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   // Adjust the type that flows through an expression, updating that type as
   // necessary.
   void adjustTypeFlowingThrough(Expression* curr) {
-    if (analyzer.getInteraction(curr) !=
-        ParentChildInteraction::Flows) {
+    if (analyzer.getInteraction(curr) != ParentChildInteraction::Flows) {
       return;
     }
 
@@ -640,8 +639,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   void visitLoop(Loop* curr) { adjustTypeFlowingThrough(curr); }
 
   void visitLocalSet(LocalSet* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -655,8 +653,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitLocalGet(LocalGet* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -678,8 +675,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitBreak(Break* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -761,8 +757,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitRefIsNull(RefIsNull* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -773,8 +768,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitRefEq(RefEq* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -788,18 +782,15 @@ struct Struct2Local : PostWalker<Struct2Local> {
     // compared to something else, the result must be 0, as our reference does
     // not escape to any other place.
     int32_t result =
-      analyzer.getInteraction(curr->left) ==
-        ParentChildInteraction::Flows &&
-      analyzer.getInteraction(curr->right) ==
-        ParentChildInteraction::Flows;
+      analyzer.getInteraction(curr->left) == ParentChildInteraction::Flows &&
+      analyzer.getInteraction(curr->right) == ParentChildInteraction::Flows;
     replaceCurrent(builder.makeBlock({builder.makeDrop(curr->left),
                                       builder.makeDrop(curr->right),
                                       builder.makeConst(Literal(result))}));
   }
 
   void visitRefAs(RefAs* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -810,8 +801,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitRefTest(RefTest* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -828,8 +818,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitRefCast(RefCast* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -853,8 +842,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitStructSet(StructSet* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -866,8 +854,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   }
 
   void visitStructGet(StructGet* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -1057,8 +1044,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
   }
 
   void visitArraySet(ArraySet* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -1078,8 +1064,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
   }
 
   void visitArrayGet(ArrayGet* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -1101,8 +1086,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
   // Some additional operations need special handling
 
   void visitRefTest(RefTest* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 
@@ -1118,8 +1102,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
   }
 
   void visitRefCast(RefCast* curr) {
-    if (analyzer.getInteraction(curr) ==
-        ParentChildInteraction::None) {
+    if (analyzer.getInteraction(curr) == ParentChildInteraction::None) {
       return;
     }
 

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -224,7 +224,9 @@ struct EscapeAnalyzer {
   // at the end, and how we fix it up may depend on the interaction,
   // specifically, it can matter if the allocations flows out of here (Flows,
   // which is the case for e.g. a Block that we flow through) or if it is fully
-  // consumed (FullyConsumes, e.g. for a struct.get).
+  // consumed (FullyConsumes, e.g. for a struct.get). We do not store irrelevant
+  // things here (that is, anything not in the map has the interaction |None|,
+  // implicitly).
   std::unordered_map<Expression*, ParentChildInteraction> reachedInteractions;
 
   // Analyze an allocation to see if it escapes or not.

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -526,7 +526,7 @@ struct EscapeAnalyzer {
   // Helper function for Struct2Local and Array2Struct. Given an old expression
   // that is being replaced by a new one, add the proper interaction for the
   // replacement.
-  void updateInteractionsMap(Expression* old, Expression* rep) {
+  void applyOldInteractionToReplacement(Expression* old, Expression* rep) {
     // We can only replace something relevant that we found in the analysis.
     // (Not only would anything else be invalid to process, but also we wouldn't
     // know what interaction to give the replacement.)
@@ -588,7 +588,7 @@ struct Struct2Local : PostWalker<Struct2Local> {
   bool refinalize = false;
 
   Expression* replaceCurrent(Expression* expression) {
-    analyzer.updateInteractionsMap(getCurrent(), expression);
+    analyzer.applyOldInteractionToReplacement(getCurrent(), expression);
     PostWalker<Struct2Local>::replaceCurrent(expression);
     return expression;
   }
@@ -1012,7 +1012,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
 
   // As in Struct2Local, when we replace something, copy the interaction.
   Expression* replaceCurrent(Expression* expression) {
-    analyzer.updateInteractionsMap(getCurrent(), expression);
+    analyzer.applyOldInteractionToReplacement(getCurrent(), expression);
     PostWalker<Array2Struct>::replaceCurrent(expression);
     return expression;
   }

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -286,8 +286,8 @@ struct EscapeAnalyzer {
       // If we got to here, then we can continue to hope that we can optimize
       // this allocation. Mark the parent and child as reached by it, and
       // continue.
-      assert(reached.count(parent));
-      reached[child] = interaction;
+      reached[child] = ParentChildInteraction::Flows;
+      reached[parent] = interaction;
     }
 
     // We finished the loop over the flows. Do the final checks.

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -523,9 +523,8 @@ struct EscapeAnalyzer {
     return true;
   }
 
-  // Helper function for Struct2Local and Array2Struct. Given a map of
-  // expressions to their ParentChildInteraction, and an old expression that is
-  // being replaced by a new one, add the proper interaction for the
+  // Helper function for Struct2Local and Array2Struct. Given an old expression
+  // that is being replaced by a new one, add the proper interaction for the
   // replacement.
   void updateInteractionsMap(Expression* old, Expression* rep) {
     // We can only replace something relevant that we found in the analysis.

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -216,8 +216,8 @@ struct EscapeAnalyzer {
 
   // A map of every expression we reached during the flow analysis (which is
   // exactly all the places where our allocation is used) to the interaction of
-  // the allocation there. Anything in this map will be fixed up at the end if
-  // we optimize, and how we fix it up may depend on the interaction,
+  // the allocation there. If we optimize, anything in this map will be fixed up
+  // at the end, and how we fix it up may depend on the interaction,
   // specifically, it can matter if the allocations flows out of here (Flows,
   // which is the case for e.g. a Block that we flow through) or if it is fully
   // consumed (FullyConsumes, e.g. for a struct.get).

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -1011,7 +1011,6 @@ struct Array2Struct : PostWalker<Array2Struct> {
     }
   }
 
-  // As in Struct2Local, when we replace something, copy the interaction.
   Expression* replaceCurrent(Expression* expression) {
     analyzer.applyOldInteractionToReplacement(getCurrent(), expression);
     PostWalker<Array2Struct>::replaceCurrent(expression);

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -784,8 +784,8 @@ struct Struct2Local : PostWalker<Struct2Local> {
       return iter->second == EscapeAnalyzer::ParentChildInteraction::Flows;
     };
 
-    int32_t result = isTheAllocation(curr->left) &&
-                     isTheAllocation(curr->right);
+    int32_t result =
+      isTheAllocation(curr->left) && isTheAllocation(curr->right);
     replaceCurrent(builder.makeBlock({builder.makeDrop(curr->left),
                                       builder.makeDrop(curr->right),
                                       builder.makeConst(Literal(result))}));
@@ -959,7 +959,7 @@ struct Array2Struct : PostWalker<Array2Struct> {
     // there is no harm to doing this twice in that case.
     analyzer.reachedInteractions[structNew] =
       analyzer.reachedInteractions[arrayNewReplacement] =
-      EscapeAnalyzer::ParentChildInteraction::Flows;
+        EscapeAnalyzer::ParentChildInteraction::Flows;
 
     // Update types along the path reached by the allocation: whenever we see
     // the array type, it should be the struct type. Note that we do this before

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -2194,7 +2194,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (i32.const 0)
+  ;; CHECK-NEXT:  (i32.const 1)
   ;; CHECK-NEXT: )
   (func $ref-eq-self (result i32)
     (local $eq eqref)

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -4435,9 +4435,7 @@
   ;; CHECK:      (type $A (sub (struct (field structref))))
   (type $A (sub (struct (field structref))))
 
-  ;; CHECK:      (export "1" (func $1))
-
-  ;; CHECK:      (func $1 (type $0)
+  ;; CHECK:      (func $struct.get-ref.eq (type $0)
   ;; CHECK-NEXT:  (local $x (ref $A))
   ;; CHECK-NEXT:  (local $1 structref)
   ;; CHECK-NEXT:  (if
@@ -4465,7 +4463,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $1 (export "1")
+  (func $struct.get-ref.eq
     (local $x (ref $A))
     ;; This ref.eq ends up comparing the tee'd allocation with a read of null
     ;; from the allocation's field, which returns 0. This tests that we can

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -2194,7 +2194,7 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (i32.const 1)
+  ;; CHECK-NEXT:  (i32.const 0)
   ;; CHECK-NEXT: )
   (func $ref-eq-self (result i32)
     (local $eq eqref)
@@ -4424,6 +4424,65 @@
         (local.tee $eq
           (array.new_fixed $array 0)
         )
+      )
+    )
+  )
+)
+
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (type $A (sub (struct (field structref))))
+  (type $A (sub (struct (field structref))))
+
+  ;; CHECK:      (export "1" (func $1))
+
+  ;; CHECK:      (func $1 (type $0)
+  ;; CHECK-NEXT:  (local $x (ref $A))
+  ;; CHECK-NEXT:  (local $1 structref)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result structref)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (block (result nullref)
+  ;; CHECK-NEXT:        (local.set $1
+  ;; CHECK-NEXT:         (ref.null none)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (ref.null none)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $1 (export "1")
+    (local $x (ref $A))
+    ;; This ref.eq ends up comparing the tee'd allocation with a read of null
+    ;; from the allocation's field, which returns 0. This tests that we can
+    ;; differentiate when the allocation gets somewhere vs when it flows out
+    ;; from that place, as the allocation does reach the struct.get - hence we
+    ;; need to update it, when we optimize - but it does not flow it back out.
+    (if
+      (ref.eq
+        (struct.get $A 0
+          (local.tee $x
+            (struct.new_default $A)
+          )
+        )
+        (local.get $x)
+      )
+      (then
+        (unreachable)
       )
     )
   )


### PR DESCRIPTION
Previously we tracked only whether an expression was relevant to analysis, that is,
whether it interacted with the allocation we were tracing the behavior of. That is
not enough for all cases, though, so also track the form of the interaction, namely
whether the allocation flows through or is fully consumed. An example where that
matters:

```wat
(ref.eq
  (struct.get $A 0
    (local.tee $x
      (struct.new_default $A)
    )
  )
  (local.get $x)
)
```
Here the `local.get` flows out the allocation, but the `struct.get` only fully consumes
it. Before this PR we thought the `struct.get` flowed the allocation, and we misoptimized
this to `1`.

To make this possible, do a bunch of minor refactoring:

* Move ParentChildInteraction out of the class.
* Add a "None" interaction there.
* Replace the set of reached expressions with a map of them to their interactions.
* Add helper functions to get an expression's interaction or to update it when replacing.

The new testcase here shows the main fix. The new assertions are covered by existing
testcases.