### PR TITLE
[NFC] Refactor nice methods in fuzz_shell.js

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -138,9 +138,11 @@ function logValue(x, y) {
   console.log('[LoggingExternalInterface logging ' + printed(x, y) + ']');
 }
 
-// Track the exports in a map (similar to the Exports object from wasm) and also
-// in a list of names, as some imports need to access by index.
+// Track the exports in a map (similar to the Exports object from wasm, i.e.,
+// whose keys are strings and whose values are the corresponding exports).
 var exports = {};
+
+// Also track exports in a list of names, to allow access by index.
 var exportNames = [];
 
 // Given a wasm function, call it as best we can from JS, and return the result.

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -288,7 +288,9 @@ function build(binary) {
   // Update the exports. Note that this adds onto |exports|, |exportNames|,
   // which is intentional: if we build another wasm, or build this one more
   // than once, we want to be able to call them all, so we unify all their
-  // exports.
+  // exports. (We do trample in |exports| when keys are equal - basically this
+  // is a single global namespace - but |exportNames| is appended to, so we do
+  // keep the ability to call anything that was ever exported.)
   for (var e in instance.exports) {
     exports[e] = instance.exports[e];
     exportNames.push(e);

--- a/test/lit/node/fuzz_shell.wast
+++ b/test/lit/node/fuzz_shell.wast
@@ -1,0 +1,20 @@
+;; Test running a wasm file in fuzz_shell.js.
+
+(module
+  (func $test (export "test") (result i32)
+    (i32.const 42)
+  )
+)
+
+;; Build to a binary wasm.
+;;
+;; RUN: wasm-opt %s -o %t.wasm -q
+
+;; Run in node.
+;;
+;; RUN: node %S/../../../scripts/fuzz_shell.js %t.wasm | filecheck %s
+;;
+;; CHECK: [fuzz-exec] calling test
+;; CHECK: [fuzz-exec] note result: test => 42
+
+


### PR DESCRIPTION
This just moves the code around and avoids some duplication. It will make
later PRs simpler.

Also add a first test of running `fuzz_shell.js` in node.

edit: This does make `build()` append the exports, which was done before
on the main module but not the second one. That only affects the wasm-split
fuzzer, which is not active yet, so this is still NFC.