### PR TITLE
wasm2js fuzzing: Fix up call-* import names

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1089,6 +1089,7 @@ class Wasm2JS(TestCaseHandler):
             # wasm2js converts exports to valid JS forms, which affects some of
             # the names in the test suite. Fix those up.
             x = x.replace('log-', 'log_')
+            x = x.replace('call-', 'call_')
 
             # check if a number is 0 or a subnormal, which is basically zero
             def is_basically_zero(x):

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1090,6 +1090,7 @@ class Wasm2JS(TestCaseHandler):
             # the names in the test suite. Fix those up.
             x = x.replace('log-', 'log_')
             x = x.replace('call-', 'call_')
+            x = x.replace('export-', 'export_')
 
             # check if a number is 0 or a subnormal, which is basically zero
             def is_basically_zero(x):


### PR DESCRIPTION
This is needed for the same reasons as log-*. I believe no other import needs
fixing, as they require features not supported in wasm2js (like reference types
for table operations).