### PR TITLE
[NFC] Encapsulate source map reader state

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -26,32 +26,20 @@ namespace wasm::ModuleUtils {
 
 // Update the file name indices when moving a set of debug locations from one
 // module to another.
-static void updateLocationSet(std::set<Function::DebugLocation>& locations,
-                              std::vector<Index>& fileIndexMap) {
-  std::set<Function::DebugLocation> updatedLocations;
-
-  for (auto iter : locations) {
-    iter.fileIndex = fileIndexMap[iter.fileIndex];
-    updatedLocations.insert(iter);
+static void updateLocation(std::optional<Function::DebugLocation>& location,
+                           std::vector<Index>& fileIndexMap) {
+  if (location) {
+    location->fileIndex = fileIndexMap[location->fileIndex];
   }
-  locations.clear();
-  std::swap(locations, updatedLocations);
 }
 
 // Update the symbol name indices when moving a set of debug locations from one
 // module to another.
-static void updateSymbolSet(std::set<Function::DebugLocation>& locations,
-                            std::vector<Index>& symbolIndexMap) {
-  std::set<Function::DebugLocation> updatedLocations;
-
-  for (auto iter : locations) {
-    if (iter.symbolNameIndex) {
-      iter.symbolNameIndex = symbolIndexMap[*iter.symbolNameIndex];
-    }
-    updatedLocations.insert(iter);
+static void updateSymbol(std::optional<Function::DebugLocation>& location,
+                         std::vector<Index>& symbolIndexMap) {
+  if (location && location->symbolNameIndex) {
+    location->symbolNameIndex = symbolIndexMap[*location->symbolNameIndex];
   }
-  locations.clear();
-  std::swap(locations, updatedLocations);
 }
 
 // Copies a function into a module. If newName is provided it is used as the
@@ -94,8 +82,8 @@ copyFunctionWithoutAdd(Function* func,
         iter.second->fileIndex = (*fileIndexMap)[iter.second->fileIndex];
       }
     }
-    updateLocationSet(ret->prologLocation, *fileIndexMap);
-    updateLocationSet(ret->epilogLocation, *fileIndexMap);
+    updateLocation(ret->prologLocation, *fileIndexMap);
+    updateLocation(ret->epilogLocation, *fileIndexMap);
   }
   if (symbolNameIndexMap) {
     for (auto& iter : ret->debugLocations) {
@@ -105,8 +93,8 @@ copyFunctionWithoutAdd(Function* func,
             (*symbolNameIndexMap)[*(iter.second->symbolNameIndex)];
         }
       }
-      updateSymbolSet(ret->prologLocation, *symbolNameIndexMap);
-      updateSymbolSet(ret->epilogLocation, *symbolNameIndexMap);
+      updateSymbol(ret->prologLocation, *symbolNameIndexMap);
+      updateSymbol(ret->epilogLocation, *symbolNameIndexMap);
     }
   }
   ret->module = func->module;

--- a/src/parsing.h
+++ b/src/parsing.h
@@ -43,15 +43,6 @@ struct ParseException {
   void dump(std::ostream& o) const;
 };
 
-struct MapParseException {
-  std::string text;
-
-  MapParseException() : text("unknown parse error") {}
-  MapParseException(std::string text) : text(text) {}
-
-  void dump(std::ostream& o) const;
-};
-
 // Helper for parsers that may not have unique label names. This transforms
 // the names into unique ones, as required by Binaryen IR.
 struct UniqueNameMapper {

--- a/src/passes/DebugLocationPropagation.cpp
+++ b/src/passes/DebugLocationPropagation.cpp
@@ -64,10 +64,10 @@ struct DebugLocationPropagation
         if (auto it = locs.find(previous); it != locs.end()) {
           locs[curr] = it->second;
         }
-      } else if (self->getFunction()->prologLocation.size()) {
+      } else if (self->getFunction()->prologLocation) {
         // Instructions may inherit their locations from the function
         // prolog.
-        locs[curr] = *self->getFunction()->prologLocation.begin();
+        locs[curr] = *self->getFunction()->prologLocation;
       }
     }
     expressionStack.push_back(curr);

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3060,8 +3060,8 @@ void PrintSExpression::visitDefinedFunction(Function* curr) {
   currFunction = curr;
   lastPrintedLocation = std::nullopt;
   lastPrintIndent = 0;
-  if (currFunction->prologLocation.size()) {
-    printDebugLocation(*currFunction->prologLocation.begin());
+  if (currFunction->prologLocation) {
+    printDebugLocation(*currFunction->prologLocation);
   }
   handleSignature(curr, true);
   incIndent();
@@ -3095,14 +3095,14 @@ void PrintSExpression::visitDefinedFunction(Function* curr) {
     }
     assert(controlFlowDepth == 0);
   }
-  if (currFunction->epilogLocation.size()) {
+  if (currFunction->epilogLocation) {
     // Print last debug location: mix of decIndent and printDebugLocation
     // logic.
     doIndent(o, indent);
     if (!minify) {
       indent--;
     }
-    printDebugLocation(*currFunction->epilogLocation.begin());
+    printDebugLocation(*currFunction->epilogLocation);
     o << ')';
   } else {
     decIndent();

--- a/src/source-map.h
+++ b/src/source-map.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_source_map_h
+#define wasm_source_map_h
+
+#include <optional>
+#include <unordered_map>
+
+#include "wasm.h"
+
+namespace wasm {
+
+struct MapParseException {
+  std::string text;
+
+  MapParseException(std::string text) : text(text) {}
+  void dump(std::ostream& o) const;
+};
+
+class SourceMapReader {
+  const std::vector<char>& buffer;
+
+  // Current position in the source map buffer.
+  size_t pos = 0;
+
+  // The location in the binary the next debug location will correspond to. 0
+  // iff there are not more debug locations.
+  size_t location = 0;
+
+  // The file index, line, column, and symbol index the next debug location will
+  // be offset from.
+  uint32_t file = 0;
+  uint32_t line = 1;
+  uint32_t col = 0;
+  uint32_t symbol = 0;
+
+  // Whether the last read record had position and symbol information.
+  bool hasInfo = false;
+  bool hasSymbol = false;
+
+public:
+  SourceMapReader(const std::vector<char>& buffer) : buffer(buffer) {}
+
+  void readHeader(Module& wasm);
+
+  std::optional<Function::DebugLocation>
+  readDebugLocationAt(size_t currLocation);
+
+  // Do not reuse debug info across function boundaries.
+  void finishFunction() { hasInfo = false; }
+
+private:
+  char peek() {
+    if (pos >= buffer.size()) {
+      throw MapParseException("unexpected end of source map");
+    }
+    return buffer[pos];
+  }
+
+  char get() {
+    char c = peek();
+    ++pos;
+    return c;
+  }
+
+  bool maybeGet(char c) {
+    if (pos < buffer.size() && peek() == c) {
+      ++pos;
+      return true;
+    }
+    return false;
+  }
+
+  void expect(char c) {
+    using namespace std::string_literals;
+    char got = get();
+    if (got != c) {
+      throw MapParseException("expected '"s + c + "', got '" + got + "'");
+    }
+  }
+
+  int32_t readBase64VLQ();
+};
+
+} // namespace wasm
+
+#endif // wasm_source_map_h

--- a/src/source-map.h
+++ b/src/source-map.h
@@ -38,7 +38,7 @@ class SourceMapReader {
   size_t pos = 0;
 
   // The location in the binary the next debug location will correspond to. 0
-  // iff there are not more debug locations.
+  // iff there are no more debug locations.
   size_t location = 0;
 
   // The file index, line, column, and symbol index the next debug location will

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -18,6 +18,7 @@
 // wasm2asm console tool
 //
 
+#include "source-map.h"
 #include "support/colors.h"
 #include "support/file.h"
 #include "wasm-io.h"

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1404,6 +1404,8 @@ private:
   void prepare();
 };
 
+extern std::vector<char> defaultEmptySourceMap;
+
 class WasmBinaryReader {
   Module& wasm;
   MixedArena& allocator;
@@ -1432,7 +1434,7 @@ public:
   WasmBinaryReader(Module& wasm,
                    FeatureSet features,
                    const std::vector<char>& input,
-                   const std::vector<char>& sourceMap = {});
+                   const std::vector<char>& sourceMap = defaultEmptySourceMap);
 
   void setDebugInfo(bool value) { debugInfo = value; }
   void setDWARF(bool value) { DWARF = value; }

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -456,8 +456,8 @@ public:
 
   void emit(Expression* curr) { writer.visit(curr); }
   void emitHeader() {
-    if (func->prologLocation.size()) {
-      parent.writeDebugLocation(*func->prologLocation.begin());
+    if (func->prologLocation) {
+      parent.writeDebugLocation(*func->prologLocation);
     }
     writer.mapLocalsAndEmitHeader();
   }
@@ -469,8 +469,8 @@ public:
   void emitFunctionEnd() {
     // Indicate the debug location corresponding to the end opcode
     // that terminates the function code.
-    if (func->epilogLocation.size()) {
-      parent.writeDebugLocation(*func->epilogLocation.begin());
+    if (func->epilogLocation) {
+      parent.writeDebugLocation(*func->epilogLocation);
     } else {
       // The end opcode has no debug location.
       parent.writeNoDebugLocation();

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2095,8 +2095,8 @@ public:
   // One can explicitly set the debug location of an expression to
   // nullopt to stop the propagation of debug locations.
   std::unordered_map<Expression*, std::optional<DebugLocation>> debugLocations;
-  std::set<DebugLocation> prologLocation;
-  std::set<DebugLocation> epilogLocation;
+  std::optional<DebugLocation> prologLocation;
+  std::optional<DebugLocation> epilogLocation;
 
   // General debugging info support: track instructions and the function itself.
   std::unordered_map<Expression*, BinaryLocations::Span> expressionLocations;

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB wasm_HEADERS ../*.h)
 set(wasm_SOURCES
   literal.cpp
   parsing.cpp
+  source-map.cpp
   wasm.cpp
   wasm-binary.cpp
   wasm-debug.cpp

--- a/src/wasm/parsing.cpp
+++ b/src/wasm/parsing.cpp
@@ -36,18 +36,6 @@ void ParseException::dump(std::ostream& o) const {
   Colors::normal(o);
 }
 
-void MapParseException::dump(std::ostream& o) const {
-  Colors::magenta(o);
-  o << "[";
-  Colors::red(o);
-  o << "map parse exception: ";
-  Colors::green(o);
-  o << text;
-  Colors::magenta(o);
-  o << "]";
-  Colors::normal(o);
-}
-
 // UniqueNameMapper
 
 Name UniqueNameMapper::getPrefixedName(Name prefix) {

--- a/src/wasm/source-map.cpp
+++ b/src/wasm/source-map.cpp
@@ -19,6 +19,8 @@
 
 namespace wasm {
 
+std::vector<char> defaultEmptySourceMap;
+
 void MapParseException::dump(std::ostream& o) const {
   Colors::magenta(o);
   o << "[";

--- a/src/wasm/source-map.cpp
+++ b/src/wasm/source-map.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "source-map.h"
+#include "support/colors.h"
+
+namespace wasm {
+
+void MapParseException::dump(std::ostream& o) const {
+  Colors::magenta(o);
+  o << "[";
+  Colors::red(o);
+  o << "map parse exception: ";
+  Colors::green(o);
+  o << text;
+  Colors::magenta(o);
+  o << "]";
+  Colors::normal(o);
+}
+
+void SourceMapReader::readHeader(Module& wasm) {
+  assert(pos == 0);
+  if (buffer.empty()) {
+    return;
+  }
+
+  auto skipWhitespace = [&]() {
+    while (pos < buffer.size() && (buffer[pos] == ' ' || buffer[pos] == '\n')) {
+      ++pos;
+    }
+  };
+
+  auto findField = [&](const char* name) {
+    bool matching = false;
+    size_t len = strlen(name);
+    size_t index = 0;
+    while (1) {
+      char ch = get();
+      if (ch == '\"') {
+        if (matching) {
+          if (index == len) {
+            // We matched a terminating quote.
+            break;
+          }
+          matching = false;
+        } else {
+          // Beginning of a new potential match.
+          matching = true;
+          index = 0;
+        }
+      } else if (matching && name[index] == ch) {
+        ++index;
+      } else if (matching) {
+        matching = false;
+      }
+    }
+    skipWhitespace();
+    expect(':');
+    skipWhitespace();
+    return true;
+  };
+
+  auto readString = [&](std::string& str) {
+    std::vector<char> vec;
+    skipWhitespace();
+    expect('\"');
+    while (1) {
+      if (maybeGet('\"')) {
+        break;
+      }
+      vec.push_back(get());
+    }
+    skipWhitespace();
+    str = std::string(vec.begin(), vec.end());
+  };
+
+  if (!findField("sources")) {
+    throw MapParseException("cannot find the 'sources' field in map");
+  }
+
+  skipWhitespace();
+  expect('[');
+  if (!maybeGet(']')) {
+    do {
+      std::string file;
+      readString(file);
+      wasm.debugInfoFileNames.push_back(file);
+    } while (maybeGet(','));
+    expect(']');
+  }
+
+  if (findField("names")) {
+    skipWhitespace();
+    expect('[');
+    if (!maybeGet(']')) {
+      do {
+        std::string symbol;
+        readString(symbol);
+        wasm.debugInfoSymbolNames.push_back(symbol);
+      } while (maybeGet(','));
+      expect(']');
+    }
+  }
+
+  if (!findField("mappings")) {
+    throw MapParseException("cannot find the 'mappings' field in map");
+  }
+
+  expect('\"');
+  if (maybeGet('\"')) {
+    // There are no mappings.
+    location = 0;
+    return;
+  }
+
+  // Read the location of the first debug location.
+  location = readBase64VLQ();
+}
+
+std::optional<Function::DebugLocation>
+SourceMapReader::readDebugLocationAt(size_t currLocation) {
+  if (pos >= buffer.size()) {
+    return std::nullopt;
+  }
+
+  while (location && location <= currLocation) {
+    do {
+      char next = peek();
+      if (next == ',' || next == '\"') {
+        // This is a 1-length entry, so the next location has no debug info.
+        hasInfo = false;
+        break;
+      }
+
+      hasInfo = true;
+      file += readBase64VLQ();
+      line += readBase64VLQ();
+      col += readBase64VLQ();
+
+      next = peek();
+      if (next == ',' || next == '\"') {
+        hasSymbol = false;
+        break;
+      }
+
+      hasSymbol = true;
+      symbol += readBase64VLQ();
+
+    } while (false);
+
+    // Check whether there is another record to read the position for.
+    char next = get();
+    if (next == '\"') {
+      // End of records.
+      location = 0;
+      break;
+    }
+    if (next != ',') {
+      throw MapParseException("Expected delimiter");
+    }
+
+    // Set up for the next record.
+    location += readBase64VLQ();
+  }
+
+  if (!hasInfo) {
+    return std::nullopt;
+  }
+
+  auto sym = hasSymbol ? symbol : std::optional<uint32_t>{};
+  return Function::DebugLocation{file, line, col, sym};
+}
+
+int32_t SourceMapReader::readBase64VLQ() {
+  uint32_t value = 0;
+  uint32_t shift = 0;
+  while (1) {
+    auto ch = get();
+    if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch < 'g')) {
+      // last number digit
+      uint32_t digit = ch < 'a' ? ch - 'A' : ch - 'a' + 26;
+      value |= digit << shift;
+      break;
+    }
+    if (!(ch >= 'g' && ch <= 'z') && !(ch >= '0' && ch <= '9') && ch != '+' &&
+        ch != '/') {
+      throw MapParseException("invalid VLQ digit");
+    }
+    uint32_t digit =
+      ch > '9' ? ch - 'g' : (ch >= '0' ? ch - '0' + 20 : (ch == '+' ? 30 : 31));
+    value |= digit << shift;
+    shift += 5;
+  }
+  return value & 1 ? -int32_t(value >> 1) : int32_t(value >> 1);
+}
+
+} // namespace wasm

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -709,7 +709,7 @@ Result<> IRBuilder::visitFunctionStart(Function* func) {
     return Err{"unexpected start of function"};
   }
   if (auto* loc = std::get_if<Function::DebugLocation>(&debugLoc)) {
-    func->prologLocation.insert(*loc);
+    func->prologLocation = *loc;
   }
   debugLoc = CanReceiveDebug();
   scopeStack.push_back(ScopeCtx::makeFunc(func));
@@ -975,7 +975,7 @@ Result<> IRBuilder::visitEnd() {
   }
   if (auto* func = scope.getFunction()) {
     if (auto* loc = std::get_if<Function::DebugLocation>(&debugLoc)) {
-      func->epilogLocation.insert(*loc);
+      func->epilogLocation = *loc;
     }
   }
   debugLoc = CanReceiveDebug();

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -3096,8 +3096,8 @@ ModuleStackIR::ModuleStackIR(Module& wasm, const PassOptions& options)
     }) {}
 
 void StackIRToBinaryWriter::write() {
-  if (func->prologLocation.size()) {
-    parent.writeDebugLocation(*func->prologLocation.begin());
+  if (func->prologLocation) {
+    parent.writeDebugLocation(*func->prologLocation);
   }
   writer.mapLocalsAndEmitHeader();
   // Stack to track indices of catches within a try
@@ -3158,8 +3158,8 @@ void StackIRToBinaryWriter::write() {
   }
   // Indicate the debug location corresponding to the end opcode that
   // terminates the function code.
-  if (func->epilogLocation.size()) {
-    parent.writeDebugLocation(*func->epilogLocation.begin());
+  if (func->epilogLocation) {
+    parent.writeDebugLocation(*func->epilogLocation);
   } else {
     // The end opcode has no debug location.
     parent.writeNoDebugLocation();

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1503,8 +1503,8 @@ void Function::clearNames() { localNames.clear(); }
 void Function::clearDebugInfo() {
   localIndices.clear();
   debugLocations.clear();
-  prologLocation.clear();
-  epilogLocation.clear();
+  prologLocation.reset();
+  epilogLocation.reset();
 }
 
 template<typename Map>

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -3,7 +3,7 @@ include_directories(../../src/wasm)
 
 set(unittest_SOURCES
   arena.cpp
-  binary-reader.cpp
+  source-map.cpp
   cfg.cpp
   dfa_minimization.cpp
   disjoint_sets.cpp


### PR DESCRIPTION
Move all state relevant to reading source maps out of WasmBinaryReader
and into a new utility, SourceMapReader. This is a prerequisite for
parallelizing the parsing of function bodies, since the source map
reader state is different at the beginning of each function.

Also take the opportunity to simplify the way we read source maps, for
example by deferring the reading of anything but the position of a debug
location until it will be used and by using `std::optional` instead of
singleton `std::set`s to store function prologue and epilogue debug
locations.
