### PR TITLE
[Outlining] Remove overlapping sequences

### DIFF
--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -281,7 +281,7 @@ struct Outlining : public Pass {
     // Remove substrings that are substrings of longer repeat substrings.
     substrings = StringifyProcessor::dedupe(substrings);
     // Remove substrings with overlapping indices
-    substrings = StringifyProcessor::removeOverlaps(substrings);
+    substrings = StringifyProcessor::filterOverlaps(substrings);
     // Remove substrings with branch and return instructions until an analysis
     // is performed to see if the intended destination of the branch is included
     // in the substring to be outlined.

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -280,6 +280,8 @@ struct Outlining : public Pass {
     DBG(printHashString(stringify.hashString, stringify.exprs));
     // Remove substrings that are substrings of longer repeat substrings.
     substrings = StringifyProcessor::dedupe(substrings);
+    // Remove substrings with overlapping indices
+    substrings = StringifyProcessor::removeOverlaps(substrings);
     // Remove substrings with branch and return instructions until an analysis
     // is performed to see if the intended destination of the branch is included
     // in the substring to be outlined.

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -280,7 +280,7 @@ struct Outlining : public Pass {
     DBG(printHashString(stringify.hashString, stringify.exprs));
     // Remove substrings that are substrings of longer repeat substrings.
     substrings = StringifyProcessor::dedupe(substrings);
-    // Remove substrings with overlapping indices
+    // Remove substrings with overlapping indices.
     substrings = StringifyProcessor::filterOverlaps(substrings);
     // Remove substrings with branch and return instructions until an analysis
     // is performed to see if the intended destination of the branch is included

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -150,7 +150,6 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
 
 std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   const std::vector<SuffixTree::RepeatedSubstring>& substrings) {
-  std::unordered_map<Interval, unsigned> intervalMap;
   std::vector<Interval> intervals;
   std::vector<int> substringIdxs;
 
@@ -164,27 +163,21 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
                  startIdx + substring.Length - 1,
                  substring.Length * substring.StartIndices.size());
       intervals.push_back(interval);
-      intervalMap[std::move(interval)] = i;
       substringIdxs.push_back(i);
     }
   }
 
   // Get the overlapping intervals
-  std::set<Interval> overlaps = IntervalProcessor::getOverlaps(intervals);
-  std::set<unsigned> doNotInclude;
-  for (auto& interval : overlaps) {
-    doNotInclude.insert(intervalMap[interval]);
-  }
-
-  // Add the substrings that don't overlap to the result
   std::vector<SuffixTree::RepeatedSubstring> result;
