### PR TITLE
[NFC-ish] Avoid repeated ReFinalize etc. when inlining

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -635,6 +635,8 @@ static void doInlining(Module* module,
   TypeUpdating::handleNonDefaultableLocals(into, *module);
 }
 
+// A map of function names to the inlining actions we've decided to actually
+// perform in them.
 using ChosenActions = std::unordered_map<Name, std::vector<InliningAction>>;
 
 // A pass that calls doInlining() on a bunch of actions that were chosen to
@@ -654,6 +656,7 @@ struct DoInlining : public Pass {
     // We must be called on a function that we actually want to inline into.
     assert(iter != chosenActions.end());
     const auto& actions = iter->second;
+    assert(!actions.empty());
     for (auto action : actions) {
       doInlining(module, func, action, getPassOptions());
     }
@@ -1299,9 +1302,7 @@ struct Inlining : public Pass {
     Planner(&state).run(getPassRunner(), module);
 
     // Choose which inlinings to perform. We do this sequentially so that we
-    // can consider interactions between them, and avoid nondeterminism. The
-    // result of this process is a map of function names to the inlining actions
-    // we've decided to actually perform in them.
+    // can consider interactions between them, and avoid nondeterminism.
     ChosenActions chosenActions;
 
     // How many uses (calls of the function) we inlined.

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -640,7 +640,7 @@ using ChosenActions = std::unordered_map<Name, std::vector<InliningAction>>;
 // A pass that calls doInlining() on a bunch of actions that were chosen to
 // perform.
 struct DoInlining : public Pass {
-  virtual bool isFunctionParallel() { return true; }
+  bool isFunctionParallel() override { return true; }
 
   std::unique_ptr<Pass> create() override {
     return std::make_unique<DoInlining>(chosenActions);

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -244,14 +244,18 @@ struct InliningAction {
   Function* contents;
   bool insideATry;
 
-  // An optional name hint can be provided, which will then be used in the name of
-  // the block we put the inlined code in. Using a unique name hint in each inlining
-  // can reduce the risk of name overlaps (which cause fixup work
-  // in UniqueNameMapper::uniquify).
+  // An optional name hint can be provided, which will then be used in the name
+  // of the block we put the inlined code in. Using a unique name hint in each
+  // inlining can reduce the risk of name overlaps (which cause fixup work in
+  // UniqueNameMapper::uniquify).
   Index nameHint = 0;
 
-  InliningAction(Expression** callSite, Function* contents, bool insideATry, Index nameHint = 0)
-    : callSite(callSite), contents(contents), insideATry(insideATry), nameHint(nameHint) {}
+  InliningAction(Expression** callSite,
+                 Function* contents,
+                 bool insideATry,
+                 Index nameHint = 0)
+    : callSite(callSite), contents(contents), insideATry(insideATry),
+      nameHint(nameHint) {}
 };
 
 struct InliningState {
@@ -642,7 +646,8 @@ struct DoInlining : public Pass {
     return std::make_unique<DoInlining>(chosenActions);
   }
 
-  DoInlining(const ChosenActions& chosenActions) : chosenActions(chosenActions) {}
+  DoInlining(const ChosenActions& chosenActions)
+    : chosenActions(chosenActions) {}
 
   void runOnFunction(Module* module, Function* func) override {
     auto iter = chosenActions.find(func->name);
@@ -1296,7 +1301,7 @@ struct Inlining : public Pass {
     // Choose which inlinings to perform. We do this sequentially so that we
     // can consider interactions between them, and avoid nondeterminism. The
     // result of this process is a map of function names to the inlining actions
-    // we've decided to actually perform in them.    
+    // we've decided to actually perform in them.
     ChosenActions chosenActions;
 
     // How many uses (calls of the function) we inlined.
@@ -1354,7 +1359,8 @@ struct Inlining : public Pass {
     // inline into, but in parallel between them). If we are optimizing, do so
     // as well.
     {
-      PassUtils::FilteredPassRunner runner(module, inlinedInto, getPassRunner()->options);
+      PassUtils::FilteredPassRunner runner(
+        module, inlinedInto, getPassRunner()->options);
       runner.setIsNested(true);
       runner.add(std::make_unique<DoInlining>(chosenActions));
       if (optimize) {

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1336,7 +1336,7 @@ struct Inlining : public Pass {
         std::cout << "inline " << inlinedName << " into " << func->name << '\n';
 #endif
 
-        // Update the action for the actual inlining we are chose to perform
+        // Update the action for the actual inlining we have chosen to perform
         // (when splitting, we will actually inline one of the split pieces and
         // not the original function itself; note how even if we do that then
         // we are still removing a call to the original function here, and so

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -627,8 +627,7 @@ static void doCodeInlining(Module* module,
 // Updates the outer function after we inline into it. This is a general
 // operation that does not depend on what we inlined, it just makes sure that we
 // refinalize everything, have no duplicate break labels, etc.
-static void updateAfterInlining(Module* module,
-                                Function* into) {
+static void updateAfterInlining(Module* module, Function* into) {
   // Anything we inlined into may now have non-unique label names, fix it up.
   // Note that we must do this before refinalization, as otherwise duplicate
   // block labels can lead to errors (the IR must be valid before we

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -28,15 +28,23 @@
 
 namespace wasm::OptUtils {
 
+// Given a PassRunner, applies a set of useful passes that make sense to run
+// after inlining.
+inline void addUsefulPassesAfterInlining(PassRunner& runner) {
+  // Propagating constants makes a lot of sense after inlining, as new constants
+  // may have arrived.
+  runner.add("precompute-propagate");
+  // Do all the usual stuff.
+  runner.addDefaultFunctionOptimizationPasses();
+}
+
 // Run useful optimizations after inlining new code into a set of functions.
 inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
                                   Module* module,
                                   PassRunner* parentRunner) {
   PassUtils::FilteredPassRunner runner(module, funcs, parentRunner->options);
   runner.setIsNested(true);
-  // this is especially useful after inlining
-  runner.add("precompute-propagate");
-  runner.addDefaultFunctionOptimizationPasses(); // do all the usual stuff
+  addUsefulPassesAfterInlining(runner);
   runner.run();
 }
 

--- a/test/lit/passes/inlining-optimizing_optimize-level=3.wast
+++ b/test/lit/passes/inlining-optimizing_optimize-level=3.wast
@@ -8820,7 +8820,7 @@
  ;; CHECK-NEXT:                      (br $__rjti$8)
  ;; CHECK-NEXT:                     )
  ;; CHECK-NEXT:                     (block $label$break$L8
- ;; CHECK-NEXT:                      (block $__rjti$20
+ ;; CHECK-NEXT:                      (block $__rjti$23
  ;; CHECK-NEXT:                       (if
  ;; CHECK-NEXT:                        (i32.and
  ;; CHECK-NEXT:                         (local.tee $9
@@ -8845,7 +8845,7 @@
  ;; CHECK-NEXT:                          (local.get $5)
  ;; CHECK-NEXT:                         )
  ;; CHECK-NEXT:                         (loop $while-in5
- ;; CHECK-NEXT:                          (br_if $__rjti$20
+ ;; CHECK-NEXT:                          (br_if $__rjti$23
  ;; CHECK-NEXT:                           (i32.eqz
  ;; CHECK-NEXT:                            (i32.load8_u
  ;; CHECK-NEXT:                             (local.get $8)
@@ -8890,7 +8890,7 @@
  ;; CHECK-NEXT:                         )
  ;; CHECK-NEXT:                        )
  ;; CHECK-NEXT:                       )
- ;; CHECK-NEXT:                       (br_if $__rjti$20
+ ;; CHECK-NEXT:                       (br_if $__rjti$23
  ;; CHECK-NEXT:                        (local.get $9)
  ;; CHECK-NEXT:                       )
  ;; CHECK-NEXT:                       (local.set $9

--- a/test/lit/passes/inlining_optimize-level=3.wast
+++ b/test/lit/passes/inlining_optimize-level=3.wast
@@ -503,23 +503,6 @@
 ;; (That avoids possible validation problems, and maximizes DCE.) To keep it
 ;; unreachable we'll add an unreachable instruction after the inlined code.
 (module
- ;; CHECK:      (type $0 (func (param f32)))
-
- ;; CHECK:      (type $1 (func))
-
- ;; CHECK:      (func $A (param $0 f32)
- ;; CHECK-NEXT:  (local $1 f32)
- ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result f32)
- ;; CHECK-NEXT:    (block $__inlined_func$C (result f32)
- ;; CHECK-NEXT:     (local.set $1
- ;; CHECK-NEXT:      (local.get $0)
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (local.get $1)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT: )
  (func $A (param $0 f32)
   (drop
    (call $C
@@ -527,12 +510,16 @@
    )
   )
  )
+ ;; CHECK:      (type $0 (func))
+
  ;; CHECK:      (func $B
  ;; CHECK-NEXT:  (local $0 f32)
- ;; CHECK-NEXT:  (call $A
- ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:  (local $1 f32)
+ ;; CHECK-NEXT:  (local $2 f32)
+ ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:   (block $__inlined_func$A$3
+ ;; CHECK-NEXT:    (local.set $1
+ ;; CHECK-NEXT:     (block (result f32)
  ;; CHECK-NEXT:      (block $__inlined_func$C$2 (result f32)
  ;; CHECK-NEXT:       (local.tee $0
  ;; CHECK-NEXT:        (block
@@ -544,7 +531,19 @@
  ;; CHECK-NEXT:       (local.get $0)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (unreachable)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (local.set $2
+ ;; CHECK-NEXT:     (f32.const 0)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (block (result f32)
+ ;; CHECK-NEXT:      (block $__inlined_func$C (result f32)
+ ;; CHECK-NEXT:       (local.set $2
+ ;; CHECK-NEXT:        (local.get $1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (local.get $2)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )


### PR DESCRIPTION
We may inline multiple times into a single function. Previously, if we did so, we
did the "fixups" such as ReFinalize and non-nullable local fixes once per such
inlining. But that is wasteful as each ReFinalize etc. scans the whole function,
and could be done after we copy all the code from all the inlinings, which is
what this PR does: it splits `doInlining()` into one function that inlines code and
one that does the updates after, and the update is done after all inlinings.

This turns out to be very important, a 5x speedup on a large real-world wasm
file I am looking at. The reason is that we actually inline more than once in
half the cases, and sometimes far more - in one case we inline over 1,000
times into a function! It is helpful to replaces 1,000 ReFinalizes with a single one...

This is practically NFC, but it turns out that there are some tiny noticeable
differences between running ReFinalize once at the end vs. once after each
inlining. These differences are not really functional or observable in the
behavior of the code, and optimizations would remove them anyhow, but
they are noticeable in two tests here. The changes to tests are, in order:

* Different block names, just because the counter we use sees more things.
* In a testcase with unreachable code, we inline twice into a function, and
  the first inlining brings in an unreachable, and ReFinalizing early will lead
  to it propagating differently than if we wait to ReFinalize. (It actually leads
  to another cycle of inlining in that case, as a fluke.)