### PR TITLE
[NFC] Store function effects on functions

### DIFF
--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -522,7 +522,7 @@ private:
       }
 
       const auto* targetEffects =
-        parent.module.getFunction(curr->name)->effects.get();
+        parent.module.getFunction(curr->target)->effects.get();
 
       if (curr->isReturn) {
         parent.branchesOut = true;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -29,8 +29,7 @@ class EffectAnalyzer {
 public:
   EffectAnalyzer(const PassOptions& passOptions, Module& module)
     : ignoreImplicitTraps(passOptions.ignoreImplicitTraps),
-      trapsNeverHappen(passOptions.trapsNeverHappen),
-      module(module),
+      trapsNeverHappen(passOptions.trapsNeverHappen), module(module),
       features(module.features) {}
 
   EffectAnalyzer(const PassOptions& passOptions,
@@ -522,7 +521,8 @@ private:
         return;
       }
 
-      const auto* targetEffects = parent.module.getFunction(curr->name)->effects.get();
+      const auto* targetEffects =
+        parent.module.getFunction(curr->name)->effects.get();
 
       if (curr->isReturn) {
         parent.branchesOut = true;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -30,7 +30,7 @@ public:
   EffectAnalyzer(const PassOptions& passOptions, Module& module)
     : ignoreImplicitTraps(passOptions.ignoreImplicitTraps),
       trapsNeverHappen(passOptions.trapsNeverHappen),
-      funcEffectsMap(passOptions.funcEffectsMap), module(module),
+      module(module),
       features(module.features) {}
 
   EffectAnalyzer(const PassOptions& passOptions,
@@ -47,7 +47,6 @@ public:
 
   bool ignoreImplicitTraps;
   bool trapsNeverHappen;
-  std::shared_ptr<FuncEffectsMap> funcEffectsMap;
   Module& module;
   FeatureSet features;
 
@@ -523,13 +522,7 @@ private:
         return;
       }
 
-      const EffectAnalyzer* targetEffects = nullptr;
-      if (parent.funcEffectsMap) {
-        auto iter = parent.funcEffectsMap->find(curr->target);
-        if (iter != parent.funcEffectsMap->end()) {
-          targetEffects = &iter->second;
-        }
-      }
+      const auto* targetEffects = parent.module.getFunction(curr->name)->effects.get();
 
       if (curr->isReturn) {
         parent.branchesOut = true;

--- a/src/ir/effects.h
+++ b/src/ir/effects.h
@@ -521,8 +521,15 @@ private:
         return;
       }
 
-      const auto* targetEffects =
-        parent.module.getFunction(curr->target)->effects.get();
+      // Get the target's effects, if they exist. Note that we must handle the
+      // case of the function not yet existing (we may be executed in the middle
+      // of a pass, which may have built up calls but not the targets of those
+      // calls; in such a case, we do not find the targets and therefore assume
+      // we know nothing about the effects, which is safe).
+      const EffectAnalyzer* targetEffects = nullptr;
+      if (auto* target = parent.module.getFunctionOrNull(curr->target)) {
+        targetEffects = target->effects.get();
+      }
 
       if (curr->isReturn) {
         parent.branchesOut = true;

--- a/src/pass.h
+++ b/src/pass.h
@@ -99,11 +99,6 @@ struct InliningOptions {
   Index partialInliningIfs = 0;
 };
 
-// Forward declaration for FuncEffectsMap.
-class EffectAnalyzer;
-
-using FuncEffectsMap = std::unordered_map<Name, EffectAnalyzer>;
-
 struct PassOptions {
   friend Pass;
 
@@ -236,15 +231,6 @@ struct PassOptions {
   std::unordered_map<std::string, std::string> arguments;
   // Passes to skip and not run.
   std::unordered_set<std::string> passesToSkip;
-
-  // Effect info computed for functions. One pass can generate this and then
-  // other passes later can benefit from it. It is up to the sequence of passes
-  // to update or discard this when necessary - in particular, when new effects
-  // are added to a function this must be changed or we may optimize
-  // incorrectly. However, it is extremely rare for a pass to *add* effects;
-  // passes normally only remove effects. Passes that do add effects must set
-  // addsEffects() so the pass runner is aware of them.
-  std::shared_ptr<FuncEffectsMap> funcEffectsMap;
 
   // -Os is our default
   static constexpr const int DEFAULT_OPTIMIZE_LEVEL = 2;

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -96,6 +96,10 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
       if (self.hasUnremovableSideEffects()) {
         return curr;
       }
+if (curr->is<Call>()) {
+  std::cout << "call " << *curr << '\n';
+//return curr;
+}
       // The result isn't used, and this has no side effects itself, so we can
       // get rid of it. However, the children may have side effects.
       SmallVector<Expression*, 1> childrenWithEffects;

--- a/src/passes/Vacuum.cpp
+++ b/src/passes/Vacuum.cpp
@@ -96,10 +96,6 @@ struct Vacuum : public WalkerPass<ExpressionStackWalker<Vacuum>> {
       if (self.hasUnremovableSideEffects()) {
         return curr;
       }
-if (curr->is<Call>()) {
-  std::cout << "call " << *curr << '\n';
-//return curr;
-}
       // The result isn't used, and this has no side effects itself, so we can
       // get rid of it. However, the children may have side effects.
       SmallVector<Expression*, 1> childrenWithEffects;

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -1044,9 +1044,9 @@ void PassRunner::handleAfterEffects(Pass* pass, Function* func) {
     TypeUpdating::handleNonDefaultableLocals(func, *wasm);
   }
 
-  if (options.funcEffectsMap && pass->addsEffects()) {
+  if (pass->addsEffects()) {
     // Effects were added, so discard any computed effects for this function.
-    options.funcEffectsMap->erase(func->name);
+    func->effects.reset();
   }
 }
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2137,6 +2137,9 @@ struct BinaryLocations {
   std::unordered_map<Function*, FunctionLocations> functions;
 };
 
+// Forward declaration for FuncEffectsMap.
+class EffectAnalyzer;
+
 class Function : public Importable {
 public:
   HeapType type = HeapType(Signature()); // parameters and return value
@@ -2182,6 +2185,13 @@ public:
   std::unordered_map<Expression*, BinaryLocations::DelimiterLocations>
     delimiterLocations;
   BinaryLocations::FunctionLocations funcLocation;
+
+  // The effects for this function, if they have been computed. We use a shared
+  // ptr here to avoid compilation errors with the forward-declared
+  // EffectAnalyzer.
+  //
+  // See addsEffects() in pass.h for more details.
+  std::shared_ptr<EffectAnalyzer> effects;
 
   // Inlining metadata: whether to disallow full and/or partial inlining (for
   // details on what those mean, see Inlining.cpp).


### PR DESCRIPTION
This fixes an unsettling bug where, with a long-enough sequence of passes,
we might create a function A, compute it has no effects, remove that
function, create another function with the same but with effects, and think
the old effects apply to it. This is basically a danger of using a map from
function name to effects.

To avoid that, store the effects on function objects themselves.