### PR TITLE
Fix supertype counts when collecting heap types

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -506,23 +506,12 @@ InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
   while (!newTypes.empty()) {
     while (!newTypes.empty()) {
       auto ht = newTypes.pop();
-      // TODO: Use getReferencedHeapTypes instead and remove separate
-      // consideration of supertypes below.
-      for (HeapType child : ht.getHeapTypeChildren()) {
+      for (HeapType child : ht.getReferencedHeapTypes()) {
         if (!child.isBasic()) {
           if (!info.contains(child)) {
             noteNewType(child);
           }
           info.note(child);
-        }
-      }
-
-      if (auto super = ht.getDeclaredSuperType()) {
-        if (!info.contains(*super)) {
-          noteNewType(*super);
-          // TODO: This should be unconditional for the count to be correct, but
-          // this will be moot once we use getReferencedHeapTypes above.
-          info.note(*super);
         }
       }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -3037,9 +3037,9 @@ TypeBuilderErrorReasonForwardSupertypeReference: 2
 TypeBuilderErrorReasonForwardChildReference: 3
 module with recursive GC types:
 (module
+ (type $SomeStruct (sub (struct (field $SomeField (mut (ref null $SomeStruct))))))
  (type $SomeArray (sub (array (mut (ref null $SomeArray)))))
  (type $SomeSignature (sub (func (param (ref null $SomeSignature) (ref null $SomeArray)) (result (ref null $SomeSignature)))))
- (type $SomeStruct (sub (struct (field $SomeField (mut (ref null $SomeStruct))))))
  (type $3 (func))
  (type $SomeSubStruct (sub $SomeStruct (struct (field $SomeField (mut (ref null $SomeStruct))) (field $SomePackedField i8))))
  (func $test (type $3)

--- a/test/lit/basic/subtypes.wast
+++ b/test/lit/basic/subtypes.wast
@@ -11,55 +11,49 @@
 
 ;; Test that we can roundtrip struct and array types
 (module
-  ;; Arrays
+  ;; Recursive structs
   ;; CHECK-TEXT:      (type $struct-rec-one (sub (struct (field (ref $struct-rec-one)))))
-
+  ;; CHECK-BIN:      (type $struct-rec-one (sub (struct (field (ref $struct-rec-one)))))
+  (type $struct-rec-one (sub (struct
+    (field (ref $struct-rec-one))
+  )))
   ;; CHECK-TEXT:      (type $struct-rec-two (sub $struct-rec-one (struct (field (ref $struct-rec-two)) (field (ref $struct-rec-two)))))
+  ;; CHECK-BIN:      (type $struct-rec-two (sub $struct-rec-one (struct (field (ref $struct-rec-two)) (field (ref $struct-rec-two)))))
+  (type $struct-rec-two (sub $struct-rec-one (struct
+    (field (ref $struct-rec-two))
+    (field (ref $struct-rec-two))
+ )))
+
+  ;; Non-recursive structs
+  ;; CHECK-TEXT:      (type $struct-any (sub (struct (field (ref any)))))
+  ;; CHECK-BIN:      (type $struct-any (sub (struct (field (ref any)))))
+  (type $struct-any (sub (struct
+    (field (ref any))
+  )))
+  ;; CHECK-TEXT:      (type $struct-i31 (sub $struct-any (struct (field (ref i31)))))
+  ;; CHECK-BIN:      (type $struct-i31 (sub $struct-any (struct (field (ref i31)))))
+  (type $struct-i31 (sub $struct-any (struct
+    (field (ref i31))
+ )))
+
+  ;; Arrays
+  ;; CHECK-TEXT:      (type $vector-any (sub (array (ref any))))
+  ;; CHECK-BIN:      (type $vector-any (sub (array (ref any))))
+  (type $vector-any (sub (array (ref any))))
 
   ;; CHECK-TEXT:      (type $vector-i32 (array i32))
-  ;; CHECK-BIN:      (type $struct-rec-one (sub (struct (field (ref $struct-rec-one)))))
-
-  ;; CHECK-BIN:      (type $struct-rec-two (sub $struct-rec-one (struct (field (ref $struct-rec-two)) (field (ref $struct-rec-two)))))
-
   ;; CHECK-BIN:      (type $vector-i32 (array i32))
   (type $vector-i32 (array i32))
 
-  ;; CHECK-TEXT:      (type $struct-any (sub (struct (field (ref any)))))
-
-  ;; CHECK-TEXT:      (type $struct-i31 (sub $struct-any (struct (field (ref i31)))))
-
-  ;; CHECK-TEXT:      (type $vector-any (sub (array (ref any))))
-  ;; CHECK-BIN:      (type $struct-any (sub (struct (field (ref any)))))
-
-  ;; CHECK-BIN:      (type $struct-i31 (sub $struct-any (struct (field (ref i31)))))
-
-  ;; CHECK-BIN:      (type $vector-any (sub (array (ref any))))
-  (type $vector-any (sub (array (ref any))))
   ;; CHECK-TEXT:      (type $vector-i31 (sub $vector-any (array (ref i31))))
   ;; CHECK-BIN:      (type $vector-i31 (sub $vector-any (array (ref i31))))
   (type $vector-i31 (sub $vector-any (array (ref i31))))
 
-  ;; Structs
-  (type $struct-any (sub (struct
-    (field (ref any))
-  )))
-  (type $struct-i31 (sub $struct-any (struct
-    (field (ref i31))
- )))
   ;; CHECK-TEXT:      (type $struct-i31_any (sub $struct-i31 (struct (field (ref i31)) (field (ref any)))))
   ;; CHECK-BIN:      (type $struct-i31_any (sub $struct-i31 (struct (field (ref i31)) (field (ref any)))))
   (type $struct-i31_any (sub $struct-i31(struct
     (field (ref i31))
     (field (ref any))
- )))
-
-  ;; Recursive structs
-  (type $struct-rec-one (sub (struct
-    (field (ref $struct-rec-one))
-  )))
-  (type $struct-rec-two (sub $struct-rec-one (struct
-    (field (ref $struct-rec-two))
-    (field (ref $struct-rec-two))
  )))
 
   ;; CHECK-TEXT:      (type $8 (func (param (ref $vector-i32) (ref null $vector-i32))))
@@ -166,47 +160,47 @@
 
 ;; CHECK-BIN-NODEBUG:      (type $1 (sub $0 (struct (field (ref $1)) (field (ref $1)))))
 
-;; CHECK-BIN-NODEBUG:      (type $2 (array i32))
+;; CHECK-BIN-NODEBUG:      (type $2 (sub (struct (field (ref any)))))
 
-;; CHECK-BIN-NODEBUG:      (type $3 (sub (struct (field (ref any)))))
+;; CHECK-BIN-NODEBUG:      (type $3 (sub $2 (struct (field (ref i31)))))
 
-;; CHECK-BIN-NODEBUG:      (type $4 (sub $3 (struct (field (ref i31)))))
+;; CHECK-BIN-NODEBUG:      (type $4 (sub (array (ref any))))
 
-;; CHECK-BIN-NODEBUG:      (type $5 (sub (array (ref any))))
+;; CHECK-BIN-NODEBUG:      (type $5 (array i32))
 
-;; CHECK-BIN-NODEBUG:      (type $6 (sub $5 (array (ref i31))))
+;; CHECK-BIN-NODEBUG:      (type $6 (sub $4 (array (ref i31))))
 
-;; CHECK-BIN-NODEBUG:      (type $7 (sub $4 (struct (field (ref i31)) (field (ref any)))))
+;; CHECK-BIN-NODEBUG:      (type $7 (sub $3 (struct (field (ref i31)) (field (ref any)))))
 
-;; CHECK-BIN-NODEBUG:      (type $8 (func (param (ref $2) (ref null $2))))
+;; CHECK-BIN-NODEBUG:      (type $8 (func (param (ref $5) (ref null $5))))
 
-;; CHECK-BIN-NODEBUG:      (type $9 (func (param (ref $6) (ref $5))))
+;; CHECK-BIN-NODEBUG:      (type $9 (func (param (ref $6) (ref $4))))
 
-;; CHECK-BIN-NODEBUG:      (type $10 (func (param (ref $4) (ref $3))))
+;; CHECK-BIN-NODEBUG:      (type $10 (func (param (ref $3) (ref $2))))
 
-;; CHECK-BIN-NODEBUG:      (type $11 (func (param (ref $4) (ref $7))))
+;; CHECK-BIN-NODEBUG:      (type $11 (func (param (ref $3) (ref $7))))
 
 ;; CHECK-BIN-NODEBUG:      (type $12 (func (param (ref $0) (ref $1))))
 
-;; CHECK-BIN-NODEBUG:      (func $0 (type $8) (param $0 (ref $2)) (param $1 (ref null $2))
+;; CHECK-BIN-NODEBUG:      (func $0 (type $8) (param $0 (ref $5)) (param $1 (ref null $5))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $1
 ;; CHECK-BIN-NODEBUG-NEXT:   (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:  )
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
-;; CHECK-BIN-NODEBUG:      (func $1 (type $9) (param $0 (ref $6)) (param $1 (ref $5))
+;; CHECK-BIN-NODEBUG:      (func $1 (type $9) (param $0 (ref $6)) (param $1 (ref $4))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $1
 ;; CHECK-BIN-NODEBUG-NEXT:   (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:  )
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
-;; CHECK-BIN-NODEBUG:      (func $2 (type $10) (param $0 (ref $4)) (param $1 (ref $3))
+;; CHECK-BIN-NODEBUG:      (func $2 (type $10) (param $0 (ref $3)) (param $1 (ref $2))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $1
 ;; CHECK-BIN-NODEBUG-NEXT:   (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:  )
 ;; CHECK-BIN-NODEBUG-NEXT: )
 
-;; CHECK-BIN-NODEBUG:      (func $3 (type $11) (param $0 (ref $4)) (param $1 (ref $7))
+;; CHECK-BIN-NODEBUG:      (func $3 (type $11) (param $0 (ref $3)) (param $1 (ref $7))
 ;; CHECK-BIN-NODEBUG-NEXT:  (local.set $0
 ;; CHECK-BIN-NODEBUG-NEXT:   (local.get $1)
 ;; CHECK-BIN-NODEBUG-NEXT:  )

--- a/test/lit/isorecursive-good.wast
+++ b/test/lit/isorecursive-good.wast
@@ -25,8 +25,6 @@
   )
 
   (rec
-    ;; CHECK:      (type $final-root (struct))
-
     ;; CHECK:      (rec
     ;; CHECK-NEXT:  (type $super-func (sub (func (param (ref $sub-array)) (result (ref $super-array)))))
     (type $super-func (sub (func (param (ref $sub-array)) (result (ref $super-array)))))
@@ -36,6 +34,7 @@
     (type $final-func (sub final $sub-func (func (param (ref $super-array)) (result (ref $final-array)))))
   )
 
+  ;; CHECK:      (type $final-root (struct))
   (type $final-root (sub final (struct)))
 
   ;; CHECK:      (func $make-super-struct (type $10) (result (ref $super-struct))

--- a/test/lit/passes/dae-gc-refine-return.wast
+++ b/test/lit/passes/dae-gc-refine-return.wast
@@ -55,7 +55,7 @@
  )
 
  ;; Refine the return type based on the value flowing out.
- ;; CHECK:      (func $refine-return-flow (type $3) (result i31ref)
+ ;; CHECK:      (func $refine-return-flow (type $4) (result i31ref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local $i31 i31ref)
  ;; CHECK-NEXT:  (local.set $temp
@@ -71,7 +71,7 @@
 
   (local.get $i31)
  )
- ;; CHECK:      (func $call-refine-return-flow (type $3) (result i31ref)
+ ;; CHECK:      (func $call-refine-return-flow (type $4) (result i31ref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (call $call-refine-return-flow)
@@ -105,7 +105,7 @@
  )
 
  ;; Refine the return type based on a return.
- ;; CHECK:      (func $refine-return-return (type $3) (result i31ref)
+ ;; CHECK:      (func $refine-return-return (type $4) (result i31ref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local $i31 i31ref)
  ;; CHECK-NEXT:  (local.set $temp
@@ -125,7 +125,7 @@
  )
 
  ;; Refine the return type based on multiple values.
- ;; CHECK:      (func $refine-return-many (type $3) (result i31ref)
+ ;; CHECK:      (func $refine-return-many (type $4) (result i31ref)
  ;; CHECK-NEXT:  (local $temp anyref)
  ;; CHECK-NEXT:  (local $i31 i31ref)
  ;; CHECK-NEXT:  (local.set $temp
@@ -353,7 +353,7 @@
   )
   (return_call $tail-callee)
  )
- ;; CHECK:      (func $tail-call-caller (type $4)
+ ;; CHECK:      (func $tail-call-caller (type $5)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (call $tail-caller-yes)
  ;; CHECK-NEXT:  )
@@ -410,7 +410,7 @@
   )
   (return_call_indirect (type $"return_{}") (i32.const 0))
  )
- ;; CHECK:      (func $tail-call-caller-indirect (type $4)
+ ;; CHECK:      (func $tail-call-caller-indirect (type $5)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (call $tail-caller-indirect-yes)
  ;; CHECK-NEXT:  )
@@ -484,7 +484,7 @@
   ;; should not hit an assertion on such things.
   (return_call_ref $"return_{}" (unreachable))
  )
- ;; CHECK:      (func $tail-call-caller-call_ref (type $4)
+ ;; CHECK:      (func $tail-call-caller-call_ref (type $5)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (call $tail-caller-call_ref-yes)
  ;; CHECK-NEXT:  )

--- a/test/lit/passes/gufa-tnh.wast
+++ b/test/lit/passes/gufa-tnh.wast
@@ -1346,8 +1346,6 @@
   (type $A (sub (struct (field (mut i32)))))
 
   (rec
-    ;; CHECK:      (type $1 (func (param (ref null $A))))
-
     ;; CHECK:      (rec
     ;; CHECK-NEXT:  (type $B1 (sub $A (struct (field (mut i32)))))
     (type $B1 (sub $A (struct (field (mut i32)))))
@@ -1359,11 +1357,13 @@
     (type $C1 (sub $B1 (struct (field (mut i32)))))
   )
 
+  ;; CHECK:      (type $4 (func (param (ref null $A))))
+
   ;; CHECK:      (type $5 (func (param anyref)))
 
   ;; CHECK:      (export "caller" (func $caller))
 
-  ;; CHECK:      (func $called (type $1) (param $x (ref null $A))
+  ;; CHECK:      (func $called (type $4) (param $x (ref null $A))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast (ref $B1)
   ;; CHECK-NEXT:    (local.get $x)

--- a/test/lit/passes/gufa-vs-cfp.wast
+++ b/test/lit/passes/gufa-vs-cfp.wast
@@ -1145,10 +1145,10 @@
 ;; different values in the sub-most type. Create the top and bottom types, but
 ;; not the middle one.
 (module
-  ;; CHECK:      (type $0 (func))
-
   ;; CHECK:      (type $struct1 (sub (struct (field i32) (field i32))))
   (type $struct1 (sub (struct i32 i32)))
+
+  ;; CHECK:      (type $1 (func))
 
   ;; CHECK:      (type $struct2 (sub $struct1 (struct (field i32) (field i32) (field f64) (field f64))))
   (type $struct2 (sub $struct1 (struct i32 i32 f64 f64)))
@@ -1200,7 +1200,7 @@
     )
   )
 
-  ;; CHECK:      (func $get-1 (type $0)
+  ;; CHECK:      (func $get-1 (type $1)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
@@ -1235,7 +1235,7 @@
     )
   )
 
-  ;; CHECK:      (func $get-2 (type $0)
+  ;; CHECK:      (func $get-2 (type $1)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
@@ -1295,7 +1295,7 @@
     )
   )
 
-  ;; CHECK:      (func $get-3 (type $0)
+  ;; CHECK:      (func $get-3 (type $1)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop

--- a/test/lit/passes/optimize-instructions-gc.wast
+++ b/test/lit/passes/optimize-instructions-gc.wast
@@ -89,7 +89,7 @@
   )
 
   ;; Stored values automatically truncate unneeded bytes.
-  ;; CHECK:      (func $store-trunc (type $10) (param $x (ref null $struct))
+  ;; CHECK:      (func $store-trunc (type $11) (param $x (ref null $struct))
   ;; CHECK-NEXT:  (struct.set $struct $i8
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (i32.const 35)
@@ -402,7 +402,7 @@
     (unreachable)
   )
 
-  ;; CHECK:      (func $ref-eq (type $9) (param $x eqref) (param $y eqref)
+  ;; CHECK:      (func $ref-eq (type $10) (param $x eqref) (param $y eqref)
   ;; CHECK-NEXT:  (local $lx eqref)
   ;; CHECK-NEXT:  (local $ly eqref)
   ;; CHECK-NEXT:  (drop
@@ -920,7 +920,7 @@
     )
   )
 
-  ;; CHECK:      (func $ref-eq-possible (type $9) (param $x eqref) (param $y eqref)
+  ;; CHECK:      (func $ref-eq-possible (type $10) (param $x eqref) (param $y eqref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.eq
   ;; CHECK-NEXT:    (ref.cast (ref null $struct)
@@ -947,7 +947,7 @@
     )
   )
 
-  ;; CHECK:      (func $ref-eq-impossible (type $9) (param $x eqref) (param $y eqref)
+  ;; CHECK:      (func $ref-eq-impossible (type $10) (param $x eqref) (param $y eqref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
@@ -1039,7 +1039,7 @@
     )
   )
 
-  ;; CHECK:      (func $ref-eq-possible-b (type $9) (param $x eqref) (param $y eqref)
+  ;; CHECK:      (func $ref-eq-possible-b (type $10) (param $x eqref) (param $y eqref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.eq
   ;; CHECK-NEXT:    (ref.cast (ref $A)
@@ -1144,7 +1144,7 @@
     )
   )
 
-  ;; CHECK:      (func $incompatible-cast-of-null (type $10) (param $x (ref null $struct))
+  ;; CHECK:      (func $incompatible-cast-of-null (type $11) (param $x (ref null $struct))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
@@ -1179,7 +1179,7 @@
     )
   )
 
-  ;; CHECK:      (func $incompatible-cast-of-unknown (type $10) (param $struct (ref null $struct))
+  ;; CHECK:      (func $incompatible-cast-of-unknown (type $11) (param $struct (ref null $struct))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.cast nullref
   ;; CHECK-NEXT:    (local.get $struct)
@@ -1194,7 +1194,7 @@
     )
   )
 
-  ;; CHECK:      (func $incompatible-test (type $10) (param $struct (ref null $struct))
+  ;; CHECK:      (func $incompatible-test (type $11) (param $struct (ref null $struct))
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
@@ -2214,7 +2214,7 @@
     )
   )
 
-  ;; CHECK:      (func $ref-boolean (type $9) (param $x eqref) (param $y eqref)
+  ;; CHECK:      (func $ref-boolean (type $10) (param $x eqref) (param $y eqref)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (ref.eq
   ;; CHECK-NEXT:    (local.get $x)

--- a/test/lit/passes/precompute-partial.wast
+++ b/test/lit/passes/precompute-partial.wast
@@ -538,7 +538,7 @@
     (ref.func $B$func)
   ))
 
-  ;; CHECK:      (func $test-expanded (type $0) (param $x i32) (result funcref)
+  ;; CHECK:      (func $test-expanded (type $4) (param $x i32) (result funcref)
   ;; CHECK-NEXT:  (select (result (ref $specific-func))
   ;; CHECK-NEXT:   (ref.func $A$func)
   ;; CHECK-NEXT:   (ref.func $B$func)
@@ -561,7 +561,7 @@
     )
   )
 
-  ;; CHECK:      (func $test-subtyping (type $0) (param $x i32) (result funcref)
+  ;; CHECK:      (func $test-subtyping (type $4) (param $x i32) (result funcref)
   ;; CHECK-NEXT:  (select (result (ref $specific-func))
   ;; CHECK-NEXT:   (ref.func $A$func)
   ;; CHECK-NEXT:   (ref.func $B$func)
@@ -657,7 +657,7 @@
     )
   )
 
-  ;; CHECK:      (func $test-trap (type $0) (param $x i32) (result funcref)
+  ;; CHECK:      (func $test-trap (type $4) (param $x i32) (result funcref)
   ;; CHECK-NEXT:  (struct.get $vtable 0
   ;; CHECK-NEXT:   (select (result (ref null $vtable))
   ;; CHECK-NEXT:    (ref.null none)

--- a/test/lit/passes/simplify-locals-gc.wast
+++ b/test/lit/passes/simplify-locals-gc.wast
@@ -4,21 +4,19 @@
 ;; RUN:   | filecheck %s
 
 (module
-  ;; CHECK:      (type $struct (struct (field (mut i32))))
-  (type $struct (struct (field (mut i32))))
-
   ;; CHECK:      (type $A (sub (struct (field structref))))
-
-  ;; CHECK:      (type $B (sub $A (struct (field (ref struct)))))
-
-  ;; CHECK:      (type $struct-immutable (struct (field i32)))
-  (type $struct-immutable (struct (field i32)))
-
   (type $A (sub (struct (field (ref null struct)))))
 
   ;; $B is a subtype of $A, and its field has a more refined type (it is non-
   ;; nullable).
+  ;; CHECK:      (type $B (sub $A (struct (field (ref struct)))))
   (type $B (sub $A (struct (field (ref struct)))))
+
+  ;; CHECK:      (type $struct (struct (field (mut i32))))
+  (type $struct (struct (field (mut i32))))
+
+  ;; CHECK:      (type $struct-immutable (struct (field i32)))
+  (type $struct-immutable (struct (field i32)))
 
   ;; Writes to heap objects cannot be reordered with reads.
   ;; CHECK:      (func $no-reorder-past-write (type $5) (param $x (ref $struct)) (result i32)


### PR DESCRIPTION
We previous incremented the use count for a declared supertype only if
it was also a type we had never seen before. Fix the count by treating
the supertype the same as any other type used in a type definition.
Update tests accordingly, including by manually moving input types
around to better match the output.
