### PR TITLE
[NFC-ish] Remove LocalGraph from LocalSubtyping

### DIFF
--- a/test/lit/passes/local-subtyping.wast
+++ b/test/lit/passes/local-subtyping.wast
@@ -397,28 +397,18 @@
   )
 
   ;; CHECK:      (func $incompatible-sets (type $1) (result i32)
-  ;; CHECK-NEXT:  (local $temp (ref $1))
+  ;; CHECK-NEXT:  (local $temp (ref null $1))
   ;; CHECK-NEXT:  (local.set $temp
   ;; CHECK-NEXT:   (ref.func $incompatible-sets)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (local.tee $temp
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (ref.null nofunc)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (unreachable)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (ref.null nofunc)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.tee $temp
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.null nofunc)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (local.set $temp
+  ;; CHECK-NEXT:   (ref.null nofunc)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
@@ -431,9 +421,8 @@
     ;; Make all code unreachable from here.
     (unreachable)
     ;; In unreachable code, assign values that are not compatible with the more
-    ;; specific type we will optimize to. Those cannot be left as they are, and
-    ;; will be fixed up so that they validate. (All we need is validation, as
-    ;; their contents do not matter, given they are not reached.)
+    ;; specific type we will optimize to. This prevents optimization here (we
+    ;; will optimize better after --dce is run).
     (drop
       (local.tee $temp
         (ref.null func)


### PR DESCRIPTION
The LocalGraph there was used for two purposes:

1. Get the list of gets and sets.
2. Get only the reachable gets and sets.

It is trivial to get all the gets and sets in a much faster way, by just walking the
code as this PR does. The downside is that we also consider unreachable gets
and sets, so unreachable code can prevent us from optimizing, but that seems
worthwhile as many passes make that assumption (and they all become
maximally effective after --dce).

Removing LocalGraph + the fixup code for unreachability makes this
significantly shorter, and also 2-3x faster.