### PR TITLE
Testing: Add an env var to pick the V8 binary

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -198,7 +198,7 @@ NATIVEXX = (os.environ.get('CXX') or which('mingw32-g++') or
 NODEJS = os.getenv('NODE', which('node') or which('nodejs'))
 MOZJS = which('mozjs') or which('spidermonkey')
 
-V8 = which('v8') or which('d8')
+V8 = os.environ.get('V8') or which('v8') or which('d8')
 
 BINARYEN_INSTALL_DIR = os.path.dirname(options.binaryen_bin)
 WASM_OPT = [os.path.join(options.binaryen_bin, 'wasm-opt')]

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -195,7 +195,7 @@ NATIVECC = (os.environ.get('CC') or which('mingw32-gcc') or
             which('gcc') or which('clang'))
 NATIVEXX = (os.environ.get('CXX') or which('mingw32-g++') or
             which('g++') or which('clang++'))
-NODEJS = os.getenv('NODE', which('node') or which('nodejs'))
+NODEJS = os.environ.get('NODE') or which('node') or which('nodejs')
 MOZJS = which('mozjs') or which('spidermonkey')
 
 V8 = os.environ.get('V8') or which('v8') or which('d8')


### PR DESCRIPTION
Also we had a mix of `os.environ.get` and `os.getenv`. Prefer the former, as the default
value does actual work, so it's a little more efficient to not run it unnecessarily. That is,
`os.getenv('X', work())` is less efficient than `os.environ.get('X') or work()`.