### PR TITLE
[NFC] Move a TypeInfo constructor out of a header

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -280,7 +280,7 @@ struct TypeInfo {
     Ref ref;
   };
 
-  TypeInfo(const Tuple& tuple) : kind(TupleKind), tuple(tuple) {}
+  TypeInfo(const Tuple& tuple);
   TypeInfo(Tuple&& tuple) : kind(TupleKind), tuple(std::move(tuple)) {}
   TypeInfo(HeapType heapType, Nullability nullable)
     : kind(RefKind), ref{heapType, nullable} {}

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -479,6 +479,8 @@ std::optional<HeapType> getBasicHeapTypeLUB(HeapType::BasicHeapType a,
 
 } // anonymous namespace
 
+TypeInfo::TypeInfo(const Tuple& tuple) : kind(TupleKind), tuple(tuple) {}
+
 TypeInfo::TypeInfo(const TypeInfo& other) {
   kind = other.kind;
   switch (kind) {


### PR DESCRIPTION
Some versions of libcxx or clang error without this, apparently due to Type
being a forward declaration.