### PR TITLE
[ci] set-output changed to echoing to GITHUB_OUTPUT create_release.yml

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -72,7 +72,7 @@ jobs:
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV    
+        echo "shasum=$shasum" >> $GITHUB_ENV
 
     - name: archive-arm64
       id: archive-arm64
@@ -88,7 +88,7 @@ jobs:
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV    
+        echo "shasum=$shasum" >> $GITHUB_ENV
       if: matrix.os == 'macos-latest'
 
     - name: upload tarball
@@ -162,7 +162,7 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV    
+        echo "shasum=$shasum" >> $GITHUB_ENV
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1
@@ -228,7 +228,7 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV    
+        echo "shasum=$shasum" >> $GITHUB_ENV
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -71,8 +71,8 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "::set-output name=tarball::$TARBALL"
-        echo "::set-output name=shasum::$SHASUM"
+        echo "tarball=$tarball" >> $GITHUB_ENV
+        echo "shasum=$shasum" >> $GITHUB_ENV    
 
     - name: archive-arm64
       id: archive-arm64
@@ -87,8 +87,8 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "::set-output name=tarball::$TARBALL"
-        echo "::set-output name=shasum::$SHASUM"
+        echo "tarball=$tarball" >> $GITHUB_ENV
+        echo "shasum=$shasum" >> $GITHUB_ENV    
       if: matrix.os == 'macos-latest'
 
     - name: upload tarball
@@ -161,8 +161,8 @@ jobs:
         mv install binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "::set-output name=tarball::$TARBALL"
-        echo "::set-output name=shasum::$SHASUM"
+        echo "tarball=$tarball" >> $GITHUB_ENV
+        echo "shasum=$shasum" >> $GITHUB_ENV    
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1
@@ -227,8 +227,8 @@ jobs:
         cp out/bin/wasm-opt* binaryen-$VERSION/
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "::set-output name=tarball::$TARBALL"
-        echo "::set-output name=shasum::$SHASUM"
+        echo "tarball=$tarball" >> $GITHUB_ENV
+        echo "shasum=$shasum" >> $GITHUB_ENV    
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -71,8 +71,8 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_OUTPUT
-        echo "shasum=$shasum" >> $GITHUB_OUTPUT
+        echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
+        echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
 
     - name: archive-arm64
       id: archive-arm64
@@ -87,8 +87,8 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_OUTPUT
-        echo "shasum=$shasum" >> $GITHUB_OUTPUT
+        echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
+        echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
       if: matrix.os == 'macos-latest'
 
     - name: upload tarball
@@ -96,10 +96,10 @@ jobs:
       with:
         draft: true
         files: |
-          ${{ steps.archive.outputs.tarball }}
-          ${{ steps.archive.outputs.shasum }}
-          ${{ steps.archive-arm64.outputs.tarball }}
-          ${{ steps.archive-arm64.outputs.shasum }}
+          ${{ steps.archive.outputs.TARBALL }}
+          ${{ steps.archive.outputs.SHASUM }}
+          ${{ steps.archive-arm64.outputs.TARBALL }}
+          ${{ steps.archive-arm64.outputs.SHASUM }}
 
   # Build with gcc 6.3 and run tests on Alpine Linux (inside chroot).
   # Note: Alpine uses musl libc.
@@ -161,16 +161,16 @@ jobs:
         mv install binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_OUTPUT
-        echo "shasum=$shasum" >> $GITHUB_OUTPUT
+        echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
+        echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: |
-          ${{ steps.archive.outputs.tarball }}
-          ${{ steps.archive.outputs.shasum }}
+          ${{ steps.archive.outputs.TARBALL }}
+          ${{ steps.archive.outputs.SHASUM }}
 
   # Build using Emscripten to JavaScript+WebAssembly.
   build-node:
@@ -227,13 +227,13 @@ jobs:
         cp out/bin/wasm-opt* binaryen-$VERSION/
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_OUTPUT
-        echo "shasum=$shasum" >> $GITHUB_OUTPUT
+        echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
+        echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1
       with:
         draft: true
         files: |
-          ${{ steps.archive.outputs.tarball }}
-          ${{ steps.archive.outputs.shasum }}
+          ${{ steps.archive.outputs.TARBALL }}
+          ${{ steps.archive.outputs.SHASUM }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -71,8 +71,8 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV
+        echo "tarball=$tarball" >> $GITHUB_OUTPUT
+        echo "shasum=$shasum" >> $GITHUB_OUTPUT
 
     - name: archive-arm64
       id: archive-arm64
@@ -87,8 +87,8 @@ jobs:
         tar -czf $TARBALL binaryen-$VERSION
         # on Windows, MSYS2 will strip the carriage return from CMake output
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV
+        echo "tarball=$tarball" >> $GITHUB_OUTPUT
+        echo "shasum=$shasum" >> $GITHUB_OUTPUT
       if: matrix.os == 'macos-latest'
 
     - name: upload tarball
@@ -161,8 +161,8 @@ jobs:
         mv install binaryen-$VERSION
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV
+        echo "tarball=$tarball" >> $GITHUB_OUTPUT
+        echo "shasum=$shasum" >> $GITHUB_OUTPUT
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1
@@ -227,8 +227,8 @@ jobs:
         cp out/bin/wasm-opt* binaryen-$VERSION/
         tar -czf $TARBALL binaryen-$VERSION
         cmake -E sha256sum $TARBALL > $SHASUM
-        echo "tarball=$tarball" >> $GITHUB_ENV
-        echo "shasum=$shasum" >> $GITHUB_ENV
+        echo "tarball=$tarball" >> $GITHUB_OUTPUT
+        echo "shasum=$shasum" >> $GITHUB_OUTPUT
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
If you look here https://github.com/WebAssembly/binaryen/actions/runs/13124901726 , you'll see that when the create_release.yml workflow you runs you get a warning that "The `set-output` command is deprecated and will be disabled soon". I believe this is the modern version of set-output. I got the suggestion from here https://stackoverflow.com/questions/75892082/warning-for-set-output-command-is-deprecated-and-will-be-disabled-soon-wont .