### PR TITLE
Remove FeaturePrefix::FeatureRequired (NFC)

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1156,10 +1156,7 @@ enum MemoryAccess {
 
 enum MemoryFlags { HasMaximum = 1 << 0, IsShared = 1 << 1, Is64 = 1 << 2 };
 
-enum FeaturePrefix {
-  FeatureUsed = '+',
-  FeatureDisallowed = '-'
-};
+enum FeaturePrefix { FeatureUsed = '+', FeatureDisallowed = '-' };
 
 } // namespace BinaryConsts
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1158,7 +1158,6 @@ enum MemoryFlags { HasMaximum = 1 << 0, IsShared = 1 << 1, Is64 = 1 << 2 };
 
 enum FeaturePrefix {
   FeatureUsed = '+',
-  FeatureRequired = '=',
   FeatureDisallowed = '-'
 };
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3816,14 +3816,10 @@ void WasmBinaryReader::readFeatures(size_t payloadLen) {
     uint8_t prefix = getInt8();
 
     bool disallowed = prefix == BinaryConsts::FeatureDisallowed;
-    bool required = prefix == BinaryConsts::FeatureRequired;
     bool used = prefix == BinaryConsts::FeatureUsed;
 
-    if (!disallowed && !required && !used) {
+    if (!disallowed && !used) {
       throwError("Unrecognized feature policy prefix");
-    }
-    if (required) {
-      std::cerr << "warning: required features in feature section are ignored";
     }
 
     Name name = getInlineString();
@@ -3881,7 +3877,7 @@ void WasmBinaryReader::readFeatures(size_t payloadLen) {
         << "warning: feature " << feature.toString()
         << " was enabled by the user, but disallowed in the features section.";
     }
-    if (required || used) {
+    if (used) {
       wasm.features.enable(feature);
     }
   }


### PR DESCRIPTION
This has not been emitted in LLVM since
https://github.com/llvm/llvm-project/commit/3f34e1b883351c7d98426b084386a7aa762aa366.

The corresponding proposed tool-conventions change:
https://github.com/WebAssembly/tool-conventions/pull/236