### PR TITLE
Print castType for unreachable br_on_cast{_fail}

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2221,10 +2221,9 @@ struct PrintExpressionContents
         o << ' ';
         if (curr->ref->type == Type::unreachable) {
           // Need to print some reference type in the correct hierarchy rather
-          // than unreachable, and the bottom type is valid in the most
-          // contexts.
-          printType(
-            Type(curr->castType.getHeapType().getBottom(), NonNullable));
+          // than unreachable, and the cast type itself is the best possible
+          // option.
+          printType(curr->castType);
         } else {
           printType(curr->ref->type);
         }
@@ -2236,8 +2235,7 @@ struct PrintExpressionContents
         curr->name.print(o);
         o << ' ';
         if (curr->ref->type == Type::unreachable) {
-          printType(
-            Type(curr->castType.getHeapType().getBottom(), NonNullable));
+          printType(curr->castType);
         } else {
           printType(curr->ref->type);
         }

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -4069,7 +4069,7 @@
  ;; CHECK-NEXT:   (block $block (result i31ref)
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (block (result (ref any))
- ;; CHECK-NEXT:      (br_on_cast $block (ref none) i31ref
+ ;; CHECK-NEXT:      (br_on_cast $block i31ref i31ref
  ;; CHECK-NEXT:       (unreachable)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )
@@ -4119,7 +4119,7 @@
  ;; CHECK-NEXT:   (block $block (result (ref any))
  ;; CHECK-NEXT:    (drop
  ;; CHECK-NEXT:     (block (result i31ref)
- ;; CHECK-NEXT:      (br_on_cast_fail $block (ref none) i31ref
+ ;; CHECK-NEXT:      (br_on_cast_fail $block i31ref i31ref
  ;; CHECK-NEXT:       (unreachable)
  ;; CHECK-NEXT:      )
  ;; CHECK-NEXT:     )


### PR DESCRIPTION
I forgot that there is a validation rule that the output type for
br_on_cast and br_on_cast_fail must be a subtype of the input type. We
were previously printing bottom input types in cases where the cast
operand was unreachable, but that's only valid if the cast type is the
same bottom type. Instead print the most precise valid input type, which
is the cast type itself.
