### PR TITLE
Simplify validation of stale types

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3593,7 +3593,7 @@ static void validateBinaryenIR(Module& wasm, ValidationInfo& info) {
       ReFinalizeNode().visit(curr);
       auto newType = curr->type;
       // It's ok for types to be further refinable, but they must admit a
-      // supertype of the values allowed by the most precise possible type, i.e.
+      // superset of the values allowed by the most precise possible type, i.e.
       // they must not be strict subtypes of or unrelated to the refined type.
       if (!Type::isSubType(newType, oldType)) {
         std::ostringstream ss;


### PR DESCRIPTION
The previous rules for stale types were complicated and hard to
remember: in general it was ok for result types to be further refinable
as long as they were not refinable all the way to `unreachable`, but
control flow structures had a carve-out and it was ok for them to be
refinable all the way to unreachable.

Simplify the rules so that further refinable result types are always ok,
no matter what they can be refined to and no matter what kind of
instruction is being validated. This will be much easier to remember and
reason about.

This relaxation of the rules strictly increases the set of valid IR, so
no passes or tests need to be updated. It does make it possible for us
to miss type refinement opportunities that previously would have been
validation errors, but only in cases where non-control-flow instructions
could have been refined all the way to unreachable, so the risk seems
small.
