### PR TITLE
[NFC] hash constant string as void*

### DIFF
--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -620,7 +620,7 @@ template<> struct hash<wasm::TagLocation> {
 
 template<> struct hash<wasm::CaughtExnRefLocation> {
   size_t operator()(const wasm::CaughtExnRefLocation& loc) const {
-    return std::hash<const char*>()("caught-exnref-location");
+    return std::hash<const void*>()("caught-exnref-location");
   }
 };
 


### PR DESCRIPTION
possible-contents.h hashes the location for caught exnrefs by hashing an
arbitrary string, "caught-exnref-location". It previously used
`std::hash<const char*>` for this, but some standard library
implementations report an error when this template instantiation is used
because hashing the location of a string is almost never correct. In
this case it is fine, so switch to using `std::hash<const void*>`.
