### PR TITLE
[NFC] Convert LocalGraph influences accesses to function calls

### DIFF
--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -74,7 +74,8 @@ struct LocalGraph {
   bool equivalent(LocalGet* a, LocalGet* b);
 
   // Optional: compute the influence graphs between sets and gets (useful for
-  // algorithms that propagate changes).
+  // algorithms that propagate changes). Set influences are the gets that can
+  // read from it; get influences are the sets that can (directly) read from it.
   void computeSetInfluences();
   void computeGetInfluences();
 
@@ -83,11 +84,15 @@ struct LocalGraph {
     computeGetInfluences();
   }
 
-  // for each get, the sets whose values are influenced by that get
-  using GetInfluences = std::unordered_set<LocalSet*>;
-  std::unordered_map<LocalGet*, GetInfluences> getInfluences;
   using SetInfluences = std::unordered_set<LocalGet*>;
-  std::unordered_map<LocalSet*, SetInfluences> setInfluences;
+  using GetInfluences = std::unordered_set<LocalSet*>;
+
+  const& SetInfluences getSetInfluences(LocalSet* set) {
+    return setInfluences[set];
+  }
+  const& GetInfluences getGetInfluences(LocalGet* get) {
+    return getInfluences[get];
+  }
 
   // Optional: Compute the local indexes that are SSA, in the sense of
   //  * a single set for all the gets for that local index
@@ -132,6 +137,9 @@ private:
   // with that. It could alternatively be a shared_ptr, but that runs into what
   // seems to be a false positive of clang's (but not gcc's) UBSan.
   std::unique_ptr<LocalGraphFlower> flower;
+
+  std::unordered_map<LocalSet*, SetInfluences> setInfluences;
+  std::unordered_map<LocalGet*, GetInfluences> getInfluences;
 };
 
 } // namespace wasm

