### PR TITLE
wasm-split: Add fuzzer support

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1461,10 +1461,11 @@ class Split(TestCaseHandler):
         if random.random() < 0.5:
             secondary = optimize(secondary)
 
-        # prepare the list of exports to call. if there are no exports then we
-        # must still pass in something, to override the default behavior of
-        # calling all exports; pass in '-' in that case.
-        exports_to_call = ','.join(exports) or '-'
+        # prepare the list of exports to call. the format is
+        #
+        #  exports:A,B,C
+        #
+        exports_to_call = 'exports:' + ','.join(exports)
 
         # get the output from the split modules, linking them using JS
         # TODO run liftoff/turboshaft/etc.

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1391,6 +1391,9 @@ class Merge(TestCaseHandler):
         compare_between_vms(output, merged_output, 'Merge')
 
 
+FUNC_NAMES_REGEX = re.compile(r'\n [(]func [$](\S+)')
+
+
 # Tests wasm-split
 class Split(TestCaseHandler):
     frequency = 1  # TODO: adjust lower when we actually enable this
@@ -1399,7 +1402,7 @@ class Split(TestCaseHandler):
         # get the list of function names, some of which we will decide to split
         # out
         wat = run([in_bin('wasm-dis'), wasm] + FEATURE_OPTS)
-        all_funcs = re.findall(r'\n [(]func [$](\S+)', wat)
+        all_funcs = re.findall(FUNC_NAMES_REGEX, wat)
 
         # get the original output before splitting
         output = run_d8_wasm(wasm)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1393,7 +1393,7 @@ class Merge(TestCaseHandler):
 
 # Tests wasm-split
 class Split(TestCaseHandler):
-    frequency = 0.15
+    frequency = 1 # TODO: adjust lower when we actually enable this
 
     def handle(self, wasm):
         # get the list of function names, some of which we will decide to split
@@ -1507,7 +1507,7 @@ testcase_handlers = [
     TrapsNeverHappen(),
     CtorEval(),
     Merge(),
-    # TODO: enable when stable enough
+    # TODO: enable when stable enough, and adjust |frequency| (see above)
     # Split(),
     RoundtripText()
 ]

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1444,6 +1444,7 @@ class Split(TestCaseHandler):
 
         # sometimes also optimize the split modules
         optimized = False
+
         def optimize(name):
             # do not optimize if it would change the ABI
             if CLOSED_WORLD:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1393,7 +1393,7 @@ class Merge(TestCaseHandler):
 
 # Tests wasm-split
 class Split(TestCaseHandler):
-    frequency = 1 # TODO: adjust lower when we actually enable this
+    frequency = 1  # TODO: adjust lower when we actually enable this
 
     def handle(self, wasm):
         # get the list of function names, some of which we will decide to split
@@ -1438,9 +1438,9 @@ class Split(TestCaseHandler):
         split_feature_opts = FEATURE_OPTS + ['--enable-reference-types']
 
         run([in_bin('wasm-split'), wasm, '--split',
-            '--split-funcs', ','.join(split_funcs),
-            '--primary-output', primary,
-            '--secondary-output', secondary] + split_feature_opts)
+             '--split-funcs', ','.join(split_funcs),
+             '--primary-output', primary,
+             '--secondary-output', secondary] + split_feature_opts)
 
         # sometimes also optimize the split modules
         def optimize(name):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1455,6 +1455,7 @@ class Split(TestCaseHandler):
             opts = ['-O3']
             new_name = name + '.opt.wasm'
             run([in_bin('wasm-opt'), name, '-o', new_name, '-all'] + opts + split_feature_opts)
+            nonlocal optimized
             optimized = True
             return new_name
 
@@ -1477,7 +1478,7 @@ class Split(TestCaseHandler):
         # see D8.can_compare_to_self: we cannot compare optimized outputs if
         # NaNs are allowed, as the optimizer can modify NaNs differently than
         # the JS engine.
-        if not NANS or not optimized:
+        if not (NANS and optimized):
             compare_between_vms(output, linked_output, 'Split')
 
     def can_run_on_feature_opts(self, feature_opts):

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -38,8 +38,8 @@ if (argv[1]) {
 }
 
 var exportsToCall;
-if (argv[2]) {
-  exportsToCall = argv[2].split(',');
+if (argv[2] && argv[2].startsWith('exports:')) {
+  exportsToCall = argv[2].substr('exports:'.length).split(',');
 }
 
 // Utilities.
@@ -214,14 +214,6 @@ if (secondBinary) {
   } catch (e) {
     console.log('exception thrown: failed to instantiate second module');
     quit();
-  }
-}
-
-// Recreate the view. This is important both initially and after a growth.
-var view;
-function refreshView() {
-  if (exports.memory) {
-    view = new Int32Array(exports.memory.buffer);
   }
 }
 

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -169,8 +169,14 @@ if (typeof WebAssembly.Tag !== 'undefined') {
 if (secondBinary) {
   imports['placeholder'] = new Proxy({}, {
     get(target, prop, receiver) {
-      // Return a function that does an indirect call using the exported table.
-      return (...args) => exports['table'].get(+prop)(...args);
+      // Return a function that throws. We could do an indirect call using the
+      // exported table, but as we immediately link in the secondary module,
+      // these stubs will not be called (they are written to the table, and the
+      // secondary module overwrites them). We do need to return something so
+      // the primary module links without erroring, though.
+      return () => {
+        throw 'proxy stub should not be called';
+      }
     }
   });
 }

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -199,16 +199,12 @@ var exports = instance.exports;
 if (secondBinary) {
   var secondModule = new WebAssembly.Module(secondBinary);
 
-  // Merge the original imports object with the exports from the first module.
-  // Note that, sadly, Object.assign does not work on wasm exports.
-  var combinedImports = Object.assign({}, imports);
-  combinedImports['primary'] = {};
-  for (var e in exports) {
-    combinedImports['primary'][e] = exports[e];
-  }
+  // The secondary module just needs to import the primary one: all original
+  // imports it might have needed were exported from there.
+  var secondImports = {'primary': exports};
   var secondInstance;
   try {
-    secondInstance = new WebAssembly.Instance(secondModule, combinedImports);
+    secondInstance = new WebAssembly.Instance(secondModule, secondImports);
   } catch (e) {
     console.log('exception thrown: failed to instantiate second module');
     quit();


### PR DESCRIPTION
The support is added but not enabled as this is still finding bugs, but I'd
like to land it now as it will conflict with other work I am doing.

The first part here is to add Split testcase handler to the fuzzer,
which runs a wasm, then runs it again after splitting it and then
linking it at runtime, and checking for different results.

The second part is support for linking two modules at runtime
in the fuzzer's JS code, that works in tandem with the first part.
New options are added to load and link a second wasm, and to
pick which exports to run.
