### PR TITLE
[EH][GC] Add missing subtyping constraints from TryTable

### DIFF
--- a/src/ir/subtype-exprs.h
+++ b/src/ir/subtype-exprs.h
@@ -249,7 +249,13 @@ struct SubtypingDiscoverer : public OverriddenVisitor<SubType> {
       self()->noteSubtype(body, curr);
     }
   }
-  void visitTryTable(TryTable* curr) { self()->noteSubtype(curr->body, curr); }
+  void visitTryTable(TryTable* curr) {
+    self()->noteSubtype(curr->body, curr);
+    for (Index i = 0; i < curr->catchTags.size(); i++) {
+      self()->noteSubtype(curr->sentTypes[i],
+                          self()->findBreakTarget(curr->catchDests[i]));
+    }
+  }
   void visitThrow(Throw* curr) {
     Type params = self()->getModule()->getTag(curr->tag)->sig.params;
     assert(params.size() == curr->operands.size());

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -1779,3 +1779,39 @@
   )
  )
 )
+
+;; try_table
+(module
+ (rec
+  ;; CHECK:      (rec
+  ;; CHECK-NEXT:  (type $super (sub (func)))
+  (type $super (sub (func)))
+  ;; CHECK:       (type $sub (sub $super (func)))
+  (type $sub (sub $super (func)))
+ )
+
+ ;; CHECK:       (type $2 (func (result (ref $super))))
+
+ ;; CHECK:       (type $3 (func (param (ref $sub))))
+
+ ;; CHECK:      (type $4 (func (param (ref $sub))))
+
+ ;; CHECK:      (tag $tag (param (ref $sub)))
+ (tag $tag (param (ref $sub)))
+
+ ;; CHECK:      (func $test (type $2) (result (ref $super))
+ ;; CHECK-NEXT:  (block $label (result (ref $sub))
+ ;; CHECK-NEXT:   (try_table (catch $tag $label)
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $test (result (ref $super))
+  (block $label (result (ref $super))
+   ;; Sending the contents of $tag to $label cause us to require $sub <: $super
+   (try_table (catch $tag $label)
+    (unreachable)
+   )
+  )
+ )
+)


### PR DESCRIPTION
Similar to Break, BrOn, etc., we must apply subtyping constraints of the
types we send to blocks, so that Unsubtyping will not remove subtypings
that are actually needed.