### PR TITLE
[wasm-split] Minimize non-function export names

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -826,8 +826,11 @@ void ModuleSplitter::shareImportableItems() {
     if (exportIt != exports.end()) {
       secondaryItem.base = exportIt->second;
     } else {
-      Name exportName = Names::getValidExportName(
-        primary, config.newExportPrefix + genericExportName);
+      std::string baseName =
+        config.newExportPrefix + (config.minimizeNewExportNames
+                                    ? minified.getName()
+                                    : genericExportName);
+      Name exportName = Names::getValidExportName(primary, baseName);
       primary.addExport(new Export{exportName, primaryItem.name, kind});
       secondaryItem.base = exportName;
     }

--- a/test/lit/wasm-split/minimized-exports.wast
+++ b/test/lit/wasm-split/minimized-exports.wast
@@ -9,7 +9,7 @@
 ;; PRIMARY-NEXT:   (export "baz" (func $2)
 ;; PRIMARY-NEXT:   (export "%a" (func $1))
 ;; PRIMARY-NEXT:   (export "%b" (func $0))
-;; PRIMARY-NEXT:   (export "%table" (table $0))
+;; PRIMARY-NEXT:   (export "%c" (table $0))
 ;; PRIMARY-NEXT:   (func $0
 ;; PRIMARY-NEXT:     (nop)
 ;; PRIMARY-NEXT:   )
@@ -25,7 +25,7 @@
 
 ;; SECONDARY:      (module
 ;; SECONDARY-NEXT:   (type $0 (func))
-;; SECONDARY-NEXT:   (import "primary" "%table" (table $timport$0 1 funcref))
+;; SECONDARY-NEXT:   (import "primary" "%c" (table $timport$0 1 funcref))
 ;; SECONDARY-NEXT:   (import "primary" "%a" (func $fimport$0))
 ;; SECONDARY-NEXT:   (import "primary" "%b" (func $fimport$1))
 ;; SECONDARY-NEXT:   (elem $0 (i32.const 0) $0)

--- a/test/lit/wasm-split/multi-split.wast
+++ b/test/lit/wasm-split/multi-split.wast
@@ -20,7 +20,7 @@
 
  ;; CHECK-A:      (type $2 (func (result i32)))
 
- ;; CHECK-A:      (import "" "table" (table $timport$0 1 funcref))
+ ;; CHECK-A:      (import "" "c" (table $timport$0 1 funcref))
 
  ;; CHECK-A:      (import "" "a" (func $B (result i64)))
 
@@ -70,11 +70,11 @@
 
  ;; CHECK-B:      (type $2 (func (result i64)))
 
- ;; CHECK-B:      (import "" "table_4" (table $timport$0 1 funcref))
+ ;; CHECK-B:      (import "" "e" (table $timport$0 1 funcref))
 
  ;; CHECK-B:      (import "" "b" (func $C (result f32)))
 
- ;; CHECK-B:      (import "" "c" (func $fimport$1 (result i32)))
+ ;; CHECK-B:      (import "" "d" (func $fimport$1 (result i32)))
 
  ;; CHECK-B:      (elem $0 (i32.const 0) $B)
 
@@ -120,11 +120,11 @@
 
  ;; CHECK-C:      (type $2 (func (result f32)))
 
- ;; CHECK-C:      (import "" "table_6" (table $timport$0 1 funcref))
+ ;; CHECK-C:      (import "" "g" (table $timport$0 1 funcref))
 
- ;; CHECK-C:      (import "" "c" (func $fimport$0 (result i32)))
+ ;; CHECK-C:      (import "" "d" (func $fimport$0 (result i32)))
 
- ;; CHECK-C:      (import "" "d" (func $fimport$1 (result i64)))
+ ;; CHECK-C:      (import "" "f" (func $fimport$1 (result i64)))
 
  ;; CHECK-C:      (elem $0 (i32.const 0) $C)
 
@@ -181,15 +181,15 @@
 
 ;; PRIMARY:      (export "b" (func $3))
 
-;; PRIMARY:      (export "table" (table $0))
+;; PRIMARY:      (export "c" (table $0))
 
-;; PRIMARY:      (export "c" (func $0))
+;; PRIMARY:      (export "d" (func $0))
 
-;; PRIMARY:      (export "table_4" (table $1))
+;; PRIMARY:      (export "e" (table $1))
 
-;; PRIMARY:      (export "d" (func $2))
+;; PRIMARY:      (export "f" (func $2))
 
-;; PRIMARY:      (export "table_6" (table $2))
+;; PRIMARY:      (export "g" (table $2))
 
 ;; PRIMARY:      (func $0 (result i32)
 ;; PRIMARY-NEXT:  (call_indirect (type $ret-i32)


### PR DESCRIPTION
The module splitting utility has a configuration option for minimizing
new export names, but it was previously applied only to newly exported
functions. Using the new multi-split mode can produce lots of exported
tables and splitting WasmGC programs can produce lots of exported
globals, so minimizing these export names can have a big impact on code
size.
