### PR TITLE
[NFC] Send the closed-world flag to TranslateToFuzzReader

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -225,10 +225,12 @@ def randomize_fuzz_settings():
         # optimizations we use to create any other wasm file.
         FUZZ_OPTS += ['--dce']
 
-    # Enclose the world much of the time when fuzzing closed-world, so that many
-    # types are private and hence optimizable.
-    if CLOSED_WORLD and random.random() < 0.5:
-        GEN_ARGS += ['--enclose-world']
+    if CLOSED_WORLD:
+        GEN_ARGS += [CLOSED_WORLD_FLAG]
+        # Enclose the world much of the time when fuzzing closed-world, so that
+        # many types are private and hence optimizable.
+        if random.random() < 0.5:
+            GEN_ARGS += ['--enclose-world']
 
     print('randomized settings (NaNs, OOB, legalize):', NANS, OOB, LEGALIZE)
 

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -65,8 +65,12 @@ struct BinaryArgs {
 
 class TranslateToFuzzReader {
 public:
-  TranslateToFuzzReader(Module& wasm, std::vector<char>&& input);
-  TranslateToFuzzReader(Module& wasm, std::string& filename);
+  TranslateToFuzzReader(Module& wasm,
+                        std::vector<char>&& input,
+                        bool closedWorld = false);
+  TranslateToFuzzReader(Module& wasm,
+                        std::string& filename,
+                        bool closedWorld = false);
 
   void pickPasses(OptimizationOptions& options);
   void setAllowMemory(bool allowMemory_) { allowMemory = allowMemory_; }
@@ -77,6 +81,8 @@ public:
   Module& wasm;
 
 private:
+  // Whether the module will be tested in a closed-world environment.
+  bool closedWorld;
   Builder builder;
   Random random;
 

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -303,7 +303,8 @@ int main(int argc, const char* argv[]) {
     }
   }
   if (translateToFuzz) {
-    TranslateToFuzzReader reader(wasm, options.extra["infile"]);
+    TranslateToFuzzReader reader(
+      wasm, options.extra["infile"], options.passOptions.closedWorld);
     if (fuzzPasses) {
       reader.pickPasses(options);
     }


### PR DESCRIPTION
This sends `--closed-world` to `wasm-opt` from the fuzzer, when we use that
flag (before we just used it on optimizations, but not fuzz generation). And
TranslateToFuzzReader now stores a boolean about whether we are in closed-
world mode or not.

This has no effect so far, but will be needed in a later PR, where we must
generate code differently based on whether we are in closed-world mode
or not.