### PR TITLE
Parser: Error on tuples in signatures

### DIFF
--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1215,6 +1215,14 @@ struct ParseImplicitTypeDefsCtx : TypeParserCtx<ParseImplicitTypeDefsCtx> {
       resultTypes = *results;
     }
 
+    for (auto& v : {paramTypes, resultTypes}) {
+      for (auto t : v) {
+        if (!t.isSingle()) {
+          return in.err("tuple types not allowed in signature");
+        }
+      }
+    }
+
     auto sig = Signature(Type(paramTypes), Type(resultTypes));
     auto [it, inserted] = sigTypes.insert({sig, HeapType::func});
     if (inserted) {

--- a/test/lit/parse-bad-tuple-in-sig.wast
+++ b/test/lit/parse-bad-tuple-in-sig.wast
@@ -1,0 +1,10 @@
+;; Test that tuple types in signatures lead to errors
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s
+
+;; CHECK: Fatal: 9:1: error: tuple types not allowed in signature
+
+(module
+ (func $stacky-later-tuple (param (tuple i32 i32))
+ )
+)

--- a/test/lit/parse-bad-tuple-in-sig.wast
+++ b/test/lit/parse-bad-tuple-in-sig.wast
@@ -5,6 +5,6 @@
 ;; CHECK: Fatal: 9:1: error: tuple types not allowed in signature
 
 (module
- (func $stacky-later-tuple (param (tuple i32 i32))
+ (func $tuple-in-sig (param (tuple i32 i32))
  )
 )


### PR DESCRIPTION
Without this, we reach an assertion when we construct the Type for the
params or results, as Types accept lists with single values only.