### PR TITLE
Adjust the cost of allocations to a much higher value

### DIFF
--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -771,7 +771,6 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
   }
 
   CostType visitContNew(ContNew* curr) {
-    // This "high" value reflects that this may allocate a stack.
     return AllocationCost + 10 + visit(curr->func);
   }
   CostType visitContBind(ContBind* curr) {

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -675,10 +675,6 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return base + nullCheckCost(curr->ref) + maybeVisit(curr->ref);
   }
   CostType visitStructNew(StructNew* curr) {
-    // While allocation itself is almost free with generational GC, there is
-    // at least some baseline cost, plus writing the fields. (If we use default
-    // values for the fields, then it is possible they are all 0 and if so, we
-    // can get that almost for free as well, so don't add anything there.)
     CostType ret = AllocationCost + curr->operands.size();
     for (auto* child : curr->operands) {
       ret += visit(child);

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -43,8 +43,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
   // but usually requires some loads and comparisons.
   static const CostType CastCost = 5;
 
-  // Generational GC can be very efficient, but even so an allocations have a
-  // cost even if just shortening the time to the next collection.
+  // Generational GC can be very efficient, but even so allocations have a high
+  // due to shortening the time to the next collection.
   static const CostType AllocationCost = 100;
 
   CostType maybeVisit(Expression* curr) { return curr ? visit(curr) : 0; }

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -756,7 +756,8 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
     return 6 + visit(curr->ref);
   }
   CostType visitStringEncode(StringEncode* curr) {
-    return AllocationCost + 2 + visit(curr->str) + visit(curr->array) + visit(curr->start);
+    return AllocationCost + 2 + visit(curr->str) + visit(curr->array) +
+           visit(curr->start);
   }
   CostType visitStringConcat(StringConcat* curr) {
     return AllocationCost + 6 + visit(curr->left) + visit(curr->right);

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -744,8 +744,9 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
            maybeVisit(curr->end);
   }
   CostType visitStringConst(StringConst* curr) {
-    // We do not use AllocationCost here because such constants will end up
-    // imported as constants from the outside.
+    // We do not use AllocationCost here because these will end up imported as
+    // constants from the outside, after string lowering (and even natively, a
+    // VM can implement them as global constants).
     return 4;
   }
   CostType visitStringMeasure(StringMeasure* curr) {

--- a/src/ir/cost.h
+++ b/src/ir/cost.h
@@ -44,7 +44,7 @@ struct CostAnalyzer : public OverriddenVisitor<CostAnalyzer, CostType> {
   static const CostType CastCost = 5;
 
   // Generational GC can be very efficient, but even so allocations have a high
-  // due to shortening the time to the next collection.
+  // cost due to shortening the time to the next collection.
   static const CostType AllocationCost = 100;
 
   CostType maybeVisit(Expression* curr) { return curr ? visit(curr) : 0; }

--- a/test/lit/passes/monomorphize-benefit.wast
+++ b/test/lit/passes/monomorphize-benefit.wast
@@ -947,15 +947,11 @@
 
   ;; THIRD__:      (type $3 (func (param anyref i32)))
 
-  ;; THIRD__:      (type $4 (func (param (ref $A))))
+  ;; THIRD__:      (type $4 (func (param i32)))
 
-  ;; THIRD__:      (type $5 (func (param anyref)))
+  ;; THIRD__:      (type $5 (func (param (ref $A))))
 
-  ;; THIRD__:      (type $6 (func (param i32) (result (ref $A))))
-
-  ;; THIRD__:      (type $7 (func (param i32)))
-
-  ;; THIRD__:      (type $8 (func (result (ref $A))))
+  ;; THIRD__:      (type $6 (func (param anyref)))
 
   ;; THIRD__:      (import "a" "b" (func $import (type $1)))
   ;; TWOTRDS:      (type $1 (func))
@@ -964,11 +960,11 @@
 
   ;; TWOTRDS:      (type $3 (func (param anyref i32)))
 
-  ;; TWOTRDS:      (type $4 (func (param (ref $A))))
+  ;; TWOTRDS:      (type $4 (func (param i32)))
 
-  ;; TWOTRDS:      (type $5 (func (param anyref)))
+  ;; TWOTRDS:      (type $5 (func (param (ref $A))))
 
-  ;; TWOTRDS:      (type $6 (func (param i32)))
+  ;; TWOTRDS:      (type $6 (func (param anyref)))
 
   ;; TWOTRDS:      (import "a" "b" (func $import (type $1)))
   ;; HUNDRED:      (type $1 (func (param anyref) (result (ref $A))))
@@ -984,8 +980,8 @@
 
   ;; DEFAULT:      (import "a" "c" (func $import2 (type $4) (param (ref $A))))
   ;; ZERO___:      (import "a" "c" (func $import2 (type $8) (param (ref $A))))
-  ;; THIRD__:      (import "a" "c" (func $import2 (type $4) (param (ref $A))))
-  ;; TWOTRDS:      (import "a" "c" (func $import2 (type $4) (param (ref $A))))
+  ;; THIRD__:      (import "a" "c" (func $import2 (type $5) (param (ref $A))))
+  ;; TWOTRDS:      (import "a" "c" (func $import2 (type $5) (param (ref $A))))
   ;; HUNDRED:      (import "a" "c" (func $import2 (type $4) (param (ref $A))))
   (import "a" "c" (func $import2 (param (ref $A))))
 
@@ -1173,12 +1169,8 @@
   ;; THIRD__-NEXT:    )
   ;; THIRD__-NEXT:   )
   ;; THIRD__-NEXT:  )
