### PR TITLE
[EH] Fuzzer: Fix infinite loop with nested exnrefs

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -200,6 +200,9 @@ private:
 
   Index numAddedFunctions = 0;
 
+  // The name of an empty tag.
+  Name trivialTag;
+
   // RAII helper for managing the state used to create a single function.
   struct FunctionCreationContext {
     TranslateToFuzzReader& parent;


### PR DESCRIPTION
When we need an exnref value we may create a try-catch with a throw (so
when we catch it, we get an exnref). But if the exception tag contains an
exnref, then we will try to create another exnref in the throw, leading to
recursion (possibly infinite). To avoid this, just create a trivial tag with no
values when we just want a trivial value.