### PR TITLE
[wasm2js] Properly handle loops without labels

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -1181,6 +1181,11 @@ Ref Wasm2JSBuilder::processExpression(Expression* curr,
 
     Ref visitLoop(Loop* curr) {
       Name asmLabel = curr->name;
+      if (!asmLabel) {
+        // This loop has no label, so it cannot be continued to. We can just
+        // emit the body.
+        return visit(curr->body, result);
+      }
       continueLabels.insert(asmLabel);
       Ref body = visit(curr->body, result);
       // if we can reach the end of the block, we must leave the while (1) loop
@@ -1779,7 +1784,7 @@ Ref Wasm2JSBuilder::processExpression(Expression* curr,
           return ret;
         }
         default: {
-          Fatal() << "Unhandled type in unary: " << curr;
+          Fatal() << "Unhandled type in unary: " << *curr;
         }
       }
     }
@@ -1949,7 +1954,7 @@ Ref Wasm2JSBuilder::processExpression(Expression* curr,
           }
           return ret;
         default:
-          Fatal() << "Unhandled type in binary: " << curr;
+          Fatal() << "Unhandled type in binary: " << *curr;
       }
       return makeJsCoercion(ret, wasmToJsType(curr->type));
     }

--- a/test/wasm2js/br_table_temp.2asm.js
+++ b/test/wasm2js/br_table_temp.2asm.js
@@ -12554,12 +12554,10 @@ function asmFunc(imports) {
  function $19() {
   var $1_1 = 0, $2_1 = 0, $4_1 = 0;
   label : {
-   $null_Name_ : while (1) {
-    $1_1 = 3;
-    switch (0 | 0) {
-    default:
-     break label;
-    };
+   $1_1 = 3;
+   switch (0 | 0) {
+   default:
+    break label;
    };
   }
   return $1_1 | 0;
@@ -12568,13 +12566,11 @@ function asmFunc(imports) {
  function $20() {
   var $1_1 = 0, $2_1 = 0, $4_1 = 0;
   label : {
-   $null_Name_ : while (1) {
-    dummy();
-    $1_1 = 4;
-    switch (-1 | 0) {
-    default:
-     break label;
-    };
+   dummy();
+   $1_1 = 4;
+   switch (-1 | 0) {
+   default:
+    break label;
    };
   }
   return $1_1 | 0;
@@ -12583,13 +12579,11 @@ function asmFunc(imports) {
  function $21() {
   var $1_1 = 0;
   label : {
-   $null_Name_ : while (1) {
-    dummy();
-    $1_1 = 5;
-    switch (1 | 0) {
-    default:
-     break label;
-    };
+   dummy();
+   $1_1 = 5;
+   switch (1 | 0) {
+   default:
+    break label;
    };
   }
   return $1_1 | 0;

--- a/test/wasm2js/loop.2asm.js
+++ b/test/wasm2js/loop.2asm.js
@@ -1,0 +1,28 @@
+
+function wasm2js_trap() { throw new Error('abort'); }
+
+function asmFunc(imports) {
+ var Math_imul = Math.imul;
+ var Math_fround = Math.fround;
+ var Math_abs = Math.abs;
+ var Math_clz32 = Math.clz32;
+ var Math_min = Math.min;
+ var Math_max = Math.max;
+ var Math_floor = Math.floor;
+ var Math_ceil = Math.ceil;
+ var Math_trunc = Math.trunc;
+ var Math_sqrt = Math.sqrt;
+ var g = 0;
+ function test() {
+  g = 0;
+  wasm2js_trap();
+ }
+ 
+ return {
+  "test": test
+ };
+}
+
+var retasmFunc = asmFunc({
+});
+export var test = retasmFunc.test;

--- a/test/wasm2js/loop.2asm.js.opt
+++ b/test/wasm2js/loop.2asm.js.opt
@@ -1,0 +1,26 @@
+
+function wasm2js_trap() { throw new Error('abort'); }
+
+function asmFunc(imports) {
+ var Math_imul = Math.imul;
+ var Math_fround = Math.fround;
+ var Math_abs = Math.abs;
+ var Math_clz32 = Math.clz32;
+ var Math_min = Math.min;
+ var Math_max = Math.max;
+ var Math_floor = Math.floor;
+ var Math_ceil = Math.ceil;
+ var Math_trunc = Math.trunc;
+ var Math_sqrt = Math.sqrt;
+ function test() {
+  wasm2js_trap();
+ }
+ 
+ return {
+  "test": test
+ };
+}
+
+var retasmFunc = asmFunc({
+});
+export var test = retasmFunc.test;

--- a/test/wasm2js/loop.wast
+++ b/test/wasm2js/loop.wast
@@ -1,0 +1,18 @@
+(module
+ (global $g (mut i32) (i32.const 0))
+
+ (func $test (export "test")
+  ;; Loops without labels. We should not emit anything invalid here (like a
+  ;; null name, which would end up identical between the two, which is wrong).
+  (loop
+   (loop
+    ;; Some content, so the loop is not trivial.
+    (global.set $g
+     (i32.const 0)
+    )
+    (unreachable)
+   )
+   (unreachable)
+  )
+ )
+)


### PR DESCRIPTION
When a loop has no name, the name does not matter, but we also cannot
emit the same name for all such loops, as that is invalid JS.

Fixes #7099

Also fix two missing `*` in error reporting logic, that was printing pointers
rather than the expression we wanted to print. I think we changed how
iostream prints things years ago, and forgot to update these.