-  for (Index i = 0; i < substrings.size(); i++) {
-    if (doNotInclude.find(i) != doNotInclude.end()) {
+  std::unordered_set<unsigned> substringsIncluded;
+  std::vector<int> indices = IntervalProcessor::filterOverlaps(intervals);
+  for (auto i : indices) {
+    auto substringIdx = substringIdxs[i];
+    if (substringsIncluded.find(substringIdx) != substringsIncluded.end()) {
       continue;
     }
-
-    auto substring = substrings[i];
-    result.push_back(substring);
+    substringsIncluded.insert(substringIdx);
+    result.push_back(substrings[substringIdx]);
   }
 
   return result;

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -160,7 +160,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
       // TODO: This weight was picked with an assumption
       auto interval =
         Interval(startIdx,
-                 startIdx + substring.Length - 1,
+                 startIdx + substring.Length,
                  substring.Length * substring.StartIndices.size());
       intervals.push_back(interval);
       substringIdxs.push_back(i);
@@ -172,6 +172,9 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   std::unordered_set<unsigned> substringsIncluded;
   std::vector<int> indices = IntervalProcessor::filterOverlaps(intervals);
   for (auto i : indices) {
+    // i is the idx of the Interval in the intervals vector
+    // i in substringIdxs returns the idx of the substring that needs to be
+    // included in result
     auto substringIdx = substringIdxs[i];
     if (substringsIncluded.find(substringIdx) != substringsIncluded.end()) {
       continue;

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -163,7 +163,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
     auto& substring = substrings[i];
     for (auto startIdx : substring.StartIndices) {
       intervals.emplace_back(
-          startIdx, startIdx + substring.Length, substring.Length);
+        startIdx, startIdx + substring.Length, substring.Length);
       substringIdxs.push_back(i);
     }
   }

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -157,7 +157,9 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   for (Index i = 0; i < substrings.size(); i++) {
     auto substring = substrings[i];
     for (auto startIdx : substring.StartIndices) {
-      // TODO: This weight was picked with an assumption
+      // The weight, third parameter to the Interval constructor, was picked
+      // with the assumption that it is more worthwhile to outline substrings
+      // that are the longest and have the most occurrences.
       auto interval =
         Interval(startIdx,
                  startIdx + substring.Length,
@@ -170,14 +172,18 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   // Get the overlapping intervals
   std::vector<SuffixTree::RepeatedSubstring> result;
   std::unordered_set<unsigned> substringsIncluded;
+  std::vector<Index> seenCount(substrings.size(), 0);
   std::vector<int> indices = IntervalProcessor::filterOverlaps(intervals);
   for (auto i : indices) {
     // i is the idx of the Interval in the intervals vector
     // i in substringIdxs returns the idx of the substring that needs to be
     // included in result
     auto substringIdx = substringIdxs[i];
-    if (substringsIncluded.insert(substringIdx).second) {
-      result.push_back(substrings[substringIdx]);
+    seenCount[substringIdx] += 1;
+    auto& substring = substrings[substringIdx];
+    if (seenCount[substringIdx] == substring.StartIndices.size() &&
+        substringsIncluded.insert(substringIdx).second) {
+      result.push_back(substring);
     }
   }
 

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -162,7 +162,8 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   for (Index i = 0; i < substrings.size(); i++) {
     auto& substring = substrings[i];
     for (auto startIdx : substring.StartIndices) {
-      intervals.emplace_back(startIdx, startIdx + substring.Length, substring.Length);
+      intervals.emplace_back(
+          startIdx, startIdx + substring.Length, substring.Length);
       substringIdxs.push_back(i);
     }
   }

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -148,21 +148,24 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
   return result;
 }
 
-std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::removeOverlaps(
+std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   const std::vector<SuffixTree::RepeatedSubstring>& substrings) {
-  std::vector<Interval> intervals;
   std::unordered_map<Interval, unsigned> intervalMap;
+  std::vector<Interval> intervals;
+  std::vector<int> substringIdxs;
 
   // Construct intervals
   for (Index i = 0; i < substrings.size(); i++) {
     auto substring = substrings[i];
     for (auto startIdx : substring.StartIndices) {
+      // TODO: This weight was picked with an assumption
       auto interval =
         Interval(startIdx,
                  startIdx + substring.Length - 1,
                  substring.Length * substring.StartIndices.size());
       intervals.push_back(interval);
       intervalMap[std::move(interval)] = i;
+      substringIdxs.push_back(i);
     }
   }
 

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -153,8 +153,8 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   // A substring represents a contiguous set of instructions that appear more
   // than once in a Wasm binary. For each appearance of the substring, an
   // Interval is created that lacks a connection back to its originating
-  // substring. To fix, upon Interval creation, a second vector is populated with
-  // the index of the corresponding substring.
+  // substring. To fix, upon Interval creation, a second vector is populated
+  // with the index of the corresponding substring.
   std::vector<Interval> intervals;
   std::vector<int> substringIdxs;
 

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -176,11 +176,9 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
     // i in substringIdxs returns the idx of the substring that needs to be
     // included in result
     auto substringIdx = substringIdxs[i];
-    if (substringsIncluded.find(substringIdx) != substringsIncluded.end()) {
-      continue;
+    if (substringsIncluded.insert(substringIdx).second) {
+      result.push_back(substrings[substringIdx]);
     }
-    substringsIncluded.insert(substringIdx);
-    result.push_back(substrings[substringIdx]);
   }
 
   return result;

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -150,9 +150,11 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::dedupe(
 
 std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   const std::vector<SuffixTree::RepeatedSubstring>& substrings) {
-  // Substring has a 1 to many relationship with Interval, i.e., 1 substring is
-  // represented by n intervals. Each interval represents an occurrence of when
-  // the substring repeats.
+  // A substring represents a contiguous set of instructions that appear more
+  // than once in a Wasm binary. For each appearance of the substring, an
+  // Interval is created that lacks a connection back to its originating
+  // substring. To fix, upon Interval creation, a second vector is populated with
+  // the index of the corresponding substring.
   std::vector<Interval> intervals;
   std::vector<int> substringIdxs;
 

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -159,7 +159,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::removeOverlaps(
     for (auto startIdx : substring.StartIndices) {
       auto interval =
         Interval(startIdx,
-                 startIdx + substring.Length,
+                 startIdx + substring.Length - 1,
                  substring.Length * substring.StartIndices.size());
       intervals.push_back(interval);
       intervalMap[std::move(interval)] = i;
@@ -173,7 +173,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::removeOverlaps(
     doNotInclude.insert(intervalMap[interval]);
   }
 
-  // Only include non-overlapping substrings
+  // Add the substrings that don't overlap to the result
   std::vector<SuffixTree::RepeatedSubstring> result;
   for (Index i = 0; i < substrings.size(); i++) {
     if (doNotInclude.find(i) != doNotInclude.end()) {

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -162,9 +162,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   for (Index i = 0; i < substrings.size(); i++) {
     auto& substring = substrings[i];
     for (auto startIdx : substring.StartIndices) {
-      auto interval =
-        Interval(startIdx, startIdx + substring.Length, substring.Length);
-      intervals.push_back(interval);
+      intervals.emplace_back(startIdx, startIdx + substring.Length, substring.Length);
       substringIdxs.push_back(i);
     }
   }
@@ -182,7 +180,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
   }
   for (Index i = 0; i < startIndices.size(); i++) {
     if (startIndices[i].size() > 1) {
-      result.push_back(SuffixTree::RepeatedSubstring(
+      result.emplace_back(SuffixTree::RepeatedSubstring(
         {substrings[i].Length, std::move(startIndices[i])}));
     }
   }

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -160,7 +160,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filterOverlaps(
 
   // Construct intervals
   for (Index i = 0; i < substrings.size(); i++) {
-    auto substring = substrings[i];
+    auto& substring = substrings[i];
     for (auto startIdx : substring.StartIndices) {
       auto interval =
         Interval(startIdx, startIdx + substring.Length, substring.Length);

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -265,7 +265,7 @@ using Substrings = std::vector<SuffixTree::RepeatedSubstring>;
 struct StringifyProcessor {
   static Substrings repeatSubstrings(std::vector<uint32_t>& hashString);
   static Substrings dedupe(const Substrings& substrings);
-  static Substrings removeOverlaps(const Substrings& substrings);
+  static Substrings filterOverlaps(const Substrings& substrings);
   // Filter is the general purpose function backing subsequent filter functions.
   // It can be used directly, but generally prefer a wrapper function
   // to encapsulate your condition and make it available for tests.

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -21,6 +21,7 @@
 #include "ir/module-utils.h"
 #include "ir/stack-utils.h"
 #include "ir/utils.h"
+#include "support/intervals.h"
 #include "support/suffix_tree.h"
 #include "wasm-ir-builder.h"
 #include "wasm-traversal.h"
@@ -264,6 +265,7 @@ using Substrings = std::vector<SuffixTree::RepeatedSubstring>;
 struct StringifyProcessor {
   static Substrings repeatSubstrings(std::vector<uint32_t>& hashString);
   static Substrings dedupe(const Substrings& substrings);
+  static Substrings removeOverlaps(const Substrings& substrings);
   // Filter is the general purpose function backing subsequent filter functions.
   // It can be used directly, but generally prefer a wrapper function
   // to encapsulate your condition and make it available for tests.

--- a/src/support/CMakeLists.txt
+++ b/src/support/CMakeLists.txt
@@ -7,6 +7,7 @@ set(support_SOURCES
   debug.cpp
   dfa_minimization.cpp
   file.cpp
+  intervals.cpp
   istring.cpp
   json.cpp
   name.cpp

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -24,26 +24,37 @@ using namespace wasm;
 
 std::set<Interval>
 IntervalProcessor::getOverlaps(std::vector<Interval>& intervals) {
-  std::sort(intervals.begin(), intervals.end(), [](Interval a, Interval b) {
-    return a.start < b.end;
-  });
+  std::vector<std::tuple<Interval, int>> intIntervals;
+  for (Index i = 0; i < intervals.size(); i++) {
+    auto& interval = intervals[i];
+    intIntervals.push_back(std::make_tuple(interval, i));
+  }
+
+  std::sort(
+    intIntervals.begin(), intIntervals.end(), [](const auto& a, const auto& b) {
+      return std::get<0>(a).start < std::get<0>(b).end;
+    });
+
+  if (intervals.size() == 0) {
+    return std::set<Interval>();
+  }
 
   std::set<Interval> overlaps;
-  auto& firstInterval = intervals[0];
+  auto& firstInterval = intIntervals[0];
   // Look for overlapping intervals
   for (Index i = 1; i < intervals.size(); i++) {
-    auto& nextInterval = intervals[i];
-    if (firstInterval.end < nextInterval.start) {
+    auto& nextInterval = intIntervals[i];
+    if (std::get<0>(firstInterval).end < std::get<0>(nextInterval).start) {
       firstInterval = nextInterval;
       continue;
     }
 
     // Keep the interval with the higher weight
-    if (nextInterval.weight > firstInterval.weight) {
-      overlaps.insert(firstInterval);
+    if (std::get<0>(nextInterval).weight > std::get<0>(firstInterval).weight) {
+      overlaps.insert(std::get<0>(firstInterval));
       firstInterval = nextInterval;
     } else {
-      overlaps.insert(nextInterval);
+      overlaps.insert(std::get<0>(nextInterval));
     }
   }
 

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -22,8 +22,12 @@
 
 using namespace wasm;
 
-std::set<Interval>
-IntervalProcessor::getOverlaps(std::vector<Interval>& intervals) {
+std::vector<int>
+IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
+  if (intervals.size() == 0) {
+    return std::vector<int>();
+  }
+
   std::vector<std::tuple<Interval, int>> intIntervals;
   for (Index i = 0; i < intervals.size(); i++) {
     auto& interval = intervals[i];
@@ -35,28 +39,25 @@ IntervalProcessor::getOverlaps(std::vector<Interval>& intervals) {
       return std::get<0>(a).start < std::get<0>(b).end;
     });
 
-  if (intervals.size() == 0) {
-    return std::set<Interval>();
-  }
-
-  std::set<Interval> overlaps;
+  std::vector<int> result;
   auto& firstInterval = intIntervals[0];
   // Look for overlapping intervals
   for (Index i = 1; i < intervals.size(); i++) {
     auto& nextInterval = intIntervals[i];
     if (std::get<0>(firstInterval).end < std::get<0>(nextInterval).start) {
+      result.push_back(std::get<1>(firstInterval));
       firstInterval = nextInterval;
       continue;
     }
 
     // Keep the interval with the higher weight
     if (std::get<0>(nextInterval).weight > std::get<0>(firstInterval).weight) {
-      overlaps.insert(std::get<0>(firstInterval));
+      result.push_back(std::get<1>(nextInterval));
       firstInterval = nextInterval;
     } else {
-      overlaps.insert(std::get<0>(nextInterval));
+      result.push_back(std::get<1>(firstInterval));
     }
   }
 
-  return overlaps;
+  return result;
 }

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -19,8 +19,6 @@
 #include "intervals.h"
 #include "support/index.h"
 #include <algorithm>
-#include <iostream>
-#include <optional>
 
 using namespace wasm;
 
@@ -47,8 +45,7 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
       continue;
     }
 
-    // former overlaps with candidate
-    // replace former if the weights are the same but the candidate ends earlier
+    // Former overlaps with candidate. Replace former if the weights are the same but the candidate ends earlier.
     if (former.first.weight == candidate.first.weight &&
         former.first.end > candidate.first.end) {
       former = candidate;

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -28,15 +28,15 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
     return std::vector<int>();
   }
 
-  std::vector<std::tuple<Interval, int>> intIntervals;
+  std::vector<std::pair<Interval, int>> intIntervals;
   for (Index i = 0; i < intervals.size(); i++) {
     auto& interval = intervals[i];
-    intIntervals.push_back(std::make_tuple(interval, i));
+    intIntervals.push_back({interval, i});
   }
 
   std::sort(
     intIntervals.begin(), intIntervals.end(), [](const auto& a, const auto& b) {
-      return std::get<0>(a).start < std::get<0>(b).end;
+      return a.first.start < b.first.end;
     });
 
   std::vector<int> result;
@@ -44,18 +44,18 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
   // Look for overlapping intervals
   for (Index i = 1; i < intervals.size(); i++) {
     auto& nextInterval = intIntervals[i];
-    if (std::get<0>(firstInterval).end < std::get<0>(nextInterval).start) {
-      result.push_back(std::get<1>(firstInterval));
+    if (firstInterval.first.end < nextInterval.first.start) {
+      result.push_back(firstInterval.second);
       firstInterval = nextInterval;
       continue;
     }
 
     // Keep the interval with the higher weight
-    if (std::get<0>(nextInterval).weight > std::get<0>(firstInterval).weight) {
-      result.push_back(std::get<1>(nextInterval));
+    if (nextInterval.first.weight > firstInterval.first.weight) {
+      result.push_back(nextInterval.second);
       firstInterval = nextInterval;
     } else {
-      result.push_back(std::get<1>(firstInterval));
+      result.push_back(firstInterval.second);
     }
   }
 

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -41,19 +41,21 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
     });
 
   std::vector<int> result;
-  auto& formerInterval = intIntervals[0];
+  Index formerInterval = 0;
   // Look for overlapping intervals
-  for (Index i = 1; i <= intIntervals.size(); i++) {
-    auto& latterInterval = intIntervals[i];
-    if (i == intIntervals.size() ||
-        formerInterval.first.end <= latterInterval.first.start) {
-      result.push_back(formerInterval.second);
+  for (Index latterInterval = 1; latterInterval <= intIntervals.size();
+       latterInterval++) {
+    if (latterInterval == intIntervals.size() ||
+        intIntervals[formerInterval].first.end <=
+          intIntervals[latterInterval].first.start) {
+      result.push_back(intIntervals[formerInterval].second);
       formerInterval = latterInterval;
       continue;
     }
 
     // Keep the interval with the higher weight
-    if (latterInterval.first.weight > formerInterval.first.weight) {
+    if (intIntervals[latterInterval].first.weight >
+        intIntervals[formerInterval].first.weight) {
       formerInterval = latterInterval;
     }
   }

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -45,7 +45,9 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
       continue;
     }
 
-    // Former overlaps with candidate. Replace former if the weights are the same but the candidate ends earlier.
+    // When two intervals overlap with the same weight, prefer to keep the
+    // interval that ends sooner under the presumption that it will overlap with
+    // fewer subsequent intervals.
     if (former.first.weight == candidate.first.weight &&
         former.first.end > candidate.first.end) {
       former = candidate;

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -38,7 +38,7 @@ IntervalProcessor::getOverlaps(std::vector<Interval>& intervals) {
       continue;
     }
 
-    // Keep the interval with the higher score
+    // Keep the interval with the higher weight
     if (nextInterval.weight > firstInterval.weight) {
       overlaps.insert(firstInterval);
       firstInterval = nextInterval;

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -19,6 +19,7 @@
 #include "intervals.h"
 #include "support/index.h"
 #include <algorithm>
+#include <iostream>
 
 using namespace wasm;
 
@@ -36,26 +37,24 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
 
   std::sort(
     intIntervals.begin(), intIntervals.end(), [](const auto& a, const auto& b) {
-      return a.first.start < b.first.end;
+      return a.first.start < b.first.start;
     });
 
   std::vector<int> result;
-  auto& firstInterval = intIntervals[0];
+  auto& formerInterval = intIntervals[0];
   // Look for overlapping intervals
-  for (Index i = 1; i < intervals.size(); i++) {
-    auto& nextInterval = intIntervals[i];
-    if (firstInterval.first.end < nextInterval.first.start) {
-      result.push_back(firstInterval.second);
-      firstInterval = nextInterval;
+  for (Index i = 1; i <= intIntervals.size(); i++) {
+    auto& latterInterval = intIntervals[i];
+    if (i == intIntervals.size() ||
+        formerInterval.first.end <= latterInterval.first.start) {
+      result.push_back(formerInterval.second);
+      formerInterval = latterInterval;
       continue;
     }
 
     // Keep the interval with the higher weight
-    if (nextInterval.first.weight > firstInterval.first.weight) {
-      result.push_back(nextInterval.second);
-      firstInterval = nextInterval;
-    } else {
-      result.push_back(firstInterval.second);
+    if (latterInterval.first.weight > formerInterval.first.weight) {
+      formerInterval = latterInterval;
     }
   }
 

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -36,8 +36,7 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
     intIntervals.push_back({interval, i});
   }
 
-  std::sort(
-    intIntervals.begin(), intIntervals.end());
+  std::sort(intIntervals.begin(), intIntervals.end());
 
   std::vector<std::pair<Interval, int>> kept;
   kept.push_back(intIntervals[0]);
@@ -50,7 +49,8 @@ IntervalProcessor::filterOverlaps(std::vector<Interval>& intervals) {
 
     // former overlaps with candidate
     // replace former if the weights are the same but the candidate ends earlier
-    if (former.first.weight == candidate.first.weight && former.first.end > candidate.first.end) {
+    if (former.first.weight == candidate.first.weight &&
+        former.first.end > candidate.first.end) {
       former = candidate;
     } else if (former.first.weight < candidate.first.weight) {
       former = candidate;

--- a/src/support/intervals.cpp
+++ b/src/support/intervals.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+
+#include "intervals.h"
+#include "support/index.h"
+#include <algorithm>
+
+using namespace wasm;
+
+std::set<Interval>
+IntervalProcessor::getOverlaps(std::vector<Interval>& intervals) {
+  std::sort(intervals.begin(), intervals.end(), [](Interval a, Interval b) {
+    return a.start < b.end;
+  });
+
+  std::set<Interval> overlaps;
+  auto& firstInterval = intervals[0];
+  // Look for overlapping intervals
+  for (Index i = 1; i < intervals.size(); i++) {
+    auto& nextInterval = intervals[i];
+    if (firstInterval.end < nextInterval.start) {
+      firstInterval = nextInterval;
+      continue;
+    }
+
+    // Keep the interval with the higher score
+    if (nextInterval.weight > firstInterval.weight) {
+      overlaps.insert(firstInterval);
+      firstInterval = nextInterval;
+    } else {
+      overlaps.insert(nextInterval);
+    }
+  }
+
+  return overlaps;
+}

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -43,9 +43,9 @@ struct Interval {
 };
 
 struct IntervalProcessor {
-  // TODO: Given a vector of Interval, returns a vector of the indices, mapping back
-  // to the original input vector, of non-overlapping indices, ie, the intervals
-  // that overlap have already been removed.
+  // TODO: Given a vector of Interval, returns a vector of the indices, mapping
+  // back to the original input vector, of non-overlapping indices, ie, the
+  // intervals that overlap have already been removed.
   static std::vector<int> filterOverlaps(std::vector<Interval>&);
 };
 

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Helpers for handling a generic range of values
+
+#ifndef wasm_support_intervals_h
+#define wasm_support_intervals_h
+
+#include <set>
+#include <vector>
+
+namespace wasm {
+
+// The weight determines the value of the
+// interval when comparing against another interval, higher is better.
+struct Interval {
+  unsigned start;
+  unsigned end;
+  unsigned weight;
+  Interval(unsigned start, unsigned end, unsigned weight)
+    : start(start), end(end), weight(weight) {}
+
+  bool operator<(const Interval& other) const {
+    return start < other.start && weight < other.weight;
+  }
+
+  bool operator==(const Interval& other) const {
+    return start == other.start && end == other.end && weight == other.weight;
+  }
+};
+
+struct IntervalProcessor {
+  // Given a vector of intervals, returns a new vector. To resolve overlapping
+  // intervals, the interval with the highest weight is kept.
+  static std::set<Interval> getOverlaps(std::vector<Interval>&);
+};
+
+} // namespace wasm
+
+namespace std {
+
+template<> struct hash<wasm::Interval> {
+  size_t operator()(const wasm::Interval& i) const {
+    return std::hash<unsigned>{}(i.start) + std::hash<unsigned>{}(i.end) +
+           std::hash<unsigned>{}(i.weight);
+  }
+};
+
+} // namespace std
+
+#endif // wasm_suport_intervals

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -43,9 +43,9 @@ struct Interval {
 };
 
 struct IntervalProcessor {
-  // TODO: Given a vector of Interval, returns a vector of the indices, mapping
-  // back to the original input vector, of non-overlapping indices, ie, the
-  // intervals that overlap have already been removed.
+  // Given a vector of Interval, returns a vector of the indices that, mapping
+  // back to the original input vector, do not overlap with each other, ie: the
+  // interval indexes with overlapping interval indexes already removed.
   static std::vector<int> filterOverlaps(std::vector<Interval>&);
 };
 

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -34,15 +34,9 @@ struct Interval {
     : start(start), end(end), weight(weight) {}
 
   bool operator<(const Interval& other) const {
-    /*return weight != other.weight ? weight < other.weight
-             : end != other.end ? end < other.end
-             : start < other.start;*/
-    /*return end != other.end ? end < other.end
-             : weight != other.weight ? weight < other.weight
-             : start < other.start;*/
-    return start != other.start ? start < other.start
-             : weight != other.weight ? weight < other.weight
-             : end < other.end;
+    return start != other.start     ? start < other.start
+           : weight != other.weight ? weight < other.weight
+                                    : end < other.end;
   }
 
   bool operator==(const Interval& other) const {

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -43,20 +43,12 @@ struct Interval {
 };
 
 struct IntervalProcessor {
-  static std::set<Interval> getOverlaps(std::vector<Interval>&);
+  // TODO: Given a vector of Interval, returns a vector of the indices, mapping back
+  // to the original input vector, of non-overlapping indices, ie, the intervals
+  // that overlap have already been removed.
+  static std::vector<int> filterOverlaps(std::vector<Interval>&);
 };
 
 } // namespace wasm
-
-namespace std {
-
-template<> struct hash<wasm::Interval> {
-  size_t operator()(const wasm::Interval& i) const {
-    return std::hash<unsigned>{}(i.start) + std::hash<unsigned>{}(i.end) +
-           std::hash<unsigned>{}(i.weight);
-  }
-};
-
-} // namespace std
 
 #endif // wasm_suport_intervals

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -46,7 +46,7 @@ struct Interval {
 
 struct IntervalProcessor {
   // Given a vector of Interval, returns a vector of the indices that, mapping
-  // back to the original input vector, do not overlap with each other, ie: the
+  // back to the original input vector, do not overlap with each other, i.e. the
   // interval indexes with overlapping interval indexes already removed.
   static std::vector<int> filterOverlaps(std::vector<Interval>&);
 };

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -24,11 +24,11 @@
 
 namespace wasm {
 
-// The weight determines the value of the
-// interval when comparing against another interval, higher is better.
 struct Interval {
   unsigned start;
   unsigned end;
+  // The weight is used to determine which interval to keep when two overlap,
+  // higher is better
   unsigned weight;
   Interval(unsigned start, unsigned end, unsigned weight)
     : start(start), end(end), weight(weight) {}
@@ -43,8 +43,6 @@ struct Interval {
 };
 
 struct IntervalProcessor {
-  // Given a vector of intervals, returns a new vector. To resolve overlapping
-  // intervals, the interval with the highest weight is kept.
   static std::set<Interval> getOverlaps(std::vector<Interval>&);
 };
 

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -37,9 +37,12 @@ struct Interval {
     /*return weight != other.weight ? weight < other.weight
              : end != other.end ? end < other.end
              : start < other.start;*/
-    return end != other.end ? end < other.end
+    /*return end != other.end ? end < other.end
              : weight != other.weight ? weight < other.weight
-             : start < other.start;
+             : start < other.start;*/
+    return start != other.start ? start < other.start
+             : weight != other.weight ? weight < other.weight
+             : end < other.end;
   }
 
   bool operator==(const Interval& other) const {

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -34,7 +34,12 @@ struct Interval {
     : start(start), end(end), weight(weight) {}
 
   bool operator<(const Interval& other) const {
-    return start < other.start && end < other.end && weight < other.weight;
+    /*return weight != other.weight ? weight < other.weight
+             : end != other.end ? end < other.end
+             : start < other.start;*/
+    return end != other.end ? end < other.end
+             : weight != other.weight ? weight < other.weight
+             : start < other.start;
   }
 
   bool operator==(const Interval& other) const {

--- a/src/support/intervals.h
+++ b/src/support/intervals.h
@@ -34,7 +34,7 @@ struct Interval {
     : start(start), end(end), weight(weight) {}
 
   bool operator<(const Interval& other) const {
-    return start < other.start && weight < other.weight;
+    return start < other.start && end < other.end && weight < other.weight;
   }
 
   bool operator==(const Interval& other) const {

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -8,6 +8,7 @@ set(unittest_SOURCES
   dfa_minimization.cpp
   disjoint_sets.cpp
   interpreter.cpp
+  intervals.cpp
   json.cpp
   lattices.cpp
   local-graph.cpp

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -8,7 +8,8 @@ TEST(IntervalsTest, TestNoOverlapFound) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 4, 2});
   intervals.emplace_back(Interval{4, 8, 2});
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 2u);
+  std::vector<int> expected{0, 1};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapFound) {
@@ -16,16 +17,19 @@ TEST(IntervalsTest, TestOverlapFound) {
   intervals.emplace_back(Interval{0, 2, 5});
   intervals.emplace_back(Interval{1, 4, 10});
   intervals.emplace_back(Interval{4, 5, 15});
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 2u);
+  std::vector<int> expected{1, 2};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestEmpty) {
   std::vector<Interval> intervals;
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 0u);
+  std::vector<int> expected;
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOne) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 2, 5});
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 1u);
+  std::vector<int> expected{0};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -76,10 +76,10 @@ TEST(IntervalsTest, TestOverlapRandomSequence) {
 
 TEST(IntervalsTest, TestOverlapInnerNested) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(0, 2, 3);
+  intervals.emplace_back(0, 12, 3);
   intervals.emplace_back(2, 4, 2);
   intervals.emplace_back(3, 6, 5);
-  intervals.emplace_back(6, 15, 4);
+  intervals.emplace_back(12, 15, 4);
   std::vector<int> expected{0, 2, 3};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -12,84 +12,84 @@ TEST(IntervalsTest, TestEmpty) {
 
 TEST(IntervalsTest, TestOne) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 2, 5});
+  intervals.emplace_back(0, 2, 5);
   std::vector<int> expected{0};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestNoOverlapFound) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 4, 2});
-  intervals.emplace_back(Interval{4, 8, 2});
+  intervals.emplace_back(0, 4, 2);
+  intervals.emplace_back(4, 8, 2);
   std::vector<int> expected{0, 1};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapFound) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 2, 5});
-  intervals.emplace_back(Interval{1, 4, 10});
-  intervals.emplace_back(Interval{4, 5, 15});
+  intervals.emplace_back(0, 2, 5);
+  intervals.emplace_back(1, 4, 10);
+  intervals.emplace_back(4, 5, 15);
   std::vector<int> expected{1, 2};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapAscendingSequence) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 3, 6});
-  intervals.emplace_back(Interval{2, 6, 2});
-  intervals.emplace_back(Interval{3, 15, 5});
-  intervals.emplace_back(Interval{4, 11, 1});
-  intervals.emplace_back(Interval{6, 20, 15});
-  intervals.emplace_back(Interval{12, 18, 3});
-  intervals.emplace_back(Interval{14, 21, 5});
-  intervals.emplace_back(Interval{23, 28, 5});
-  std::vector<int> expected{4, 3, 7};
+  intervals.emplace_back(0, 3, 6);
+  intervals.emplace_back(2, 6, 2);
+  intervals.emplace_back(3, 15, 5);
+  intervals.emplace_back(4, 11, 1);
+  intervals.emplace_back(6, 20, 15);
+  intervals.emplace_back(12, 18, 3);
+  intervals.emplace_back(14, 21, 5);
+  intervals.emplace_back(23, 28, 5);
+  std::vector<int> expected{0, 4, 7};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapDescendingSequence) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{9, 15, 5});
-  intervals.emplace_back(Interval{8, 11, 1});
-  intervals.emplace_back(Interval{3, 15, 5});
-  intervals.emplace_back(Interval{3, 6, 2});
-  intervals.emplace_back(Interval{2, 10, 3});
-  intervals.emplace_back(Interval{0, 3, 6});
+  intervals.emplace_back(9, 15, 5);
+  intervals.emplace_back(8, 11, 1);
+  intervals.emplace_back(3, 15, 5);
+  intervals.emplace_back(3, 6, 2);
+  intervals.emplace_back(2, 10, 3);
+  intervals.emplace_back(0, 3, 6);
   std::vector<int> expected{5, 2};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapRandomSequence) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{21, 24, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{11, 18, 1});
-  intervals.emplace_back(Interval{28, 35, 1});
-  intervals.emplace_back(Interval{5, 11, 1});
-  intervals.emplace_back(Interval{18, 21, 1});
-  intervals.emplace_back(Interval{35, 40, 1});
-  intervals.emplace_back(Interval{24, 28, 1});
+  intervals.emplace_back(21, 24, 1);
+  intervals.emplace_back(0, 5, 1);
+  intervals.emplace_back(11, 18, 1);
+  intervals.emplace_back(28, 35, 1);
+  intervals.emplace_back(5, 11, 1);
+  intervals.emplace_back(18, 21, 1);
+  intervals.emplace_back(35, 40, 1);
+  intervals.emplace_back(24, 28, 1);
   std::vector<int> expected{1, 4, 2, 5, 0, 7, 3, 6};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapInnerNested) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 2, 3});
-  intervals.emplace_back(Interval{2, 4, 2});
-  intervals.emplace_back(Interval{3, 6, 5});
-  intervals.emplace_back(Interval{6, 15, 4});
+  intervals.emplace_back(0, 2, 3);
+  intervals.emplace_back(2, 4, 2);
+  intervals.emplace_back(3, 6, 5);
+  intervals.emplace_back(6, 15, 4);
   std::vector<int> expected{0, 2, 3};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
 TEST(IntervalsTest, TestOverlapOuterNested) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 3, 6});
-  intervals.emplace_back(Interval{4, 11, 1});
-  intervals.emplace_back(Interval{12, 18, 3});
-  intervals.emplace_back(Interval{2, 15, 6});
+  intervals.emplace_back(0, 3, 6);
+  intervals.emplace_back(4, 11, 1);
+  intervals.emplace_back(12, 18, 3);
+  intervals.emplace_back(2, 15, 6);
   std::vector<int> expected{0, 1, 2};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -1,0 +1,31 @@
+#include "support/intervals.h"
+#include "ir/utils.h"
+#include "gtest/gtest.h"
+
+using namespace wasm;
+
+TEST(IntervalsTest, TestNoOverlapFound) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 4, 2});
+  intervals.emplace_back(Interval{4, 8, 2});
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 2u);
+}
+
+TEST(IntervalsTest, TestOverlapFound) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 2, 5});
+  intervals.emplace_back(Interval{1, 4, 10});
+  intervals.emplace_back(Interval{4, 5, 15});
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 2u);
+}
+
+TEST(IntervalsTest, TestEmpty) {
+  std::vector<Interval> intervals;
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 0u);
+}
+
+TEST(IntervalsTest, TestOne) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 2, 5});
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals).size(), 1u);
+}

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -80,7 +80,7 @@ TEST(IntervalsTest, TestOverlapInnerNested) {
   intervals.emplace_back(2, 4, 2);
   intervals.emplace_back(3, 6, 5);
   intervals.emplace_back(12, 15, 4);
-  std::vector<int> expected{0, 2, 3};
+  std::vector<int> expected{2, 3};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -34,54 +34,33 @@ TEST(IntervalsTest, TestOverlapFound) {
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFoundA) {
-  std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 2, 1});
-  intervals.emplace_back(Interval{1, 4, 1});
-  intervals.emplace_back(Interval{4, 6, 1});
-  intervals.emplace_back(Interval{4, 5, 1});
-  std::vector<int> expected{0, 3};
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
-}
-
-TEST(IntervalsTest, TestOverlapFoundB) {
-  std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 3, 4});
-  intervals.emplace_back(Interval{3, 6, 2});
-  intervals.emplace_back(Interval{6, 10, 3});
-  intervals.emplace_back(Interval{8, 11, 1});
-  intervals.emplace_back(Interval{7, 15, 5});
-  std::vector<int> expected{0, 1, 4};
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
-}
-
-TEST(IntervalsTest, TestOverlapFoundC) {
+TEST(IntervalsTest, TestOverlapAscendingSequence) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 3, 6});
-  intervals.emplace_back(Interval{3, 6, 2});
-  intervals.emplace_back(Interval{2, 10, 3});
-  intervals.emplace_back(Interval{8, 11, 1});
-  intervals.emplace_back(Interval{9, 15, 5});
-  intervals.emplace_back(Interval{3, 15, 5});
-  std::vector<int> expected{0, 5};
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
-}
-
-TEST(IntervalsTest, TestOverlapFoundD) {
-  std::vector<Interval> intervals;
   intervals.emplace_back(Interval{2, 6, 2});
-  intervals.emplace_back(Interval{12, 18, 3});
+  intervals.emplace_back(Interval{3, 15, 5});
   intervals.emplace_back(Interval{4, 11, 1});
   intervals.emplace_back(Interval{6, 20, 15});
-  intervals.emplace_back(Interval{0, 3, 6});
-  intervals.emplace_back(Interval{3, 15, 5});
+  intervals.emplace_back(Interval{12, 18, 3});
   intervals.emplace_back(Interval{14, 21, 5});
   intervals.emplace_back(Interval{23, 28, 5});
   std::vector<int> expected{4, 3, 7};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFoundE) {
+TEST(IntervalsTest, TestOverlapDescendingSequence) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{9, 15, 5});
+  intervals.emplace_back(Interval{8, 11, 1});
+  intervals.emplace_back(Interval{3, 15, 5});
+  intervals.emplace_back(Interval{3, 6, 2});
+  intervals.emplace_back(Interval{2, 10, 3});
+  intervals.emplace_back(Interval{0, 3, 6});
+  std::vector<int> expected{5, 2};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapRandomSequence) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{21, 24, 1});
   intervals.emplace_back(Interval{0, 5, 1});
