### PR TITLE
Check for required actions when parsing wast

### DIFF
--- a/src/parser/wast-parser.cpp
+++ b/src/parser/wast-parser.cpp
@@ -49,7 +49,7 @@ Result<Literals> consts(Lexer& in) {
   return lits;
 }
 
-MaybeResult<Action> action(Lexer& in) {
+MaybeResult<Action> maybeAction(Lexer& in) {
   if (in.takeSExprStart("invoke"sv)) {
     auto id = in.takeID();
     auto name = in.takeName();
@@ -77,6 +77,14 @@ MaybeResult<Action> action(Lexer& in) {
   }
 
   return {};
+}
+
+Result<Action> action(Lexer& in) {
+  if (auto a = maybeAction(in)) {
+    CHECK_ERR(a);
+    return *a;
+  }
+  return in.err("expected action");
 }
 
 // (module id? binary string*)
@@ -348,7 +356,7 @@ MaybeResult<Assertion> assertTrap(Lexer& in) {
     return {};
   }
   auto pos = in.getPos();
-  if (auto a = action(in)) {
+  if (auto a = maybeAction(in)) {
     CHECK_ERR(a);
     auto msg = in.takeString();
     if (!msg) {
@@ -423,7 +431,7 @@ Result<WASTCommand> command(Lexer& in) {
     CHECK_ERR(cmd);
     return *cmd;
   }
-  if (auto cmd = action(in)) {
+  if (auto cmd = maybeAction(in)) {
     CHECK_ERR(cmd);
     return *cmd;
   }

--- a/test/lit/parse-bad-assertion.wast
+++ b/test/lit/parse-bad-assertion.wast
@@ -1,0 +1,8 @@
+;; Check that we properly error when an action is missing from an assertion that
+;; requires one. Regression test for #6872.
+
+;; RUN: not wasm-shell %s 2>&1 | filecheck %s
+
+(assert_exhaustion "wrong, lol")
+
+;; CHECK: 6:19: error: expected action


### PR DESCRIPTION
The parser function for `action` returned a `MaybeResult`, but we were
treating it as returning a normal `Result` and not checking that it had
contents in several places. Replace the current `action()` with
`maybeAction()` and add a new `action()` that requires the action to be
present.

Fixes #6872.
