### PR TITLE
Support more reference constants in wast scripts

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -452,16 +452,16 @@ SPEC_TESTSUITE_TESTS_TO_SKIP = [
     'table.wast',  # Requires support for table default elements
     'type-equivalence.wast',  # Recursive types allowed by GC
     'unreached-invalid.wast',  # Requires more precise unreachable validation
-    'array.wast',  # Requires ref.array wast constants
+    'array.wast',  # Requires support for table default elements
     'array_init_elem.wast',  # Requires support for elem.drop
     'br_if.wast',  # Requires more precise branch validation
     'br_on_cast.wast',  # Requires sending values on br_on_cast
     'br_on_cast_fail.wast',  # Requires sending values on br_on_cast_fail
     'extern.wast',    # Requires ref.host wast constants
-    'i31.wast',       # Requires ref.i31 wast constants
+    'i31.wast',       # Requires support for table default elements
     'ref_cast.wast',  # Requires host references to not be externalized i31refs
     'ref_test.wast',  # Requires host references to not be externalized i31refs
-    'struct.wast',    # Requires ref.struct wast constants
+    'struct.wast',    # Duplicate field names not properly rejected
     'type-rec.wast',  # Requires wast `register` support
     'type-subtyping.wast',  # ShellExternalInterface::callTable does not handle subtyping
     'call_indirect.wast',   # Bug with 64-bit inline element segment parsing

--- a/src/literal.h
+++ b/src/literal.h
@@ -211,7 +211,6 @@ public:
   }
 
   static Literal makeFromMemory(void* p, Type type);
-  static Literal makeFromMemory(void* p, const Field& field);
 
   static Literal makeSignedMin(Type type) {
     switch (type.getBasic()) {

--- a/src/parser/wast-parser.cpp
+++ b/src/parser/wast-parser.cpp
@@ -217,6 +217,34 @@ Result<ExpectedResult> result(Lexer& in) {
     return RefResult{HeapType::func};
   }
 
+  if (in.takeSExprStart("ref.struct")) {
+    if (!in.takeRParen()) {
+      return in.err("expected end of ref.struct");
+    }
+    return RefResult{HeapType::struct_};
+  }
+
+  if (in.takeSExprStart("ref.array")) {
+    if (!in.takeRParen()) {
+      return in.err("expected end of ref.array");
+    }
+    return RefResult{HeapType::array};
+  }
+
+  if (in.takeSExprStart("ref.eq")) {
+    if (!in.takeRParen()) {
+      return in.err("expected end of ref.eq");
+    }
+    return RefResult{HeapType::eq};
+  }
+
+  if (in.takeSExprStart("ref.i31")) {
+    if (!in.takeRParen()) {
+      return in.err("expected end of ref.i31");
+    }
+    return RefResult{HeapType::i31};
+  }
+
   if (in.takeSExprStart("ref.i31_shared")) {
     if (!in.takeRParen()) {
       return in.err("expected end of ref.i31_shared");

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -294,24 +294,6 @@ Literal Literal::makeFromMemory(void* p, Type type) {
   }
 }
 
-Literal Literal::makeFromMemory(void* p, const Field& field) {
-  switch (field.packedType) {
-    case Field::not_packed:
-      return makeFromMemory(p, field.type);
-    case Field::i8: {
-      int8_t i;
-      memcpy(&i, p, sizeof(i));
-      return Literal(int32_t(i));
-    }
-    case Field::i16: {
-      int16_t i;
-      memcpy(&i, p, sizeof(i));
-      return Literal(int32_t(i));
-    }
-  }
-  WASM_UNREACHABLE("unexpected type");
-}
-
 Literal Literal::standardizeNaN(const Literal& input) {
   if (!std::isnan(input.getFloat())) {
     return input;


### PR DESCRIPTION
Spec tests use constants like `ref.array` and `ref.eq` to assert that
exported function return references of the correct types. Support more
such constants in the wast parser.

Also fix a bug where the interpretation of `array.new_data` for arrays
of packed fields was not properly truncating the packed data. Move the
function for reading fields from memory from literal.cpp to
wasm-interpreter.h, where the function for truncating packed data lives.

Other bugs prevent us from enabling any more spec tests as a result of
this change, but we can get farther through several of them before
failing. Update the comments about the failures accordingly.
