### PR TITLE
[NFC] Move code from fuzz_opt.py to a shared place

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -41,6 +41,7 @@ import time
 import traceback
 from os.path import abspath
 
+from test import fuzzing
 from test import shared
 from test import support
 
@@ -242,7 +243,7 @@ def randomize_fuzz_settings():
 def init_important_initial_contents():
     # Fuzz dir contents are always important to us.
     fuzz_dir = os.path.join(shared.options.binaryen_root, 'fuzz')
-    fuzz_cases = shared.get_tests(fuzz_dir, test_suffixes, recursive=True)
+    fuzz_cases = shared.get_tests(fuzz_dir, shared.test_suffixes, recursive=True)
     FIXED_IMPORTANT_INITIAL_CONTENTS = fuzz_cases
 
     # If auto_initial_contents is set we'll also grab all test files that are
@@ -306,66 +307,9 @@ def init_important_initial_contents():
     IMPORTANT_INITIAL_CONTENTS = [os.path.join(shared.get_test_dir('.'), t) for t in initial_contents]
 
 
-INITIAL_CONTENTS_IGNORE = [
-    # Float16 is still experimental.
-    'f16.wast',
-    # not all relaxed SIMD instructions are implemented in the interpreter
-    'relaxed-simd.wast',
-    # TODO: fuzzer and interpreter support for strings
-    'strings.wast',
-    'simplify-locals-strings.wast',
-    'string-lowering-instructions.wast',
-    # TODO: fuzzer and interpreter support for extern conversions
-    'extern-conversions.wast',
-    # ignore DWARF because it is incompatible with multivalue atm
-    'zlib.wasm',
-    'cubescript.wasm',
-    'class_with_dwarf_noprint.wasm',
-    'fib2_dwarf.wasm',
-    'fib_nonzero-low-pc_dwarf.wasm',
-    'inlined_to_start_dwarf.wasm',
-    'fannkuch3_manyopts_dwarf.wasm',
-    'fib2_emptylocspan_dwarf.wasm',
-    'fannkuch3_dwarf.wasm',
-    'dwarf-local-order.wasm',
-    'strip-producers.wasm',
-    'multi_unit_abbrev_noprint.wasm',
-    'reverse_dwarf_abbrevs.wasm',
-    'print_g.wasm',
-    'print_g_strip-dwarf.wasm',
-    'fannkuch0_dwarf.wasm',
-    'dwarfdump_roundtrip_dwarfdump.wasm',
-    'dwarfdump.wasm',
-    'fannkuch3_dwarf.wasm',
-    'dwarf-local-order.wasm',
-    'dwarf_unit_with_no_abbrevs_noprint.wasm',
-    'strip-debug.wasm',
-    'multi_line_table_dwarf.wasm',
-    'dwarf_with_exceptions.wasm',
-    'strip-dwarf.wasm',
-    'ignore_missing_func_dwarf.wasm',
-    'print.wasm',
-    # TODO fuzzer support for multimemory
-    'multi-memories-atomics64.wast',
-    'multi-memories-basics.wast',
-    'multi-memories-simd.wast',
-    'multi-memories-atomics64.wasm',
-    'multi-memories-basics.wasm',
-    'multi-memories-simd.wasm',
-    'multi-memories_size.wast',
-    # TODO: fuzzer support for internalize/externalize
-    'optimize-instructions-gc-extern.wast',
-    'gufa-extern.wast',
-    # the fuzzer does not support imported memories
-    'multi-memory-lowering-import.wast',
-    'multi-memory-lowering-import-error.wast',
-    # the fuzzer does not support typed continuations
-    'typed_continuations.wast',
-    'typed_continuations_resume.wast',
-    'typed_continuations_contnew.wast',
-    'typed_continuations_contbind.wast',
-    'typed_continuations_suspend.wast',
-]
+all_tests = shared.get_all_tests()
+
+INITIAL_CONTENTS_IGNORE = fuzzing.unfuzzable_tests
 
 
 def pick_initial_contents():
@@ -1800,18 +1744,6 @@ testcase_handlers = [
     ClusterFuzz(),
     Two(),
 ]
-
-
-test_suffixes = ['*.wasm', '*.wast', '*.wat']
-
-core_tests = shared.get_tests(shared.get_test_dir('.'), test_suffixes)
-passes_tests = shared.get_tests(shared.get_test_dir('passes'), test_suffixes)
-spec_tests = shared.get_tests(shared.get_test_dir('spec'), test_suffixes)
-wasm2js_tests = shared.get_tests(shared.get_test_dir('wasm2js'), test_suffixes)
-lld_tests = shared.get_tests(shared.get_test_dir('lld'), test_suffixes)
-unit_tests = shared.get_tests(shared.get_test_dir(os.path.join('unit', 'input')), test_suffixes)
-lit_tests = shared.get_tests(shared.get_test_dir('lit'), test_suffixes, recursive=True)
-all_tests = core_tests + passes_tests + spec_tests + wasm2js_tests + lld_tests + unit_tests + lit_tests
 
 
 # Do one test, given an input file for -ttf and some optimizations to run

