### PR TITLE
Remove incorrect warning when reading name section

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4730,11 +4730,6 @@ void WasmBinaryReader::findAndReadNames() {
       auto numTypes = getU32LEB();
       for (size_t i = 0; i < numTypes; i++) {
         auto typeIndex = getU32LEB();
-        bool validType =
-          typeIndex < types.size() && types[typeIndex].isStruct();
-        if (!validType) {
-          std::cerr << "warning: invalid field index in name field section\n";
-        }
         auto numFields = getU32LEB();
         NameProcessor processor;
         for (size_t i = 0; i < numFields; i++) {


### PR DESCRIPTION
When we refactored how the name section is read, we accidentally left an
old warning about invalid field name indices in place. The old warning
code compares the type index from the names section to the size of the
parsed type vector to determine if the index is out-of-bounds. Now that
we parse the name section before the type section, this is no longer
correct. Delete the old warning; we already have a new, correct warning
for out-of-bound indices when we parse the type section.
