### PR TITLE
[NFC] Early-exit PickLoadSigns if there are no memories

### DIFF
--- a/src/passes/PickLoadSigns.cpp
+++ b/src/passes/PickLoadSigns.cpp
@@ -45,6 +45,11 @@ struct PickLoadSigns : public WalkerPass<ExpressionStackWalker<PickLoadSigns>> {
   std::unordered_map<Load*, Index> loads;
 
   void doWalkFunction(Function* func) {
+    if (getModule()->memories.empty()) {
+      // There can be no loads without a memory.
+      return;
+    }
+
     // prepare
     usages.resize(func->getNumLocals());
     // walk


### PR DESCRIPTION
In WasmGC modules there is often no memory at all, and we can skip
walking the code in this pass in such cases.