### PR TITLE
[NFC] Standardize Super:: over super::

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -530,7 +530,7 @@ template<typename WalkerType>
 class WalkerPass : public Pass, public WalkerType {
 
 protected:
-  using super = WalkerPass<WalkerType>;
+  using Super = WalkerPass<WalkerType>;
 
 public:
   void run(Module* module) override {

--- a/src/passes/CoalesceLocals.cpp
+++ b/src/passes/CoalesceLocals.cpp
@@ -112,7 +112,7 @@ private:
 };
 
 void CoalesceLocals::doWalkFunction(Function* func) {
-  super::doWalkFunction(func);
+  Super::doWalkFunction(func);
   // prioritize back edges
   increaseBackEdgePriorities();
   // use liveness to find interference

--- a/src/passes/CodeFolding.cpp
+++ b/src/passes/CodeFolding.cpp
@@ -293,7 +293,7 @@ struct CodeFolding : public WalkerPass<ControlFlowWalker<CodeFolding>> {
     while (anotherPass) {
       anotherPass = false;
       needEHFixups = false;
-      super::doWalkFunction(func);
+      Super::doWalkFunction(func);
       optimizeTerminatingTails(unreachableTails);
       // optimize returns at the end, so we can benefit from a fallthrough if
       // there is a value TODO: separate passes for them?

--- a/src/passes/DeadCodeElimination.cpp
+++ b/src/passes/DeadCodeElimination.cpp
@@ -61,7 +61,7 @@ struct DeadCodeElimination
     if (old == expression) {
       return expression;
     }
-    super::replaceCurrent(expression);
+    Super::replaceCurrent(expression);
     // also update the type updater
     typeUpdater.noteReplacement(old, expression);
     return expression;

--- a/src/passes/LogExecution.cpp
+++ b/src/passes/LogExecution.cpp
@@ -47,7 +47,7 @@ struct LogExecution : public WalkerPass<PostWalker<LogExecution>> {
 
   void run(Module* module) override {
     loggerModule = getArgumentOrDefault("log-execution", "");
-    super::run(module);
+    Super::run(module);
   }
 
   void visitLoop(Loop* curr) { curr->body = makeLogCall(curr->body); }

--- a/src/passes/LoopInvariantCodeMotion.cpp
+++ b/src/passes/LoopInvariantCodeMotion.cpp
@@ -53,7 +53,7 @@ struct LoopInvariantCodeMotion
     LazyLocalGraph localGraphInstance(func, getModule());
     localGraph = &localGraphInstance;
     // Traverse the function.
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
   }
 
   void visitLoop(Loop* loop) {

--- a/src/passes/Memory64Lowering.cpp
+++ b/src/passes/Memory64Lowering.cpp
@@ -181,7 +181,7 @@ struct Memory64Lowering : public WalkerPass<PostWalker<Memory64Lowering>> {
     if (!module->features.has(FeatureSet::Memory64)) {
       return;
     }
-    super::run(module);
+    Super::run(module);
     // Don't modify the memories themselves until after the traversal since we
     // that would require memories to be the last thing that get visited, and
     // we don't want to depend on that specific ordering.

--- a/src/passes/MemoryPacking.cpp
+++ b/src/passes/MemoryPacking.cpp
@@ -500,7 +500,7 @@ void MemoryPacking::optimizeSegmentOps(Module* module) {
     }
     void doWalkFunction(Function* func) {
       needsRefinalizing = false;
-      super::doWalkFunction(func);
+      Super::doWalkFunction(func);
       if (needsRefinalizing) {
         ReFinalize().walkFunctionInModule(func, getModule());
       }

--- a/src/passes/MergeLocals.cpp
+++ b/src/passes/MergeLocals.cpp
@@ -81,7 +81,7 @@ struct MergeLocals
     // have a new assignment of $y at the location of the copy,
     // which makes it easy for us to see if the value if $y
     // is still used after that point
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
 
     // optimize the copies, merging when we can, and removing
     // the trivial assigns we added temporarily

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -109,7 +109,7 @@ struct MultiMemoryLowering : public Pass {
           return;
         }
       }
-      super::walkFunction(func);
+      Super::walkFunction(func);
     }
 
     void visitMemoryGrow(MemoryGrow* curr) {

--- a/src/passes/OptimizeAddedConstants.cpp
+++ b/src/passes/OptimizeAddedConstants.cpp
@@ -304,7 +304,7 @@ struct OptimizeAddedConstants
         localGraph->computeSSAIndexes();
         findPropagatable();
       }
-      super::doWalkFunction(func);
+      Super::doWalkFunction(func);
       if (!helperIndexes.empty()) {
         createHelperIndexes();
       }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -238,7 +238,7 @@ struct OptimizeInstructions
     }
 
     // Main walk.
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
 
     if (refinalize) {
       ReFinalize().walkFunctionInModule(func, getModule());

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -250,7 +250,7 @@ struct Precompute
     canPartiallyPrecompute = getPassOptions().optimizeLevel >= 2;
 
     // Walk the function and precompute things.
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
     partiallyPrecompute(func);
     if (!propagate) {
       return;
@@ -264,7 +264,7 @@ struct Precompute
       // We found constants to propagate and entered them in getValues. Do
       // another walk to apply them and perhaps other optimizations that are
       // unlocked.
-      super::doWalkFunction(func);
+      Super::doWalkFunction(func);
       // We could also try to partially precompute again, but that is a somewhat
       // heavy operation, so we only do it the first time, and leave such things
       // for later runs of this pass and for --converge.

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -485,7 +485,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
       self->pushTask(clear, currp); // clear all flow after the condition
       self->pushTask(scan, &iff->condition);
     } else {
-      super::scan(self, currp);
+      Super::scan(self, currp);
     }
   }
 
@@ -921,7 +921,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
     // multiple cycles may be needed
     do {
       anotherCycle = false;
-      super::doWalkFunction(func);
+      Super::doWalkFunction(func);
       assert(ifStack.empty());
       // flows may contain returns, which are flowing out and so can be
       // optimized

--- a/src/passes/SignExtLowering.cpp
+++ b/src/passes/SignExtLowering.cpp
@@ -73,7 +73,7 @@ struct SignExtLowering : public WalkerPass<PostWalker<SignExtLowering>> {
     if (!module->features.has(FeatureSet::SignExt)) {
       return;
     }
-    super::run(module);
+    Super::run(module);
     module->features.disable(FeatureSet::SignExt);
   }
 };

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -336,7 +336,7 @@ struct ConstantGlobalApplier
   : public WalkerPass<
       LinearExecutionWalker<ConstantGlobalApplier,
                             UnifiedExpressionVisitor<ConstantGlobalApplier>>> {
-  using super = WalkerPass<
+  using Super = WalkerPass<
     LinearExecutionWalker<ConstantGlobalApplier,
                           UnifiedExpressionVisitor<ConstantGlobalApplier>>>;
 
@@ -361,7 +361,7 @@ struct ConstantGlobalApplier
       // This operation will change the type, so refinalize.
       refinalize = true;
     }
-    super::replaceCurrent(rep);
+    Super::replaceCurrent(rep);
   }
 
   void visitExpression(Expression* curr) {

--- a/src/passes/SpillPointers.cpp
+++ b/src/passes/SpillPointers.cpp
@@ -69,7 +69,7 @@ struct SpillPointers
   // main entry point
 
   void doWalkFunction(Function* func) {
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
     spillPointers();
   }
 

--- a/src/passes/Table64Lowering.cpp
+++ b/src/passes/Table64Lowering.cpp
@@ -138,7 +138,7 @@ struct Table64Lowering : public WalkerPass<PostWalker<Table64Lowering>> {
   }
 
   void run(Module* module) override {
-    super::run(module);
+    Super::run(module);
     // Don't modify the tables themselves until after the traversal since we
     // that would require tables to be the last thing that get visited, and
     // we don't want to depend on that specific ordering.

--- a/src/passes/TranslateEH.cpp
+++ b/src/passes/TranslateEH.cpp
@@ -806,7 +806,7 @@ struct TranslateToExnref : public WalkerPass<PostWalker<TranslateToExnref>> {
       delegateTargetToTrampoline[target] = labels->getUnique(target.toString());
     }
 
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
 
     // Similar to processDelegateTarget(), but for the caller target.
     if (delegateTargetToTrampoline.find(DELEGATE_CALLER_TARGET) !=

--- a/src/passes/TrapMode.cpp
+++ b/src/passes/TrapMode.cpp
@@ -323,7 +323,7 @@ public:
   void doWalkModule(Module* module) {
     trappingFunctions =
       std::make_unique<TrappingFunctionContainer>(mode, *module);
-    super::doWalkModule(module);
+    Super::doWalkModule(module);
   }
 
 private:

--- a/src/passes/TupleOptimization.cpp
+++ b/src/passes/TupleOptimization.cpp
@@ -102,7 +102,7 @@ struct TupleOptimization : public WalkerPass<PostWalker<TupleOptimization>> {
     copiedIndexes.resize(numLocals);
 
     // Walk the code to collect info.
-    super::doWalkFunction(func);
+    Super::doWalkFunction(func);
 
     // Analyze and optimize.
     optimize(func);

--- a/src/passes/TypeGeneralizing.cpp
+++ b/src/passes/TypeGeneralizing.cpp
@@ -908,7 +908,7 @@ struct TypeGeneralizing : WalkerPass<PostWalker<TypeGeneralizing>> {
     }
 
     // Update gets and sets accordingly.
-    super::runOnFunction(wasm, func);
+    Super::runOnFunction(wasm, func);
 
     if (refinalize) {
       ReFinalize().walkFunctionInModule(func, wasm);


### PR DESCRIPTION
As the name of a class, uppercase seems better here.

Context: https://github.com/WebAssembly/binaryen/pull/6897#discussion_r1744065962