### PR TITLE
Count supertypes when collecting module types

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -516,11 +516,7 @@ InsertOrderedMap<HeapType, size_t> getHeapTypeCounts(Module& wasm,
       if (auto super = ht.getDeclaredSuperType()) {
         if (!counts.counts.count(*super)) {
           noteNewType(*super);
-          // We should unconditionally count supertypes, but while the type
-          // system is in flux, skip counting them to keep the type orderings in
-          // nominal test outputs more similar to the orderings in the
-          // equirecursive outputs. FIXME
-          counts.include(*super);
+          counts.note(*super);
         }
       }
 

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -658,17 +658,17 @@
 ;;            reference to the subtype (we never create a supertype) and so we
 ;;            can optimize.
 (module
-  ;; CHECK:      (type $0 (func))
-
   ;; CHECK:      (type $struct (sub (struct (field i32))))
   (type $struct (sub (struct i32)))
+
+  ;; CHECK:      (type $1 (func))
 
   ;; CHECK:      (type $substruct (sub $struct (struct (field i32) (field f64))))
   (type $substruct (sub $struct (struct i32 f64)))
 
   ;; CHECK:      (type $3 (func (param (ref null $struct))))
 
-  ;; CHECK:      (func $create (type $0)
+  ;; CHECK:      (func $create (type $1)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (struct.new $substruct
   ;; CHECK-NEXT:    (i32.const 10)


### PR DESCRIPTION
Previously we included supertypes, but did not increase their count.
This was done so that the output for the nominal type system, which
introduced explicitly supertypes, would more closely match the output
with the old equirecursive types system. Neither type system exists
anymore and we only support the single, standard isorecursive type
system, so we can now properly count supertypes. It turns out it doesn't
make much of a difference in the test outputs anyway.