@@ -95,27 +74,22 @@ TEST(IntervalsTest, TestOverlapFoundE) {
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFoundF) {
+TEST(IntervalsTest, TestOverlapInnerNested) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 5, 10});
-  intervals.emplace_back(Interval{5, 11, 100});
-  intervals.emplace_back(Interval{11, 18, 5});
-  intervals.emplace_back(Interval{18, 21, 8});
-  intervals.emplace_back(Interval{21, 24, 2});
-  intervals.emplace_back(Interval{24, 28, 4});
-  intervals.emplace_back(Interval{28, 35, 6});
-  intervals.emplace_back(Interval{35, 40, 7});
-  std::vector<int> expected{0, 1, 2, 3, 4, 5, 6, 7};
+  intervals.emplace_back(Interval{0, 2, 3});
+  intervals.emplace_back(Interval{2, 4, 2});
+  intervals.emplace_back(Interval{3, 6, 5});
+  intervals.emplace_back(Interval{6, 15, 4});
+  std::vector<int> expected{0, 2, 3};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFoundG) {
+TEST(IntervalsTest, TestOverlapOuterNested) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
-  std::vector<int> expected{0};
+  intervals.emplace_back(Interval{0, 3, 6});
+  intervals.emplace_back(Interval{4, 11, 1});
+  intervals.emplace_back(Interval{12, 18, 3});
+  intervals.emplace_back(Interval{2, 15, 6});
+  std::vector<int> expected{0, 1, 2};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -71,7 +71,7 @@ TEST(IntervalsTest, TestOverlapFound4) {
   intervals.emplace_back(Interval{6, 10, 3});
   intervals.emplace_back(Interval{8, 11, 1});
   intervals.emplace_back(Interval{7, 15, 5});
-  std::vector<int> expected{1, 2};
+  std::vector<int> expected{};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
@@ -83,7 +83,7 @@ TEST(IntervalsTest, TestOverlapFound5) {
   intervals.emplace_back(Interval{8, 11, 1});
   intervals.emplace_back(Interval{9, 15, 5});
   intervals.emplace_back(Interval{3, 15, 5});
-  std::vector<int> expected{1, 2};
+  std::vector<int> expected{};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
@@ -97,6 +97,48 @@ TEST(IntervalsTest, TestOverlapFound6) {
   intervals.emplace_back(Interval{3, 15, 5});
   intervals.emplace_back(Interval{14, 21, 5});
   intervals.emplace_back(Interval{23, 28, 5});
-  std::vector<int> expected{1, 2};
+  std::vector<int> expected{};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound7) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{5, 11, 1});
+  intervals.emplace_back(Interval{11, 18, 1});
+  intervals.emplace_back(Interval{18, 21, 1});
+  intervals.emplace_back(Interval{21, 24, 1});
+  intervals.emplace_back(Interval{24, 28, 1});
+  intervals.emplace_back(Interval{28, 35, 1});
+  intervals.emplace_back(Interval{35, 40, 1});
+  std::vector<int> expected{};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound8) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 5, 10});
+  intervals.emplace_back(Interval{5, 11, 100});
+  intervals.emplace_back(Interval{11, 18, 5});
+  intervals.emplace_back(Interval{18, 21, 8});
+  intervals.emplace_back(Interval{21, 24, 2});
+  intervals.emplace_back(Interval{24, 28, 4});
+  intervals.emplace_back(Interval{28, 35, 6});
+  intervals.emplace_back(Interval{35, 40, 7});
+  std::vector<int> expected{};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound9) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  std::vector<int> expected{};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -34,48 +34,28 @@ TEST(IntervalsTest, TestOverlapFound) {
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound1) {
+TEST(IntervalsTest, TestOverlapFoundA) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 2, 1});
   intervals.emplace_back(Interval{1, 4, 1});
   intervals.emplace_back(Interval{4, 6, 1});
   intervals.emplace_back(Interval{4, 5, 1});
