### PR TITLE
Fuzzing: Ignore differences in names that wasm2js fixes up

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1086,6 +1086,10 @@ class Wasm2JS(TestCaseHandler):
             # fuzzer can notice.
             x = re.sub(r' null', ' 0', x)
 
+            # wasm2js converts exports to valid JS forms, which affects some of
+            # the names in the test suite. Fix those up.
+            x = x.replace('log-', 'log_')
+
             # check if a number is 0 or a subnormal, which is basically zero
             def is_basically_zero(x):
                 # to check if something is a subnormal, compare it to the largest one


### PR DESCRIPTION
wasm2js renames exports to js-valid names. That difference can be noticeable
when we compare it to the original names, so fix that up.

This must land before #7198: that PR adds more invokes, including invokes of
imports, whose names can be modified by wasm2js.