### PR TITLE
[NFC] Fix spurious uninitialized variable warning

### DIFF
--- a/src/support/string.cpp
+++ b/src/support/string.cpp
@@ -152,7 +152,7 @@ std::optional<uint32_t> takeWTF8CodePoint(std::string_view& str) {
 
   uint8_t leading = str[0];
   size_t trailingBytes;
-  uint32_t u;
+  uint32_t u = 0;
   if ((leading & 0b10000000) == 0b00000000) {
     // 0xxxxxxx
     trailingBytes = 0;

--- a/src/support/string.cpp
+++ b/src/support/string.cpp
@@ -152,6 +152,7 @@ std::optional<uint32_t> takeWTF8CodePoint(std::string_view& str) {
 
   uint8_t leading = str[0];
   size_t trailingBytes;
+  // Initialized only to avoid spurious compiler warnings.
   uint32_t u = 0;
   if ((leading & 0b10000000) == 0b00000000) {
     // 0xxxxxxx


### PR DESCRIPTION
The coverage CI builder was failing because of a spurious error about a
variable being possibly used uninitialized. Fix the warning by
initializing the variable to 0.
