### PR TITLE
Add a string lowering mode disallowing non-UTF-8 strings

### DIFF
--- a/src/passes/StringLowering.cpp
+++ b/src/passes/StringLowering.cpp
@@ -195,11 +195,15 @@ struct StringLowering : public StringGathering {
   bool useMagicImports;
 
   // Whether to throw a fatal error on non-UTF8 strings that would not be able
-  // to use the "magic import" mechanism.
+  // to use the "magic import" mechanism. Only usable in conjunction with magic
+  // imports.
   bool assertUTF8;
 
   StringLowering(bool useMagicImports = false, bool assertUTF8 = false)
-    : useMagicImports(useMagicImports), assertUTF8(assertUTF8) {}
+    : useMagicImports(useMagicImports), assertUTF8(assertUTF8) {
+    // If we are asserting valid UTF-8, we must be using magic imports.
+    assert(!assertUTF8 || useMagicImports);
+  }
 
   void run(Module* module) override {
     if (!module->features.has(FeatureSet::Strings)) {
@@ -242,7 +246,7 @@ struct StringLowering : public StringGathering {
             global->module = "'";
             global->base = Name(utf8.str());
           } else {
-            if (useMagicImports && assertUTF8) {
+            if (assertUTF8) {
               std::stringstream escaped;
               String::printEscaped(escaped, utf8.str());
               Fatal() << "Cannot lower non-UTF-16 string " << escaped.str()

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -503,6 +503,10 @@ void PassRegistry::registerPasses() {
     "string-lowering-magic-imports",
     "same as string-lowering, but encodes well-formed strings as magic imports",
     createStringLoweringMagicImportPass);
+  registerPass("string-lowering-magic-imports-assert",
+               "same as string-lowering-magic-imports, but raise a fatal error "
+               "if there are invalid strings",
+               createStringLoweringMagicImportAssertPass);
   registerPass(
     "strip", "deprecated; same as strip-debug", createStripDebugPass);
   registerPass("stack-check",

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -158,6 +158,7 @@ Pass* createStackCheckPass();
 Pass* createStringGatheringPass();
 Pass* createStringLoweringPass();
 Pass* createStringLoweringMagicImportPass();
+Pass* createStringLoweringMagicImportAssertPass();
 Pass* createStripDebugPass();
 Pass* createStripDWARFPass();
 Pass* createStripProducersPass();

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -478,6 +478,11 @@
 ;; CHECK-NEXT:                                                 encodes well-formed strings as
 ;; CHECK-NEXT:                                                 magic imports
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --string-lowering-magic-imports-assert        same as
+;; CHECK-NEXT:                                                 string-lowering-magic-imports,
+;; CHECK-NEXT:                                                 but raise a fatal error if there
+;; CHECK-NEXT:                                                 are invalid strings
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --strip                                       deprecated; same as strip-debug
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --strip-debug                                 strip debug info (including the

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -487,6 +487,11 @@
 ;; CHECK-NEXT:                                                 encodes well-formed strings as
 ;; CHECK-NEXT:                                                 magic imports
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --string-lowering-magic-imports-assert        same as
+;; CHECK-NEXT:                                                 string-lowering-magic-imports,
+;; CHECK-NEXT:                                                 but raise a fatal error if there
+;; CHECK-NEXT:                                                 are invalid strings
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --strip                                       deprecated; same as strip-debug
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --strip-debug                                 strip debug info (including the

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -441,6 +441,11 @@
 ;; CHECK-NEXT:                                                 encodes well-formed strings as
 ;; CHECK-NEXT:                                                 magic imports
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --string-lowering-magic-imports-assert        same as
+;; CHECK-NEXT:                                                 string-lowering-magic-imports,
+;; CHECK-NEXT:                                                 but raise a fatal error if there
+;; CHECK-NEXT:                                                 are invalid strings
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --strip                                       deprecated; same as strip-debug
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --strip-debug                                 strip debug info (including the

--- a/test/lit/passes/string-lowering.wast
+++ b/test/lit/passes/string-lowering.wast
@@ -35,9 +35,16 @@
 ;; RUN: wasm-opt %s --string-lowering-magic-imports -all -S -o - \
 ;; RUN:     | filecheck %s --check-prefix=MAGIC
 ;;
+;; If we use magic imports with asserts, we should get an error.
+;;
+;; RUN: not wasm-opt %s --string-lowering-magic-imports-assert -all -S -o - \
+;; RUN:     2>&1 | filecheck %s --check-prefix=ASSERT
+;;
 ;; CHECK: custom section "string.consts", size 136, contents: "[\"bar\",\"foo\",\"needs\\tescaping\\u0000.'#%\\\"- .\\r\\n\\\\08\\f\\n\\r\\t.\\ua66e\",\"unpaired high surrogate \\ud800 \",\"unpaired low surrogate \\udf48 \"]"
 ;;
 ;; MAGIC: custom section "string.consts", size 68, contents: "[\"unpaired high surrogate \\ud800 \",\"unpaired low surrogate \\udf48 \"]"
+;;
+;; ASSERT: Fatal: Cannot lower non-UTF-16 string "unpaired high surrogate \ef\bf\bd "
 
 ;; The custom section should parse OK using JSON.parse from node.
 ;; (Note we run --remove-unused-module-elements to remove externref-using


### PR DESCRIPTION
The best way to lower strings is via the "magic imports" API that uses
the names of imported string globals as their values. This approach only
works for valid UTF-8 strings, though. The existing
string-lowering-magic-imports pass falls back to putting non-UTF-8
strings in a JSON custom section, but this requires the runtime to
support that custom section for correctness. To help catch errors early
when runtimes do not support the strings custom section, add a new pass
that uses magic imports and raises an error if there are any invalid
strings.
