### PR TITLE
Fuzzer: Ignore tests with the linking section

### DIFF
--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -55,6 +55,9 @@ unfuzzable = [
     'strip-dwarf.wasm',
     'ignore_missing_func_dwarf.wasm',
     'print.wasm',
+    # ignore linking section as it causes us to warn about it not being fully
+    # supported
+    'strip-target-features.wasm',
     # TODO fuzzer support for multimemory
     'multi-memories-atomics64.wast',
     'multi-memories-basics.wast',


### PR DESCRIPTION
We warn on that, saying we don't support it, which is both an error in the
fuzzer but also means it isn't useful to fuzz.

Fixes https://github.com/WebAssembly/binaryen/pull/7212#issuecomment-2590839205