-  std::vector<int> expected{1, 2};
+  std::vector<int> expected{0, 3};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound2) {
-  std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 2, 3});
-  intervals.emplace_back(Interval{1, 4, 2});
-  intervals.emplace_back(Interval{4, 6, 1});
-  intervals.emplace_back(Interval{4, 5, 4});
-  std::vector<int> expected{1, 2};
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
-}
-
-TEST(IntervalsTest, TestOverlapFound3) {
-  std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 3, 1});
-  intervals.emplace_back(Interval{3, 6, 2});
-  intervals.emplace_back(Interval{6, 10, 3});
-  intervals.emplace_back(Interval{8, 11, 4});
-  std::vector<int> expected{1, 2};
-  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
-}
-
-TEST(IntervalsTest, TestOverlapFound4) {
+TEST(IntervalsTest, TestOverlapFoundB) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 3, 4});
   intervals.emplace_back(Interval{3, 6, 2});
   intervals.emplace_back(Interval{6, 10, 3});
   intervals.emplace_back(Interval{8, 11, 1});
   intervals.emplace_back(Interval{7, 15, 5});
-  std::vector<int> expected{};
+  std::vector<int> expected{0, 1, 4};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound5) {
+TEST(IntervalsTest, TestOverlapFoundC) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 3, 6});
   intervals.emplace_back(Interval{3, 6, 2});
