### PR TITLE
Validate pops while ignoring nameless blocks?

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ There are a few differences between Binaryen IR and the WebAssembly language:
       much about this when writing Binaryen passes. For more details see the
       `requiresNonNullableLocalFixups()` hook in `pass.h` and the
       `LocalStructuralDominance` class.
+  * Validation of the `pop` instruction in Wasm Exceptions will ignore nameless
+    blocks, similar to validation of non-nullable locals in the previous point
+    (and for the same reasons).
   * `br_if` output types are more refined in Binaryen IR: they have the type of
     the value, when a value flows in. In the wasm spec the type is that of the
     branch target, which may be less refined. Using the more refined type here

--- a/src/ir/eh-utils.cpp
+++ b/src/ir/eh-utils.cpp
@@ -64,7 +64,18 @@ getFirstPop(Expression* catchBody, bool& isPopNested, Expression**& popPtr) {
         // run more than once
         return nullptr;
       }
-      if (firstChild->is<Block>()) {
+      if (auto* block = firstChild->dynCast<Block>()) {
+        // Ignore nameless blocks, as they vanish in the binary format.
+        if (!block->name.is()) {
+          if (block->list.empty()) {
+            // No children.
+            return nullptr;
+          }
+          firstChild = block->list[0];
+          firstChildPtr = &block->list[0];
+          continue;
+        }
+
         // If there are no branches that targets the implicit block, it will be
         // removed when written back. But if there are branches that target the
         // implicit block,

--- a/src/ir/eh-utils.h
+++ b/src/ir/eh-utils.h
@@ -30,6 +30,8 @@ namespace EHUtils {
 //   whose tag type is void or a catch_all's body, this returns false.
 // - This returns true even if there are more pops after the first one within a
 //   catch body, which is invalid. That will be taken care of in validation.
+// - This ignores blocks without a name, as we never emit those in the binary
+//   format.
 bool containsValidDanglingPop(Expression* catchBody);
 
 // Given a 'Try' expression, fixes up 'pop's nested in blocks, which are

--- a/test/lit/passes/code-folding-eh-legacy.wast
+++ b/test/lit/passes/code-folding-eh-legacy.wast
@@ -343,28 +343,22 @@
   )
 
   ;; CHECK:      (func $if-arms-in-catch (type $0) (result i32)
-  ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $e-i32
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (i32.eqz
-  ;; CHECK-NEXT:        (i32.const 1)
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (pop i32)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (i32.eqz
+  ;; CHECK-NEXT:       (i32.const 1)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -375,7 +369,7 @@
       )
       (catch $e-i32
         ;; These if arms can be folded, after which the if is replaced by a
-        ;; block, so we need a fixup for the pop.
+        ;; block. The block is nameless, so we need no fixup for the pop.
         (if
           (pop i32)
           (then

--- a/test/lit/passes/dce-eh-legacy.wast
+++ b/test/lit/passes/dce-eh-legacy.wast
@@ -122,23 +122,17 @@
   )
 
   ;; CHECK:      (func $call-pop-catch (type $0)
-  ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (block $label
   ;; CHECK-NEXT:   (try
   ;; CHECK-NEXT:    (do
   ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (catch $e-i32
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (pop i32)
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (br $label)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (br $label)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -151,8 +145,8 @@
          (nop)
        )
        (catch $e-i32
-         ;; This call is unreachable and can be removed. The pop, however, must
-         ;; be carefully handled while we do so, to not break validation.
+         ;; This call is unreachable and can be removed. A nameless block will
+         ;; be added around the pop, but that is ok.
          (call $helper-i32-i32
            (pop i32)
            (br $label)
@@ -171,24 +165,18 @@
   )
 
   ;; CHECK:      (func $pop-within-block (type $4) (result i32)
-  ;; CHECK-NEXT:  (local $0 eqref)
   ;; CHECK-NEXT:  (try (result i32)
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $e-eqref
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop eqref)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (struct.new $struct
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (struct.new $struct
+  ;; CHECK-NEXT:       (pop eqref)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -200,16 +188,7 @@
       )
       (catch $e-eqref
         (drop
-          ;; Optimization moves the 'pop' inside a block, which needs to be
-          ;; extracted out of the block at the end.
-          ;; (block
-          ;;   (drop
-          ;;     (struct.new $struct.0
-          ;;       (pop eqref)
-          ;;     )
-          ;;   )
-          ;;   (unreachable)
-          ;; )
+          ;; Optimization moves the 'pop' inside a nameless block.
           (ref.eq
             (struct.new $struct
               (pop (ref null eq))

--- a/test/lit/passes/flatten-eh-legacy.wast
+++ b/test/lit/passes/flatten-eh-legacy.wast
@@ -57,37 +57,29 @@
 
   ;; CHECK:      (func $try_catch_pop_fixup (type $1)
   ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (block $l0
   ;; CHECK-NEXT:   (try
   ;; CHECK-NEXT:    (do
   ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (catch $e-i32
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (pop i32)
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (local.set $0
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (br $l0)
-  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (br $l0)
   ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $try_catch_pop_fixup
-    ;; After --flatten, a block is created within the 'catch', which makes the
-    ;; pop's location invalid. This tests whether it is fixed up correctly after
-    ;; --flatten.
+    ;; After --flatten, a nameless block is created within the 'catch'.
     (block $l0
       (try
         (do)
@@ -180,7 +172,6 @@
   ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (local $3 i32)
   ;; CHECK-NEXT:  (local $4 i32)
-  ;; CHECK-NEXT:  (local $5 i32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (local.set $3
@@ -188,26 +179,21 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $e-i32
-  ;; CHECK-NEXT:    (local.set $5
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (local.set $0
-  ;; CHECK-NEXT:       (local.get $5)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (unreachable)
-  ;; CHECK-NEXT:      (unreachable)
+  ;; CHECK-NEXT:     (local.set $0
+  ;; CHECK-NEXT:      (pop i32)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (local.set $2
-  ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (local.set $3
-  ;; CHECK-NEXT:      (local.get $2)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
+  ;; CHECK-NEXT:     (unreachable)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (local.set $2
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (local.set $3
+  ;; CHECK-NEXT:     (local.get $2)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/gto-removals.wast
+++ b/test/lit/passes/gto-removals.wast
@@ -1405,3 +1405,54 @@
     )
   )
 )
+
+;; Test we handle a pop in a removed field properly without erroring.
+(module
+  ;; CHECK:      (type $0 (func (param eqref)))
+
+  ;; CHECK:      (rec
+  ;; CHECK-NEXT:  (type $struct (struct))
+  (type $struct (struct (field (mut eqref))))
+
+  ;; CHECK:       (type $2 (func))
+
+  ;; CHECK:       (type $3 (func (param eqref)))
+
+  ;; CHECK:      (tag $tag (param eqref))
+  (tag $tag (param eqref))
+
+  ;; CHECK:      (func $test (type $2)
+  ;; CHECK-NEXT:  (local $0 eqref)
+  ;; CHECK-NEXT:  (try
+  ;; CHECK-NEXT:   (do
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (catch $tag
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result (ref $struct))
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (pop eqref)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (struct.new_default $struct)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    (try
+      (do
+        (nop)
+      )
+      (catch $tag
+        (drop
+          (struct.new $struct
+            ;; This field receives a pop, but can also be removed from the type.
+            (pop eqref)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -1911,7 +1911,6 @@
   (tag $empty (param))
 
   ;; CHECK:      (func $func (type $0)
-  ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (throw $nothing
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:  )
@@ -1920,15 +1919,12 @@
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $nothing
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop anyref)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block
   ;; CHECK-NEXT:      (drop
   ;; CHECK-NEXT:       (block (result nullref)
   ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (local.get $0)
+  ;; CHECK-NEXT:         (pop anyref)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (ref.null none)
   ;; CHECK-NEXT:       )
@@ -2139,7 +2135,6 @@
   (tag $tag (param (ref null any)) (param (ref null any)))
 
   ;; CHECK:      (func $func (type $1)
-  ;; CHECK-NEXT:  (local $0 (tuple anyref anyref))
   ;; CHECK-NEXT:  (throw $tag
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:   (struct.new_default $struct)
@@ -2149,13 +2144,10 @@
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop (tuple anyref anyref))
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (tuple.drop 2
-  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:       (pop (tuple anyref anyref))
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (ref.null none)
   ;; CHECK-NEXT:     )
@@ -4171,7 +4163,6 @@
   )
 
   ;; CHECK:      (func $rethrow (type $0)
-  ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (try $l0
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (throw $e-i32
@@ -4179,20 +4170,15 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $e-i32
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (block (result i32)
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (rethrow $l0)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (rethrow $l0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )

--- a/test/lit/passes/gufa-tags.wast
+++ b/test/lit/passes/gufa-tags.wast
@@ -17,8 +17,6 @@
   (tag $tag$f32 (param f32))
 
   ;; CHECK:      (func $test (type $2)
-  ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local $1 f32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (throw $tag$i32
@@ -26,26 +24,20 @@
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag$i32
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result i32)
   ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.const 42)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag$f32
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (pop f32)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block
   ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:       (pop f32)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )

--- a/test/lit/passes/heap2local.wast
+++ b/test/lit/passes/heap2local.wast
@@ -4504,19 +4504,15 @@
   ;; CHECK:      (func $struct-with-pop (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag
-  ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (local.set $1
-  ;; CHECK-NEXT:       (local.get $2)
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (local.set $0
   ;; CHECK-NEXT:       (local.get $1)
@@ -4534,8 +4530,7 @@
       )
       (catch $tag
         (drop
-          ;; We create a block when we replace the struct with locals, which the
-          ;; pop must be moved out of.
+          ;; We create a nameless block when we replace the struct with locals.
           (struct.new $struct
             (pop i32)
           )
@@ -4552,19 +4547,15 @@
   ;; CHECK-NEXT:  (local $4 i32)
   ;; CHECK-NEXT:  (local $5 i32)
   ;; CHECK-NEXT:  (local $6 i32)
-  ;; CHECK-NEXT:  (local $7 i32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag
-  ;; CHECK-NEXT:    (local.set $7
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result (ref null $2))
   ;; CHECK-NEXT:      (local.set $0
-  ;; CHECK-NEXT:       (local.get $7)
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (block (result nullref)
   ;; CHECK-NEXT:       (local.set $4
@@ -4599,7 +4590,7 @@
       )
       (catch $tag
         (drop
-          ;; As above, but with an array
+          ;; As above, but with an array.
           (array.new $array
             (pop i32)
             (i32.const 3)

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -997,33 +997,27 @@
   ;; CHECK:      (func $catch-pop (type $2) (result i32)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (block $block (result i32)
   ;; CHECK-NEXT:   (try $try
   ;; CHECK-NEXT:    (do
   ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (catch $tag
-  ;; CHECK-NEXT:     (local.set $2
-  ;; CHECK-NEXT:      (pop i32)
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (local.set $0
-  ;; CHECK-NEXT:        (local.get $2)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (local.set $1
-  ;; CHECK-NEXT:        (br_if $block
-  ;; CHECK-NEXT:         (i32.const 1)
-  ;; CHECK-NEXT:         (i32.const 2)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $target
-  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (pop i32)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.set $1
+  ;; CHECK-NEXT:       (br_if $block
+  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (nop)
+  ;; CHECK-NEXT:      (call $target
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.const 3)
@@ -1039,15 +1033,13 @@
           (call $target
             (pop i32)
             ;; We can remove this parameter by moving it to a local first, which
-            ;; also moves the pop, which then needs to be fixed up.
+            ;; also moves the pop.
             (br_if $block
               (i32.const 1)
               (i32.const 2)
             )
           )
-          ;; This nop causes the call to be in a block. When we add another
-          ;; block to hold the code that we move, we'd get an error if we don't
-          ;; apply fixups.
+          ;; This nop causes the call to be in a block.
           (nop)
         )
       )
@@ -1086,33 +1078,27 @@
   ;; CHECK:      (func $catch-pop (type $2) (result i32)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (local $2 i32)
   ;; CHECK-NEXT:  (block $block (result i32)
   ;; CHECK-NEXT:   (try $try
   ;; CHECK-NEXT:    (do
   ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (catch $tag
-  ;; CHECK-NEXT:     (local.set $2
-  ;; CHECK-NEXT:      (pop i32)
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (local.set $0
-  ;; CHECK-NEXT:        (local.get $2)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (local.set $1
-  ;; CHECK-NEXT:        (br_if $block
-  ;; CHECK-NEXT:         (i32.const 1)
-  ;; CHECK-NEXT:         (i32.const 2)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (call $target
-  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (pop i32)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.set $1
+  ;; CHECK-NEXT:       (br_if $block
+  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:        (i32.const 2)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (nop)
+  ;; CHECK-NEXT:      (call $target
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.const 3)


### PR DESCRIPTION
@aheejin The fuzzer found another issue on pops in blocks (see `test/lit/passes/gto-removals.wast` in this PR), so I started to think that we might want a more general solution here. This draft PR changes validation so that nameless blocks, which vanish in the binary format, are ignored for validation. So `makeSequence()` etc. will never break pop validation.

This seems to work on the test suite. Do you remember if we considered this before? Is there a problem I am missing?