### PR TITLE
[ci] Cancel CI jobs when new commits are added to a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - kripken/*
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   lint:


### PR DESCRIPTION
This should really be the default shouldn't it?