@@ -83,11 +63,11 @@ TEST(IntervalsTest, TestOverlapFound5) {
   intervals.emplace_back(Interval{8, 11, 1});
   intervals.emplace_back(Interval{9, 15, 5});
   intervals.emplace_back(Interval{3, 15, 5});
-  std::vector<int> expected{};
+  std::vector<int> expected{0, 5};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound6) {
+TEST(IntervalsTest, TestOverlapFoundD) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{2, 6, 2});
   intervals.emplace_back(Interval{12, 18, 3});
@@ -97,11 +77,11 @@ TEST(IntervalsTest, TestOverlapFound6) {
   intervals.emplace_back(Interval{3, 15, 5});
   intervals.emplace_back(Interval{14, 21, 5});
   intervals.emplace_back(Interval{23, 28, 5});
-  std::vector<int> expected{};
+  std::vector<int> expected{4, 3, 7};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound7) {
+TEST(IntervalsTest, TestOverlapFoundE) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{21, 24, 1});
   intervals.emplace_back(Interval{0, 5, 1});
@@ -111,11 +91,11 @@ TEST(IntervalsTest, TestOverlapFound7) {
   intervals.emplace_back(Interval{18, 21, 1});
   intervals.emplace_back(Interval{35, 40, 1});
   intervals.emplace_back(Interval{24, 28, 1});
-  std::vector<int> expected{};
+  std::vector<int> expected{1, 4, 2, 5, 0, 7, 3, 6};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound8) {
+TEST(IntervalsTest, TestOverlapFoundF) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 5, 10});
   intervals.emplace_back(Interval{5, 11, 100});
