### PR TITLE
Optimize `Module::get_*` family of functions with `std::string_view` in `Module::getModuleElement`

### DIFF
--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1523,7 +1523,7 @@ void Function::clearDebugInfo() {
 
 template<typename Map>
 typename Map::mapped_type&
-getModuleElement(Map& m, Name name, const std::string& funcName) {
+getModuleElement(Map& m, Name name, std::string_view funcName) {
   auto iter = m.find(name);
   if (iter == m.end()) {
     Fatal() << "Module::" << funcName << ": " << name << " does not exist";


### PR DESCRIPTION
Passing a constant string to functions requires memory allocation, and allocation is inherently slow. Since we are using C++17, we can use `string_view` and remove this unnecessary allocation.

Although the code seems simple enough for the optimizer to remove this allocation after inlining, tests on Clang 18 show that this is not the case (on Apple Silicon at least).

<details>
  <summary>Assembly</summary>
  
  Before:
  
  ```asm
wasm::Module::getFunction(wasm::Name):
	sub	sp, sp, #64
	stp	x20, x19, [sp, #32]
	stp	x29, x30, [sp, #48]
	add	x29, sp, #48
	mov	w8, #11
	strb	w8, [sp, #31]
	mov	w8, #26996
	movk	w8, #28271, lsl #16
	stur	w8, [sp, #15]
Lloh143:
	adrp	x8, l_.str.246@PAGE
Lloh144:
	add	x8, x8, l_.str.246@PAGEOFF
Lloh145:
	ldr	x8, [x8]
	add	x0, x0, #480
	str	x8, [sp, #8]
	strb	wzr, [sp, #19]
	add	x3, sp, #8
	bl	std::__1::unordered_map<wasm::Name, wasm::Function*, std::__1::hash<wasm::Name>, std::__1::equal_to<wasm::Name>, std::__1::allocator<std::__1::pair<wasm::Name const, wasm::Function*>>>::mapped_type& wasm::getModuleElement<std::__1::unordered_map<wasm::Name, wasm::Function*, std::__1::hash<wasm::Name>, std::__1::equal_to<wasm::Name>, std::__1::allocator<std::__1::pair<wasm::Name const, wasm::Function*>>>>(std::__1::unordered_map<wasm::Name, wasm::Function*, std::__1::hash<wasm::Name>, std::__1::equal_to<wasm::Name>, std::__1::allocator<std::__1::pair<wasm::Name const, wasm::Function*>>>&, wasm::Name, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)
	ldr	x19, [x0]
	ldrsb	w8, [sp, #31]
	tbnz	w8, #31, LBB132_3
	mov	x0, x19
	ldp	x29, x30, [sp, #48]
	ldp	x20, x19, [sp, #32]
	add	sp, sp, #64
	ret
LBB132_3:
	ldr	x0, [sp, #8]
	bl	operator delete(void*)
	mov	x0, x19
	ldp	x29, x30, [sp, #48]
	ldp	x20, x19, [sp, #32]
	add	sp, sp, #64
	ret
	mov	x19, x0
	ldrsb	w8, [sp, #31]
	tbz	w8, #31, LBB132_6
	ldr	x0, [sp, #8]
	bl	operator delete(void*)
LBB132_6:
	mov	x0, x19
	bl	__Unwind_Resume
  ```

  After:
  
  ```asm
wasm::Module::getFunction(wasm::Name):
	stp	x29, x30, [sp, #-16]!
	mov	x29, sp
	add	x0, x0, #480
Lloh150:
	adrp	x3, l_.str.246@PAGE
Lloh151:
	add	x3, x3, l_.str.246@PAGEOFF
	mov	w4, #11
	bl	std::__1::unordered_map<wasm::Name, wasm::Function*, std::__1::hash<wasm::Name>, std::__1::equal_to<wasm::Name>, std::__1::allocator<std::__1::pair<wasm::Name const, wasm::Function*>>>::mapped_type& wasm::getModuleElement<std::__1::unordered_map<wasm::Name, wasm::Function*, std::__1::hash<wasm::Name>, std::__1::equal_to<wasm::Name>, std::__1::allocator<std::__1::pair<wasm::Name const, wasm::Function*>>>>(std::__1::unordered_map<wasm::Name, wasm::Function*, std::__1::hash<wasm::Name>, std::__1::equal_to<wasm::Name>, std::__1::allocator<std::__1::pair<wasm::Name const, wasm::Function*>>>&, wasm::Name, std::__1::basic_string_view<char, std::__1::char_traits<char>>)
	ldr	x0, [x0]
	ldp	x29, x30, [sp], #16
	ret
  ```

  Clang info:

  ```
Homebrew clang version 18.1.8
Target: arm64-apple-darwin24.1.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm/bin
  ```
  
</details>

P.S. This is my first PR in binaryen and my knowledge is very limited, so I'm very sorry if these changes are not what you would like to see in the PRs. Thank you for your patience!