### PR TITLE
Fuzz the Table from JS

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1178,10 +1178,11 @@ class Wasm2JS(TestCaseHandler):
         return all_disallowed(['exception-handling', 'simd', 'threads', 'bulk-memory', 'nontrapping-float-to-int', 'tail-call', 'sign-ext', 'reference-types', 'multivalue', 'gc', 'multimemory'])
 
 
-# given a wasm, find all the exports.
+# given a wasm, find all the exports. for now this supports function and table
+# exports
 def get_exports(wasm):
     wat = run([in_bin('wasm-dis'), wasm] + FEATURE_OPTS)
-    p = re.compile(r'^ [(]export "(.*[^\\]?)" [(]func')
+    p = re.compile(r'^ [(]export "(.*[^\\]?)" [(](?:func|table)')
     exports = []
     for line in wat.splitlines():
         m = p.match(line)

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -158,8 +158,7 @@ var imports = {
     'table-get': (index) => {
       index = index >>> 0;
       if (!exports.table || index >= exports.table.length) {
-        // Emit a trap, the same as the wasm instruction.
-        throw new WebAssembly.RuntimeError();
+        throw 'oob';
       }
       // Manually convert an undefined to null, as the JS/wasm conversion rules
       // would trap on it.
@@ -168,7 +167,7 @@ var imports = {
     'table-set': (index, value) => {
       index = index >>> 0;
       if (!exports.table || index >= exports.table.length) {
-        throw new WebAssembly.RuntimeError();
+        throw 'oob';
       }
       exports.table[index] = value;
     },

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -152,7 +152,21 @@ var imports = {
     // Throw an exception from JS.
     'throw': () => {
       throw 'some JS error';
-    }
+    },
+
+    // Table operations.
+    'table-get': (index) => {
+      if (index >= exports.table.length) {
+        throw 'oob';
+      }
+      return exports.table[index];
+    },
+    'table-set': (index, value) => {
+      if (index >= exports.table.length) {
+        throw 'oob';
+      }
+      exports.table[index] = value;
+    },
   },
   // Emscripten support.
   'env': {

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -156,20 +156,10 @@ var imports = {
 
     // Table operations.
     'table-get': (index) => {
-      index = index >>> 0;
-      if (!exports.table || index >= exports.table.length) {
-        throw 'oob';
-      }
-      // Manually convert an undefined to null, as the JS/wasm conversion rules
-      // would trap on it.
-      return exports.table[index] || null;
+      return exports.table.get(index >>> 0);
     },
     'table-set': (index, value) => {
-      index = index >>> 0;
-      if (!exports.table || index >= exports.table.length) {
-        throw 'oob';
-      }
-      exports.table[index] = value;
+      exports.table.set(index >>> 0, value);
     },
   },
   // Emscripten support.

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -159,7 +159,9 @@ var imports = {
       if (index >= exports.table.length) {
         throw 'oob';
       }
-      return exports.table[index];
+      // Manually convert an undefined to null, as the JS/wasm conversion rules
+      // would trap on it.
+      return exports.table[index] || null;
     },
     'table-set': (index, value) => {
       if (index >= exports.table.length) {

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -157,7 +157,7 @@ var imports = {
     // Table operations.
     'table-get': (index) => {
       index = index >>> 0;
-      if (index >= exports.table.length) {
+      if (!exports.table || index >= exports.table.length) {
         throw 'oob';
       }
       // Manually convert an undefined to null, as the JS/wasm conversion rules
@@ -166,7 +166,7 @@ var imports = {
     },
     'table-set': (index, value) => {
       index = index >>> 0;
-      if (index >= exports.table.length) {
+      if (!exports.table || index >= exports.table.length) {
         throw 'oob';
       }
       exports.table[index] = value;

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -158,7 +158,8 @@ var imports = {
     'table-get': (index) => {
       index = index >>> 0;
       if (!exports.table || index >= exports.table.length) {
-        throw 'oob';
+        // Emit a trap, the same as the wasm instruction.
+        throw new WebAssembly.RuntimeError();
       }
       // Manually convert an undefined to null, as the JS/wasm conversion rules
       // would trap on it.
@@ -167,7 +168,7 @@ var imports = {
     'table-set': (index, value) => {
       index = index >>> 0;
       if (!exports.table || index >= exports.table.length) {
-        throw 'oob';
+        throw new WebAssembly.RuntimeError();
       }
       exports.table[index] = value;
     },

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -156,6 +156,7 @@ var imports = {
 
     // Table operations.
     'table-get': (index) => {
+      index = index >>> 0;
       if (index >= exports.table.length) {
         throw 'oob';
       }
@@ -164,6 +165,7 @@ var imports = {
       return exports.table[index] || null;
     },
     'table-set': (index, value) => {
+      index = index >>> 0;
       if (index >= exports.table.length) {
         throw 'oob';
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -78,22 +78,21 @@ public:
         std::cout << "]\n";
         return {};
       } else if (import->base == "throw") {
-        // Throw something. We use a (hopefully) private name here.
-        auto payload = std::make_shared<ExnData>("__private", Literals{});
-        throwException(WasmException{Literal(payload)});
+        // Throw something.
+        throwEmptyException();
       } else if (import->base == "table-get") {
         try {
           return {tableLoad(exportedTable, arguments[0].geti32())};
         } catch (const TrapException&) {
           // Convert a trap to an exception: the JS will only ever throw, not
           // trap.
-          throw WasmException{};
+          throwEmptyException();
         }
       } else if (import->base == "table-set") {
         try {
           tableStore(exportedTable, arguments[0].geti32(), arguments[1]);
         } catch (const TrapException&) {
-          throw WasmException{};
+          throwEmptyException();
         }
         return {};
       } else {
@@ -117,6 +116,12 @@ public:
     std::cerr << "[LoggingExternalInterface ignoring an unknown import "
               << import->module << " . " << import->base << '\n';
     return {};
+  }
+
+  void throwEmptyException() {
+    // Use a hopefully private tag.
+    auto payload = std::make_shared<ExnData>("__private", Literals{});
+    throwException(WasmException{Literal(payload)});
   }
 };
 

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -83,6 +83,7 @@ public:
         return {tableLoad(exportedTable, arguments[0].geti32())};
       } else if (import->base == "table-set") {
         tableStore(exportedTable, arguments[0].geti32(), arguments[1]);
+        return {};
       } else {
         WASM_UNREACHABLE("unknown fuzzer import");
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -80,9 +80,25 @@ public:
       } else if (import->base == "throw") {
         throwEmptyException();
       } else if (import->base == "table-get") {
-        return {tableLoad(exportedTable, arguments[0].geti32())};
+        // Check for errors here, duplicating tableLoad(), because that will
+        // trap, and we just want to throw an exception (the same as JS would).
+        if (!exportedTable) {
+          throwEmptyException();
+        }
+        Index index = arguments[0].geti32();
+        if (index >= tables[exportedTable].size()) {
+          throwEmptyException();
+        }
+        return {tableLoad(exportedTable, index)};
       } else if (import->base == "table-set") {
-        tableStore(exportedTable, arguments[0].geti32(), arguments[1]);
+        if (!exportedTable) {
+          throwEmptyException();
+        }
+        Index index = arguments[0].geti32();
+        if (index >= tables[exportedTable].size()) {
+          throwEmptyException();
+        }
+        tableStore(exportedTable, index, arguments[1]);
         return {};
       } else {
         WASM_UNREACHABLE("unknown fuzzer import");

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -78,23 +78,11 @@ public:
         std::cout << "]\n";
         return {};
       } else if (import->base == "throw") {
-        // Throw something.
         throwEmptyException();
       } else if (import->base == "table-get") {
-        try {
-          return {tableLoad(exportedTable, arguments[0].geti32())};
-        } catch (const TrapException&) {
-          // Convert a trap to an exception: the JS will only ever throw, not
-          // trap.
-          throwEmptyException();
-        }
+        return {tableLoad(exportedTable, arguments[0].geti32())};
       } else if (import->base == "table-set") {
-        try {
-          tableStore(exportedTable, arguments[0].geti32(), arguments[1]);
-        } catch (const TrapException&) {
-          throwEmptyException();
-        }
-        return {};
+        tableStore(exportedTable, arguments[0].geti32(), arguments[1]);
       } else {
         WASM_UNREACHABLE("unknown fuzzer import");
       }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -43,7 +43,7 @@ private:
 
 public:
   LoggingExternalInterface(Loggings& loggings, Module& wasm)
-    : loggings(loggings), wasm(wasm) {
+    : loggings(loggings) {
     for (auto& exp : wasm.exports) {
       if (exp->kind == ExternalKind::Table && exp->name == "table") {
         exportedTable = exp->value;

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -29,7 +29,6 @@ using Loggings = std::vector<Literal>;
 struct LoggingExternalInterface : public ShellExternalInterface {
 private:
   Loggings& loggings;
-  Module& wasm;
 
   struct State {
     // Legalization for JS emits get/setTempRet0 calls ("temp ret 0" means a

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -43,7 +43,8 @@ private:
   Name exportedTable;
 
 public:
-  LoggingExternalInterface(Loggings& loggings, Module& wasm) : loggings(loggings), wasm(wasm) {
+  LoggingExternalInterface(Loggings& loggings, Module& wasm)
+    : loggings(loggings), wasm(wasm) {
     for (auto& exp : wasm.exports) {
       if (exp->kind == ExternalKind::Table && exp->name == "table") {
         exportedTable = exp->value;

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -107,6 +107,8 @@ private:
   std::unordered_map<Type, Name> logImportNames;
 
   Name throwImportName;
+  Name tableGetImportName;
+  Name tableSetImportName;
 
   std::unordered_map<Type, std::vector<Name>> globalsByType;
   std::unordered_map<Type, std::vector<Name>> mutableGlobalsByType;
@@ -228,12 +230,15 @@ private:
   void addImportLoggingSupport();
   // An import that we call to throw an exception from outside.
   void addImportThrowingSupport();
+  void addImportTableSupport();
   void addHashMemorySupport();
 
   // Special expression makers
   Expression* makeHangLimitCheck();
   Expression* makeImportLogging();
   Expression* makeImportThrowing(Type type);
+  Expression* makeImportTableGet();
+  Expression* makeImportTableSet(Type type);
   Expression* makeMemoryHashLogging();
 
   // Function creation

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -767,7 +767,7 @@ Expression* TranslateToFuzzReader::makeImportTableGet() {
 
 Expression* TranslateToFuzzReader::makeImportTableSet(Type type) {
   assert(type == Type::none);
-  return builder.makeCall(tableGetImportName, {make(Type::i32), makeBasicRef(Type(HeapType::func, Nullable))});
+  return builder.makeCall(tableGetImportName, {make(Type::i32), makeBasicRef(Type(HeapType::func, Nullable))}, Type::none);
 }
 
 Expression* TranslateToFuzzReader::makeMemoryHashLogging() {
@@ -1528,7 +1528,7 @@ Expression* TranslateToFuzzReader::_makenone() {
          &Self::makeGlobalSet)
     .add(FeatureSet::BulkMemory, &Self::makeBulkMemory)
     .add(FeatureSet::Atomics, &Self::makeAtomic)
-    .add(FeatureSet::ReferenceTypes, &Self.makeImportTableSet)
+    .add(FeatureSet::ReferenceTypes, &Self::makeImportTableSet)
     .add(FeatureSet::ExceptionHandling, &Self::makeTry)
     .add(FeatureSet::ExceptionHandling, &Self::makeTryTable)
     .add(FeatureSet::ExceptionHandling, &Self::makeImportThrowing)

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -649,8 +649,8 @@ void TranslateToFuzzReader::addImportTableSupport() {
     func->name = tableSetImportName;
     func->module = "fuzzing-support";
     func->base = "table-set";
-    func->type = Signature({Type::i32, Type(HeapType::func, Nullable)},
-                           Type::none);
+    func->type =
+      Signature({Type::i32, Type(HeapType::func, Nullable)}, Type::none);
     wasm.addFunction(std::move(func));
   }
 }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -632,7 +632,7 @@ void TranslateToFuzzReader::addImportTableSupport() {
     func->name = tableGetImportName;
     func->module = "fuzzing-support";
     func->base = "table-get";
-    func->type = Signature(Type::none, Type(HeapType::func, Nullable));
+    func->type = Signature({Type::i32}, Type(HeapType::func, Nullable));
     wasm.addFunction(std::move(func));
   }
 
@@ -643,7 +643,8 @@ void TranslateToFuzzReader::addImportTableSupport() {
     func->name = tableSetImportName;
     func->module = "fuzzing-support";
     func->base = "table-set";
-    func->type = Signature(Type(HeapType::func, Nullable), Type::none);
+    func->type = Signature({Type::i32, Type(HeapType::func, Nullable)},
+                           Type::none);
     wasm.addFunction(std::move(func));
   }
 }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -762,14 +762,16 @@ Expression* TranslateToFuzzReader::makeImportThrowing(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeImportTableGet() {
+  assert(tableGetImportName);
   return builder.makeCall(
     tableGetImportName, {make(Type::i32)}, Type(HeapType::func, Nullable));
 }
 
 Expression* TranslateToFuzzReader::makeImportTableSet(Type type) {
   assert(type == Type::none);
+  assert(tableSetImportName);
   return builder.makeCall(
-    tableGetImportName,
+    tableSetImportName,
     {make(Type::i32), makeBasicRef(Type(HeapType::func, Nullable))},
     Type::none);
 }
@@ -2732,8 +2734,9 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       return null;
     }
     case HeapType::func: {
-      // Rarely, emit a call to imported table.get (when nullable).
-      if (type.isNullable() && !oneIn(3)) {
+      // Rarely, emit a call to imported table.get (when nullable, and where we
+      // can emit a call).
+      if (type.isNullable() && funcContext && !oneIn(3)) {
         return makeImportTableGet();
       }
       return makeRefFuncConst(type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -178,6 +178,9 @@ void TranslateToFuzzReader::build() {
     setupTags();
     addImportThrowingSupport();
   }
+  if (wasm.features.hasReferenceTypes()) {
+    addImportTableSupport();
+  }
   addImportLoggingSupport();
   modifyInitialFunctions();
   // keep adding functions until we run out of input
@@ -609,6 +612,42 @@ void TranslateToFuzzReader::addImportThrowingSupport() {
   wasm.addFunction(std::move(func));
 }
 
+void TranslateToFuzzReader::addImportTableSupport() {
+  // For the table imports to be able to do anything, we must export a table
+  // for them. For simplicity, use the funcref table we use internally, though
+  // we could pick one at random, support non-funcref ones, and even export
+  // multiple ones TODO
+  if (!funcrefTableName) {
+    return;
+  }
+
+  // Export it.
+  wasm.addExport(builder.makeExport(
+    "table", funcrefTableName, ExternalKind::Table));
+
+  // Get from the table.
+  {
+    tableGetImportName = Names::getValidFunctionName(wasm, "table-get");
+    auto func = std::make_unique<Function>();
+    func->name = tableGetImportName;
+    func->module = "fuzzing-support";
+    func->base = "table-get";
+    func->type = Signature(Type::none, Type(HeapType::func, Nullable));
+    wasm.addFunction(std::move(func));
+  }
+
+  // Set into the table.
+  {
+    tableSetImportName = Names::getValidFunctionName(wasm, "table-set");
+    auto func = std::make_unique<Function>();
+    func->name = tableSetImportName;
+    func->module = "fuzzing-support";
+    func->base = "table-set";
+    func->type = Signature(Type(HeapType::func, Nullable), Type::none);
+    wasm.addFunction(std::move(func));
+  }
+}
+
 void TranslateToFuzzReader::addHashMemorySupport() {
   // Add memory hasher helper (for the hash, see hash.h). The function looks
   // like:
@@ -720,6 +759,15 @@ Expression* TranslateToFuzzReader::makeImportThrowing(Type type) {
 
   // TODO: This and makeThrow should probably be rare, as they halt the program.
   return builder.makeCall(throwImportName, {}, Type::none);
+}
+
+Expression* TranslateToFuzzReader::makeImportTableGet() {
+  return builder.makeCall(tableGetImportName, {make(Type::i32)}, Type(HeapType::func, Nullable));
+}
+
+Expression* TranslateToFuzzReader::makeImportTableSet(Type type) {
+  assert(type == Type::none);
+  return builder.makeCall(tableGetImportName, {make(Type::i32), makeBasicRef(Type(HeapType::func, Nullable))});
 }
 
 Expression* TranslateToFuzzReader::makeMemoryHashLogging() {
@@ -1480,6 +1528,7 @@ Expression* TranslateToFuzzReader::_makenone() {
          &Self::makeGlobalSet)
     .add(FeatureSet::BulkMemory, &Self::makeBulkMemory)
     .add(FeatureSet::Atomics, &Self::makeAtomic)
+    .add(FeatureSet::ReferenceTypes, &Self.makeImportTableSet)
     .add(FeatureSet::ExceptionHandling, &Self::makeTry)
     .add(FeatureSet::ExceptionHandling, &Self::makeTryTable)
     .add(FeatureSet::ExceptionHandling, &Self::makeImportThrowing)
@@ -2679,6 +2728,10 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       return null;
     }
     case HeapType::func: {
+      // Rarely, emit a call to imported table.get (when nullable).
+      if (type.isNullable() && !oneIn(3)) {
+        return makeImportTableGet();
+      }
       return makeRefFuncConst(type);
     }
     case HeapType::cont: {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2735,9 +2735,9 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       return null;
     }
     case HeapType::func: {
-      // Rarely, emit a call to imported table.get (when nullable, and where we
-      // can emit a call).
-      if (type.isNullable() && funcContext && !oneIn(3)) {
+      // Rarely, emit a call to imported table.get (when nullable, unshared, and
+      // where we can emit a call).
+      if (type.isNullable() && share == Unshared && funcContext && !oneIn(3)) {
         return makeImportTableGet();
       }
       return makeRefFuncConst(type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -622,8 +622,8 @@ void TranslateToFuzzReader::addImportTableSupport() {
   }
 
   // Export it.
-  wasm.addExport(builder.makeExport(
-    "table", funcrefTableName, ExternalKind::Table));
+  wasm.addExport(
+    builder.makeExport("table", funcrefTableName, ExternalKind::Table));
 
   // Get from the table.
   {
@@ -762,12 +762,16 @@ Expression* TranslateToFuzzReader::makeImportThrowing(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeImportTableGet() {
-  return builder.makeCall(tableGetImportName, {make(Type::i32)}, Type(HeapType::func, Nullable));
+  return builder.makeCall(
+    tableGetImportName, {make(Type::i32)}, Type(HeapType::func, Nullable));
 }
 
 Expression* TranslateToFuzzReader::makeImportTableSet(Type type) {
   assert(type == Type::none);
-  return builder.makeCall(tableGetImportName, {make(Type::i32), makeBasicRef(Type(HeapType::func, Nullable))}, Type::none);
+  return builder.makeCall(
+    tableGetImportName,
+    {make(Type::i32), makeBasicRef(Type(HeapType::func, Nullable))},
+    Type::none);
 }
 
 Expression* TranslateToFuzzReader::makeMemoryHashLogging() {

--- a/test/lit/exec/fuzzing-api.wast
+++ b/test/lit/exec/fuzzing-api.wast
@@ -37,7 +37,6 @@
 
  ;; CHECK:      [fuzz-exec] calling table.setting
  ;; CHECK-NEXT: [trap out of bounds table access]
- ;; CHECK-NEXT: [exception thrown: __private ()]
  (func $table.setting (export "table.setting")
   (call $table.set
    (i32.const 5)
@@ -54,7 +53,6 @@
  ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
  ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
  ;; CHECK-NEXT: [trap out of bounds table access]
- ;; CHECK-NEXT: [exception thrown: __private ()]
  ;; CHECK-NEXT: warning: no passes specified, not doing any work
  (func $table.getting (export "table.getting")
   ;; There is a non-null value at 5, and a null at 6.
@@ -89,13 +87,11 @@
 
 ;; CHECK:      [fuzz-exec] calling table.setting
 ;; CHECK-NEXT: [trap out of bounds table access]
-;; CHECK-NEXT: [exception thrown: __private ()]
 
 ;; CHECK:      [fuzz-exec] calling table.getting
 ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
 ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
 ;; CHECK-NEXT: [trap out of bounds table access]
-;; CHECK-NEXT: [exception thrown: __private ()]
 ;; CHECK-NEXT: [fuzz-exec] comparing logging
 ;; CHECK-NEXT: [fuzz-exec] comparing table.getting
 ;; CHECK-NEXT: [fuzz-exec] comparing table.setting

--- a/test/lit/exec/fuzzing-api.wast
+++ b/test/lit/exec/fuzzing-api.wast
@@ -36,7 +36,7 @@
  )
 
  ;; CHECK:      [fuzz-exec] calling table.setting
- ;; CHECK-NEXT: [trap out of bounds table access]
+ ;; CHECK-NEXT: [exception thrown: __private ()]
  (func $table.setting (export "table.setting")
   (call $table.set
    (i32.const 5)
@@ -52,7 +52,7 @@
  ;; CHECK:      [fuzz-exec] calling table.getting
  ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
  ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
- ;; CHECK-NEXT: [trap out of bounds table access]
+ ;; CHECK-NEXT: [exception thrown: __private ()]
  ;; CHECK-NEXT: warning: no passes specified, not doing any work
  (func $table.getting (export "table.getting")
   ;; There is a non-null value at 5, and a null at 6.
@@ -86,12 +86,12 @@
 ;; CHECK-NEXT: [exception thrown: __private ()]
 
 ;; CHECK:      [fuzz-exec] calling table.setting
-;; CHECK-NEXT: [trap out of bounds table access]
+;; CHECK-NEXT: [exception thrown: __private ()]
 
 ;; CHECK:      [fuzz-exec] calling table.getting
 ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
 ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
-;; CHECK-NEXT: [trap out of bounds table access]
+;; CHECK-NEXT: [exception thrown: __private ()]
 ;; CHECK-NEXT: [fuzz-exec] comparing logging
 ;; CHECK-NEXT: [fuzz-exec] comparing table.getting
 ;; CHECK-NEXT: [fuzz-exec] comparing table.setting

--- a/test/lit/exec/fuzzing-api.wast
+++ b/test/lit/exec/fuzzing-api.wast
@@ -10,6 +10,10 @@
 
  (import "fuzzing-support" "throw" (func $throw))
 
+ (table $table 10 20 funcref)
+
+ (export "table" (table $table))
+
  ;; CHECK:      [fuzz-exec] calling logging
  ;; CHECK-NEXT: [LoggingExternalInterface logging 42]
  ;; CHECK-NEXT: [LoggingExternalInterface logging 3.14159]
@@ -27,6 +31,31 @@
  ;; CHECK-NEXT: warning: no passes specified, not doing any work
  (func $throwing (export "throwing")
   (call $throw)
+ )
+
+ (func $table.setting (export "table.set")
+  (call $table.set
+   (i32.const 5)
+   (ref.func $table.setting)
+  )
+ )
+
+ (func $table.getting (export "table.get")
+  ;; There is a non-null value at 5, and a null at 6.
+  (call $log-i32
+   (ref.is_null
+    (call $table.get
+     (i32.const 5)
+    )
+   )
+  )
+  (call $log-i32
+   (ref.is_null
+    (call $table.get
+     (i32.const 6)
+    )
+   )
+  )
  )
 )
 ;; CHECK:      [fuzz-exec] calling logging

--- a/test/lit/exec/fuzzing-api.wast
+++ b/test/lit/exec/fuzzing-api.wast
@@ -36,9 +36,16 @@
  )
 
  ;; CHECK:      [fuzz-exec] calling table.setting
+ ;; CHECK-NEXT: [trap out of bounds table access]
+ ;; CHECK-NEXT: [exception thrown: __private ()]
  (func $table.setting (export "table.setting")
   (call $table.set
    (i32.const 5)
+   (ref.func $table.setting)
+  )
+  ;; Out of bounds sets will throw.
+  (call $table.set
+   (i32.const 9999)
    (ref.func $table.setting)
   )
  )
@@ -46,6 +53,8 @@
  ;; CHECK:      [fuzz-exec] calling table.getting
  ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
  ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
+ ;; CHECK-NEXT: [trap out of bounds table access]
+ ;; CHECK-NEXT: [exception thrown: __private ()]
  ;; CHECK-NEXT: warning: no passes specified, not doing any work
  (func $table.getting (export "table.getting")
   ;; There is a non-null value at 5, and a null at 6.
@@ -63,6 +72,12 @@
     )
    )
   )
+  ;; Out of bounds gets will throw.
+  (drop
+   (call $table.get
+    (i32.const 9999)
+   )
+  )
  )
 )
 ;; CHECK:      [fuzz-exec] calling logging
@@ -73,10 +88,14 @@
 ;; CHECK-NEXT: [exception thrown: __private ()]
 
 ;; CHECK:      [fuzz-exec] calling table.setting
+;; CHECK-NEXT: [trap out of bounds table access]
+;; CHECK-NEXT: [exception thrown: __private ()]
 
 ;; CHECK:      [fuzz-exec] calling table.getting
 ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
 ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
+;; CHECK-NEXT: [trap out of bounds table access]
+;; CHECK-NEXT: [exception thrown: __private ()]
 ;; CHECK-NEXT: [fuzz-exec] comparing logging
 ;; CHECK-NEXT: [fuzz-exec] comparing table.getting
 ;; CHECK-NEXT: [fuzz-exec] comparing table.setting

--- a/test/lit/exec/fuzzing-api.wast
+++ b/test/lit/exec/fuzzing-api.wast
@@ -10,6 +10,9 @@
 
  (import "fuzzing-support" "throw" (func $throw))
 
+ (import "fuzzing-support" "table-set" (func $table.set (param i32 funcref)))
+ (import "fuzzing-support" "table-get" (func $table.get (param i32) (result funcref)))
+
  (table $table 10 20 funcref)
 
  (export "table" (table $table))
@@ -28,7 +31,6 @@
 
  ;; CHECK:      [fuzz-exec] calling throwing
  ;; CHECK-NEXT: [exception thrown: __private ()]
- ;; CHECK-NEXT: warning: no passes specified, not doing any work
  (func $throwing (export "throwing")
   (call $throw)
  )
@@ -64,5 +66,3 @@
 
 ;; CHECK:      [fuzz-exec] calling throwing
 ;; CHECK-NEXT: [exception thrown: __private ()]
-;; CHECK-NEXT: [fuzz-exec] comparing logging
-;; CHECK-NEXT: [fuzz-exec] comparing throwing

--- a/test/lit/exec/fuzzing-api.wast
+++ b/test/lit/exec/fuzzing-api.wast
@@ -35,14 +35,19 @@
   (call $throw)
  )
 
- (func $table.setting (export "table.set")
+ ;; CHECK:      [fuzz-exec] calling table.setting
+ (func $table.setting (export "table.setting")
   (call $table.set
    (i32.const 5)
    (ref.func $table.setting)
   )
  )
 
- (func $table.getting (export "table.get")
+ ;; CHECK:      [fuzz-exec] calling table.getting
+ ;; CHECK-NEXT: [LoggingExternalInterface logging 0]
+ ;; CHECK-NEXT: [LoggingExternalInterface logging 1]
+ ;; CHECK-NEXT: warning: no passes specified, not doing any work
+ (func $table.getting (export "table.getting")
   ;; There is a non-null value at 5, and a null at 6.
   (call $log-i32
    (ref.is_null
@@ -66,3 +71,13 @@
 
 ;; CHECK:      [fuzz-exec] calling throwing
 ;; CHECK-NEXT: [exception thrown: __private ()]
+
+;; CHECK:      [fuzz-exec] calling table.setting
+
+;; CHECK:      [fuzz-exec] calling table.getting
+;; CHECK-NEXT: [LoggingExternalInterface logging 0]
+;; CHECK-NEXT: [LoggingExternalInterface logging 1]
+;; CHECK-NEXT: [fuzz-exec] comparing logging
+;; CHECK-NEXT: [fuzz-exec] comparing table.getting
+;; CHECK-NEXT: [fuzz-exec] comparing table.setting
+;; CHECK-NEXT: [fuzz-exec] comparing throwing

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,58 +1,51 @@
 Metrics
 total
- [exports]      : 3       
- [funcs]        : 4       
+ [exports]      : 4       
+ [funcs]        : 3       
  [globals]      : 26      
- [imports]      : 6       
+ [imports]      : 8       
  [memories]     : 1       
  [memory-data]  : 20      
  [table-data]   : 0       
  [tables]       : 1       
  [tags]         : 2       
- [total]        : 665     
- [vars]         : 20      
- ArrayGet       : 2       
- ArrayLen       : 2       
- ArrayNew       : 15      
- ArrayNewFixed  : 3       
- AtomicCmpxchg  : 1       
- AtomicRMW      : 1       
- Binary         : 71      
- Block          : 63      
- BrOn           : 4       
- Break          : 7       
- Call           : 18      
- CallRef        : 2       
- Const          : 142     
- Drop           : 10      
- GlobalGet      : 33      
+ [total]        : 534     
+ [vars]         : 21      
+ ArrayGet       : 1       
+ ArrayLen       : 1       
+ ArrayNew       : 13      
+ ArrayNewFixed  : 2       
+ AtomicNotify   : 2       
+ Binary         : 68      
+ Block          : 53      
+ BrOn           : 1       
+ Break          : 8       
+ Call           : 11      
+ CallRef        : 1       
+ Const          : 117     
+ DataDrop       : 1       
+ Drop           : 7       
+ GlobalGet      : 27      
  GlobalSet      : 16      
- I31Get         : 1       
- If             : 21      
- Load           : 20      
- LocalGet       : 61      
- LocalSet       : 52      
+ If             : 13      
+ Load           : 19      
+ LocalGet       : 56      
+ LocalSet       : 39      
  Loop           : 6       
- MemoryFill     : 1       
- MemoryInit     : 1       
- Nop            : 7       
- Pop            : 1       
- RefAs          : 11      
- RefEq          : 1       
- RefFunc        : 3       
- RefI31         : 1       
- RefNull        : 14      
- Return         : 5       
- SIMDExtract    : 1       
- Select         : 2       
- StringConst    : 5       
- StringEncode   : 1       
- StructGet      : 4       
- StructNew      : 16      
- StructSet      : 1       
- Try            : 1       
+ Nop            : 2       
+ Pop            : 3       
+ RefAs          : 4       
+ RefFunc        : 2       
+ RefNull        : 7       
+ RefTest        : 1       
+ Return         : 3       
+ SIMDExtract    : 3       
+ Store          : 2       
+ StringConst    : 2       
+ StringWTF16Get : 1       
+ StructNew      : 11      
+ Try            : 3       
  TryTable       : 1       
- TupleExtract   : 2       
- TupleMake      : 6       
- Unary          : 20      
- Unreachable    : 9       
+ TupleMake      : 3       
+ Unary          : 14      
+ Unreachable    : 10      


### PR DESCRIPTION
Continues the work from #7027 which added throwing from JS, this adds
table get/set operations from JS, to further increase our coverage of
Wasm/JS interactions (the table can be used from both sides).