### PR TITLE
[NFC] Use HeapType::getKind more broadly

### DIFF
--- a/src/ir/gc-type-utils.h
+++ b/src/ir/gc-type-utils.h
@@ -149,10 +149,15 @@ inline EvaluationResult evaluateCastCheck(Type refType, Type castType) {
 //
 // TODO: use in more places
 inline std::optional<Field> getField(HeapType type, Index index = 0) {
-  if (type.isStruct()) {
-    return type.getStruct().fields[index];
-  } else if (type.isArray()) {
-    return type.getArray().element;
+  switch (type.getKind()) {
+    case HeapTypeKind::Struct:
+      return type.getStruct().fields[index];
+    case HeapTypeKind::Array:
+      return type.getArray().element;
+    case HeapTypeKind::Func:
+    case HeapTypeKind::Cont:
+    case HeapTypeKind::Basic:
+      break;
   }
   return {};
 }

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -125,13 +125,20 @@ struct SubTypes {
     for (auto type : types) {
       HeapType basic;
       auto share = type.getShared();
-      if (type.isStruct()) {
-        basic = HeapTypes::struct_.getBasic(share);
-      } else if (type.isArray()) {
-        basic = HeapTypes::array.getBasic(share);
-      } else {
-        assert(type.isSignature());
-        basic = HeapTypes::func.getBasic(share);
+      switch (type.getKind()) {
+        case HeapTypeKind::Func:
+          basic = HeapTypes::func.getBasic(share);
+          break;
+        case HeapTypeKind::Struct:
+          basic = HeapTypes::struct_.getBasic(share);
+          break;
+        case HeapTypeKind::Array:
+          basic = HeapTypes::array.getBasic(share);
+          break;
+        case HeapTypeKind::Cont:
+          WASM_UNREACHABLE("TODO: cont");
+        case HeapTypeKind::Basic:
+          WASM_UNREACHABLE("unexpected kind");
       }
       auto& basicDepth = depths[basic];
       basicDepth = std::max(basicDepth, depths[type] + 1);

--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -237,12 +237,17 @@ struct TypeSSA : public Pass {
     for (Index i = 0; i < num; i++) {
       auto* curr = newsToModify[i];
       auto oldType = curr->type.getHeapType();
-      if (oldType.isStruct()) {
-        builder[i] = oldType.getStruct();
-      } else if (oldType.isArray()) {
-        builder[i] = oldType.getArray();
-      } else {
-        WASM_UNREACHABLE("unexpected type kind");
+      switch (oldType.getKind()) {
+        case HeapTypeKind::Struct:
+          builder[i] = oldType.getStruct();
+          break;
+        case HeapTypeKind::Array:
+          builder[i] = oldType.getArray();
+          break;
+        case HeapTypeKind::Func:
+        case HeapTypeKind::Cont:
+        case HeapTypeKind::Basic:
+          WASM_UNREACHABLE("unexpected kind");
       }
       builder[i].subTypeOf(oldType);
       builder[i].setShared(oldType.getShared());

--- a/src/passes/Unsubtyping.cpp
+++ b/src/passes/Unsubtyping.cpp
@@ -264,21 +264,31 @@ struct Unsubtyping
         if (super.isBasic()) {
           continue;
         }
-        if (type.isStruct()) {
-          const auto& fields = type.getStruct().fields;
-          const auto& superFields = super.getStruct().fields;
-          for (size_t i = 0, size = superFields.size(); i < size; ++i) {
-            noteSubtype(fields[i].type, superFields[i].type);
+        switch (type.getKind()) {
+          case HeapTypeKind::Func: {
+            auto sig = type.getSignature();
+            auto superSig = super.getSignature();
+            noteSubtype(superSig.params, sig.params);
+            noteSubtype(sig.results, superSig.results);
+            break;
           }
-        } else if (type.isArray()) {
-          auto elem = type.getArray().element;
-          noteSubtype(elem.type, super.getArray().element.type);
-        } else {
-          assert(type.isSignature());
-          auto sig = type.getSignature();
-          auto superSig = super.getSignature();
-          noteSubtype(superSig.params, sig.params);
-          noteSubtype(sig.results, superSig.results);
+          case HeapTypeKind::Struct: {
+            const auto& fields = type.getStruct().fields;
+            const auto& superFields = super.getStruct().fields;
+            for (size_t i = 0, size = superFields.size(); i < size; ++i) {
+              noteSubtype(fields[i].type, superFields[i].type);
+            }
+            break;
+          }
+          case HeapTypeKind::Array: {
+            auto elem = type.getArray().element;
+            noteSubtype(elem.type, super.getArray().element.type);
+            break;
+          }
+          case HeapTypeKind::Cont:
+            WASM_UNREACHABLE("TODO: cont");
+          case HeapTypeKind::Basic:
+            WASM_UNREACHABLE("unexpected kind");
         }
       }
 

--- a/src/tools/wasm-fuzz-types.cpp
+++ b/src/tools/wasm-fuzz-types.cpp
@@ -297,15 +297,22 @@ void Fuzzer::checkCanonicalization() {
       // Copy the original types
       for (; index < types.size(); ++index) {
         auto type = types[index];
-        if (type.isSignature()) {
-          builder[index] = getSignature(type.getSignature());
-        } else if (type.isStruct()) {
-          builder[index] = getStruct(type.getStruct());
-        } else if (type.isArray()) {
-          builder[index] = getArray(type.getArray());
-        } else {
-          WASM_UNREACHABLE("unexpected type kind");
+        switch (type.getKind()) {
+          case HeapTypeKind::Func:
+            builder[index] = getSignature(type.getSignature());
+            continue;
+          case HeapTypeKind::Struct:
+            builder[index] = getStruct(type.getStruct());
+            continue;
+          case HeapTypeKind::Array:
+            builder[index] = getArray(type.getArray());
+            continue;
+          case HeapTypeKind::Cont:
+            WASM_UNREACHABLE("TODO: cont");
+          case HeapTypeKind::Basic:
+            break;
         }
+        WASM_UNREACHABLE("unexpected type kind");
       }
     }
 


### PR DESCRIPTION
Replace code that checked `isStruct()`, `isArray()`, etc. in sequence
with uses of `HeapType::getKind()` and switch statements. This will make
it easier to find the code that needs updating if/when we add new heap
type kinds in the future. It also makes it much easier to find code that
already needs updating to handle continuation types by grepping for
"TODO: cont".
