### PR TITLE
[EH] Rename Catch(All)_P3 to Catch(All)_Legacy (NFC)

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1108,8 +1108,8 @@ enum ASTNodes {
   // exception handling opcodes
 
   Try = 0x06,
-  Catch_P3 = 0x07,    // Old Phase 3 'catch'
-  CatchAll_P3 = 0x19, // Old Phase 3 'catch_all'
+  Catch_Legacy = 0x07,    // Legacy 'catch'
+  CatchAll_Legacy = 0x19, // Legacy 'catch_all'
   Delegate = 0x18,
   Throw = 0x08,
   Rethrow = 0x09,

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3121,7 +3121,8 @@ void WasmBinaryReader::processExpressions() {
       }
       auto peek = input[pos];
       if (peek == BinaryConsts::End || peek == BinaryConsts::Else ||
-          peek == BinaryConsts::Catch_P3 || peek == BinaryConsts::CatchAll_P3 ||
+          peek == BinaryConsts::Catch_Legacy ||
+          peek == BinaryConsts::CatchAll_Legacy ||
           peek == BinaryConsts::Delegate) {
         BYN_TRACE("== processExpressions finished with unreachable"
                   << std::endl);
@@ -4070,8 +4071,8 @@ BinaryConsts::ASTNodes WasmBinaryReader::readExpression(Expression*& curr) {
       }
       break;
     case BinaryConsts::Else:
-    case BinaryConsts::Catch_P3:
-    case BinaryConsts::CatchAll_P3: {
+    case BinaryConsts::Catch_Legacy:
+    case BinaryConsts::CatchAll_Legacy: {
       curr = nullptr;
       if (DWARF && currFunction) {
         assert(!controlFlowStack.empty());
@@ -7213,9 +7214,9 @@ void WasmBinaryReader::visitTryOrTryInBlock(Expression*& out) {
   // here, then do that later.
   std::vector<Index> tagIndexes;
 
-  while (lastSeparator == BinaryConsts::Catch_P3 ||
-         lastSeparator == BinaryConsts::CatchAll_P3) {
-    if (lastSeparator == BinaryConsts::Catch_P3) {
+  while (lastSeparator == BinaryConsts::Catch_Legacy ||
+         lastSeparator == BinaryConsts::CatchAll_Legacy) {
+    if (lastSeparator == BinaryConsts::Catch_Legacy) {
       auto index = getU32LEB();
       if (index >= wasm.tags.size()) {
         throwError("bad tag index");

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2142,7 +2142,7 @@ void BinaryInstWriter::emitCatch(Try* curr, Index i) {
   if (func && !sourceMap) {
     parent.writeExtraDebugLocation(curr, func, i);
   }
-  o << int8_t(BinaryConsts::Catch_P3)
+  o << int8_t(BinaryConsts::Catch_Legacy)
     << U32LEB(parent.getTagIndex(curr->catchTags[i]));
 }
 
@@ -2150,7 +2150,7 @@ void BinaryInstWriter::emitCatchAll(Try* curr) {
   if (func && !sourceMap) {
     parent.writeExtraDebugLocation(curr, func, curr->catchBodies.size());
   }
-  o << int8_t(BinaryConsts::CatchAll_P3);
+  o << int8_t(BinaryConsts::CatchAll_Legacy);
 }
 
 void BinaryInstWriter::emitDelegate(Try* curr) {


### PR DESCRIPTION
This renames `Catch(All)_P3` enum to denote the old Phase 3 `catch(_all)` instructions to `Catch(All)_Legacy`, which sounds clearer.

This is also to be consistent with
https://github.com/llvm/llvm-project/pull/107187.