### PR TITLE
Fuzzing: Fix fuzz_shell.js on exports whose name is an integer

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -350,13 +350,20 @@ function build(binary) {
     quit();
   }
 
-  // Update the exports. Note that this adds onto |exports|, |exportList|,
+  // Update the exports. Note that this adds onto |exports| and |exportList|,
   // which is intentional: if we build another wasm, or build this one more
   // than once, we want to be able to call them all, so we unify all their
   // exports. (We do trample in |exports| when keys are equal - basically this
   // is a single global namespace - but |exportList| is appended to, so we do
   // keep the ability to call anything that was ever exported.)
-  for (var key in instance.exports) {
+  //
+  // Note we do not iterate on instance.exports: the order there is not
+  // necessarily the order in the wasm (which is what wasm-opt --fuzz-exec uses,
+  // for example), because of JS object iteration rules (numbers are considered
+  // "array indexes" and appear first,
+  // https://tc39.es/ecma262/#sec-ordinaryownpropertykeys).
+  for (var e of WebAssembly.Module.exports(module)) {
+    var key = e.name;
     var value = instance.exports[key];
     value = wrapExportForJSPI(value);
     exports[key] = value;

--- a/scripts/wasm2js.js
+++ b/scripts/wasm2js.js
@@ -67,6 +67,15 @@ var WebAssembly = {
     info['env']['__tempMemory__'] = 0; // risky!
     // This will be replaced by the actual wasm2js code.
     var exports = instantiate(info, wasmMemory);
+
+    // Save the exports on the module object, so that
+    // WebAssembly.Module.exports() works. Ideally we would do this in
+    // WebAssembly.Module(), but we don't know the exports at that point - all
+    // the actual work happens in Instance(), here. In practice this is enough
+    // as calls to WebAssembly.Module.exports() from the fuzzer happen after
+    // instantiation.
+    module.exports = exports;
+
     return {
       'exports': exports
     };
@@ -81,6 +90,15 @@ var WebAssembly = {
       }
     };
   }
+};
+
+// Add the exports() API on top of the Module constructor.
+WebAssembly.Module.exports = (module) => {
+  var ret = [];
+  for (var key in module.exports) {
+    ret.push({ name: key });
+  }
+  return ret;
 };
 
 var tempRet0 = 0;

--- a/test/lit/node/fuzz_shell_numeric_export.wast
+++ b/test/lit/node/fuzz_shell_numeric_export.wast
@@ -1,0 +1,29 @@
+;; Test that numeric exports appear in the right position. The JS rules
+;; affecting the order of instance.exports can be confusing, and we want the
+;; actual order in the wasm.
+
+(module
+  (func $a (export "a") (result i32)
+    (i32.const 10)
+  )
+
+  (func $0 (export "0") (result i32)
+    (i32.const 20)
+  )
+
+  (func $c (export "c") (result i32)
+    (i32.const 30)
+  )
+)
+
+;; Run in wasm-opt and in node to see they agree.
+;; RUN: wasm-opt %s -o %t.wasm -q --fuzz-exec-before | filecheck %s
+;; RUN: node %S/../../../scripts/fuzz_shell.js %t.wasm | filecheck %s
+;;
+;; CHECK: [fuzz-exec] calling a
+;; CHECK: [fuzz-exec] note result: a => 10
+;; CHECK: [fuzz-exec] calling 0
+;; CHECK: [fuzz-exec] note result: 0 => 20
+;; CHECK: [fuzz-exec] calling c
+;; CHECK: [fuzz-exec] note result: c => 30
+


### PR DESCRIPTION
JS sorts such indexes to the start of `wasm.exports`, but we want the order in
the wasm, so get the proper ordering using `WebAssembly.Module.exports`.