### PR TITLE
[NFC] Eagerly set local names in binary reader

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1571,6 +1571,7 @@ public:
 
   void readFunctions();
   void readVars();
+  void setLocalNames(Function& func, Index i);
 
   void readExports();
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -2735,6 +2735,15 @@ void WasmBinaryReader::readFunctionSignatures() {
     }
     usedNames.insert(name);
   }
+  // Also check that the function indices in the local names subsection are
+  // in-bounds, even though we don't use them here.
+  for (auto& [index, locals] : localNames) {
+    if (index >= num + numImports) {
+      std::cerr << "warning: function index out of bounds in name section: "
+                   "locals at index "
+                << index << '\n';
+    }
+  }
   for (size_t i = 0; i < num; i++) {
     auto [name, isExplicit] =
       getOrMakeName(functionNames, numImports + i, makeName("", i), usedNames);


### PR DESCRIPTION
Instead of setting the local names at the end of binary reading, eagerly
set them before parsing function bodies. This is NFC now, but will fix a
future bug once the binary reader uses IRBuilder. IRBuilder can
introduce new scratch locals, and it gives them the names `$scratch`,
`$scratch_1`, etc. If the name section includes locals with the same
names and we set those local names after parsing function bodies, then
we can end up with multiple locals with the same names. Setting the
names before parsing the function bodies ensures that IRBuilder will
generate different names for the scratch locals.

The alternative fix would be to generate fresh names when setting names
from the name section, but it is better to respect the names in the name
section and use fresh names for the newly introduced scratch locals
instead.
