### PR TITLE
[NFC] Avoid quadratic time when precomputing blocks

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1401,19 +1401,27 @@ class RoundtripText(TestCaseHandler):
         # names which are very long, causing names to collide and the wast to be
         # invalid
         # FIXME: run name-types by default during load?
-        run([in_bin('wasm-opt'), wasm, '--name-types', '-S', '-o', abspath('a.wast')] + FEATURE_OPTS)
-        run([in_bin('wasm-opt'), abspath('a.wast')] + FEATURE_OPTS)
+        #opts = ['--precompute']
+        opts = [random.choice(['-O1', '-O2', '-O3', '-Os', '-Oz'])]
+
+        run([in_bin('wasm-opt'), wasm, '-o', 'old.wasm'] + FEATURE_OPTS + opts)
+
+        os.environ['NEW'] = '1'
+        run([in_bin('wasm-opt'), wasm, '-o', 'new.wasm'] + FEATURE_OPTS + opts)
+        del os.environ['NEW']
+
+        assert open('old.wasm', 'rb').read() == open('new.wasm', 'rb').read()
 
 
 # The global list of all test case handlers
 testcase_handlers = [
-    FuzzExec(),
-    CompareVMs(),
-    CheckDeterminism(),
-    Wasm2JS(),
-    TrapsNeverHappen(),
-    CtorEval(),
-    Merge(),
+    #FuzzExec(),
+    #CompareVMs(),
+    #CheckDeterminism(),
+    #Wasm2JS(),
+    #TrapsNeverHappen(),
+    #CtorEval(),
+    #Merge(),
     RoundtripText()
 ]
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1401,27 +1401,19 @@ class RoundtripText(TestCaseHandler):
         # names which are very long, causing names to collide and the wast to be
         # invalid
         # FIXME: run name-types by default during load?
-        #opts = ['--precompute']
-        opts = [random.choice(['-O1', '-O2', '-O3', '-Os', '-Oz'])]
-
-        run([in_bin('wasm-opt'), wasm, '-o', 'old.wasm'] + FEATURE_OPTS + opts)
-
-        os.environ['NEW'] = '1'
-        run([in_bin('wasm-opt'), wasm, '-o', 'new.wasm'] + FEATURE_OPTS + opts)
-        del os.environ['NEW']
-
-        assert open('old.wasm', 'rb').read() == open('new.wasm', 'rb').read()
+        run([in_bin('wasm-opt'), wasm, '--name-types', '-S', '-o', abspath('a.wast')] + FEATURE_OPTS)
+        run([in_bin('wasm-opt'), abspath('a.wast')] + FEATURE_OPTS)
 
 
 # The global list of all test case handlers
 testcase_handlers = [
-    #FuzzExec(),
-    #CompareVMs(),
-    #CheckDeterminism(),
-    #Wasm2JS(),
-    #TrapsNeverHappen(),
-    #CtorEval(),
-    #Merge(),
+    FuzzExec(),
+    CompareVMs(),
+    CheckDeterminism(),
+    Wasm2JS(),
+    TrapsNeverHappen(),
+    CtorEval(),
+    Merge(),
     RoundtripText()
 ]
 

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -424,7 +424,7 @@ struct Precompute
     }
 
     // Otherwise, precompute normally like all other expressions.
-    visitExpression(curr); // TODO fuzz to find any differenceses
+    visitExpression(curr);
   }
 
   // If we failed to precompute a constant, perhaps we can still precompute part


### PR DESCRIPTION
When precomputing fails on a child block of a parent block, there is no point
to precompute the parent, as that will fail as well.

At least, I can't think of any instruction sequence in wasm that could cause that
(see detailed comment in the code). I also fuzzed this (see second commit,
which is later reverted), and failed to find anything after a few thousand
iterations. But in theory this is not NFC if there is something that could be
optimized.

This makes `--precompute` on Emscripten's `test_biggerswitch` go from 1.44
seconds to 0.02 seconds (not a typo, that is 72x faster). The absolute number
is not that big, but we do run this pass more than once, so it saves a noticeable
chunk of time.
