### PR TITLE
[NFC] Optimize propagateLocals()

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -796,7 +796,7 @@ private:
       // matter either, as if we managed to precompute it then the value had
       // the more specific (in this example, non-nullable) type. But there
       // is a situation where this can cause an issue: RefCast. An attempt to
-      // perform a "bad" cast, say of a function to a struct, is a case where
+      // perform a "bad" cast, say of a null to non-null, is a tricky case where
       // the fallthrough value's type is very different than the actually
       // returned value's type. To handle that, if we precomputed a value and
       // if it has the wrong type then precompute it again without looking

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -44,7 +44,7 @@ namespace wasm {
 
 // A map of gets to their constant values. If a get does not have a constant
 // value then it does not appear in the map (that avoids allocating for the
-//majority of gets).
+// majority of gets).
 using GetValues = std::unordered_map<LocalGet*, Literals>;
 
 // A map of values on the heap. This maps the expressions that create the

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -781,8 +781,8 @@ private:
       // somehow know the entire expression precomputes to a 42, then we can
       // propagate that 42 along to the users, regardless of whatever the call
       // did globally.)
-      auto values = precomputeValue(Properties::getFallthrough(
-        set->value, getPassOptions(), *getModule()));
+      auto values = precomputeValue(
+        Properties::getFallthrough(set->value, getPassOptions(), *getModule()));
 
       // Fix up the value. The computation we just did was to look at the
       // fallthrough, then precompute that; that looks through expressions

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -43,7 +43,8 @@
 namespace wasm {
 
 // A map of gets to their constant values. If a get does not have a constant
-// value then it does not appear in the map.
+// value then it does not appear in the map (that avoids allocating for the
+//majority of gets).
 using GetValues = std::unordered_map<LocalGet*, Literals>;
 
 // A map of values on the heap. This maps the expressions that create the
@@ -753,8 +754,7 @@ private:
     localGraph.computeInfluences();
 
     // A map of sets to their constant values. If a set does not appear here
-    // then it is not constant (that avoids allocating for the majority of
-    // sets).
+    // then it is not constant, like |getValues|.
     std::unordered_map<LocalSet*, Literals> setValues;
 
     // The work list, which will contain sets and gets that have just been

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -842,7 +842,7 @@ private:
           }
         } else {
           // If there is an entry for the set, use that constant. Otherwise, the
-          // set is not constant, and we leave curr as none.
+          // set is not constant, and we give up.
           auto iter = setValues.find(set);
           if (iter == setValues.end()) {
             return;


### PR DESCRIPTION
That is the slowest part of `--precompute-propagate`, which is one of our slowest
passes. This makes that pass 25% faster.

The main change is to make the maps consider missing elements as non-constant,
rather than storing a None element in them. That saves allocating entries for the
common case of a non-constant set/get.

Also switch to a simple vector for the work queue, which is possible if we only
add work when a get/set becomes constant (which can only happen once). Another
benefit to adding work in that manner is that we don't start by adding every single
get/set as "work" at the start.

Diff without whitespace is smaller.