-  ;; THIRD__-NEXT:  (drop
-  ;; THIRD__-NEXT:   (call $target-long
-  ;; THIRD__-NEXT:    (struct.new $A
-  ;; THIRD__-NEXT:     (local.get $y)
-  ;; THIRD__-NEXT:    )
-  ;; THIRD__-NEXT:   )
+  ;; THIRD__-NEXT:  (call $target-long_6
+  ;; THIRD__-NEXT:   (local.get $y)
   ;; THIRD__-NEXT:  )
   ;; THIRD__-NEXT:  (call $import2
   ;; THIRD__-NEXT:   (call $target-long
@@ -1187,7 +1179,7 @@
   ;; THIRD__-NEXT:    )
   ;; THIRD__-NEXT:   )
   ;; THIRD__-NEXT:  )
-  ;; THIRD__-NEXT:  (call $target-long_6)
+  ;; THIRD__-NEXT:  (call $target-long_7)
   ;; THIRD__-NEXT: )
   ;; TWOTRDS:      (func $calls-long (type $3) (param $x anyref) (param $y i32)
   ;; TWOTRDS-NEXT:  (call $import2
@@ -1207,12 +1199,8 @@
   ;; TWOTRDS-NEXT:    )
   ;; TWOTRDS-NEXT:   )
   ;; TWOTRDS-NEXT:  )
-  ;; TWOTRDS-NEXT:  (drop
-  ;; TWOTRDS-NEXT:   (call $target-long
-  ;; TWOTRDS-NEXT:    (struct.new $A
-  ;; TWOTRDS-NEXT:     (local.get $y)
-  ;; TWOTRDS-NEXT:    )
-  ;; TWOTRDS-NEXT:   )
+  ;; TWOTRDS-NEXT:  (call $target-long_6
+  ;; TWOTRDS-NEXT:   (local.get $y)
   ;; TWOTRDS-NEXT:  )
   ;; TWOTRDS-NEXT:  (call $import2
   ;; TWOTRDS-NEXT:   (call $target-long
@@ -1221,13 +1209,7 @@
   ;; TWOTRDS-NEXT:    )
   ;; TWOTRDS-NEXT:   )
   ;; TWOTRDS-NEXT:  )
