### PR TITLE
Customize the limit of MaxDataSegments

### DIFF
--- a/src/ir/memory-utils.h
+++ b/src/ir/memory-utils.h
@@ -46,7 +46,9 @@ inline void ensureExists(Module* wasm) {
 // Try to merge segments until they fit into web limitations.
 // Return true if successful.
 // Does not yet support multimemory
-inline bool ensureLimitedSegments(Module& module, uint32_t maxDataSegments=WebLimitations::MaxDataSegments) {
+inline bool
+ensureLimitedSegments(Module& module,
+                      Index maxDataSegments = WebLimitations::MaxDataSegments) {
   if (module.memories.size() > 1) {
     return false;
   }

--- a/src/passes/LimitSegments.cpp
+++ b/src/passes/LimitSegments.cpp
@@ -22,11 +22,10 @@ namespace wasm {
 
 struct LimitSegments : public Pass {
   void run(Module* module) override {
-    uint32_t maxDataSegments;
-    if(hasArgument("limit-segments")) {
+    Index maxDataSegments;
+    if (hasArgument("limit-segments")) {
       maxDataSegments = std::stoul(getArgument("limit-segments", ""));
-    }
-    else {
+    } else {
       maxDataSegments = WebLimitations::MaxDataSegments;
     }
     if (!MemoryUtils::ensureLimitedSegments(*module, maxDataSegments)) {

--- a/src/passes/LimitSegments.cpp
+++ b/src/passes/LimitSegments.cpp
@@ -18,6 +18,17 @@
 #include "pass.h"
 #include "wasm.h"
 
+//
+// Attempt to merge segments to fit within a specified limit.
+//
+// By default this limit is equal to the one commonly used by wasm VMs
+// (see wasm-limits.h), but it can be changed with the option below:
+//
+//   --pass-arg=limit-segments@max-data-segments
+//
+//       Specify a custom maximum number of data segments.
+//
+
 namespace wasm {
 
 struct LimitSegments : public Pass {

--- a/src/passes/LimitSegments.cpp
+++ b/src/passes/LimitSegments.cpp
@@ -22,7 +22,14 @@ namespace wasm {
 
 struct LimitSegments : public Pass {
   void run(Module* module) override {
-    if (!MemoryUtils::ensureLimitedSegments(*module)) {
+    uint32_t maxDataSegments;
+    if(hasArgument("limit-segments")) {
+      maxDataSegments = std::stoul(getArgument("limit-segments", ""));
+    }
+    else {
+      maxDataSegments = WebLimitations::MaxDataSegments;
+    }
+    if (!MemoryUtils::ensureLimitedSegments(*module, maxDataSegments)) {
       std::cerr << "Unable to merge segments. "
                 << "wasm VMs may not accept this binary" << std::endl;
     }

--- a/test/lit/passes/custom-max-data-segments.wast
+++ b/test/lit/passes/custom-max-data-segments.wast
@@ -1,0 +1,13 @@
+;; RUN: wasm-opt %s --limit-segments --pass-arg=limit-segments@3 -S -o - | filecheck %s
+
+;; Test that the data segments custom limit is respected.
+(module
+ (memory 256 256)
+ ;; CHECK:      (data $0 (i32.const 0) "A")
+ (data (i32.const 0) "A")
+ ;; CHECK:      (data $"" (i32.const 1) "AAAA")
+ (data (i32.const 1) "A")
+ (data (i32.const 2) "A")
+ (data (i32.const 3) "A")
+ (data (i32.const 4) "A")
+)


### PR DESCRIPTION
Related to #7229.

The custom limit can be passed by doing `--pass-arg=limit-segments@1024 `.

I didn't commit a unit test because I don't think it's necessary to add one, but I wrote one to test everything works:
```diff --git a/test/unit/test_memory_packing.py b/test/unit/test_memory_packing.py
index e2468e689..42e696421 100644
--- a/test/unit/test_memory_packing.py
+++ b/test/unit/test_memory_packing.py
@@ -40,3 +40,19 @@ class MemoryPackingTest(utils.BinaryenTestCase):
         self.assertEqual(p.returncode, 0)
         self.assertIn('Some VMs may not accept this binary', p.stderr)
         self.assertIn('Run the limit-segments pass to merge segments.', p.stderr)
+
+    def test_limit_segments_arg(self):
+        max_data_segments = 1024
+        data = '\n'.join('(data (i32.const %i) "A")' % i for i in range(100001))
+        module = '(module (memory 256 256) %s)' % data
+        opts = ['--limit-segments', f'--pass-arg=limit-segments@{max_data_segments}', '--print',
+                '-o', os.devnull]
+        output = [
+            f'(data ${max_data_segments-3} (i32.const {max_data_segments-3}) "A")',
+            f'(data $ (i32.const {max_data_segments-2}) "{"A"*(100001-(max_data_segments-2))}")'
+        ]
+        p = shared.run_process(shared.WASM_OPT + opts, input=module,
+                               check=False, capture_output=True)
+        self.assertEqual(p.returncode, 0)
+        for line in output:
+            self.assertIn(line, p.stdout)
```