### PR TITLE
Fuzz combinations of two modules

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1727,8 +1727,10 @@ class Two(TestCaseHandler):
 
     def can_run_on_wasm(self, wasm):
         # We cannot optimize wasm files we are going to link in closed world
-        # mode. We also cannot run shared-everything code in d8 yet.
-        return not CLOSED_WORLD and all_disallowed(['shared-everything'])
+        # mode. We also cannot run shared-everything code in d8 yet. We also
+        # cannot compare if there are NaNs (as optimizations can lead to
+        # different outputs)
+        return not CLOSED_WORLD and all_disallowed(['shared-everything']) and not NANS
 
 
 # The global list of all test case handlers

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1623,8 +1623,8 @@ class Two(TestCaseHandler):
 
     def can_run_on_wasm(self, wasm):
         # We cannot optimize wasm files we are going to link in closed world
-        # mode.
-        return not CLOSED_WORLD
+        # mode. We also cannot run shared-everything code in d8 yet.
+        return not CLOSED_WORLD and all_disallowed(['shared-everything'])
 
 
 # Check that the text format round-trips without error.

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1595,6 +1595,11 @@ class Two(TestCaseHandler):
         # from JS using fuzz_shell.js's support for two files.
         output = run_d8_wasm(wasm, args=[second_wasm])
 
+        if output == IGNORE:
+            # There is no point to continue since we can't compare this output
+            # to anything.
+            return
+
         # Make sure that fuzz_shell.js actually executed all exports from both
         # wasm files.
         exports = get_exports(wasm, ['func']) + get_exports(second_wasm, ['func'])

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1597,10 +1597,10 @@ class Two(TestCaseHandler):
 
         # Make sure that fuzz_shell.js actually executed all exports from both
         # wasm files.
-        num_exports = get_exports(wasm, ['func']) + get_exports(second_wasm, ['func'])
-        assert output.count(FUZZ_EXEC_CALL_PREFIX) == num_exports
+        exports = get_exports(wasm, ['func']) + get_exports(second_wasm, ['func'])
+        assert output.count(FUZZ_EXEC_CALL_PREFIX) == len(exports)
 
-        # ???we compare a vm to itself??? output = fix_output(output)
+        output = fix_output(output)
 
         # Optimize at least one of the two.
         # TODO: Use other optimizations here. See comment in Split().
@@ -1617,7 +1617,7 @@ class Two(TestCaseHandler):
 
         # Run again, and compare the output
         optimized_output = run_d8_wasm(wasms[0], args=[wasms[1]])
-        # ??? optimized_output = fix_output(optimized_output)
+        optimized_output = fix_output(optimized_output)
 
         compare(output, optimized_output, 'Two')
 
@@ -1720,18 +1720,7 @@ class ClusterFuzz(TestCaseHandler):
 
 # The global list of all test case handlers
 testcase_handlers = [
-    FuzzExec(),
-    CompareVMs(),
-    CheckDeterminism(),
-    Wasm2JS(),
-    TrapsNeverHappen(),
-    CtorEval(),
-    Merge(),
     Two(),
-    # TODO: enable when stable enough, and adjust |frequency| (see above)
-    # Split(),
-    RoundtripText(),
-    ClusterFuzz(),
 ]
 
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1477,7 +1477,9 @@ class Merge(TestCaseHandler):
 FUNC_NAMES_REGEX = re.compile(r'\n [(]func [$](\S+)')
 
 
-# Tests wasm-split
+# Tests wasm-split. This also tests that fuzz_shell.js properly executes 2 wasm
+# files, which adds coverage for ClusterFuzz (which sometimes runs two wasm
+# files in that way).
 class Split(TestCaseHandler):
     frequency = 1  # TODO: adjust lower when we actually enable this
 
@@ -1671,9 +1673,8 @@ class ClusterFuzz(TestCaseHandler):
 
 
 # Tests linking two wasm files at runtime, and that optimizations do not break
-# anything. This also tests that fuzz_shell.js properly executes two wasm
-# files, which adds coverage for ClusterFuzz (which sometimes runs two wasm
-# files in that way).
+# anything. This is similar to Split(), but rather than split a wasm file into
+# two and link them at runtime, this starts with two separate wasm files
 class Two(TestCaseHandler):
     frequency = 1 # XXX
 
