### PR TITLE
[NFC] Add validation checks in OptUtils::optimizeAfterInlining

### DIFF
--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -44,8 +44,10 @@ inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
                                   Module* module,
                                   PassRunner* parentRunner) {
   // In pass-debug mode, validate before and after these optimizations. This
-  // helps catch bugs in the middle of passes like inlining and dae.
-  if (PassRunner::getPassDebug()) {
+  // helps catch bugs in the middle of passes like inlining and dae. We do this
+  // at level 2+ and not 1 so that this extra validation is not added to the
+  // timings that level 1 reports.
+  if (PassRunner::getPassDebug() >= 2) {
     if (!WasmValidator().validate(*module, parentRunner->options)) {
       Fatal() << "invalid wasm before optimizeAfterInlining";
     }
@@ -54,7 +56,7 @@ inline void optimizeAfterInlining(const PassUtils::FuncSet& funcs,
   runner.setIsNested(true);
   addUsefulPassesAfterInlining(runner);
   runner.run();
-  if (PassRunner::getPassDebug()) {
+  if (PassRunner::getPassDebug() >= 2) {
     if (!WasmValidator().validate(*module, parentRunner->options)) {
       Fatal() << "invalid wasm after optimizeAfterInlining";
     }

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -24,8 +24,8 @@
 #include "ir/module-utils.h"
 #include "pass.h"
 #include "passes/pass-utils.h"
-#include "wasm.h"
 #include "wasm-validator.h"
+#include "wasm.h"
 
 namespace wasm::OptUtils {
 


### PR DESCRIPTION
This can help find errors in the middle of passes like Inlining, that do
multiple cycles and include optimizations in the middle.