### PR TITLE
Don't strip target features in wasm-emscripten-finalize

### DIFF
--- a/src/tools/wasm-emscripten-finalize.cpp
+++ b/src/tools/wasm-emscripten-finalize.cpp
@@ -266,8 +266,6 @@ int main(int argc, const char* argv[]) {
     passRunner.add("legalize-js-interface");
   }
 
-  passRunner.add("strip-target-features");
-
   // If DWARF is unused, strip it out. This avoids us keeping it alive
   // until wasm-opt strips it later.
   if (!DWARF) {

--- a/test/lld/em_asm_pthread.wasm.out
+++ b/test/lld/em_asm_pthread.wasm.out
@@ -12830,4 +12830,5 @@
   )
  )
  ;; custom section "producers", size 172
+ ;; features section: threads, mutable-globals, bulk-memory, sign-ext
 )


### PR DESCRIPTION
This makes the behavior consistent with emcc builds where we don't run
finalization, and potentially makes testing and debugging easier.
Emscripten still strips the target features section when optimizing.