### PR TITLE
[NFC] Use an unordered map in Parents

### DIFF
--- a/src/ir/parents.h
+++ b/src/ir/parents.h
@@ -37,7 +37,7 @@ private:
     : public ExpressionStackWalker<Inner, UnifiedExpressionVisitor<Inner>> {
     void visitExpression(Expression* curr) { parentMap[curr] = getParent(); }
 
-    std::map<Expression*, Expression*> parentMap;
+    std::unordered_map<Expression*, Expression*> parentMap;
   } inner;
 };
 


### PR DESCRIPTION
This makes it slightly faster.

Followup to https://github.com/WebAssembly/binaryen/pull/6953#discussion_r1765313401