### PR TITLE
[Wasm EH] Optimize values flowing out of TryTable

### DIFF
--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -260,15 +260,16 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
         }
       }
     } else if (curr->is<Nop>()) {
-      // ignore (could be result of a previous cycle)
+      // Ignore (could be result of a previous cycle).
       self->stopValueFlow();
-    } else if (curr->is<Loop>()) { // TODO: eh
-      // do nothing - it's ok for values to flow out
+    } else if (curr->is<Loop>() || curr->is<TryTable>()) {
+      // Do nothing - it's ok for values to flow out.
+      // TODO: Legacy Try as well?
     } else if (auto* sw = curr->dynCast<Switch>()) {
       self->stopFlow();
       self->optimizeSwitch(sw);
     } else {
-      // anything else stops the flow
+      // Anything else stops the flow.
       self->stopFlow();
     }
   }


### PR DESCRIPTION
This allows
```wat
(block $out (result i32)
  (try_table (catch..)
    ..
    (br $out
      (i32.const 42)
    )
  )
)

=>

(block $out (result i32)
  (try_table (result i32) (catch..)  ;; add a result
    ..
    (i32.const 42)  ;; remove the br around the value
  )
)
```
