### PR TITLE
[GC][Threads] Atomic GC operations require --enable-threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
+ - `struct.atomic.get`/`struct.atomic.set` now require the threads feature,
+   `--enable-threads`. (#7185)
+
 v121
 ----
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2989,11 +2989,15 @@ void FunctionValidator::visitStructGet(StructGet* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "struct.get requires gc [--enable-gc]");
-  shouldBeTrue(curr->order == MemoryOrder::Unordered ||
-                 getModule()->features.hasSharedEverything(),
-               curr,
-               "struct.atomic.get requires shared-everything "
-               "[--enable-shared-everything]");
+  if (curr->order != MemoryOrder::Unordered) {
+    shouldBeTrue(getModule()->features.hasSharedEverything(),
+                 curr,
+                 "struct.atomic.get requires shared-everything "
+                 "[--enable-shared-everything]");
+    shouldBeTrue(getModule()->features.hasAtomics(),
+                 curr,
+                 "struct.atomic.get requires threads [--enable-threads]");
+  }
   if (curr->type == Type::unreachable || curr->ref->type.isNull()) {
     return;
   }
@@ -3021,11 +3025,15 @@ void FunctionValidator::visitStructSet(StructSet* curr) {
   shouldBeTrue(getModule()->features.hasGC(),
                curr,
                "struct.set requires gc [--enable-gc]");
-  shouldBeTrue(curr->order == MemoryOrder::Unordered ||
-                 getModule()->features.hasSharedEverything(),
-               curr,
-               "struct.atomic.set requires shared-everything "
-               "[--enable-shared-everything]");
+  if (curr->order != MemoryOrder::Unordered) {
+    shouldBeTrue(getModule()->features.hasSharedEverything(),
+                 curr,
+                 "struct.atomic.set requires shared-everything "
+                 "[--enable-shared-everything]");
+    shouldBeTrue(getModule()->features.hasAtomics(),
+                 curr,
+                 "struct.atomic.set requires threads [--enable-threads]");
+  }
   if (curr->ref->type == Type::unreachable) {
     return;
   }

--- a/test/lit/validation/gc-atomics.wast
+++ b/test/lit/validation/gc-atomics.wast
@@ -1,12 +1,13 @@
 ;; Test that shared-everything GC instructions require the shared-everything
 ;; feature.
 
-;; RUN: not wasm-opt -all --disable-shared-everything %s 2>&1 | filecheck %s
+;; RUN: not wasm-opt -all --disable-shared-everything --disable-threads %s 2>&1 | filecheck %s
 
 (module
   (type $struct (struct (field (mut i32))))
 
   ;; CHECK: struct.atomic.get requires shared-everything [--enable-shared-everything]
+  ;; CHECK: struct.atomic.get requires threads [--enable-threads]
   (func $get-seqcst (result i32)
     (struct.atomic.get seqcst $struct 0
       (struct.new_default $struct)
@@ -14,6 +15,7 @@
   )
 
   ;; CHECK: struct.atomic.get requires shared-everything [--enable-shared-everything]
+  ;; CHECK: struct.atomic.get requires threads [--enable-threads]
   (func $get-acqrel (result i32)
     (struct.atomic.get acqrel $struct 0
       (struct.new_default $struct)
@@ -21,6 +23,7 @@
   )
 
   ;; CHECK: struct.atomic.set requires shared-everything [--enable-shared-everything]
+  ;; CHECK: struct.atomic.set requires threads [--enable-threads]
   (func $set-seqcst
     (struct.atomic.set seqcst $struct 0
       (struct.new_default $struct)
@@ -29,6 +32,7 @@
   )
 
   ;; CHECK: struct.atomic.set requires shared-everything [--enable-shared-everything]
+  ;; CHECK: struct.atomic.set requires threads [--enable-threads]
   (func $set-acqrel
     (struct.atomic.set acqrel $struct 0
       (struct.new_default $struct)


### PR DESCRIPTION
Without this, it is invalid to lower them to simpler atomic operations like
`atomic.fence` (as some passes do) or linear memory atomics (as a future
lowering pass might do).

Fixes #7184