### PR TITLE
Binary parser: lift the limit on the number of locals

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -472,6 +472,10 @@ void WasmBinaryWriter::writeFunctions() {
       std::cerr << "Some VMs may not accept this binary because it has a large "
                 << "number of parameters in function " << func->name << ".\n";
     }
+    if (func->getNumLocals() > WebLimitations::MaxFunctionLocals) {
+      std::cerr << "Some VMs may not accept this binary because it has a large "
+                << "number of locals in function " << func->name << ".\n";
+    }
   });
   finishSection(sectionStart);
 }
@@ -2722,16 +2726,18 @@ void WasmBinaryReader::readFunctions() {
 void WasmBinaryReader::readVars() {
   uint32_t totalVars = 0;
   size_t numLocalTypes = getU32LEB();
+  std::vector<std::pair<uint32_t, Type>> decodedVars;
+  decodedVars.reserve(numLocalTypes);
   for (size_t t = 0; t < numLocalTypes; t++) {
     auto num = getU32LEB();
-    // The core spec allows up to 2^32 locals, but to avoid allocation failures,
-    // we additionally impose a much smaller limit, matching the JS embedding.
-    if (std::ckd_add(&totalVars, totalVars, num) ||
-        totalVars > WebLimitations::MaxFunctionLocals) {
-      throwError("too many locals");
+    if (std::ckd_add(&totalVars, totalVars, num)) {
+      throwError("unaddressable number of locals");
     }
     auto type = getConcreteType();
-
+    decodedVars.emplace_back(num, type);
+  }
+  currFunction->vars.reserve(totalVars);
+  for (auto [num, type] : decodedVars) {
     while (num > 0) {
       currFunction->vars.push_back(type);
       num--;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2726,7 +2726,9 @@ void WasmBinaryReader::readFunctions() {
 void WasmBinaryReader::readVars() {
   uint32_t totalVars = 0;
   size_t numLocalTypes = getU32LEB();
-  std::vector<std::pair<uint32_t, Type>> decodedVars;
+  // Use a SmallVector as in the common (MVP) case there are only 4 possible
+  // types.
+  SmallVector<std::pair<uint32_t, Type>, 4> decodedVars;
   decodedVars.reserve(numLocalTypes);
   for (size_t t = 0; t < numLocalTypes; t++) {
     auto num = getU32LEB();

--- a/test/unit/test_web_limitations.py
+++ b/test/unit/test_web_limitations.py
@@ -20,3 +20,19 @@ class WebLimitations(utils.BinaryenTestCase):
                                input=module, capture_output=True)
         self.assertIn('Some VMs may not accept this binary because it has a large number of parameters in function foo.',
                       p.stderr)
+
+    def test_many_locals(self):
+        """Test that we warn on large numbers of locals, which Web VMs
+        disallow."""
+
+        params = '(local i32) ' * 50_001
+        module = '''
+        (module
+         (func $foo %s
+         )
+        )
+        ''' % params
+        p = shared.run_process(shared.WASM_OPT + ['-o', os.devnull],
+                               input=module, capture_output=True)
+        self.assertIn('Some VMs may not accept this binary because it has a large number of locals in function foo.',
+                      p.stderr)


### PR DESCRIPTION
This raises the number of locals accepted by the binary parser to the absolute limit in the spec. A warning is now printed when writing a binary file if the Web limit of 50,000 locals is exceeded. This fixes #6968.