### PR TITLE
Fix BranchUtils::operateOnScopeNameUsesAndSentValues() on BrOn

### DIFF
--- a/src/ir/branch-utils.h
+++ b/src/ir/branch-utils.h
@@ -108,7 +108,8 @@ void operateOnScopeNameUsesAndSentValues(Expression* expr, T func) {
     } else if (auto* sw = expr->dynCast<Switch>()) {
       func(name, sw->value);
     } else if (auto* br = expr->dynCast<BrOn>()) {
-      func(name, br->ref);
+      // A value may not be sent (e.g. BrOnNull does *not* send a null).
+      func(name, br->getSentType() != Type::none ? br->ref : nullptr);
     } else if (expr->is<TryTable>()) {
       // The values are supplied by throwing instructions, so we are unable to
       // know what they will be here.


### PR DESCRIPTION
BrOn does not always send a value. This is an odd asymmetry in the wasm
spec, where `br_on_null` does not send the null on the branch (which makes sense,
but the asymmetry does mean we need to special-case it).

Found by fuzzing with some BrOn additions that I will open a PR for later.