### PR TITLE
Fuzzer: Add invokes for initial functions

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1648,6 +1648,20 @@ void TranslateToFuzzReader::modifyInitialFunctions() {
       //       them.
     }
   }
+
+  // Add invocations, which can help execute the code here even if the function
+  // was not exported (or was exported but with a signature that traps
+  // immediately, like receiving a non-nullable ref, that the fuzzer can't
+  // provide from JS). Note we need to use a temp vector for iteration, as
+  // addInvocations modifies wasm.functions.
+  std::vector<Function*> funcs;
+  for (auto& func : wasm.functions) {
+    funcs.push_back(func.get());
+  }
+  for (auto* func : funcs) {
+    addInvocations(func);
+  }
+
   // Remove a start function - the fuzzing harness expects code to run only
   // from exports.
   wasm.start = Name();

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 46      
- [funcs]        : 68      
+ [exports]      : 65      
+ [funcs]        : 85      
  [globals]      : 18      
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 24      
- [table-data]   : 22      
+ [table-data]   : 24      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 9465    
- [vars]         : 215     
- Binary         : 671     
- Block          : 1531    
- Break          : 370     
- Call           : 366     
- CallIndirect   : 67      
- Const          : 1478    
- Drop           : 111     
- GlobalGet      : 766     
- GlobalSet      : 558     
- If             : 514     
- Load           : 173     
- LocalGet       : 729     
- LocalSet       : 550     
- Loop           : 202     
- Nop            : 133     
- RefFunc        : 22      
- Return         : 99      
- Select         : 84      
- Store          : 83      
- Switch         : 2       
- Unary          : 682     
- Unreachable    : 274     
+ [total]        : 8396    
+ [vars]         : 239     
+ Binary         : 573     
+ Block          : 1420    
+ Break          : 276     
+ Call           : 382     
+ CallIndirect   : 56      
+ Const          : 1258    
+ Drop           : 124     
+ GlobalGet      : 731     
+ GlobalSet      : 531     
+ If             : 468     
+ Load           : 129     
+ LocalGet       : 578     
+ LocalSet       : 422     
+ Loop           : 173     
+ Nop            : 134     
+ RefFunc        : 24      
+ Return         : 122     
+ Select         : 58      
+ Store          : 57      
+ Switch         : 6       
+ Unary          : 605     
+ Unreachable    : 269     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 43      
- [funcs]        : 56      
+ [exports]      : 84      
+ [funcs]        : 112     
  [globals]      : 17      
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 11      
- [table-data]   : 16      
+ [table-data]   : 36      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 10611   
- [vars]         : 184     
- Binary         : 754     
- Block          : 1699    
- Break          : 397     
- Call           : 325     
- CallIndirect   : 112     
- Const          : 1783    
- Drop           : 101     
- GlobalGet      : 869     
- GlobalSet      : 657     
- If             : 549     
- Load           : 195     
- LocalGet       : 893     
- LocalSet       : 609     
- Loop           : 251     
- Nop            : 123     
- RefFunc        : 16      
- Return         : 78      
- Select         : 74      
- Store          : 84      
- Switch         : 3       
- Unary          : 730     
- Unreachable    : 309     
+ [total]        : 7833    
+ [vars]         : 292     
+ Binary         : 578     
+ Block          : 1340    
+ Break          : 204     
+ Call           : 414     
+ CallIndirect   : 35      
+ Const          : 1256    
+ Drop           : 107     
+ GlobalGet      : 698     
+ GlobalSet      : 535     
+ If             : 418     
+ Load           : 134     
+ LocalGet       : 502     
+ LocalSet       : 331     
+ Loop           : 149     
+ Nop            : 87      
+ RefFunc        : 36      
+ Return         : 103     
+ Select         : 49      
+ Store          : 70      
+ Switch         : 6       
+ Unary          : 508     
+ Unreachable    : 273     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,7 +1,7 @@
 Metrics
 total
- [exports]      : 3       
- [funcs]        : 3       
+ [exports]      : 10      
+ [funcs]        : 9       
  [globals]      : 4       
  [imports]      : 8       
  [memories]     : 1       
@@ -9,44 +9,44 @@ total
  [table-data]   : 0       
  [tables]       : 1       
  [tags]         : 1       
- [total]        : 630     
- [vars]         : 23      
- ArrayNewFixed  : 3       
- AtomicCmpxchg  : 1       
- AtomicFence    : 1       
- AtomicNotify   : 1       
- Binary         : 63      
- Block          : 60      
- BrOn           : 3       
- Break          : 8       
- Call           : 4       
- CallRef        : 3       
- Const          : 129     
- DataDrop       : 1       
- Drop           : 8       
- GlobalGet      : 21      
- GlobalSet      : 20      
- I31Get         : 1       
- If             : 12      
+ [total]        : 553     
+ [vars]         : 38      
+ ArrayCopy      : 2       
+ ArrayLen       : 4       
+ ArrayNew       : 1       
+ ArrayNewFixed  : 7       
+ Binary         : 69      
+ Block          : 55      
+ BrOn           : 1       
+ Break          : 1       
+ Call           : 23      
+ Const          : 107     
+ Drop           : 7       
+ GlobalGet      : 19      
+ GlobalSet      : 18      
+ If             : 17      
  Load           : 17      
- LocalGet       : 74      
- LocalSet       : 52      
- Loop           : 8       
- MemoryFill     : 1       
- Nop            : 4       
- RefAs          : 19      
- RefFunc        : 26      
- RefI31         : 1       
- RefIsNull      : 1       
- RefNull        : 11      
- Return         : 2       
- Select         : 5       
+ LocalGet       : 66      
+ LocalSet       : 39      
+ Loop           : 1       
+ Nop            : 3       
+ RefAs          : 13      
+ RefFunc        : 9       
+ RefI31         : 2       
+ RefIsNull      : 2       
+ RefNull        : 7       
+ RefTest        : 1       
+ Return         : 5       
+ SIMDReplace    : 1       
+ Select         : 3       
+ Store          : 1       
+ StringConst    : 3       
  StringEncode   : 1       
- StructGet      : 3       
- StructNew      : 26      
- Try            : 1       
- TryTable       : 6       
+ StringMeasure  : 1       
+ StructGet      : 1       
+ StructNew      : 15      
+ StructSet      : 2       
  TupleExtract   : 1       
- TupleMake      : 2       
- Unary          : 20      
- Unreachable    : 10      
+ TupleMake      : 3       
+ Unary          : 16      
+ Unreachable    : 9       


### PR DESCRIPTION
This adds more of a chance to call code from initial content. This includes
invokes of function imports, which we didn't do before.