-  ;; TWOTRDS-NEXT:  (drop
-  ;; TWOTRDS-NEXT:   (call $target-long
-  ;; TWOTRDS-NEXT:    (struct.new $A
-  ;; TWOTRDS-NEXT:     (i32.const 42)
-  ;; TWOTRDS-NEXT:    )
-  ;; TWOTRDS-NEXT:   )
-  ;; TWOTRDS-NEXT:  )
+  ;; TWOTRDS-NEXT:  (call $target-long_7)
   ;; TWOTRDS-NEXT: )
   ;; HUNDRED:      (func $calls-long (type $2) (param $x anyref) (param $y i32)
   ;; HUNDRED-NEXT:  (call $import2
@@ -1275,9 +1257,9 @@
     ;;  * Optimize in all cases when the minimum benefit is 0% (except the
     ;;    first call, which is a trivial call context). Removing a cast is
     ;;    enough to justify optimizing.
-    ;;  * In 33% we optimize only the very last case. There we remove both a
-    ;;    cast and a struct.new, which ends up just over 33%.
-    ;;  * In 66% and 100% we optimize nothing at all.
+    ;;  * In 33% and 66% we optimize only two cases. There we remove both a cast
+    ;;    and a struct.new, and the struct.new's high cost makes it worthwhile.
+    ;;  * In 100% we optimize nothing at all.
 
     ;; Call with an unknown input and the output is sent to an import.
     (call $import2
@@ -1379,21 +1361,27 @@
   ;; THIRD__-NEXT:    (local.get $x)
   ;; THIRD__-NEXT:   )
   ;; THIRD__-NEXT:  )
-  ;; THIRD__-NEXT:  (call $target-short_7
+  ;; THIRD__-NEXT:  (call $target-short_8
   ;; THIRD__-NEXT:   (local.get $x)
   ;; THIRD__-NEXT:  )
   ;; THIRD__-NEXT:  (call $import2
-  ;; THIRD__-NEXT:   (call $target-short_8
-  ;; THIRD__-NEXT:    (local.get $y)
+  ;; THIRD__-NEXT:   (call $target-short
+  ;; THIRD__-NEXT:    (struct.new $A
+  ;; THIRD__-NEXT:     (local.get $y)
+  ;; THIRD__-NEXT:    )
   ;; THIRD__-NEXT:   )
   ;; THIRD__-NEXT:  )
   ;; THIRD__-NEXT:  (call $target-short_9
   ;; THIRD__-NEXT:   (local.get $y)
   ;; THIRD__-NEXT:  )
   ;; THIRD__-NEXT:  (call $import2
-  ;; THIRD__-NEXT:   (call $target-short_10)
+  ;; THIRD__-NEXT:   (call $target-short
+  ;; THIRD__-NEXT:    (struct.new $A
+  ;; THIRD__-NEXT:     (i32.const 42)
+  ;; THIRD__-NEXT:    )
+  ;; THIRD__-NEXT:   )
   ;; THIRD__-NEXT:  )
-  ;; THIRD__-NEXT:  (call $target-short_11)
+  ;; THIRD__-NEXT:  (call $target-short_10)
   ;; THIRD__-NEXT: )
   ;; TWOTRDS:      (func $calls-short (type $3) (param $x anyref) (param $y i32)
   ;; TWOTRDS-NEXT:  (call $import2
@@ -1401,7 +1389,7 @@
   ;; TWOTRDS-NEXT:    (local.get $x)
   ;; TWOTRDS-NEXT:   )
   ;; TWOTRDS-NEXT:  )
-  ;; TWOTRDS-NEXT:  (call $target-short_6
+  ;; TWOTRDS-NEXT:  (call $target-short_8
   ;; TWOTRDS-NEXT:   (local.get $x)
   ;; TWOTRDS-NEXT:  )
   ;; TWOTRDS-NEXT:  (call $import2
@@ -1411,7 +1399,7 @@
   ;; TWOTRDS-NEXT:    )
   ;; TWOTRDS-NEXT:   )
   ;; TWOTRDS-NEXT:  )
-  ;; TWOTRDS-NEXT:  (call $target-short_7
+  ;; TWOTRDS-NEXT:  (call $target-short_9
   ;; TWOTRDS-NEXT:   (local.get $y)
   ;; TWOTRDS-NEXT:  )
   ;; TWOTRDS-NEXT:  (call $import2
@@ -1421,7 +1409,7 @@
   ;; TWOTRDS-NEXT:    )
   ;; TWOTRDS-NEXT:   )
   ;; TWOTRDS-NEXT:  )
