### PR TITLE
Add explicit errors on unhandled instructions in Flatten

### DIFF
--- a/src/passes/Flatten.cpp
+++ b/src/passes/Flatten.cpp
@@ -329,6 +329,11 @@ struct Flatten
       }
     }
 
+    if (curr->is<BrOn>() || curr->is<TryTable>()) {
+      Fatal() << "Unsupported instruction for Flatten: "
+              << getExpressionName(curr);
+    }
+
     // continue for general handling of everything, control flow or otherwise
     curr = getCurrent(); // we may have replaced it
     // we have changed children


### PR DESCRIPTION
This error makes #6989 less confusing.