### PR TITLE
Add fp16 feature flag in V8 invocations

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -49,7 +49,8 @@ assert sys.version_info.major == 3, 'requires Python 3!'
 # parameters
 
 # feature options that are always passed to the tools.
-CONSTANT_FEATURE_OPTS = ['--all-features']
+# XXX fp16 is not yet stable, remove from here when it is
+CONSTANT_FEATURE_OPTS = ['--all-features', '--disable-fp16']
 
 INPUT_SIZE_MIN = 1024
 INPUT_SIZE_MEAN = 40 * 1024

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -257,6 +257,7 @@ V8_OPTS = [
     '--experimental-wasm-compilation-hints',
     '--experimental-wasm-memory64',
     '--experimental-wasm-stringref',
+    '--experimental-wasm-fp16',
 ]
 
 # external tools


### PR DESCRIPTION
I had fp16 disabled locally using a hack. I removed it and now I need this to fix the fuzzer.

@brendandahl Should the fuzzer be working without this atm? Maybe I'm doing something wrong.