### PR TITLE
[NFC] Make the GCData constructor a move constructor

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -763,7 +763,8 @@ struct GCData {
   // The element or field values.
   Literals values;
 
-  GCData(HeapType type, Literals values) : type(type), values(values) {}
+  GCData(HeapType type, Literals&& values) : type(type),
+                                             values(std::move(values)) {}
 };
 
 // The data of a (ref exn) literal.

--- a/src/literal.h
+++ b/src/literal.h
@@ -763,8 +763,8 @@ struct GCData {
   // The element or field values.
   Literals values;
 
-  GCData(HeapType type, Literals&& values) : type(type),
-                                             values(std::move(values)) {}
+  GCData(HeapType type, Literals&& values)
+    : type(type), values(std::move(values)) {}
 };
 
 // The data of a (ref exn) literal.

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -65,12 +65,21 @@ public:
   using value_type = T;
 
   SmallVector() {}
+  SmallVector(const SmallVector<T, N>& other) : usedFixed(other.usedFixed), fixed(other.fixed), flexible(other.flexible) {}
+  SmallVector(SmallVector<T, N>&& other) : usedFixed(other.usedFixed), fixed(std::move(other.fixed)), flexible(std::move(other.flexible)) {}
   SmallVector(std::initializer_list<T> init) {
     for (T item : init) {
       push_back(item);
     }
   }
   SmallVector(size_t initialSize) { resize(initialSize); }
+
+  SmallVector<T, N>& operator=(const SmallVector<T, N>& other) {
+    usedFixed = other.usedFixed;
+    fixed = other.fixed;
+    flexible = other.flexible;
+    return *this;
+  }
 
   T& operator[](size_t i) {
     if (i < N) {

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -65,8 +65,12 @@ public:
   using value_type = T;
 
   SmallVector() {}
-  SmallVector(const SmallVector<T, N>& other) : usedFixed(other.usedFixed), fixed(other.fixed), flexible(other.flexible) {}
-  SmallVector(SmallVector<T, N>&& other) : usedFixed(other.usedFixed), fixed(std::move(other.fixed)), flexible(std::move(other.flexible)) {}
+  SmallVector(const SmallVector<T, N>& other)
+    : usedFixed(other.usedFixed), fixed(other.fixed), flexible(other.flexible) {
+  }
+  SmallVector(SmallVector<T, N>&& other)
+    : usedFixed(other.usedFixed), fixed(std::move(other.fixed)),
+      flexible(std::move(other.flexible)) {}
   SmallVector(std::initializer_list<T> init) {
     for (T item : init) {
       push_back(item);

--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -85,6 +85,13 @@ public:
     return *this;
   }
 
+  SmallVector<T, N>& operator=(SmallVector<T, N>&& other) {
+    usedFixed = other.usedFixed;
+    fixed = std::move(other.fixed);
+    flexible = std::move(other.flexible);
+    return *this;
+  }
+
   T& operator[](size_t i) {
     if (i < N) {
       return fixed[i];

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1658,7 +1658,7 @@ public:
         data[i] = truncateForPacking(value.getSingleValue(), field);
       }
     }
-    return makeGCData(data, curr->type);
+    return makeGCData(std::move(data), curr->type);
   }
   Flow visitStructGet(StructGet* curr) {
     NOTE_ENTER("StructGet");
@@ -1738,7 +1738,7 @@ public:
         data[i] = value;
       }
     }
-    return makeGCData(data, curr->type);
+    return makeGCData(std::move(data), curr->type);
   }
   Flow visitArrayNewData(ArrayNewData* curr) { WASM_UNREACHABLE("unimp"); }
   Flow visitArrayNewElem(ArrayNewElem* curr) { WASM_UNREACHABLE("unimp"); }
@@ -1769,7 +1769,7 @@ public:
       }
       data[i] = truncateForPacking(value.getSingleValue(), field);
     }
-    return makeGCData(data, curr->type);
+    return makeGCData(std::move(data), curr->type);
   }
   Flow visitArrayGet(ArrayGet* curr) {
     NOTE_ENTER("ArrayGet");
@@ -1974,7 +1974,7 @@ public:
             contents.push_back(ptrDataValues[i]);
           }
         }
