### PR TITLE
Print unreachable loads with valid types

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -106,6 +106,14 @@ static Type forceConcrete(Type type) {
   return type.isConcrete() ? type : Type::i32;
 }
 
+// Whatever type we print must be valid for the alignment.
+static Type forceConcrete(Type type, Index align) {
+  return type.isConcrete() ? type
+         : align >= 16     ? Type::v128
+         : align >= 8      ? Type::i64
+                           : Type::i32;
+}
+
 struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
   std::ostream& o;
   unsigned indent = 0;
@@ -538,7 +546,7 @@ struct PrintExpressionContents
     curr->name.print(o);
   }
   void visitLoad(Load* curr) {
-    prepareColor(o) << forceConcrete(curr->type);
+    prepareColor(o) << forceConcrete(curr->type, curr->align);
     if (curr->isAtomic) {
       o << ".atomic";
     }

--- a/test/lit/wat-kitchen-sink.wast
+++ b/test/lit/wat-kitchen-sink.wast
@@ -3171,6 +3171,23 @@
   drop
  )
 
+ ;; CHECK:      (func $load-v128-unreachable (type $0)
+ ;; CHECK-NEXT:  (v128.load $mimport$0
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (i64.load $mimport$0 align=8
+ ;; CHECK-NEXT:   (unreachable)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
+ (func $load-v128-unreachable
+  unreachable
+  v128.load align=16
+  unreachable
+  v128.load align=8
+  unreachable
+ )
+
  ;; CHECK:      (func $store (type $7) (param $0 i32) (param $1 i64)
  ;; CHECK-NEXT:  (i32.store $mimport$0 offset=42 align=1
  ;; CHECK-NEXT:   (local.get $0)
@@ -3660,7 +3677,7 @@
  (func $ref-func
   ref.func $ref-func
   drop
-  ref.func 161
+  ref.func 162
   drop
  )
 


### PR DESCRIPTION
Since Load expressions use their `type` field to encode the type of the
loaded value, unreachable loads need to come up with some other valid
type to print. Previously we always chose i32 as that type, but that's
not valid when the load was originally a v128 load with an alignment of
8, since 8 is greater than the maximum valid alignment of 4 for an i32.
Fix the problem by taking alignment into account when choosing a type
for the unreachable load.
