### PR TITLE
Properly error on a return in a non-function scope

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1698,6 +1698,9 @@ Result<> IRBuilder::makeDrop() {
 }
 
 Result<> IRBuilder::makeReturn() {
+  if (!func) {
+    return Err{"return is only valid in a function context"};
+  }
   Return curr;
   CHECK_ERR(visitReturn(&curr));
   push(builder.makeReturn(curr.value));

--- a/test/lit/parse-error-return-nofunc.wast
+++ b/test/lit/parse-error-return-nofunc.wast
@@ -1,0 +1,10 @@
+;; We should error properly on a return in a non-function scope
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s
+;; CHECK: Fatal: 8:5: error: return is only valid in a function context
+
+(module
+  (elem
+    (return)
+  )
+)


### PR DESCRIPTION
Without this we get an assertion later on,
```
child-typer.h:720:  Assertion `func' failed.
```
Returns use the function to find the return values, so like local
get and set, we must error early on lacking a function.