### PR TITLE
Fuzzer: Generate ThrowRef, and avoid unneeded traps with it

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -483,6 +483,7 @@ private:
   Expression* makeArrayBulkMemoryOp(Type type);
   Expression* makeI31Get(Type type);
   Expression* makeThrow(Type type);
+  Expression* makeThrowRef(Type type);
 
   Expression* makeMemoryInit();
   Expression* makeDataDrop();

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1992,7 +1992,7 @@ Expression* TranslateToFuzzReader::_makeunreachable() {
          &Self::makeSwitch,
          &Self::makeDrop,
          &Self::makeReturn)
-    .add(FeatureSet::ExceptionHandling, &Self::makeThrow)
+    .add(FeatureSet::ExceptionHandling, &Self::makeThrow, &Self::makeThrowRef)
     .add(FeatureSet::ReferenceTypes | FeatureSet::GC, &Self::makeCallRef);
   return (this->*pick(options))(Type::unreachable);
 }
@@ -4807,6 +4807,15 @@ Expression* TranslateToFuzzReader::makeThrow(Type type) {
     operands.push_back(make(t));
   }
   return builder.makeThrow(tag, operands);
+}
+
+Expression* TranslateToFuzzReader::makeThrowRef(Type type) {
+  assert(type == Type::unreachable);
+  // Use a nullable type here to avoid the risk of trapping (when we find no way
+  // to make a non-nullable ref, we end up fixing validation with
+  // ref.as_non_null of a null, which validates but traps).
+  auto* ref = make(Type(HeapType::exn, Nullable));
+  return builder.makeThrowRef(ref);
 }
 
 Expression* TranslateToFuzzReader::makeMemoryInit() {


### PR DESCRIPTION
We generate a `throw_ref` by generating an exnref for it to throw. To avoid that
causing lots of traps due to not having an exnref, add some logic to generate
an exnref (by making a try that throws and catches).