### PR TITLE
[NFC] Print type names in more places when logging

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3702,4 +3702,9 @@ std::ostream& operator<<(std::ostream& o, wasm::StackInst& inst) {
   return wasm::printStackInst(&inst, o);
 }
 
+std::ostream& operator<<(std::ostream& o, wasm::ModuleType pair) {
+  wasm::printTypeOrName(pair.second, o, &pair.first);
+  return o;
+}
+
 } // namespace std

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -237,10 +237,8 @@ public:
       if (type.isConcrete() || curr->type.isConcrete()) {
 #if 1 // def WASM_INTERPRETER_DEBUG
         if (!Type::isSubType(type, curr->type)) {
-          std::cerr << "expected "
-                    << ModuleType(*module, curr->type) << ", seeing "
-                    << ModuleType(*module, type)
-                    << " from\n"
+          std::cerr << "expected " << ModuleType(*module, curr->type)
+                    << ", seeing " << ModuleType(*module, type) << " from\n"
                     << ModuleExpression(*module, curr) << '\n';
         }
 #endif

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -237,9 +237,11 @@ public:
       if (type.isConcrete() || curr->type.isConcrete()) {
 #if 1 // def WASM_INTERPRETER_DEBUG
         if (!Type::isSubType(type, curr->type)) {
-          std::cerr << "expected " << curr->type << ", seeing " << type
+          std::cerr << "expected "
+                    << ModuleType(*module, curr->type) << ", seeing "
+                    << ModuleType(*module, type)
                     << " from\n"
-                    << *curr << '\n';
+                    << ModuleExpression(*module, curr) << '\n';
         }
 #endif
         assert(Type::isSubType(type, curr->type));

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2397,6 +2397,9 @@ public:
 // Utility for printing an expression with named types.
 using ModuleExpression = std::pair<Module&, Expression*>;
 
+// Utility for printing an type with a name, if the module defines a name.
+using ModuleType = std::pair<Module&, Type>;
+
 // Utility for printing only the top level of an expression. Named types will be
 // used if `module` is non-null.
 struct ShallowExpression {
@@ -2418,6 +2421,7 @@ std::ostream& operator<<(std::ostream& o, wasm::Function& func);
 std::ostream& operator<<(std::ostream& o, wasm::Expression& expression);
 std::ostream& operator<<(std::ostream& o, wasm::ModuleExpression pair);
 std::ostream& operator<<(std::ostream& o, wasm::ShallowExpression expression);
+std::ostream& operator<<(std::ostream& o, wasm::ModuleType pair);
 
 } // namespace std
 


### PR DESCRIPTION
I found this useful in local debugging just now.