### PR TITLE
[Interpreter] i32.sub

### DIFF
--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -94,6 +94,9 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     if (curr->op == AddInt32) {
       push(lhs.add(rhs));
       return {};
+    } else if (curr->op == SubInt32) {
+      push(lhs.sub(rhs));
+      return {};
     }
     WASM_UNREACHABLE("TODO");
   }

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -97,6 +97,9 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     } else if (curr->op == SubInt32) {
       push(lhs.sub(rhs));
       return {};
+    } else if (curr->op == MulInt32) {
+      push(lhs.mul(rhs));
+      return {};
     }
     WASM_UNREACHABLE("TODO");
   }

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -97,9 +97,6 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     } else if (curr->op == SubInt32) {
       push(lhs.sub(rhs));
       return {};
-    } else if (curr->op == MulInt32) {
-      push(lhs.mul(rhs));
-      return {};
     }
     WASM_UNREACHABLE("TODO");
   }

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -25,7 +25,7 @@
 
 using namespace wasm;
 
-TEST(InterpreterTest, Addi32) {
+TEST(InterpreterTest, AddI32) {
   Module wasm;
   IRBuilder builder(wasm);
 
@@ -42,7 +42,7 @@ TEST(InterpreterTest, Addi32) {
   EXPECT_EQ(results, expected);
 }
 
-TEST(InterpreterTest, Subi32) {
+TEST(InterpreterTest, SubI32) {
   Module wasm;
   IRBuilder builder(wasm);
 

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -58,3 +58,20 @@ TEST(InterpreterTest, SubI32) {
 
   EXPECT_EQ(results, expected);
 }
+
+TEST(InterpreterTest, MulI32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(MulInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(2))};
+
+  EXPECT_EQ(results, expected);
+}

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -58,20 +58,3 @@ TEST(InterpreterTest, SubI32) {
 
   EXPECT_EQ(results, expected);
 }
-
-TEST(InterpreterTest, MulI32) {
-  Module wasm;
-  IRBuilder builder(wasm);
-
-  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(1))).getErr());
-  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(2))).getErr());
-  ASSERT_FALSE(builder.makeBinary(MulInt32).getErr());
-
-  auto expr = builder.build();
-  ASSERT_FALSE(expr.getErr());
-
-  auto results = Interpreter{}.run(*expr);
-  std::vector<Literal> expected{Literal(uint32_t(2))};
-
-  EXPECT_EQ(results, expected);
-}

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -25,7 +25,7 @@
 
 using namespace wasm;
 
-TEST(InterpreterTest, Add) {
+TEST(InterpreterTest, Addi32) {
   Module wasm;
   IRBuilder builder(wasm);
 
@@ -38,6 +38,23 @@ TEST(InterpreterTest, Add) {
 
   auto results = Interpreter{}.run(*expr);
   std::vector<Literal> expected{Literal(uint32_t(3))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, Subi32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(SubInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(-1))};
 
   EXPECT_EQ(results, expected);
 }


### PR DESCRIPTION
Building on top of #7227, i32.sub is implemented and tested.