### PR TITLE
ReFinalize in MergeBlocks so we can optimize unreachable instructions too

### DIFF
--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -197,11 +197,6 @@ static bool optimizeDroppedBlock(Drop* drop,
                                  PassOptions& options,
                                  BranchUtils::BranchSeekerCache& branchInfo) {
   assert(drop->value == block);
-  if (hasUnreachableChild(block)) {
-    // Don't move around unreachable code, as it can change types (leave it for
-    // DCE).
-    return false;
-  }
   if (block->name.is()) {
     // There may be breaks: see if we can remove their values.
     Expression* expression = block;

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -475,13 +475,6 @@ struct MergeBlocks
     }
     if (auto* block = child->dynCast<Block>()) {
       if (!block->name.is() && block->list.size() >= 2) {
-        // if we move around unreachable code, type changes could occur. avoid
-        // that, as anyhow it means we should have run dce before getting here
-        if (curr->type == Type::none) {
-          // moving the block to the outside would replace a none with an
-          // unreachable
-          return outer;
-        }
         auto* back = block->list.back();
         if (back->type == Type::unreachable) {
           // curr is not reachable, dce could remove it; don't try anything

--- a/src/passes/MergeBlocks.cpp
+++ b/src/passes/MergeBlocks.cpp
@@ -253,11 +253,6 @@ static bool optimizeBlock(Block* curr,
         if (auto* drop = list[i]->dynCast<Drop>()) {
           childBlock = drop->value->dynCast<Block>();
           if (childBlock) {
-            if (hasUnreachableChild(childBlock)) {
-              // don't move around unreachable code, as it can change types
-              // dce should have been run anyhow
-              continue;
-            }
             if (optimizeDroppedBlock(
                   drop, childBlock, *module, passOptions, branchInfo)) {
               child = list[i] = childBlock;
@@ -700,7 +695,7 @@ struct MergeBlocks
 
   void visitFunction(Function* curr) {
     if (refinalize) {
-      ReFinalize().walkFunctionInModule(curr, *getModule());
+      ReFinalize().walkFunctionInModule(curr, getModule());
     }
   }
 };

--- a/test/lit/passes/merge-blocks.wast
+++ b/test/lit/passes/merge-blocks.wast
@@ -405,12 +405,11 @@
  )
 
  ;; CHECK:      (func $toplevel (type $4)
- ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block $label (result i32)
- ;; CHECK-NEXT:    (br $label
- ;; CHECK-NEXT:     (i32.const 42)
- ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:  (block $label
+ ;; CHECK-NEXT:   (drop
+ ;; CHECK-NEXT:    (i32.const 42)
  ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (br $label)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $toplevel

--- a/test/lit/passes/monomorphize-drop.wast
+++ b/test/lit/passes/monomorphize-drop.wast
@@ -672,12 +672,7 @@
 
 ;; CAREFUL:      (func $return-normal_4 (type $1)
 ;; CAREFUL-NEXT:  (drop
-;; CAREFUL-NEXT:   (block
-;; CAREFUL-NEXT:    (drop
-;; CAREFUL-NEXT:     (call $import)
-;; CAREFUL-NEXT:    )
-;; CAREFUL-NEXT:    (return)
-;; CAREFUL-NEXT:   )
+;; CAREFUL-NEXT:   (call $import)
 ;; CAREFUL-NEXT:  )
 ;; CAREFUL-NEXT: )
 

--- a/test/passes/Oz_fuzz-exec_all-features.txt
+++ b/test/passes/Oz_fuzz-exec_all-features.txt
@@ -183,14 +183,10 @@
   (nop)
  )
  (func $br-on_non_null-2 (type $void_func)
-  (drop
-   (block
-    (call $log
-     (i32.const 1)
-    )
-    (unreachable)
-   )
+  (call $log
+   (i32.const 1)
   )
+  (unreachable)
  )
  (func $cast-on-func (type $void_func)
   (call $log

--- a/test/passes/merge-blocks.txt
+++ b/test/passes/merge-blocks.txt
@@ -10,11 +10,12 @@
   )
  )
  (func $drop-block-br
-  (drop
-   (block $x (result i32)
-    (br $x
-     (i32.const 1)
-    )
+  (block $x
+   (drop
+    (i32.const 1)
+   )
+   (br $x)
+   (drop
     (i32.const 0)
    )
   )
@@ -77,15 +78,9 @@
   )
  )
  (func $drop-block-squared-iloop
-  (drop
-   (block $label$0 (result i32)
-    (drop
-     (block $label$1
-      (loop $label$2
-       (br $label$2)
-      )
-     )
-    )
+  (block $label$0
+   (loop $label$2
+    (br $label$2)
    )
   )
  )
@@ -109,11 +104,7 @@
  (func $loop-block-drop-block-return
   (loop $label$4
    (block $label$5
-    (drop
-     (block $label$6 (result i32)
-      (return)
-     )
-    )
+    (return)
    )
   )
  )

--- a/test/passes/remove-unused-names_merge-blocks_all-features.txt
+++ b/test/passes/remove-unused-names_merge-blocks_all-features.txt
@@ -754,13 +754,11 @@
  (func $block-type-change (type $3)
   (local $0 f64)
   (local $1 f64)
+  (nop)
   (if
-   (block (result i32)
-    (nop)
-    (f64.gt
-     (local.get $0)
-     (local.get $1)
-    )
+   (f64.gt
+    (local.get $0)
+    (local.get $1)
    )
    (then
     (nop)

--- a/test/passes/remove-unused-names_merge-blocks_all-features.txt
+++ b/test/passes/remove-unused-names_merge-blocks_all-features.txt
@@ -286,15 +286,11 @@
    (i32.const 30)
   )
   (drop
-   (block
-    (drop
-     (i32.const 10)
-    )
-    (i32.add
-     (unreachable)
-     (i32.const 20)
-    )
-   )
+   (i32.const 10)
+  )
+  (i32.add
+   (unreachable)
+   (i32.const 20)
   )
   (block
    (unreachable)
@@ -820,17 +816,13 @@
  )
  (func $drop-unreachable (type $2) (result i32)
   (local $0 i32)
-  (drop
-   (block (result i32)
-    (unreachable)
-   )
-  )
+  (unreachable)
   (unreachable)
  )
  (func $concrete_finale_in_unreachable (type $5) (result f64)
-  (drop
-   (block (result f64)
-    (unreachable)
+  (block
+   (unreachable)
+   (drop
     (f64.const 6.322092475576799e-96)
    )
   )
@@ -838,22 +830,16 @@
  )
  (func $dont-move-unreachable (type $3)
   (loop $label$0
+   (br $label$0)
    (drop
-    (block (result i32)
-     (br $label$0)
-     (i32.const 1)
-    )
+    (i32.const 1)
    )
   )
  )
  (func $dont-move-unreachable-last (type $3)
   (loop $label$0
-   (drop
-    (block (result i32)
-     (call $dont-move-unreachable-last)
-     (br $label$0)
-    )
-   )
+   (call $dont-move-unreachable-last)
+   (br $label$0)
   )
  )
  (func $move-around-unreachable-in-middle (type $3)
@@ -876,16 +862,10 @@
  )
  (func $drop-unreachable-block-with-concrete-final (type $3)
   (drop
-   (block (result i32)
-    (drop
-     (block
-      (drop
-       (return)
-      )
-     )
-    )
-    (i32.const -452)
-   )
+   (return)
+  )
+  (drop
+   (i32.const -452)
   )
  )
  (func $merging-with-unreachable-in-middle (type $2) (result i32)
@@ -901,13 +881,9 @@
  )
  (func $remove-br-after-unreachable (type $3)
   (block $label$9
-   (drop
-    (block
-     (block
-      (return)
-      (br $label$9)
-     )
-    )
+   (block
+    (return)
+    (br $label$9)
    )
   )
  )

--- a/test/passes/remove-unused-names_merge-blocks_all-features.txt
+++ b/test/passes/remove-unused-names_merge-blocks_all-features.txt
@@ -292,16 +292,16 @@
    (unreachable)
    (i32.const 20)
   )
-  (drop
-   (i32.const 20)
-  )
-  (drop
-   (i32.add
-    (block (result i32)
-     (unreachable)
+  (block
+   (unreachable)
+   (drop
+    (i32.const 20)
+   )
+   (drop
+    (i32.add
      (i32.const 10)
+     (i32.const 30)
     )
-    (i32.const 30)
    )
   )
  )
@@ -409,20 +409,20 @@
     )
    )
   )
-  (drop
-   (i32.const 30)
-  )
-  (drop
-   (i32.const 50)
-  )
-  (drop
-   (select
-    (block (result i32)
-     (unreachable)
+  (block
+   (unreachable)
+   (drop
+    (i32.const 30)
+   )
+   (drop
+    (i32.const 50)
+   )
+   (drop
+    (select
      (i32.const 20)
+     (i32.const 40)
+     (i32.const 60)
     )
-    (i32.const 40)
-    (i32.const 60)
    )
   )
   (drop
@@ -433,7 +433,7 @@
   )
   (drop
    (select
-    (block (result i32)
+    (block
      (drop
       (i32.const 10)
      )
@@ -443,20 +443,20 @@
     (i32.const 60)
    )
   )
-  (drop
-   (i32.const 10)
-  )
-  (drop
-   (i32.const 50)
-  )
-  (drop
-   (select
-    (i32.const 20)
-    (block (result i32)
-     (unreachable)
+  (block
+   (drop
+    (i32.const 10)
+   )
+   (unreachable)
+   (drop
+    (i32.const 50)
+   )
+   (drop
+    (select
+     (i32.const 20)
      (i32.const 40)
+     (i32.const 60)
     )
-    (i32.const 60)
    )
   )
   (drop
@@ -468,7 +468,7 @@
   (drop
    (select
     (i32.const 20)
-    (block (result i32)
+    (block
      (drop
       (i32.const 30)
      )
@@ -477,18 +477,18 @@
     (i32.const 60)
    )
   )
-  (drop
-   (i32.const 10)
-  )
-  (drop
-   (i32.const 30)
-  )
-  (drop
-   (select
-    (i32.const 20)
-    (i32.const 40)
-    (block (result i32)
-     (unreachable)
+  (block
+   (drop
+    (i32.const 10)
+   )
+   (drop
+    (i32.const 30)
+   )
+   (unreachable)
+   (drop
+    (select
+     (i32.const 20)
+     (i32.const 40)
      (i32.const 60)
     )
    )
@@ -503,7 +503,7 @@
    (select
     (i32.const 20)
     (i32.const 40)
-    (block (result i32)
+    (block
      (drop
       (i32.const 50)
      )
@@ -593,21 +593,21 @@
    (i32.const 20)
    (i32.const 40)
   )
-  (drop
-   (i32.const 20)
-  )
-  (call $call-ii
-   (block (result i32)
-    (unreachable)
-    (i32.const 10)
+  (block
+   (unreachable)
+   (drop
+    (i32.const 20)
    )
-   (i32.const 30)
+   (call $call-ii
+    (i32.const 10)
+    (i32.const 30)
+   )
   )
   (drop
    (i32.const 20)
   )
   (call $call-ii
-   (block (result i32)
+   (block
     (drop
      (i32.const 10)
     )
@@ -615,13 +615,13 @@
    )
    (i32.const 30)
   )
-  (drop
-   (i32.const 10)
-  )
-  (call $call-ii
-   (i32.const 20)
-   (block (result i32)
-    (unreachable)
+  (block
+   (drop
+    (i32.const 10)
+   )
+   (unreachable)
+   (call $call-ii
+    (i32.const 20)
     (i32.const 30)
    )
   )
@@ -630,7 +630,7 @@
   )
   (call $call-ii
    (i32.const 20)
-   (block (result i32)
+   (block
     (drop
      (i32.const 30)
     )
@@ -754,11 +754,13 @@
  (func $block-type-change (type $3)
   (local $0 f64)
   (local $1 f64)
-  (nop)
   (if
-   (f64.gt
-    (local.get $0)
-    (local.get $1)
+   (block (result i32)
+    (nop)
+    (f64.gt
+     (local.get $0)
+     (local.get $1)
+    )
    )
    (then
     (nop)
@@ -803,15 +805,11 @@
  )
  (func $return-different-type (type $2) (result i32)
   (drop
-   (f64.abs
-    (block
-     (drop
-      (i32.const 2)
-     )
-     (return
-      (i32.const 1)
-     )
-    )
+   (i32.const 2)
+  )
+  (f64.abs
+   (return
+    (i32.const 1)
    )
   )
   (unreachable)
@@ -850,9 +848,11 @@
    (drop
     (block $label$3 (result i32)
      (drop
-      (br_if $label$3
+      (block
        (br $label$0)
-       (i32.const 0)
+       (drop
+        (i32.const 0)
+       )
       )
      )
      (i32.const 1)


### PR DESCRIPTION
In #6984 we optimized dropped blocks even if they had unreachable code. In #6988
that part was reverted, and blocks with unreachable code were ignored once more.
However, I realized that the check was not actually for unreachable code, but for
having an unreachable child, so it would miss things like this:
```wat
(block
  (block
    ..
    (br $somewhere) ;; unreachable type, but no unreachable code
  )
)
```
But it is useful to merge such blocks: we don't need the inner block here.

To fix this, just run ReFinalize if we change anything, which will propagate
unreachability as needed. I think MergeBlocks was written before we had
that utility, so it didn't use it...

This is not only useful for itself but will unblock an EH optimization in a
later PR, that has code in this form. It also simplifies the code by removing
the `hasUnreachableChild` checks.

(As with previous PRs, the diff without whitespace is smaller. It is in fact
the same diff as earlier, sorry for the churn.)