### PR TITLE
Do not optimize tag types in SignaturePruning

### DIFF
--- a/src/passes/SignaturePruning.cpp
+++ b/src/passes/SignaturePruning.cpp
@@ -169,6 +169,12 @@ struct SignaturePruning : public Pass {
       }
     }
 
+    // Similarly, we cannot yet modify types used in exception handling or stack
+    // switching tags. TODO.
+    for (auto& tag : module->tags) {
+      allInfo[tag->type].optimizable = false;
+    }
+
     // A type must have the same number of parameters and results as its
     // supertypes and subtypes, so we only attempt to modify types without
     // supertypes or subtypes.

--- a/test/lit/passes/signature-pruning.wast
+++ b/test/lit/passes/signature-pruning.wast
@@ -1239,3 +1239,34 @@
   )
 )
 
+;; Test that we do not prune parameters from types used in tags.
+(module
+  ;; CHECK:      (type $sig (func (param anyref)))
+  (type $sig (func (param anyref)))
+
+  ;; CHECK:      (type $1 (func))
+
+  ;; CHECK:      (tag $e (type $sig) (param anyref))
+  (tag $e (type $sig))
+
+  ;; CHECK:      (func $unused-param (type $sig) (param $0 anyref)
+  ;; CHECK-NEXT:  (nop)
+  ;; CHECK-NEXT: )
+  (func $unused-param (type $sig) (param anyref)
+    (nop)
+  )
+
+  ;; CHECK:      (func $throw (type $1)
+  ;; CHECK-NEXT:  (local $0 anyref)
+  ;; CHECK-NEXT:  (throw $e
+  ;; CHECK-NEXT:   (local.get $0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $throw
+    (local anyref)
+    ;; This would be invalid if we optimized $sig.
+    (throw $e
+      (local.get 0)
+    )
+  )
+)


### PR DESCRIPTION
Now that we preserve tag heap types in the IR, it was possible for
SignaturePruning to optimize heap types used by tags in such a way that
the tag uses would no longer be valid. An ideal fix would be to have
SignaturePruning analyze and optimize tag usage as well as calls, but
for now just skip optimizing any heap type used in a tag.
