### PR TITLE
WAT parser: include file name in error messages

### DIFF
--- a/src/parser/lexer.h
+++ b/src/parser/lexer.h
@@ -61,11 +61,15 @@ struct Lexer {
 private:
   size_t pos = 0;
   std::vector<Annotation> annotations;
+  std::optional<std::string> file;
 
 public:
   std::string_view buffer;
 
-  Lexer(std::string_view buffer) : buffer(buffer) { setPos(0); }
+  Lexer(std::string_view buffer, std::optional<std::string> file = std::nullopt)
+    : file(file), buffer(buffer) {
+    setPos(0);
+  }
 
   size_t getPos() const { return pos; }
 
@@ -169,6 +173,9 @@ public:
 
   [[nodiscard]] Err err(size_t pos, std::string reason) {
     std::stringstream msg;
+    if (file) {
+      msg << *file << ":";
+    }
     msg << position(pos) << ": error: " << reason;
     return Err{msg.str()};
   }

--- a/src/parser/wat-parser.cpp
+++ b/src/parser/wat-parser.cpp
@@ -121,6 +121,13 @@ Result<> doParseModule(Module& wasm, Lexer& input, bool allowExtra) {
 
 } // anonymous namespace
 
+Result<> parseModule(Module& wasm,
+                     std::string_view in,
+                     std::optional<std::string> filename) {
+  Lexer lexer(in, filename);
+  return doParseModule(wasm, lexer, false);
+}
+
 Result<> parseModule(Module& wasm, std::string_view in) {
   Lexer lexer(in);
   return doParseModule(wasm, lexer, false);

--- a/src/parser/wat-parser.h
+++ b/src/parser/wat-parser.h
@@ -26,7 +26,9 @@
 namespace wasm::WATParser {
 
 // Parse a single WAT module.
-Result<> parseModule(Module& wasm, std::string_view in);
+Result<> parseModule(Module& wasm,
+                     std::string_view in,
+                     std::optional<std::string> filename = std::nullopt);
 
 // Parse a single WAT module that may have other things after it, as in a wast
 // file.

--- a/src/wasm/wasm-io.cpp
+++ b/src/wasm/wasm-io.cpp
@@ -34,8 +34,11 @@ namespace wasm {
 
 #define DEBUG_TYPE "writer"
 
-static void readTextData(std::string& input, Module& wasm, IRProfile profile) {
-  if (auto parsed = WATParser::parseModule(wasm, input);
+static void readTextData(std::optional<std::string> filename,
+                         std::string& input,
+                         Module& wasm,
+                         IRProfile profile) {
+  if (auto parsed = WATParser::parseModule(wasm, input, filename);
       auto err = parsed.getErr()) {
     Fatal() << err->msg;
   }
@@ -44,7 +47,7 @@ static void readTextData(std::string& input, Module& wasm, IRProfile profile) {
 void ModuleReader::readText(std::string filename, Module& wasm) {
   BYN_TRACE("reading text from " << filename << "\n");
   auto input(read_file<std::string>(filename, Flags::Text));
-  readTextData(input, wasm, profile);
+  readTextData(filename, input, wasm, profile);
 }
 
 void ModuleReader::readBinaryData(std::vector<char>& input,
@@ -114,7 +117,7 @@ void ModuleReader::readStdin(Module& wasm, std::string sourceMapFilename) {
     std::ostringstream s;
     s.write(input.data(), input.size());
     std::string input_str = s.str();
-    readTextData(input_str, wasm, profile);
+    readTextData(std::nullopt, input_str, wasm, profile);
   }
 }
 

--- a/test/lit/parse-bad-optional-memidx.wast
+++ b/test/lit/parse-bad-optional-memidx.wast
@@ -3,7 +3,7 @@
 
 ;; RUN: not wasm-opt -all %s 2>&1 | filecheck %s
 
-;; CHECK: Fatal: 12:22: error: expected end of instruction
+;; CHECK: Fatal: {{.*}}:12:22: error: expected end of instruction
 
 (module
  (memory 1 1)

--- a/test/lit/parse-bad-supertype-8616.wast
+++ b/test/lit/parse-bad-supertype-8616.wast
@@ -1,6 +1,6 @@
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: Fatal: 9:2: error: invalid type: Heap type has an undeclared supertype
+;; CHECK: Fatal: {{.*}}:9:2: error: invalid type: Heap type has an undeclared supertype
 
 ;; Regression test for a parser bug that caused an assertion failure in this case.
 (module

--- a/test/lit/parse-bad-supertype.wast
+++ b/test/lit/parse-bad-supertype.wast
@@ -2,7 +2,7 @@
 
 ;; RUN: not wasm-opt %s -all 2>&1 | filecheck %s
 
-;; CHECK: Fatal: 8:2: error: invalid type: Heap type has an invalid supertype
+;; CHECK: Fatal: {{.*}}:8:2: error: invalid type: Heap type has an invalid supertype
 (module
   (type $super (sub (struct i32)))
   (type $sub (sub $super (struct i64)))

--- a/test/lit/parse-bad-tuple-extract-index.wast
+++ b/test/lit/parse-bad-tuple-extract-index.wast
@@ -2,7 +2,7 @@
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: Fatal: 9:3: error: tuple index out of bounds
+;; CHECK: Fatal: {{.*}}:9:3: error: tuple index out of bounds
 
 (module
  (func

--- a/test/lit/parse-bad-tuple-in-sig.wast
+++ b/test/lit/parse-bad-tuple-in-sig.wast
@@ -2,7 +2,7 @@
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
 
-;; CHECK: Fatal: 9:1: error: tuple types not allowed in signature
+;; CHECK: Fatal: {{.*}}:9:1: error: tuple types not allowed in signature
 
 (module
  (func $tuple-in-sig (param (tuple i32 i32))

--- a/test/lit/parse-error-func-param-type.wast
+++ b/test/lit/parse-error-func-param-type.wast
@@ -1,7 +1,7 @@
 ;; This function's type does not match the param we define for it.
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
-;; CHECK: Fatal: 9:10: error: type does not match provided signature
+;; CHECK: Fatal: {{.*}}:9:10: error: type does not match provided signature
 
 (module
  (type $0 (func))

--- a/test/lit/parse-error-return-nofunc.wast
+++ b/test/lit/parse-error-return-nofunc.wast
@@ -1,7 +1,7 @@
 ;; We should error properly on a return in a non-function scope
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
-;; CHECK: Fatal: 8:5: error: return is only valid in a function context
+;; CHECK: Fatal: {{.*}}:8:5: error: return is only valid in a function context
 
 (module
   (elem

--- a/test/lit/parse-error.wast
+++ b/test/lit/parse-error.wast
@@ -1,7 +1,7 @@
 ;; Test that parse errors have helpful messages
 
 ;; RUN: not wasm-opt %s 2>&1 | filecheck %s
-;; CHECK: Fatal: 8:5: error: unrecognized instruction
+;; CHECK: Fatal: {{.*}}:8:5: error: unrecognized instruction
 
 (module
   (func $foo


### PR DESCRIPTION
This is especially useful with `wasm-merge` which takes several file as inputs.