-        return makeGCData(contents, curr->type);
+        return makeGCData(std::move(contents), curr->type);
       }
       case StringNewFromCodePoint: {
         uint32_t codePoint = ptr.getSingleValue().getUnsigned();
@@ -2044,7 +2044,7 @@ public:
       contents.push_back(l);
     }
 
-    return makeGCData(contents, curr->type);
+    return makeGCData(std::move(contents), curr->type);
   }
   Flow visitStringEncode(StringEncode* curr) {
     // For now we only support JS-style strings into arrays.
@@ -2206,7 +2206,7 @@ public:
         }
       }
     }
-    return makeGCData(contents, curr->type);
+    return makeGCData(std::move(contents), curr->type);
   }
 
   virtual void trap(const char* why) { WASM_UNREACHABLE("unimp"); }
@@ -4013,7 +4013,7 @@ public:
       auto addr = (void*)&seg.data[i];
       contents.push_back(this->makeFromMemory(addr, element));
     }
-    return self()->makeGCData(contents, curr->type);
+    return self()->makeGCData(std::move(contents), curr->type);
   }
   Flow visitArrayNewElem(ArrayNewElem* curr) {
     NOTE_ENTER("ArrayNewElem");
@@ -4044,7 +4044,7 @@ public:
       auto val = self()->visit(seg.data[i]).getSingleValue();
       contents.push_back(val);
     }
-    return self()->makeGCData(contents, curr->type);
+    return self()->makeGCData(std::move(contents), curr->type);
   }
   Flow visitArrayInitData(ArrayInitData* curr) {
     NOTE_ENTER("ArrayInit");

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -194,7 +194,8 @@ protected:
   //
   // This consumes the input |data| entirely.
   Literal makeGCData(Literals& data, Type type) {
-    auto allocation = std::make_shared<GCData>(type.getHeapType(), std::move(data));
+    auto allocation =
+      std::make_shared<GCData>(type.getHeapType(), std::move(data));
 #if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
     // GC data with cycles will leak, since shared_ptrs do not handle cycles.
     // Binaryen is generally not used in long-running programs so we just ignore

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -191,8 +191,10 @@ protected:
   // data, as we don't have a cycle collector. Those leaks are not a serious
   // problem as Binaryen is not really used in long-running tasks, so we ignore
   // this function in LSan.
-  Literal makeGCData(const Literals& data, Type type) {
-    auto allocation = std::make_shared<GCData>(type.getHeapType(), data);
+  //
+  // This consumes the input |data| entirely.
+  Literal makeGCData(Literals& data, Type type) {
+    auto allocation = std::make_shared<GCData>(type.getHeapType(), std::move(data));
 #if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
     // GC data with cycles will leak, since shared_ptrs do not handle cycles.
     // Binaryen is generally not used in long-running programs so we just ignore

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -193,7 +193,7 @@ protected:
   // this function in LSan.
   //
   // This consumes the input |data| entirely.
-  Literal makeGCData(Literals& data, Type type) {
+  Literal makeGCData(Literals&& data, Type type) {
     auto allocation =
       std::make_shared<GCData>(type.getHeapType(), std::move(data));
 #if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -96,7 +96,7 @@ Literal::Literal(std::string_view string)
     int32_t u = uint8_t(string[i]) | (uint8_t(string[i + 1]) << 8);
     contents.push_back(Literal(u));
   }
-  gcData = std::make_shared<GCData>(HeapType::string, contents);
+  gcData = std::make_shared<GCData>(HeapType::string, std::move(contents));
 }
 
 Literal::Literal(const Literal& other) : type(other.type) {


### PR DESCRIPTION
This avoids creating a large Literals (SmallVector of Literal) and then copying it. All the places
that construct GCData do not need the Literals afterwards.

Also add a few other constructor type things, all as a result of C++ compiler errors after
the GCData constructor change.

This gives a 7% speedup on the `--precompute` benchmark from #6931 