### PR TITLE
Fuzzer: Avoid massive initial sizes for memories

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -753,9 +753,18 @@ void TranslateToFuzzReader::finalizeMemory() {
         maxOffset = maxOffset + offset->value.getInteger();
       }
     }
-    memory->initial = std::max(
-      memory->initial,
-      Address((maxOffset + Memory::kPageSize - 1) / Memory::kPageSize));
+
+    // Ensure the initial memory can fit the segment (so we don't just trap),
+    // but only do so when the segment is at a reasonable offset (to avoid
+    // validation errors on the initial size >= 4GB in wasm32, but also to
+    // avoid OOM errors on trying to allocate too much initial memory, which is
+    // annoying in the fuzzer).
+    Address ONE_GB = 1024 * 1024 * 1024;
+    if (maxOffset <= ONE_GB) {
+      memory->initial = std::max(
+        memory->initial,
+        Address((maxOffset + Memory::kPageSize - 1) / Memory::kPageSize));
+    }
   }
   memory->initial = std::max(memory->initial, fuzzParams->USABLE_MEMORY);
   // Avoid an unlimited memory size, which would make fuzzing very difficult


### PR DESCRIPTION
We generate random segments and then make the memory's initial
size big enough to accomodate them, but if the size is massive then
we will just OOM anyhow (or even not validate in wasm32 in some
cases). To avoid that, put a limit on the maximum initial memory
size as influenced by segments.