### PR TITLE
Fuzzer: Modify functions late

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -343,8 +343,14 @@ private:
   Expression* makeImportSleep(Type type);
   Expression* makeMemoryHashLogging();
 
-  // Function creation
+  // Function operations. The main processFunctions() loop will call addFunction
+  // as well as modFunction().
+  void processFunctions();
+  // Add a new function.
   Function* addFunction();
+  // Modify an existing function.
+  void modFunction(Function* func);
+
   void addHangLimitChecks(Function* func);
 
   // Recombination and mutation

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -228,10 +228,7 @@ private:
     // type => list of locals with that type
     std::unordered_map<Type, std::vector<Index>> typeLocals;
 
-    FunctionCreationContext(TranslateToFuzzReader& parent, Function* func)
-      : parent(parent), func(func) {
-      parent.funcContext = this;
-    }
+    FunctionCreationContext(TranslateToFuzzReader& parent, Function* func);
 
     ~FunctionCreationContext();
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1147,9 +1147,6 @@ TranslateToFuzzReader::FunctionCreationContext::~FunctionCreationContext() {
   // fixup to ensure we validate.
   TypeUpdating::handleNonDefaultableLocals(func, parent.wasm);
 
-  if (parent.fuzzParams->HANG_LIMIT > 0) {
-    parent.addHangLimitChecks(func);
-  }
   assert(breakableStack.empty());
   assert(hangStack.empty());
   parent.funcContext = nullptr;
@@ -1344,6 +1341,15 @@ void TranslateToFuzzReader::processFunctions() {
       // in the code we just generated, and any changes could break that.
       if (allowOOB) {
         moddable.push_back(func);
+      }
+    }
+  }
+
+  // At the very end, add hang limit checks (so no modding can override them).
+  if (fuzzParams->HANG_LIMIT > 0) {
+    for (auto& func : wasm.functions) {
+      if (!func->imported()) {
+        addHangLimitChecks(func.get());
       }
     }
   }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1379,13 +1379,6 @@ void TranslateToFuzzReader::processFunctions() {
     }
   }
 
