### PR TITLE
[wasm64] Fuzzer: Fix type of unimported offsets

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -535,7 +535,7 @@ void TranslateToFuzzReader::finalizeMemory() {
           // TODO: It would be better to avoid segment overlap so that
           //       MemoryPacking can run.
           segment->offset =
-            builder.makeConst(Literal::makeFromInt32(0, Type::i32));
+            builder.makeConst(Literal::makeFromInt32(0, memory->addressType));
         }
       }
       if (auto* offset = segment->offset->dynCast<Const>()) {
@@ -579,7 +579,7 @@ void TranslateToFuzzReader::finalizeTable() {
             assert(!wasm.getGlobal(get->name)->imported());
             // TODO: the segments must not overlap...
             segment->offset =
-              builder.makeConst(Literal::makeFromInt32(0, Type::i32));
+              builder.makeConst(Literal::makeFromInt32(0, table->addressType));
           }
         }
         Address maxOffset = segment->data.size();


### PR DESCRIPTION
When the fuzzer sees an imported segment, it makes it non-imported
(because imported ones would trap when we tried to run them: we don't
have the normal runtime they expect). We had hardcoded i32 offets there,
which need to be generalized.