### PR TITLE
Fuzzer: Log locals and values referred to from locals

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -723,7 +723,8 @@ Expression* TranslateToFuzzReader::makeLogging() {
     // "shallowly" log it by seeing if it is null (if it is nullable - if not,
     // then there is no point to such a check).
     auto* get = builder.makeLocalGet(index, type);
-    auto* isNullCheck = type.isNullable() ? builder.makeRefIsNull(get) : nullptr;
+    auto* isNullCheck =
+      type.isNullable() ? builder.makeRefIsNull(get) : nullptr;
     if (choice & 1) {
       // Try to also "deeply" log it, by reading a value from it, if we can.
       auto heapType = type.getHeapType();

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 23      
- [funcs]        : 34      
+ [exports]      : 58      
+ [funcs]        : 81      
  [globals]      : 9       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 2       
- [table-data]   : 6       
+ [table-data]   : 33      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 4303    
- [vars]         : 100     
- Binary         : 355     
- Block          : 684     
- Break          : 149     
- Call           : 219     
- CallIndirect   : 23      
- Const          : 643     
- Drop           : 50      
- GlobalGet      : 367     
- GlobalSet      : 258     
- If             : 206     
- Load           : 78      
- LocalGet       : 339     
- LocalSet       : 236     
- Loop           : 93      
- Nop            : 41      
- RefFunc        : 6       
- Return         : 45      
- Select         : 41      
- Store          : 36      
- Switch         : 1       
- Unary          : 304     
- Unreachable    : 129     
+ [total]        : 9015    
+ [vars]         : 210     
+ Binary         : 668     
+ Block          : 1543    
+ Break          : 293     
+ Call           : 256     
+ CallIndirect   : 64      
+ Const          : 1436    
+ Drop           : 92      
+ GlobalGet      : 779     
+ GlobalSet      : 585     
+ If             : 485     
+ Load           : 161     
+ LocalGet       : 592     
+ LocalSet       : 478     
+ Loop           : 207     
+ Nop            : 138     
+ RefFunc        : 33      
+ Return         : 89      
+ Select         : 63      
+ Store          : 85      
+ Switch         : 7       
+ Unary          : 667     
+ Unreachable    : 294     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,53 +1,48 @@
 Metrics
 total
  [exports]      : 5       
- [funcs]        : 9       
+ [funcs]        : 12      
  [globals]      : 26      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 20      
- [table-data]   : 3       
+ [table-data]   : 6       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 669     
- [vars]         : 27      
+ [total]        : 534     
+ [vars]         : 22      
  ArrayNew       : 16      
  ArrayNewFixed  : 3       
- AtomicCmpxchg  : 1       
  AtomicFence    : 1       
- Binary         : 75      
- Block          : 70      
- Break          : 7       
- Call           : 26      
+ Binary         : 66      
+ Block          : 53      
+ Break          : 3       
+ Call           : 8       
  CallRef        : 1       
- Const          : 143     
- Drop           : 3       
- GlobalGet      : 37      
- GlobalSet      : 27      
+ Const          : 130     
+ Drop           : 2       
+ GlobalGet      : 38      
+ GlobalSet      : 26      
  I31Get         : 1       
- If             : 20      
- Load           : 21      
- LocalGet       : 55      
- LocalSet       : 40      
- Loop           : 6       
- Nop            : 5       
- Pop            : 5       
- RefAs          : 2       
- RefEq          : 2       
- RefFunc        : 5       
- RefI31         : 2       
- RefNull        : 11      
- RefTest        : 2       
- Return         : 6       
- Select         : 2       
+ If             : 15      
+ Load           : 17      
+ LocalGet       : 35      
+ LocalSet       : 21      
+ Loop           : 3       
+ Nop            : 3       
+ RefAs          : 1       
+ RefCast        : 1       
+ RefFunc        : 9       
+ RefI31         : 1       
+ RefNull        : 10      
+ Return         : 4       
+ Select         : 5       
  StringConst    : 6       
- StringEq       : 1       
- StringMeasure  : 1       
- StringWTF16Get : 1       
- StructNew      : 17      
+ StringMeasure  : 2       
+ StructNew      : 15      
  StructSet      : 1       
- Try            : 4       
- TupleExtract   : 3       
+ Try            : 1       
+ TupleExtract   : 1       
  TupleMake      : 5       
- Unary          : 20      
+ Unary          : 15      
  Unreachable    : 15      


### PR DESCRIPTION
Logging values is important in the fuzzer as the loggings are observable
effects that we can then compare to other VMs and after optimizations.
Previously we logged random things, which had some chance to pick
useful data, but it makes sense to focus on sensitive values such as locals.
By logging locals, we get a higher chance to notice when a bad change to a
local happens.

If the local is a reference then we can't log its value, but we can log if it is
null at least. We can also try to find a field that is loggable, if it is a reference
to a struct.