### PR TITLE
Fix CFP to avoid removing synchronization

### DIFF
--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -340,10 +340,10 @@ struct FunctionOptimizer : public WalkerPass<PostWalker<FunctionOptimizer>> {
     // disjoint. In general we could compute the LUB of each set and see if it
     // overlaps with the other, but for efficiency we only want to do this
     // optimization if the type we test on is closed/final, since ref.test on a
-    // final type can be fairly fast (perhaps constant time). We therefore
-    // look if one of the sets of types contains a single type and it is
-    // final, and if so then we'll test on it. (However, see a few lines below
-    // on how we test for finality.)
+    // final type can be fairly fast (perhaps constant time). We therefore look
+    // if one of the sets of types contains a single type and it is final, and
+    // if so then we'll test on it. (However, see a few lines below on how we
+    // test for finality.)
     // TODO: Consider adding a variation on this pass that uses non-final types.
     auto isProperTestType = [&](const Value& value) -> std::optional<HeapType> {
       auto& types = value.types;

--- a/test/lit/passes/cfp-rmw.wast
+++ b/test/lit/passes/cfp-rmw.wast
@@ -272,8 +272,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $rmw-cmpxchg (param (ref $A) i32 (ref $A)) (result i32)
-    ;; This cmpxchg copies the field, so does not change the value. It can still
-    ;; not be optimized.
+    ;; This cmpxchg copies the field, so does not change the value. It still
+    ;; cannot be optimized.
     (struct.atomic.rmw.cmpxchg $A 0
       (local.get 0)
       (local.get 1)

--- a/test/lit/passes/cfp.wast
+++ b/test/lit/passes/cfp.wast
@@ -2870,24 +2870,13 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.as_non_null
-  ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   (struct.atomic.get acqrel $shared 0
+  ;; CHECK-NEXT:    (local.get $0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result i32)
-  ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (ref.as_non_null
-  ;; CHECK-NEXT:      (local.get $0)
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (atomic.fence)
-  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   (struct.atomic.get $shared 0
+  ;; CHECK-NEXT:    (local.get $0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -2898,13 +2887,14 @@
       )
     )
     (drop
-      ;; This can be optimzied and does not require a fence.
+      ;; This can be optimzied in principle, but our analysis cannot yet prove
+      ;; there is no synchronization. TODO.
       (struct.atomic.get acqrel $shared 0
         (local.get 0)
       )
     )
     (drop
-      ;; This can be optimized, but requires a seqcst fence.
+      ;; Same as above.
       (struct.atomic.get $shared 0
         (local.get 0)
       )


### PR DESCRIPTION
ConstantFieldPropagation previously reasoned that if a field has a
constant value, then it is not possible for release-acquire operations
to use it for synchronization, since the read can be assumed to be from
a previous write. This logic was incorrect because reads must read the
value written by the last write in the global modification order for the
accessed location.

In principle it would be possible for CFP to detect fields that have
both constant values and also either no acquire reads or no release
writes. Such fields cannot possibly be part of synchronization edges and
their gets could be optimized normally. For now though, simply do not
optimize any gets with acquire or seqcst ordering. Similarly, stop
optimizing RMW operations because they can also form synchronization
edges.
