### PR TITLE
[tests] Fix wasm2js test command line generation

### DIFF
--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -81,7 +81,7 @@ def test_wasm2js_output():
                                         '--disable-exception-handling']
                 if opt:
                     cmd += ['-O']
-                if 'emscripten' in t:
+                if 'emscripten' in basename:
                     cmd += ['--emscripten']
                 if 'deterministic' in t:
                     cmd += ['--deterministic']

--- a/scripts/test/wasm2js.py
+++ b/scripts/test/wasm2js.py
@@ -83,7 +83,7 @@ def test_wasm2js_output():
                     cmd += ['-O']
                 if 'emscripten' in basename:
                     cmd += ['--emscripten']
-                if 'deterministic' in t:
+                if 'deterministic' in basename:
                     cmd += ['--deterministic']
                 js = support.run_command(cmd)
                 all_js.append(js)


### PR DESCRIPTION
--emscripten is added to the command line if the filename contains the string
'emscripten', but the current logic includes the cwd, so it fails if the tests
are run from a directory with 'emscripten' in the name. Fix it so the test only
includes the basename.
