### PR TITLE
Special-case unreachable If conditions in IRBuilder

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -769,8 +769,7 @@ Result<Expression*> IRBuilder::finishScope(Block* block) {
       } else {
         // As a special case, look for unreachable if conditions, since they may
         // not make their ifs unreachable.
-        for (auto* curr = scope.exprStack[i]->dynCast<If>();
-             curr;
+        for (auto* curr = scope.exprStack[i]->dynCast<If>(); curr;
              curr = curr->condition->dynCast<If>()) {
           if (curr->condition->type == Type::unreachable) {
             sawUnreachable = true;

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -1280,6 +1280,67 @@
   end
  )
 
+ ;; CHECK:      (func $if-else-unreachable (type $1) (result i32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (if (result i32)
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:   (then
+ ;; CHECK-NEXT:    (i32.const 1)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (else
+ ;; CHECK-NEXT:    (i32.const 2)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $if-else-unreachable (result i32)
+  i32.const 0 ;; This will be dropped
+  unreachable
+  if (result i32)
+   i32.const 1
+  else
+   i32.const 2
+  end
+ )
+
+ ;; CHECK:      (func $if-else-nested-unreachable (type $1) (result i32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (if (result i32)
+ ;; CHECK-NEXT:   (if (result i32)
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:    (then
+ ;; CHECK-NEXT:     (i32.const 1)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (else
+ ;; CHECK-NEXT:     (i32.const 2)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (then
+ ;; CHECK-NEXT:    (i32.const 3)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:   (else
+ ;; CHECK-NEXT:    (i32.const 4)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $if-else-nested-unreachable (result i32)
+   i32.const 0 ;; This will be dropped
+   unreachable
+   if (result i32)
+    i32.const 1
+   else
+    i32.const 2
+   end
+   if (result i32)
+    i32.const 3
+   else
+    i32.const 4
+   end
+  )
+
  ;; CHECK:      (func $if-else-labeled-result (type $1) (result i32)
  ;; CHECK-NEXT:  (block $l (result i32)
  ;; CHECK-NEXT:   (if (result i32)
@@ -3660,7 +3721,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 161
+  ref.func 163
   drop
  )
 


### PR DESCRIPTION
When IRBuilder completes a scope that contains an unreachable
expression, it has to find the last unreachable expression and drop any
concretely typed expression that precedes it. If the original
unreachable expression has been made a child of some other expression,
that's usually fine because that other expression will become
unreachable as well. However, if conditions are special because they can
be unreachable without making their ifs unreachable, so we have to work
harder to find unreachable if conditions.
