### PR TITLE
Do not optimize tag types in SignatureRefining

### DIFF
--- a/src/passes/SignatureRefining.cpp
+++ b/src/passes/SignatureRefining.cpp
@@ -154,6 +154,13 @@ struct SignatureRefining : public Pass {
       }
     }
 
+    // Also skip modifying types used in tags, even private tags, since we don't
+    // analyze exception handling or stack switching instructions. TODO: Analyze
+    // and optimize exception handling and stack switching instructions.
+    for (auto& tag : module->tags) {
+      allInfo[tag->type].canModify = false;
+    }
+
     // For now, do not optimize types that have subtypes. When we modify such a
     // type we need to modify subtypes as well, similar to the analysis in
     // TypeRefining, and perhaps we can unify this pass with that. TODO

--- a/test/lit/passes/signature-refining.wast
+++ b/test/lit/passes/signature-refining.wast
@@ -1126,8 +1126,7 @@
 
  ;; CHECK:      (func $func (type $sig) (param $x anyref)
  ;; CHECK-NEXT: )
- (func $func (type $sig) (param $x anyref)
- )
+ (func $func (type $sig) (param $x anyref))
 
  ;; CHECK:      (func $caller (type $2)
  ;; CHECK-NEXT:  (call $func
@@ -1141,3 +1140,43 @@
  )
 )
 
+;; Tags: The type we'd like to refine, $sig, is used by a tag, so do not
+;; optimize.
+(module
+  ;; CHECK:      (type $sig (func (param anyref)))
+  (type $sig (func (param anyref)))
+
+  ;; CHECK:      (type $1 (func))
+
+  ;; CHECK:      (tag $e (type $sig) (param anyref))
+  (tag $e (type $sig))
+
+  ;; CHECK:      (func $optimizable (type $sig) (param $0 anyref)
+  ;; CHECK-NEXT:  (call $optimizable
+  ;; CHECK-NEXT:   (ref.cast eqref
+  ;; CHECK-NEXT:    (local.get $0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $optimizable (type $sig) (param anyref)
+    (call $optimizable
+      (ref.cast eqref
+        (local.get 0)
+      )
+    )
+  )
+
+  ;; CHECK:      (func $throw (type $1)
+  ;; CHECK-NEXT:  (local $0 anyref)
+  ;; CHECK-NEXT:  (throw $e
+  ;; CHECK-NEXT:   (local.get $0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $throw
+    (local anyref)
+    ;; This would be invalid if we optimized $sig.
+    (throw $e
+      (local.get 0)
+    )
+  )
+)


### PR DESCRIPTION
Now that we preserve tag heap types in the IR, it was possible for
SignatureRefining to refine heap types used by tags in such a way that
the tag uses would no longer be valid. An ideal fix would be to have
SignatureRefining analyze and optimize tag usage as well as calls, but
for now just skip optimizing any heap type used in a tag.
