### PR TITLE
Explicitly disable WASM_BIGINT in emcc build when the CMake flag is off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,8 @@ if(EMSCRIPTEN)
   option(ENABLE_BIGINT "Enable wasm BigInt support" OFF)
   if(ENABLE_BIGINT)
     add_link_flag("-sWASM_BIGINT")
+   else()
+    add_link_flag("-sWASM_BIGINT=0")
   endif()
 
   if("${CMAKE_BUILD_TYPE}" MATCHES "Release")


### PR DESCRIPTION
This handles the case where WASM_BIGINT is enabled by default by emcc.
Binaryen's JS bindings do not currently work with bigint (see #7163)
