### PR TITLE
Fuzzer: Fix escaping of wasm-ctor-eval names

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1346,7 +1346,7 @@ class CtorEval(TestCaseHandler):
         # Fix escaping of the names, as we will be passing them as commandline
         # parameters below (e.g. we want --ctors=foo\28bar and not
         # --ctors=foo\\28bar; that extra escaping \ would cause an error).
-        ctors = bytes(ctors, 'utf-8').decode('unicode_escape')
+        ctors = ctors.replace('\\\\', '\\')
 
         # eval the wasm.
         # we can use --ignore-external-input because the fuzzer passes in 0 to

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1343,6 +1343,11 @@ class CtorEval(TestCaseHandler):
         if not ctors:
             return
 
+        # Fix escaping of the names, as we will be passing them as commandline
+        # parameters below (e.g. we want --ctors=foo\28bar and not
+        # --ctors=foo\\28bar; that extra escaping \ would cause an error).
+        ctors = bytes(ctors, 'utf-8').decode('unicode_escape')
+
         # eval the wasm.
         # we can use --ignore-external-input because the fuzzer passes in 0 to
         # all params, which is the same as ctor-eval assumes in this mode.


### PR DESCRIPTION
Apparently we have some exports that need escaping in their names, and
we should not escape them twice.