### PR TITLE
[NFC] Improve ClusterFuzz testing

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1662,7 +1662,7 @@ class ClusterFuzz(TestCaseHandler):
         # We should not see any mention of a wasm-opt error that caused a
         # retry. On production ClusterFuzz this is not an error, but we do want
         # to know about such issues, as they may be real bugs in wasm-opt.
-        assert not 'retry' in out, out
+        assert 'retry' not in out, out
 
         # We should see the two files.
         assert os.path.exists(fuzz_file)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1654,10 +1654,14 @@ class ClusterFuzz(TestCaseHandler):
                 os.unlink(f)
 
         # Call run.py(), similarly to how ClusterFuzz does.
-        run([sys.executable,
-             os.path.join(self.clusterfuzz_dir, 'run.py'),
-             '--output_dir=' + os.getcwd(),
-             '--no_of_files=1'])
+        out = run([sys.executable,
+                   os.path.join(self.clusterfuzz_dir, 'run.py'),
+                   '--output_dir=' + os.getcwd(),
+                   '--no_of_files=1'])
+
+        # We should not see any mention of a wasm-opt error that caused a
+        # retry
+        assert not 'retry' in out, out
 
         # We should see the two files.
         assert os.path.exists(fuzz_file)

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1660,7 +1660,8 @@ class ClusterFuzz(TestCaseHandler):
                    '--no_of_files=1'])
 
         # We should not see any mention of a wasm-opt error that caused a
-        # retry
+        # retry. On production ClusterFuzz this is not an error, but we do want
+        # to know about such issues, as they may be real bugs in wasm-opt.
         assert not 'retry' in out, out
 
         # We should see the two files.

--- a/test/unit/test_cluster_fuzz.py
+++ b/test/unit/test_cluster_fuzz.py
@@ -78,9 +78,6 @@ class ClusterFuzz(utils.BinaryenTestCase):
         # We should have logged the creation of N testcases.
         self.assertEqual(proc.stdout.count('Created testcase:'), N)
 
-        # We should never hit a wasm-opt error that causes us to retry.
-        self.assertNotIn(proc.stdout, 'retry')
-
         # We should have actually created them.
         for i in range(0, N + 2):
             fuzz_file = os.path.join(testcase_dir, f'fuzz-binaryen-{i}.js')

--- a/test/unit/test_cluster_fuzz.py
+++ b/test/unit/test_cluster_fuzz.py
@@ -74,6 +74,25 @@ class ClusterFuzz(utils.BinaryenTestCase):
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)
         self.assertEqual(proc.returncode, 0)
+
+        # We should have logged the creation of N testcases.
+        self.assertEqual(proc.stdout.count('Created testcase:'), N)
+
+        # We should never hit a wasm-opt error that causes us to retry.
+        self.assertNotIn(proc.stdout, 'retry')
+
+        # We should have actually created them.
+        for i in range(0, N + 2):
+            fuzz_file = os.path.join(testcase_dir, f'fuzz-binaryen-{i}.js')
+            flags_file = os.path.join(testcase_dir, f'flags-binaryen-{i}.js')
+            # We actually emit the range [1, N], so 0 or N+1 should not exist.
+            if i >= 1 and i <= N:
+                self.assertTrue(os.path.exists(fuzz_file))
+                self.assertTrue(os.path.exists(flags_file))
+            else:
+                self.assertTrue(not os.path.exists(fuzz_file))
+                self.assertTrue(not os.path.exists(flags_file))
+
         return proc
 
     # Test the bundled run.py script.
@@ -83,23 +102,10 @@ class ClusterFuzz(utils.BinaryenTestCase):
         N = 10
         proc = self.generate_testcases(N, temp_dir.name)
 
-        # We should have logged the creation of N testcases.
-        self.assertEqual(proc.stdout.count('Created testcase:'), N)
-
-        # We should have actually created them.
-        for i in range(0, N + 2):
-            fuzz_file = os.path.join(temp_dir.name, f'fuzz-binaryen-{i}.js')
-            flags_file = os.path.join(temp_dir.name, f'flags-binaryen-{i}.js')
-            # We actually emit the range [1, N], so 0 or N+1 should not exist.
-            if i >= 1 and i <= N:
-                self.assertTrue(os.path.exists(fuzz_file))
-                self.assertTrue(os.path.exists(flags_file))
-            else:
-                self.assertTrue(not os.path.exists(fuzz_file))
-                self.assertTrue(not os.path.exists(flags_file))
-
         # Run.py should report no errors or warnings to stderr, except from
-        # those we know are safe.
+        # those we know are safe (we cannot test this in generate_testcases,
+        # because the caller could do something like set BINARYEN_PASS_DEBUG,
+        # which generates intentional stderr warnings).
         SAFE_WARNINGS = [
             # When we randomly pick no passes to run, this is shown.
             'warning: no passes specified, not doing any work',


### PR DESCRIPTION
1. Error on retrying due to a `wasm-opt` issue, locally (in production, we
  don't want to error on ClusterFuzz).
3. Move some asserts from `test_run_py` to the helper `generate_testcases`
  (so that the asserts happen in all callers).