--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -87,10 +87,10 @@ struct LocalGraph {
   using SetInfluences = std::unordered_set<LocalGet*>;
   using GetInfluences = std::unordered_set<LocalSet*>;
 
-  const& SetInfluences getSetInfluences(LocalSet* set) {
+  const SetInfluences& getSetInfluences(LocalSet* set) {
     return setInfluences[set];
   }
-  const& GetInfluences getGetInfluences(LocalGet* get) {
+  const GetInfluences& getGetInfluences(LocalGet* get) {
     return getInfluences[get];
   }
 

--- a/src/ir/local-graph.h
+++ b/src/ir/local-graph.h
@@ -87,11 +87,23 @@ struct LocalGraph {
   using SetInfluences = std::unordered_set<LocalGet*>;
   using GetInfluences = std::unordered_set<LocalSet*>;
 
-  const SetInfluences& getSetInfluences(LocalSet* set) {
-    return setInfluences[set];
+  const SetInfluences& getSetInfluences(LocalSet* set) const {
+    auto iter = setInfluences.find(set);
+    if (iter == setInfluences.end()) {
+      // Use a canonical constant empty set to avoid allocation.
+      static const SetInfluences empty;
+      return empty;
+    }
+    return iter->second;
   }
-  const GetInfluences& getGetInfluences(LocalGet* get) {
-    return getInfluences[get];
+  const GetInfluences& getGetInfluences(LocalGet* get) const {
+    auto iter = getInfluences.find(get);
+    if (iter == getInfluences.end()) {
+      // Use a canonical constant empty set to avoid allocation.
+      static const GetInfluences empty;
+      return empty;
+    }
+    return iter->second;
   }
 
   // Optional: Compute the local indexes that are SSA, in the sense of

--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -279,10 +279,8 @@ struct EscapeAnalyzer {
         sets.insert(set);
 
         // We must also look at how the value flows from those gets.
-        if (auto* getsReached = getGetsReached(set)) {
-          for (auto* get : *getsReached) {
-            flows.push({get, parents.getParent(get)});
-          }
+        for (auto* get : localGraph.getSetInfluences(set)) {
+          flows.push({get, parents.getParent(get)});
         }
       }
 
@@ -479,14 +477,6 @@ struct EscapeAnalyzer {
     return ParentChildInteraction::Mixes;
   }
 
-  const LocalGraph::SetInfluences* getGetsReached(LocalSet* set) {
-    auto iter = localGraph.setInfluences.find(set);
-    if (iter != localGraph.setInfluences.end()) {
-      return &iter->second;
-    }
-    return nullptr;
-  }
-
   const BranchUtils::NameSet branchesSentByParent(Expression* child,
                                                   Expression* parent) {
     BranchUtils::NameSet names;
@@ -508,10 +498,8 @@ struct EscapeAnalyzer {
     // Find all the relevant gets (which may overlap between the sets).
     std::unordered_set<LocalGet*> gets;
     for (auto* set : sets) {
-      if (auto* getsReached = getGetsReached(set)) {
-        for (auto* get : *getsReached) {
-          gets.insert(get);
-        }
+      for (auto* get : localGraph.getSetInfluences(set)) {
+        gets.insert(get);
       }
     }
 

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -115,7 +115,7 @@ struct MergeLocals
     for (auto* copy : copies) {
       auto* trivial = copy->value->cast<LocalSet>();
       bool canOptimizeToCopy = false;
-      auto& trivialInfluences = preGraph.setInfluences[trivial];
+      auto& trivialInfluences = preGraph.getSetInfluences(trivial);
       if (!trivialInfluences.empty()) {
         canOptimizeToCopy = true;
         for (auto* influencedGet : trivialInfluences) {
@@ -156,7 +156,7 @@ struct MergeLocals
 
         // if the trivial set we added has influences, it means $y lives on
         if (!trivialInfluences.empty()) {
-          auto& copyInfluences = preGraph.setInfluences[copy];
+          auto& copyInfluences = preGraph.getSetInfluences(copy);
           if (!copyInfluences.empty()) {
             bool canOptimizeToTrivial = true;
             for (auto* influencedGet : copyInfluences) {
@@ -198,7 +198,7 @@ struct MergeLocals
       LocalGraph postGraph(func, getModule());
       postGraph.computeSetInfluences();
       for (auto& [copy, trivial] : optimizedToCopy) {
-        auto& trivialInfluences = preGraph.setInfluences[trivial];
+        auto& trivialInfluences = preGraph.getSetInfluences(trivial);
         for (auto* influencedGet : trivialInfluences) {
           // verify the set
           auto& sets = postGraph.getSets(influencedGet);
@@ -212,7 +212,7 @@ struct MergeLocals
         }
       }
       for (auto& [copy, trivial] : optimizedToTrivial) {
-        auto& copyInfluences = preGraph.setInfluences[copy];
+        auto& copyInfluences = preGraph.getSetInfluences(copy);
         for (auto* influencedGet : copyInfluences) {
           // verify the set
           auto& sets = postGraph.getSets(influencedGet);

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -359,7 +359,7 @@ private:
             if (add->left->is<Const>() || add->right->is<Const>()) {
               // Looks like this might be relevant, check all uses.
               bool canPropagate = true;
-              for (auto* get : localGraph->setInfluences[set]) {
+              for (auto* get : localGraph->getSetInfluences(set)) {
                 auto* parent = parents.getParent(get);
                 // if this is at the top level, it's the whole body - no set can
                 // exist!

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -802,7 +802,7 @@ private:
         }
         setValues[set] = values;
         if (values.isConcrete()) {
-          for (auto* get : localGraph.setInfluences[set]) {
+          for (auto* get : localGraph.getSetInfluences(set)) {
             work.push(get);
           }
         }
@@ -861,7 +861,7 @@ private:
         if (values.isConcrete()) {
           // we did!
           getValues[get] = values;
-          for (auto* set : localGraph.getInfluences[get]) {
+          for (auto* set : localGraph.getGetInfluences(get)) {
             work.push(set);
           }
           propagated = true;

--- a/src/passes/SSAify.cpp
+++ b/src/passes/SSAify.cpp
@@ -120,7 +120,7 @@ struct SSAify : public Pass {
   }
 
   bool hasMerges(LocalSet* set, LocalGraph& graph) {
-    for (auto* get : graph.setInfluences[set]) {
+    for (auto* get : graph.getSetInfluences(set)) {
       if (graph.getSets(get).size() > 1) {
         return true;
       }

--- a/src/passes/Souperify.cpp
+++ b/src/passes/Souperify.cpp
@@ -90,7 +90,7 @@ struct UseFinder {
       return;
     }
     // Find all the uses of that set.
-    auto& gets = localGraph.setInfluences[set];
+    auto& gets = localGraph.getSetInfluences(set);
     if (debug() >= 2) {
       std::cout << "addSetUses for " << set << ", " << gets.size() << " gets\n";
     }
@@ -98,7 +98,7 @@ struct UseFinder {
       // Each of these relevant gets is either
       //  (1) a child of a set, which we can track, or
       //  (2) not a child of a set, e.g., a call argument or such
-      auto& sets = localGraph.getInfluences[get]; // TODO: iterator
+      auto& sets = localGraph.getGetInfluences(get); // TODO: iterator
       // In flat IR, each get can influence at most 1 set.
       assert(sets.size() <= 1);
       if (sets.size() == 0) {

--- a/src/wasm/wasm-stack-opts.cpp
+++ b/src/wasm/wasm-stack-opts.cpp
@@ -227,7 +227,7 @@ void StackIROptimizer::local2Stack() {
               // used by this get and nothing else, check that.
               auto& sets = localGraph.getSets(get);
               if (sets.size() == 1 && *sets.begin() == set) {
-                auto& setInfluences = localGraph.setInfluences[set];
+                auto& setInfluences = localGraph.getSetInfluences(set);
                 // If this has the proper value of 1, also do the potentially-
                 // expensive check of whether we can remove this pair at all.
                 if (setInfluences.size() == 1 &&


### PR DESCRIPTION
This replaces direct access of the data structure `graph.*influences[foo]` with a call
`graph.get*influences(foo)`. This will allow a later PR to make those calls optionally
lazy.