### PR TITLE
Fix ArenaVector::swap

### DIFF
--- a/src/mixed_arena.h
+++ b/src/mixed_arena.h
@@ -263,12 +263,9 @@ public:
   void operator=(SubType& other) { set(other); }
 
   void swap(SubType& other) {
-    data = other.data;
-    usedElements = other.usedElements;
-    allocatedElements = other.allocatedElements;
-
-    other.data = nullptr;
-    other.usedElements = other.allocatedElements = 0;
+    std::swap(data, other.data);
+    std::swap(usedElements, other.usedElements);
+    std::swap(allocatedElements, other.allocatedElements);
   }
 
   // iteration

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(../../third_party/googletest/googletest/include)
 include_directories(../../src/wasm)
 
 set(unittest_SOURCES
+  arena.cpp
   binary-reader.cpp
   cfg.cpp
   dfa_minimization.cpp

--- a/test/gtest/arena.cpp
+++ b/test/gtest/arena.cpp
@@ -19,4 +19,9 @@ TEST_F(ArenaTest, Swap) {
 
   EXPECT_EQ(a.size(), 0U);
   EXPECT_EQ(b.size(), 2U);
+
+  a.swap(b);
+
+  EXPECT_EQ(a.size(), 2U);
+  EXPECT_EQ(b.size(), 0U);
 }

--- a/test/gtest/arena.cpp
+++ b/test/gtest/arena.cpp
@@ -1,0 +1,22 @@
+#include "mixed_arena.h"
+#include "gtest/gtest.h"
+
+using ArenaTest = ::testing::Test;
+
+TEST_F(ArenaTest, Swap) {
+  MixedArena arena;
+
+  ArenaVector<int> a(arena);
+  a.push_back(10);
+  a.push_back(20);
+
+  ArenaVector<int> b(arena);
+
+  EXPECT_EQ(a.size(), 2U);
+  EXPECT_EQ(b.size(), 0U);
+
+  a.swap(b);
+
+  EXPECT_EQ(a.size(), 0U);
+  EXPECT_EQ(b.size(), 2U);
+}

--- a/test/gtest/arena.cpp
+++ b/test/gtest/arena.cpp
@@ -24,4 +24,16 @@ TEST_F(ArenaTest, Swap) {
 
   EXPECT_EQ(a.size(), 2U);
   EXPECT_EQ(b.size(), 0U);
+
+  // Now reverse a and b. The swap should be the same.
+
+  b.swap(a);
+
+  EXPECT_EQ(a.size(), 0U);
+  EXPECT_EQ(b.size(), 2U);
+
+  b.swap(a);
+
+  EXPECT_EQ(a.size(), 2U);
+  EXPECT_EQ(b.size(), 0U);
 }


### PR DESCRIPTION
This was never right for over a decade, and just never used I suppose... it should
have been called "take" since it grabbed data from the other item and then set
that other item to empty. Fix it so it swaps properly.