### PR TITLE
[NFC] Refactor out the dropped-block optimization code in MergeBlocks

### DIFF
--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -197,7 +197,42 @@ static bool hasDeadCode(Block* block) {
   return false;
 }
 
-// core block optimizer routine
+// Given a dropped block, see if we can simplify it by optimizing the drop into
+// the block, removing the return value while doin so. Returns whether we
+// succeeded.
+bool optimizeDroppedBlock(Drop* drop, Block* block, Module& wasm, PassOptions& options) {
+  assert(drop->value == block);
+  if (block->name.is()) {
+    // There may be breaks: see if we can remove their values.
+    Expression* expression = block;
+    ProblemFinder finder(options);
+    finder.setModule(&wasm);
+    finder.origin = block->name;
+    finder.walk(expression);
+    if (finder.found()) {
+      // We found a problem that blocks us.
+      return false;
+    }
+
+    // Success. Fix up breaks before continuing to handle the drop itself.
+    BreakValueDropper fixer(options, branchInfo);
+    fixer.origin = block->name;
+    fixer.setModule(&wasm);
+    fixer.walk(expression);
+  }
+
+  // Optimize by removing the block. Reuse the drop, if we still need it.
+  auto* last = block->list.back();
+  if (last->type.isConcrete()) {
+    drop->value = last;
+    drop->finalize();
+    block->list.back() = drop;
+  }
+  block->finalize();
+  return true;
+}
+
+// Core block optimizer routine.
 static void optimizeBlock(Block* curr,
                           Module* module,
                           PassOptions& passOptions,
@@ -218,8 +253,8 @@ static void optimizeBlock(Block* curr,
       Loop* loop = nullptr;
       // To to handle a non-block child.
       if (!childBlock) {
-        // if we have a child that is (drop (block ..)) then we can move the
-        // drop into the block, and remove br values. this allows more merging,
+        // Tf we have a child that is (drop (block ..)) then we can move the
+        // drop into the block, and remove br values. This allows more merging.
         if (auto* drop = list[i]->dynCast<Drop>()) {
           childBlock = drop->value->dynCast<Block>();
           if (childBlock) {
@@ -228,36 +263,12 @@ static void optimizeBlock(Block* curr,
               // dce should have been run anyhow
               continue;
             }
-            if (childBlock->name.is()) {
-              Expression* expression = childBlock;
-              // check if it's ok to remove the value from all breaks to us
-              ProblemFinder finder(passOptions);
-              finder.setModule(module);
-              finder.origin = childBlock->name;
-              finder.walk(expression);
-              if (finder.found()) {
-                childBlock = nullptr;
-              } else {
-                // fix up breaks
-                BreakValueDropper fixer(passOptions, branchInfo);
-                fixer.origin = childBlock->name;
-                fixer.setModule(module);
-                fixer.walk(expression);
-              }
-            }
-            if (childBlock) {
-              // we can do it!
-              // reuse the drop, if we still need it
-              auto* last = childBlock->list.back();
-              if (last->type.isConcrete()) {
-                drop->value = last;
-                drop->finalize();
-                childBlock->list.back() = drop;
-              }
-              childBlock->finalize();
+            if (optimizeDroppedBlock(drop, childBlock, *module, passOptions)) {
               child = list[i] = childBlock;
               more = true;
               changed = true;
+            } else {
+              childBlock = nullptr;
             }
           }
         } else if ((loop = list[i]->dynCast<Loop>())) {

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -257,7 +257,7 @@ static void optimizeBlock(Block* curr,
       Loop* loop = nullptr;
       // To to handle a non-block child.
       if (!childBlock) {
-        // Tf we have a child that is (drop (block ..)) then we can move the
+        // If we have a child that is (drop (block ..)) then we can move the
         // drop into the block, and remove br values. This allows more merging.
         if (auto* drop = list[i]->dynCast<Drop>()) {
           childBlock = drop->value->dynCast<Block>();

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -200,11 +200,11 @@ static bool hasDeadCode(Block* block) {
 // Given a dropped block, see if we can simplify it by optimizing the drop into
 // the block, removing the return value while doin so. Returns whether we
 // succeeded.
-bool optimizeDroppedBlock(Drop* drop,
-                          Block* block,
-                          Module& wasm,
-                          PassOptions& options,
-                          BranchUtils::BranchSeekerCache& branchInfo) {
+static bool optimizeDroppedBlock(Drop* drop,
+                                 Block* block,
+                                 Module& wasm,
+                                 PassOptions& options,
+                                 BranchUtils::BranchSeekerCache& branchInfo) {
   assert(drop->value == block);
   if (block->name.is()) {
     // There may be breaks: see if we can remove their values.

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -200,7 +200,11 @@ static bool hasDeadCode(Block* block) {
 // Given a dropped block, see if we can simplify it by optimizing the drop into
 // the block, removing the return value while doin so. Returns whether we
 // succeeded.
-bool optimizeDroppedBlock(Drop* drop, Block* block, Module& wasm, PassOptions& options,                           BranchUtils::BranchSeekerCache& branchInfo) {
+bool optimizeDroppedBlock(Drop* drop,
+                          Block* block,
+                          Module& wasm,
+                          PassOptions& options,
+                          BranchUtils::BranchSeekerCache& branchInfo) {
   assert(drop->value == block);
   if (block->name.is()) {
     // There may be breaks: see if we can remove their values.
@@ -263,7 +267,8 @@ static void optimizeBlock(Block* curr,
               // dce should have been run anyhow
               continue;
             }
-            if (optimizeDroppedBlock(drop, childBlock, *module, passOptions, branchInfo)) {
+            if (optimizeDroppedBlock(
+                  drop, childBlock, *module, passOptions, branchInfo)) {
               child = list[i] = childBlock;
               more = true;
               changed = true;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -200,7 +200,7 @@ static bool hasDeadCode(Block* block) {
 // Given a dropped block, see if we can simplify it by optimizing the drop into
 // the block, removing the return value while doin so. Returns whether we
 // succeeded.
-bool optimizeDroppedBlock(Drop* drop, Block* block, Module& wasm, PassOptions& options) {
+bool optimizeDroppedBlock(Drop* drop, Block* block, Module& wasm, PassOptions& options,                           BranchUtils::BranchSeekerCache& branchInfo) {
   assert(drop->value == block);
   if (block->name.is()) {
     // There may be breaks: see if we can remove their values.
@@ -263,7 +263,7 @@ static void optimizeBlock(Block* curr,
               // dce should have been run anyhow
               continue;
             }
-            if (optimizeDroppedBlock(drop, childBlock, *module, passOptions)) {
+            if (optimizeDroppedBlock(drop, childBlock, *module, passOptions, branchInfo)) {
               child = list[i] = childBlock;
               more = true;
               changed = true;

--- a/test/lit/passes/merge-blocks.wast
+++ b/test/lit/passes/merge-blocks.wast
@@ -15,7 +15,7 @@
 
  (type $array (array (mut i32)))
 
- ;; CHECK:      (func $br_on_to_drop (type $5)
+ ;; CHECK:      (func $br_on_to_drop (type $4)
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block $label$1 (result i31ref)
@@ -43,7 +43,7 @@
   )
  )
 
- ;; CHECK:      (func $struct.set (type $4) (param $struct (ref null $struct))
+ ;; CHECK:      (func $struct.set (type $5) (param $struct (ref null $struct))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.const 1234)
@@ -68,7 +68,7 @@
   )
  )
 
- ;; CHECK:      (func $struct.get (type $4) (param $struct (ref null $struct))
+ ;; CHECK:      (func $struct.get (type $5) (param $struct (ref null $struct))
  ;; CHECK-NEXT:  (nop)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (i32.const 1234)
@@ -401,6 +401,27 @@
     (i32.const 4)
    )
    (i32.const 2)
+  )
+ )
+
+ ;; CHECK:      (func $toplevel (type $4)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block $label (result i32)
+ ;; CHECK-NEXT:    (br $label
+ ;; CHECK-NEXT:     (i32.const 42)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $toplevel
+  ;; Test we can remove a block value even when the drop is at the toplevel of
+  ;; a function. This is not done yet TODO
+  (drop
+   (block $label (result i32)
+    (br $label
+     (i32.const 42)
+    )
+   )
   )
  )
 


### PR DESCRIPTION
This just moves the code out into a function. A later PR will use it in another place.

Add a test that shows the motivation for that later PR: we fail to optimize away
a block return value at the top level of a function. Fixing that will involve calling
the new function here from another place.