### PR TITLE
[GC] Fix TypeRefining on StructGets without content but with a reachable ref

### DIFF
--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -271,7 +271,7 @@ struct TypeRefining : public Pass {
         }
 
         Type newFieldType;
-        if (curr->ref->type.isNull()) {
+        if (!curr->ref->type.isNull()) {
           auto oldType = curr->ref->type.getHeapType();
           newFieldType = parent.finalInfos[oldType][curr->index].getLUB();
         }

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -58,11 +58,13 @@ struct FieldInfoScanner
 
   void
   noteDefault(Type fieldType, HeapType type, Index index, FieldInfo& info) {
-    // Default values do not affect what the heap type of a field can be turned
-    // into. Note them, however, as they force us to keep the type nullable.
+    // Default values must be noted, so that we know there is content there.
     if (fieldType.isRef()) {
-      info.note(Type(fieldType.getHeapType().getBottom(), Nullable));
+      // All we need to note here is nullability (the field must remain
+      // nullable), but not anything else about the type.
+      fieldType = Type(fieldType.getHeapType().getBottom(), Nullable);
     }
+    info.note(fieldType);
   }
 
   void noteCopy(HeapType type, Index index, FieldInfo& info) {

--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -276,8 +276,7 @@ struct TypeRefining : public Pass {
           newFieldType = parent.finalInfos[oldType][curr->index].getLUB();
         }
 
-        if (curr->ref->type.isNull() ||
-            newFieldType == Type::unreachable ||
+        if (curr->ref->type.isNull() || newFieldType == Type::unreachable ||
             !Type::isSubType(newFieldType, curr->type)) {
           // This get will trap, or cannot be reached: either the ref is null,
           // or the field is never written any contents, or the contents we see

--- a/test/lit/passes/gto_and_cfp_in_O.wast
+++ b/test/lit/passes/gto_and_cfp_in_O.wast
@@ -50,7 +50,7 @@
   ;; CHECK:      (export "main" (func $main))
 
   ;; CHECK:      (func $main (type $0) (result i32)
-  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT:  (i32.const 100)
   ;; CHECK-NEXT: )
   ;; OPEN_WORLD:      (func $main (type $2) (result i32)
   ;; OPEN_WORLD-NEXT:  (struct.get $struct 1

--- a/test/lit/passes/gto_and_cfp_in_O.wast
+++ b/test/lit/passes/gto_and_cfp_in_O.wast
@@ -50,7 +50,7 @@
   ;; CHECK:      (export "main" (func $main))
 
   ;; CHECK:      (func $main (type $0) (result i32)
-  ;; CHECK-NEXT:  (i32.const 100)
+  ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
   ;; OPEN_WORLD:      (func $main (type $2) (result i32)
   ;; OPEN_WORLD-NEXT:  (struct.get $struct 1

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -26,8 +26,11 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.get $struct 2
-  ;; CHECK-NEXT:    (local.get $struct)
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $struct)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -432,8 +435,11 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $struct 0
   ;; CHECK-NEXT:   (local.get $struct)
-  ;; CHECK-NEXT:   (struct.get $struct 0
-  ;; CHECK-NEXT:    (local.get $struct)
+  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.get $struct)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -969,12 +975,18 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new $A
-  ;; CHECK-NEXT:    (local.tee $a
-  ;; CHECK-NEXT:     (struct.get $A 0
-  ;; CHECK-NEXT:      (local.get $A)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $a
+  ;; CHECK-NEXT:      (block
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (local.get $A)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -1017,12 +1029,13 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $A 0
   ;; CHECK-NEXT:   (local.get $A)
-  ;; CHECK-NEXT:   (if (result (ref $A))
+  ;; CHECK-NEXT:   (if
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (then
-  ;; CHECK-NEXT:     (struct.get $A 0
+  ;; CHECK-NEXT:     (drop
   ;; CHECK-NEXT:      (local.get $A)
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (else
   ;; CHECK-NEXT:     (unreachable)
@@ -1030,18 +1043,22 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (struct.new $A
-  ;; CHECK-NEXT:    (if (result (ref $A))
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:     (then
-  ;; CHECK-NEXT:      (struct.get $A 0
-  ;; CHECK-NEXT:       (local.get $A)
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (if
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:      (then
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (local.get $A)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (else
+  ;; CHECK-NEXT:       (unreachable)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (else
-  ;; CHECK-NEXT:      (unreachable)
-  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -1099,7 +1116,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $struct 0
   ;; CHECK-NEXT:   (local.get $struct)
-  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
+  ;; CHECK-NEXT:   (block
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (ref.null none)
@@ -1147,14 +1164,23 @@
   ;; CHECK:       (type $2 (func (result (ref $A))))
 
   ;; CHECK:      (func $0 (type $2) (result (ref $A))
-  ;; CHECK-NEXT:  (struct.new $A
-  ;; CHECK-NEXT:   (ref.cast (ref $B)
-  ;; CHECK-NEXT:    (struct.get $A 0
-  ;; CHECK-NEXT:     (struct.new $A
-  ;; CHECK-NEXT:      (struct.new_default $B)
+  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (block ;; (replaces unreachable RefCast we can't emit)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (block
+  ;; CHECK-NEXT:       (drop
+  ;; CHECK-NEXT:        (struct.new $A
+  ;; CHECK-NEXT:         (struct.new_default $B)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $0 (result (ref $A))
@@ -1193,10 +1219,13 @@
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (block
+  ;; CHECK-NEXT:      (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (struct.get $B 0
-  ;; CHECK-NEXT:         (struct.new_default $B)
+  ;; CHECK-NEXT:        (block
+  ;; CHECK-NEXT:         (drop
+  ;; CHECK-NEXT:          (struct.new_default $B)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:         (unreachable)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (unreachable)
@@ -1257,13 +1286,14 @@
   ;; CHECK-NEXT:   (ref.cast (ref noextern)
   ;; CHECK-NEXT:    (try (result externref)
   ;; CHECK-NEXT:     (do
-  ;; CHECK-NEXT:      (struct.get $A 0
+  ;; CHECK-NEXT:      (drop
   ;; CHECK-NEXT:       (struct.new $A
   ;; CHECK-NEXT:        (ref.as_non_null
   ;; CHECK-NEXT:         (ref.null noextern)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (catch $tag
   ;; CHECK-NEXT:      (local.get $extern)
@@ -1309,13 +1339,14 @@
   ;; CHECK-NEXT:   (ref.cast (ref noextern)
   ;; CHECK-NEXT:    (try (result externref)
   ;; CHECK-NEXT:     (do
-  ;; CHECK-NEXT:      (struct.get $A 0
+  ;; CHECK-NEXT:      (drop
   ;; CHECK-NEXT:       (struct.new $A
   ;; CHECK-NEXT:        (ref.as_non_null
   ;; CHECK-NEXT:         (ref.null noextern)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (catch $tag
   ;; CHECK-NEXT:      (local.get $extern)
@@ -1554,10 +1585,13 @@
  ;; CHECK:      (func $1 (type $3) (result (ref null $8))
  ;; CHECK-NEXT:  (local $l (ref $9))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (struct.get $5 0
- ;; CHECK-NEXT:    (struct.new $5
- ;; CHECK-NEXT:     (ref.func $1)
+ ;; CHECK-NEXT:   (block
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (struct.new $5
+ ;; CHECK-NEXT:      (ref.func $1)
+ ;; CHECK-NEXT:     )
  ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (ref.null nofunc)
@@ -1572,5 +1606,72 @@
    )
   )
   (ref.null $8)
+ )
+)
+
+;; Test for a bug where we made a struct.get unreachable because it was reading
+;; a field that had no writes, but in a situation where it is invalid for the
+;; struct.get to be unreachable.
+(module
+ ;; CHECK:      (type $never (sub (struct (field i32))))
+ (type $never (sub (struct (field i32))))
+
+ ;; CHECK:      (rec
+ ;; CHECK-NEXT:  (type $optimizable (struct (field (mut nullfuncref))))
+ (type $optimizable (struct (field (mut (ref null func)))))
+
+ ;; CHECK:       (type $2 (func))
+
+ ;; CHECK:      (type $3 (func (result (ref $never))))
+
+ ;; CHECK:      (export "export" (func $export))
+
+ ;; CHECK:      (func $setup (type $2)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (struct.new $optimizable
+ ;; CHECK-NEXT:    (ref.null nofunc)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (block
+ ;; CHECK-NEXT:    (drop
+ ;; CHECK-NEXT:     (block (result (ref none))
+ ;; CHECK-NEXT:      (ref.as_non_null
+ ;; CHECK-NEXT:       (ref.null none)
+ ;; CHECK-NEXT:      )
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $setup
+  ;; A struct.new, so that we have a field to refine.
+  (drop
+   (struct.new $optimizable
+    (ref.null func)
+   )
+  )
+  ;; A struct.get that reads a $never, but the actual fallthrough value is none.
+  ;; We never create this type, so the field has no possible content, and we can
+  ;; replace this with an unreachable.
+  (drop
+   (struct.get $never 0
+    (block (result (ref $never))
+     (ref.as_non_null
+      (ref.null none)
+     )
+    )
+   )
+  )
+ )
+
+ ;; CHECK:      (func $export (type $3) (result (ref $never))
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
+ (func $export (export "export") (result (ref $never))
+  ;; Make the type $never public (if it were private, we'd optimize in a
+  ;; different way that avoids the bug that this tests for).
+  (unreachable)
  )
 )

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -1588,9 +1588,14 @@
 
  ;; CHECK:       (type $2 (func))
 
- ;; CHECK:      (type $3 (func (result (ref $never))))
+ ;; CHECK:      (global $never (ref null $never) (ref.null none))
+ (global $never (export "never") (ref null $never)
+   ;; Make the type $never public (if it were private, we'd optimize in a
+   ;; different way that avoids the bug that this tests for).
+   (ref.null $never)
+ )
 
- ;; CHECK:      (export "export" (func $export))
+ ;; CHECK:      (export "never" (global $never))
 
  ;; CHECK:      (func $setup (type $2)
  ;; CHECK-NEXT:  (drop
@@ -1612,7 +1617,8 @@
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
  (func $setup
-  ;; A struct.new, so that we have a field to refine.
+  ;; A struct.new, so that we have a field to refine (which avoids the pass
+  ;; early-exiting).
   (drop
    (struct.new $optimizable
     (ref.null func)
@@ -1630,14 +1636,5 @@
     )
    )
   )
- )
-
- ;; CHECK:      (func $export (type $3) (result (ref $never))
- ;; CHECK-NEXT:  (unreachable)
- ;; CHECK-NEXT: )
- (func $export (export "export") (result (ref $never))
-  ;; Make the type $never public (if it were private, we'd optimize in a
-  ;; different way that avoids the bug that this tests for).
-  (unreachable)
  )
 )

--- a/test/lit/passes/type-refining.wast
+++ b/test/lit/passes/type-refining.wast
@@ -26,11 +26,8 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $struct)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   (struct.get $struct 2
+  ;; CHECK-NEXT:    (local.get $struct)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -435,11 +432,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $struct 0
   ;; CHECK-NEXT:   (local.get $struct)
-  ;; CHECK-NEXT:   (block
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.get $struct)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   (struct.get $struct 0
+  ;; CHECK-NEXT:    (local.get $struct)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -975,18 +969,12 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (local.tee $a
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (local.get $A)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:    (local.tee $a
+  ;; CHECK-NEXT:     (struct.get $A 0
+  ;; CHECK-NEXT:      (local.get $A)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -1029,13 +1017,12 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $A 0
   ;; CHECK-NEXT:   (local.get $A)
-  ;; CHECK-NEXT:   (if
+  ;; CHECK-NEXT:   (if (result (ref $A))
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:    (then
-  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:     (struct.get $A 0
   ;; CHECK-NEXT:      (local.get $A)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (else
   ;; CHECK-NEXT:     (unreachable)
@@ -1043,22 +1030,18 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructNew we can't emit)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (if
-  ;; CHECK-NEXT:      (i32.const 1)
-  ;; CHECK-NEXT:      (then
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (local.get $A)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (else
-  ;; CHECK-NEXT:       (unreachable)
+  ;; CHECK-NEXT:   (struct.new $A
+  ;; CHECK-NEXT:    (if (result (ref $A))
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:     (then
+  ;; CHECK-NEXT:      (struct.get $A 0
+  ;; CHECK-NEXT:       (local.get $A)
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (else
+  ;; CHECK-NEXT:      (unreachable)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -1116,7 +1099,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (struct.set $struct 0
   ;; CHECK-NEXT:   (local.get $struct)
-  ;; CHECK-NEXT:   (block
+  ;; CHECK-NEXT:   (block ;; (replaces unreachable StructGet we can't emit)
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (ref.null none)
@@ -1164,23 +1147,14 @@
   ;; CHECK:       (type $2 (func (result (ref $A))))
 
   ;; CHECK:      (func $0 (type $2) (result (ref $A))
-  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (block ;; (replaces unreachable RefCast we can't emit)
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (block
-  ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (struct.new $A
-  ;; CHECK-NEXT:         (struct.new_default $B)
-  ;; CHECK-NEXT:        )
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (unreachable)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:  (struct.new $A
+  ;; CHECK-NEXT:   (ref.cast (ref $B)
+  ;; CHECK-NEXT:    (struct.get $A 0
+  ;; CHECK-NEXT:     (struct.new $A
+  ;; CHECK-NEXT:      (struct.new_default $B)
   ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (unreachable)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (unreachable)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $0 (result (ref $A))
@@ -1219,13 +1193,10 @@
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (block ;; (replaces unreachable StructNew we can't emit)
   ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (block ;; (replaces unreachable StructGet we can't emit)
+  ;; CHECK-NEXT:      (block
   ;; CHECK-NEXT:       (drop
-  ;; CHECK-NEXT:        (block
-  ;; CHECK-NEXT:         (drop
-  ;; CHECK-NEXT:          (struct.new_default $B)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:         (unreachable)
+  ;; CHECK-NEXT:        (struct.get $B 0
+  ;; CHECK-NEXT:         (struct.new_default $B)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:       (unreachable)
@@ -1286,14 +1257,13 @@
   ;; CHECK-NEXT:   (ref.cast (ref noextern)
   ;; CHECK-NEXT:    (try (result externref)
   ;; CHECK-NEXT:     (do
-  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:      (struct.get $A 0
   ;; CHECK-NEXT:       (struct.new $A
   ;; CHECK-NEXT:        (ref.as_non_null
   ;; CHECK-NEXT:         (ref.null noextern)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (catch $tag
   ;; CHECK-NEXT:      (local.get $extern)
@@ -1339,14 +1309,13 @@
   ;; CHECK-NEXT:   (ref.cast (ref noextern)
   ;; CHECK-NEXT:    (try (result externref)
   ;; CHECK-NEXT:     (do
-  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:      (struct.get $A 0
   ;; CHECK-NEXT:       (struct.new $A
   ;; CHECK-NEXT:        (ref.as_non_null
   ;; CHECK-NEXT:         (ref.null noextern)
   ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (catch $tag
   ;; CHECK-NEXT:      (local.get $extern)
@@ -1585,13 +1554,10 @@
  ;; CHECK:      (func $1 (type $3) (result (ref null $8))
  ;; CHECK-NEXT:  (local $l (ref $9))
  ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (block
- ;; CHECK-NEXT:    (drop
- ;; CHECK-NEXT:     (struct.new $5
- ;; CHECK-NEXT:      (ref.func $1)
- ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:   (struct.get $5 0
+ ;; CHECK-NEXT:    (struct.new $5
+ ;; CHECK-NEXT:     (ref.func $1)
  ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:    (unreachable)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT:  (ref.null nofunc)


### PR DESCRIPTION
If we see a StructGet with no content (the type it reads from has no writes)
then we can make it unreachable. The old code literally just changed the type
to unreachable, which would later work out with refinalization - but only if
the StructGet's ref was unreachable. But it is possible for this situation to
occur without that, and if so, this hit the validation error "can't have an
unreachable node without an unreachable child".

To fix this, merge all code paths that handle "impossible" situations, which
simplifies things, and add this situation.