@@ -125,17 +105,17 @@ TEST(IntervalsTest, TestOverlapFound8) {
   intervals.emplace_back(Interval{24, 28, 4});
   intervals.emplace_back(Interval{28, 35, 6});
   intervals.emplace_back(Interval{35, 40, 7});
-  std::vector<int> expected{};
+  std::vector<int> expected{0, 1, 2, 3, 4, 5, 6, 7};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOverlapFound9) {
+TEST(IntervalsTest, TestOverlapFoundG) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});
-  std::vector<int> expected{};
+  std::vector<int> expected{0};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -4,6 +4,19 @@
 
 using namespace wasm;
 
+TEST(IntervalsTest, TestEmpty) {
+  std::vector<Interval> intervals;
+  std::vector<int> expected;
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOne) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 2, 5});
+  std::vector<int> expected{0};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
 TEST(IntervalsTest, TestNoOverlapFound) {
   std::vector<Interval> intervals;
   intervals.emplace_back(Interval{0, 4, 2});
@@ -21,15 +34,69 @@ TEST(IntervalsTest, TestOverlapFound) {
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestEmpty) {
+TEST(IntervalsTest, TestOverlapFound1) {
   std::vector<Interval> intervals;
-  std::vector<int> expected;
+  intervals.emplace_back(Interval{0, 2, 1});
+  intervals.emplace_back(Interval{1, 4, 1});
+  intervals.emplace_back(Interval{4, 6, 1});
+  intervals.emplace_back(Interval{4, 5, 1});
+  std::vector<int> expected{1, 2};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
 
-TEST(IntervalsTest, TestOne) {
+TEST(IntervalsTest, TestOverlapFound2) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 2, 5});
-  std::vector<int> expected{0};
+  intervals.emplace_back(Interval{0, 2, 3});
+  intervals.emplace_back(Interval{1, 4, 2});
+  intervals.emplace_back(Interval{4, 6, 1});
+  intervals.emplace_back(Interval{4, 5, 4});
+  std::vector<int> expected{1, 2};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound3) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 3, 1});
+  intervals.emplace_back(Interval{3, 6, 2});
+  intervals.emplace_back(Interval{6, 10, 3});
+  intervals.emplace_back(Interval{8, 11, 4});
+  std::vector<int> expected{1, 2};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound4) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 3, 4});
+  intervals.emplace_back(Interval{3, 6, 2});
+  intervals.emplace_back(Interval{6, 10, 3});
+  intervals.emplace_back(Interval{8, 11, 1});
+  intervals.emplace_back(Interval{7, 15, 5});
+  std::vector<int> expected{1, 2};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound5) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 3, 6});
+  intervals.emplace_back(Interval{3, 6, 2});
+  intervals.emplace_back(Interval{2, 10, 3});
+  intervals.emplace_back(Interval{8, 11, 1});
+  intervals.emplace_back(Interval{9, 15, 5});
+  intervals.emplace_back(Interval{3, 15, 5});
+  std::vector<int> expected{1, 2};
+  ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
+}
+
+TEST(IntervalsTest, TestOverlapFound6) {
+  std::vector<Interval> intervals;
+  intervals.emplace_back(Interval{0, 3, 6});
+  intervals.emplace_back(Interval{2, 6, 2});
+  intervals.emplace_back(Interval{12, 18, 3});
+  intervals.emplace_back(Interval{4, 11, 1});
+  intervals.emplace_back(Interval{6, 20, 15});
+  intervals.emplace_back(Interval{3, 15, 5});
+  intervals.emplace_back(Interval{14, 21, 5});
+  intervals.emplace_back(Interval{23, 28, 5});
+  std::vector<int> expected{1, 2};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }

