### PR TITLE
Avoid conflicts with public rec groups in MinimizeRecGroups

### DIFF
--- a/src/passes/MinimizeRecGroups.cpp
+++ b/src/passes/MinimizeRecGroups.cpp
@@ -387,7 +387,7 @@ struct MinimizeRecGroups : Pass {
 
     // We cannot optimize public types, but we do need to make sure we don't
     // generate new groups with the same shape.
-    InsertOrderedSet<RecGroup> publicGroups;
+    std::unordered_set<RecGroup> publicGroups;
     for (auto& [type, info] : typeInfo) {
       if (info.visibility == ModuleUtils::Visibility::Private) {
         // We can optimize private types.

--- a/src/passes/MinimizeRecGroups.cpp
+++ b/src/passes/MinimizeRecGroups.cpp
@@ -401,7 +401,7 @@ struct MinimizeRecGroups : Pass {
     publicGroupTypes.reserve(publicGroups.size());
     for (auto group : publicGroups) {
       publicGroupTypes.emplace_back(group.begin(), group.end());
-      [[maybe_unused]] auto [it, inserted] = groupShapeIndices.insert(
+      [[maybe_unused]] auto [_, inserted] = groupShapeIndices.insert(
         {RecGroupShape(publicGroupTypes.back()), PublicGroupIndex});
       assert(inserted);
     }

--- a/test/lit/passes/minimize-rec-groups.wast
+++ b/test/lit/passes/minimize-rec-groups.wast
@@ -484,3 +484,83 @@
   ;; CHECK:      (global $a3 (ref null $a3) (ref.null none))
   (global $a3 (ref null $a3) (ref.null none))
 )
+
+;; We must avoid conflicts with public types
+(module
+  ;; CHECK:      (type $public (struct))
+  (type $public (struct))
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $1 (array (mut i8)))
+
+    ;; CHECK:       (type $private (struct))
+    (type $private (struct))
+    (type $other (struct (field (ref null $private))))
+  )
+
+  ;; CHECK:      (global $public (ref null $public) (ref.null none))
+  (global $public (export "g") (ref null $public) (ref.null none))
+
+  ;; CHECK:      (global $private (ref null $private) (ref.null none))
+  (global $private (ref null $private) (ref.null none))
+)
+
+;; Same as above, but now the public types are more complicated.
+;; CHECK:      (export "g" (global $public))
+(module
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $publicA (struct (field (ref null $publicB))))
+    (type $publicA (struct (field (ref null $publicB))))
+    ;; CHECK:       (type $publicB (struct (field (ref null $publicA))))
+    (type $publicB (struct (field (ref null $publicA))))
+  )
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $2 (struct))
+
+    ;; CHECK:       (type $privateB (struct (field (ref null $privateA))))
+
+    ;; CHECK:       (type $privateA (struct (field (ref null $privateB))))
+    (type $privateA (struct (field (ref null $privateB))))
+    (type $privateB (struct (field (ref null $privateA))))
+    (type $other (struct (field i32)))
+  )
+
+  ;; CHECK:      (global $public (ref null $publicA) (ref.null none))
+  (global $public (export "g") (ref null $publicA) (ref.null none))
+  ;; CHECK:      (global $private (ref null $privateA) (ref.null none))
+  (global $private (ref null $privateA) (ref.null none))
+)
+
+;; Now the conflict with the public type does not arise until we try to resolve
+;; a conflict between the private types.
+;; CHECK:      (export "g" (global $public))
+(module
+  (rec
+    ;; CHECK:      (type $privateA (struct (field i32) (field i64)))
+
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $publicBrand (struct))
+    (type $publicBrand (struct))
+    ;; CHECK:       (type $public (struct (field i32) (field i64)))
+    (type $public (struct (field i32 i64)))
+  )
+  (rec
+    (type $privateA (struct (field i32 i64)))
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $privateB (struct (field i32) (field i64)))
+    (type $privateB (struct (field i32 i64)))
+  )
+
+  ;; CHECK:       (type $4 (struct))
+
+  ;; CHECK:      (global $public (ref null $public) (ref.null none))
+  (global $public (export "g") (ref null $public) (ref.null none))
+
+  ;; CHECK:      (global $privateA (ref null $privateA) (ref.null none))
+  (global $privateA (ref null $privateA) (ref.null none))
+  ;; CHECK:      (global $privateB (ref null $privateB) (ref.null none))
+  (global $privateB (ref null $privateB) (ref.null none))
+)
+;; CHECK:      (export "g" (global $public))

--- a/test/lit/passes/minimize-rec-groups.wast
+++ b/test/lit/passes/minimize-rec-groups.wast
@@ -485,7 +485,7 @@
   (global $a3 (ref null $a3) (ref.null none))
 )
 
-;; We must avoid conflicts with public types
+;; We must avoid conflicts with public types.
 (module
   ;; CHECK:      (type $public (struct))
   (type $public (struct))


### PR DESCRIPTION
As with all type optimizations, MinimizeRecGroups only changes private types,
which are the only types that are safe to modify. However, it is important for
correctness that MinimimizeRecGroups maintain separate type identities for all
types, whether public or private, to ensure that casts that should differentiate
two types cannot change behavior.

Previously the pass worked exclusively on private types, so there was nothing
preventing it from constructing a minimial rec group that happened to have the
same shape, and therefore type identity, as a public rec group. #6886 exhibits a
fuzzer test case where this happens and changes the behavior of the program.

Fix the bug by recording all public rec group shapes and resolve conflicts with
these shapes by updating the shape of the conflicting non-public type.

Fixes #6886.
