### PR TITLE
[NFC] Remove unused `useNewWATParser` bool

### DIFF
--- a/src/wasm-io.h
+++ b/src/wasm-io.h
@@ -28,10 +28,6 @@
 
 namespace wasm {
 
-// TODO: Remove this after switching to the new WAT parser by default and
-// removing the old one.
-extern bool useNewWATParser;
-
 class ModuleIOBase {
 protected:
   bool debugInfo;


### PR DESCRIPTION
We always use the new WAT parser now.