--- a/test/gtest/intervals.cpp
+++ b/test/gtest/intervals.cpp
@@ -89,11 +89,11 @@ TEST(IntervalsTest, TestOverlapFound5) {
 
 TEST(IntervalsTest, TestOverlapFound6) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 3, 6});
   intervals.emplace_back(Interval{2, 6, 2});
   intervals.emplace_back(Interval{12, 18, 3});
   intervals.emplace_back(Interval{4, 11, 1});
   intervals.emplace_back(Interval{6, 20, 15});
+  intervals.emplace_back(Interval{0, 3, 6});
   intervals.emplace_back(Interval{3, 15, 5});
   intervals.emplace_back(Interval{14, 21, 5});
   intervals.emplace_back(Interval{23, 28, 5});
@@ -103,14 +103,14 @@ TEST(IntervalsTest, TestOverlapFound6) {
 
 TEST(IntervalsTest, TestOverlapFound7) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{5, 11, 1});
-  intervals.emplace_back(Interval{11, 18, 1});
-  intervals.emplace_back(Interval{18, 21, 1});
   intervals.emplace_back(Interval{21, 24, 1});
-  intervals.emplace_back(Interval{24, 28, 1});
+  intervals.emplace_back(Interval{0, 5, 1});
+  intervals.emplace_back(Interval{11, 18, 1});
   intervals.emplace_back(Interval{28, 35, 1});
+  intervals.emplace_back(Interval{5, 11, 1});
+  intervals.emplace_back(Interval{18, 21, 1});
   intervals.emplace_back(Interval{35, 40, 1});
+  intervals.emplace_back(Interval{24, 28, 1});
   std::vector<int> expected{};
   ASSERT_EQ(IntervalProcessor::filterOverlaps(intervals), expected);
 }
@@ -131,9 +131,6 @@ TEST(IntervalsTest, TestOverlapFound8) {
 
 TEST(IntervalsTest, TestOverlapFound9) {
   std::vector<Interval> intervals;
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
-  intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});
   intervals.emplace_back(Interval{0, 5, 1});

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1006,3 +1006,57 @@
     (loop (nop))
   )
 )
