### PR TITLE
[NFC] Parallelize the actual inlining part of the Inlining pass

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -635,6 +635,8 @@ static void doInlining(Module* module,
   TypeUpdating::handleNonDefaultableLocals(into, *module);
 }
 
+// A map of function names to the inlining actions we've decided to actually
+// perform in them.
 using ChosenActions = std::unordered_map<Name, std::vector<InliningAction>>;
 
 // A pass that calls doInlining() on a bunch of actions that were chosen to
@@ -654,6 +656,7 @@ struct DoInlining : public Pass {
     // We must be called on a function that we actually want to inline into.
     assert(iter != chosenActions.end());
     const auto& actions = iter->second;
+    assert(!actions.empty());
     for (auto action : actions) {
       doInlining(module, func, action, getPassOptions());
     }
@@ -1299,9 +1302,7 @@ struct Inlining : public Pass {
     Planner(&state).run(getPassRunner(), module);
 
     // Choose which inlinings to perform. We do this sequentially so that we
-    // can consider interactions between them, and avoid nondeterminism. The
-    // result of this process is a map of function names to the inlining actions
-    // we've decided to actually perform in them.
+    // can consider interactions between them, and avoid nondeterminism.
     ChosenActions chosenActions;
 
     // How many uses (calls of the function) we inlined.

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -640,7 +640,7 @@ using ChosenActions = std::unordered_map<Name, std::vector<InliningAction>>;
 // A pass that calls doInlining() on a bunch of actions that were chosen to
 // perform.
 struct DoInlining : public Pass {
-  virtual bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
 
   std::unique_ptr<Pass> create() override {
     return std::make_unique<DoInlining>(chosenActions);

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -244,14 +244,18 @@ struct InliningAction {
   Function* contents;
   bool insideATry;
 
-  // An optional name hint can be provided, which will then be used in the name of
-  // the block we put the inlined code in. Using a unique name hint in each inlining
-  // can reduce the risk of name overlaps (which cause fixup work
-  // in UniqueNameMapper::uniquify).
+  // An optional name hint can be provided, which will then be used in the name
+  // of the block we put the inlined code in. Using a unique name hint in each
+  // inlining can reduce the risk of name overlaps (which cause fixup work in
+  // UniqueNameMapper::uniquify).
   Index nameHint = 0;
 
-  InliningAction(Expression** callSite, Function* contents, bool insideATry, Index nameHint = 0)
-    : callSite(callSite), contents(contents), insideATry(insideATry), nameHint(nameHint) {}
+  InliningAction(Expression** callSite,
+                 Function* contents,
+                 bool insideATry,
+                 Index nameHint = 0)
+    : callSite(callSite), contents(contents), insideATry(insideATry),
+      nameHint(nameHint) {}
 };
 
 struct InliningState {
@@ -642,7 +646,8 @@ struct DoInlining : public Pass {
     return std::make_unique<DoInlining>(chosenActions);
   }
 
-  DoInlining(const ChosenActions& chosenActions) : chosenActions(chosenActions) {}
+  DoInlining(const ChosenActions& chosenActions)
+    : chosenActions(chosenActions) {}
 
   void runOnFunction(Module* module, Function* func) override {
     auto iter = chosenActions.find(func->name);
@@ -1296,7 +1301,7 @@ struct Inlining : public Pass {
     // Choose which inlinings to perform. We do this sequentially so that we
     // can consider interactions between them, and avoid nondeterminism. The
     // result of this process is a map of function names to the inlining actions
-    // we've decided to actually perform in them.    
+    // we've decided to actually perform in them.
     ChosenActions chosenActions;
 
     // How many uses (calls of the function) we inlined.
@@ -1354,7 +1359,8 @@ struct Inlining : public Pass {
     // inline into, but in parallel between them). If we are optimizing, do so
     // as well.
     {
-      PassUtils::FilteredPassRunner runner(module, inlinedInto, getPassRunner()->options);
+      PassUtils::FilteredPassRunner runner(
+        module, inlinedInto, getPassRunner()->options);
       runner.setIsNested(true);
       runner.add(std::make_unique<DoInlining>(chosenActions));
       if (optimize) {

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1336,7 +1336,7 @@ struct Inlining : public Pass {
         std::cout << "inline " << inlinedName << " into " << func->name << '\n';
 #endif
 
-        // Update the action for the actual inlining we are chose to perform
+        // Update the action for the actual inlining we have chosen to perform
         // (when splitting, we will actually inline one of the split pieces and
         // not the original function itself; note how even if we do that then
         // we are still removing a call to the original function here, and so

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -28,15 +28,23 @@
 
 namespace wasm::OptUtils {
 
+// Given a PassRunner, applies a set of useful passes that make sense to run
+// after inlining.
+inline void addUsefulPassesAfterInlining(PassRunner& runner) {
+  // Propagating constants makes a lot of sense after inlining, as new constants
+  // may have arrived.
+  runner.add("precompute-propagate");
+  // Do all the usual stuff.
+  runner.addDefaultFunctionOptimizationPasses();
+}
+
 // Run useful optimizations after inlining new code into a set of functions.
 inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
                                   Module* module,
                                   PassRunner* parentRunner) {
   PassUtils::FilteredPassRunner runner(module, funcs, parentRunner->options);
   runner.setIsNested(true);
-  // this is especially useful after inlining
-  runner.add("precompute-propagate");
-  runner.addDefaultFunctionOptimizationPasses(); // do all the usual stuff
+  addUsefulPassesAfterInlining(runner);
   runner.run();
 }
 


### PR DESCRIPTION
We already parallelized collecting info about functions and finding
inlining opportunities, but the actual inlining - copying the code into
the target function - was done sequentially. It turns out that a lot of
work happens there: this PR makes the pass over 2x faster.

Details:
 * Move nameHint to InliningAction, so it is there when we apply the actions.
 * Add a DoInlining internal pass which calls doInlining().
 * Refactor OptUtils a little to make it easy to run DoInlining before opts.
 * Also remove the return value of doInlining which was not used.