### PR TITLE
Pin Github runner images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     name: lint
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # Keep this in sync with clang-format-diff.sh
       LLVM_VERSION: 17
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-14, windows-2022]
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -65,19 +65,19 @@ jobs:
 
     - name: gen-s-parser
       run: ./scripts/gen-s-parser.py | diff src/gen-s-parser.inc -
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-*'
 
     - name: install ninja (linux)
       run: sudo apt-get install ninja-build
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-*'
 
     - name: install ninja (macos)
       run: brew install ninja
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-*'
 
     - name: install ninja (win)
       run: choco install ninja
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-*'
 
     - name: install v8
       run: |
@@ -89,16 +89,16 @@ jobs:
 
     - name: cmake (linux)
       run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-*'
 
     - name: cmake (macos)
       run: cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install '-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64'
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-*'
 
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
       run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out/install
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-*'
 
     - name: build
       run: cmake --build out --config Release -v
@@ -108,7 +108,7 @@ jobs:
 
     - name: strip
       run: find out/install/ -type f -perm -u=x -exec strip -x {} +
-      if: matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-*'
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -124,7 +124,7 @@ jobs:
 
   build-clang:
     name: clang (LTO)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -154,7 +154,7 @@ jobs:
   # Copied and modified from build-clang
   build-fuzztest:
     name: clang with fuzztest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -182,7 +182,7 @@ jobs:
   # TODO(sbc): Find a way to reduce the duplicate between these sanitizer jobs
   build-asan:
     name: asan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       ASAN_OPTIONS: "symbolize=1"
       COMPILER_FLAGS: "-fsanitize=address"
@@ -262,7 +262,7 @@ jobs:
   # Duplicates build-asan.  Please keep in sync
   build-ubsan:
     name: ubsan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       COMPILER_FLAGS: "-fsanitize=undefined -fno-sanitize-recover=all"
       CC: "clang"
@@ -294,7 +294,7 @@ jobs:
   # Duplicates build-asan.  Please keep in sync
   build-tsan:
     name: tsan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       COMPILER_FLAGS: "-fsanitize=thread"
       LINKER_FLAGS: "-fsanitize=thread"
@@ -332,7 +332,7 @@ jobs:
   # Build the .js outputs using emcc
   build-emscripten:
     name: emscripten
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       # Set this environment variable to test a specific Emscripten branch.
       # Format: https://github.com/<fork>/emscripten/tree/<refspec>
@@ -369,7 +369,7 @@ jobs:
   # Windows + gcc needs work before the tests will run, so just test the compile
   build-mingw:
     name: mingw
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -387,7 +387,7 @@ jobs:
   # Duplicates build-asan.  Please keep in sync
   build-gcov:
     name: coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       COMPILER_FLAGS: "-fprofile-arcs -ftest-coverage"
       CC: "gcc"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-14, windows-2022]
     defaults:
       run:
         shell: bash
@@ -27,11 +27,11 @@ jobs:
 
     - name: install ninja (macos)
       run: brew install ninja
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-*'
 
     - name: install ninja (win)
       run: choco install ninja
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-*'
 
     - name: mkdir
       run: mkdir -p out
@@ -40,28 +40,28 @@ jobs:
       run: |
         cmake -S . -B out -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_OSX_ARCHITECTURES=x86_64
         cmake -S . -B out-arm64 -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=out-arm64/install -DCMAKE_OSX_ARCHITECTURES=arm64
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-*'
 
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
       run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out/install
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-*'
 
     - name: build
       run: cmake --build out -v --config Release --target install
 
     - name: build-arm64
       run: cmake --build out-arm64 -v --config Release --target install
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-*'
 
     - name: strip
       run: find out*/install/ -type f -perm -u=x -exec strip -x {} +
-      if: matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-*'
 
     - name: archive
       id: archive
       run: |
-        OSNAME=$(echo ${{ matrix.os }} | sed 's/-latest//')
+        OSNAME=$(echo ${{ matrix.os }} | sed 's/-.*//')
         VERSION=$GITHUB_REF_NAME
         PKGNAME="binaryen-$VERSION-x86_64-$OSNAME"
         TARBALL=$PKGNAME.tar.gz
@@ -73,11 +73,12 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "::set-output name=tarball::$TARBALL"
         echo "::set-output name=shasum::$SHASUM"
+      if: matrix.os != 'macos-*'
 
     - name: archive-arm64
       id: archive-arm64
       run: |
-        OSNAME=$(echo ${{ matrix.os }} | sed 's/-latest//')
+        OSNAME=$(echo ${{ matrix.os }} | sed 's/-.*//')
         VERSION=$GITHUB_REF_NAME
         PKGNAME="binaryen-$VERSION-arm64-$OSNAME"
         TARBALL=$PKGNAME.tar.gz
@@ -89,7 +90,7 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "::set-output name=tarball::$TARBALL"
         echo "::set-output name=shasum::$SHASUM"
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-*'
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1
@@ -108,7 +109,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
     steps:
     - uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
This PR pins the versions used for the Github runner images. This is so if anything goes wrong in the ci then you know exactly which os it was running on without inspecting the ci output.