### PR TITLE
[GC] Fix ConstantFieldPropagation on incompatible types

### DIFF
--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -180,7 +180,8 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
     auto field = GCTypeUtils::getField(type, curr->index);
     assert(field);
     // Apply packing, if needed.
-    value = Bits::makePackedFieldGet(value, *field, curr->signed_, *getModule());
+    value =
+      Bits::makePackedFieldGet(value, *field, curr->signed_, *getModule());
     // Check if the value makes sense. The analysis below flows values around
     // without considering where they are placed, that is, when we see a parent
     // type can contain a value in a field then we assume a child may as well

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -189,8 +189,8 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
     // write that value to it, but the reference might actually point to a
     // child instance). If we tracked the types of fields then we might avoid
     // flowing values into places they cannot reside, like when a child field is
-    // a subtype, and so we can ignore things not refined enough for it. GUFA
-    // does a better job at this. For here, just check we do not break
+    // a subtype, and so we could ignore things not refined enough for it (GUFA
+    // does a better job at this). For here, just check we do not break
     // validation, and if we do, then we've inferred the only possible value is
     // an impossible one, making the code unreachable.
     if (!Type::isSubType(value->type, field->type)) {

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2710,3 +2710,51 @@
     )
   )
 )
+
+;; $C is created with two values for its field: a global.get, and a copy from
+;; another $C, which does not expand the set of possible values. We should not
+;; get confused about $A, its parent, or $B, its sibling - we do not create
+;; those at all, and even the copy cannot refer to them.
+(module
+  (rec
+    (type $X (sub (struct)))
+    (type $Y (sub final $X (struct)))
+    (type $Z (sub final $X (struct)))
+
+    (type $A (sub (struct (field (ref null $X)))))
+    (type $B (sub final $A (struct (field (ref null $Y)))))
+    (type $C (sub final $A (struct (field (ref null $Z)))))
+  )
+
+  (global $global (ref null $Z) (struct.new_default $Z))
+
+  (func $new
+    (drop
+      (struct.new $C
+        (global.get $global)
+      )
+    )
+  )
+
+  (func $copy (param $C (ref null $C))
+    (drop
+      (struct.new $C
+        (struct.get $C 0
+          (local.get $C)
+        )
+      )
+    )
+  )
+
+  (func $get-A (param $A (ref null $A)) (result (ref null $X))
+    (struct.get $A 0
+      (local.get $A)
+    )
+  )
+
+  (func $get-B (param $B (ref null $B)) (result (ref null $Y))
+    (struct.get $B 0
+      (local.get $B)
+    )
+  )
+)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2819,7 +2819,8 @@
     ;; cannot refer to anything that is actually created. If we mistakenly
     ;; thought this field can contain the global.get (as we do for the parent
     ;; $A) then we would error here: $B's field contains $Y, but the global is
-    ;; is of a sibling type $Z.
+    ;; is of a sibling type $Z. Instead, we can add an unreachable here, as no
+    ;; valid value is possible.
     (struct.get $B 0
       (local.get $B)
     )

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2737,6 +2737,7 @@
   )
 
   (func $copy (param $C (ref null $C))
+    ;; The struct.get here can be optimized to a global.get.
     (drop
       (struct.new $C
         (struct.get $C 0
@@ -2747,12 +2748,15 @@
   )
 
   (func $get-A (param $A (ref null $A)) (result (ref null $X))
+    ;; This should not be optimized to a global.get.
     (struct.get $A 0
       (local.get $A)
     )
   )
 
   (func $get-B (param $B (ref null $B)) (result (ref null $Y))
+    ;; This should not be optimized to a global.get (in fact, it would error, as
+    ;; $B's field contains $Y, but the global here is of a sibling type $Z).
     (struct.get $B 0
       (local.get $B)
     )


### PR DESCRIPTION
CFP is less precise than GUFA, in particular, when it flows around types then
it does not consider what field it is flowing them to, and its core data
structure is "if a `struct.get` is done on this type's field, what can be read?".
To see the issue this PR fixes, assume we have

```
  A
 / \
B   C
```
Then if we see `struct.set $C`, we know that can be read by a `struct.get $A`
(we can store a reference to a `C` in such a local/param/etc.), so we propagate
the value of that set to `A`. And, in general, anything in `A` can appear in `B`
(say, if we see a copy, a `struct.set` of `struct.get` that operates on types `A`,
then one of the sides might be a `B`), so we propagate from `A` to `B`. But
now we have propagated something from `C` to `B`, which might be of an
incompatible type.

This cannot cause runtime issues, as it just means we are propagating more
than we should, and will end up with less-useful results. But it can break
validation if no other value is possible but one with an incompatible type,
as we'd replace a `struct.get $B` with a value that only makes sense for `C`.
(The qualifier "no other value is possible" was added in the previous
sentence because if another one *is* possible then we'd end up with too
many values to infer anything, and not optimize at all, avoiding any error.)