### PR TITLE
[ci] Bump setup_python version in create_release.yml

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -110,7 +110,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - uses: actions/checkout@v1
@@ -180,7 +180,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - uses: actions/checkout@v1


### PR DESCRIPTION
Hopefully this will fix the current failure:

```
Run actions/setup-python@v1
  with:
    python-version: 3.x
    architecture: x64
Error: Version 3.x with arch x64 not found
```