### PR TITLE
Fuzzer: Fix up rethrows after changes

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1666,7 +1666,7 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
         }
         i--;
       }
-    } 
+    }
   };
   Fixer fixer(wasm, *this);
   fixer.walk(func->body);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1635,10 +1635,14 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
     }
 
     bool isValidRethrow(Name target) {
-      if (controlFlowStack.empty()) {
+      // The rethrow must be on top.
+      assert(!controlFlowStack.empty());
+      assert(controlFlowStack.back()->is<Rethrow>());
+      if (controlFlowStack.size() < 2) {
+        // There must be a try for this rethrow to be valid.
         return false;
       }
-      Index i = controlFlowStack.size() - 1;
+      Index i = controlFlowStack.size() - 2;
       while (1) {
         auto* curr = controlFlowStack[i];
         if (auto* tryy = curr->dynCast<Try>()) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1606,10 +1606,13 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
     void replace() { replaceCurrent(parent.makeTrivial(getCurrent()->type)); }
 
     bool hasBreakTarget(Name name) {
-      if (expressionStack.empty()) {
+      // The break must be on top.
+      assert(!expressionStack.empty());
+      if (expressionStack.size() < 2) {
+        // There must be a scope for this break to be valid.
         return false;
       }
-      Index i = expressionStack.size() - 1;
+      Index i = expressionStack.size() - 2;
       while (1) {
         auto* curr = expressionStack[i];
         bool has = false;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1650,7 +1650,7 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
               return false;
             }
             auto* child = controlFlowStack[i + 1];
-            return child == tryy->body;
+            return child != tryy->body;
           }
         }
         if (i == 0) {


### PR DESCRIPTION
We may move a rethrow into an invalid position when we `mutate()` etc. This finds
such invalid rethrows and replaces them with something trivial so that we validate.