### PR TITLE
[wasm64] Make interpreter table methods operate on Address, not Index

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -151,7 +151,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
   }
 
   Literals callTable(Name tableName,
-                     Index index,
+                     Address index,
                      HeapType sig,
                      Literals& arguments,
                      Type results,
@@ -287,7 +287,8 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
     return (Index)tables[tableName].size();
   }
 
-  void tableStore(Name tableName, Index index, const Literal& entry) override {
+  void
+  tableStore(Name tableName, Address index, const Literal& entry) override {
     auto& table = tables[tableName];
     if (index >= table.size()) {
       trap("out of bounds table access");
@@ -296,7 +297,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
     }
   }
 
-  Literal tableLoad(Name tableName, Index index) override {
+  Literal tableLoad(Name tableName, Address index) override {
     auto it = tables.find(tableName);
     if (it == tables.end()) {
       trap("tableGet on non-existing table");

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -84,7 +84,7 @@ public:
         if (!exportedTable) {
           throwEmptyException();
         }
-        Index index = arguments[0].geti32();
+        auto index = arguments[0].getUnsigned();
         if (index >= tables[exportedTable].size()) {
           throwEmptyException();
         }
@@ -93,7 +93,7 @@ public:
         if (!exportedTable) {
           throwEmptyException();
         }
-        Index index = arguments[0].geti32();
+        auto index = arguments[0].getUnsigned();
         if (index >= tables[exportedTable].size()) {
           throwEmptyException();
         }

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -290,7 +290,7 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
 
   // We assume the table is not modified FIXME
   Literals callTable(Name tableName,
-                     Index index,
+                     Address index,
                      HeapType sig,
                      Literals& arguments,
                      Type result,
@@ -363,12 +363,13 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
     return wasm->getTableOrNull(tableName)->initial;
   }
 
-  Literal tableLoad(Name tableName, Index index) override {
+  Literal tableLoad(Name tableName, Address index) override {
     throw FailToEvalException("table.get: TODO");
   }
 
   // called during initialization
-  void tableStore(Name tableName, Index index, const Literal& value) override {
+  void
+  tableStore(Name tableName, Address index, const Literal& value) override {
     // We allow stores to the table during initialization, but not after, as we
     // assume the table does not change at runtime.
     // TODO: Allow table changes by updating the table later like we do with the

--- a/test/lit/exec/table64.wast
+++ b/test/lit/exec/table64.wast
@@ -6,18 +6,31 @@
  (type $i32 (func (result i32)))
 
  (table $table i64 10 funcref)
- (elem (i64.const 0) $i32)
+ (elem (i64.const 0) $i32-a $i32-b)
 
- (func $i32 (result i32)
+ (func $i32-a (result i32)
   (i32.const 42)
  )
 
- ;; CHECK:      [fuzz-exec] calling call
- ;; CHECK-NEXT: [fuzz-exec] note result: call => 42
- (func $call (export "call") (result i32)
-  ;; This call succeeds, and calls $i32 which returns 42.
+ (func $i32-b (result i32)
+  (i32.const 1337)
+ )
+
+ ;; CHECK:      [fuzz-exec] calling call-a
+ ;; CHECK-NEXT: [fuzz-exec] note result: call-a => 42
+ (func $call-a (export "call-a") (result i32)
+  ;; This call succeeds, and calls $i32-a which returns 42.
   (call_indirect (type $i32)
    (i64.const 0)
+  )
+ )
+
+ ;; CHECK:      [fuzz-exec] calling call-b
+ ;; CHECK-NEXT: [fuzz-exec] note result: call-b => 1337
+ (func $call-b (export "call-b") (result i32)
+  ;; This call succeeds, and calls $i32-b which returns 1337.
+  (call_indirect (type $i32)
+   (i64.const 1)
   )
  )
 
@@ -33,10 +46,14 @@
  ;; CHECK:      [fuzz-exec] calling oob-huge
  ;; CHECK-NEXT: [trap callTable overflow]
  (func $oob-huge (export "oob-huge") (result i32)
-  ;; This call traps on oob with a value over 32 bits, 2**32 + 5, which if we
-  ;; truncated to 32 bits, would seem in bounds.
+  ;; This call traps on oob with a value over 32 bits, 2**32 + 1, which if we
+  ;; truncated to 32 bits, would seem in bounds, and end up calling a valid
+  ;; function.
   (call_indirect (type $i32)
-   (i64.const 4294967301)
+   (i64.add
+    (i64.const 0x100000000)
+    (i64.const 1)
+   )
   )
  )
 
@@ -45,13 +62,16 @@
  (func $null (export "null") (result i32)
   ;; This call traps on null
   (call_indirect (type $i32)
-   (i64.const 1)
+   (i64.const 2)
   )
  )
 )
 
-;; CHECK:      [fuzz-exec] calling call
-;; CHECK-NEXT: [fuzz-exec] note result: call => 42
+;; CHECK:      [fuzz-exec] calling call-a
+;; CHECK-NEXT: [fuzz-exec] note result: call-a => 42
+
+;; CHECK:      [fuzz-exec] calling call-b
+;; CHECK-NEXT: [fuzz-exec] note result: call-b => 1337
 
 ;; CHECK:      [fuzz-exec] calling oob
 ;; CHECK-NEXT: [trap callTable overflow]
@@ -61,7 +81,8 @@
 
 ;; CHECK:      [fuzz-exec] calling null
 ;; CHECK-NEXT: [trap uninitialized table element]
-;; CHECK-NEXT: [fuzz-exec] comparing call
+;; CHECK-NEXT: [fuzz-exec] comparing call-a
+;; CHECK-NEXT: [fuzz-exec] comparing call-b
 ;; CHECK-NEXT: [fuzz-exec] comparing null
 ;; CHECK-NEXT: [fuzz-exec] comparing oob
 ;; CHECK-NEXT: [fuzz-exec] comparing oob-huge

--- a/test/lit/exec/table64.wast
+++ b/test/lit/exec/table64.wast
@@ -30,6 +30,16 @@
   )
  )
 
+ ;; CHECK:      [fuzz-exec] calling oob-huge
+ ;; CHECK-NEXT: [trap callTable overflow]
+ (func $oob-huge (export "oob-huge") (result i32)
+  ;; This call traps on oob with a value over 32 bits, 2**32 + 5, which if we
+  ;; truncated to 32 bits, would seem in bounds.
+  (call_indirect (type $i32)
+   (i64.const 4294967301)
+  )
+ )
+
  ;; CHECK:      [fuzz-exec] calling null
  ;; CHECK-NEXT: [trap uninitialized table element]
  (func $null (export "null") (result i32)
@@ -46,8 +56,12 @@
 ;; CHECK:      [fuzz-exec] calling oob
 ;; CHECK-NEXT: [trap callTable overflow]
 
+;; CHECK:      [fuzz-exec] calling oob-huge
+;; CHECK-NEXT: [trap callTable overflow]
+
 ;; CHECK:      [fuzz-exec] calling null
 ;; CHECK-NEXT: [trap uninitialized table element]
 ;; CHECK-NEXT: [fuzz-exec] comparing call
 ;; CHECK-NEXT: [fuzz-exec] comparing null
 ;; CHECK-NEXT: [fuzz-exec] comparing oob
+;; CHECK-NEXT: [fuzz-exec] comparing oob-huge


### PR DESCRIPTION
This allows 64-bit bounds checking to work properly.