### PR TITLE
Propagate public visibility through all types

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -598,26 +598,23 @@ void classifyTypeVisibility(Module& wasm,
   // We will need to traverse the types used by public types and mark them
   // public as well.
   std::vector<HeapType> workList;
+  std::unordered_set<RecGroup> publicGroups;
 
   auto notePublic = [&](HeapType type) {
     if (type.isBasic()) {
-      return false;
+      return;
     }
-    // All the rec group members are public as well.
-    bool inserted = false;
+    auto group = type.getRecGroup();
+    if (!publicGroups.insert(group).second) {
+      // The groups in this type have already been marked public.
+      return;
+    }
     for (auto member : type.getRecGroup()) {
       if (auto it = types.find(member); it != types.end()) {
-        if (it->second.visibility == Visibility::Public) {
-          // Since we mark all elements of a group public at once, if there is a
-          // member that is already public, all members must already be public.
-          break;
-        }
         it->second.visibility = Visibility::Public;
-        workList.push_back(member);
-        inserted = true;
       }
+      workList.push_back(member);
     }
-    return inserted;
   };
 
   // TODO: Consider Tags as well, but they should store HeapTypes instead of


### PR DESCRIPTION
Previously the classification of public types propagated public
visibility only through types that had previously been collected by
`collectHeapTypes`. Since there are settings that cause
`collectHeapTypes` to collect fewer types, it was possible for public
types to be missed if they were only public because they were reached by
an uncollected types.

Ensure that all public heap types are properly classified by propagating
public visibility even through types that are not part of the collected
output.

Fixes #7103.
