### PR TITLE
Fix OOB read bug - issue 6833

### DIFF
--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -2329,6 +2329,7 @@ Result<> makeArrayInitElem(Ctx& ctx,
   auto type = typeidx(ctx);
   CHECK_ERR(type);
   auto elem = elemidx(ctx);
+  CHECK_ERR(elem);
   return ctx.makeArrayInitElem(pos, annotations, *type, *elem);
 }
 


### PR DESCRIPTION
This PR fixes the out-of-bounds read bug noted in [issue 6833](https://github.com/WebAssembly/binaryen/issues/6833) by performing error checking on a pointer before it is used.

**Post fix output:**
```
./wasm-opt ./wasm-oob-read.wasm
Fatal: 1:184: error: expected elem index or identifier
```