### PR TITLE
Require reference-types instead of bulk-memory for `table.fill`

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2454,9 +2454,11 @@ void FunctionValidator::visitTableGrow(TableGrow* curr) {
 }
 
 void FunctionValidator::visitTableFill(TableFill* curr) {
-  shouldBeTrue(getModule()->features.hasBulkMemory(),
+  shouldBeTrue(getModule()->features.hasBulkMemory() &&
+                 getModule()->features.hasReferenceTypes(),
                curr,
-               "table.fill requires bulk-memory [--enable-bulk-memory]");
+               "table.fill requires bulk-memory [--enable-bulk-memory] and "
+               "reference-types [--enable-reference-types]");
   auto* table = getModule()->getTableOrNull(curr->table);
   if (shouldBeTrue(!!table, curr, "table.fill table must exist")) {
     shouldBeSubType(curr->value->type,


### PR DESCRIPTION
I believe that `table.fill` was introduced by the `reference-types` proposal and not by `bulk-memory`.
See [the proposal](https://github.com/WebAssembly/reference-types/blob/c7a3558bb5cbacb9c8879a91e08d0ac7276b740c/proposals/reference-types/Overview.md#:~:text=The%20new%20instruction%20table.fill%20fills,size%20%28analoguous%20to%20memory.fill%29).