### PR TITLE
[ci] Update checkout action in create_release.yml to v4

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -113,7 +113,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
 


### PR DESCRIPTION
This may be a case of if its not broke, don't fix it, but the checkout action used in the release workflow is very old (and I'm slightly surprised it works). This PR updates to the latest version of the action, making it consistent with the main ci workflow here https://github.com/WebAssembly/binaryen/blob/83c82e56172506572098cbc590e7b0b0d6edcd1f/.github/workflows/ci.yml#L29 .