### PR TITLE
Fuzzer: Simplify and improve emitting of unreachable code

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2009,7 +2009,7 @@ Expression* TranslateToFuzzReader::_makeunreachable() {
   options
     .add(FeatureSet::MVP,
          WeightedOption{&Self::makeBreak, Important},
-         WeightedOption{&Self::makeUnreachable},
+         &Self::makeUnreachable,
          &Self::makeCall,
          &Self::makeCallIndirect,
          &Self::makeSwitch,

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 65      
- [funcs]        : 85      
+ [exports]      : 84      
+ [funcs]        : 115     
  [globals]      : 18      
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 24      
- [table-data]   : 24      
+ [table-data]   : 49      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 8396    
- [vars]         : 239     
- Binary         : 573     
- Block          : 1420    
- Break          : 276     
- Call           : 382     
- CallIndirect   : 56      
- Const          : 1258    
- Drop           : 124     
- GlobalGet      : 731     
- GlobalSet      : 531     
- If             : 468     
- Load           : 129     
- LocalGet       : 578     
- LocalSet       : 422     
- Loop           : 173     
- Nop            : 134     
- RefFunc        : 24      
- Return         : 122     
- Select         : 58      
- Store          : 57      
- Switch         : 6       
- Unary          : 605     
- Unreachable    : 269     
+ [total]        : 10300   
+ [vars]         : 325     
+ Binary         : 679     
+ Block          : 1736    
+ Break          : 323     
+ Call           : 340     
+ CallIndirect   : 93      
+ Const          : 1686    
+ Drop           : 129     
+ GlobalGet      : 882     
+ GlobalSet      : 665     
+ If             : 581     
+ Load           : 146     
+ LocalGet       : 738     
+ LocalSet       : 614     
+ Loop           : 211     
+ Nop            : 156     
+ RefFunc        : 49      
+ Return         : 111     
+ Select         : 67      
+ Store          : 83      
+ Switch         : 1       
+ Unary          : 680     
+ Unreachable    : 330     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 84      
- [funcs]        : 112     
+ [exports]      : 46      
+ [funcs]        : 62      
  [globals]      : 17      
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 11      
- [table-data]   : 36      
+ [table-data]   : 11      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 7833    
- [vars]         : 292     
- Binary         : 578     
- Block          : 1340    
- Break          : 204     
- Call           : 414     
- CallIndirect   : 35      
- Const          : 1256    
- Drop           : 107     
- GlobalGet      : 698     
- GlobalSet      : 535     
- If             : 418     
- Load           : 134     
- LocalGet       : 502     
- LocalSet       : 331     
- Loop           : 149     
- Nop            : 87      
- RefFunc        : 36      
- Return         : 103     
- Select         : 49      
- Store          : 70      
- Switch         : 6       
- Unary          : 508     
- Unreachable    : 273     
+ [total]        : 4599    
+ [vars]         : 195     
+ Binary         : 353     
+ Block          : 753     
+ Break          : 106     
+ Call           : 195     
+ CallIndirect   : 39      
+ Const          : 776     
+ Drop           : 77      
+ GlobalGet      : 381     
+ GlobalSet      : 299     
+ If             : 220     
+ Load           : 83      
+ LocalGet       : 346     
+ LocalSet       : 266     
+ Loop           : 83      
+ Nop            : 46      
+ RefFunc        : 11      
+ Return         : 67      
+ Select         : 20      
+ Store          : 33      
+ Switch         : 2       
+ Unary          : 299     
+ Unreachable    : 144     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,45 +1,46 @@
 Metrics
 total
- [exports]      : 14      
- [funcs]        : 18      
+ [exports]      : 13      
+ [funcs]        : 14      
  [globals]      : 4       
  [imports]      : 12      
  [memories]     : 1       
  [memory-data]  : 112     
- [table-data]   : 3       
+ [table-data]   : 2       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 626     
- [vars]         : 49      
- ArrayNew       : 1       
- ArrayNewFixed  : 5       
- ArraySet       : 1       
- AtomicCmpxchg  : 1       
- AtomicFence    : 1       
+ [total]        : 654     
+ [vars]         : 15      
+ ArrayGet       : 1       
+ ArrayLen       : 1       
+ ArrayNew       : 6       
+ ArrayNewFixed  : 11      
  Binary         : 74      
- Block          : 79      
- Call           : 40      
- Const          : 138     
- Drop           : 9       
- GlobalGet      : 42      
- GlobalSet      : 38      
- If             : 20      
- Load           : 16      
- LocalGet       : 46      
- LocalSet       : 22      
- Loop           : 2       
- Nop            : 4       
+ Block          : 64      
+ Call           : 43      
+ CallIndirect   : 1       
+ Const          : 170     
+ Drop           : 7       
+ GlobalGet      : 38      
+ GlobalSet      : 32      
+ If             : 18      
+ Load           : 17      
+ LocalGet       : 42      
+ LocalSet       : 23      
+ Loop           : 3       
+ Nop            : 3       
  RefAs          : 2       
- RefFunc        : 8       
- RefNull        : 4       
+ RefFunc        : 7       
+ RefNull        : 7       
  Return         : 3       
  Select         : 1       
  Store          : 1       
- StringConst    : 3       
- StructNew      : 18      
+ StringConst    : 1       
+ StringEncode   : 1       
+ StructNew      : 37      
  StructSet      : 1       
  Throw          : 1       
  TryTable       : 2       
  TupleMake      : 3       
- Unary          : 21      
- Unreachable    : 19      
+ Unary          : 17      
+ Unreachable    : 16      


### PR DESCRIPTION
In the earlier days of the fuzzer we would call `makeUnary` with unreachable
sometimes, and then emit an unreachable `i32.eqz` for example. Later we
added `mutate()` which randomly emits unreachable into places, which gives
even better coverage - no need to manually handle unreachability in every
single instruction. This PR removes the old form.

Also remove the "Important" label from `makeUnreachable`. The
unreachable instruction is now one of many that have that type, and we
have no reason to prefer it to others.

These changes have the effect of improving the chance to emit interesting
instructions with unreachable type, like `throw, throw_ref`.