### PR TITLE
Make RemoveMemory pass also remove the start function

### DIFF
--- a/src/passes/CMakeLists.txt
+++ b/src/passes/CMakeLists.txt
@@ -102,7 +102,7 @@ set(passes_SOURCES
   TraceCalls.cpp
   RedundantSetElimination.cpp
   RemoveImports.cpp
-  RemoveMemory.cpp
+  RemoveMemoryInit.cpp
   RemoveNonJSOps.cpp
   RemoveUnusedBrs.cpp
   RemoveUnusedNames.cpp

--- a/src/passes/RemoveMemoryInit.cpp
+++ b/src/passes/RemoveMemoryInit.cpp
@@ -15,7 +15,8 @@
  */
 
 //
-// Removeds memory segments, leaving only code in the module.
+// Removes memory segments, leaving only code in the module. It also removes
+// the start function, which is only used for initializing the memory.
 //
 
 #include <pass.h>
@@ -23,12 +24,16 @@
 
 namespace wasm {
 
-struct RemoveMemory : public Pass {
+struct RemoveMemoryInit : public Pass {
   void run(Module* module) override {
     module->removeDataSegments([&](DataSegment* curr) { return true; });
+    if (module->start) {
+      module->removeFunction(module->start);
+      module->start = Name();
+    }
   }
 };
 
-Pass* createRemoveMemoryPass() { return new RemoveMemory(); }
+Pass* createRemoveMemoryInitPass() { return new RemoveMemoryInit(); }
 
 } // namespace wasm

--- a/src/passes/RemoveMemoryInit.cpp
+++ b/src/passes/RemoveMemoryInit.cpp
@@ -16,8 +16,8 @@
 
 //
 // Removes memory segments, leaving only code in the module. It also removes
-// the start function, which is only used for initializing the memory.
-//
+// the start function, which (in LLVM use cases) is only used for initializing
+// the memory.
 
 #include <pass.h>
 #include <wasm.h>

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -411,10 +411,12 @@ void PassRegistry::registerPasses() {
   registerPass("remove-imports",
                "removes imports and replaces them with nops",
                createRemoveImportsPass);
-  registerPass(
-    "remove-memory-init", "removes memory initialization", createRemoveMemoryInitPass);
-  registerPass(
-    "remove-memory", "removes memory init (legacy name)", createRemoveMemoryInitPass);
+  registerPass("remove-memory-init",
+               "removes memory initialization",
+               createRemoveMemoryInitPass);
+  registerPass("remove-memory",
+               "removes memory init (legacy name)",
+               createRemoveMemoryInitPass);
   registerPass("remove-unused-brs",
                "removes breaks from locations that are not needed",
                createRemoveUnusedBrsPass);

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -412,7 +412,9 @@ void PassRegistry::registerPasses() {
                "removes imports and replaces them with nops",
                createRemoveImportsPass);
   registerPass(
-    "remove-memory", "removes memory segments", createRemoveMemoryPass);
+    "remove-memory-init", "removes memory initialization", createRemoveMemoryInitPass);
+  registerPass(
+    "remove-memory", "removes memory init (legacy name)", createRemoveMemoryInitPass);
   registerPass("remove-unused-brs",
                "removes breaks from locations that are not needed",
                createRemoveUnusedBrsPass);

--- a/src/passes/passes.h
+++ b/src/passes/passes.h
@@ -132,7 +132,7 @@ Pass* createPrintFunctionMapPass();
 Pass* createPropagateGlobalsGloballyPass();
 Pass* createRemoveNonJSOpsPass();
 Pass* createRemoveImportsPass();
-Pass* createRemoveMemoryPass();
+Pass* createRemoveMemoryInitPass();
 Pass* createRemoveUnusedBrsPass();
 Pass* createRemoveUnusedModuleElementsPass();
 Pass* createRemoveUnusedNonFunctionModuleElementsPass();

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -294,7 +294,7 @@ struct Reducer
       "--optimize-instructions",
       "--precompute",
       "--remove-imports",
-      "--remove-memory",
+      "--remove-memory-init",
       "--remove-unused-names --remove-unused-brs",
       "--remove-unused-module-elements",
       "--remove-unused-nonfunction-module-elements",

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -388,7 +388,10 @@
 ;; CHECK-NEXT:   --remove-imports                              removes imports and replaces
 ;; CHECK-NEXT:                                                 them with nops
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --remove-memory                               removes memory segments
+;; CHECK-NEXT:   --remove-memory                               removes memory init (legacy
+;; CHECK-NEXT:                                                 name)
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --remove-memory-init                          removes memory initialization
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --remove-non-js-ops                           removes operations incompatible
 ;; CHECK-NEXT:                                                 with js

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -397,7 +397,10 @@
 ;; CHECK-NEXT:   --remove-imports                              removes imports and replaces
 ;; CHECK-NEXT:                                                 them with nops
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --remove-memory                               removes memory segments
+;; CHECK-NEXT:   --remove-memory                               removes memory init (legacy
+;; CHECK-NEXT:                                                 name)
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --remove-memory-init                          removes memory initialization
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --remove-non-js-ops                           removes operations incompatible
 ;; CHECK-NEXT:                                                 with js

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -351,7 +351,10 @@
 ;; CHECK-NEXT:   --remove-imports                              removes imports and replaces
 ;; CHECK-NEXT:                                                 them with nops
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --remove-memory                               removes memory segments
+;; CHECK-NEXT:   --remove-memory                               removes memory init (legacy
+;; CHECK-NEXT:                                                 name)
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --remove-memory-init                          removes memory initialization
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --remove-non-js-ops                           removes operations incompatible
 ;; CHECK-NEXT:                                                 with js

--- a/test/lit/passes/remove-memory-init.wast
+++ b/test/lit/passes/remove-memory-init.wast
@@ -5,7 +5,7 @@
  ;; CHECK:      (memory $mem 2)
  (memory $mem 2)
  (data (memory $mem) (i32.const 0) "Hello, world\00")
-  (func $__wasm_init_memory (type $0)
+ (func $__wasm_init_memory (type $0)
   (memory.fill 0
    (i32.const 0)
    (i32.const 0)

--- a/test/lit/passes/remove-memory-init.wast
+++ b/test/lit/passes/remove-memory-init.wast
@@ -1,0 +1,19 @@
+;; RUN: wasm-opt %s --remove-memory-init -all -S -o - | filecheck %s
+
+(module
+ (type $0 (func))
+ ;; CHECK:      (memory $mem 2)
+ (memory $mem 2)
+ (data (memory $mem) (i32.const 0) "Hello, world\00")
+  (func $__wasm_init_memory (type $0)
+  (memory.fill 0
+   (i32.const 0)
+   (i32.const 0)
+   (i32.const 0)
+  )
+ )
+ (start $__wasm_init_memory)
+)
+
+;; CHECK-NOT: data
+;; CHECK-NOT: __wasm_init_memory

--- a/test/passes/remove-memory.txt
+++ b/test/passes/remove-memory.txt
@@ -1,3 +1,0 @@
-(module
- (memory $mem 1024 1024)
-)

--- a/test/passes/remove-memory.wast
+++ b/test/passes/remove-memory.wast
@@ -1,5 +1,0 @@
-(module
-  (memory $mem 1024 1024)
-  (data (memory $mem) (i32.const 10) "123")
-  (data (memory $mem) (i32.const 20) "149")
-)


### PR DESCRIPTION
Also rename it to RemoveMemoryInit to make it more clear what it's for.
For now, keep the legacy pass name, to be deleted after rolling into Emscripten.