### PR TITLE
[GC][EH] Fuzz exnref in GC structs

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1858,9 +1858,8 @@ Expression* TranslateToFuzzReader::make(Type type) {
     ret = _makeunreachable();
   }
   if (!Type::isSubType(ret->type, type)) {
-    std::cerr << "Did not generate the right type of thing " << type
-            << " but have " << ret->type << " : " << *ret << '\n';
-              assert(0);
+    Fatal() << "Did not generate the right type of " << type
+            << ", instead we have " << ret->type << " : " << *ret << '\n';
   }
   nesting--;
   return ret;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -5142,7 +5142,7 @@ Type TranslateToFuzzReader::getSubType(Type type) {
     if (!funcContext && heapType.isMaybeShared(HeapType::exn)) {
       return type;
     }
-    heapType = getSubType(type.getHeapType());
+    heapType = getSubType(heapType);
     auto nullability = getSubType(type.getNullability());
     auto subType = Type(heapType, nullability);
     // We don't want to emit lots of uninhabitable types like (ref none), so

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1858,8 +1858,9 @@ Expression* TranslateToFuzzReader::make(Type type) {
     ret = _makeunreachable();
   }
   if (!Type::isSubType(ret->type, type)) {
-    Fatal() << "Did not generate the right type of thing " << type
+    std::cerr << "Did not generate the right type of thing " << type
             << " but have " << ret->type << " : " << *ret << '\n';
+              assert(0);
   }
   nesting--;
   return ret;
@@ -5052,11 +5053,6 @@ Nullability TranslateToFuzzReader::getSubType(Nullability nullability) {
 }
 
 HeapType TranslateToFuzzReader::getSubType(HeapType type) {
-  // Do not generate new shared exnrefs, which we cannot generate in wasm.
-  if (type.isMaybeShared(HeapType::exn)) {
-    return type;
-  }
-
   if (oneIn(3)) {
     return type;
   }
@@ -5108,6 +5104,7 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
       case HeapType::array:
         return pick(HeapTypes::array, HeapTypes::none).getBasic(share);
       case HeapType::exn:
+        assert(share == Unshared);
         return HeapTypes::exn.getBasic(share);
       case HeapType::string:
         assert(share == Unshared);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -5056,7 +5056,7 @@ Nullability TranslateToFuzzReader::getSubType(Nullability nullability) {
 
 HeapType TranslateToFuzzReader::getSubType(HeapType type) {
   // Do not generate new shared exnrefs, which we cannot generate in wasm.
-  if (heapType.isMaybeShared(HeapType::exn)) {
+  if (type.isMaybeShared(HeapType::exn)) {
     return type;
   }
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1858,7 +1858,7 @@ Expression* TranslateToFuzzReader::make(Type type) {
     ret = _makeunreachable();
   }
   if (!Type::isSubType(ret->type, type)) {
-    Fatal() << "Did not generate the right type of " << type
+    Fatal() << "Did not generate the right subtype of " << type
             << ", instead we have " << ret->type << " : " << *ret << '\n';
   }
   nesting--;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1857,8 +1857,10 @@ Expression* TranslateToFuzzReader::make(Type type) {
     assert(type == Type::unreachable);
     ret = _makeunreachable();
   }
-  // We should create the right type of thing.
-  assert(Type::isSubType(ret->type, type));
+  if (!Type::isSubType(ret->type, type)) {
+    Fatal() << "Did not generate the right type of thing " << type
+            << " but have " << ret->type << " : " << *ret << '\n';
+  }
   nesting--;
   return ret;
 }

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -160,26 +160,21 @@ struct HeapTypeGeneratorImpl {
         rand.pick(HeapType::noext, HeapType::nofunc, HeapType::none);
       return ht.getBasic(share);
     }
+
+    std::vector<HeapType> options{
+                              HeapType::func,
+                              HeapType::ext,
+                              HeapType::any,
+                              HeapType::eq,
+                              HeapType::i31,
+                              HeapType::struct_,
+                              HeapType::array
+                              };
     // Avoid shared exn, which we cannot generate.
-    HeapType ht;
-    if (share == Unshared) {
-      ht = rand.pick(HeapType::func,
-                              HeapType::ext,
-                              HeapType::any,
-                              HeapType::eq,
-                              HeapType::i31,
-                              HeapType::struct_,
-                              HeapType::array,
-                              HeapType::exn);
-    } else {
-      ht = rand.pick(HeapType::func,
-                              HeapType::ext,
-                              HeapType::any,
-                              HeapType::eq,
-                              HeapType::i31,
-                              HeapType::struct_,
-                              HeapType::array);
+    if (features.hasExceptionHandling() && share == Unshared) {
+      options.push_back(HeapType::exn);
     }
+    auto ht = rand.pick(options);
     if (share == Unshared && features.hasSharedEverything() && rand.oneIn(2)) {
       share = Shared;
     }

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -160,14 +160,26 @@ struct HeapTypeGeneratorImpl {
         rand.pick(HeapType::noext, HeapType::nofunc, HeapType::none);
       return ht.getBasic(share);
     }
-    HeapType ht = rand.pick(HeapType::func,
-                            HeapType::ext,
-                            HeapType::any,
-                            HeapType::eq,
-                            HeapType::i31,
-                            HeapType::struct_,
-                            HeapType::array,
-                            HeapType::exn);
+    // Avoid shared exn, which we cannot generate.
+    HeapType ht;
+    if (share == Unshared) {
+      ht = rand.pick(HeapType::func,
+                              HeapType::ext,
+                              HeapType::any,
+                              HeapType::eq,
+                              HeapType::i31,
+                              HeapType::struct_,
+                              HeapType::array,
+                              HeapType::exn);
+    } else {
+      ht = rand.pick(HeapType::func,
+                              HeapType::ext,
+                              HeapType::any,
+                              HeapType::eq,
+                              HeapType::i31,
+                              HeapType::struct_,
+                              HeapType::array);
+    }
     if (share == Unshared && features.hasSharedEverything() && rand.oneIn(2)) {
       share = Shared;
     }

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -173,7 +173,8 @@ struct HeapTypeGeneratorImpl {
       options.push_back(HeapType::exn);
     }
     auto ht = rand.pick(options);
-    if (share == Unshared && features.hasSharedEverything() && rand.oneIn(2)) {
+    if (share == Unshared && features.hasSharedEverything() &&
+        ht != HeapType::exn && rand.oneIn(2)) {
       share = Shared;
     }
     return ht.getBasic(share);

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -161,15 +161,13 @@ struct HeapTypeGeneratorImpl {
       return ht.getBasic(share);
     }
 
-    std::vector<HeapType> options{
-                              HeapType::func,
-                              HeapType::ext,
-                              HeapType::any,
-                              HeapType::eq,
-                              HeapType::i31,
-                              HeapType::struct_,
-                              HeapType::array
-                              };
+    std::vector<HeapType> options{HeapType::func,
+                                  HeapType::ext,
+                                  HeapType::any,
+                                  HeapType::eq,
+                                  HeapType::i31,
+                                  HeapType::struct_,
+                                  HeapType::array};
     // Avoid shared exn, which we cannot generate.
     if (features.hasExceptionHandling() && share == Unshared) {
       options.push_back(HeapType::exn);

--- a/test/lit/fuzz-types.test
+++ b/test/lit/fuzz-types.test
@@ -4,7 +4,7 @@
 ;; CHECK-NEXT: Built 20 types:
 ;; CHECK-NEXT: (rec
 ;; CHECK-NEXT:  (type $0 (sub (struct (field (mut i16)) (field (mut (ref $2))) (field (mut (ref null $2))))))
-;; CHECK-NEXT:  (type $1 (sub (func (param (ref $1)) (result f64 (ref $0) f32 (ref null (shared eq))))))
+;; CHECK-NEXT:  (type $1 (sub (func (param (ref $1)) (result f64 (ref $0) f32 structref))))
 ;; CHECK-NEXT:  (type $2 (sub (shared (struct (field (mut (ref null (shared extern)))) (field (mut (ref null $2)))))))
 ;; CHECK-NEXT:  (type $3 (sub (shared (struct))))
 ;; CHECK-NEXT: )
@@ -22,21 +22,21 @@
 ;; CHECK-NEXT:  (type $12 (sub (shared (array (ref $3)))))
 ;; CHECK-NEXT:  (type $13 (sub (shared (func (param (ref null $19) v128) (result (ref null $12))))))
 ;; CHECK-NEXT:  (type $14 (sub final $12 (shared (array (ref $3)))))
-;; CHECK-NEXT:  (type $15 (sub (shared (func (param (ref null (shared struct)) i31ref) (result nullfuncref)))))
+;; CHECK-NEXT:  (type $15 (sub (shared (func (param i31ref (ref $5)) (result i32)))))
 ;; CHECK-NEXT:  (type $16 (sub $5 (array i32)))
-;; CHECK-NEXT:  (type $17 (sub (func (param v128) (result f64))))
-;; CHECK-NEXT:  (type $18 (sub (array (ref $11))))
-;; CHECK-NEXT:  (type $19 (shared (array i8)))
+;; CHECK-NEXT:  (type $17 (sub (func (result (ref $7)))))
+;; CHECK-NEXT:  (type $18 (sub (array (mut i8))))
+;; CHECK-NEXT:  (type $19 (shared (array v128)))
 ;; CHECK-NEXT: )
-;; CHECK-NEXT:
+;; CHECK-NEXT: 
 ;; CHECK-NEXT: Inhabitable types:
-;; CHECK-NEXT:
+;; CHECK-NEXT: 
 ;; CHECK-NEXT: Built 20 types:
 ;; CHECK-NEXT: (rec
 ;; CHECK-NEXT:  (type $0 (sub (struct (field (mut i16)) (field (mut (ref $2))) (field (mut (ref null $2))))))
-;; CHECK-NEXT:  (type $1 (sub (func (param (ref $1)) (result f64 (ref $0) f32 (ref null (shared eq))))))
+;; CHECK-NEXT:  (type $1 (sub (func (param (ref $1)) (result f64 (ref $0) f32 structref))))
 ;; CHECK-NEXT:  (type $2 (sub (shared (struct (field (mut (ref null (shared extern)))) (field (mut (ref null $2)))))))
-;; CHECK-NEXT:  (type $3 (sub (shared (struct)))
+;; CHECK-NEXT:  (type $3 (sub (shared (struct))))
 ;; CHECK-NEXT: )
 ;; CHECK-NEXT: (rec
 ;; CHECK-NEXT:  (type $4 (sub (array i32)))
@@ -52,9 +52,9 @@
 ;; CHECK-NEXT:  (type $12 (sub (shared (array (ref $3)))))
 ;; CHECK-NEXT:  (type $13 (sub (shared (func (param (ref null $19) v128) (result (ref null $12))))))
 ;; CHECK-NEXT:  (type $14 (sub final $12 (shared (array (ref $3)))))
-;; CHECK-NEXT:  (type $15 (sub (shared (func (param (ref null (shared struct)) i31ref) (result nullfuncref)))))
+;; CHECK-NEXT:  (type $15 (sub (shared (func (param i31ref (ref $5)) (result i32)))))
 ;; CHECK-NEXT:  (type $16 (sub $5 (array i32)))
-;; CHECK-NEXT:  (type $17 (sub (func (param v128) (result f64))))
-;; CHECK-NEXT:  (type $18 (sub (array (ref $11))))
-;; CHECK-NEXT:  (type $19 (shared (array i8)))
+;; CHECK-NEXT:  (type $17 (sub (func (result (ref $7)))))
+;; CHECK-NEXT:  (type $18 (sub (array (mut i8))))
+;; CHECK-NEXT:  (type $19 (shared (array v128)))
 ;; CHECK-NEXT: )

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,7 +1,7 @@
 Metrics
 total
- [exports]      : 14      
- [funcs]        : 18      
+ [exports]      : 13      
+ [funcs]        : 14      
  [globals]      : 4       
  [imports]      : 12      
  [memories]     : 1       
@@ -9,37 +9,32 @@ total
  [table-data]   : 3       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 626     
- [vars]         : 49      
- ArrayNew       : 1       
- ArrayNewFixed  : 5       
- ArraySet       : 1       
- AtomicCmpxchg  : 1       
- AtomicFence    : 1       
- Binary         : 74      
- Block          : 79      
- Call           : 40      
- Const          : 138     
- Drop           : 9       
- GlobalGet      : 42      
- GlobalSet      : 38      
- If             : 20      
+ [total]        : 557     
+ [vars]         : 23      
+ ArrayNewFixed  : 1       
+ Binary         : 66      
+ Block          : 70      
+ BrOn           : 1       
+ Break          : 2       
+ Call           : 42      
+ Const          : 121     
+ Drop           : 8       
+ GlobalGet      : 38      
+ GlobalSet      : 34      
+ I31Get         : 1       
+ If             : 17      
  Load           : 16      
- LocalGet       : 46      
- LocalSet       : 22      
- Loop           : 2       
+ LocalGet       : 35      
+ LocalSet       : 19      
+ Loop           : 4       
  Nop            : 4       
- RefAs          : 2       
  RefFunc        : 8       
- RefNull        : 4       
- Return         : 3       
- Select         : 1       
- Store          : 1       
+ RefNull        : 3       
+ Return         : 2       
  StringConst    : 3       
- StructNew      : 18      
- StructSet      : 1       
- Throw          : 1       
- TryTable       : 2       
+ StringEq       : 1       
+ StructNew      : 22      
+ TryTable       : 1       
  TupleMake      : 3       
- Unary          : 21      
- Unreachable    : 19      
+ Unary          : 18      
+ Unreachable    : 17      

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,7 +1,7 @@
 Metrics
 total
- [exports]      : 13      
- [funcs]        : 14      
+ [exports]      : 14      
+ [funcs]        : 18      
  [globals]      : 4       
  [imports]      : 12      
  [memories]     : 1       
@@ -9,32 +9,37 @@ total
  [table-data]   : 3       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 557     
- [vars]         : 23      
- ArrayNewFixed  : 1       
- Binary         : 66      
- Block          : 70      
- BrOn           : 1       
- Break          : 2       
- Call           : 42      
- Const          : 121     
- Drop           : 8       
- GlobalGet      : 38      
- GlobalSet      : 34      
- I31Get         : 1       
- If             : 17      
+ [total]        : 626     
+ [vars]         : 49      
+ ArrayNew       : 1       
+ ArrayNewFixed  : 5       
+ ArraySet       : 1       
+ AtomicCmpxchg  : 1       
+ AtomicFence    : 1       
+ Binary         : 74      
+ Block          : 79      
+ Call           : 40      
+ Const          : 138     
+ Drop           : 9       
+ GlobalGet      : 42      
+ GlobalSet      : 38      
+ If             : 20      
  Load           : 16      
- LocalGet       : 35      
- LocalSet       : 19      
- Loop           : 4       
+ LocalGet       : 46      
+ LocalSet       : 22      
+ Loop           : 2       
  Nop            : 4       
+ RefAs          : 2       
  RefFunc        : 8       
- RefNull        : 3       
- Return         : 2       
+ RefNull        : 4       
+ Return         : 3       
+ Select         : 1       
+ Store          : 1       
  StringConst    : 3       
- StringEq       : 1       
- StructNew      : 22      
- TryTable       : 1       
+ StructNew      : 18      
+ StructSet      : 1       
+ Throw          : 1       
+ TryTable       : 2       
  TupleMake      : 3       
- Unary          : 18      
- Unreachable    : 17      
+ Unary          : 21      
+ Unreachable    : 19      


### PR DESCRIPTION
Most of the work here is avoiding shared and non-nullable exnref in
various places, as we cannot support those in the fuzzer (I don't see
a way to generate shared exnrefs, and non-nullable ones can be
created but not in global places, as the way to create them needs a
block and a try).

Some example output:
```wat
 (type $0 (struct (field (mut exnref)) (field (mut i64)) (field (mut v128))))
 (type $1 (sub (struct (field (ref null $1)) (field (mut i16)) (field (mut exnref)) (field (ref struct)))))
 (type $3 (sub final $1 (struct (field (ref null $3)) (field (mut i16)) (field (mut exnref)) (field (ref $2)))))
```