### PR TITLE
[GC] Fix trapping on array.new_data of dropped segments of offset > 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,8 +367,8 @@ jobs:
     # Make sure we can still build on older Ubuntu
     runs-on: ubuntu-20.04
     env:
-      CC: "gcc-14"
-      CXX: "g++-14"
+      CC: "gcc"
+      CXX: "g++"
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,8 +367,8 @@ jobs:
     # Make sure we can still build on older Ubuntu
     runs-on: ubuntu-20.04
     env:
-      CC: "gcc"
-      CXX: "g++"
+      CC: "gcc-14"
+      CXX: "g++-14"
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4022,10 +4022,14 @@ public:
 
     const auto& seg = *wasm.getDataSegment(curr->segment);
     auto elemBytes = element.getByteSize();
-    auto end = offset + size * elemBytes;
-    if ((offset + size > 0 && droppedDataSegments.count(curr->segment)) ||
-        end > seg.data.size()) {
+    uint64_t end;
+    if (std::ckd_add(&end, offset, size * elemBytes) || end > seg.data.size()) {
       trap("out of bounds segment access in array.new_data");
+    }
+    uint64_t sum;
+    if (std::ckd_add(&sum, offset, size) ||
+        (sum > 0 && droppedDataSegments.count(curr->segment))) {
+      trap("dropped segment access in array.new_data");
     }
     contents.reserve(size);
     for (Index i = offset; i < end; i += elemBytes) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4026,9 +4026,7 @@ public:
     if (std::ckd_add(&end, offset, size * elemBytes) || end > seg.data.size()) {
       trap("out of bounds segment access in array.new_data");
     }
-    uint64_t sum;
-    if (std::ckd_add(&sum, offset, size) ||
-        (sum > 0 && droppedDataSegments.count(curr->segment))) {
+    if (droppedDataSegments.count(curr->segment) && end > 0) {
       trap("dropped segment access in array.new_data");
     }
     contents.reserve(size);

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4023,7 +4023,7 @@ public:
     const auto& seg = *wasm.getDataSegment(curr->segment);
     auto elemBytes = element.getByteSize();
     auto end = offset + size * elemBytes;
-    if ((size != 0ull && droppedDataSegments.count(curr->segment)) ||
+    if ((offset + size > 0 && droppedDataSegments.count(curr->segment)) ||
         end > seg.data.size()) {
       trap("out of bounds segment access in array.new_data");
     }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4022,6 +4022,10 @@ public:
 
     const auto& seg = *wasm.getDataSegment(curr->segment);
     auto elemBytes = element.getByteSize();
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
     uint64_t end;
     if (std::ckd_add(&end, offset, size * elemBytes) || end > seg.data.size()) {
       trap("out of bounds segment access in array.new_data");
@@ -4034,6 +4038,9 @@ public:
       auto addr = (void*)&seg.data[i];
       contents.push_back(this->makeFromMemory(addr, element));
     }
+
+#pragma GCC diagnostic pop
+
     return self()->makeGCData(std::move(contents), curr->type);
   }
   Flow visitArrayNewElem(ArrayNewElem* curr) {

--- a/test/lit/exec/array.wast
+++ b/test/lit/exec/array.wast
@@ -13,6 +13,8 @@
 
  (elem $passive $func)
 
+ (data $data "a")
+
  ;; CHECK:      [fuzz-exec] calling func
  ;; CHECK-NEXT: [fuzz-exec] note result: func => 1
  (func $func (export "func") (result i32)
@@ -98,6 +100,21 @@
    (i32.const 0)
   )
  )
+
+ ;; CHECK:      [fuzz-exec] calling drop_array.new_data
+ ;; CHECK-NEXT: [trap out of bounds segment access in array.new_data]
+ (func $drop_array.new_data (export "drop_array.new_data")
+  ;; Dropping the data segment causes the next instruction to trap, even though
+  ;; the size there is 0, because the offset is > 0.
+  (data.drop $data)
+  (drop
+   (array.new_data $array $data
+    (i32.const 1)
+    (i32.const 0)
+   )
+  )
+ )
+
 )
 ;; CHECK:      [fuzz-exec] calling func
 ;; CHECK-NEXT: [fuzz-exec] note result: func => 1
@@ -115,6 +132,10 @@
 ;; CHECK:      [fuzz-exec] calling init_active_in_bounds
 
 ;; CHECK:      [fuzz-exec] calling init_passive
+
+;; CHECK:      [fuzz-exec] calling drop_array.new_data
+;; CHECK-NEXT: [trap out of bounds segment access in array.new_data]
+;; CHECK-NEXT: [fuzz-exec] comparing drop_array.new_data
 ;; CHECK-NEXT: [fuzz-exec] comparing func
 ;; CHECK-NEXT: [fuzz-exec] comparing init_active
 ;; CHECK-NEXT: [fuzz-exec] comparing init_active_in_bounds

--- a/test/lit/exec/array.wast
+++ b/test/lit/exec/array.wast
@@ -102,7 +102,7 @@
  )
 
  ;; CHECK:      [fuzz-exec] calling drop_array.new_data
- ;; CHECK-NEXT: [trap out of bounds segment access in array.new_data]
+ ;; CHECK-NEXT: [trap dropped segment access in array.new_data]
  (func $drop_array.new_data (export "drop_array.new_data")
   ;; Dropping the data segment causes the next instruction to trap, even though
   ;; the size there is 0, because the offset is > 0.
@@ -134,7 +134,7 @@
 ;; CHECK:      [fuzz-exec] calling init_passive
 
 ;; CHECK:      [fuzz-exec] calling drop_array.new_data
-;; CHECK-NEXT: [trap out of bounds segment access in array.new_data]
+;; CHECK-NEXT: [trap dropped segment access in array.new_data]
 ;; CHECK-NEXT: [fuzz-exec] comparing drop_array.new_data
 ;; CHECK-NEXT: [fuzz-exec] comparing func
 ;; CHECK-NEXT: [fuzz-exec] comparing init_active


### PR DESCRIPTION
Even if the size is 0, if the offset is > 0 then we should trap.

@tlively Is it expected there are no spec tests for this combination of GC+bulk memory?