### PR TITLE
Fuzzer: Remove --enclose-world from list of fuzz-exec passes

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1795,7 +1795,6 @@ opt_choices = [
     ("--dce",),
     ("--directize",),
     ("--discard-global-effects",),
-    ("--enclose-world",),
     ("--flatten", "--dfo",),
     ("--duplicate-function-elimination",),
     ("--flatten",),


### PR DESCRIPTION
It is ok to use this pass to shape the wasm, but not to test for changes using
fuzz-exec, as the pass is destructive: it can alter observable behavior.