### PR TITLE
Fuzzer: Interpose on existing exports

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1413,9 +1413,8 @@ void TranslateToFuzzReader::processFunctions() {
       if (exp->kind == ExternalKind::Function && upTo(RESOLUTION) < chance) {
         auto* func = wasm.getFunction(exp->value);
         if (!func->imported()) {
-          auto* call = builder.makeCall(pick(noParamsOrResultFuncs),
-                                        {},
-                                        Type::none);
+          auto* call =
+            builder.makeCall(pick(noParamsOrResultFuncs), {}, Type::none);
           func->body = builder.makeSequence(call, func->body);
         }
       }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1410,10 +1410,12 @@ void TranslateToFuzzReader::processFunctions() {
       auto& exp = wasm.exports[i];
       if (exp->kind == ExternalKind::Function && upTo(RESOLUTION) < chance) {
         auto* func = wasm.getFunction(exp->value);
-        auto* call = builder.makeCall(pick(noParamsOrResultFuncs),
-                                      {},
-                                      Type::none);
-        func->body = builder.makeSequence(call, func->body);
+        if (!func->imported()) {
+          auto* call = builder.makeCall(pick(noParamsOrResultFuncs),
+                                        {},
+                                        Type::none);
+          func->body = builder.makeSequence(call, func->body);
+        }
       }
     }
   }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1386,7 +1386,9 @@ void TranslateToFuzzReader::processFunctions() {
   // be useful to add new code that executes in them, rather than just adding
   // new exports later. To some extent modifying the initially-exported function
   // gives us that, but typically these are small changes, not calls to entirely
-  // new code.
+  // new code (and this is especially important when preserveImportsAndExports,
+  // as in that mode we do not add new exports, so this interposing is our main
+  // chance to run new code using the existing exports).
   //
   // Interpose with a call before the old code. We do a call here so that we end
   // up running a useful amount of new code (rather than just make(none) which


### PR DESCRIPTION
If the initial wasm we are fuzzing with had an export, then some of
the time add more code in that export, interposing before the
usual code:

```wat
(func $foo (export "bar") (result i32)
  (..code..)
)

=>

(func $foo (export "bar") (result i32)
  (call $something) ;; new code
  (..code..)
)
```

We interpose by inserting a call to another function.

We already got something like this from modifying functions
from initial content, but adding such calls gives a much better
chance to execute an interesting amount of new code (calling
one of the new functions we generated ourselves, which could
contain anything).