### PR TITLE
Validate array.init_elem segment in IRBuilder

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1813,7 +1813,7 @@ Result<> IRBuilder::makeArrayInitElem(HeapType type, Name elem) {
   }
   ArrayInitElem curr;
   CHECK_ERR(ChildPopper{*this}.visitArrayInitElem(&curr, type));
-  CHECK_ERR(validateTypeAnnotation(type, curr.ref, true));
+  CHECK_ERR(validateTypeAnnotation(type, curr.ref));
   push(builder.makeArrayInitElem(
     elem, curr.ref, curr.index, curr.offset, curr.size));
   return Ok{};

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1801,9 +1801,19 @@ Result<> IRBuilder::makeArrayInitData(HeapType type, Name data) {
 }
 
 Result<> IRBuilder::makeArrayInitElem(HeapType type, Name elem) {
+  // Validate the elem type, too, before we potentially forget the type
+  // annotation.
+  if (!type.isArray()) {
+    return Err{"expected array type annotation on array.init_elem"};
+  }
+  if (!Type::isSubType(wasm.getElementSegment(elem)->type,
+                       type.getArray().element.type)) {
+    return Err{"element segment type must be a subtype of array element type "
+               "on array.init_elem"};
+  }
   ArrayInitElem curr;
   CHECK_ERR(ChildPopper{*this}.visitArrayInitElem(&curr, type));
-  CHECK_ERR(validateTypeAnnotation(type, curr.ref));
+  CHECK_ERR(validateTypeAnnotation(type, curr.ref, true));
   push(builder.makeArrayInitElem(
     elem, curr.ref, curr.index, curr.offset, curr.size));
   return Ok{};

--- a/test/spec/shared-array.wast
+++ b/test/spec/shared-array.wast
@@ -122,7 +122,7 @@
   (type $funcs (shared (array (mut (ref null (shared func))))))
 
   (data)
-  (elem (ref null (shared any)))
+  (elem (ref null (shared func)))
 
   (func (array.get_s $i8 (ref.null (shared none)) (i32.const 0)) (drop))
   (func (array.get_u $i8 (ref.null (shared none)) (i32.const 0)) (drop))
@@ -136,4 +136,14 @@
   (func (array.fill $i8 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
   (func (array.init_data $i8 0 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
   (func (array.init_elem $funcs 0 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
+)
+
+;; Check validation of element segments
+(assert_invalid
+  (module
+    (type $array (shared (array (mut (ref null (shared any))))))
+    (elem (ref null (shared func)))
+    (func (array.init_elem $array 0 (ref.null (shared none)) (i32.const 0) (i32.const 0) (i32.const 0)))
+  )
+  "invalid field type"
 )


### PR DESCRIPTION
IRBuilder is responsible for validation involving type annotations on GC
instructions because those type annotations may not be preserved in the
built IR to be used by the main validator. For `array.init_elem`, we
were not using the type annotation to validate the element segment,
which allowed us to parse invalid modules when the reference operand was
a nullref. Add the missing validation in IRBuilder and fix a relevant
spec test.
