### PR TITLE
[NFC-ish] Stop creating unneeded blocks around calls when inlining

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -290,15 +290,12 @@ struct Planner : public WalkerPass<TryDepthWalker<Planner>> {
     }
     if (state->inlinableFunctions.count(curr->target) && !isUnreachable &&
         curr->target != getFunction()->name) {
-      // nest the call in a block. that way the location of the pointer to the
-      // call will not change even if we inline multiple times into the same
-      // function, otherwise call1(call2()) might be a problem
-      auto* block = Builder(*getModule()).makeBlock(curr);
-      replaceCurrent(block);
       // can't add a new element in parallel
       assert(state->actionsForFunction.count(getFunction()->name) > 0);
       state->actionsForFunction[getFunction()->name].emplace_back(
-        &block->list[0], getModule()->getFunction(curr->target), tryDepth > 0);
+        getCurrentPointer(),
+        getModule()->getFunction(curr->target),
+        tryDepth > 0);
     }
   }
 

--- a/test/lit/passes/inlining-eh-legacy.wast
+++ b/test/lit/passes/inlining-eh-legacy.wast
@@ -22,16 +22,14 @@
 
   ;; CHECK:      (func $caller-with-label (type $1) (param $x i32)
   ;; CHECK-NEXT:  (loop $label
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (block $__inlined_func$callee-with-label
-  ;; CHECK-NEXT:     (try $label0
-  ;; CHECK-NEXT:      (do
-  ;; CHECK-NEXT:       (nop)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (catch $tag$0
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (pop i32)
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:   (block $__inlined_func$callee-with-label
+  ;; CHECK-NEXT:    (try $label0
+  ;; CHECK-NEXT:     (do
+  ;; CHECK-NEXT:      (nop)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (catch $tag$0
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (pop i32)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
@@ -89,10 +87,8 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (delegate 0)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block (result i32)
-  ;; CHECK-NEXT:   (block $__inlined_func$callee-a$1 (result i32)
-  ;; CHECK-NEXT:    (i32.const 42)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$callee-a$1 (result i32)
+  ;; CHECK-NEXT:   (i32.const 42)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $caller-with-try-delegate (result i32)
@@ -109,22 +105,16 @@
 
   ;; CHECK:      (func $caller-with-pop (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
-  ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (try
   ;; CHECK-NEXT:   (do
   ;; CHECK-NEXT:    (nop)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (catch $tag$0
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (pop i32)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (block $__inlined_func$callee-b$2
-  ;; CHECK-NEXT:      (local.set $0
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (nop)
+  ;; CHECK-NEXT:    (block $__inlined_func$callee-b$2
+  ;; CHECK-NEXT:     (local.set $0
+  ;; CHECK-NEXT:      (pop i32)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/inlining-eh-legacy.wast
+++ b/test/lit/passes/inlining-eh-legacy.wast
@@ -123,12 +123,59 @@
     (try
       (do)
       (catch $tag$0
-        ;; After this $callee-b is inlined, there will be additional 'block's
-        ;; surrouding this 'pop', which makes its location invalid. We fix it by
+        ;; After this $callee-b is inlined, there will be an additional block
+        ;; surrouding this 'pop'. However, that block has no breaks to it, and
+        ;; will be considered the implicit block of the catch scope, so no
+        ;; fixups are done.
+        (call $callee-b
+          (pop i32)
+        )
+      )
+    )
+  )
+
+  (func $callee-c (param $x i32) (result i32)
+    (local.get $x)
+  )
+
+  ;; CHECK:      (func $caller-with-pop-twice (type $0)
+  ;; CHECK-NEXT:  (local $0 i32)
+  ;; CHECK-NEXT:  (local $1 i32)
+  ;; CHECK-NEXT:  (local $2 i32)
+  ;; CHECK-NEXT:  (try
+  ;; CHECK-NEXT:   (do
+  ;; CHECK-NEXT:    (nop)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (catch $tag$0
+  ;; CHECK-NEXT:    (local.set $2
+  ;; CHECK-NEXT:     (pop i32)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block $__inlined_func$callee-b$4
+  ;; CHECK-NEXT:     (local.set $1
+  ;; CHECK-NEXT:      (block $__inlined_func$callee-c$3 (result i32)
+  ;; CHECK-NEXT:       (local.set $0
+  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $caller-with-pop-twice
+    (try
+      (do)
+      (catch $tag$0
+        ;; As above, but now with two calls here, both of whom will be inlined.
+        ;; As a result we have two blocks that nest the pops. We fix that by
         ;; creating a new local to set the result of 'pop' and later use
         ;; local.get to get the value within the inlined function body.
         (call $callee-b
-          (pop i32)
+          (call $callee-c
+            (pop i32)
+          )
         )
       )
     )

--- a/test/lit/passes/inlining-unreachable.wast
+++ b/test/lit/passes/inlining-unreachable.wast
@@ -75,11 +75,9 @@
 
   ;; CHECK:      (func $caller (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (block $__inlined_func$callee
-  ;; CHECK-NEXT:     (call $imported
-  ;; CHECK-NEXT:      (unreachable)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$callee
+  ;; CHECK-NEXT:    (call $imported
+  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -100,22 +98,20 @@
 
   ;; CHECK:      (func $caller-2 (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (block $__inlined_func$callee-2$1
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (block $__return_call
-  ;; CHECK-NEXT:       (block
-  ;; CHECK-NEXT:        (try
-  ;; CHECK-NEXT:         (do
-  ;; CHECK-NEXT:          (unreachable)
-  ;; CHECK-NEXT:          (br $__return_call)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:   (block $__inlined_func$callee-2$1
+  ;; CHECK-NEXT:    (block
+  ;; CHECK-NEXT:     (block $__return_call
+  ;; CHECK-NEXT:      (block
+  ;; CHECK-NEXT:       (try
+  ;; CHECK-NEXT:        (do
+  ;; CHECK-NEXT:         (unreachable)
+  ;; CHECK-NEXT:         (br $__return_call)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (call $imported
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (call $imported
+  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -179,11 +175,9 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (return
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (block $__inlined_func$1
-  ;; CHECK-NEXT:     (block $block0
-  ;; CHECK-NEXT:      (unreachable)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$1
+  ;; CHECK-NEXT:    (block $block0
+  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/inlining_all-features.wast
+++ b/test/lit/passes/inlining_all-features.wast
@@ -20,10 +20,8 @@
   (func $foo)
 
   ;; CHECK:      (func $ref_func_test (type $1) (result funcref)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$foo
-  ;; CHECK-NEXT:    (nop)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$foo
+  ;; CHECK-NEXT:   (nop)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (ref.func $foo)
   ;; CHECK-NEXT: )

--- a/test/lit/passes/inlining_all-features.wast
+++ b/test/lit/passes/inlining_all-features.wast
@@ -137,3 +137,38 @@
   )
  )
 )
+
+;; Test handling of nested inlined calls.
+(module
+ (func $callee-a (param i32))
+
+ (func $callee-b (param $x i32) (result i32)
+  (local.get $x)
+ )
+
+ ;; CHECK:      (type $0 (func))
+
+ ;; CHECK:      (func $caller-with-pop-twice (type $0)
+ ;; CHECK-NEXT:  (local $0 i32)
+ ;; CHECK-NEXT:  (local $1 i32)
+ ;; CHECK-NEXT:  (block $__inlined_func$callee-a$1
+ ;; CHECK-NEXT:   (local.set $1
+ ;; CHECK-NEXT:    (block $__inlined_func$callee-b (result i32)
+ ;; CHECK-NEXT:     (local.set $0
+ ;; CHECK-NEXT:      (i32.const 42)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $0)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (nop)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $caller-with-pop-twice
+  ;; Both these calls should be inlined.
+  (call $callee-a
+   (call $callee-b
+    (i32.const 42)
+   )
+  )
+ )
+)

--- a/test/lit/passes/inlining_enable-tail-call.wast
+++ b/test/lit/passes/inlining_enable-tail-call.wast
@@ -24,124 +24,92 @@
   ;; CHECK-NEXT:  (local $4 f32)
   ;; CHECK-NEXT:  (local $5 i64)
   ;; CHECK-NEXT:  (local $6 f32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$exported
-  ;; CHECK-NEXT:    (nop)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$exported
+  ;; CHECK-NEXT:   (nop)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$tabled$1
-  ;; CHECK-NEXT:    (nop)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$tabled$1
+  ;; CHECK-NEXT:   (nop)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$multi$2
-  ;; CHECK-NEXT:    (nop)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$multi$2
+  ;; CHECK-NEXT:   (nop)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$multi$3
-  ;; CHECK-NEXT:    (nop)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$multi$3
+  ;; CHECK-NEXT:   (nop)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$ok$4
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$ok$4
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$int$5 (result i32)
-  ;; CHECK-NEXT:     (i32.const 2)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (block $__inlined_func$int$5 (result i32)
+  ;; CHECK-NEXT:    (i32.const 2)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result f64)
-  ;; CHECK-NEXT:    (block $__inlined_func$double$6 (result f64)
-  ;; CHECK-NEXT:     (f64.const 3.14159)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (block $__inlined_func$double$6 (result f64)
+  ;; CHECK-NEXT:    (f64.const 3.14159)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$int2$7 (result i32)
-  ;; CHECK-NEXT:     (i32.const 112)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (block $__inlined_func$int2$7 (result i32)
+  ;; CHECK-NEXT:    (i32.const 112)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (local.set $y
-  ;; CHECK-NEXT:   (block (result f64)
-  ;; CHECK-NEXT:    (block $__inlined_func$double2$8 (result f64)
-  ;; CHECK-NEXT:     (f64.const 113.14159)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (block $__inlined_func$double2$8 (result f64)
+  ;; CHECK-NEXT:    (f64.const 113.14159)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$with-local$9
-  ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (f32.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (f32.const 2.1418280601501465)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$with-local$9
+  ;; CHECK-NEXT:   (local.set $2
+  ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $2
+  ;; CHECK-NEXT:    (f32.const 2.1418280601501465)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$with-local2$10
-  ;; CHECK-NEXT:    (local.set $3
-  ;; CHECK-NEXT:     (i64.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $3
-  ;; CHECK-NEXT:     (i64.const 4)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$with-local2$10
+  ;; CHECK-NEXT:   (local.set $3
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $3
+  ;; CHECK-NEXT:    (i64.const 4)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$return$11 (result i32)
-  ;; CHECK-NEXT:     (br $__inlined_func$return$11
-  ;; CHECK-NEXT:      (i32.const 5)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$return$11 (result i32)
+  ;; CHECK-NEXT:    (br $__inlined_func$return$11
+  ;; CHECK-NEXT:     (i32.const 5)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$multipass$12
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (block
-  ;; CHECK-NEXT:      (block $__inlined_func$multipass2$15
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (i32.const 6)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$multipass$12
+  ;; CHECK-NEXT:   (block $__inlined_func$multipass2$15
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 6)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$param$13
-  ;; CHECK-NEXT:    (local.set $4
-  ;; CHECK-NEXT:     (f32.const 12.34000015258789)
+  ;; CHECK-NEXT:  (block $__inlined_func$param$13
+  ;; CHECK-NEXT:   (local.set $4
+  ;; CHECK-NEXT:    (f32.const 12.34000015258789)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $5
+  ;; CHECK-NEXT:    (i64.const 890005350012)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $6
+  ;; CHECK-NEXT:    (f32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $4)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $5
-  ;; CHECK-NEXT:     (i64.const 890005350012)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $5)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $6
-  ;; CHECK-NEXT:     (f32.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (local.get $4)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (local.get $5)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (local.get $6)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $6)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -184,9 +152,7 @@
   )
   ;; CHECK:      (func $cycle1
   ;; CHECK-NEXT:  (block $__inlined_func$cycle2$14
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (call $cycle1)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (call $cycle1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $cycle1
@@ -313,18 +279,16 @@
  ;; CHECK-NEXT:     (then
  ;; CHECK-NEXT:      (if (result i32)
  ;; CHECK-NEXT:       (i32.eqz
- ;; CHECK-NEXT:        (block (result i32)
- ;; CHECK-NEXT:         (block $__inlined_func$func_3 (result i32)
- ;; CHECK-NEXT:          (local.set $8
- ;; CHECK-NEXT:           (i32.const 0)
+ ;; CHECK-NEXT:        (block $__inlined_func$func_3 (result i32)
+ ;; CHECK-NEXT:         (local.set $8
+ ;; CHECK-NEXT:          (i32.const 0)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (select
+ ;; CHECK-NEXT:          (local.get $8)
+ ;; CHECK-NEXT:          (local.tee $8
+ ;; CHECK-NEXT:           (i32.const -1)
  ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (select
- ;; CHECK-NEXT:           (local.get $8)
- ;; CHECK-NEXT:           (local.tee $8
- ;; CHECK-NEXT:            (i32.const -1)
- ;; CHECK-NEXT:           )
- ;; CHECK-NEXT:           (i32.const 1)
- ;; CHECK-NEXT:          )
+ ;; CHECK-NEXT:          (i32.const 1)
  ;; CHECK-NEXT:         )
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
@@ -474,14 +438,12 @@
  ;; CHECK:      (type $0 (func))
 
  ;; CHECK:      (func $caller
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$callee
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (i32.const 42)
- ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:  (block $__inlined_func$callee
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (i32.const 42)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (return)
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return)
  ;; CHECK-NEXT: )
  (func $caller
   (return_call $callee)
@@ -561,17 +523,15 @@
 
  ;; CHECK:      (func $caller
  ;; CHECK-NEXT:  (local $0 i32)
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$callee
- ;; CHECK-NEXT:    (local.set $0
- ;; CHECK-NEXT:     (i32.const 42)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (local.get $0)
- ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:  (block $__inlined_func$callee
+ ;; CHECK-NEXT:   (local.set $0
+ ;; CHECK-NEXT:    (i32.const 42)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (return)
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return)
  ;; CHECK-NEXT: )
  (func $caller
   (return_call $callee
@@ -583,12 +543,10 @@
  ;; CHECK-NEXT:  (block $__original_body
  ;; CHECK-NEXT:   (try
  ;; CHECK-NEXT:    (do
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (local.set $0
- ;; CHECK-NEXT:       (i32.const 42)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (br $__original_body)
+ ;; CHECK-NEXT:     (local.set $0
+ ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (br $__original_body)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (return)
@@ -641,12 +599,10 @@
  ;; CHECK-NEXT:   (return
  ;; CHECK-NEXT:    (try
  ;; CHECK-NEXT:     (do
- ;; CHECK-NEXT:      (block
- ;; CHECK-NEXT:       (local.set $0
- ;; CHECK-NEXT:        (i32.const 42)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (br $__original_body)
+ ;; CHECK-NEXT:      (local.set $0
+ ;; CHECK-NEXT:       (i32.const 42)
  ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (br $__original_body)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -678,25 +634,23 @@
  ;; CHECK-NEXT:  (local $y i32)
  ;; CHECK-NEXT:  (local $2 i32)
  ;; CHECK-NEXT:  (local $3 i32)
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$callee
- ;; CHECK-NEXT:    (local.set $2
- ;; CHECK-NEXT:     (local.get $x)
+ ;; CHECK-NEXT:  (block $__inlined_func$callee
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $3
+ ;; CHECK-NEXT:    (local.get $y)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (block
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (local.get $2)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.set $3
- ;; CHECK-NEXT:     (local.get $y)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (drop
- ;; CHECK-NEXT:      (local.get $2)
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (drop
- ;; CHECK-NEXT:      (local.get $3)
- ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (local.get $3)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (return)
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return)
  ;; CHECK-NEXT: )
  (func $caller
   (local $x i32)
@@ -727,15 +681,13 @@
  ;; CHECK-NEXT:  (block $__original_body
  ;; CHECK-NEXT:   (try
  ;; CHECK-NEXT:    (do
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (local.set $2
- ;; CHECK-NEXT:       (local.get $x)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (local.set $3
- ;; CHECK-NEXT:       (local.get $y)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (br $__original_body)
+ ;; CHECK-NEXT:     (local.set $2
+ ;; CHECK-NEXT:      (local.get $x)
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.set $3
+ ;; CHECK-NEXT:      (local.get $y)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (br $__original_body)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (return)
@@ -778,23 +730,17 @@
  ;; CHECK:      (type $0 (func))
 
  ;; CHECK:      (func $first
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$second
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (block
- ;; CHECK-NEXT:       (block $__inlined_func$third$2
- ;; CHECK-NEXT:        (drop
- ;; CHECK-NEXT:         (i32.const 42)
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (return)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:  (block $__inlined_func$second
+ ;; CHECK-NEXT:   (block
+ ;; CHECK-NEXT:    (block $__inlined_func$third$2
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (return)
  ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:   (return)
  ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (return)
  ;; CHECK-NEXT: )
  (func $first
   (return_call $second)
@@ -813,9 +759,7 @@
  ;; CHECK-NEXT:    (block $__inlined_func$second-2$1
  ;; CHECK-NEXT:     (try
  ;; CHECK-NEXT:      (do
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (br $__original_body_0)
- ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (br $__original_body_0)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
@@ -871,26 +815,22 @@
  ;; CHECK-NEXT:    (local.set $3
  ;; CHECK-NEXT:     (local.get $y)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (return
- ;; CHECK-NEXT:       (block $__inlined_func$third$1 (result i32)
- ;; CHECK-NEXT:        (local.set $4
- ;; CHECK-NEXT:         (local.get $2)
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (local.set $5
- ;; CHECK-NEXT:         (local.get $3)
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (block (result i32)
- ;; CHECK-NEXT:         (drop
- ;; CHECK-NEXT:          (local.get $4)
- ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:         (drop
- ;; CHECK-NEXT:          (local.get $5)
- ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:         (i32.const 42)
- ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:    (return
+ ;; CHECK-NEXT:     (block $__inlined_func$third$1 (result i32)
+ ;; CHECK-NEXT:      (local.set $4
+ ;; CHECK-NEXT:       (local.get $2)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (local.set $5
+ ;; CHECK-NEXT:       (local.get $3)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (block (result i32)
+ ;; CHECK-NEXT:       (drop
+ ;; CHECK-NEXT:        (local.get $4)
  ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (drop
+ ;; CHECK-NEXT:        (local.get $5)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (i32.const 42)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
@@ -940,15 +880,13 @@
  ;; CHECK-NEXT:      (return
  ;; CHECK-NEXT:       (try
  ;; CHECK-NEXT:        (do
- ;; CHECK-NEXT:         (block
- ;; CHECK-NEXT:          (local.set $2
- ;; CHECK-NEXT:           (local.get $x)
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (local.set $3
- ;; CHECK-NEXT:           (local.get $y)
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (br $__original_body)
+ ;; CHECK-NEXT:         (local.set $2
+ ;; CHECK-NEXT:          (local.get $x)
  ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (local.set $3
+ ;; CHECK-NEXT:          (local.get $y)
+ ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:         (br $__original_body)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
@@ -956,17 +894,13 @@
  ;; CHECK-NEXT:     (block $__inlined_func$second
  ;; CHECK-NEXT:      (try
  ;; CHECK-NEXT:       (do
- ;; CHECK-NEXT:        (block
- ;; CHECK-NEXT:         (block
- ;; CHECK-NEXT:          (local.set $4
- ;; CHECK-NEXT:           (local.get $2)
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (local.set $5
- ;; CHECK-NEXT:           (local.get $3)
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (br $__original_body_0)
- ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:        (local.set $4
+ ;; CHECK-NEXT:         (local.get $2)
  ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (local.set $5
+ ;; CHECK-NEXT:         (local.get $3)
+ ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:        (br $__original_body_0)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
@@ -1023,16 +957,10 @@
 
  ;; CHECK:      (func $first
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (block $__inlined_func$second (result i32)
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (br $__inlined_func$second
- ;; CHECK-NEXT:       (block (result i32)
- ;; CHECK-NEXT:        (block $__inlined_func$third$2 (result i32)
- ;; CHECK-NEXT:         (i32.const 42)
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:   (block $__inlined_func$second (result i32)
+ ;; CHECK-NEXT:    (br $__inlined_func$second
+ ;; CHECK-NEXT:     (block $__inlined_func$third$2 (result i32)
+ ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -1045,25 +973,19 @@
  )
  ;; CHECK:      (func $first-2
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (block $__inlined_func$second-2$1 (result i32)
- ;; CHECK-NEXT:     (block (result i32)
- ;; CHECK-NEXT:      (block $__return_call
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (try
- ;; CHECK-NEXT:         (do
- ;; CHECK-NEXT:          (block
- ;; CHECK-NEXT:           (br $__return_call)
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:   (block $__inlined_func$second-2$1 (result i32)
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (block $__return_call
+ ;; CHECK-NEXT:      (block
+ ;; CHECK-NEXT:       (try
+ ;; CHECK-NEXT:        (do
+ ;; CHECK-NEXT:         (br $__return_call)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (block (result i32)
- ;; CHECK-NEXT:       (block $__inlined_func$third$3 (result i32)
- ;; CHECK-NEXT:        (i32.const 42)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (block $__inlined_func$third$3 (result i32)
+ ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -1096,19 +1018,15 @@
  ;; CHECK-NEXT:  (local $0 i32)
  ;; CHECK-NEXT:  (block $__inlined_func$second
  ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (block $__inlined_func$third$2
- ;; CHECK-NEXT:       (local.set $0
- ;; CHECK-NEXT:        (i32.const 42)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (drop
- ;; CHECK-NEXT:        (local.get $0)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:    (block $__inlined_func$third$2
+ ;; CHECK-NEXT:     (local.set $0
+ ;; CHECK-NEXT:      (i32.const 42)
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (br $__inlined_func$second)
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (local.get $0)
+ ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (br $__inlined_func$second)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -1122,21 +1040,17 @@
  ;; CHECK-NEXT:    (block $__return_call
  ;; CHECK-NEXT:     (try
  ;; CHECK-NEXT:      (do
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (br $__return_call)
- ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (br $__return_call)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (br $__inlined_func$second-2$1)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (block $__inlined_func$third$3
- ;; CHECK-NEXT:      (local.set $0
- ;; CHECK-NEXT:       (i32.const 42)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (drop
- ;; CHECK-NEXT:       (local.get $0)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:    (block $__inlined_func$third$3
+ ;; CHECK-NEXT:     (local.set $0
+ ;; CHECK-NEXT:      (i32.const 42)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (local.get $0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -1241,14 +1155,12 @@
  ;; CHECK:      (func $first
  ;; CHECK-NEXT:  (block $__inlined_func$second
  ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (call $third
- ;; CHECK-NEXT:      (block
- ;; CHECK-NEXT:       (br $__inlined_func$second)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:    (call $third
+ ;; CHECK-NEXT:     (block
+ ;; CHECK-NEXT:      (br $__inlined_func$second)
  ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:     (br $__inlined_func$second)
  ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (br $__inlined_func$second)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -1263,26 +1175,22 @@
  ;; CHECK-NEXT:    (block $__return_call
  ;; CHECK-NEXT:     (try
  ;; CHECK-NEXT:      (do
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (local.tee $0
- ;; CHECK-NEXT:         (block
- ;; CHECK-NEXT:          (br $__inlined_func$second-2$1)
- ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:       (local.tee $0
+ ;; CHECK-NEXT:        (block
+ ;; CHECK-NEXT:         (br $__inlined_func$second-2$1)
  ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (br $__return_call)
  ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (br $__return_call)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:     (br $__inlined_func$second-2$1)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (block $__inlined_func$third$2
- ;; CHECK-NEXT:      (local.set $1
- ;; CHECK-NEXT:       (local.get $0)
- ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (drop
- ;; CHECK-NEXT:       (local.get $1)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:    (block $__inlined_func$third$2
+ ;; CHECK-NEXT:     (local.set $1
+ ;; CHECK-NEXT:      (local.get $0)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (drop
+ ;; CHECK-NEXT:      (local.get $1)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -1331,13 +1239,11 @@
 
  ;; CHECK:      (func $caller
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (block $__inlined_func$callee (result i32)
- ;; CHECK-NEXT:     (br $__inlined_func$callee
- ;; CHECK-NEXT:      (call_indirect (type $T)
- ;; CHECK-NEXT:       (i32.const 42)
- ;; CHECK-NEXT:       (i32.const 0)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:   (block $__inlined_func$callee (result i32)
+ ;; CHECK-NEXT:    (br $__inlined_func$callee
+ ;; CHECK-NEXT:     (call_indirect (type $T)
+ ;; CHECK-NEXT:      (i32.const 42)
+ ;; CHECK-NEXT:      (i32.const 0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -1356,22 +1262,20 @@
  )
  ;; CHECK:      (func $caller-2
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block (result i32)
- ;; CHECK-NEXT:    (block $__inlined_func$callee-2$1 (result i32)
- ;; CHECK-NEXT:     (block (result i32)
- ;; CHECK-NEXT:      (block $__return_call
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (try
- ;; CHECK-NEXT:         (do
- ;; CHECK-NEXT:          (br $__return_call)
- ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:   (block $__inlined_func$callee-2$1 (result i32)
+ ;; CHECK-NEXT:    (block (result i32)
+ ;; CHECK-NEXT:     (block $__return_call
+ ;; CHECK-NEXT:      (block
+ ;; CHECK-NEXT:       (try
+ ;; CHECK-NEXT:        (do
+ ;; CHECK-NEXT:         (br $__return_call)
  ;; CHECK-NEXT:        )
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (call_indirect (type $T)
- ;; CHECK-NEXT:       (i32.const 42)
- ;; CHECK-NEXT:       (i32.const 0)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (call_indirect (type $T)
+ ;; CHECK-NEXT:      (i32.const 42)
+ ;; CHECK-NEXT:      (i32.const 0)
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
@@ -1484,35 +1388,29 @@
   (return_call $2)
  )
  ;; CHECK:      (func $19
- ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:  (block $__inlined_func$13$1
  ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (block $__inlined_func$13$1
- ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (if
- ;; CHECK-NEXT:       (global.get $global$0)
- ;; CHECK-NEXT:       (then
- ;; CHECK-NEXT:        (unreachable)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:    (if
+ ;; CHECK-NEXT:     (global.get $global$0)
+ ;; CHECK-NEXT:     (then
+ ;; CHECK-NEXT:      (unreachable)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (block
+ ;; CHECK-NEXT:     (block $__inlined_func$2
  ;; CHECK-NEXT:      (block
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (block $__inlined_func$2
- ;; CHECK-NEXT:         (block
- ;; CHECK-NEXT:          (if
- ;; CHECK-NEXT:           (global.get $global$0)
- ;; CHECK-NEXT:           (then
- ;; CHECK-NEXT:            (br $__inlined_func$2)
- ;; CHECK-NEXT:           )
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:          (global.set $global$0
- ;; CHECK-NEXT:           (i32.const 1)
- ;; CHECK-NEXT:          )
- ;; CHECK-NEXT:         )
+ ;; CHECK-NEXT:       (if
+ ;; CHECK-NEXT:        (global.get $global$0)
+ ;; CHECK-NEXT:        (then
+ ;; CHECK-NEXT:         (br $__inlined_func$2)
  ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (br $__inlined_func$13$1)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (global.set $global$0
+ ;; CHECK-NEXT:        (i32.const 1)
  ;; CHECK-NEXT:       )
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (br $__inlined_func$13$1)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -1558,38 +1456,34 @@
   )
  )
  ;; CHECK:      (func $19
- ;; CHECK-NEXT:  (block
+ ;; CHECK-NEXT:  (block $__inlined_func$13$1
  ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (block $__inlined_func$13$1
+ ;; CHECK-NEXT:    (block $__original_body
  ;; CHECK-NEXT:     (block
- ;; CHECK-NEXT:      (block $__original_body
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (if
- ;; CHECK-NEXT:         (global.get $global$0)
- ;; CHECK-NEXT:         (then
- ;; CHECK-NEXT:          (unreachable)
- ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (try
- ;; CHECK-NEXT:         (do
- ;; CHECK-NEXT:          (br $__original_body)
- ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:      (if
+ ;; CHECK-NEXT:       (global.get $global$0)
+ ;; CHECK-NEXT:       (then
+ ;; CHECK-NEXT:        (unreachable)
  ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (br $__inlined_func$13$1)
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (block $__inlined_func$2
- ;; CHECK-NEXT:       (block
- ;; CHECK-NEXT:        (if
- ;; CHECK-NEXT:         (global.get $global$0)
- ;; CHECK-NEXT:         (then
- ;; CHECK-NEXT:          (br $__inlined_func$2)
- ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (global.set $global$0
- ;; CHECK-NEXT:         (i32.const 1)
- ;; CHECK-NEXT:        )
+ ;; CHECK-NEXT:      (try
+ ;; CHECK-NEXT:       (do
+ ;; CHECK-NEXT:        (br $__original_body)
  ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (br $__inlined_func$13$1)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (block $__inlined_func$2
+ ;; CHECK-NEXT:     (block
+ ;; CHECK-NEXT:      (if
+ ;; CHECK-NEXT:       (global.get $global$0)
+ ;; CHECK-NEXT:       (then
+ ;; CHECK-NEXT:        (br $__inlined_func$2)
+ ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:      (global.set $global$0
+ ;; CHECK-NEXT:       (i32.const 1)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )

--- a/test/lit/passes/inlining_optimize-level=3.wast
+++ b/test/lit/passes/inlining_optimize-level=3.wast
@@ -82,138 +82,106 @@
   )
   ;; CHECK:      (func $intoHere
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$yes$2 (result i32)
+  ;; CHECK-NEXT:   (block $__inlined_func$yes$2 (result i32)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block $__inlined_func$yes-big-but-single-use$3 (result i32)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
+  ;; CHECK-NEXT:     (nop)
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$yes-big-but-single-use$3 (result i32)
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (nop)
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$no-calls$21 (result i32)
+  ;; CHECK-NEXT:    (block $__inlined_func$yes (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block (result i32)
-  ;; CHECK-NEXT:     (block $__inlined_func$no-calls$21 (result i32)
-  ;; CHECK-NEXT:      (block (result i32)
-  ;; CHECK-NEXT:       (block $__inlined_func$yes (result i32)
-  ;; CHECK-NEXT:        (i32.const 1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$no-calls$22 (result i32)
+  ;; CHECK-NEXT:    (block $__inlined_func$yes0 (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block (result i32)
-  ;; CHECK-NEXT:     (block $__inlined_func$no-calls$22 (result i32)
-  ;; CHECK-NEXT:      (block (result i32)
-  ;; CHECK-NEXT:       (block $__inlined_func$yes0 (result i32)
-  ;; CHECK-NEXT:        (i32.const 1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$yes-calls-but-one-use$23 (result i32)
+  ;; CHECK-NEXT:    (block $__inlined_func$yes$1 (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block (result i32)
-  ;; CHECK-NEXT:     (block $__inlined_func$yes-calls-but-one-use$23 (result i32)
-  ;; CHECK-NEXT:      (block (result i32)
-  ;; CHECK-NEXT:       (block $__inlined_func$yes$1 (result i32)
-  ;; CHECK-NEXT:        (i32.const 1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$no-loops$4 (result i32)
+  ;; CHECK-NEXT:    (loop (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$no-loops$4 (result i32)
-  ;; CHECK-NEXT:     (loop (result i32)
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$no-loops$5 (result i32)
+  ;; CHECK-NEXT:    (loop (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$no-loops$5 (result i32)
-  ;; CHECK-NEXT:     (loop (result i32)
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$yes-loops-but-one-use$6 (result i32)
+  ;; CHECK-NEXT:    (loop (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$yes-loops-but-one-use$6 (result i32)
-  ;; CHECK-NEXT:     (loop (result i32)
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$no-loops-but-one-use-but-exported$7 (result i32)
+  ;; CHECK-NEXT:    (loop (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$no-loops-but-one-use-but-exported$7 (result i32)
-  ;; CHECK-NEXT:     (loop (result i32)
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$no-loops-but-one-use-but-tabled$8 (result i32)
-  ;; CHECK-NEXT:     (loop (result i32)
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:   (block $__inlined_func$no-loops-but-one-use-but-tabled$8 (result i32)
+  ;; CHECK-NEXT:    (loop (result i32)
+  ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -243,10 +211,8 @@
   ;; CHECK-NEXT:   (local.set $1
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (call $recursive-inlining-1
-  ;; CHECK-NEXT:     (local.get $1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (call $recursive-inlining-1
+  ;; CHECK-NEXT:    (local.get $1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -280,32 +246,24 @@
   ;; CHECK-NEXT:   (local.set $1
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$b-recursive-inlining-2$24 (result i32)
-  ;; CHECK-NEXT:     (local.set $2
-  ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:   (block $__inlined_func$b-recursive-inlining-2$24 (result i32)
+  ;; CHECK-NEXT:    (local.set $2
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block $__inlined_func$b-recursive-inlining-2$25 (result i32)
+  ;; CHECK-NEXT:     (local.set $3
+  ;; CHECK-NEXT:      (local.get $2)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (block $__inlined_func$b-recursive-inlining-2$25 (result i32)
-  ;; CHECK-NEXT:       (local.set $3
-  ;; CHECK-NEXT:        (local.get $2)
+  ;; CHECK-NEXT:     (block $__inlined_func$b-recursive-inlining-2$26 (result i32)
+  ;; CHECK-NEXT:      (local.set $4
+  ;; CHECK-NEXT:       (local.get $3)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (block $__inlined_func$b-recursive-inlining-2$27 (result i32)
+  ;; CHECK-NEXT:       (local.set $5
+  ;; CHECK-NEXT:        (local.get $4)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (block (result i32)
-  ;; CHECK-NEXT:        (block $__inlined_func$b-recursive-inlining-2$26 (result i32)
-  ;; CHECK-NEXT:         (local.set $4
-  ;; CHECK-NEXT:          (local.get $3)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (block (result i32)
-  ;; CHECK-NEXT:          (block $__inlined_func$b-recursive-inlining-2$27 (result i32)
-  ;; CHECK-NEXT:           (local.set $5
-  ;; CHECK-NEXT:            (local.get $4)
-  ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:           (call $b-recursive-inlining-2
-  ;; CHECK-NEXT:            (local.get $5)
-  ;; CHECK-NEXT:           )
-  ;; CHECK-NEXT:          )
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       (call $b-recursive-inlining-2
+  ;; CHECK-NEXT:        (local.get $5)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
@@ -335,74 +293,54 @@
   ;; a single iteration (which is the usual case, and the case here).
 
   ;; CHECK:      (func $call-many-getters
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$11
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$11
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$12
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$12
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$13
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$13
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$14
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$14
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$15
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$15
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$16
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$16
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$17
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$17
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$18
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$18
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$19
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$19
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$getter$20
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  (block $__inlined_func$getter$20
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -461,18 +399,16 @@
  ;; CHECK-NEXT:  (local $0 i32)
  ;; CHECK-NEXT:  (block $__inlined_func$0_0
  ;; CHECK-NEXT:   (drop
- ;; CHECK-NEXT:    (block
- ;; CHECK-NEXT:     (block $__inlined_func$0_0_0
- ;; CHECK-NEXT:      (local.set $0
- ;; CHECK-NEXT:       (block (result i32)
- ;; CHECK-NEXT:        (br_if $__inlined_func$0_0
- ;; CHECK-NEXT:         (i32.const 10)
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:        (i32.const 0)
+ ;; CHECK-NEXT:    (block $__inlined_func$0_0_0
+ ;; CHECK-NEXT:     (local.set $0
+ ;; CHECK-NEXT:      (block (result i32)
+ ;; CHECK-NEXT:       (br_if $__inlined_func$0_0
+ ;; CHECK-NEXT:        (i32.const 10)
  ;; CHECK-NEXT:       )
+ ;; CHECK-NEXT:       (i32.const 0)
  ;; CHECK-NEXT:      )
- ;; CHECK-NEXT:      (unreachable)
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (unreachable)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -516,34 +452,26 @@
  ;; CHECK-NEXT:  (local $0 f32)
  ;; CHECK-NEXT:  (local $1 f32)
  ;; CHECK-NEXT:  (local $2 f32)
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$A$3
- ;; CHECK-NEXT:    (local.set $1
- ;; CHECK-NEXT:     (block (result f32)
- ;; CHECK-NEXT:      (block $__inlined_func$C$2 (result f32)
- ;; CHECK-NEXT:       (local.tee $0
- ;; CHECK-NEXT:        (block
- ;; CHECK-NEXT:         (block $__inlined_func$D$1
- ;; CHECK-NEXT:          (unreachable)
- ;; CHECK-NEXT:         )
- ;; CHECK-NEXT:        )
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (local.get $0)
+ ;; CHECK-NEXT:  (block $__inlined_func$A$3
+ ;; CHECK-NEXT:   (local.set $1
+ ;; CHECK-NEXT:    (block $__inlined_func$C$2 (result f32)
+ ;; CHECK-NEXT:     (local.tee $0
+ ;; CHECK-NEXT:      (block $__inlined_func$D$1
+ ;; CHECK-NEXT:       (unreachable)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $0)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.set $2
- ;; CHECK-NEXT:     (f32.const 0)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (block (result f32)
- ;; CHECK-NEXT:      (block $__inlined_func$C (result f32)
- ;; CHECK-NEXT:       (local.set $2
- ;; CHECK-NEXT:        (local.get $1)
- ;; CHECK-NEXT:       )
- ;; CHECK-NEXT:       (local.get $2)
- ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (f32.const 0)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (block $__inlined_func$C (result f32)
+ ;; CHECK-NEXT:     (local.set $2
+ ;; CHECK-NEXT:      (local.get $1)
  ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:     (local.get $2)
  ;; CHECK-NEXT:    )
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
@@ -656,40 +584,36 @@
  ;; CHECK-NEXT:  (local $3 i32)
  ;; CHECK-NEXT:  (local $4 i32)
  ;; CHECK-NEXT:  (local $5 i32)
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$middle1
- ;; CHECK-NEXT:    (local.set $0
- ;; CHECK-NEXT:     (i32.const 1)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.set $1
- ;; CHECK-NEXT:     (i32.const 2)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.set $2
- ;; CHECK-NEXT:     (i32.const 3)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (call $top
- ;; CHECK-NEXT:     (local.get $0)
- ;; CHECK-NEXT:     (local.get $1)
- ;; CHECK-NEXT:     (local.get $2)
- ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:  (block $__inlined_func$middle1
+ ;; CHECK-NEXT:   (local.set $0
+ ;; CHECK-NEXT:    (i32.const 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $1
+ ;; CHECK-NEXT:    (i32.const 2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $2
+ ;; CHECK-NEXT:    (i32.const 3)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (call $top
+ ;; CHECK-NEXT:    (local.get $0)
+ ;; CHECK-NEXT:    (local.get $1)
+ ;; CHECK-NEXT:    (local.get $2)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (block
- ;; CHECK-NEXT:   (block $__inlined_func$middle2$1
- ;; CHECK-NEXT:    (local.set $3
- ;; CHECK-NEXT:     (i32.const 1)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.set $4
- ;; CHECK-NEXT:     (i32.const 2)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (local.set $5
- ;; CHECK-NEXT:     (i32.const 3)
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (call $top
- ;; CHECK-NEXT:     (local.get $5)
- ;; CHECK-NEXT:     (i32.const 42)
- ;; CHECK-NEXT:     (local.get $3)
- ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:  (block $__inlined_func$middle2$1
+ ;; CHECK-NEXT:   (local.set $3
+ ;; CHECK-NEXT:    (i32.const 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $4
+ ;; CHECK-NEXT:    (i32.const 2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (local.set $5
+ ;; CHECK-NEXT:    (i32.const 3)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (call $top
+ ;; CHECK-NEXT:    (local.get $5)
+ ;; CHECK-NEXT:    (i32.const 42)
+ ;; CHECK-NEXT:    (local.get $3)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (call $middle3

--- a/test/lit/passes/inlining_splitting.wast
+++ b/test/lit/passes/inlining_splitting.wast
@@ -52,53 +52,47 @@
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (local $2 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$maybe-work-hard
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$maybe-work-hard
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$maybe-work-hard
   ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$maybe-work-hard
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$maybe-work-hard$1
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 2)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$maybe-work-hard$1
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$maybe-work-hard
   ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$maybe-work-hard
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$maybe-work-hard$2
-  ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (i32.const 3)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$maybe-work-hard$2
+  ;; CHECK-NEXT:   (local.set $2
+  ;; CHECK-NEXT:    (i32.const 3)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $2)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$maybe-work-hard
   ;; CHECK-NEXT:      (local.get $2)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$maybe-work-hard
-  ;; CHECK-NEXT:       (local.get $2)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -135,32 +129,28 @@
   ;; CHECK:      (func $call-just-if (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$just-if$3
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (local.get $0)
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-B$just-if
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-B$just-if$3
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.get $0)
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-B$just-if
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$just-if$4
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 2)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (local.get $1)
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-B$just-if
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-B$just-if$4
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (local.get $1)
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-B$just-if
+  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -290,52 +280,48 @@
   ;; CHECK-NEXT:  (local $3 i64)
   ;; CHECK-NEXT:  (local $4 i32)
   ;; CHECK-NEXT:  (local $5 f64)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$many-params$6
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (i64.const 0)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$many-params$6
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $2
+  ;; CHECK-NEXT:    (f64.const 3.14159)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (f64.const 3.14159)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$many-params
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$many-params
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:       (local.get $2)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $2)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$many-params$7
-  ;; CHECK-NEXT:    (local.set $3
-  ;; CHECK-NEXT:     (i64.const 0)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$many-params$7
+  ;; CHECK-NEXT:   (local.set $3
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $4
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.set $5
+  ;; CHECK-NEXT:    (f64.const 3.14159)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $4)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $4
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (local.set $5
-  ;; CHECK-NEXT:     (f64.const 3.14159)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$many-params
+  ;; CHECK-NEXT:      (local.get $3)
   ;; CHECK-NEXT:      (local.get $4)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$many-params
-  ;; CHECK-NEXT:       (local.get $3)
-  ;; CHECK-NEXT:       (local.get $4)
-  ;; CHECK-NEXT:       (local.get $5)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $5)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -370,40 +356,36 @@
   ;; CHECK:      (func $call-condition-eqz (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$condition-eqz$8
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (i32.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$condition-eqz$8
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
   ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$condition-eqz
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$condition-eqz
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$condition-eqz$9
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$condition-eqz$9
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
   ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (i32.eqz
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$condition-eqz
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$condition-eqz
+  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -429,27 +411,23 @@
   )
 
   ;; CHECK:      (func $call-condition-global (type $0)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$condition-global$10
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (global.get $glob)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$condition-global)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$condition-global$10
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (global.get $glob)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$condition-global)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$condition-global$11
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (global.get $glob)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$condition-global)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$condition-global$11
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (global.get $glob)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$condition-global)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -478,40 +456,36 @@
   ;; CHECK:      (func $call-condition-ref.is (type $0)
   ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (local $1 anyref)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$condition-ref.is$12
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (ref.null none)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (ref.is_null
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$condition-ref.is$12
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (ref.is_null
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$condition-ref.is
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$condition-ref.is
+  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$condition-ref.is$13
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (ref.null none)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (ref.is_null
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$condition-ref.is$13
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (ref.is_null
+  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$condition-ref.is
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$condition-ref.is
+  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -640,27 +614,23 @@
   )
 
   ;; CHECK:      (func $call-start-used-globally (type $0)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$start-used-globally$14
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (global.get $glob)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$start-used-globally)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$start-used-globally$14
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (global.get $glob)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$start-used-globally)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$start-used-globally$15
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (global.get $glob)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$start-used-globally)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$start-used-globally$15
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (global.get $glob)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$start-used-globally)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -683,23 +653,19 @@
   )
 
   ;; CHECK:      (func $call-inlineable (type $0)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$inlineable$16
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (global.get $glob)
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (br $__inlined_func$inlineable$16)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$inlineable$16
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (global.get $glob)
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (br $__inlined_func$inlineable$16)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$inlineable$17
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (global.get $glob)
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (br $__inlined_func$inlineable$17)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:  (block $__inlined_func$inlineable$17
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (global.get $glob)
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (br $__inlined_func$inlineable$17)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -853,36 +819,32 @@
   ;; CHECK:      (func $call-colliding-name (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$colliding-name$18
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$colliding-name$18
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$colliding-name_67
   ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$colliding-name_67
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$colliding-name$19
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$colliding-name$19
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$colliding-name_67
   ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$colliding-name_67
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -929,50 +891,46 @@
   ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (local $1 anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$error-if-null$20 (result anyref)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (br $__inlined_func$byn-split-inlineable-B$error-if-null$20
-  ;; CHECK-NEXT:         (call $byn-split-outlined-B$error-if-null
-  ;; CHECK-NEXT:          (local.get $0)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$error-if-null$20 (result anyref)
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (br $__inlined_func$byn-split-inlineable-B$error-if-null$20
+  ;; CHECK-NEXT:        (call $byn-split-outlined-B$error-if-null
+  ;; CHECK-NEXT:         (local.get $0)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$error-if-null$21 (result anyref)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (br $__inlined_func$byn-split-inlineable-B$error-if-null$21
-  ;; CHECK-NEXT:         (call $byn-split-outlined-B$error-if-null
-  ;; CHECK-NEXT:          (local.get $1)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$error-if-null$21 (result anyref)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (br $__inlined_func$byn-split-inlineable-B$error-if-null$21
+  ;; CHECK-NEXT:        (call $byn-split-outlined-B$error-if-null
+  ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -1097,46 +1055,42 @@
   ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (local $1 anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$reachable-if-body$22 (result anyref)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$reachable-if-body$22 (result anyref)
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (call $byn-split-outlined-B$reachable-if-body
   ;; CHECK-NEXT:        (local.get $0)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (call $byn-split-outlined-B$reachable-if-body
-  ;; CHECK-NEXT:         (local.get $0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$reachable-if-body$23 (result anyref)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$reachable-if-body$23 (result anyref)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (call $byn-split-outlined-B$reachable-if-body
   ;; CHECK-NEXT:        (local.get $1)
   ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (call $byn-split-outlined-B$reachable-if-body
-  ;; CHECK-NEXT:         (local.get $1)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -1163,42 +1117,38 @@
   ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (local $1 anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$reachable-if-body-noloop$24 (result anyref)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (call $import)
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:   (block $__inlined_func$reachable-if-body-noloop$24 (result anyref)
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $0)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$reachable-if-body-noloop$25 (result anyref)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (call $import)
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:   (block $__inlined_func$reachable-if-body-noloop$25 (result anyref)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $1)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (call $import)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -1291,36 +1241,32 @@
   ;; CHECK:      (func $call-unreachable-if-body-no-result (type $0)
   ;; CHECK-NEXT:  (local $0 anyref)
   ;; CHECK-NEXT:  (local $1 anyref)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$unreachable-if-body-no-result$26
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-B$unreachable-if-body-no-result$26
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (ref.is_null
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (ref.is_null
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-B$unreachable-if-body-no-result
   ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-B$unreachable-if-body-no-result
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$unreachable-if-body-no-result$27
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-B$unreachable-if-body-no-result$27
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (ref.null none)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (ref.is_null
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (ref.is_null
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-B$unreachable-if-body-no-result
   ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-B$unreachable-if-body-no-result
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -1363,72 +1309,68 @@
   ;; CHECK-NEXT:  (local $2 anyref)
   ;; CHECK-NEXT:  (local $3 anyref)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$multi-if$28 (result anyref)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (block $__inlined_func$byn-split-outlined-B$multi-if$30
-  ;; CHECK-NEXT:         (local.set $2
-  ;; CHECK-NEXT:          (local.get $0)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (call $import)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$multi-if$28 (result anyref)
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $0)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (call $byn-split-outlined-B$multi-if_76
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (block $__inlined_func$byn-split-outlined-B$multi-if$30
+  ;; CHECK-NEXT:        (local.set $2
   ;; CHECK-NEXT:         (local.get $0)
   ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (call $import)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (call $byn-split-outlined-B$multi-if_76
+  ;; CHECK-NEXT:        (local.get $0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result anyref)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$multi-if$29 (result anyref)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (ref.null none)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result anyref)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (block $__inlined_func$byn-split-outlined-B$multi-if$31
-  ;; CHECK-NEXT:         (local.set $3
-  ;; CHECK-NEXT:          (local.get $1)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (call $import)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$multi-if$29 (result anyref)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (ref.null none)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result anyref)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $1)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (ref.is_null
-  ;; CHECK-NEXT:        (local.get $1)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (call $byn-split-outlined-B$multi-if_76
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (block $__inlined_func$byn-split-outlined-B$multi-if$31
+  ;; CHECK-NEXT:        (local.set $3
   ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (call $import)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (ref.is_null
+  ;; CHECK-NEXT:       (local.get $1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (call $byn-split-outlined-B$multi-if_76
+  ;; CHECK-NEXT:        (local.get $1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -1642,19 +1584,11 @@
   ;; CHECK-NEXT:    (return)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$1
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (call $0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$1
+  ;; CHECK-NEXT:   (call $0)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$1$1
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (call $0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  (block $__inlined_func$1$1
+  ;; CHECK-NEXT:   (call $0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $0
@@ -1669,52 +1603,34 @@
     (call $1)
   )
   ;; CHECK:      (func $1 (type $none_=>_none)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$0$2
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
-  ;; CHECK-NEXT:      (global.get $global$0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (block $__inlined_func$byn-split-outlined-A$0$3
-  ;; CHECK-NEXT:       (block
-  ;; CHECK-NEXT:        (block
-  ;; CHECK-NEXT:         (block $__inlined_func$1
-  ;; CHECK-NEXT:          (block
-  ;; CHECK-NEXT:           (block
-  ;; CHECK-NEXT:            (block
-  ;; CHECK-NEXT:             (block $__inlined_func$byn-split-inlineable-A$0$4
-  ;; CHECK-NEXT:              (if
-  ;; CHECK-NEXT:               (i32.eqz
-  ;; CHECK-NEXT:                (global.get $global$0)
-  ;; CHECK-NEXT:               )
-  ;; CHECK-NEXT:               (then
-  ;; CHECK-NEXT:                (call $byn-split-outlined-A$0)
-  ;; CHECK-NEXT:               )
-  ;; CHECK-NEXT:              )
-  ;; CHECK-NEXT:             )
-  ;; CHECK-NEXT:            )
-  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$0$2
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (global.get $global$0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (block $__inlined_func$byn-split-outlined-A$0$3
+  ;; CHECK-NEXT:      (block
+  ;; CHECK-NEXT:       (block $__inlined_func$1
+  ;; CHECK-NEXT:        (block $__inlined_func$byn-split-inlineable-A$0$4
+  ;; CHECK-NEXT:         (if
+  ;; CHECK-NEXT:          (i32.eqz
+  ;; CHECK-NEXT:           (global.get $global$0)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (then
+  ;; CHECK-NEXT:           (call $byn-split-outlined-A$0)
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (block
-  ;; CHECK-NEXT:         (block $__inlined_func$1$1
-  ;; CHECK-NEXT:          (block
-  ;; CHECK-NEXT:           (block
-  ;; CHECK-NEXT:            (block
-  ;; CHECK-NEXT:             (block $__inlined_func$byn-split-inlineable-A$0$5
-  ;; CHECK-NEXT:              (if
-  ;; CHECK-NEXT:               (i32.eqz
-  ;; CHECK-NEXT:                (global.get $global$0)
-  ;; CHECK-NEXT:               )
-  ;; CHECK-NEXT:               (then
-  ;; CHECK-NEXT:                (call $byn-split-outlined-A$0)
-  ;; CHECK-NEXT:               )
-  ;; CHECK-NEXT:              )
-  ;; CHECK-NEXT:             )
-  ;; CHECK-NEXT:            )
-  ;; CHECK-NEXT:           )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (block $__inlined_func$1$1
+  ;; CHECK-NEXT:        (block $__inlined_func$byn-split-inlineable-A$0$5
+  ;; CHECK-NEXT:         (if
+  ;; CHECK-NEXT:          (i32.eqz
+  ;; CHECK-NEXT:           (global.get $global$0)
+  ;; CHECK-NEXT:          )
+  ;; CHECK-NEXT:          (then
+  ;; CHECK-NEXT:           (call $byn-split-outlined-A$0)
   ;; CHECK-NEXT:          )
   ;; CHECK-NEXT:         )
   ;; CHECK-NEXT:        )
@@ -1839,38 +1755,26 @@
 )
 
 ;; CHECK:      (func $byn-split-outlined-A$0 (type $none_=>_none)
-;; CHECK-NEXT:  (block
-;; CHECK-NEXT:   (block $__inlined_func$1
-;; CHECK-NEXT:    (block
-;; CHECK-NEXT:     (block
-;; CHECK-NEXT:      (block $__inlined_func$byn-split-inlineable-A$0$6
-;; CHECK-NEXT:       (if
-;; CHECK-NEXT:        (i32.eqz
-;; CHECK-NEXT:         (global.get $global$0)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:        (then
-;; CHECK-NEXT:         (call $byn-split-outlined-A$0_21)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
+;; CHECK-NEXT:  (block $__inlined_func$1
+;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$0$6
+;; CHECK-NEXT:    (if
+;; CHECK-NEXT:     (i32.eqz
+;; CHECK-NEXT:      (global.get $global$0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (then
+;; CHECK-NEXT:      (call $byn-split-outlined-A$0_21)
 ;; CHECK-NEXT:     )
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (block
-;; CHECK-NEXT:   (block $__inlined_func$1$1
-;; CHECK-NEXT:    (block
-;; CHECK-NEXT:     (block
-;; CHECK-NEXT:      (block $__inlined_func$byn-split-inlineable-A$0$7
-;; CHECK-NEXT:       (if
-;; CHECK-NEXT:        (i32.eqz
-;; CHECK-NEXT:         (global.get $global$0)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:        (then
-;; CHECK-NEXT:         (call $byn-split-outlined-A$0_21)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
+;; CHECK-NEXT:  (block $__inlined_func$1$1
+;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$0$7
+;; CHECK-NEXT:    (if
+;; CHECK-NEXT:     (i32.eqz
+;; CHECK-NEXT:      (global.get $global$0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (then
+;; CHECK-NEXT:      (call $byn-split-outlined-A$0_21)
 ;; CHECK-NEXT:     )
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:   )
@@ -1878,38 +1782,26 @@
 ;; CHECK-NEXT: )
 
 ;; CHECK:      (func $byn-split-outlined-A$0_21 (type $none_=>_none)
-;; CHECK-NEXT:  (block
-;; CHECK-NEXT:   (block $__inlined_func$1
-;; CHECK-NEXT:    (block
-;; CHECK-NEXT:     (block
-;; CHECK-NEXT:      (block $__inlined_func$byn-split-inlineable-A$0$8
-;; CHECK-NEXT:       (if
-;; CHECK-NEXT:        (i32.eqz
-;; CHECK-NEXT:         (global.get $global$0)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:        (then
-;; CHECK-NEXT:         (call $byn-split-outlined-A$0_22)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
+;; CHECK-NEXT:  (block $__inlined_func$1
+;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$0$8
+;; CHECK-NEXT:    (if
+;; CHECK-NEXT:     (i32.eqz
+;; CHECK-NEXT:      (global.get $global$0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (then
+;; CHECK-NEXT:      (call $byn-split-outlined-A$0_22)
 ;; CHECK-NEXT:     )
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (block
-;; CHECK-NEXT:   (block $__inlined_func$1$1
-;; CHECK-NEXT:    (block
-;; CHECK-NEXT:     (block
-;; CHECK-NEXT:      (block $__inlined_func$byn-split-inlineable-A$0$9
-;; CHECK-NEXT:       (if
-;; CHECK-NEXT:        (i32.eqz
-;; CHECK-NEXT:         (global.get $global$0)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:        (then
-;; CHECK-NEXT:         (call $byn-split-outlined-A$0_22)
-;; CHECK-NEXT:        )
-;; CHECK-NEXT:       )
-;; CHECK-NEXT:      )
+;; CHECK-NEXT:  (block $__inlined_func$1$1
+;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$0$9
+;; CHECK-NEXT:    (if
+;; CHECK-NEXT:     (i32.eqz
+;; CHECK-NEXT:      (global.get $global$0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (then
+;; CHECK-NEXT:      (call $byn-split-outlined-A$0_22)
 ;; CHECK-NEXT:     )
 ;; CHECK-NEXT:    )
 ;; CHECK-NEXT:   )
@@ -1917,19 +1809,11 @@
 ;; CHECK-NEXT: )
 
 ;; CHECK:      (func $byn-split-outlined-A$0_22 (type $none_=>_none)
-;; CHECK-NEXT:  (block
-;; CHECK-NEXT:   (block $__inlined_func$1
-;; CHECK-NEXT:    (block
-;; CHECK-NEXT:     (call $0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
+;; CHECK-NEXT:  (block $__inlined_func$1
+;; CHECK-NEXT:   (call $0)
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (block
-;; CHECK-NEXT:   (block $__inlined_func$1$1
-;; CHECK-NEXT:    (block
-;; CHECK-NEXT:     (call $0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
+;; CHECK-NEXT:  (block $__inlined_func$1$1
+;; CHECK-NEXT:   (call $0)
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 (module
@@ -1961,87 +1845,83 @@
   ;; CHECK:      (func $call-$middle-size-A (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$middle-size-A
-  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:  (block $__inlined_func$middle-size-A
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (if
+  ;; CHECK-NEXT:     (local.get $0)
+  ;; CHECK-NEXT:     (then
+  ;; CHECK-NEXT:      (br $__inlined_func$middle-size-A)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (i32.const 0)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:      (then
-  ;; CHECK-NEXT:       (br $__inlined_func$middle-size-A)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$middle-size-A$1
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:  (block $__inlined_func$middle-size-A$1
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (if
+  ;; CHECK-NEXT:     (local.get $1)
+  ;; CHECK-NEXT:     (then
+  ;; CHECK-NEXT:      (br $__inlined_func$middle-size-A$1)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (block
-  ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:      (then
-  ;; CHECK-NEXT:       (br $__inlined_func$middle-size-A$1)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -2077,36 +1957,32 @@
   ;; CHECK:      (func $call-$big-size-A (type $0)
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$big-size-A$2
-  ;; CHECK-NEXT:    (local.set $0
-  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$big-size-A$2
+  ;; CHECK-NEXT:   (local.set $0
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$big-size-A
   ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$big-size-A
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (block
-  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-A$big-size-A$3
-  ;; CHECK-NEXT:    (local.set $1
-  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:  (block $__inlined_func$byn-split-inlineable-A$big-size-A$3
+  ;; CHECK-NEXT:   (local.set $1
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (if
-  ;; CHECK-NEXT:     (i32.eqz
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (call $byn-split-outlined-A$big-size-A
   ;; CHECK-NEXT:      (local.get $1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (call $byn-split-outlined-A$big-size-A
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
@@ -2142,92 +2018,88 @@
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$middle-size-B$4 (result i32)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (unreachable)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:   (block $__inlined_func$middle-size-B$4 (result i32)
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (local.get $0)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$middle-size-B$5 (result i32)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (i32.const 0)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:        (unreachable)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:   (block $__inlined_func$middle-size-B$5 (result i32)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (if
   ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
@@ -2268,46 +2140,42 @@
   ;; CHECK-NEXT:  (local $0 i32)
   ;; CHECK-NEXT:  (local $1 i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$big-size-B$6 (result i32)
-  ;; CHECK-NEXT:     (local.set $0
-  ;; CHECK-NEXT:      (i32.const 0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (local.get $0)
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (br $__inlined_func$byn-split-inlineable-B$big-size-B$6
-  ;; CHECK-NEXT:         (call $byn-split-outlined-B$big-size-B
-  ;; CHECK-NEXT:          (local.get $0)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$big-size-B$6 (result i32)
+  ;; CHECK-NEXT:    (local.set $0
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (local.get $0)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (br $__inlined_func$byn-split-inlineable-B$big-size-B$6
+  ;; CHECK-NEXT:        (call $byn-split-outlined-B$big-size-B
+  ;; CHECK-NEXT:         (local.get $0)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $0)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $0)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (block $__inlined_func$byn-split-inlineable-B$big-size-B$7 (result i32)
-  ;; CHECK-NEXT:     (local.set $1
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (block (result i32)
-  ;; CHECK-NEXT:      (if
-  ;; CHECK-NEXT:       (local.get $1)
-  ;; CHECK-NEXT:       (then
-  ;; CHECK-NEXT:        (br $__inlined_func$byn-split-inlineable-B$big-size-B$7
-  ;; CHECK-NEXT:         (call $byn-split-outlined-B$big-size-B
-  ;; CHECK-NEXT:          (local.get $1)
-  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:   (block $__inlined_func$byn-split-inlineable-B$big-size-B$7 (result i32)
+  ;; CHECK-NEXT:    (local.set $1
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (local.get $1)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (br $__inlined_func$byn-split-inlineable-B$big-size-B$7
+  ;; CHECK-NEXT:        (call $byn-split-outlined-B$big-size-B
+  ;; CHECK-NEXT:         (local.get $1)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (local.get $1)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (local.get $1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/inlining_splitting_basics.wast
+++ b/test/lit/passes/inlining_splitting_basics.wast
@@ -66,36 +66,32 @@
   ;; PARTIAL:      (func $call-pattern-A (type $0)
   ;; PARTIAL-NEXT:  (local $0 i32)
   ;; PARTIAL-NEXT:  (local $1 i32)
-  ;; PARTIAL-NEXT:  (block
-  ;; PARTIAL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$pattern-A
-  ;; PARTIAL-NEXT:    (local.set $0
-  ;; PARTIAL-NEXT:     (i32.const 1)
+  ;; PARTIAL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$pattern-A
+  ;; PARTIAL-NEXT:   (local.set $0
+  ;; PARTIAL-NEXT:    (i32.const 1)
+  ;; PARTIAL-NEXT:   )
+  ;; PARTIAL-NEXT:   (if
+  ;; PARTIAL-NEXT:    (i32.eqz
+  ;; PARTIAL-NEXT:     (local.get $0)
   ;; PARTIAL-NEXT:    )
-  ;; PARTIAL-NEXT:    (if
-  ;; PARTIAL-NEXT:     (i32.eqz
+  ;; PARTIAL-NEXT:    (then
+  ;; PARTIAL-NEXT:     (call $byn-split-outlined-A$pattern-A
   ;; PARTIAL-NEXT:      (local.get $0)
-  ;; PARTIAL-NEXT:     )
-  ;; PARTIAL-NEXT:     (then
-  ;; PARTIAL-NEXT:      (call $byn-split-outlined-A$pattern-A
-  ;; PARTIAL-NEXT:       (local.get $0)
-  ;; PARTIAL-NEXT:      )
   ;; PARTIAL-NEXT:     )
   ;; PARTIAL-NEXT:    )
   ;; PARTIAL-NEXT:   )
   ;; PARTIAL-NEXT:  )
-  ;; PARTIAL-NEXT:  (block
-  ;; PARTIAL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$pattern-A$1
-  ;; PARTIAL-NEXT:    (local.set $1
-  ;; PARTIAL-NEXT:     (i32.const 2)
+  ;; PARTIAL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$pattern-A$1
+  ;; PARTIAL-NEXT:   (local.set $1
+  ;; PARTIAL-NEXT:    (i32.const 2)
+  ;; PARTIAL-NEXT:   )
+  ;; PARTIAL-NEXT:   (if
+  ;; PARTIAL-NEXT:    (i32.eqz
+  ;; PARTIAL-NEXT:     (local.get $1)
   ;; PARTIAL-NEXT:    )
-  ;; PARTIAL-NEXT:    (if
-  ;; PARTIAL-NEXT:     (i32.eqz
+  ;; PARTIAL-NEXT:    (then
+  ;; PARTIAL-NEXT:     (call $byn-split-outlined-A$pattern-A
   ;; PARTIAL-NEXT:      (local.get $1)
-  ;; PARTIAL-NEXT:     )
-  ;; PARTIAL-NEXT:     (then
-  ;; PARTIAL-NEXT:      (call $byn-split-outlined-A$pattern-A
-  ;; PARTIAL-NEXT:       (local.get $1)
-  ;; PARTIAL-NEXT:      )
   ;; PARTIAL-NEXT:     )
   ;; PARTIAL-NEXT:    )
   ;; PARTIAL-NEXT:   )
@@ -155,50 +151,46 @@
   ;; PARTIAL-NEXT:  (local $0 i32)
   ;; PARTIAL-NEXT:  (local $1 i32)
   ;; PARTIAL-NEXT:  (drop
-  ;; PARTIAL-NEXT:   (block (result i32)
-  ;; PARTIAL-NEXT:    (block $__inlined_func$byn-split-inlineable-B$pattern-B$2 (result i32)
-  ;; PARTIAL-NEXT:     (local.set $0
-  ;; PARTIAL-NEXT:      (i32.const 1)
-  ;; PARTIAL-NEXT:     )
-  ;; PARTIAL-NEXT:     (block (result i32)
-  ;; PARTIAL-NEXT:      (if
-  ;; PARTIAL-NEXT:       (i32.eqz
-  ;; PARTIAL-NEXT:        (local.get $0)
-  ;; PARTIAL-NEXT:       )
-  ;; PARTIAL-NEXT:       (then
-  ;; PARTIAL-NEXT:        (br $__inlined_func$byn-split-inlineable-B$pattern-B$2
-  ;; PARTIAL-NEXT:         (call $byn-split-outlined-B$pattern-B
-  ;; PARTIAL-NEXT:          (local.get $0)
-  ;; PARTIAL-NEXT:         )
+  ;; PARTIAL-NEXT:   (block $__inlined_func$byn-split-inlineable-B$pattern-B$2 (result i32)
+  ;; PARTIAL-NEXT:    (local.set $0
+  ;; PARTIAL-NEXT:     (i32.const 1)
+  ;; PARTIAL-NEXT:    )
+  ;; PARTIAL-NEXT:    (block (result i32)
+  ;; PARTIAL-NEXT:     (if
+  ;; PARTIAL-NEXT:      (i32.eqz
+  ;; PARTIAL-NEXT:       (local.get $0)
+  ;; PARTIAL-NEXT:      )
+  ;; PARTIAL-NEXT:      (then
+  ;; PARTIAL-NEXT:       (br $__inlined_func$byn-split-inlineable-B$pattern-B$2
+  ;; PARTIAL-NEXT:        (call $byn-split-outlined-B$pattern-B
+  ;; PARTIAL-NEXT:         (local.get $0)
   ;; PARTIAL-NEXT:        )
   ;; PARTIAL-NEXT:       )
   ;; PARTIAL-NEXT:      )
-  ;; PARTIAL-NEXT:      (local.get $0)
   ;; PARTIAL-NEXT:     )
+  ;; PARTIAL-NEXT:     (local.get $0)
   ;; PARTIAL-NEXT:    )
   ;; PARTIAL-NEXT:   )
   ;; PARTIAL-NEXT:  )
   ;; PARTIAL-NEXT:  (drop
-  ;; PARTIAL-NEXT:   (block (result i32)
-  ;; PARTIAL-NEXT:    (block $__inlined_func$byn-split-inlineable-B$pattern-B$3 (result i32)
-  ;; PARTIAL-NEXT:     (local.set $1
-  ;; PARTIAL-NEXT:      (i32.const 2)
-  ;; PARTIAL-NEXT:     )
-  ;; PARTIAL-NEXT:     (block (result i32)
-  ;; PARTIAL-NEXT:      (if
-  ;; PARTIAL-NEXT:       (i32.eqz
-  ;; PARTIAL-NEXT:        (local.get $1)
-  ;; PARTIAL-NEXT:       )
-  ;; PARTIAL-NEXT:       (then
-  ;; PARTIAL-NEXT:        (br $__inlined_func$byn-split-inlineable-B$pattern-B$3
-  ;; PARTIAL-NEXT:         (call $byn-split-outlined-B$pattern-B
-  ;; PARTIAL-NEXT:          (local.get $1)
-  ;; PARTIAL-NEXT:         )
+  ;; PARTIAL-NEXT:   (block $__inlined_func$byn-split-inlineable-B$pattern-B$3 (result i32)
+  ;; PARTIAL-NEXT:    (local.set $1
+  ;; PARTIAL-NEXT:     (i32.const 2)
+  ;; PARTIAL-NEXT:    )
+  ;; PARTIAL-NEXT:    (block (result i32)
+  ;; PARTIAL-NEXT:     (if
+  ;; PARTIAL-NEXT:      (i32.eqz
+  ;; PARTIAL-NEXT:       (local.get $1)
+  ;; PARTIAL-NEXT:      )
+  ;; PARTIAL-NEXT:      (then
+  ;; PARTIAL-NEXT:       (br $__inlined_func$byn-split-inlineable-B$pattern-B$3
+  ;; PARTIAL-NEXT:        (call $byn-split-outlined-B$pattern-B
+  ;; PARTIAL-NEXT:         (local.get $1)
   ;; PARTIAL-NEXT:        )
   ;; PARTIAL-NEXT:       )
   ;; PARTIAL-NEXT:      )
-  ;; PARTIAL-NEXT:      (local.get $1)
   ;; PARTIAL-NEXT:     )
+  ;; PARTIAL-NEXT:     (local.get $1)
   ;; PARTIAL-NEXT:    )
   ;; PARTIAL-NEXT:   )
   ;; PARTIAL-NEXT:  )

--- a/test/lit/passes/no-inline-monomorphize-inlining.wast
+++ b/test/lit/passes/no-inline-monomorphize-inlining.wast
@@ -48,53 +48,45 @@
   ;; YESINLINE-NEXT:  (local $5 (ref $A))
   ;; YESINLINE-NEXT:  (local $6 (ref $B))
   ;; YESINLINE-NEXT:  (local $7 (ref $A))
-  ;; YESINLINE-NEXT:  (block
-  ;; YESINLINE-NEXT:   (block $__inlined_func$refinable_noinline
-  ;; YESINLINE-NEXT:    (local.set $2
-  ;; YESINLINE-NEXT:     (local.get $A)
+  ;; YESINLINE-NEXT:  (block $__inlined_func$refinable_noinline
+  ;; YESINLINE-NEXT:   (local.set $2
+  ;; YESINLINE-NEXT:    (local.get $A)
+  ;; YESINLINE-NEXT:   )
+  ;; YESINLINE-NEXT:   (drop
+  ;; YESINLINE-NEXT:    (local.get $2)
+  ;; YESINLINE-NEXT:   )
+  ;; YESINLINE-NEXT:  )
+  ;; YESINLINE-NEXT:  (block $__inlined_func$refinable_noinline$1
+  ;; YESINLINE-NEXT:   (local.set $3
+  ;; YESINLINE-NEXT:    (local.get $A)
+  ;; YESINLINE-NEXT:   )
+  ;; YESINLINE-NEXT:   (drop
+  ;; YESINLINE-NEXT:    (local.get $3)
+  ;; YESINLINE-NEXT:   )
+  ;; YESINLINE-NEXT:  )
+  ;; YESINLINE-NEXT:  (block $__inlined_func$refinable_noinline_2$2
+  ;; YESINLINE-NEXT:   (local.set $4
+  ;; YESINLINE-NEXT:    (local.get $B)
+  ;; YESINLINE-NEXT:   )
+  ;; YESINLINE-NEXT:   (block
+  ;; YESINLINE-NEXT:    (local.set $5
+  ;; YESINLINE-NEXT:     (local.get $4)
   ;; YESINLINE-NEXT:    )
   ;; YESINLINE-NEXT:    (drop
-  ;; YESINLINE-NEXT:     (local.get $2)
+  ;; YESINLINE-NEXT:     (local.get $5)
   ;; YESINLINE-NEXT:    )
   ;; YESINLINE-NEXT:   )
   ;; YESINLINE-NEXT:  )
-  ;; YESINLINE-NEXT:  (block
-  ;; YESINLINE-NEXT:   (block $__inlined_func$refinable_noinline$1
-  ;; YESINLINE-NEXT:    (local.set $3
-  ;; YESINLINE-NEXT:     (local.get $A)
+  ;; YESINLINE-NEXT:  (block $__inlined_func$refinable_noinline_2$3
+  ;; YESINLINE-NEXT:   (local.set $6
+  ;; YESINLINE-NEXT:    (local.get $B)
+  ;; YESINLINE-NEXT:   )
+  ;; YESINLINE-NEXT:   (block
+  ;; YESINLINE-NEXT:    (local.set $7
+  ;; YESINLINE-NEXT:     (local.get $6)
   ;; YESINLINE-NEXT:    )
   ;; YESINLINE-NEXT:    (drop
-  ;; YESINLINE-NEXT:     (local.get $3)
-  ;; YESINLINE-NEXT:    )
-  ;; YESINLINE-NEXT:   )
-  ;; YESINLINE-NEXT:  )
-  ;; YESINLINE-NEXT:  (block
-  ;; YESINLINE-NEXT:   (block $__inlined_func$refinable_noinline_2$2
-  ;; YESINLINE-NEXT:    (local.set $4
-  ;; YESINLINE-NEXT:     (local.get $B)
-  ;; YESINLINE-NEXT:    )
-  ;; YESINLINE-NEXT:    (block
-  ;; YESINLINE-NEXT:     (local.set $5
-  ;; YESINLINE-NEXT:      (local.get $4)
-  ;; YESINLINE-NEXT:     )
-  ;; YESINLINE-NEXT:     (drop
-  ;; YESINLINE-NEXT:      (local.get $5)
-  ;; YESINLINE-NEXT:     )
-  ;; YESINLINE-NEXT:    )
-  ;; YESINLINE-NEXT:   )
-  ;; YESINLINE-NEXT:  )
-  ;; YESINLINE-NEXT:  (block
-  ;; YESINLINE-NEXT:   (block $__inlined_func$refinable_noinline_2$3
-  ;; YESINLINE-NEXT:    (local.set $6
-  ;; YESINLINE-NEXT:     (local.get $B)
-  ;; YESINLINE-NEXT:    )
-  ;; YESINLINE-NEXT:    (block
-  ;; YESINLINE-NEXT:     (local.set $7
-  ;; YESINLINE-NEXT:      (local.get $6)
-  ;; YESINLINE-NEXT:     )
-  ;; YESINLINE-NEXT:     (drop
-  ;; YESINLINE-NEXT:      (local.get $7)
-  ;; YESINLINE-NEXT:     )
+  ;; YESINLINE-NEXT:     (local.get $7)
   ;; YESINLINE-NEXT:    )
   ;; YESINLINE-NEXT:   )
   ;; YESINLINE-NEXT:  )

--- a/test/lit/passes/no-inline.wast
+++ b/test/lit/passes/no-inline.wast
@@ -101,52 +101,44 @@
   ;; YES_ALL-NEXT:  (local $1 i32)
   ;; YES_ALL-NEXT:  (local $2 i32)
   ;; YES_ALL-NEXT:  (local $3 i32)
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$full-yes-inline
-  ;; YES_ALL-NEXT:    (local.set $0
-  ;; YES_ALL-NEXT:     (i32.const 0)
-  ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (call $import)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$full-yes-inline
+  ;; YES_ALL-NEXT:   (local.set $0
+  ;; YES_ALL-NEXT:    (i32.const 0)
   ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (call $import)
   ;; YES_ALL-NEXT:  )
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$full-maybe-inline$1
-  ;; YES_ALL-NEXT:    (local.set $1
-  ;; YES_ALL-NEXT:     (i32.const 1)
-  ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (call $import)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$full-maybe-inline$1
+  ;; YES_ALL-NEXT:   (local.set $1
+  ;; YES_ALL-NEXT:    (i32.const 1)
   ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (call $import)
   ;; YES_ALL-NEXT:  )
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$2
-  ;; YES_ALL-NEXT:    (local.set $2
-  ;; YES_ALL-NEXT:     (i32.const 2)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$2
+  ;; YES_ALL-NEXT:   (local.set $2
+  ;; YES_ALL-NEXT:    (i32.const 2)
+  ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (if
+  ;; YES_ALL-NEXT:    (i32.eqz
+  ;; YES_ALL-NEXT:     (local.get $2)
   ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (if
-  ;; YES_ALL-NEXT:     (i32.eqz
+  ;; YES_ALL-NEXT:    (then
+  ;; YES_ALL-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; YES_ALL-NEXT:      (local.get $2)
   ;; YES_ALL-NEXT:     )
-  ;; YES_ALL-NEXT:     (then
-  ;; YES_ALL-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; YES_ALL-NEXT:       (local.get $2)
-  ;; YES_ALL-NEXT:      )
-  ;; YES_ALL-NEXT:     )
   ;; YES_ALL-NEXT:    )
   ;; YES_ALL-NEXT:   )
   ;; YES_ALL-NEXT:  )
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$3
-  ;; YES_ALL-NEXT:    (local.set $3
-  ;; YES_ALL-NEXT:     (i32.const 3)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$3
+  ;; YES_ALL-NEXT:   (local.set $3
+  ;; YES_ALL-NEXT:    (i32.const 3)
+  ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (if
+  ;; YES_ALL-NEXT:    (i32.eqz
+  ;; YES_ALL-NEXT:     (local.get $3)
   ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (if
-  ;; YES_ALL-NEXT:     (i32.eqz
+  ;; YES_ALL-NEXT:    (then
+  ;; YES_ALL-NEXT:     (call $byn-split-outlined-A$partial-maybe-inline
   ;; YES_ALL-NEXT:      (local.get $3)
-  ;; YES_ALL-NEXT:     )
-  ;; YES_ALL-NEXT:     (then
-  ;; YES_ALL-NEXT:      (call $byn-split-outlined-A$partial-maybe-inline
-  ;; YES_ALL-NEXT:       (local.get $3)
-  ;; YES_ALL-NEXT:      )
   ;; YES_ALL-NEXT:     )
   ;; YES_ALL-NEXT:    )
   ;; YES_ALL-NEXT:   )
@@ -156,35 +148,29 @@
   ;; NO_PART-NEXT:  (local $0 i32)
   ;; NO_PART-NEXT:  (local $1 i32)
   ;; NO_PART-NEXT:  (local $2 i32)
-  ;; NO_PART-NEXT:  (block
-  ;; NO_PART-NEXT:   (block $__inlined_func$full-yes-inline
-  ;; NO_PART-NEXT:    (local.set $0
-  ;; NO_PART-NEXT:     (i32.const 0)
-  ;; NO_PART-NEXT:    )
-  ;; NO_PART-NEXT:    (call $import)
+  ;; NO_PART-NEXT:  (block $__inlined_func$full-yes-inline
+  ;; NO_PART-NEXT:   (local.set $0
+  ;; NO_PART-NEXT:    (i32.const 0)
   ;; NO_PART-NEXT:   )
+  ;; NO_PART-NEXT:   (call $import)
   ;; NO_PART-NEXT:  )
-  ;; NO_PART-NEXT:  (block
-  ;; NO_PART-NEXT:   (block $__inlined_func$full-maybe-inline$1
-  ;; NO_PART-NEXT:    (local.set $1
-  ;; NO_PART-NEXT:     (i32.const 1)
-  ;; NO_PART-NEXT:    )
-  ;; NO_PART-NEXT:    (call $import)
+  ;; NO_PART-NEXT:  (block $__inlined_func$full-maybe-inline$1
+  ;; NO_PART-NEXT:   (local.set $1
+  ;; NO_PART-NEXT:    (i32.const 1)
   ;; NO_PART-NEXT:   )
+  ;; NO_PART-NEXT:   (call $import)
   ;; NO_PART-NEXT:  )
-  ;; NO_PART-NEXT:  (block
-  ;; NO_PART-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$2
-  ;; NO_PART-NEXT:    (local.set $2
-  ;; NO_PART-NEXT:     (i32.const 2)
+  ;; NO_PART-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$2
+  ;; NO_PART-NEXT:   (local.set $2
+  ;; NO_PART-NEXT:    (i32.const 2)
+  ;; NO_PART-NEXT:   )
+  ;; NO_PART-NEXT:   (if
+  ;; NO_PART-NEXT:    (i32.eqz
+  ;; NO_PART-NEXT:     (local.get $2)
   ;; NO_PART-NEXT:    )
-  ;; NO_PART-NEXT:    (if
-  ;; NO_PART-NEXT:     (i32.eqz
+  ;; NO_PART-NEXT:    (then
+  ;; NO_PART-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; NO_PART-NEXT:      (local.get $2)
-  ;; NO_PART-NEXT:     )
-  ;; NO_PART-NEXT:     (then
-  ;; NO_PART-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; NO_PART-NEXT:       (local.get $2)
-  ;; NO_PART-NEXT:      )
   ;; NO_PART-NEXT:     )
   ;; NO_PART-NEXT:    )
   ;; NO_PART-NEXT:   )
@@ -197,47 +183,41 @@
   ;; NO_FULL-NEXT:  (local $0 i32)
   ;; NO_FULL-NEXT:  (local $1 i32)
   ;; NO_FULL-NEXT:  (local $2 i32)
-  ;; NO_FULL-NEXT:  (block
-  ;; NO_FULL-NEXT:   (block $__inlined_func$full-yes-inline
-  ;; NO_FULL-NEXT:    (local.set $0
-  ;; NO_FULL-NEXT:     (i32.const 0)
-  ;; NO_FULL-NEXT:    )
-  ;; NO_FULL-NEXT:    (call $import)
+  ;; NO_FULL-NEXT:  (block $__inlined_func$full-yes-inline
+  ;; NO_FULL-NEXT:   (local.set $0
+  ;; NO_FULL-NEXT:    (i32.const 0)
   ;; NO_FULL-NEXT:   )
+  ;; NO_FULL-NEXT:   (call $import)
   ;; NO_FULL-NEXT:  )
   ;; NO_FULL-NEXT:  (call $full-maybe-inline
   ;; NO_FULL-NEXT:   (i32.const 1)
   ;; NO_FULL-NEXT:  )
-  ;; NO_FULL-NEXT:  (block
-  ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$1
-  ;; NO_FULL-NEXT:    (local.set $1
-  ;; NO_FULL-NEXT:     (i32.const 2)
+  ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$1
+  ;; NO_FULL-NEXT:   (local.set $1
+  ;; NO_FULL-NEXT:    (i32.const 2)
+  ;; NO_FULL-NEXT:   )
+  ;; NO_FULL-NEXT:   (if
+  ;; NO_FULL-NEXT:    (i32.eqz
+  ;; NO_FULL-NEXT:     (local.get $1)
   ;; NO_FULL-NEXT:    )
-  ;; NO_FULL-NEXT:    (if
-  ;; NO_FULL-NEXT:     (i32.eqz
+  ;; NO_FULL-NEXT:    (then
+  ;; NO_FULL-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; NO_FULL-NEXT:      (local.get $1)
-  ;; NO_FULL-NEXT:     )
-  ;; NO_FULL-NEXT:     (then
-  ;; NO_FULL-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; NO_FULL-NEXT:       (local.get $1)
-  ;; NO_FULL-NEXT:      )
   ;; NO_FULL-NEXT:     )
   ;; NO_FULL-NEXT:    )
   ;; NO_FULL-NEXT:   )
   ;; NO_FULL-NEXT:  )
-  ;; NO_FULL-NEXT:  (block
-  ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$2
-  ;; NO_FULL-NEXT:    (local.set $2
-  ;; NO_FULL-NEXT:     (i32.const 3)
+  ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$2
+  ;; NO_FULL-NEXT:   (local.set $2
+  ;; NO_FULL-NEXT:    (i32.const 3)
+  ;; NO_FULL-NEXT:   )
+  ;; NO_FULL-NEXT:   (if
+  ;; NO_FULL-NEXT:    (i32.eqz
+  ;; NO_FULL-NEXT:     (local.get $2)
   ;; NO_FULL-NEXT:    )
-  ;; NO_FULL-NEXT:    (if
-  ;; NO_FULL-NEXT:     (i32.eqz
+  ;; NO_FULL-NEXT:    (then
+  ;; NO_FULL-NEXT:     (call $byn-split-outlined-A$partial-maybe-inline
   ;; NO_FULL-NEXT:      (local.get $2)
-  ;; NO_FULL-NEXT:     )
-  ;; NO_FULL-NEXT:     (then
-  ;; NO_FULL-NEXT:      (call $byn-split-outlined-A$partial-maybe-inline
-  ;; NO_FULL-NEXT:       (local.get $2)
-  ;; NO_FULL-NEXT:      )
   ;; NO_FULL-NEXT:     )
   ;; NO_FULL-NEXT:    )
   ;; NO_FULL-NEXT:   )
@@ -246,30 +226,26 @@
   ;; NO_BOTH:      (func $caller
   ;; NO_BOTH-NEXT:  (local $0 i32)
   ;; NO_BOTH-NEXT:  (local $1 i32)
-  ;; NO_BOTH-NEXT:  (block
-  ;; NO_BOTH-NEXT:   (block $__inlined_func$full-yes-inline
-  ;; NO_BOTH-NEXT:    (local.set $0
-  ;; NO_BOTH-NEXT:     (i32.const 0)
-  ;; NO_BOTH-NEXT:    )
-  ;; NO_BOTH-NEXT:    (call $import)
+  ;; NO_BOTH-NEXT:  (block $__inlined_func$full-yes-inline
+  ;; NO_BOTH-NEXT:   (local.set $0
+  ;; NO_BOTH-NEXT:    (i32.const 0)
   ;; NO_BOTH-NEXT:   )
+  ;; NO_BOTH-NEXT:   (call $import)
   ;; NO_BOTH-NEXT:  )
   ;; NO_BOTH-NEXT:  (call $full-maybe-inline
   ;; NO_BOTH-NEXT:   (i32.const 1)
   ;; NO_BOTH-NEXT:  )
-  ;; NO_BOTH-NEXT:  (block
-  ;; NO_BOTH-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$1
-  ;; NO_BOTH-NEXT:    (local.set $1
-  ;; NO_BOTH-NEXT:     (i32.const 2)
+  ;; NO_BOTH-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$1
+  ;; NO_BOTH-NEXT:   (local.set $1
+  ;; NO_BOTH-NEXT:    (i32.const 2)
+  ;; NO_BOTH-NEXT:   )
+  ;; NO_BOTH-NEXT:   (if
+  ;; NO_BOTH-NEXT:    (i32.eqz
+  ;; NO_BOTH-NEXT:     (local.get $1)
   ;; NO_BOTH-NEXT:    )
-  ;; NO_BOTH-NEXT:    (if
-  ;; NO_BOTH-NEXT:     (i32.eqz
+  ;; NO_BOTH-NEXT:    (then
+  ;; NO_BOTH-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; NO_BOTH-NEXT:      (local.get $1)
-  ;; NO_BOTH-NEXT:     )
-  ;; NO_BOTH-NEXT:     (then
-  ;; NO_BOTH-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; NO_BOTH-NEXT:       (local.get $1)
-  ;; NO_BOTH-NEXT:      )
   ;; NO_BOTH-NEXT:     )
   ;; NO_BOTH-NEXT:    )
   ;; NO_BOTH-NEXT:   )
@@ -298,52 +274,44 @@
   ;; YES_ALL-NEXT:  (local $1 i32)
   ;; YES_ALL-NEXT:  (local $2 i32)
   ;; YES_ALL-NEXT:  (local $3 i32)
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$full-yes-inline$4
-  ;; YES_ALL-NEXT:    (local.set $0
-  ;; YES_ALL-NEXT:     (i32.const 0)
-  ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (call $import)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$full-yes-inline$4
+  ;; YES_ALL-NEXT:   (local.set $0
+  ;; YES_ALL-NEXT:    (i32.const 0)
   ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (call $import)
   ;; YES_ALL-NEXT:  )
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$full-maybe-inline$5
-  ;; YES_ALL-NEXT:    (local.set $1
-  ;; YES_ALL-NEXT:     (i32.const 1)
-  ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (call $import)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$full-maybe-inline$5
+  ;; YES_ALL-NEXT:   (local.set $1
+  ;; YES_ALL-NEXT:    (i32.const 1)
   ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (call $import)
   ;; YES_ALL-NEXT:  )
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$6
-  ;; YES_ALL-NEXT:    (local.set $2
-  ;; YES_ALL-NEXT:     (i32.const 2)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$6
+  ;; YES_ALL-NEXT:   (local.set $2
+  ;; YES_ALL-NEXT:    (i32.const 2)
+  ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (if
+  ;; YES_ALL-NEXT:    (i32.eqz
+  ;; YES_ALL-NEXT:     (local.get $2)
   ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (if
-  ;; YES_ALL-NEXT:     (i32.eqz
+  ;; YES_ALL-NEXT:    (then
+  ;; YES_ALL-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; YES_ALL-NEXT:      (local.get $2)
   ;; YES_ALL-NEXT:     )
-  ;; YES_ALL-NEXT:     (then
-  ;; YES_ALL-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; YES_ALL-NEXT:       (local.get $2)
-  ;; YES_ALL-NEXT:      )
-  ;; YES_ALL-NEXT:     )
   ;; YES_ALL-NEXT:    )
   ;; YES_ALL-NEXT:   )
   ;; YES_ALL-NEXT:  )
-  ;; YES_ALL-NEXT:  (block
-  ;; YES_ALL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$7
-  ;; YES_ALL-NEXT:    (local.set $3
-  ;; YES_ALL-NEXT:     (i32.const 3)
+  ;; YES_ALL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$7
+  ;; YES_ALL-NEXT:   (local.set $3
+  ;; YES_ALL-NEXT:    (i32.const 3)
+  ;; YES_ALL-NEXT:   )
+  ;; YES_ALL-NEXT:   (if
+  ;; YES_ALL-NEXT:    (i32.eqz
+  ;; YES_ALL-NEXT:     (local.get $3)
   ;; YES_ALL-NEXT:    )
-  ;; YES_ALL-NEXT:    (if
-  ;; YES_ALL-NEXT:     (i32.eqz
+  ;; YES_ALL-NEXT:    (then
+  ;; YES_ALL-NEXT:     (call $byn-split-outlined-A$partial-maybe-inline
   ;; YES_ALL-NEXT:      (local.get $3)
-  ;; YES_ALL-NEXT:     )
-  ;; YES_ALL-NEXT:     (then
-  ;; YES_ALL-NEXT:      (call $byn-split-outlined-A$partial-maybe-inline
-  ;; YES_ALL-NEXT:       (local.get $3)
-  ;; YES_ALL-NEXT:      )
   ;; YES_ALL-NEXT:     )
   ;; YES_ALL-NEXT:    )
   ;; YES_ALL-NEXT:   )
@@ -353,35 +321,29 @@
   ;; NO_PART-NEXT:  (local $0 i32)
   ;; NO_PART-NEXT:  (local $1 i32)
   ;; NO_PART-NEXT:  (local $2 i32)
-  ;; NO_PART-NEXT:  (block
-  ;; NO_PART-NEXT:   (block $__inlined_func$full-yes-inline$3
-  ;; NO_PART-NEXT:    (local.set $0
-  ;; NO_PART-NEXT:     (i32.const 0)
-  ;; NO_PART-NEXT:    )
-  ;; NO_PART-NEXT:    (call $import)
+  ;; NO_PART-NEXT:  (block $__inlined_func$full-yes-inline$3
+  ;; NO_PART-NEXT:   (local.set $0
+  ;; NO_PART-NEXT:    (i32.const 0)
   ;; NO_PART-NEXT:   )
+  ;; NO_PART-NEXT:   (call $import)
   ;; NO_PART-NEXT:  )
-  ;; NO_PART-NEXT:  (block
-  ;; NO_PART-NEXT:   (block $__inlined_func$full-maybe-inline$4
-  ;; NO_PART-NEXT:    (local.set $1
-  ;; NO_PART-NEXT:     (i32.const 1)
-  ;; NO_PART-NEXT:    )
-  ;; NO_PART-NEXT:    (call $import)
+  ;; NO_PART-NEXT:  (block $__inlined_func$full-maybe-inline$4
+  ;; NO_PART-NEXT:   (local.set $1
+  ;; NO_PART-NEXT:    (i32.const 1)
   ;; NO_PART-NEXT:   )
+  ;; NO_PART-NEXT:   (call $import)
   ;; NO_PART-NEXT:  )
-  ;; NO_PART-NEXT:  (block
-  ;; NO_PART-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$5
-  ;; NO_PART-NEXT:    (local.set $2
-  ;; NO_PART-NEXT:     (i32.const 2)
+  ;; NO_PART-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$5
+  ;; NO_PART-NEXT:   (local.set $2
+  ;; NO_PART-NEXT:    (i32.const 2)
+  ;; NO_PART-NEXT:   )
+  ;; NO_PART-NEXT:   (if
+  ;; NO_PART-NEXT:    (i32.eqz
+  ;; NO_PART-NEXT:     (local.get $2)
   ;; NO_PART-NEXT:    )
-  ;; NO_PART-NEXT:    (if
-  ;; NO_PART-NEXT:     (i32.eqz
+  ;; NO_PART-NEXT:    (then
+  ;; NO_PART-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; NO_PART-NEXT:      (local.get $2)
-  ;; NO_PART-NEXT:     )
-  ;; NO_PART-NEXT:     (then
-  ;; NO_PART-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; NO_PART-NEXT:       (local.get $2)
-  ;; NO_PART-NEXT:      )
   ;; NO_PART-NEXT:     )
   ;; NO_PART-NEXT:    )
   ;; NO_PART-NEXT:   )
@@ -394,47 +356,41 @@
   ;; NO_FULL-NEXT:  (local $0 i32)
   ;; NO_FULL-NEXT:  (local $1 i32)
   ;; NO_FULL-NEXT:  (local $2 i32)
-  ;; NO_FULL-NEXT:  (block
-  ;; NO_FULL-NEXT:   (block $__inlined_func$full-yes-inline$3
-  ;; NO_FULL-NEXT:    (local.set $0
-  ;; NO_FULL-NEXT:     (i32.const 0)
-  ;; NO_FULL-NEXT:    )
-  ;; NO_FULL-NEXT:    (call $import)
+  ;; NO_FULL-NEXT:  (block $__inlined_func$full-yes-inline$3
+  ;; NO_FULL-NEXT:   (local.set $0
+  ;; NO_FULL-NEXT:    (i32.const 0)
   ;; NO_FULL-NEXT:   )
+  ;; NO_FULL-NEXT:   (call $import)
   ;; NO_FULL-NEXT:  )
   ;; NO_FULL-NEXT:  (call $full-maybe-inline
   ;; NO_FULL-NEXT:   (i32.const 1)
   ;; NO_FULL-NEXT:  )
-  ;; NO_FULL-NEXT:  (block
-  ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$4
-  ;; NO_FULL-NEXT:    (local.set $1
-  ;; NO_FULL-NEXT:     (i32.const 2)
+  ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$4
+  ;; NO_FULL-NEXT:   (local.set $1
+  ;; NO_FULL-NEXT:    (i32.const 2)
+  ;; NO_FULL-NEXT:   )
+  ;; NO_FULL-NEXT:   (if
+  ;; NO_FULL-NEXT:    (i32.eqz
+  ;; NO_FULL-NEXT:     (local.get $1)
   ;; NO_FULL-NEXT:    )
-  ;; NO_FULL-NEXT:    (if
-  ;; NO_FULL-NEXT:     (i32.eqz
+  ;; NO_FULL-NEXT:    (then
+  ;; NO_FULL-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; NO_FULL-NEXT:      (local.get $1)
-  ;; NO_FULL-NEXT:     )
-  ;; NO_FULL-NEXT:     (then
-  ;; NO_FULL-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; NO_FULL-NEXT:       (local.get $1)
-  ;; NO_FULL-NEXT:      )
   ;; NO_FULL-NEXT:     )
   ;; NO_FULL-NEXT:    )
   ;; NO_FULL-NEXT:   )
   ;; NO_FULL-NEXT:  )
-  ;; NO_FULL-NEXT:  (block
-  ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$5
-  ;; NO_FULL-NEXT:    (local.set $2
-  ;; NO_FULL-NEXT:     (i32.const 3)
+  ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-maybe-inline$5
+  ;; NO_FULL-NEXT:   (local.set $2
+  ;; NO_FULL-NEXT:    (i32.const 3)
+  ;; NO_FULL-NEXT:   )
+  ;; NO_FULL-NEXT:   (if
+  ;; NO_FULL-NEXT:    (i32.eqz
+  ;; NO_FULL-NEXT:     (local.get $2)
   ;; NO_FULL-NEXT:    )
-  ;; NO_FULL-NEXT:    (if
-  ;; NO_FULL-NEXT:     (i32.eqz
+  ;; NO_FULL-NEXT:    (then
+  ;; NO_FULL-NEXT:     (call $byn-split-outlined-A$partial-maybe-inline
   ;; NO_FULL-NEXT:      (local.get $2)
-  ;; NO_FULL-NEXT:     )
-  ;; NO_FULL-NEXT:     (then
-  ;; NO_FULL-NEXT:      (call $byn-split-outlined-A$partial-maybe-inline
-  ;; NO_FULL-NEXT:       (local.get $2)
-  ;; NO_FULL-NEXT:      )
   ;; NO_FULL-NEXT:     )
   ;; NO_FULL-NEXT:    )
   ;; NO_FULL-NEXT:   )
@@ -443,30 +399,26 @@
   ;; NO_BOTH:      (func $caller-2
   ;; NO_BOTH-NEXT:  (local $0 i32)
   ;; NO_BOTH-NEXT:  (local $1 i32)
-  ;; NO_BOTH-NEXT:  (block
-  ;; NO_BOTH-NEXT:   (block $__inlined_func$full-yes-inline$2
-  ;; NO_BOTH-NEXT:    (local.set $0
-  ;; NO_BOTH-NEXT:     (i32.const 0)
-  ;; NO_BOTH-NEXT:    )
-  ;; NO_BOTH-NEXT:    (call $import)
+  ;; NO_BOTH-NEXT:  (block $__inlined_func$full-yes-inline$2
+  ;; NO_BOTH-NEXT:   (local.set $0
+  ;; NO_BOTH-NEXT:    (i32.const 0)
   ;; NO_BOTH-NEXT:   )
+  ;; NO_BOTH-NEXT:   (call $import)
   ;; NO_BOTH-NEXT:  )
   ;; NO_BOTH-NEXT:  (call $full-maybe-inline
   ;; NO_BOTH-NEXT:   (i32.const 1)
   ;; NO_BOTH-NEXT:  )
-  ;; NO_BOTH-NEXT:  (block
-  ;; NO_BOTH-NEXT:   (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$3
-  ;; NO_BOTH-NEXT:    (local.set $1
-  ;; NO_BOTH-NEXT:     (i32.const 2)
+  ;; NO_BOTH-NEXT:  (block $__inlined_func$byn-split-inlineable-A$partial-yes-inline$3
+  ;; NO_BOTH-NEXT:   (local.set $1
+  ;; NO_BOTH-NEXT:    (i32.const 2)
+  ;; NO_BOTH-NEXT:   )
+  ;; NO_BOTH-NEXT:   (if
+  ;; NO_BOTH-NEXT:    (i32.eqz
+  ;; NO_BOTH-NEXT:     (local.get $1)
   ;; NO_BOTH-NEXT:    )
-  ;; NO_BOTH-NEXT:    (if
-  ;; NO_BOTH-NEXT:     (i32.eqz
+  ;; NO_BOTH-NEXT:    (then
+  ;; NO_BOTH-NEXT:     (call $byn-split-outlined-A$partial-yes-inline
   ;; NO_BOTH-NEXT:      (local.get $1)
-  ;; NO_BOTH-NEXT:     )
-  ;; NO_BOTH-NEXT:     (then
-  ;; NO_BOTH-NEXT:      (call $byn-split-outlined-A$partial-yes-inline
-  ;; NO_BOTH-NEXT:       (local.get $1)
-  ;; NO_BOTH-NEXT:      )
   ;; NO_BOTH-NEXT:     )
   ;; NO_BOTH-NEXT:    )
   ;; NO_BOTH-NEXT:   )
@@ -691,109 +643,101 @@
  ;; YES_ALL-NEXT:  (local $1 i32)
  ;; YES_ALL-NEXT:  (local $2 i32)
  ;; YES_ALL-NEXT:  (local $3 i32)
- ;; YES_ALL-NEXT:  (block
- ;; YES_ALL-NEXT:   (block $__inlined_func$maybe-partial-or-full-1
- ;; YES_ALL-NEXT:    (local.set $0
+ ;; YES_ALL-NEXT:  (block $__inlined_func$maybe-partial-or-full-1
+ ;; YES_ALL-NEXT:   (local.set $0
+ ;; YES_ALL-NEXT:    (i32.const 0)
+ ;; YES_ALL-NEXT:   )
+ ;; YES_ALL-NEXT:   (if
+ ;; YES_ALL-NEXT:    (local.get $0)
+ ;; YES_ALL-NEXT:    (then
+ ;; YES_ALL-NEXT:     (call $import)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:   )
+ ;; YES_ALL-NEXT:  )
+ ;; YES_ALL-NEXT:  (block $__inlined_func$maybe-partial-or-full-1$1
+ ;; YES_ALL-NEXT:   (local.set $1
+ ;; YES_ALL-NEXT:    (i32.const 1)
+ ;; YES_ALL-NEXT:   )
+ ;; YES_ALL-NEXT:   (if
+ ;; YES_ALL-NEXT:    (local.get $1)
+ ;; YES_ALL-NEXT:    (then
+ ;; YES_ALL-NEXT:     (call $import)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:   )
+ ;; YES_ALL-NEXT:  )
+ ;; YES_ALL-NEXT:  (block $__inlined_func$maybe-partial-or-full-2$2
+ ;; YES_ALL-NEXT:   (local.set $2
+ ;; YES_ALL-NEXT:    (i32.const 0)
+ ;; YES_ALL-NEXT:   )
+ ;; YES_ALL-NEXT:   (block
+ ;; YES_ALL-NEXT:    (if
+ ;; YES_ALL-NEXT:     (local.get $2)
+ ;; YES_ALL-NEXT:     (then
+ ;; YES_ALL-NEXT:      (br $__inlined_func$maybe-partial-or-full-2$2)
+ ;; YES_ALL-NEXT:     )
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (nop)
+ ;; YES_ALL-NEXT:    (drop
  ;; YES_ALL-NEXT:     (i32.const 0)
  ;; YES_ALL-NEXT:    )
- ;; YES_ALL-NEXT:    (if
- ;; YES_ALL-NEXT:     (local.get $0)
- ;; YES_ALL-NEXT:     (then
- ;; YES_ALL-NEXT:      (call $import)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:    )
- ;; YES_ALL-NEXT:   )
- ;; YES_ALL-NEXT:  )
- ;; YES_ALL-NEXT:  (block
- ;; YES_ALL-NEXT:   (block $__inlined_func$maybe-partial-or-full-1$1
- ;; YES_ALL-NEXT:    (local.set $1
- ;; YES_ALL-NEXT:     (i32.const 1)
- ;; YES_ALL-NEXT:    )
- ;; YES_ALL-NEXT:    (if
- ;; YES_ALL-NEXT:     (local.get $1)
- ;; YES_ALL-NEXT:     (then
- ;; YES_ALL-NEXT:      (call $import)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:    )
- ;; YES_ALL-NEXT:   )
- ;; YES_ALL-NEXT:  )
- ;; YES_ALL-NEXT:  (block
- ;; YES_ALL-NEXT:   (block $__inlined_func$maybe-partial-or-full-2$2
- ;; YES_ALL-NEXT:    (local.set $2
+ ;; YES_ALL-NEXT:    (drop
  ;; YES_ALL-NEXT:     (i32.const 0)
  ;; YES_ALL-NEXT:    )
- ;; YES_ALL-NEXT:    (block
- ;; YES_ALL-NEXT:     (if
- ;; YES_ALL-NEXT:      (local.get $2)
- ;; YES_ALL-NEXT:      (then
- ;; YES_ALL-NEXT:       (br $__inlined_func$maybe-partial-or-full-2$2)
- ;; YES_ALL-NEXT:      )
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (nop)
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
  ;; YES_ALL-NEXT:    )
  ;; YES_ALL-NEXT:   )
  ;; YES_ALL-NEXT:  )
- ;; YES_ALL-NEXT:  (block
- ;; YES_ALL-NEXT:   (block $__inlined_func$maybe-partial-or-full-2$3
- ;; YES_ALL-NEXT:    (local.set $3
- ;; YES_ALL-NEXT:     (i32.const 1)
+ ;; YES_ALL-NEXT:  (block $__inlined_func$maybe-partial-or-full-2$3
+ ;; YES_ALL-NEXT:   (local.set $3
+ ;; YES_ALL-NEXT:    (i32.const 1)
+ ;; YES_ALL-NEXT:   )
+ ;; YES_ALL-NEXT:   (block
+ ;; YES_ALL-NEXT:    (if
+ ;; YES_ALL-NEXT:     (local.get $3)
+ ;; YES_ALL-NEXT:     (then
+ ;; YES_ALL-NEXT:      (br $__inlined_func$maybe-partial-or-full-2$3)
+ ;; YES_ALL-NEXT:     )
  ;; YES_ALL-NEXT:    )
- ;; YES_ALL-NEXT:    (block
- ;; YES_ALL-NEXT:     (if
- ;; YES_ALL-NEXT:      (local.get $3)
- ;; YES_ALL-NEXT:      (then
- ;; YES_ALL-NEXT:       (br $__inlined_func$maybe-partial-or-full-2$3)
- ;; YES_ALL-NEXT:      )
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (nop)
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
- ;; YES_ALL-NEXT:     (drop
- ;; YES_ALL-NEXT:      (i32.const 0)
- ;; YES_ALL-NEXT:     )
+ ;; YES_ALL-NEXT:    (nop)
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
+ ;; YES_ALL-NEXT:    )
+ ;; YES_ALL-NEXT:    (drop
+ ;; YES_ALL-NEXT:     (i32.const 0)
  ;; YES_ALL-NEXT:    )
  ;; YES_ALL-NEXT:   )
  ;; YES_ALL-NEXT:  )
@@ -817,66 +761,58 @@
  ;; NO_FULL-NEXT:  (local $1 i32)
  ;; NO_FULL-NEXT:  (local $2 i32)
  ;; NO_FULL-NEXT:  (local $3 i32)
- ;; NO_FULL-NEXT:  (block
- ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-B$maybe-partial-or-full-1
- ;; NO_FULL-NEXT:    (local.set $0
- ;; NO_FULL-NEXT:     (i32.const 0)
- ;; NO_FULL-NEXT:    )
- ;; NO_FULL-NEXT:    (if
- ;; NO_FULL-NEXT:     (local.get $0)
- ;; NO_FULL-NEXT:     (then
- ;; NO_FULL-NEXT:      (call $byn-split-outlined-B$maybe-partial-or-full-1
- ;; NO_FULL-NEXT:       (local.get $0)
- ;; NO_FULL-NEXT:      )
+ ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-B$maybe-partial-or-full-1
+ ;; NO_FULL-NEXT:   (local.set $0
+ ;; NO_FULL-NEXT:    (i32.const 0)
+ ;; NO_FULL-NEXT:   )
+ ;; NO_FULL-NEXT:   (if
+ ;; NO_FULL-NEXT:    (local.get $0)
+ ;; NO_FULL-NEXT:    (then
+ ;; NO_FULL-NEXT:     (call $byn-split-outlined-B$maybe-partial-or-full-1
+ ;; NO_FULL-NEXT:      (local.get $0)
  ;; NO_FULL-NEXT:     )
  ;; NO_FULL-NEXT:    )
  ;; NO_FULL-NEXT:   )
  ;; NO_FULL-NEXT:  )
- ;; NO_FULL-NEXT:  (block
- ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-B$maybe-partial-or-full-1$1
- ;; NO_FULL-NEXT:    (local.set $1
- ;; NO_FULL-NEXT:     (i32.const 1)
- ;; NO_FULL-NEXT:    )
- ;; NO_FULL-NEXT:    (if
- ;; NO_FULL-NEXT:     (local.get $1)
- ;; NO_FULL-NEXT:     (then
- ;; NO_FULL-NEXT:      (call $byn-split-outlined-B$maybe-partial-or-full-1
- ;; NO_FULL-NEXT:       (local.get $1)
- ;; NO_FULL-NEXT:      )
+ ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-B$maybe-partial-or-full-1$1
+ ;; NO_FULL-NEXT:   (local.set $1
+ ;; NO_FULL-NEXT:    (i32.const 1)
+ ;; NO_FULL-NEXT:   )
+ ;; NO_FULL-NEXT:   (if
+ ;; NO_FULL-NEXT:    (local.get $1)
+ ;; NO_FULL-NEXT:    (then
+ ;; NO_FULL-NEXT:     (call $byn-split-outlined-B$maybe-partial-or-full-1
+ ;; NO_FULL-NEXT:      (local.get $1)
  ;; NO_FULL-NEXT:     )
  ;; NO_FULL-NEXT:    )
  ;; NO_FULL-NEXT:   )
  ;; NO_FULL-NEXT:  )
- ;; NO_FULL-NEXT:  (block
- ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$maybe-partial-or-full-2$2
- ;; NO_FULL-NEXT:    (local.set $2
- ;; NO_FULL-NEXT:     (i32.const 0)
+ ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$maybe-partial-or-full-2$2
+ ;; NO_FULL-NEXT:   (local.set $2
+ ;; NO_FULL-NEXT:    (i32.const 0)
+ ;; NO_FULL-NEXT:   )
+ ;; NO_FULL-NEXT:   (if
+ ;; NO_FULL-NEXT:    (i32.eqz
+ ;; NO_FULL-NEXT:     (local.get $2)
  ;; NO_FULL-NEXT:    )
- ;; NO_FULL-NEXT:    (if
- ;; NO_FULL-NEXT:     (i32.eqz
+ ;; NO_FULL-NEXT:    (then
+ ;; NO_FULL-NEXT:     (call $byn-split-outlined-A$maybe-partial-or-full-2
  ;; NO_FULL-NEXT:      (local.get $2)
  ;; NO_FULL-NEXT:     )
- ;; NO_FULL-NEXT:     (then
- ;; NO_FULL-NEXT:      (call $byn-split-outlined-A$maybe-partial-or-full-2
- ;; NO_FULL-NEXT:       (local.get $2)
- ;; NO_FULL-NEXT:      )
- ;; NO_FULL-NEXT:     )
  ;; NO_FULL-NEXT:    )
  ;; NO_FULL-NEXT:   )
  ;; NO_FULL-NEXT:  )
- ;; NO_FULL-NEXT:  (block
- ;; NO_FULL-NEXT:   (block $__inlined_func$byn-split-inlineable-A$maybe-partial-or-full-2$3
- ;; NO_FULL-NEXT:    (local.set $3
- ;; NO_FULL-NEXT:     (i32.const 1)
+ ;; NO_FULL-NEXT:  (block $__inlined_func$byn-split-inlineable-A$maybe-partial-or-full-2$3
+ ;; NO_FULL-NEXT:   (local.set $3
+ ;; NO_FULL-NEXT:    (i32.const 1)
+ ;; NO_FULL-NEXT:   )
+ ;; NO_FULL-NEXT:   (if
+ ;; NO_FULL-NEXT:    (i32.eqz
+ ;; NO_FULL-NEXT:     (local.get $3)
  ;; NO_FULL-NEXT:    )
- ;; NO_FULL-NEXT:    (if
- ;; NO_FULL-NEXT:     (i32.eqz
+ ;; NO_FULL-NEXT:    (then
+ ;; NO_FULL-NEXT:     (call $byn-split-outlined-A$maybe-partial-or-full-2
  ;; NO_FULL-NEXT:      (local.get $3)
- ;; NO_FULL-NEXT:     )
- ;; NO_FULL-NEXT:     (then
- ;; NO_FULL-NEXT:      (call $byn-split-outlined-A$maybe-partial-or-full-2
- ;; NO_FULL-NEXT:       (local.get $3)
- ;; NO_FULL-NEXT:      )
  ;; NO_FULL-NEXT:     )
  ;; NO_FULL-NEXT:    )
  ;; NO_FULL-NEXT:   )


### PR DESCRIPTION
Inlining was careful about nested calls like this:
```wat
(call $a
  (call $b)
)
```
If we inlined the outer call first, we'd have
```wat
(block $inlined-code-from-a
  ..code..
  (call $b)
)
```
After that, the inner call is a child of a block, not of a call. That is,
we've moved the inner call to another parent. To replace that
inner call when we inline, we'd need to update the new parent,
which would require work. To avoid that work, the pass simply
created a block in the middle:
```wat
(call $a
  (block
    (call $b)
  )
)
```
Now the inner call's immediate parent will not change when we
inline the outer call.

However, it turns out that this was entirely unnecessary. We find
the calls using a post-order traversal, and we store the actions in
a vector that we traverse in order, so we only ever process things
in the optimal order of children before parents. And in that order
there is no problem: inlining the inner call first leads to
```wat
(call $a
  (block $inlined-code-from-b
    (..code..)
  )
)
```
That does not affect the outer call's parent.

This PR removes the creation of the unnecessary blocks. This doesn't
improve the final output as optimizations remove the unneeded
blocks later anyhow, but it does make the code simpler and a little
faster. It also makes debugging less confusing. But this is not truly
NFC because `--inlining` (but not `--inlining-optimizing`) will actually
emit fewer blocks now (but only `--inlining-optimizing` is used by
default in production).

The diff on tests here is very small when ignoring whitespace. The
remaining differences are just emitting fewer obviously-unneeded
blocks. There is also one test that needed manual changes,
`inlining-eh-legacy`, because it tested that we do Pop fixups, but
after emitting one fewer block, those fixups were not needed. I
added a new test there with two nested calls, which does end up
needing those fixups. I also added such a test in
`inlining_all-features` so that we have coverage for such nested
calls (we might remove the eh-legacy file some day, and other
existing tests with nested calls that I found were more complex).