### PR TITLE
[NFC] Rename the old topological sort utility

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -18,7 +18,7 @@
 #define wasm_ir_subtypes_h
 
 #include "ir/module-utils.h"
-#include "support/topological_sort.h"
+#include "support/old_topological_sort.h"
 #include "wasm.h"
 
 namespace wasm {
@@ -80,7 +80,7 @@ struct SubTypes {
 
   // A topological sort that visits subtypes first.
   auto getSubTypesFirstSort() const {
-    struct SubTypesFirstSort : TopologicalSort<HeapType, SubTypesFirstSort> {
+    struct SubTypesFirstSort : OldTopologicalSort<HeapType, SubTypesFirstSort> {
       const SubTypes& parent;
 
       SubTypesFirstSort(const SubTypes& parent) : parent(parent) {

--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -20,7 +20,6 @@
 #include "ir/module-utils.h"
 #include "ir/names.h"
 #include "ir/utils.h"
-#include "support/topological_sort.h"
 #include "wasm-type-ordering.h"
 #include "wasm-type.h"
 #include "wasm.h"

--- a/src/support/old_topological_sort.h
+++ b/src/support/old_topological_sort.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef wasm_support_topological_sort_h
-#define wasm_support_topological_sort_h
+#ifndef wasm_support_old_topological_sort_h
+#define wasm_support_old_topological_sort_h
 
 #include <cstddef>
 #include <iterator>
@@ -35,7 +35,7 @@ namespace wasm {
 // the immediate predecessors of `item`.
 //
 // Cycles in the graph are not detected and will result in an infinite loop.
-template<typename T, typename Subtype> struct TopologicalSort {
+template<typename T, typename Subtype> struct OldTopologicalSort {
 private:
   // The DFS work list.
   std::vector<T> workStack;
@@ -45,9 +45,10 @@ private:
 
   // Should be overridden by `Subtype`.
   void pushPredecessors(T item) {
-    static_assert(&TopologicalSort<T, Subtype>::pushPredecessors !=
-                    &Subtype::pushPredecessors,
-                  "TopologicalSort subclass must implement `pushPredecessors`");
+    static_assert(
+      &OldTopologicalSort<T, Subtype>::pushPredecessors !=
+        &Subtype::pushPredecessors,
+      "OldTopologicalSort subclass must implement `pushPredecessors`");
   }
 
   // Pop until the stack is empty or it has an unfinished item on top.
@@ -90,7 +91,7 @@ public:
     using pointer = T*;
     using iterator_category = std::input_iterator_tag;
 
-    TopologicalSort<T, Subtype>* parent;
+    OldTopologicalSort<T, Subtype>* parent;
 
     bool isEnd() const { return !parent || parent->workStack.empty(); }
     bool operator==(Iterator& other) const { return isEnd() == other.isEnd(); }
@@ -115,4 +116,4 @@ public:
 
 } // namespace wasm
 
-#endif // wasm_support_topological_sort_h
+#endif // wasm_support_old_topological_sort_h

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -36,9 +36,9 @@
 #include "support/colors.h"
 #include "support/file.h"
 #include "support/insert_ordered.h"
+#include "support/old_topological_sort.h"
 #include "support/small_set.h"
 #include "support/string.h"
-#include "support/topological_sort.h"
 #include "tool-options.h"
 #include "wasm-builder.h"
 #include "wasm-interpreter.h"
@@ -678,7 +678,7 @@ private:
 
     if (!mustBeAfter.empty()) {
       // We found constraints that require reordering, so do so.
-      struct MustBeAfterSort : TopologicalSort<Name, MustBeAfterSort> {
+      struct MustBeAfterSort : OldTopologicalSort<Name, MustBeAfterSort> {
         MustBeAfter& mustBeAfter;
 
         MustBeAfterSort(MustBeAfter& mustBeAfter) : mustBeAfter(mustBeAfter) {

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -20,7 +20,7 @@
 #include <unordered_set>
 
 #include "support/insert_ordered.h"
-#include "support/topological_sort.h"
+#include "support/old_topological_sort.h"
 #include "wasm-type.h"
 
 namespace wasm::HeapTypeOrdering {
@@ -30,7 +30,7 @@ namespace wasm::HeapTypeOrdering {
 // visited.
 template<typename SupertypeProvider>
 struct SupertypesFirstBase
-  : TopologicalSort<HeapType, SupertypesFirstBase<SupertypeProvider>> {
+  : OldTopologicalSort<HeapType, SupertypesFirstBase<SupertypeProvider>> {
   // For each type in the input collection, whether it is a supertype. Used to
   // track membership in the input collection.
   InsertOrderedMap<HeapType, bool> typeSet;


### PR DESCRIPTION
This will allow both the old and new topological sort utilities to be included
into the same .cpp file while we phase out the old utility.
