### PR TITLE
Fix the type of reused RefFunc in Precompute

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -298,7 +298,8 @@ struct Precompute
                    singleValue.type.getHeapType().isSignature()) {
           if (auto* r = curr->value->template dynCast<RefFunc>()) {
             r->func = singleValue.getFunc();
-            r->finalize();
+            auto heapType = getModule()->getFunction(r->func)->type;
+            r->finalize(Type(heapType, NonNullable));
             curr->finalize();
             return;
           }

--- a/test/lit/passes/precompute-ref-func.wast
+++ b/test/lit/passes/precompute-ref-func.wast
@@ -4,8 +4,11 @@
 (module
   ;; CHECK:      (type $0 (func (result funcref)))
 
+  (type $func (func (result funcref)))
+
   ;; CHECK:      (type $shared-func (shared (func (result (ref null (shared func))))))
   (type $shared-func (shared (func (result (ref null (shared func))))))
+
   ;; CHECK:      (elem declare func $test $test-shared)
 
   ;; CHECK:      (func $test (type $0) (result funcref)
@@ -13,7 +16,7 @@
   ;; CHECK-NEXT:   (ref.func $test)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $test (result funcref)
+  (func $test (type $func) (result funcref)
     (block
       (return
         (ref.func $test)
@@ -31,6 +34,27 @@
       (return
         (ref.func $test-shared)
       )
+    )
+  )
+
+  (func $precompute-nested-brs (result (ref $shared-func))
+    ;; We have two nested brs here, and we can precompute it all. While doing so
+    ;; we must not get confused between the targets and values: one sends a
+    ;; shared func, the other a normal func, so the types are different, and any
+    ;; mistake there will fail validation (say, if we reused the ref.func from
+    ;; the inner br when generating the outer one).
+    (block $shared (result (ref $shared-func))
+      (drop
+        (block $func (result (ref $func))
+          (br_if $func
+            (ref.func $test)
+            (br $shared
+              (ref.func $test-shared)
+            )
+          )
+        )
+      )
+      (ref.func $test-shared)
     )
   )
 )

--- a/test/lit/passes/precompute-ref-func.wast
+++ b/test/lit/passes/precompute-ref-func.wast
@@ -4,11 +4,10 @@
 (module
 
   ;; CHECK:      (type $shared-func (shared (func (result (ref null (shared func))))))
+  (type $shared-func (shared (func (result (ref null (shared func))))))
 
   ;; CHECK:      (type $func (func (result funcref)))
   (type $func (func (result funcref)))
-
-  (type $shared-func (shared (func (result (ref null (shared func))))))
 
   ;; CHECK:      (type $2 (func (result (ref $shared-func))))
 

--- a/test/lit/passes/precompute-ref-func.wast
+++ b/test/lit/passes/precompute-ref-func.wast
@@ -2,16 +2,19 @@
 ;; RUN: wasm-opt %s -all --precompute -S -o - | filecheck %s
 
 (module
-  ;; CHECK:      (type $0 (func (result funcref)))
-
-  (type $func (func (result funcref)))
 
   ;; CHECK:      (type $shared-func (shared (func (result (ref null (shared func))))))
+
+  ;; CHECK:      (type $func (func (result funcref)))
+  (type $func (func (result funcref)))
+
   (type $shared-func (shared (func (result (ref null (shared func))))))
+
+  ;; CHECK:      (type $2 (func (result (ref $shared-func))))
 
   ;; CHECK:      (elem declare func $test $test-shared)
 
-  ;; CHECK:      (func $test (type $0) (result funcref)
+  ;; CHECK:      (func $test (type $func) (result funcref)
   ;; CHECK-NEXT:  (return
   ;; CHECK-NEXT:   (ref.func $test)
   ;; CHECK-NEXT:  )
@@ -37,6 +40,9 @@
     )
   )
 
+  ;; CHECK:      (func $precompute-nested-brs (type $2) (result (ref $shared-func))
+  ;; CHECK-NEXT:  (ref.func $test-shared)
+  ;; CHECK-NEXT: )
   (func $precompute-nested-brs (result (ref $shared-func))
     ;; We have two nested brs here, and we can precompute it all. While doing so
     ;; we must not get confused between the targets and values: one sends a


### PR DESCRIPTION
When we precompute something, we try to avoid allocating a new copy. That's important to
avoid many allocations each time we run Precompute - otherwise, each time we see a `br`
we'd allocate a fresh one, and for its values. But we had a bug where we reused a RefFunc
as the value of a `br` without updating the type. It's actually tricky to reach a situation where
we find a RefFunc to reuse and it is different from the actual one we want, but the fuzzer
found one.

Fixes the fuzz bug reported here: https://github.com/WebAssembly/binaryen/pull/6845#issuecomment-2377800299