### PR TITLE
Mark Result and MaybeResult [[nodiscard]]

### DIFF
--- a/src/parser/parsers.h
+++ b/src/parser/parsers.h
@@ -1099,7 +1099,7 @@ block(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto type = blocktype(ctx);
   CHECK_ERR(type);
 
-  ctx.makeBlock(pos, annotations, label, *type);
+  CHECK_ERR(ctx.makeBlock(pos, annotations, label, *type));
 
   CHECK_ERR(instrs(ctx));
 
@@ -1162,7 +1162,7 @@ ifelse(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
       return ctx.in.err("else label does not match if label");
     }
 
-    ctx.visitElse();
+    CHECK_ERR(ctx.visitElse());
 
     CHECK_ERR(instrs(ctx));
 
@@ -1205,7 +1205,7 @@ loop(Ctx& ctx, const std::vector<Annotation>& annotations, bool folded) {
   auto type = blocktype(ctx);
   CHECK_ERR(type);
 
-  ctx.makeLoop(pos, annotations, label, *type);
+  CHECK_ERR(ctx.makeLoop(pos, annotations, label, *type));
 
   CHECK_ERR(instrs(ctx));
 

--- a/src/support/result.h
+++ b/src/support/result.h
@@ -40,7 +40,7 @@ struct Err {
   }
 
 // Represent a result of type T or an error message.
-template<typename T = Ok> struct Result {
+template<typename T = Ok> struct [[nodiscard]] Result {
   std::variant<T, Err> val;
 
   Result(Result<T>& other) = default;
@@ -56,7 +56,7 @@ template<typename T = Ok> struct Result {
 };
 
 // Represent an optional result of type T or an error message.
-template<typename T = Ok> struct MaybeResult {
+template<typename T = Ok> struct [[nodiscard]] MaybeResult {
   std::variant<T, None, Err> val;
 
   MaybeResult() : val(None{}) {}

--- a/test/gtest/local-graph.cpp
+++ b/test/gtest/local-graph.cpp
@@ -25,7 +25,7 @@ TEST_F(LocalGraphTest, ObstacleBasics) {
   )wasm";
 
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
 
   // Get access to the contents of the wasm.
   auto* func = wasm.functions[0].get();
@@ -79,7 +79,7 @@ TEST_F(LocalGraphTest, ObstacleMultiblock) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* block = func->body->cast<Block>();
   auto* set = block->list[0]->cast<LocalSet>();
@@ -113,7 +113,7 @@ TEST_F(LocalGraphTest, ObstacleUnreachable) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* block = func->body->cast<Block>();
   auto* set = block->list[0]->cast<LocalSet>();
@@ -149,7 +149,7 @@ TEST_F(LocalGraphTest, ObstacleMultiGet) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* block = func->body->cast<Block>();
   auto* set = block->list[0]->cast<LocalSet>();
@@ -185,7 +185,7 @@ TEST_F(LocalGraphTest, ObstacleMultiSet) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* block = func->body->cast<Block>();
   auto* setA = block->list[0]->cast<LocalSet>();
@@ -227,7 +227,7 @@ TEST_F(LocalGraphTest, ObstacleMultiSetIndexes) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* block = func->body->cast<Block>();
   auto* setA = block->list[0]->cast<LocalSet>();
@@ -276,7 +276,7 @@ TEST_F(LocalGraphTest, ObstacleMultiSetIf) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* block = func->body->cast<Block>();
   auto* iff = block->list[0]->cast<If>();
@@ -332,7 +332,7 @@ TEST_F(LocalGraphTest, ObstacleStructSet) {
     )
   )wasm";
   Module wasm;
-  WATParser::parseModule(wasm, moduleText);
+  ASSERT_FALSE(WATParser::parseModule(wasm, moduleText).getErr());
   auto* func = wasm.functions[0].get();
   auto* outerBlock = func->body->cast<Block>();
   auto* block = outerBlock->list[0]->cast<Block>();


### PR DESCRIPTION
Since these types may be carrying errors that need to be handled or
propagated, it is always an error not to use them in some way. Adding
the [[nodiscard]] attribute caused the compiler to find a few instances
where we were incorrectly ignoring results. Fix these places.
