### PR TITLE
[EH] Prune exnref-returning/receiving exports

### DIFF
--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -374,7 +374,7 @@ struct LegalizeAndPruneJSInterface : public LegalizeJSInterface {
       }
 
       // The params are allowed to be multivalue, but not the results. Otherwise
-      // look for SIMD.
+      // look for SIMD etc.
       auto sig = func->type.getSignature();
       auto illegal = isIllegal(sig.results);
       illegal =
@@ -409,7 +409,8 @@ struct LegalizeAndPruneJSInterface : public LegalizeJSInterface {
 
   bool isIllegal(Type type) {
     auto features = type.getFeatures();
-    return features.hasSIMD() || features.hasMultivalue();
+    return features.hasSIMD() || features.hasMultivalue() ||
+           features.hasExceptionHandling();
   }
 };
 

--- a/test/lit/passes/legalize-and-prune-js-interface.wast
+++ b/test/lit/passes/legalize-and-prune-js-interface.wast
@@ -128,11 +128,13 @@
 
   ;; CHECK:      (type $3 (func (result i32 i32)))
 
-  ;; CHECK:      (type $4 (func (param i32)))
+  ;; CHECK:      (type $4 (func (result exnref)))
 
-  ;; CHECK:      (type $5 (func (param i32 i32) (result i32)))
+  ;; CHECK:      (type $5 (func (param i32)))
 
-  ;; CHECK:      (import "env" "setTempRet0" (func $setTempRet0 (type $4) (param i32)))
+  ;; CHECK:      (type $6 (func (param i32 i32) (result i32)))
+
+  ;; CHECK:      (import "env" "setTempRet0" (func $setTempRet0 (type $5) (param i32)))
 
   ;; CHECK:      (export "export-64" (func $legalstub$export-64))
 
@@ -167,9 +169,17 @@
     ;; This will be pruned.
     (unreachable)
   )
+
+  ;; CHECK:      (func $export-exn (type $4) (result exnref)
+  ;; CHECK-NEXT:  (ref.null noexn)
+  ;; CHECK-NEXT: )
+  (func $export-exn (export "export-exn") (result exnref)
+    ;; This will be pruned.
+    (ref.null noexn)
+  )
 )
 
-;; CHECK:      (func $legalstub$export-64 (type $5) (param $0 i32) (param $1 i32) (result i32)
+;; CHECK:      (func $legalstub$export-64 (type $6) (param $0 i32) (param $1 i32) (result i32)
 ;; CHECK-NEXT:  (local $2 i64)
 ;; CHECK-NEXT:  (local.set $2
 ;; CHECK-NEXT:   (call $export-64


### PR DESCRIPTION
Like v128, JS VMs will trap on an exnref on the boundary between JS and wasm,
so the fuzzer must prune such exports (we run that pruning when we intend
to compare d8 to the binaryen interpreter; after the pruning, all exports should
behave the same between those VMs).