--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -74,4 +74,3 @@ unfuzzable_tests = [
     'typed_continuations_contbind.wast',
     'typed_continuations_suspend.wast',
 ]
-

--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -1,0 +1,77 @@
+# Copyright 2024 WebAssembly Community Group participants
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Tests that the fuzzers should not operate on.
+unfuzzable_tests = [
+    # Float16 is still experimental.
+    'f16.wast',
+    # not all relaxed SIMD instructions are implemented in the interpreter
+    'relaxed-simd.wast',
+    # TODO: fuzzer and interpreter support for strings
+    'strings.wast',
+    'simplify-locals-strings.wast',
+    'string-lowering-instructions.wast',
+    # TODO: fuzzer and interpreter support for extern conversions
+    'extern-conversions.wast',
+    # ignore DWARF because it is incompatible with multivalue atm
+    'zlib.wasm',
+    'cubescript.wasm',
+    'class_with_dwarf_noprint.wasm',
+    'fib2_dwarf.wasm',
+    'fib_nonzero-low-pc_dwarf.wasm',
+    'inlined_to_start_dwarf.wasm',
+    'fannkuch3_manyopts_dwarf.wasm',
+    'fib2_emptylocspan_dwarf.wasm',
+    'fannkuch3_dwarf.wasm',
+    'dwarf-local-order.wasm',
+    'strip-producers.wasm',
+    'multi_unit_abbrev_noprint.wasm',
+    'reverse_dwarf_abbrevs.wasm',
+    'print_g.wasm',
+    'print_g_strip-dwarf.wasm',
+    'fannkuch0_dwarf.wasm',
+    'dwarfdump_roundtrip_dwarfdump.wasm',
+    'dwarfdump.wasm',
+    'fannkuch3_dwarf.wasm',
+    'dwarf-local-order.wasm',
+    'dwarf_unit_with_no_abbrevs_noprint.wasm',
+    'strip-debug.wasm',
+    'multi_line_table_dwarf.wasm',
+    'dwarf_with_exceptions.wasm',
+    'strip-dwarf.wasm',
+    'ignore_missing_func_dwarf.wasm',
+    'print.wasm',
+    # TODO fuzzer support for multimemory
+    'multi-memories-atomics64.wast',
+    'multi-memories-basics.wast',
+    'multi-memories-simd.wast',
+    'multi-memories-atomics64.wasm',
+    'multi-memories-basics.wasm',
+    'multi-memories-simd.wasm',
+    'multi-memories_size.wast',
+    # TODO: fuzzer support for internalize/externalize
+    'optimize-instructions-gc-extern.wast',
+    'gufa-extern.wast',
+    # the fuzzer does not support imported memories
+    'multi-memory-lowering-import.wast',
+    'multi-memory-lowering-import-error.wast',
+    # the fuzzer does not support typed continuations
+    'typed_continuations.wast',
+    'typed_continuations_resume.wast',
+    'typed_continuations_contnew.wast',
+    'typed_continuations_contbind.wast',
+    'typed_continuations_suspend.wast',
+]
+

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -561,3 +561,19 @@ def skip_if_on_windows(name):
         print('skipping test "%s" on windows' % name)
         return True
     return False
+
+
+test_suffixes = ['*.wasm', '*.wast', '*.wat']
+
+
+# return a list of all the tests in the entire test suite
+def get_all_tests():
+    core_tests = get_tests(get_test_dir('.'), test_suffixes)
+    passes_tests = get_tests(get_test_dir('passes'), test_suffixes)
+    spec_tests = get_tests(get_test_dir('spec'), test_suffixes)
+    wasm2js_tests = get_tests(get_test_dir('wasm2js'), test_suffixes)
+    lld_tests = get_tests(get_test_dir('lld'), test_suffixes)
+    unit_tests = get_tests(get_test_dir(os.path.join('unit', 'input')), test_suffixes)
+    lit_tests = get_tests(get_test_dir('lit'), test_suffixes, recursive=True)
+
+    return core_tests + passes_tests + spec_tests + wasm2js_tests + lld_tests + unit_tests + lit_tests


### PR DESCRIPTION
The list of tests, and which tests cannot be fuzzed, will be useful in
a future PR that uses it for ClusterFuzz as well. This just moves things
out so they are reusable.