### PR TITLE
Do not fuzz gc-atomics.wast

### DIFF
--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -75,6 +75,8 @@ unfuzzable = [
     'typed_continuations_contnew.wast',
     'typed_continuations_contbind.wast',
     'typed_continuations_suspend.wast',
+    # the fuzzer does not support struct RMW ops
+    'gc-atomics.wast',
     # contains too many segments to run in a wasm VM
     'limit-segments_disable-bulk-memory.wast',
     # https://github.com/WebAssembly/binaryen/issues/7176


### PR DESCRIPTION
The interpreter does not yet support the struct RMW ops, so this test
file cannot be fuzzed.
