### PR TITLE
Do not sink blocks into ifs with unreachable conditions

### DIFF
--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -757,6 +757,12 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
             replaceCurrent(loop);
             worked = true;
           } else if (auto* iff = curr->list[0]->dynCast<If>()) {
+            if (iff->condition->type == Type::unreachable) {
+              // The block result type may not be compatible with the arm result
+              // types since the unreachable If can satisfy any type of block.
+              // Just leave this for DCE.
+              return;
+            }
             // The label can't be used in the condition.
             if (BranchUtils::BranchSeeker::count(iff->condition, curr->name) ==
                 0) {

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -594,4 +594,34 @@
       )
     )
   )
+
+  ;; CHECK:      (func $unreachable-if (type $1)
+  ;; CHECK-NEXT:  (block $block
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (br $block)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $unreachable-if
+    ;; Regression test for a problem where blocks were sunk into ifs with
+    ;; unreachable conditions, causing validation errors when the block type was
+    ;; incompatible with the if type.
+    (block $block
+      (if (result i32)
+        (unreachable)
+        (then
+          (i32.const 0)
+        )
+        (else
+          (br $block)
+        )
+      )
+    )
+  )
 )


### PR DESCRIPTION
RemoveUnusedBrs sinks blocks into If arms when those arms contain
branches to the blocks and the other arm and condition do not. Now that
we type Ifs with unreachable conditions as unreachable, it is possible
for the If arms to have a different type than the block that would be
sunk, so sinking the block would produce invalid IR. Fix the problem by
never sinking blocks into Ifs with unreachable conditions.

Fixes #7128.
