### PR TITLE
fix null dereference in FunctionValidator::visitBlock validateCallParamsAndResult

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -606,9 +606,13 @@ private:
                     Type(Type::unreachable),
                     printable,
                     "return_call* should have unreachable type");
+      auto* func = getFunction();
+      if (!shouldBeTrue(!!func, curr, "function not defined")) {
+        return;
+      }
       shouldBeSubType(
         sig.results,
-        getFunction()->getResults(),
+        func->getResults(),
         printable,
         "return_call* callee return type must match caller return type");
     } else {
@@ -696,7 +700,12 @@ void FunctionValidator::visitBlock(Block* curr) {
     }
     breakTypes.erase(iter);
   }
-  switch (getFunction()->profile) {
+
+  auto* func = getFunction();
+  if (!shouldBeTrue(!!func, curr, "function not defined")) {
+    return;
+  }
+  switch (func->profile) {
     case IRProfile::Normal:
       validateNormalBlockElements(curr);
       break;

--- a/test/lit/validation/function-missing.wast
+++ b/test/lit/validation/function-missing.wast
@@ -1,0 +1,12 @@
+;; Test that we validate functions declaration and usage for globals.
+
+;; RUN: not wasm-opt %s -all 2>&1 | filecheck %s
+
+(module
+    ;; CHECK: function not defined
+    (global (mut i32)(block))
+
+    ;; CHECK: function not defined
+    (global (mut i32)(return_call 0))
+    (func $0(return_call 0)(return_call 0))
+)

--- a/test/lit/validation/function-missing.wast
+++ b/test/lit/validation/function-missing.wast
@@ -3,10 +3,12 @@
 ;; RUN: not wasm-opt %s -all 2>&1 | filecheck %s
 
 (module
-    ;; CHECK: function not defined
-    (global (mut i32)(block))
+  ;; CHECK: function not defined
+  (global (mut i32) (block))
 
-    ;; CHECK: function not defined
-    (global (mut i32)(return_call 0))
-    (func $0(return_call 0)(return_call 0))
+  ;; CHECK: function not defined
+  (global (mut i32) (return_call 0))
+
+  (func $0
+  )
 )


### PR DESCRIPTION
fix for #6847 and #6848 