### PR TITLE
Parallelize the binary parsing of function bodies

### DIFF
--- a/src/pass.h
+++ b/src/pass.h
@@ -452,7 +452,7 @@ public:
   // This method is used to create instances per function for a
   // function-parallel pass. You may need to override this if you subclass a
   // Walker, as otherwise this will create the parent class.
-  virtual std::unique_ptr<Pass> create() { WASM_UNREACHABLE("unimplenented"); }
+  virtual std::unique_ptr<Pass> create() { WASM_UNREACHABLE("unimplemented"); }
 
   // Whether this pass modifies the Binaryen IR in the module. This is true for
   // most passes, except for passes that have no side effects, or passes that

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1524,16 +1524,15 @@ public:
   std::unordered_map<Index, Name> dataNames;
   std::unordered_map<Index, Name> elemNames;
 
-  Function* currFunction = nullptr;
-  // before we see a function (like global init expressions), there is no end of
-  // function to check
-  Index endOfFunction = -1;
-
   void readFunctions(size_t& pos);
-  void readVars(size_t& pos);
-  void setLocalNames(Function& func, Index i);
+  void readVars(size_t& pos, Function* func);
+  void setLocalNames(Function* func, Index i);
 
-  Result<> readInst(size_t& pos);
+  Result<>
+  readInst(size_t& pos, IRBuilder& builder, SourceMapReader& sourceMapReader);
+  Result<> readInst(size_t& pos) {
+    return readInst(pos, builder, sourceMapReader);
+  }
 
   void readExports(size_t& pos);
 

--- a/test/lit/binary/debug-bad-binary.test
+++ b/test/lit/binary/debug-bad-binary.test
@@ -38,4 +38,9 @@ RUN: not wasm-opt --debug %s.wasm 2>&1 | filecheck %s
 ;; CHECK-NEXT:    (i32.const 10)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (func $2
+;; CHECK-NEXT:   (drop
+;; CHECK-NEXT:    (i32.const 30)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )


### PR DESCRIPTION
After a linear scan through the code section and input source map to
find the start locations corresponding to each function body, parse the
locals and instructions for each function in parallel.

This speeds up binary parsing with a sourcemap by about 20% with 8 cores
on my machine, but only by about 2% with all 128 cores, so this
parallelization has potential but suffers from scaling overhead[^1].

When running a full -O3 optimization pipeline, the parallel parsing
slightly reduces the number of minor page faults, presumably by better
allocating the original instructions in separate thread-local arenas. It
also slightly reduces the max RSS, but these improvements do not
translate into better overall performance. In fact, overall performance
is slightly lower with this change (at least on my machine.)

[^1]: FWIW the full -O3 pipeline also performs significantly better with
8 cores than with 128 cores on my machine.