-  // Fix up after we finished all modifications.
-  for (auto& func : wasm.functions) {
-    if (!func->imported()) {
-      fixAfterChanges(func.get());
-    }
-  }
-
   // At the very end, add hang limit checks (so no modding can override them).
   if (fuzzParams->HANG_LIMIT > 0) {
     for (auto& func : wasm.functions) {
@@ -1480,6 +1473,7 @@ void TranslateToFuzzReader::modFunction(Function* func) {
   //       check variations on initial testcases even at the risk of OOB.
   recombine(func);
   mutate(func);
+  fixAfterChanges(func);
 }
 
 void TranslateToFuzzReader::addHangLimitChecks(Function* func) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1121,7 +1121,8 @@ void TranslateToFuzzReader::addHashMemorySupport() {
   }
 }
 
-TranslateToFuzzReader::FunctionCreationContext::FunctionCreationContext(TranslateToFuzzReader& parent, Function* func)
+TranslateToFuzzReader::FunctionCreationContext::FunctionCreationContext(
+  TranslateToFuzzReader& parent, Function* func)
   : parent(parent), func(func) {
   parent.funcContext = this;
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1794,8 +1794,6 @@ void TranslateToFuzzReader::mutate(Function* func) {
 }
 
 void TranslateToFuzzReader::fixAfterChanges(Function* func) {
-  FunctionCreationContext context(*this, func);
-
   struct Fixer
     : public ExpressionStackWalker<Fixer, UnifiedExpressionVisitor<Fixer>> {
     Module& wasm;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1127,7 +1127,7 @@ TranslateToFuzzReader::FunctionCreationContext::FunctionCreationContext(Translat
 
   // Find the right index for labelIndex: we emit names like label$5, so we need
   // the index to be larger than all currently existing.
-  if (func->body) {
+  if (!func->body) {
     return;
   }
 

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1134,7 +1134,7 @@ TranslateToFuzzReader::FunctionCreationContext::FunctionCreationContext(Translat
     return;
   }
 
-  struct Finder : public PostWalker<Finder> {
+  struct Finder : public PostWalker<Finder, UnifiedExpressionVisitor<Finder>> {
     Index maxIndex = 0;
 
     void visitExpression(Expression* curr) {
@@ -1145,7 +1145,7 @@ TranslateToFuzzReader::FunctionCreationContext::FunctionCreationContext(Translat
             auto str = name.toString();
             str = str.substr(6);
             Index index = atoi(str.c_str());
-            maxIndex = std::max(maxIndex, index);
+            maxIndex = std::max(maxIndex, index + 1);
           }
         }
       });

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1297,9 +1297,11 @@ void TranslateToFuzzReader::processFunctions() {
   // function, at most, so once we do we remove it from here.
   std::vector<Function*> moddable;
 
-  // Initial functions are moddable.
+  // Defined initial functions are moddable.
   for (auto& func : wasm.functions) {
-    moddable.push_back(func.get());
+    if (!func->imported()) {
+      moddable.push_back(func.get());
+    }
   }
 
   // Add invocations, which can help execute the code here even if the function

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 68      
- [funcs]        : 101     
+ [exports]      : 77      
+ [funcs]        : 111     
  [globals]      : 21      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 5       
- [table-data]   : 33      
+ [table-data]   : 45      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 5891    
- [vars]         : 249     
- Binary         : 400     
- Block          : 948     
- Break          : 156     
- Call           : 393     
- CallIndirect   : 53      
- Const          : 1058    
- Drop           : 107     
- GlobalGet      : 475     
- GlobalSet      : 379     
- If             : 307     
- Load           : 84      
- LocalGet       : 400     
- LocalSet       : 281     
- Loop           : 88      
- Nop            : 53      
- RefFunc        : 33      
- Return         : 50      
- Select         : 38      
- Store          : 25      
+ [total]        : 9163    
+ [vars]         : 296     
+ Binary         : 620     
+ Block          : 1503    
+ Break          : 288     
+ Call           : 580     
+ CallIndirect   : 101     
+ Const          : 1500    
+ Drop           : 136     
+ GlobalGet      : 772     
+ GlobalSet      : 562     
+ If             : 478     
+ Load           : 126     
+ LocalGet       : 630     
+ LocalSet       : 487     
+ Loop           : 166     
+ Nop            : 78      
+ RefFunc        : 45      
+ Return         : 87      
+ Select         : 75      
+ Store          : 60      
  Switch         : 2       
- Unary          : 369     
- Unreachable    : 192     
+ Unary          : 588     
+ Unreachable    : 279     

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,34 +1,34 @@
 Metrics
 total
- [exports]      : 34      
- [funcs]        : 50      
+ [exports]      : 18      
+ [funcs]        : 22      
  [globals]      : 21      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 5       
- [table-data]   : 17      
+ [table-data]   : 3       
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3185    
- [vars]         : 154     
- Binary         : 261     
- Block          : 560     
- Break          : 72      
- Call           : 118     
- CallIndirect   : 12      
- Const          : 559     
- Drop           : 45      
- GlobalGet      : 319     
- GlobalSet      : 265     
- If             : 169     
- Load           : 52      
- LocalGet       : 154     
- LocalSet       : 122     
- Loop           : 48      
- Nop            : 31      
- RefFunc        : 17      
- Return         : 18      
- Select         : 15      
+ [total]        : 1889    
+ [vars]         : 62      
+ Binary         : 155     
+ Block          : 299     
+ Break          : 52      
+ Call           : 57      
+ CallIndirect   : 4       
+ Const          : 360     
+ Drop           : 40      
+ GlobalGet      : 163     
+ GlobalSet      : 128     
+ If             : 93      
+ Load           : 34      
+ LocalGet       : 151     
+ LocalSet       : 91      
+ Loop           : 27      
+ Nop            : 18      
+ RefFunc        : 3       
+ Return         : 14      
+ Select         : 9       
  Store          : 9       
- Unary          : 206     
- Unreachable    : 133     
+ Unary          : 119     
+ Unreachable    : 63      

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,35 +1,34 @@
 Metrics
 total
- [exports]      : 24      
- [funcs]        : 30      
+ [exports]      : 34      
+ [funcs]        : 50      
  [globals]      : 21      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 5       
- [table-data]   : 8       
+ [table-data]   : 17      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3231    
- [vars]         : 112     
- Binary         : 266     
- Block          : 529     
- Break          : 115     
- Call           : 122     
- CallIndirect   : 3       
- Const          : 529     
- Drop           : 31      
- GlobalGet      : 271     
- GlobalSet      : 190     
- If             : 181     
- Load           : 58      
- LocalGet       : 233     
- LocalSet       : 177     
- Loop           : 65      
- Nop            : 59      
- RefFunc        : 8       
- Return         : 31      
- Select         : 16      
- Store          : 29      
- Switch         : 4       
- Unary          : 220     
- Unreachable    : 94      
+ [total]        : 3185    
+ [vars]         : 154     
+ Binary         : 261     
+ Block          : 560     
+ Break          : 72      
+ Call           : 118     
+ CallIndirect   : 12      
+ Const          : 559     
+ Drop           : 45      
+ GlobalGet      : 319     
+ GlobalSet      : 265     
+ If             : 169     
+ Load           : 52      
+ LocalGet       : 154     
+ LocalSet       : 122     
+ Loop           : 48      
+ Nop            : 31      
+ RefFunc        : 17      
+ Return         : 18      
+ Select         : 15      
+ Store          : 9       
+ Unary          : 206     
+ Unreachable    : 133     

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -1,34 +1,35 @@
 Metrics
 total
- [exports]      : 18      
- [funcs]        : 22      
+ [exports]      : 68      
+ [funcs]        : 101     
  [globals]      : 21      
  [imports]      : 5       
  [memories]     : 1       
  [memory-data]  : 5       
- [table-data]   : 3       
+ [table-data]   : 33      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 1889    
- [vars]         : 62      
- Binary         : 155     
- Block          : 299     
- Break          : 52      
- Call           : 57      
- CallIndirect   : 4       
- Const          : 360     
- Drop           : 40      
- GlobalGet      : 163     
- GlobalSet      : 128     
- If             : 93      
- Load           : 34      
- LocalGet       : 151     
- LocalSet       : 91      
- Loop           : 27      
- Nop            : 18      
- RefFunc        : 3       
- Return         : 14      
- Select         : 9       
- Store          : 9       
- Unary          : 119     
- Unreachable    : 63      
+ [total]        : 5891    
+ [vars]         : 249     
+ Binary         : 400     
+ Block          : 948     
+ Break          : 156     
+ Call           : 393     
+ CallIndirect   : 53      
+ Const          : 1058    
+ Drop           : 107     
+ GlobalGet      : 475     
+ GlobalSet      : 379     
+ If             : 307     
+ Load           : 84      
+ LocalGet       : 400     
+ LocalSet       : 281     
+ Loop           : 88      
+ Nop            : 53      
+ RefFunc        : 33      
+ Return         : 50      
+ Select         : 38      
+ Store          : 25      
+ Switch         : 2       
+ Unary          : 369     
+ Unreachable    : 192     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -1,34 +1,35 @@
 Metrics
 total
- [exports]      : 39      
- [funcs]        : 53      
+ [exports]      : 20      
+ [funcs]        : 34      
  [globals]      : 7       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 29      
- [table-data]   : 24      
+ [table-data]   : 10      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 4272    
- [vars]         : 162     
- Binary         : 328     
- Block          : 670     
- Break          : 131     
- Call           : 194     
- CallIndirect   : 38      
- Const          : 764     
- Drop           : 65      
- GlobalGet      : 364     
- GlobalSet      : 260     
- If             : 219     
- Load           : 80      
- LocalGet       : 299     
- LocalSet       : 209     
- Loop           : 77      
- Nop            : 41      
- RefFunc        : 24      
- Return         : 32      
- Select         : 34      
- Store          : 28      
- Unary          : 284     
- Unreachable    : 131     
+ [total]        : 4470    
+ [vars]         : 142     
+ Binary         : 326     
+ Block          : 726     
+ Break          : 164     
+ Call           : 135     
+ CallIndirect   : 31      
+ Const          : 692     
+ Drop           : 57      
+ GlobalGet      : 383     
+ GlobalSet      : 275     
+ If             : 239     
+ Load           : 82      
+ LocalGet       : 371     
+ LocalSet       : 270     
+ Loop           : 95      
+ Nop            : 58      
+ RefFunc        : 10      
+ Return         : 35      
+ Select         : 20      
+ Store          : 35      
+ Switch         : 4       
+ Unary          : 327     
+ Unreachable    : 135     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 46      
- [funcs]        : 55      
+ [exports]      : 66      
+ [funcs]        : 90      
  [globals]      : 7       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 29      
- [table-data]   : 17      
+ [table-data]   : 29      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 3649    
- [vars]         : 151     
- Binary         : 283     
- Block          : 607     
- Break          : 112     
- Call           : 142     
- CallIndirect   : 32      
- Const          : 620     
- Drop           : 43      
- GlobalGet      : 323     
- GlobalSet      : 265     
- If             : 187     
- Load           : 59      
- LocalGet       : 226     
- LocalSet       : 164     
- Loop           : 62      
- Nop            : 38      
- RefFunc        : 17      
- Return         : 38      
- Select         : 25      
- Store          : 25      
+ [total]        : 6921    
+ [vars]         : 318     
+ Binary         : 480     
+ Block          : 1167    
+ Break          : 221     
+ Call           : 312     
+ CallIndirect   : 29      
+ Const          : 1162    
+ Drop           : 79      
+ GlobalGet      : 602     
+ GlobalSet      : 469     
+ If             : 387     
+ Load           : 101     
+ LocalGet       : 437     
+ LocalSet       : 319     
+ Loop           : 139     
+ Nop            : 120     
+ RefFunc        : 29      
+ Return         : 62      
+ Select         : 57      
+ Store          : 52      
  Switch         : 1       
- Unary          : 247     
- Unreachable    : 133     
+ Unary          : 467     
+ Unreachable    : 229     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 20      
- [funcs]        : 34      
+ [exports]      : 46      
+ [funcs]        : 55      
  [globals]      : 7       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 29      
- [table-data]   : 10      
+ [table-data]   : 17      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 4470    
- [vars]         : 142     
- Binary         : 326     
- Block          : 726     
- Break          : 164     
- Call           : 135     
- CallIndirect   : 31      
- Const          : 692     
- Drop           : 57      
- GlobalGet      : 383     
- GlobalSet      : 275     
- If             : 239     
- Load           : 82      
- LocalGet       : 371     
- LocalSet       : 270     
- Loop           : 95      
- Nop            : 58      
- RefFunc        : 10      
- Return         : 35      
- Select         : 20      
- Store          : 35      
- Switch         : 4       
- Unary          : 327     
- Unreachable    : 135     
+ [total]        : 3649    
+ [vars]         : 151     
+ Binary         : 283     
+ Block          : 607     
+ Break          : 112     
+ Call           : 142     
+ CallIndirect   : 32      
+ Const          : 620     
+ Drop           : 43      
+ GlobalGet      : 323     
+ GlobalSet      : 265     
+ If             : 187     
+ Load           : 59      
+ LocalGet       : 226     
+ LocalSet       : 164     
+ Loop           : 62      
+ Nop            : 38      
+ RefFunc        : 17      
+ Return         : 38      
+ Select         : 25      
+ Store          : 25      
+ Switch         : 1       
+ Unary          : 247     
+ Unreachable    : 133     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -1,35 +1,35 @@
 Metrics
 total
- [exports]      : 66      
- [funcs]        : 90      
+ [exports]      : 36      
+ [funcs]        : 64      
  [globals]      : 7       
  [imports]      : 4       
  [memories]     : 1       
  [memory-data]  : 29      
- [table-data]   : 29      
+ [table-data]   : 19      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 6921    
- [vars]         : 318     
- Binary         : 480     
- Block          : 1167    
- Break          : 221     
- Call           : 312     
- CallIndirect   : 29      
- Const          : 1162    
- Drop           : 79      
- GlobalGet      : 602     
- GlobalSet      : 469     
- If             : 387     
- Load           : 101     
- LocalGet       : 437     
- LocalSet       : 319     
- Loop           : 139     
- Nop            : 120     
- RefFunc        : 29      
- Return         : 62      
- Select         : 57      
- Store          : 52      
- Switch         : 1       
- Unary          : 467     
- Unreachable    : 229     
+ [total]        : 10813   
+ [vars]         : 208     
+ Binary         : 791     
+ Block          : 1709    
+ Break          : 412     
+ Call           : 382     
+ CallIndirect   : 73      
+ Const          : 1793    
+ Drop           : 77      
+ GlobalGet      : 898     
+ GlobalSet      : 637     
+ If             : 561     
+ Load           : 199     
+ LocalGet       : 908     
+ LocalSet       : 616     
+ Loop           : 248     
+ Nop            : 169     
+ RefFunc        : 19      
+ Return         : 89      
+ Select         : 91      
+ Store          : 80      
+ Switch         : 2       
+ Unary          : 747     
+ Unreachable    : 312     

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,58 +1,58 @@
 Metrics
 total
- [exports]      : 11      
- [funcs]        : 14      
+ [exports]      : 16      
+ [funcs]        : 19      
  [globals]      : 4       
  [imports]      : 12      
  [memories]     : 1       
  [memory-data]  : 17      
- [table-data]   : 14      
+ [table-data]   : 6       
  [tables]       : 2       
- [tags]         : 3       
- [total]        : 863     
+ [tags]         : 2       
+ [total]        : 850     
  [vars]         : 49      
- ArrayNewFixed  : 3       
+ ArrayNewFixed  : 5       
+ AtomicCmpxchg  : 1       
+ AtomicFence    : 2       
  AtomicRMW      : 1       
- Binary         : 90      
- Block          : 122     
- BrOn           : 6       
- Break          : 8       
- Call           : 18      
+ Binary         : 91      
+ Block          : 112     
+ Break          : 5       
+ Call           : 29      
  CallIndirect   : 1       
- CallRef        : 4       
- Const          : 154     
- Drop           : 10      
- GlobalGet      : 51      
+ CallRef        : 2       
+ Const          : 171     
+ Drop           : 8       
+ GlobalGet      : 55      
  GlobalSet      : 48      
- I31Get         : 1       
- If             : 34      
- Load           : 27      
+ I31Get         : 2       
+ If             : 37      
+ Load           : 26      
  LocalGet       : 53      
- LocalSet       : 34      
- Loop           : 10      
+ LocalSet       : 31      
+ Loop           : 6       
  MemoryCopy     : 2       
- Nop            : 12      
+ MemoryFill     : 1       
+ Nop            : 6       
  Pop            : 2       
- RefCast        : 3       
+ RefAs          : 1       
  RefEq          : 3       
- RefFunc        : 22      
- RefI31         : 6       
+ RefFunc        : 11      
+ RefI31         : 8       
  RefIsNull      : 1       
- RefNull        : 7       
- Return         : 10      
- SIMDExtract    : 2       
- Select         : 12      
- Store          : 1       
- StringConst    : 7       
- StringEq       : 2       
- StringMeasure  : 1       
- StructNew      : 4       
- TableSet       : 1       
- Throw          : 7       
- ThrowRef       : 1       
+ RefNull        : 5       
+ RefTest        : 1       
+ Return         : 13      
+ SIMDExtract    : 1       
+ Select         : 8       
+ Store          : 2       
+ StringConst    : 12      
+ StringEq       : 4       
+ StringWTF16Get : 1       
+ StructNew      : 6       
  Try            : 3       
- TryTable       : 10      
+ TryTable       : 4       
  TupleExtract   : 3       
- TupleMake      : 4       
- Unary          : 35      
- Unreachable    : 27      
+ TupleMake      : 5       
+ Unary          : 37      
+ Unreachable    : 24      

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,58 +1,51 @@
 Metrics
 total
- [exports]      : 21      
- [funcs]        : 26      
+ [exports]      : 19      
+ [funcs]        : 23      
  [globals]      : 4       
  [imports]      : 12      
  [memories]     : 1       
  [memory-data]  : 17      
- [table-data]   : 4       
+ [table-data]   : 6       
  [tables]       : 2       
  [tags]         : 3       
- [total]        : 960     
- [vars]         : 45      
- ArrayNew       : 1       
- ArrayNewFixed  : 9       
- AtomicNotify   : 2       
- Binary         : 93      
- Block          : 156     
- BrOn           : 2       
+ [total]        : 867     
+ [vars]         : 69      
+ ArrayNewFixed  : 4       
+ AtomicCmpxchg  : 1       
+ Binary         : 84      
+ Block          : 127     
  Break          : 5       
- Call           : 55      
+ Call           : 46      
  CallIndirect   : 1       
- Const          : 173     
+ CallRef        : 1       
+ Const          : 156     
  DataDrop       : 1       
- Drop           : 15      
- GlobalGet      : 77      
- GlobalSet      : 70      
- If             : 40      
- Load           : 17      
- LocalGet       : 48      
- LocalSet       : 24      
- Loop           : 10      
- MemoryFill     : 1       
- MemoryInit     : 1       
- Nop            : 12      
- Pop            : 2       
- RefEq          : 2       
- RefFunc        : 4       
- RefI31         : 3       
- RefNull        : 9       
- RefTest        : 1       
+ Drop           : 19      
+ GlobalGet      : 65      
+ GlobalSet      : 62      
+ I31Get         : 1       
+ If             : 36      
+ Load           : 18      
+ LocalGet       : 50      
+ LocalSet       : 32      
+ Loop           : 4       
+ Nop            : 9       
+ RefAs          : 8       
+ RefFunc        : 10      
+ RefI31         : 9       
+ RefNull        : 4       
  Return         : 6       
- SIMDExtract    : 4       
  Select         : 2       
- Store          : 3       
- StringConst    : 8       
- StringEncode   : 1       
- StringEq       : 1       
+ StringConst    : 4       
+ StringMeasure  : 3       
  StringWTF16Get : 1       
- StructNew      : 4       
+ StructNew      : 1       
  TableSet       : 1       
- Throw          : 4       
+ Throw          : 1       
  Try            : 1       
- TryTable       : 5       
- TupleExtract   : 1       
- TupleMake      : 3       
- Unary          : 45      
- Unreachable    : 36      
+ TryTable       : 4       
+ TupleExtract   : 10      
+ TupleMake      : 5       
+ Unary          : 43      
+ Unreachable    : 32      

--- a/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
+++ b/test/passes/translate-to-fuzz_all-features_metrics_noprint.txt
@@ -1,51 +1,58 @@
 Metrics
 total
- [exports]      : 19      
- [funcs]        : 23      
+ [exports]      : 11      
+ [funcs]        : 14      
  [globals]      : 4       
  [imports]      : 12      
  [memories]     : 1       
  [memory-data]  : 17      
- [table-data]   : 6       
+ [table-data]   : 14      
  [tables]       : 2       
  [tags]         : 3       
- [total]        : 867     
- [vars]         : 69      
- ArrayNewFixed  : 4       
- AtomicCmpxchg  : 1       
- Binary         : 84      
- Block          : 127     
- Break          : 5       
- Call           : 46      
+ [total]        : 863     
+ [vars]         : 49      
+ ArrayNewFixed  : 3       
+ AtomicRMW      : 1       
+ Binary         : 90      
+ Block          : 122     
+ BrOn           : 6       
+ Break          : 8       
+ Call           : 18      
  CallIndirect   : 1       
- CallRef        : 1       
- Const          : 156     
- DataDrop       : 1       
- Drop           : 19      
- GlobalGet      : 65      
- GlobalSet      : 62      
+ CallRef        : 4       
+ Const          : 154     
+ Drop           : 10      
+ GlobalGet      : 51      
+ GlobalSet      : 48      
  I31Get         : 1       
- If             : 36      
- Load           : 18      
- LocalGet       : 50      
- LocalSet       : 32      
- Loop           : 4       
- Nop            : 9       
- RefAs          : 8       
- RefFunc        : 10      
- RefI31         : 9       
- RefNull        : 4       
- Return         : 6       
- Select         : 2       
- StringConst    : 4       
- StringMeasure  : 3       
- StringWTF16Get : 1       
- StructNew      : 1       
+ If             : 34      
+ Load           : 27      
+ LocalGet       : 53      
+ LocalSet       : 34      
+ Loop           : 10      
+ MemoryCopy     : 2       
+ Nop            : 12      
+ Pop            : 2       
+ RefCast        : 3       
+ RefEq          : 3       
+ RefFunc        : 22      
+ RefI31         : 6       
+ RefIsNull      : 1       
+ RefNull        : 7       
+ Return         : 10      
+ SIMDExtract    : 2       
+ Select         : 12      
+ Store          : 1       
+ StringConst    : 7       
+ StringEq       : 2       
+ StringMeasure  : 1       
+ StructNew      : 4       
  TableSet       : 1       
- Throw          : 1       
- Try            : 1       
- TryTable       : 4       
- TupleExtract   : 10      
- TupleMake      : 5       
- Unary          : 43      
- Unreachable    : 32      
+ Throw          : 7       
+ ThrowRef       : 1       
+ Try            : 3       
+ TryTable       : 10      
+ TupleExtract   : 3       
+ TupleMake      : 4       
+ Unary          : 35      
+ Unreachable    : 27      


### PR DESCRIPTION
Previously we would create a function and then immediately modify it in
interesting ways (replace code, move code around, etc.). We also modified any
initial functions (in the content we are given to build on top of) at the very
start. That was simple, by modifying later we can get some benefits. This PR
makes us work in a loop:

```python
while more:
  if random:
    add function
  else
    modify some random function previously added
```

This lets us unify the modification code to one place (rather than have it
separate for initial functions and for created functions). Also, by modifying
late, we can end up with calls from early functions to late ones, as we may
create A and B before modifying A, and end up mutating something into a call to
B. Previously we never had such forward calls.

For such late modding to work, the FunctionCreationContext needs to be a little
smarter, since we don't use a single context for creation and modification - now
the modification may happen later. Specifically, it needs to scan the body to
see the next label index that is valid to add, which we did not need before.
This PR also moves some things out of the context destructor, because now we
will run it more than once on the same function, and some things only need to
happen once like adding the hang limit checks.