### PR TITLE
Heap type `none` requires GC

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1496,12 +1496,12 @@ FeatureSet HeapType::getFeatures() const {
           case HeapType::i31:
           case HeapType::struct_:
           case HeapType::array:
+          case HeapType::none:
             feats |= FeatureSet::ReferenceTypes | FeatureSet::GC;
             return;
           case HeapType::string:
             feats |= FeatureSet::ReferenceTypes | FeatureSet::Strings;
             return;
-          case HeapType::none:
           case HeapType::noext:
           case HeapType::nofunc:
             // Technically introduced in GC, but used internally as part of

--- a/test/lit/binary/strings-nogc.test
+++ b/test/lit/binary/strings-nogc.test
@@ -5,8 +5,5 @@
 (module
  (func $0
   (local $0 stringref)
-  (local.set $0
-   (ref.null none)
-  )
  )
 )

--- a/test/lit/validation/nullref-no-gc.wast
+++ b/test/lit/validation/nullref-no-gc.wast
@@ -1,0 +1,11 @@
+;; Test that nullref without GC is a validation error.
+
+;; RUN: not wasm-opt %s -all --disable-gc 2>&1 | filecheck %s
+
+;; CHECK: all used types should be allowed
+
+(module
+  (func $test
+    (local nullref)
+  )
+)

--- a/test/lit/validation/shared-null.wast
+++ b/test/lit/validation/shared-null.wast
@@ -4,7 +4,7 @@
 ;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED
 
 ;; NO-SHARED: ref.null requires additional features
-;; NO-SHARED: [--enable-reference-types --enable-shared-everything]
+;; NO-SHARED: [--enable-reference-types --enable-gc --enable-shared-everything]
 ;; SHARED: (ref.null (shared none))
 
 (module


### PR DESCRIPTION
Since reference types only introduced function and extern references,
all of the types in the `any` hierarchy require GC, including `none`.

Fixes #6839.
