### PR TITLE
Fuzzing: Handle instantiation errors in ClusterFuzz

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1687,8 +1687,10 @@ class ClusterFuzz(TestCaseHandler):
 
         # Verify that we called something. The fuzzer should always emit at
         # least one exported function (unless we've decided to ignore the entire
-        # run).
-        if output != IGNORE:
+        # run, or if the wasm errored during instantiation, which can happen due
+        # to a testcase with a segment out of bounds, say).
+        if output != IGNORE and not output.startswith('exception thrown: failed to instantiate module'):
+
             assert FUZZ_EXEC_CALL_PREFIX in output
 
     def ensure(self):
@@ -1748,7 +1750,7 @@ class Two(TestCaseHandler):
             # to anything.
             return
 
-        if output.strip() == 'exception thrown: failed to instantiate module':
+        if output.startswith('exception thrown: failed to instantiate module'):
             # We may fail to instantiate the modules for valid reasons, such as
             # an active segment being out of bounds. There is no point to
             # continue in such cases, as no exports are called.

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1630,6 +1630,10 @@ class RoundtripText(TestCaseHandler):
         run([in_bin('wasm-opt'), abspath('a.wast')] + FEATURE_OPTS)
 
 
+# The error shown when a module fails to instantiate.
+INSTANTIATE_ERROR = 'exception thrown: failed to instantiate module'
+
+
 # Fuzz in a near-identical manner to how we fuzz on ClusterFuzz. This is mainly
 # to see that fuzzing that way works properly (it likely won't catch anything
 # the other fuzzers here catch, though it is possible). That is, running this
@@ -1689,7 +1693,7 @@ class ClusterFuzz(TestCaseHandler):
         # least one exported function (unless we've decided to ignore the entire
         # run, or if the wasm errored during instantiation, which can happen due
         # to a testcase with a segment out of bounds, say).
-        if output != IGNORE and not output.startswith('exception thrown: failed to instantiate module'):
+        if output != IGNORE and not output.startswith(INSTANTIATE_ERROR):
 
             assert FUZZ_EXEC_CALL_PREFIX in output
 
@@ -1750,7 +1754,7 @@ class Two(TestCaseHandler):
             # to anything.
             return
 
-        if output.startswith('exception thrown: failed to instantiate module'):
+        if output.startswith(INSTANTIATE_ERROR):
             # We may fail to instantiate the modules for valid reasons, such as
             # an active segment being out of bounds. There is no point to
             # continue in such cases, as no exports are called.

--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -346,7 +346,7 @@ function build(binary) {
   try {
     instance = new WebAssembly.Instance(module, imports);
   } catch (e) {
-    console.log('exception thrown: failed to instantiate module');
+    console.log('exception thrown: failed to instantiate module: ' + e);
     quit();
   }
 


### PR DESCRIPTION
If the module has an invalid segment offset, for example, it will error. We
should not error in the fuzzer on such rare cases.

Also add logging of the actual error, which matches what we do for
errors elsewhere, and makes debugging easier:

https://github.com/WebAssembly/binaryen/blob/dcec348ded6d7ab7bf4b758bdb92107e4262dbf4/scripts/fuzz_shell.js#L397

As a result another place needs to look for the prefix now, and not the
entire string (since we append the error contents).