### PR TITLE
Fix printing of unreachable br_on_cast{_fail}

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2219,7 +2219,14 @@ struct PrintExpressionContents
         printMedium(o, "br_on_cast ");
         curr->name.print(o);
         o << ' ';
-        printType(curr->ref->type);
+        if (curr->ref->type == Type::unreachable) {
+          // Need to print some reference type in the correct hierarchy rather
+          // than unreachable, so arbitrarily choose the cast target type.
+          printType(
+            Type(curr->castType.getHeapType().getBottom(), NonNullable));
+        } else {
+          printType(curr->ref->type);
+        }
         o << ' ';
         printType(curr->castType);
         return;
@@ -2227,7 +2234,12 @@ struct PrintExpressionContents
         printMedium(o, "br_on_cast_fail ");
         curr->name.print(o);
         o << ' ';
-        printType(curr->ref->type);
+        if (curr->ref->type == Type::unreachable) {
+          printType(
+            Type(curr->castType.getHeapType().getBottom(), NonNullable));
+        } else {
+          printType(curr->ref->type);
+        }
         o << ' ';
         printType(curr->castType);
         return;

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2221,7 +2221,8 @@ struct PrintExpressionContents
         o << ' ';
         if (curr->ref->type == Type::unreachable) {
           // Need to print some reference type in the correct hierarchy rather
-          // than unreachable, so arbitrarily choose the cast target type.
+          // than unreachable, and the bottom type is valid in the most
+          // contexts.
           printType(
             Type(curr->castType.getHeapType().getBottom(), NonNullable));
         } else {

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -4064,6 +4064,31 @@
   drop
  )
 
+ ;; CHECK:      (func $br-on-cast-unreachable (type $0)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block $block (result i31ref)
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (block (result (ref any))
+ ;; CHECK-NEXT:      (br_on_cast $block (ref none) i31ref
+ ;; CHECK-NEXT:       (unreachable)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $br-on-cast-unreachable
+  block (result i31ref)
+   block (result (ref any))
+    unreachable
+    br_on_cast 1 anyref i31ref
+   end
+   unreachable
+  end
+  drop
+ )
+
  ;; CHECK:      (func $br-on-cast-fail (type $9) (param $0 anyref)
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (block $block (result (ref any))
@@ -4082,6 +4107,31 @@
   block (result (ref any))
    block (result i31ref)
     local.get 0
+    br_on_cast_fail 1 anyref i31ref
+   end
+   unreachable
+  end
+  drop
+ )
+
+ ;; CHECK:      (func $br-on-cast-fail-unreachable (type $0)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block $block (result (ref any))
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (block (result i31ref)
+ ;; CHECK-NEXT:      (br_on_cast_fail $block (ref none) i31ref
+ ;; CHECK-NEXT:       (unreachable)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $br-on-cast-fail-unreachable
+  block (result (ref any))
+   block (result i31ref)
+    unreachable
     br_on_cast_fail 1 anyref i31ref
    end
    unreachable


### PR DESCRIPTION
br_on_cast and br_on_cast_fail have two type annotations: one for their
input type and one for their cast type. In cases where their operands
were unreachable, we were previously printing "unreachable" for the
input type annotation. This is not valid wat because "unreachable" is
not a reference type.

To fix the problem, print the bottom type of the cast type's hierarchy
as the input type for br_on_cast and br_on_cast_fail when the operand is
unreachable. This ensures that the instructions have the most precise
possible output type according to Wasm typing rules, so it maximizes the
number of contexts in which the printed instructions are valid.
