### PR TITLE
Fuzzing: Do not emit RefAsNonNull in non-function contexts

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3243,14 +3243,19 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
   // which is not ideal.
   if (type.isNonNullable() && (random.finished() || nesting >= LIMIT)) {
     // If we have a function context then we can at least emit a local.get,
-    // perhaps, which is less bad. Note that we need to check typeLocals
+    // sometimes, which is less bad. Note that we need to check typeLocals
     // manually here to avoid infinite recursion (as makeLocalGet will fall back
     // to us, if there is no local).
     // TODO: we could also look for locals containing subtypes
-    if (funcContext && !funcContext->typeLocals[type].empty()) {
-      return makeLocalGet(type);
+    if (funcContext) {
+      if (!funcContext->typeLocals[type].empty()) {
+        return makeLocalGet(type);
+      }
+      // No local, but we are in a function context so RefAsNonNull is valid.
+      return builder.makeRefAs(RefAsNonNull, builder.makeRefNull(heapType));
     }
-    return builder.makeRefAs(RefAsNonNull, builder.makeRefNull(heapType));
+    // No function context, so we are in quite the pickle. Continue onwards, as
+    // we may succeed to emit something more complex (like a struct.new).
   }
 
   // When we make children, they must be trivial if we are not in a function


### PR DESCRIPTION
Emitting that in e.g. a global init is not going to validate, so avoid doing so,
and continue to the code below, which may manage to emit something in
this case.