### PR TITLE
Module splitting: don't create new tables when splitting with Emscripten

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -217,15 +217,19 @@ TableSlotManager::TableSlotManager(Module& module) : module(module) {
 }
 
 Table* TableSlotManager::makeTable() {
-  return module.addTable(
+  Table* newTable = module.addTable(
     Builder::makeTable(Names::getValidTableName(module, Name::fromInt(0))));
+  if (Export* e = module.getExportOrNull("__indirect_function_table")) {
+      e->value = newTable->name;
+  }
+  return newTable;
 }
 
 ElementSegment* TableSlotManager::makeElementSegment() {
   return module.addElementSegment(Builder::makeElementSegment(
     Names::getValidElementSegmentName(module, Name::fromInt(0)),
     activeTable->name,
-    Builder(module).makeConst(int32_t(0))));
+    Builder(module).makeConst(int32_t(1))));
 }
 
 TableSlotManager::Slot TableSlotManager::getSlot(Name func, HeapType type) {
@@ -238,7 +242,8 @@ TableSlotManager::Slot TableSlotManager::getSlot(Name func, HeapType type) {
   if (activeSegment == nullptr) {
     if (activeTable == nullptr) {
       activeTable = makeTable();
-      activeBase = {activeTable->name, "", 0};
+      std::cout << "allocating\n";
+      activeBase = {activeTable->name, "", 1};
     }
 
     // None of the existing segments should refer to the active table

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -146,10 +146,21 @@ void TableSlotManager::addSlot(Name func, Slot slot) {
 }
 
 TableSlotManager::TableSlotManager(Module& module) : module(module) {
-  if (module.features.hasReferenceTypes()) {
+  Export* emscripten_table_export =
+    module.getExportOrNull("__indirect_function_table");
+  Table* indirect_table =
+    module.tables.size() == 1 ? module.tables[0].get() : nullptr;
+  bool emscripten_import = indirect_table->imported() &&
+                           indirect_table->module == "env" &&
+                           indirect_table->base == "__indirect_function_table";
+
+  if (module.features.hasReferenceTypes() && !emscripten_table_export &&
+      !emscripten_import) {
     // Just create a new table to manage all primary-to-secondary calls lazily.
     // Do not re-use slots for functions that will already be in existing
     // tables, since that is not correct in the face of table mutations.
+    // However, do not do this for emscripten; its loader code (and dynamic
+    // loading in particular) do not support this yet.
     // TODO: Reduce overhead by creating a separate table for each function type
     // if WasmGC is enabled.
     return;
@@ -217,19 +228,15 @@ TableSlotManager::TableSlotManager(Module& module) : module(module) {
 }
 
 Table* TableSlotManager::makeTable() {
-  Table* newTable = module.addTable(
+  return module.addTable(
     Builder::makeTable(Names::getValidTableName(module, Name::fromInt(0))));
-  if (Export* e = module.getExportOrNull("__indirect_function_table")) {
-      e->value = newTable->name;
-  }
-  return newTable;
 }
 
 ElementSegment* TableSlotManager::makeElementSegment() {
   return module.addElementSegment(Builder::makeElementSegment(
     Names::getValidElementSegmentName(module, Name::fromInt(0)),
     activeTable->name,
-    Builder(module).makeConst(int32_t(1))));
+    Builder(module).makeConst(int32_t(0))));
 }
 
 TableSlotManager::Slot TableSlotManager::getSlot(Name func, HeapType type) {
@@ -242,8 +249,7 @@ TableSlotManager::Slot TableSlotManager::getSlot(Name func, HeapType type) {
   if (activeSegment == nullptr) {
     if (activeTable == nullptr) {
       activeTable = makeTable();
-      std::cout << "allocating\n";
-      activeBase = {activeTable->name, "", 1};
+      activeBase = {activeTable->name, "", 0};
     }
 
     // None of the existing segments should refer to the active table

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -157,8 +157,9 @@ TableSlotManager::TableSlotManager(Module& module) : module(module) {
     module.getExportOrNull("__indirect_function_table");
   Table* singletonTable =
     module.tables.size() == 1 ? module.tables[0].get() : nullptr;
-  bool emscriptenTableImport = singletonTable &&
-    singletonTable->imported() && singletonTable->module == "env" &&
+  bool emscriptenTableImport =
+    singletonTable && singletonTable->imported() &&
+    singletonTable->module == "env" &&
     singletonTable->base == "__indirect_function_table";
 
   if (module.features.hasReferenceTypes() && !emscriptenTableExport &&

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -157,7 +157,7 @@ TableSlotManager::TableSlotManager(Module& module) : module(module) {
     module.getExportOrNull("__indirect_function_table");
   Table* singletonTable =
     module.tables.size() == 1 ? module.tables[0].get() : nullptr;
-  bool emscriptenTableImport =
+  bool emscriptenTableImport = singletonTable &&
     singletonTable->imported() && singletonTable->module == "env" &&
     singletonTable->base == "__indirect_function_table";
 

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -155,11 +155,11 @@ TableSlotManager::TableSlotManager(Module& module) : module(module) {
   // if WasmGC is enabled.
   Export* emscriptenTableExport =
     module.getExportOrNull("__indirect_function_table");
-  Table* indirect_table =
+  Table* singletonTable =
     module.tables.size() == 1 ? module.tables[0].get() : nullptr;
   bool emscriptenTableImport =
-    indirect_table->imported() && indirect_table->module == "env" &&
-    indirect_table->base == "__indirect_function_table";
+    singletonTable->imported() && singletonTable->module == "env" &&
+    singletonTable->base == "__indirect_function_table";
 
   if (module.features.hasReferenceTypes() && !emscriptenTableExport &&
       !emscriptenTableImport) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1631,7 +1631,7 @@ Importable* Module::getImport(ModuleItemKind kind, Name name) {
 
 Importable* Module::getImportOrNull(ModuleItemKind kind, Name name) {
   auto doReturn = [](Importable* importable) {
-    return importable->imported() ? importable : nullptr;
+    return importable ? importable->imported() ? importable : nullptr : nullptr;
   };
 
   switch (kind) {


### PR DESCRIPTION
Emscripten's JS loader code for wasm-split isn't prepared for handling multiple tables that binaryen automatically creates when reference types are enabled (especially in conjunction with dynamic loading). For now, disable creation of multiple tables when using Emscripten's table ABI (distinguished by importing or exporting a table named "__indirect_function_table". 