### PR TITLE
[NFC] Use RAII to manage call depth tracking in the interpreter

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -191,7 +191,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
     if (func->imported()) {
       return callImport(func, arguments);
     } else {
-      return instance.callFunctionInternal(func->name, arguments);
+      return instance.callFunction(func->name, arguments);
     }
   }
 

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -350,7 +350,7 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
                                 targetFunc.toString());
     }
     if (!func->imported()) {
-      return instance.callFunctionInternal(targetFunc, arguments);
+      return instance.callFunction(targetFunc, arguments);
     } else {
       throw FailToEvalException(
         std::string("callTable on imported function: ") +

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3028,6 +3028,7 @@ public:
       : function(function), parent(parent) {
       oldScope = parent.scope;
       parent.scope = this;
+      parent.callDepth++;
 
       if (function->getParams().size() != arguments.size()) {
         std::cerr << "Function `" << function->name << "` expects "
@@ -3053,7 +3054,10 @@ public:
       }
     }
 
-    ~FunctionScope() { parent.scope = oldScope; }
+    ~FunctionScope() {
+      parent.scope = oldScope;
+      parent.callDepth--;
+    }
 
     // The current delegate target, if delegation of an exception is in
     // progress. If no delegation is in progress, this will be an empty Name.
@@ -3111,7 +3115,7 @@ public:
       return Flow(RETURN_CALL_FLOW, std::move(arguments));
     }
 
-    Flow ret = callFunctionInternal(target, arguments);
+    Flow ret = callFunction(target, arguments);
 #ifdef WASM_INTERPRETER_DEBUG
     std::cout << "(returned to " << scope->function->name << ")\n";
 #endif
@@ -3176,7 +3180,7 @@ public:
       return Flow(RETURN_CALL_FLOW, std::move(arguments));
     }
 
-    Flow ret = callFunctionInternal(targetRef.getFunc(), arguments);
+    Flow ret = callFunction(targetRef.getFunc(), arguments);
 #ifdef WASM_INTERPRETER_DEBUG
     std::cout << "(returned to " << scope->function->name << ")\n";
 #endif
@@ -4297,18 +4301,7 @@ public:
     return value;
   }
 
-  // Call a function, starting an invocation.
-  Literals callFunction(Name name, const Literals& arguments) {
-    // If the last call ended in a jump up the stack, it might have left stuff
-    // for us to clean up here
-    callDepth = 0;
-    functionStack.clear();
-    return callFunctionInternal(name, arguments);
-  }
-
-  // Internal function call. Must be public so that callTable implementations
-  // can use it (refactor?)
-  Literals callFunctionInternal(Name name, Literals arguments) {
+  Literals callFunction(Name name, Literals arguments) {
     if (callDepth > maxDepth) {
       hostLimit("stack limit");
     }
@@ -4332,8 +4325,6 @@ public:
         return externalInterface->callImport(function, arguments);
       }
 
-      auto previousCallDepth = callDepth;
-      callDepth++;
       auto previousFunctionStackSize = functionStack.size();
       functionStack.push_back(name);
 
@@ -4348,8 +4339,6 @@ public:
 
       flow = self()->visit(function->body);
 
-      // may decrease more than one, if we jumped up the stack
-      callDepth = previousCallDepth;
       // if we jumped up the stack, we also need to pop higher frames
       // TODO can FunctionScope handle this automatically?
       while (functionStack.size() > previousFunctionStackSize) {


### PR DESCRIPTION
The old code manually managed it for no good reason that I can see.

After this, there is no difference between `callFunction` and `callFunctionInternal`,
so fold them together.