+
+;; Test that no attempt is made to outline overlapping repeat substrings
+(module
+  (func $a
+    (drop (i32.add
+      (i32.const 0)
+      (i32.const 1)
+    ))
+    (drop (i32.sub
+      (i32.const 2)
+      (i32.const 3)
+    ))
+    (drop (i32.mul
+      (i32.const 4)
+      (i32.const 5)
+    ))
+    (drop (i32.div_u
+      (i32.const 6)
+      (i32.const 7)
+    ))
+    (drop (i32.add
+      (i32.const 0)
+      (i32.const 1)
+    ))
+    (drop (i32.sub
+      (i32.const 2)
+      (i32.const 3)
+    ))
+    (drop (i32.mul
+      (i32.const 4)
+      (i32.const 5)
+    ))
+    (drop (i32.div_u
+      (i32.const 6)
+      (i32.const 7)
+    ))
+    (drop (i32.sub
+      (i32.const 2)
+      (i32.const 3)
+    ))
+    (drop (i32.mul
+      (i32.const 4)
+      (i32.const 5)
+    ))
+    (drop (i32.sub
+      (i32.const 2)
+      (i32.const 3)
+    ))
+    (drop (i32.mul
+      (i32.const 4)
+      (i32.const 5)
+    ))
+  )
+)

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -180,15 +180,6 @@
 
   ;; CHECK:      (func $outline$ (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.sub
-  ;; CHECK-NEXT:    (i32.const 3)
-  ;; CHECK-NEXT:    (i32.const 4)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-
-  ;; CHECK:      (func $outline$_4 (type $0)
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.add
   ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:    (i32.const 1)
@@ -196,9 +187,18 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
 
+  ;; CHECK:      (func $outline$_4 (type $0)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.sub
+  ;; CHECK-NEXT:    (i32.const 3)
+  ;; CHECK-NEXT:    (i32.const 4)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
   ;; CHECK:      (func $a (type $0)
-  ;; CHECK-NEXT:  (call $outline$_4)
   ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (call $outline$_4)
   ;; CHECK-NEXT: )
   (func $a
     (drop
@@ -215,7 +215,7 @@
     )
   )
   ;; CHECK:      (func $b (type $0)
-  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (call $outline$_4)
   ;; CHECK-NEXT: )
   (func $b
     (drop
@@ -226,7 +226,7 @@
     )
   )
   ;; CHECK:      (func $c (type $0)
-  ;; CHECK-NEXT:  (call $outline$_4)
+  ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT: )
   (func $c
     (drop

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1010,53 +1010,17 @@
 ;; Test that no attempt is made to outline overlapping repeat substrings
 (module
   (func $a
-    (drop (i32.add
-      (i32.const 0)
-      (i32.const 1)
-    ))
-    (drop (i32.sub
-      (i32.const 2)
-      (i32.const 3)
-    ))
-    (drop (i32.mul
-      (i32.const 4)
-      (i32.const 5)
-    ))
-    (drop (i32.div_u
-      (i32.const 6)
-      (i32.const 7)
-    ))
-    (drop (i32.add
-      (i32.const 0)
-      (i32.const 1)
-    ))
-    (drop (i32.sub
-      (i32.const 2)
-      (i32.const 3)
-    ))
-    (drop (i32.mul
-      (i32.const 4)
-      (i32.const 5)
-    ))
-    (drop (i32.div_u
-      (i32.const 6)
-      (i32.const 7)
-    ))
-    (drop (i32.sub
-      (i32.const 2)
-      (i32.const 3)
-    ))
-    (drop (i32.mul
-      (i32.const 4)
-      (i32.const 5)
-    ))
-    (drop (i32.sub
-      (i32.const 2)
-      (i32.const 3)
-    ))
-    (drop (i32.mul
-      (i32.const 4)
-      (i32.const 5)
-    ))
+    (drop (i32.const 0))
+    (drop (i32.const 1))
+    (drop (i32.const 2))
+    (drop (i32.const 3))
+    (drop (i32.const 0))
+    (drop (i32.const 1))
+    (drop (i32.const 2))
+    (drop (i32.const 3))
+    (drop (i32.const 1))
+    (drop (i32.const 2))
+    (drop (i32.const 1))
+    (drop (i32.const 2))
   )
 )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -180,15 +180,6 @@
 
   ;; CHECK:      (func $outline$ (type $0)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.add
-  ;; CHECK-NEXT:    (i32.const 0)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-
-  ;; CHECK:      (func $outline$_4 (type $0)
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.sub
   ;; CHECK-NEXT:    (i32.const 3)
   ;; CHECK-NEXT:    (i32.const 4)
@@ -196,9 +187,18 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
 
+  ;; CHECK:      (func $outline$_4 (type $0)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.add
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
   ;; CHECK:      (func $a (type $0)
-  ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT:  (call $outline$_4)
+  ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT: )
   (func $a
     (drop
@@ -215,7 +215,7 @@
     )
   )
   ;; CHECK:      (func $b (type $0)
-  ;; CHECK-NEXT:  (call $outline$_4)
+  ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT: )
   (func $b
     (drop
@@ -226,7 +226,7 @@
     )
   )
   ;; CHECK:      (func $c (type $0)
-  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (call $outline$_4)
   ;; CHECK-NEXT: )
   (func $c
     (drop
@@ -1008,6 +1008,11 @@
 )
 
 ;; Test that no attempt is made to outline overlapping repeat substrings
+;; TODO: The repeat substrings are:
+;; (drop (i32.const 0))
+;; (drop (i32.const 1))
+;; (drop (i32.const 2))
+;; (drop (i32.const 3))
 (module
   ;; CHECK:      (type $0 (func))
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1009,6 +1009,39 @@
 
 ;; Test that no attempt is made to outline overlapping repeat substrings
 (module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (func $outline$ (type $0)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 3)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+
+  ;; CHECK:      (func $a (type $0)
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 2)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
   (func $a
     (drop (i32.const 0))
     (drop (i32.const 1))

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1008,6 +1008,11 @@
 )
 
 ;; Test that no attempt is made to outline overlapping repeat substrings
+;; In the below module, the Outlining optimization identifies two substrings
+;; that each repeat twice. During filtering, one of the repeat substrings is
+;; found to have an overlapping interval with itself. Because an interval is
+;; dropped, only one of the substrings repeats enough times (minimum twice)
+;; to warrant outlining.
 (module
   ;; CHECK:      (type $0 (func))
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1008,11 +1008,6 @@
 )
 
 ;; Test that no attempt is made to outline overlapping repeat substrings
-;; TODO: The repeat substrings are:
-;; (drop (i32.const 0))
-;; (drop (i32.const 1))
-;; (drop (i32.const 2))
-;; (drop (i32.const 3))
 (module
   ;; CHECK:      (type $0 (func))
 
@@ -1048,17 +1043,29 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $a
-    (drop (i32.const 0))
-    (drop (i32.const 1))
-    (drop (i32.const 2))
-    (drop (i32.const 3))
-    (drop (i32.const 0))
-    (drop (i32.const 1))
-    (drop (i32.const 2))
-    (drop (i32.const 3))
-    (drop (i32.const 1))
-    (drop (i32.const 2))
-    (drop (i32.const 1))
-    (drop (i32.const 2))
+    i32.const 0 ;; Begin substring 1
+    drop
+    i32.const 1
+    drop
+    i32.const 2
+    drop
+    i32.const 3
+    drop        ;; End substring 1
+    i32.const 0 ;; Begin substring 1 repeat
+    drop
+    i32.const 1
+    drop
+    i32.const 2
+    drop
+    i32.const 3
+    drop        ;; End substring 1 repeat && Begin substring 2
+    i32.const 1
+    drop
+    i32.const 2
+    drop        ;; End substring 2 && Begin substring 2 repeat
+    i32.const 1
+    drop
+    i32.const 2
+    drop        ;; End substring 2 repeat
   )
 )


### PR DESCRIPTION
While determining whether repeat sequences of instructions are candidates for outlining, remove sequences that overlap, giving weight to sequences that are longer and appear more frequently.