-  ;; TWOTRDS-NEXT:  (call $target-short_8)
+  ;; TWOTRDS-NEXT:  (call $target-short_10)
   ;; TWOTRDS-NEXT: )
   ;; HUNDRED:      (func $calls-short (type $2) (param $x anyref) (param $y i32)
   ;; HUNDRED-NEXT:  (call $import2
@@ -1466,8 +1454,10 @@
   (func $calls-short (param $x anyref) (param $y i32)
     ;; As above, but now calling the short function:
     ;;  * 0% is the same with the long function: any improvement is enough.
-    ;;  * 33% optimizes them all (but for the first, which is a trivial call
-    ;;    context).
+    ;;  * 33% optimizes some, but not all (the first is a trivial call context;
+    ;;    some of the others do not optimize because the struct.new is
+    ;;    expensive, and if the output goes into another call, we cannot remove
+    ;;    it).
     ;;  * 66% optimizes a few less cases: when the output isn't dropped then we
     ;;    can't do enough work to justify it.
     ;;  * 100% optimizes nothing.
@@ -1606,7 +1596,7 @@
 ;; ZERO___-NEXT:  (nop)
 ;; ZERO___-NEXT: )
 
-;; THIRD__:      (func $target-long_6 (type $1)
+;; THIRD__:      (func $target-long_6 (type $4) (param $0 i32)
 ;; THIRD__-NEXT:  (call $import)
 ;; THIRD__-NEXT:  (call $import)
 ;; THIRD__-NEXT:  (call $import)
@@ -1615,38 +1605,53 @@
 ;; THIRD__-NEXT:  (call $import)
 ;; THIRD__-NEXT: )
 
-;; THIRD__:      (func $target-short_7 (type $5) (param $0 anyref)
+;; THIRD__:      (func $target-long_7 (type $1)
+;; THIRD__-NEXT:  (call $import)
+;; THIRD__-NEXT:  (call $import)
+;; THIRD__-NEXT:  (call $import)
+;; THIRD__-NEXT:  (call $import)
+;; THIRD__-NEXT:  (call $import)
+;; THIRD__-NEXT:  (call $import)
+;; THIRD__-NEXT: )
+
+;; THIRD__:      (func $target-short_8 (type $6) (param $0 anyref)
 ;; THIRD__-NEXT:  (nop)
 ;; THIRD__-NEXT: )
 
-;; THIRD__:      (func $target-short_8 (type $6) (param $0 i32) (result (ref $A))
-;; THIRD__-NEXT:  (struct.new $A
-;; THIRD__-NEXT:   (local.get $0)
-;; THIRD__-NEXT:  )
-;; THIRD__-NEXT: )
-
-;; THIRD__:      (func $target-short_9 (type $7) (param $0 i32)
+;; THIRD__:      (func $target-short_9 (type $4) (param $0 i32)
 ;; THIRD__-NEXT:  (nop)
 ;; THIRD__-NEXT: )
 
-;; THIRD__:      (func $target-short_10 (type $8) (result (ref $A))
-;; THIRD__-NEXT:  (struct.new $A
-;; THIRD__-NEXT:   (i32.const 42)
-;; THIRD__-NEXT:  )
-;; THIRD__-NEXT: )
-
-;; THIRD__:      (func $target-short_11 (type $1)
+;; THIRD__:      (func $target-short_10 (type $1)
 ;; THIRD__-NEXT:  (nop)
 ;; THIRD__-NEXT: )
 
-;; TWOTRDS:      (func $target-short_6 (type $5) (param $0 anyref)
+;; TWOTRDS:      (func $target-long_6 (type $4) (param $0 i32)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT: )
+
+;; TWOTRDS:      (func $target-long_7 (type $1)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT:  (call $import)
+;; TWOTRDS-NEXT: )
+
+;; TWOTRDS:      (func $target-short_8 (type $6) (param $0 anyref)
 ;; TWOTRDS-NEXT:  (nop)
 ;; TWOTRDS-NEXT: )
 
-;; TWOTRDS:      (func $target-short_7 (type $6) (param $0 i32)
+;; TWOTRDS:      (func $target-short_9 (type $4) (param $0 i32)
 ;; TWOTRDS-NEXT:  (nop)
 ;; TWOTRDS-NEXT: )
 
-;; TWOTRDS:      (func $target-short_8 (type $1)
+;; TWOTRDS:      (func $target-short_10 (type $1)
 ;; TWOTRDS-NEXT:  (nop)
 ;; TWOTRDS-NEXT: )

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -16,6 +16,9 @@
  ;; CHECK:      (type $struct-nn (struct (field (ref any))))
  (type $struct-nn (struct (field (ref any))))
 
+ ;; CHECK:      (global $struct (ref $struct) (struct.new_default $struct))
+ (global $struct (ref $struct) (struct.new $struct))
+
  ;; CHECK:      (func $br_on-if (type $8) (param $0 (ref struct))
  ;; CHECK-NEXT:  (block $label
  ;; CHECK-NEXT:   (drop
@@ -868,8 +871,8 @@
  ;; CHECK:      (func $select-refinalize (type $13) (param $param (ref $struct)) (result (ref struct))
  ;; CHECK-NEXT:  (select (result (ref $struct))
  ;; CHECK-NEXT:   (select (result (ref $struct))
- ;; CHECK-NEXT:    (struct.new_default $struct)
- ;; CHECK-NEXT:    (struct.new_default $struct)
+ ;; CHECK-NEXT:    (global.get $struct)
+ ;; CHECK-NEXT:    (global.get $struct)
  ;; CHECK-NEXT:    (i32.const 0)
  ;; CHECK-NEXT:   )
  ;; CHECK-NEXT:   (local.get $param)
@@ -883,10 +886,10 @@
    (if (result (ref struct))
     (i32.const 0)
     (then
-     (struct.new_default $struct)
+     (global.get $struct)
     )
     (else
-     (struct.new_default $struct)
+     (global.get $struct)
     )
    )
    (local.get $param)

--- a/test/lit/passes/remove-unused-brs-gc.wast
+++ b/test/lit/passes/remove-unused-brs-gc.wast
@@ -19,7 +19,7 @@
  ;; CHECK:      (global $struct (ref $struct) (struct.new_default $struct))
  (global $struct (ref $struct) (struct.new $struct))
 
- ;; CHECK:      (func $br_on-if (type $8) (param $0 (ref struct))
+ ;; CHECK:      (func $br_on-if (type $9) (param $0 (ref struct))
  ;; CHECK-NEXT:  (block $label
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (select (result (ref struct))
@@ -168,7 +168,7 @@
   )
  )
 
- ;; CHECK:      (func $nested_br_on_cast (type $9) (result i31ref)
+ ;; CHECK:      (func $nested_br_on_cast (type $10) (result i31ref)
  ;; CHECK-NEXT:  (block $label$1 (result (ref i31))
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (br $label$1
@@ -647,7 +647,7 @@
   )
  )
 
- ;; CHECK:      (func $casts-are-costly (type $10) (param $x i32)
+ ;; CHECK:      (func $casts-are-costly (type $8) (param $x i32)
  ;; CHECK-NEXT:  (local $struct (ref null $struct))
  ;; CHECK-NEXT:  (drop
  ;; CHECK-NEXT:   (if (result i32)
@@ -784,6 +784,54 @@
       )
       (ref.null any)
      )
+    )
+    (else
+     (ref.null any)
+    )
+   )
+  )
+ )
+
+ ;; CHECK:      (func $allocations-are-costly (type $8) (param $x i32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (if (result (ref null $struct))
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:    (then
+ ;; CHECK-NEXT:     (struct.new_default $struct)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:    (else
+ ;; CHECK-NEXT:     (ref.null none)
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (select (result nullref)
+ ;; CHECK-NEXT:    (ref.null none)
+ ;; CHECK-NEXT:    (ref.null none)
+ ;; CHECK-NEXT:    (local.get $x)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $allocations-are-costly (param $x i32)
+  ;; Allocations are too expensive for us to unconditionalize and selectify
+  ;; here.
+  (drop
+   (if (result anyref)
+    (local.get $x)
+    (then
+     (struct.new $struct)
+    )
+    (else
+     (ref.null any)
+    )
+   )
+  )
+  ;; But two nulls are fine.
+  (drop
+   (if (result anyref)
+    (local.get $x)
+    (then
+     (ref.null any)
     )
     (else
      (ref.null any)


### PR DESCRIPTION
VM feedback suggests that `struct.new` etc. should be avoided when we
selectify, as the cost is high even in generational GC implementations.