### PR TITLE
[NFC + bugfix] Remove BreakTargetLocation from GUFA

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -510,7 +510,6 @@ template<typename SubType, typename VisitorType = Visitor<SubType>>
 struct BreakTargetWalker : public PostWalker<SubType, VisitorType> {
   std::unordered_map<Name, Expression*> breakTargets;
 
-  // Uses the control flow stack to find the target of a break to a name
   Expression* findBreakTarget(Name name) { return breakTargets[name]; }
 
   static void scan(SubType* self, Expression** currp) {

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -511,15 +511,12 @@ struct BreakTargetWalker : public PostWalker<SubType, VisitorType> {
   std::unordered_map<Name, Expression*> breakTargets;
 
   // Uses the control flow stack to find the target of a break to a name
-  Expression* findBreakTarget(Name name) {
-    return breakTargets[name];
-  }
+  Expression* findBreakTarget(Name name) { return breakTargets[name]; }
 
   static void scan(SubType* self, Expression** currp) {
     auto* curr = *currp;
-    BranchUtils::operateOnScopeNameDefs(curr, [&](Name name) {
-      self->breakTargets[name] = curr;
-    });
+    BranchUtils::operateOnScopeNameDefs(
+      curr, [&](Name name) { self->breakTargets[name] = curr; });
 
     PostWalker<SubType, VisitorType>::scan(self, currp);
   }
@@ -1170,8 +1167,7 @@ struct InfoCollector
         for (Index i = 0; i < params.size(); i++) {
           if (isRelevant(params[i])) {
             info.links.push_back(
-              {TagLocation{tag, i},
-               getBreakTargetLocation(target, i)});
+              {TagLocation{tag, i}, getBreakTargetLocation(target, i)});
           }
         }
 
@@ -1314,9 +1310,8 @@ struct InfoCollector
           for (Index i = 0; i < value->type.size(); i++) {
             // Breaks send the contents of the break value to the branch target
             // that the break goes to.
-            info.links.push_back(
-              {ExpressionLocation{value, i},
-               getBreakTargetLocation(target, i)});
+            info.links.push_back({ExpressionLocation{value, i},
+                                  getBreakTargetLocation(target, i)});
           }
         }
       });

--- a/src/ir/possible-contents.h
+++ b/src/ir/possible-contents.h
@@ -402,21 +402,6 @@ struct ResultLocation {
   }
 };
 
-// The location of a break target in a function, identified by its name.
-struct BreakTargetLocation {
-  Function* func;
-  Name target;
-  // As in ExpressionLocation, the index inside the tuple, or 0 if not a tuple.
-  // That is, if the branch target has a tuple type, then each branch to that
-  // location sends a tuple, and we'll have a separate BreakTargetLocation for
-  // each, indexed by the index in the tuple that the branch sends.
-  Index tupleIndex;
-  bool operator==(const BreakTargetLocation& other) const {
-    return func == other.func && target == other.target &&
-           tupleIndex == other.tupleIndex;
-  }
-};
-
 // The location of a global in the module.
 struct GlobalLocation {
   Name name;
@@ -523,7 +508,6 @@ using Location = std::variant<ExpressionLocation,
                               ParamLocation,
                               LocalLocation,
                               ResultLocation,
-                              BreakTargetLocation,
                               GlobalLocation,
                               SignatureParamLocation,
                               SignatureResultLocation,
@@ -574,13 +558,6 @@ template<> struct hash<wasm::ResultLocation> {
   size_t operator()(const wasm::ResultLocation& loc) const {
     return std::hash<std::pair<size_t, wasm::Index>>{}(
       {size_t(loc.func), loc.index});
-  }
-};
-
-template<> struct hash<wasm::BreakTargetLocation> {
-  size_t operator()(const wasm::BreakTargetLocation& loc) const {
-    return std::hash<std::tuple<size_t, wasm::Name, wasm::Index>>{}(
-      {size_t(loc.func), loc.target, loc.tupleIndex});
   }
 };
 


### PR DESCRIPTION
Before, a `br` would send its value to a `BreakTargetLocation`. That would then be
linked to the target:

```
{ br's value } => BreakTargetLocation(target name) => { location of target }
```

This PR skips the middle:

```
{ br's value } => { location of target }
```

It just connects breaks directly to the targets. We can do that if we keep a
map of the targets as we go.

This is 2% faster as well as simplifies the code, as an NFC refactoring. But it
also fixes a bug: we have handling on ExpressionLocation that filters values as they
come in (they must accord with the expression's type). We were not doing
that on BreakTargetLocation, leading to an assert. Removing
BreakTargetLocation entirely is easier and better than adding filtering logic
for it.

Fixes https://github.com/WebAssembly/binaryen/issues/6955