### PR TITLE
[NFC] Remove some dead code in wasm2js

### DIFF
--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -2772,14 +2772,6 @@ void Wasm2JSGlue::emitPostES6() {
       default:
         continue;
     }
-    std::ostringstream export_name;
-    for (char c : exp->name.str) {
-      if (c == '-') {
-        export_name << '_';
-      } else {
-        export_name << c;
-      }
-    }
     out << "export var " << asmangle(exp->name.toString()) << " = ret"
         << moduleName << "." << asmangle(exp->name.toString()) << ";\n";
   }


### PR DESCRIPTION
This code wrote to `export_name` but it was never used. I guess we forgot
to remove it when we updated the name mangling there.