### PR TITLE
Record binary locations for nested blocks

### DIFF
--- a/test/lit/passes/heap-store-optimization.wast
+++ b/test/lit/passes/heap-store-optimization.wast
@@ -967,6 +967,29 @@
     )
   )
 
+  ;; CHECK:      (func $control-flow-in-set-value-safe-return (type $4) (result i32)
+  ;; CHECK-NEXT:  (local $ref (ref null $struct))
+  ;; CHECK-NEXT:  (block
+  ;; CHECK-NEXT:   (local.set $ref
+  ;; CHECK-NEXT:    (struct.new $struct
+  ;; CHECK-NEXT:     (if (result i32)
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (return
+  ;; CHECK-NEXT:        (i32.const 42)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (else
+  ;; CHECK-NEXT:       (i32.const 42)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (struct.get $struct 0
+  ;; CHECK-NEXT:   (local.get $ref)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $control-flow-in-set-value-safe-return (result i32)
     ;; As above, but replace the call with a return in an if. We can still
     ;; optimize (if the return is taken, we go outside of the function anyhow).

--- a/test/passes/dwarf-local-order.bin.txt
+++ b/test/passes/dwarf-local-order.bin.txt
@@ -341,6 +341,7 @@
   )
   ;; code offset: 0xa9
   (block $label$1
+   ;; code offset: 0xab
    (block $label$2
     ;; code offset: 0xaf
     (br_if $label$2

--- a/test/passes/fannkuch0_dwarf.bin.txt
+++ b/test/passes/fannkuch0_dwarf.bin.txt
@@ -7740,6 +7740,7 @@ file_names[  3]:
     )
     ;; code offset: 0xa1f
     (block $label$17
+     ;; code offset: 0xa21
      (block $label$18
       ;; code offset: 0xa27
       (br_if $label$18
@@ -7927,6 +7928,7 @@ file_names[  3]:
   )
   ;; code offset: 0xaed
   (block $label$1
+   ;; code offset: 0xaef
    (block $label$2
     ;; code offset: 0xaf4
     (br_if $label$2
@@ -8041,6 +8043,7 @@ file_names[  3]:
   )
   ;; code offset: 0xb4a
   (block $label$3
+   ;; code offset: 0xb4c
    (block $label$4
     ;; code offset: 0xb51
     (br_if $label$4
@@ -8914,6 +8917,7 @@ file_names[  3]:
     )
     ;; code offset: 0xefd
     (block $label$7
+     ;; code offset: 0xeff
      (block $label$8
       ;; code offset: 0xf04
       (br_if $label$8
@@ -9818,6 +9822,7 @@ file_names[  3]:
      )
      ;; code offset: 0x1207
      (block $label$17
+      ;; code offset: 0x1209
       (block $label$18
        ;; code offset: 0x120f
        (br_if $label$18

--- a/test/passes/fannkuch3_dwarf.bin.txt
+++ b/test/passes/fannkuch3_dwarf.bin.txt
@@ -4874,7 +4874,9 @@ file_names[  4]:
   )
   ;; code offset: 0x47
   (block $label$1
+   ;; code offset: 0x49
    (block $label$2
+    ;; code offset: 0x4b
     (block $label$3
      ;; code offset: 0x52
      (br_if $label$3
@@ -6022,7 +6024,9 @@ file_names[  4]:
   )
   ;; code offset: 0x3bd
   (block $label$1
+   ;; code offset: 0x3bf
    (block $label$2
+    ;; code offset: 0x3c1
     (block $label$3
      ;; code offset: 0x3c8
      (br_if $label$3
@@ -6192,8 +6196,11 @@ file_names[  4]:
    )
    ;; code offset: 0x444
    (block $label$6
+    ;; code offset: 0x446
     (block $label$7
+     ;; code offset: 0x448
      (block $label$8
+      ;; code offset: 0x44a
       (block $label$9
        ;; code offset: 0x451
        (br_if $label$9

--- a/test/passes/fannkuch3_manyopts_dwarf.bin.txt
+++ b/test/passes/fannkuch3_manyopts_dwarf.bin.txt
@@ -4752,6 +4752,7 @@ file_names[  4]:
   )
   ;; code offset: 0x43
   (block $label$1
+   ;; code offset: 0x45
    (block $label$2
     ;; code offset: 0x4c
     (if
@@ -5886,6 +5887,7 @@ file_names[  4]:
   )
   ;; code offset: 0x39b
   (block $label$1
+   ;; code offset: 0x39d
    (block $label$2
     ;; code offset: 0x3a4
     (if
@@ -6050,7 +6052,9 @@ file_names[  4]:
    )
    ;; code offset: 0x41a
    (block $label$6
+    ;; code offset: 0x41c
     (block $label$7
+     ;; code offset: 0x41e
      (block $label$8
       ;; code offset: 0x425
       (if

--- a/test/passes/reverse_dwarf_abbrevs.bin.txt
+++ b/test/passes/reverse_dwarf_abbrevs.bin.txt
@@ -293,7 +293,9 @@ file_names[  1]:
   (local.set $4
    ;; code offset: 0x89
    (block $label$1 (result i32)
+    ;; code offset: 0x8b
     (block $label$2
+     ;; code offset: 0x8d
      (block $label$3
       ;; code offset: 0xa5
       (if
@@ -1387,6 +1389,7 @@ file_names[  1]:
   (block $label$1
    ;; code offset: 0x43a
    (if
+    ;; code offset: 0x412
     (block $label$2 (result i32)
      ;; code offset: 0x41c
      (if
@@ -2102,6 +2105,7 @@ file_names[  1]:
   )
   ;; code offset: 0x65a
   (block $label$1
+   ;; code offset: 0x65c
    (block $label$2
     ;; code offset: 0x664
     (br_if $label$2


### PR DESCRIPTION
The binary reader has special handling for blocks immediately nested
inside other blocks to eliminate recursion while parsing very deep
stacks of blocks. This special handling did not record binary locations
for the nested blocks, though.

Add logic to record binary locations for nested blocks. This binary
reading code is about to be replaced with completely different code that
uses IRBuilder instead, but this change will eliminate some test
differences that we would otherwise see when we make that change.
