### PR TITLE
Fix TypeMerging bug with indirectly reachable public types

### DIFF
--- a/test/lit/passes/type-merging.wast
+++ b/test/lit/passes/type-merging.wast
@@ -985,6 +985,25 @@
  (global $g2 (ref $C') (struct.new_default $D2'))
 )
 
+;; Regression test for a bug where public types not directly reachable from
+;; private types were included as successors but not given states in the DFA.
+(module
+  ;; CHECK:      (type $public-child (struct))
+  (type $public-child (struct))
+  ;; CHECK:      (type $public (struct (field (ref $public-child))))
+  (type $public (struct (ref $public-child)))
+  ;; CHECK:      (type $private (struct (field (ref $public))))
+  (type $private (struct (ref $public)))
+
+  ;; CHECK:      (global $public (ref null $public) (ref.null none))
+  (global $public (ref null $public) (ref.null none))
+  ;; CHECK:      (global $private (ref null $private) (ref.null none))
+  (global $private (ref null $private) (ref.null none))
+
+  ;; CHECK:      (export "public" (global $public))
+  (export "public" (global $public))
+)
+
 ;; Check that a ref.test inhibits merging (ref.cast is already checked above).
 (module
   ;; CHECK:      (rec


### PR DESCRIPTION
TypeMerging works by representing the type definition graph as a partitioned DFA
and then refining the partitions to find mergeable types. #7023 was due to a bug
where the DFA included edges from public types to their children, but did not
necessarily include corresponding states for those children.

One way to fix the bug would have been to traverse the type graph, finding all
reachable public types and creating DFA states for them, but that might be
expensive in cases where there are large graphs of public types.

Instead, fix the problem by removing the edges from public types to their
children entirely. Types reachable from public types are also public and
therefore are not eligible to be merged, so these edges were never necessary for
correctness.

Fixes #7023.
