### PR TITLE
Fuzzer: Fix handling of JS null exceptions

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -178,9 +178,10 @@ function callFunc(func) {
     /* await */ func();
     return 0;
   } catch (e) {
-    // The exception must exist, and not behave oddly when we access a
-    // property on it. (VM bugs could cause errors here.)
-    e.a;
+    // The exception might be a JS null, but otherwise it must be valid to check
+    // if a property exists on it (VM bugs could cause errors here, specifically
+    // if a wasm exception is caught here, and it is not represented properly).
+    if (e !== null) e.a;
 
     // We only want to catch exceptions, not wasm traps: traps should still
     // halt execution. Handling this requires different code in wasm2js, so

--- a/test/lit/d8/fuzz_shell_exceptions.wast
+++ b/test/lit/d8/fuzz_shell_exceptions.wast
@@ -20,6 +20,15 @@
       (i32.const 42)
     )
   )
+
+  (func $throwing-jstag-null (export "throwing-jstag-null")
+    ;; Throwing JSTag leads to the JS side receiving the externref as a JS
+    ;; value. A null must be handled properly while doing so, without error, and
+    ;; be logged as a null.
+    (throw $imported-js-tag
+      (ref.null noextern)
+    )
+  )
 )
 
 ;; Build to a binary wasm.
@@ -34,6 +43,8 @@
 ;; CHECK: exception thrown: Error: js exception
 ;; CHECK: [fuzz-exec] calling throwing-tag
 ;; CHECK: exception thrown: [object WebAssembly.Exception]
+;; CHECK: [fuzz-exec] calling throwing-jstag-null
+;; CHECK: exception thrown: null
 
 
 


### PR DESCRIPTION
We have a test
```js
try {
  ..
} catch (e) {
  e.a; // must be valid
}
```
That test will catch various wasm exception issues, but it turns out that it
also fails on one specific JS exception: null. It is ok to do `e.a` on numbers,
objects, anything really, all except for null. This PR adds a guard for that.