### PR TITLE
Do not optimize atomic gets in GUFA

### DIFF
--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -490,7 +490,7 @@ inline bool canEmitSelectWithArms(Expression* ifTrue, Expression* ifFalse) {
 // shared memory synchronization, return the memory order corresponding to the
 // kind of synchronization it does. Return MemoryOrder::Unordered if there is no
 // synchronization. Does not look at children.
-inline MemoryOrder getSynchronization(Expression* curr) {
+inline MemoryOrder getMemoryOrder(Expression* curr) {
   if (auto* get = curr->dynCast<StructGet>()) {
     return get->order;
   }

--- a/src/passes/GUFA.cpp
+++ b/src/passes/GUFA.cpp
@@ -150,8 +150,7 @@ struct GUFAOptimizer
       return;
     }
 
-    auto order = Properties::getSynchronization(curr);
-    if (order != MemoryOrder::Unordered) {
+    if (Properties::getMemoryOrder(curr) != MemoryOrder::Unordered) {
       // This load might synchronize with some store, and if we replaced the
       // load with a constant or with a load from a global, it would not
       // synchronize with that store anymore. Since we know what value the store

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -6170,8 +6170,8 @@
       (struct.new_default $A)
     )
     (drop
-      ;; This is optmizable.
-      ;; TODO: Should it not be optimizable since it reads from shared memory?
+      ;; This is optimizable. It reads from shared memory, but there is only one
+      ;; possible value that can be read.
       (struct.get $A 0
         (local.get 0)
       )

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -6137,3 +6137,56 @@
     )
   )
 )
+
+;; Atomic accesses require special handling
+(module
+  ;; CHECK:      (type $A (shared (struct (field i32))))
+  (type $A (shared (struct (field i32))))
+
+  ;; CHECK:      (type $1 (func))
+
+  ;; CHECK:      (func $gets (type $1)
+  ;; CHECK-NEXT:  (local $0 (ref $A))
+  ;; CHECK-NEXT:  (local.set $0
+  ;; CHECK-NEXT:   (struct.new_default $A)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get acqrel $A 0
+  ;; CHECK-NEXT:    (local.get $0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (struct.atomic.get $A 0
+  ;; CHECK-NEXT:    (local.get $0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $gets
+    (local (ref $A))
+    (local.set 0
+      (struct.new_default $A)
+    )
+    (drop
+      ;; This is optmizable.
+      ;; TODO: Should it not be optimizable since it reads from shared memory?
+      (struct.get $A 0
+        (local.get 0)
+      )
+    )
+    (drop
+      ;; We do not (yet) optimize atomic gets.
+      (struct.atomic.get acqrel $A 0
+        (local.get 0)
+      )
+    )
+    (drop
+      ;; We do not (yet) optimize atomic gets.
+      (struct.atomic.get $A 0
+        (local.get 0)
+      )
+    )
+  )
+)


### PR DESCRIPTION
Conservatively avoid introducing synchronization bugs by not optimizing
atomic struct.gets at all in GUFA. It is possible that we could be more
precise in the future.

Also remove obsolete logic dealing with the types of null values as a
drive-by. All null values now have bottom types, so the type mismatch
this code checked for is impossible.