@@ -1714,15 +1715,12 @@ class Two(TestCaseHandler):
         output = fix_output(output)
 
         # Optimize at least one of the two.
-        # TODO: Use other optimizations here. See comment in Split().
-        opts = ['-O3']
-
         wasms = [wasm, second_wasm]
-
         for i in range(random.randint(1, 2)):
             wasm_index = random.randint(0, 1)
             name = wasms[wasm_index]
             new_name = name + f'.opt{i}.wasm'
+            opts = get_random_opts()
             run([in_bin('wasm-opt'), name, '-o', new_name] + opts + FEATURE_OPTS)
             wasms[wasm_index] = new_name
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1683,6 +1683,7 @@ class Two(TestCaseHandler):
         second_wasm = abspath('second.wasm')
         given = os.environ.get('BINARYEN_SECOND_WASM')
         if given:
+            # TODO: should we de-nan this etc. as with the primary?
             shutil.copyfile(given, second_wasm)
         else:
             second_input = abspath('second_input.dat')

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1741,6 +1741,17 @@ class Two(TestCaseHandler):
 
 # The global list of all test case handlers
 testcase_handlers = [
+    FuzzExec(),
+    CompareVMs(),
+    CheckDeterminism(),
+    Wasm2JS(),
+    TrapsNeverHappen(),
+    CtorEval(),
+    Merge(),
+    # TODO: enable when stable enough, and adjust |frequency| (see above)
+    # Split(),
+    RoundtripText(),
+    ClusterFuzz(),
     Two(),
 ]
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1694,6 +1694,12 @@ class Two(TestCaseHandler):
 
         # The binaryen interpreter only supports a single file, so we run them
         # from JS using fuzz_shell.js's support for two files.
+        #
+        # Note that we *cannot* run each wasm file separately and compare those
+        # to the combined output, as fuzz_shell.js intentionally allows calls
+        # *between* the wasm files, through JS APIs like call-export*. So all we
+        # do here is see the combined, linked behavior, and then later below we
+        # see that that behavior remains even after optimizations.
         output = run_d8_wasm(wasm, args=[second_wasm])
 
         if output == IGNORE:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1360,7 +1360,7 @@ class TrapsNeverHappen(TestCaseHandler):
 
 # Tests wasm-ctor-eval
 class CtorEval(TestCaseHandler):
-    frequency = 0.2
+    frequency = 0.1
 
     def handle(self, wasm):
         # get the expected execution results.
@@ -1674,9 +1674,9 @@ class ClusterFuzz(TestCaseHandler):
 
 # Tests linking two wasm files at runtime, and that optimizations do not break
 # anything. This is similar to Split(), but rather than split a wasm file into
-# two and link them at runtime, this starts with two separate wasm files
+# two and link them at runtime, this starts with two separate wasm files.
 class Two(TestCaseHandler):
-    frequency = 1 # XXX
+    frequency = 0.2
 
     def handle(self, wasm):
         # Generate a second wasm file, unless we were given one (useful during
@@ -1734,7 +1734,7 @@ class Two(TestCaseHandler):
         # We cannot optimize wasm files we are going to link in closed world
         # mode. We also cannot run shared-everything code in d8 yet. We also
         # cannot compare if there are NaNs (as optimizations can lead to
-        # different outputs)
+        # different outputs).
         return not CLOSED_WORLD and all_disallowed(['shared-everything']) and not NANS
 
 

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1702,9 +1702,9 @@ class Two(TestCaseHandler):
             return
 
         if output.strip() == 'exception thrown: failed to instantiate module':
-            # We may fail to instantiate the module for reasonable reasons, such
-            # as an active segment being out of bounds. There is no point to
-            # continue in such cases.
+            # We may fail to instantiate the modules for valid reasons, such as
+            # an active segment being out of bounds. There is no point to
+            # continue in such cases, as no exports are called.
             return
 
         # Make sure that fuzz_shell.js actually executed all exports from both


### PR DESCRIPTION
The new `Two` fuzz testcase handler generates two wasm files and
then runs them in V8, linking them using JS. It then optimizes at least one of
the two and runs it again, and checks for differences.

This is similar to the `Split` fuzzer for `wasm-split`, but the two wasm files
are arbitrary and not the result of splitting.

Also lower CtorEval priority a little. It is not very important.