### PR TITLE
[NFC] Simplify TypeGraphWalker in wasm-type.cpp

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -400,7 +400,6 @@ template<typename Self> struct HeapTypeChildWalker : TypeGraphWalkerBase<Self> {
 
 private:
   bool isTopLevel = true;
-  std::unordered_set<HeapType> seen;
 };
 
 struct HeapTypeChildCollector : HeapTypeChildWalker<HeapTypeChildCollector> {


### PR DESCRIPTION
Co-locate the declaration and implementation of TypeGraphWalkerBase and
its subtypes in wasm-type.cpp and simplify the implementation. Remove
the preVisit and postVisit tasks for both Types and HeapTypes since
overriding scanType and scanHeapType is sufficient for all users. Stop
scanning the HeapTypes in reference types because a follow-on change
(#7142) will make that much more complicated, and it turns out that it
is not necessary.
