### PR TITLE
Fix JS tag fuzzing: throw the same in JS and the binaryen interpreter

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -270,8 +270,10 @@ var imports = {
     // Throw an exception from JS.
     'throw': (which) => {
       if (!which) {
-        throw 'some JS error';
+        // Throw a JS exception.
+        throw 0;
       } else {
+        // Throw a wasm exception.
         throw new WebAssembly.Exception(wasmTag, [which]);
       }
     },

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -182,7 +182,8 @@ public:
 
   void throwJSException() {
     // JS exceptions contain an externref, which wasm can't read (so the actual
-    // value here does not matter).
+    // value here does not matter, but it does need to match what the 'throw'
+    // import does in fuzz_shell.js, as the fuzzer will do comparisons).
     Literal externref = Literal::makeI31(0, Unshared).externalize();
     Literals arguments = {externref};
     auto payload = std::make_shared<ExnData>(jsTag, arguments);

--- a/test/lit/d8/fuzz_shell_exceptions.wast
+++ b/test/lit/d8/fuzz_shell_exceptions.wast
@@ -31,7 +31,7 @@
 ;; RUN: v8 %S/../../../scripts/fuzz_shell.js -- %t.wasm | filecheck %s
 ;;
 ;; CHECK: [fuzz-exec] calling throwing-js
-;; CHECK: exception thrown: some JS error
+;; CHECK: exception thrown: 0
 ;; CHECK: [fuzz-exec] calling throwing-tag
 ;; CHECK: exception thrown: [object WebAssembly.Exception]
 


### PR DESCRIPTION
We do not compare exceptions in binaryen (not in the optimizer, where we
assume we can reorder traps, and not in the fuzzer, where we assume VMs
may have different text for them). But, since we have try-catch in wasm,
we can actually end up comparing them, by catching the exception and
logging the output. For that reason, we need to throw exactly the same
JS exception in #7283, which this fixes.

(I fuzzed #7283 for a few hours, and it found this error right after I landed the PR :smile: )