### PR TITLE
[NFC] Add a more powerful API for collecting heap types

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -581,7 +581,8 @@ void classifyTypes(Module& wasm,
     for (auto member : type.getRecGroup()) {
       if (auto it = types.find(member); it != types.end()) {
         if (it->second.classification == TypeClassification::Public) {
-          // We've already inserted this rec group.
+          // Since we mark all elements of a group public at once, if there is a
+          // member that is already public, all members must already be public.
           break;
         }
         it->second.classification = TypeClassification::Public;

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -18,6 +18,7 @@
 #define wasm_ir_module_h
 
 #include "pass.h"
+#include "support/insert_ordered.h"
 #include "support/unique_deferring_queue.h"
 #include "wasm.h"
 
@@ -441,6 +442,22 @@ template<typename T> struct CallGraphPropertyAnalysis {
     }
   }
 };
+
+enum class TypeInclusion { AllTypes, UsedIRTypes, BinaryTypes };
+
+enum class ClassifyAction { NoClassify, Classify };
+
+enum class TypeClassification { Unknown, Public, Private };
+
+struct HeapTypeInfo {
+  Index useCount = 0;
+  TypeClassification classification = TypeClassification::Unknown;
+};
+
+InsertOrderedMap<HeapType, HeapTypeInfo>
+collectHeapTypeInfo(Module& wasm,
+                    TypeInclusion inclusion = TypeInclusion::AllTypes,
+                    ClassifyAction classify = ClassifyAction::NoClassify);
 
 // Helper function for collecting all the non-basic heap types used in the
 // module, i.e. the types that would appear in the type section.

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -456,21 +456,21 @@ template<typename T> struct CallGraphPropertyAnalysis {
 enum class TypeInclusion { AllTypes, UsedIRTypes, BinaryTypes };
 
 // Whether to classify collected types as public and private.
-enum class ClassifyAction { NoClassify, Classify };
+enum class VisibilityHandling { NoVisibility, FindVisibility };
 
 // Whether a type is public or private. If no classification occurs, the type
 // will be Unknown instead.
-enum class TypeClassification { Unknown, Public, Private };
+enum class Visibility { Unknown, Public, Private };
 
 struct HeapTypeInfo {
   Index useCount = 0;
-  TypeClassification classification = TypeClassification::Unknown;
+  Visibility visibility = Visibility::Unknown;
 };
 
-InsertOrderedMap<HeapType, HeapTypeInfo>
-collectHeapTypeInfo(Module& wasm,
-                    TypeInclusion inclusion = TypeInclusion::AllTypes,
-                    ClassifyAction classify = ClassifyAction::NoClassify);
+InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
+  Module& wasm,
+  TypeInclusion inclusion = TypeInclusion::AllTypes,
+  VisibilityHandling visibility = VisibilityHandling::NoVisibility);
 
 // Helper function for collecting all the non-basic heap types used in the
 // module, i.e. the types that would appear in the type section.

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -458,8 +458,8 @@ enum class TypeInclusion { AllTypes, UsedIRTypes, BinaryTypes };
 // Whether to classify collected types as public and private.
 enum class VisibilityHandling { NoVisibility, FindVisibility };
 
-// Whether a type is public or private. If no classification occurs, the type
-// will be Unknown instead.
+// Whether a type is public or private. If visibility is not analyzed, the
+// visibility will be Unknown instead.
 enum class Visibility { Unknown, Public, Private };
 
 struct HeapTypeInfo {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -445,7 +445,7 @@ template<typename T> struct CallGraphPropertyAnalysis {
 
 // Which types to collect.
 //
-//   AllTypes - Any type anywhere reachable from anything
+//   AllTypes - Any type anywhere reachable from anything.
 //
 //   UsedIRTypes - Same as AllTypes, but excludes types reachable only because
 //   they are in a rec group with some other used type and types that are only

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -443,10 +443,23 @@ template<typename T> struct CallGraphPropertyAnalysis {
   }
 };
 
+// Which types to collect.
+//
+//   AllTypes - Any type anywhere reachable from anything
+//
+//   UsedIRTypes - Same as AllTypes, but excludes types reachable only because
+//   they are in a rec group with some other used type and types that are only
+//   used from other unreachable types.
+//
+//   BinaryTypes - Only types that need to appear in the module's type section.
+//
 enum class TypeInclusion { AllTypes, UsedIRTypes, BinaryTypes };
 
+// Whether to classify collected types as public and private.
 enum class ClassifyAction { NoClassify, Classify };
 
+// Whether a type is public or private. If no classification occurs, the type
+// will be Unknown instead.
 enum class TypeClassification { Unknown, Public, Private };
 
 struct HeapTypeInfo {


### PR DESCRIPTION
Many passes need to know both the set of all used types and also the
sets of private or public types. Previously there was no API to get both
at once, so getting both required two API calls that internally
collected all the types twice.

Furthermore, there are many reasons to collect heap types, and they have
different requirements about precisely which types need to be collected.
For example, in some edge cases the IR can reference heap types that do
not need to be emitted into a binary; passes that replace all types
would need to collect these types, but the binary writer would not. The
existing APIs for collecting types did not distinguish between these use
cases, so the code conservatively collected extra types that were not
always needed.

Refactor the type collecting code to expose a new API that takes a
description of which types need to be collected and returns the
appropriate types, their use counts, and optionally whether they are
each public or private.

Keep this change non-functional by commenting on places where the code
could be cleaned up or improved rather than actually making the changes.
Follow-up PRs will implement the improvements, which will necessarily
come with test changes.
