### PR TITLE
[NFC-ish] Eagerly create Functions in binary parser

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -448,7 +448,10 @@ InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
       for (auto type : func->vars) {
         info.note(type);
       }
-      if (!func->imported()) {
+      // Don't just use `func->imported()` here because we also might be
+      // printing an error message on a partially parsed module whose declared
+      // function bodies have not all been parsed yet.
+      if (func->body) {
         CodeScanner(wasm, info, inclusion).walk(func->body);
       }
     });

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2980,6 +2980,9 @@ void PrintSExpression::visitDefinedGlobal(Global* curr) {
 void PrintSExpression::visitFunction(Function* curr) {
   if (curr->imported()) {
     visitImportedFunction(curr);
+  } else if (curr->body == nullptr) {
+    // We are in the middle of parsing the module and have not parsed this
+    // function's code yet. Skip it.
   } else {
     visitDefinedFunction(curr);
   }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1532,6 +1532,11 @@ public:
   // reconstructing the HeapTypes from the Signatures is expensive.
   std::vector<HeapType> functionTypes;
 
+  // Used to make sure the number of imported functions, signatures, and
+  // declared functions all match up.
+  Index numFuncImports = 0;
+  Index numFuncBodies = 0;
+
   void readFunctionSignatures();
   HeapType getTypeByIndex(Index index);
   HeapType getTypeByFunctionIndex(Index index);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2600,11 +2600,8 @@ void WasmBinaryReader::readFunctionSignatures() {
     functionTypes.push_back(type);
     // Check that the type is a signature.
     getSignatureByTypeIndex(index);
-    // Create the function with a placeholder body so we don't trip over it if
-    // we have to print it as part of an error message.
-    Builder builder(wasm);
-    wasm.addFunction(builder.makeFunction(
-      makeName("", i), type, {}, builder.makeUnreachable()));
+    wasm.addFunction(
+      Builder(wasm).makeFunction(makeName("", i), type, {}, nullptr));
   }
 }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2578,6 +2578,7 @@ void WasmBinaryReader::readImports() {
       }
     }
   }
+  numFuncImports = wasm.functions.size();
 }
 
 Name WasmBinaryReader::getNextLabel() {
@@ -2595,9 +2596,15 @@ void WasmBinaryReader::readFunctionSignatures() {
   size_t num = getU32LEB();
   for (size_t i = 0; i < num; i++) {
     auto index = getU32LEB();
-    functionTypes.push_back(getTypeByIndex(index));
+    HeapType type = getTypeByIndex(index);
+    functionTypes.push_back(type);
     // Check that the type is a signature.
     getSignatureByTypeIndex(index);
+    // Create the function with a placeholder body so we don't trip over it if
+    // we have to print it as part of an error message.
+    Builder builder(wasm);
+    wasm.addFunction(builder.makeFunction(
+      makeName("", i), type, {}, builder.makeUnreachable()));
   }
 }
 
@@ -2633,12 +2640,11 @@ Signature WasmBinaryReader::getSignatureByFunctionIndex(Index index) {
 }
 
 void WasmBinaryReader::readFunctions() {
-  auto numImports = wasm.functions.size();
-  size_t total = getU32LEB();
-  if (total != functionTypes.size() - numImports) {
+  numFuncBodies = getU32LEB();
+  if (numFuncBodies + numFuncImports != wasm.functions.size()) {
     throwError("invalid function section size, must equal types");
   }
-  for (size_t i = 0; i < total; i++) {
+  for (size_t i = 0; i < numFuncBodies; i++) {
     auto sizePos = pos;
     size_t size = getU32LEB();
     if (size == 0) {
@@ -2646,9 +2652,7 @@ void WasmBinaryReader::readFunctions() {
     }
     endOfFunction = pos + size;
 
-    auto func = std::make_unique<Function>();
-    func->name = makeName("", i);
-    func->type = getTypeByFunctionIndex(numImports + i);
+    auto& func = wasm.functions[numFuncImports + i];
     currFunction = func.get();
 
     if (DWARF) {
@@ -2715,7 +2719,6 @@ void WasmBinaryReader::readFunctions() {
     std::swap(func->epilogLocation, debugLocation);
     currFunction = nullptr;
     debugLocation.clear();
-    wasm.addFunction(std::move(func));
   }
 }
 
@@ -3192,8 +3195,8 @@ void WasmBinaryReader::validateBinary() {
     throwError("Number of segments does not agree with DataCount section");
   }
 
-  if (functionTypes.size() != wasm.functions.size()) {
-    throwError("function section without code section");
+  if (functionTypes.size() != numFuncImports + numFuncBodies) {
+    throwError("function and code sections have inconsistent lengths");
   }
 }
 

--- a/test/lit/binary/debug-bad-binary.test
+++ b/test/lit/binary/debug-bad-binary.test
@@ -38,4 +38,10 @@ RUN: not wasm-opt --debug %s.wasm 2>&1 | filecheck %s
 ;; CHECK-NEXT:    (i32.const 10)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (func $1
+;; CHECK-NEXT:   (unreachable)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (func $2
+;; CHECK-NEXT:   (unreachable)
+;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )

--- a/test/lit/binary/debug-bad-binary.test
+++ b/test/lit/binary/debug-bad-binary.test
@@ -38,10 +38,4 @@ RUN: not wasm-opt --debug %s.wasm 2>&1 | filecheck %s
 ;; CHECK-NEXT:    (i32.const 10)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (func $1
-;; CHECK-NEXT:   (unreachable)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (func $2
-;; CHECK-NEXT:   (unreachable)
-;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )


### PR DESCRIPTION
In preparation for using IRBuilder in the binary parser, eagerly create
Functions when parsing the function section so that they are already
created once we parse the code section. IRBuilder will require the
functions to exist when parsing calls so it can figure out what type
each call should have, even when there is a call to a function whose
body has not been parsed yet.

NFC except that some error messages change to include the new empty
functions.
