### PR TITLE
Fix compilation under gcc 14.

### DIFF
--- a/src/parser/wat-parser.h
+++ b/src/parser/wat-parser.h
@@ -34,11 +34,16 @@ Result<> parseModule(Module& wasm, Lexer& lexer);
 
 Result<Literal> parseConst(Lexer& lexer);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 struct InvokeAction {
   std::optional<Name> base;
   Name name;
   Literals args;
 };
+
+#pragma GCC diagnostic pop
 
 struct GetAction {
   std::optional<Name> base;


### PR DESCRIPTION
This probably isn't the ideal solution but it did allow me to get binaryen building with gcc 14.2.

Fixes: https://github.com/WebAssembly/binaryen/issues/6779