### PR TITLE
Use CMAKE_MSVC_RUNTIME_LIBRARY to choose MSVC CRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,8 +246,6 @@ if(MSVC)
         CMAKE_C_FLAGS_MINSIZEREL)
       string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
         "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
-
-      string(REPLACE "/MD" "/MT" ${flags_var_to_scrub} "${${flags_var_to_scrub}}")
     endforeach()
     # Compile with `/MT` to link against `libcmt.lib`, removing a dependency
     # on `msvcrt.dll`. May result in slightly larger binaries but they should

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,11 +247,12 @@ if(MSVC)
       string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )" " "
         "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
 
-      # Compile with `/MT` to link against `libcmt.lib`, removing a dependency
-      # on `msvcrt.dll`. May result in slightly larger binaries but they should
-      # be more portable across systems.
       string(REPLACE "/MD" "/MT" ${flags_var_to_scrub} "${${flags_var_to_scrub}}")
     endforeach()
+    # Compile with `/MT` to link against `libcmt.lib`, removing a dependency
+    # on `msvcrt.dll`. May result in slightly larger binaries but they should
+    # be more portable across systems.
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
   endif()
 
   add_link_flag("/STACK:8388608")


### PR DESCRIPTION
For some reason CMake is now using the clang-style version of the flag (i.e. `-MD`
instead of `/MD`) to choose the runtime so this manual flag scrubbing no longer
works. Now that we are depending on CMake newer than version 3.15 we can use
its builtin support for choosing the MSVC runtime.