### PR TITLE
[NFC] Avoid v128 in rec groups with no other v128 uses

### DIFF
--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -1032,14 +1032,14 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $A (sub (struct (field i64) (field v128) (field nullref))))
-    (type $A (sub (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field v128) (field nullref))))
+    ;; CHECK-NEXT:  (type $A (sub (struct (field i64) (field eqref) (field nullref))))
+    (type $A (sub (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field eqref) (field nullref))))
 
-    ;; CHECK:       (type $C (sub $A (struct (field i64) (field v128) (field nullref) (field f64) (field anyref))))
-    (type $C (sub $A (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field v128) (field nullref))))
+    ;; CHECK:       (type $C (sub $A (struct (field i64) (field eqref) (field nullref) (field f64) (field anyref))))
+    (type $C (sub $A (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field eqref) (field nullref))))
 
-    ;; CHECK:       (type $B (sub $A (struct (field i64) (field v128) (field nullref) (field f32) (field anyref))))
-    (type $B (sub $A (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field v128) (field nullref))))
+    ;; CHECK:       (type $B (sub $A (struct (field i64) (field eqref) (field nullref) (field f32) (field anyref))))
+    (type $B (sub $A (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field eqref) (field nullref))))
   )
 
   ;; CHECK:       (type $3 (func (param anyref)))
@@ -1115,10 +1115,10 @@
     ;; Field 2 (f32)     is used only in $B.
     ;; Field 3 (f64)     is used only in $C.
     ;; Field 4 (anyref)  is used only in $B and $C.
-    ;; Field 5 (v128)    is used only in $A and $C.
+    ;; Field 5 (eqref)   is used only in $A and $C.
     ;; Field 6 (nullref) is used only in $A and $B.
     ;; As a result:
-    ;;   * A can keep only fields 1, 5, 6 (i64, v128, nullref).
+    ;;   * A can keep only fields 1, 5, 6 (i64, eqref, nullref).
     ;;   * B keeps A's fields, and appends 2, 4 (f32, anyref).
     ;;   * C keeps A's fields, and appends 3, 4 (f64, anyref).
 
@@ -1145,14 +1145,14 @@
 (module
   (rec
     ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $A (sub (struct (field i64) (field v128) (field nullref))))
-    (type $A (sub (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field v128) (field nullref))))
+    ;; CHECK-NEXT:  (type $A (sub (struct (field i64) (field eqref) (field nullref))))
+    (type $A (sub (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field eqref) (field nullref))))
 
-    ;; CHECK:       (type $B (sub $A (struct (field i64) (field v128) (field nullref) (field f32) (field anyref))))
-    (type $B (sub $A (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field v128) (field nullref))))
+    ;; CHECK:       (type $B (sub $A (struct (field i64) (field eqref) (field nullref) (field f32) (field anyref))))
+    (type $B (sub $A (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field eqref) (field nullref))))
 
-    ;; CHECK:       (type $C (sub $B (struct (field i64) (field v128) (field nullref) (field f32) (field anyref) (field f64))))
-    (type $C (sub $B (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field v128) (field nullref))))
+    ;; CHECK:       (type $C (sub $B (struct (field i64) (field eqref) (field nullref) (field f32) (field anyref) (field f64))))
+    (type $C (sub $B (struct (field i32) (field i64) (field f32) (field f64) (field anyref) (field eqref) (field nullref))))
   )
 
   ;; CHECK:       (type $3 (func (param anyref)))


### PR DESCRIPTION
We don't properly validate that yet. E.g.:

```wat
(module
 (rec
  (type $func (func))
  (type $unused (sub (struct (field v128))))
 )
 (func $func (type $func))
)
```
That v128 is not used, but it ends up in the output because it is in a rec group that is used.
Atm we do not require that SIMD be enabled in such a case, which can trip up the fuzzer.

Context: https://github.com/WebAssembly/binaryen/pull/6820#discussion_r1719085970 For now, modify the test that uncovered this.