### PR TITLE
[NFC] Remove no longer needed v8 flag to avoid warnings

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1718,7 +1718,10 @@ class Two(TestCaseHandler):
         # Make sure that fuzz_shell.js actually executed all exports from both
         # wasm files.
         exports = get_exports(wasm, ['func']) + get_exports(second_wasm, ['func'])
-        assert output.count(FUZZ_EXEC_CALL_PREFIX) == len(exports)
+        calls_in_output = output.count(FUZZ_EXEC_CALL_PREFIX)
+        if calls_in_output == 0:
+            print(f'warning: no calls in output. output:\n{output}')
+        assert calls_in_output == len(exports)
 
         output = fix_output(output)
 

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -255,7 +255,6 @@ def has_shell_timeout():
 V8_OPTS = [
     '--wasm-staging',
     '--experimental-wasm-compilation-hints',
-    '--experimental-wasm-memory64',
     '--experimental-wasm-stringref',
     '--experimental-wasm-fp16',
 ]


### PR DESCRIPTION
Recent v8 prints "warning: unrecognized flag" about it.

This warning broke a test. Add some logging to the test as well, to make it
easier to debug in the future.