### PR TITLE
[wasm-reduce] Add an option to save all interim working files as we reduce

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -83,6 +83,9 @@ static size_t timeout = 2;
 // default of enabling all features should work in most cases.
 static std::string extraFlags = "-all";
 
+// Whether to save all intermediate working files as we go.
+static bool saveAllWorkingFiles = false;
+
 struct ProgramResult {
   int code;
   std::string output;
@@ -322,7 +325,7 @@ struct Reducer
             if (ProgramResult(command) == expected) {
               std::cerr << "|    command \"" << currCommand
                         << "\" succeeded, reduced size to " << newSize << '\n';
-              copy_file(test, working);
+              applyTestToWorking();
               more = true;
               oldSize = newSize;
             }
@@ -332,6 +335,18 @@ struct Reducer
     }
     if (verbose) {
       std::cerr << "|    done with passes for now\n";
+    }
+  }
+
+  size_t workingFileIndex = 0;
+
+  // Apply the test file to the working file, after we saw that it successfully
+  // reduced the testcase.
+  void applyTestToWorking() {
+    copy_file(test, working);
+
+    if (saveAllWorkingFiles) {
+      copy_file(working, working + '.' + std::to_string(workingFileIndex++));
     }
   }
 
@@ -471,7 +486,7 @@ struct Reducer
 
   void noteReduction(size_t amount = 1) {
     reduced += amount;
-    copy_file(test, working);
+    applyTestToWorking();
   }
 
   // tests a reduction on an arbitrary child
@@ -1301,6 +1316,15 @@ int main(int argc, const char* argv[]) {
          [&](Options* o, const std::string& argument) {
            extraFlags = argument;
            std::cout << "|applying extraFlags: " << extraFlags << "\n";
+         })
+    .add("--save-all-working",
+         "-saw",
+         "Save all intermediate working files, as $WORKING.0, .1, .2 etc",
+         WasmReduceOption,
+         Options::Arguments::Zero,
+         [&](Options* o, const std::string& argument) {
+           saveAllWorkingFiles = true;
+           std::cout << "|saving all intermediate working files\n";
          })
     .add_positional(
       "INFILE",

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -234,6 +234,11 @@ ProgramResult expected;
 // case we may try again but much later.
 static std::unordered_set<Name> functionsWeTriedToRemove;
 
+// The index of the working file we save, when saveAllWorkingFiles. We must
+// store this globally so that the difference instances of Reducer do not
+// overlap.
+static size_t workingFileIndex = 0;
+
 struct Reducer
   : public WalkerPass<PostWalker<Reducer, UnifiedExpressionVisitor<Reducer>>> {
   std::string command, test, working;
@@ -337,8 +342,6 @@ struct Reducer
       std::cerr << "|    done with passes for now\n";
     }
   }
-
-  size_t workingFileIndex = 0;
 
   // Apply the test file to the working file, after we saw that it successfully
   // reduced the testcase.

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -51,6 +51,9 @@
 ;; CHECK-NEXT:                                        wasm-opt while reducing. (default:
 ;; CHECK-NEXT:                                        --enable-all)
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --save-all-working,-saw              Save all intermediate working files, as
+;; CHECK-NEXT:                                        $WORKING.0, .1, .2 etc
+;; CHECK-NEXT:
 ;; CHECK-NEXT:
 ;; CHECK-NEXT: Tool options:
 ;; CHECK-NEXT: -------------


### PR DESCRIPTION
With this option, each time we reduce we save a file `w.wasm.17` or such,
incrementing that counter. This is useful when debugging the reducer, but
might have more uses.