### PR TITLE
Validate features used by block return types

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -675,11 +675,11 @@ void FunctionValidator::validatePoppyExpression(Expression* curr) {
 }
 
 void FunctionValidator::visitBlock(Block* curr) {
-  if (!getModule()->features.hasMultivalue()) {
-    shouldBeTrue(
-      !curr->type.isTuple(),
-      curr,
-      "Multivalue block type require multivalue [--enable-multivalue]");
+  auto feats = curr->type.getFeatures();
+  if (!shouldBeTrue(feats <= getModule()->features,
+                    curr,
+                    "Block type requires additional features")) {
+    getStream() << getMissingFeaturesList(*getModule(), feats) << '\n';
   }
   // if we are break'ed to, then the value must be right for us
   if (curr->name.is()) {
@@ -3861,7 +3861,7 @@ static void validateGlobals(Module& module, ValidationInfo& info) {
     auto globalFeats = g->type.getFeatures();
     if (!info.shouldBeTrue(globalFeats <= module.features, g->name, "")) {
       info.getStream(nullptr)
-        << "global type requires additional features "
+        << "global type requires additional features"
         << getMissingFeaturesList(module, globalFeats) << '\n';
     }
   }

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3861,7 +3861,7 @@ static void validateGlobals(Module& module, ValidationInfo& info) {
     auto globalFeats = g->type.getFeatures();
     if (!info.shouldBeTrue(globalFeats <= module.features, g->name, "")) {
       info.getStream(nullptr)
-        << "global type requires additional features"
+        << "global type requires additional features "
         << getMissingFeaturesList(module, globalFeats) << '\n';
     }
   }

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -252,7 +252,7 @@ class FeatureValidationTest(utils.BinaryenTestCase):
          )
         )
         '''
-        self.check_multivalue(module, 'Multivalue block type require multivalue [--enable-multivalue]')
+        self.check_multivalue(module, 'Block type requires additional features')
 
     def test_i31_global(self):
         module = '''


### PR DESCRIPTION
We previously checked only for the multivalue feature when used by
blocks, but now check for all used features. This will fix a current
fuzzer error where the new unreachable-string-new.wast test validates
with shared-everything disabled even though it uses shared heap types,
allowing the fuzzer to use those shared types in other places that are
checked by the validator.
