### PR TITLE
[NFC] Rename topological_orders.h to topological_sort.h

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -20,7 +20,7 @@
 #include "ir/manipulation.h"
 #include "ir/properties.h"
 #include "support/insert_ordered.h"
-#include "support/topological_orders.h"
+#include "support/topological_sort.h"
 
 namespace wasm::ModuleUtils {
 

--- a/src/passes/MinimizeRecGroups.cpp
+++ b/src/passes/MinimizeRecGroups.cpp
@@ -75,7 +75,7 @@
 #include "pass.h"
 #include "support/disjoint_sets.h"
 #include "support/strongly_connected_components.h"
-#include "support/topological_orders.h"
+#include "support/topological_sort.h"
 #include "wasm-type-shape.h"
 #include "wasm.h"
 

--- a/src/passes/ReorderGlobals.cpp
+++ b/src/passes/ReorderGlobals.cpp
@@ -35,7 +35,7 @@
 
 #include "ir/find_all.h"
 #include "pass.h"
-#include "support/topological_orders.h"
+#include "support/topological_sort.h"
 #include "wasm.h"
 
 namespace wasm {

--- a/src/support/topological_sort.h
+++ b/src/support/topological_sort.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef wasm_support_topological_orders_h
-#define wasm_support_topological_orders_h
+#ifndef wasm_support_topological_sort_h
+#define wasm_support_topological_sort_h
 
 #include <algorithm>
 #include <cassert>
@@ -300,4 +300,4 @@ template<typename Cmp> std::vector<Index> minSort(const Graph& graph, Cmp cmp) {
 
 } // namespace wasm
 
-#endif // wasm_support_topological_orders_h
+#endif // wasm_support_topological_sort_h

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -13,7 +13,7 @@ set(unittest_SOURCES
   scc.cpp
   stringify.cpp
   suffix_tree.cpp
-  topological-orders.cpp
+  topological-sort.cpp
   type-builder.cpp
   wat-lexer.cpp
   validator.cpp

--- a/test/gtest/topological-sort.cpp
+++ b/test/gtest/topological-sort.cpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <vector>
 
-#include "support/topological_orders.h"
+#include "support/topological_sort.h"
 #include "gtest/gtest.h"
 
 using namespace wasm;


### PR DESCRIPTION
Now that the header includes topological sort utilities in addition to the
utility that iterates over all topological orders, it makes more sense for it to
be named topological_sort.h
