### PR TITLE
[NFC] Use more precise types for Expression IDs

### DIFF
--- a/src/ir/find_all.h
+++ b/src/ir/find_all.h
@@ -64,7 +64,7 @@ template<typename T> struct FindAllPointers {
   // take \ast by reference.
   FindAllPointers(Expression*& ast) {
     PointerFinder finder;
-    finder.id = (Expression::Id)T::SpecificId;
+    finder.id = T::SpecificId;
     finder.list = &list;
     finder.walk(ast);
   }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -647,7 +647,7 @@ enum StringEqOp {
 
 class Expression {
 public:
-  enum Id {
+  enum Id : int8_t {
     InvalidId = 0,
     BlockId,
     IfId,
@@ -796,6 +796,8 @@ public:
   void dump();
 };
 
+static_assert(Expression::NumExpressionIds < 256, "ids must fit in a byte");
+
 const char* getExpressionName(Expression* curr);
 
 Literal getLiteralFromConstExpression(Expression* curr);
@@ -805,9 +807,8 @@ using ExpressionList = ArenaVector<Expression*>;
 
 template<Expression::Id SID> class SpecificExpression : public Expression {
 public:
-  enum {
-    SpecificId = SID // compile-time access to the type for the class
-  };
+  // Compile-time access to the type for the class.
+  static constexpr Id SpecificId = SID;
 
   SpecificExpression() : Expression(SID) {}
 };

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -647,7 +647,7 @@ enum StringEqOp {
 
 class Expression {
 public:
-  enum Id : int8_t {
+  enum Id : uint8_t {
     InvalidId = 0,
     BlockId,
     IfId,
@@ -795,8 +795,6 @@ public:
   // Print the expression to stderr. Meant for use while debugging.
   void dump();
 };
-
-static_assert(Expression::NumExpressionIds < 256, "ids must fit in a byte");
 
 const char* getExpressionName(Expression* curr);
 


### PR DESCRIPTION
Make the ID enum an `int8_t`, and make the Specific ID a `constexpr`
of that type.

This seems more idiomatic and makes some code simpler, see the
change to `find_all.h` which no longer needs a cast to compile. It
will also simplify a future PR.

This seems to have no performance impact.

Is there maybe an even better C++ way to do this?