### PR TITLE
[Fuzzing] Add a script to embed wasm files into JS testcases

### DIFF
--- a/scripts/clusterfuzz/embed_wasms.py
+++ b/scripts/clusterfuzz/embed_wasms.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 WebAssembly Community Group participants
+# Copyright 2025 WebAssembly Community Group participants
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/clusterfuzz/embed_wasms.py
+++ b/scripts/clusterfuzz/embed_wasms.py
@@ -33,9 +33,9 @@ will emit
 
 We now have a JS file without the wasm (which includes the magic comments
 mentioned before) and one binary wasm file for each wasm. We can now re-embed
-them, created a merged JS file with JS + wasm, using
+them, creating a merged JS file containing JS + wasm, using
 
-  embed_wamss.py OUTFILE.js OUTFILE.0.wasm OUTFILE.1.wasm MERGED.js
+  embed_wasms.py OUTFILE.js OUTFILE.0.wasm OUTFILE.1.wasm MERGED.js
 
 The first argument is the input JS, then the wasm files, then the last argument
 is the output JS.

--- a/scripts/clusterfuzz/embed_wasms.py
+++ b/scripts/clusterfuzz/embed_wasms.py
@@ -17,7 +17,7 @@
 Reverse script for extract_wasms.py: That one extracts wasm files from a
 JavaScript testcase (which has wasm files embedded as arrays of numbers), and
 this one re-embeds them back. To do so, we use the magic comments that the
-extractor uses, replacing each wasm array with
+extractor uses: it replaces each wasm array with
 
   'undefined /* extracted wasm */'
 

--- a/scripts/clusterfuzz/embed_wasms.py
+++ b/scripts/clusterfuzz/embed_wasms.py
@@ -68,7 +68,7 @@ def replace_wasm(text):
     return f'new Uint8Array([{bytes}])'
 
 
-js = js.replace('undefined /* extracted wasm */', replace_wasm)
+js = re.sub(r'undefined [/][*] extracted wasm [*][/]', replace_wasm, js)
 
 # Write out the new JS.
 with open(out_js, 'w') as f:

--- a/scripts/clusterfuzz/embed_wasms.py
+++ b/scripts/clusterfuzz/embed_wasms.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2024 WebAssembly Community Group participants
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Reverse script for extract_wasms.py: That one extracts wasm files from a
+JavaScript testcase (which has wasm files embedded as arrays of numbers), and
+this one re-embeds them back. To do so, we use the magic comments that the
+extractor uses, replacing each wasm array with
+
+  'undefined /* extracted wasm */'
+
+We simply replace those with the given wasm files, in JS format.
+
+For example, assume INFILE.js contains two wasm files. Then
+
+  extract_wasms.py INFILE.js OUTFILE
+
+will emit
+
+  OUTFILE.js, OUTFILE.0.wasm, OUTFILE.1.wasm
+
+We now have a JS file without the wasm (which includes the magic comments
+mentioned before) and one binary wasm file for each wasm. We can now re-embed
+them, created a merged JS file with JS + wasm, using
+
+  embed_wamss.py OUTFILE.js OUTFILE.0.wasm OUTFILE.1.wasm MERGED.js
+
+The first argument is the input JS, then the wasm files, then the last argument
+is the output JS.
+'''
+
+import re
+import sys
+
+in_js = sys.argv[1]
+in_wasms = sys.argv[2:-1]
+out_js = sys.argv[-1]
+
+with open(in_js) as f:
+    js = f.read()
+
+wasm_index = 0
+
+
+def replace_wasm(text):
+    global wasm_index
+    wasm_file = in_wasms[wasm_index]
+    wasm_index += 1
+
+    with open(wasm_file, 'rb') as f:
+        wasm = f.read()
+
+    bytes = [str(int(x)) for x in wasm]
+    bytes = ', '.join(bytes)
+
+    return f'new Uint8Array([{bytes}])'
+
+
+js = js.replace('undefined /* extracted wasm */', replace_wasm)
+
+# Write out the new JS.
+with open(out_js, 'w') as f:
+    f.write(js)

--- a/test/lit/scripts/embed_wasms.lit
+++ b/test/lit/scripts/embed_wasms.lit
@@ -1,0 +1,28 @@
+;; Test extracting wasm files from JS.
+
+;; A proper wasm start sequence (\0asm), so we will extract it.
+;; RUN: echo "good1(new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01]));" > %t.js
+
+;; A difference in the second byte, so we won't.
+;; RUN: echo "bad1(new Uint8Array([0x00, 0xff, 0x73, 0x6D, 0x01]));" >> %t.js
+
+;; The last byte is unparseable as an integer, so we won't.
+;; RUN: echo "bad2(new Uint8Array([0x00, 0x61, 0x73, 0x6D, 6Dx0]));" >> %t.js
+
+;; This is not a Uint8Array, so we do nothing.
+;; RUN: echo "bad3(new Uint16Array([0x00, 0x61, 0x73, 0x6D, 0x01]));" >> %t.js
+
+;; Another proper one. Note the second number is in base 10, which works too,
+;; & there is various odd whitespace which we also ignore.
+;; RUN: echo "good2(new Uint8Array([0x00,97,   0x73, 0x6D,0x01]));" >> %t.js
+
+;; RUN: python %S/../../../scripts/clusterfuzz/extract_wasms.py %t.js %t.out
+;; RUN: cat %t.out.js | filecheck %s
+;;
+;; We extracted the good but not the bad.
+;; CHECK: good1(undefined /* extracted wasm */)
+;; CHECK: bad1(new Uint8Array
+;; CHECK: bad2(new Uint8Array
+;; CHECK: bad3(new Uint16Array
+;; CHECK: good2(undefined /* extracted wasm */)
+

--- a/test/lit/scripts/embed_wasms.lit
+++ b/test/lit/scripts/embed_wasms.lit
@@ -1,28 +1,25 @@
-;; Test extracting wasm files from JS.
+;; Test embedding wasm files into JS.
 
-;; A proper wasm start sequence (\0asm), so we will extract it.
-;; RUN: echo "good1(new Uint8Array([0x00, 0x61, 0x73, 0x6D, 0x01]));" > %t.js
+;; Wasm files replace undefined + magical comments, like these:
+;; RUN: echo "good1(undefined /* extracted wasm */);" > %t.js
 
-;; A difference in the second byte, so we won't.
-;; RUN: echo "bad1(new Uint8Array([0x00, 0xff, 0x73, 0x6D, 0x01]));" >> %t.js
+;; Slight changes mean we ignore the pattern.
+;; RUN: echo "bad(undefinedey /* random wasm */);" >> %t.js
 
-;; The last byte is unparseable as an integer, so we won't.
-;; RUN: echo "bad2(new Uint8Array([0x00, 0x61, 0x73, 0x6D, 6Dx0]));" >> %t.js
+;; Add a second valid one.
+;; RUN: echo "good2(undefined /* extracted wasm */);" >> %t.js
 
-;; This is not a Uint8Array, so we do nothing.
-;; RUN: echo "bad3(new Uint16Array([0x00, 0x61, 0x73, 0x6D, 0x01]));" >> %t.js
+;; Generate two valid wasm files to embed.
+;; RUN: echo "(module)" > %t.1.wat
+;; RUN: echo "(module (func $foo))" > %t.2.wat
 
-;; Another proper one. Note the second number is in base 10, which works too,
-;; & there is various odd whitespace which we also ignore.
-;; RUN: echo "good2(new Uint8Array([0x00,97,   0x73, 0x6D,0x01]));" >> %t.js
+;; RUN: wasm-as %t.1.wat -o %t.1.wasm
+;; RUN: wasm-as %t.2.wat -o %t.2.wasm
 
-;; RUN: python %S/../../../scripts/clusterfuzz/extract_wasms.py %t.js %t.out
+;; RUN: python %S/../../../scripts/clusterfuzz/embed.py %t.js %t.1.wasm %t.2.wasm %t.out.js
 ;; RUN: cat %t.out.js | filecheck %s
 ;;
-;; We extracted the good but not the bad.
 ;; CHECK: good1(undefined /* extracted wasm */)
-;; CHECK: bad1(new Uint8Array
-;; CHECK: bad2(new Uint8Array
-;; CHECK: bad3(new Uint16Array
+;; CHECK  bad(undefinedey /* random wasm */)
 ;; CHECK: good2(undefined /* extracted wasm */)
 

--- a/test/lit/scripts/embed_wasms.lit
+++ b/test/lit/scripts/embed_wasms.lit
@@ -4,7 +4,7 @@
 ;; RUN: echo "good1(undefined /* extracted wasm */);" > %t.js
 
 ;; Slight changes mean we ignore the pattern.
-;; RUN: echo "bad(undefinedey /* random wasm */);" >> %t.js
+;; RUN: echo "bad(undefinedey /* random stuff */);" >> %t.js
 
 ;; Add a second valid one.
 ;; RUN: echo "good2(undefined /* extracted wasm */);" >> %t.js
@@ -16,10 +16,10 @@
 ;; RUN: wasm-as %t.1.wat -o %t.1.wasm
 ;; RUN: wasm-as %t.2.wat -o %t.2.wasm
 
-;; RUN: python %S/../../../scripts/clusterfuzz/embed.py %t.js %t.1.wasm %t.2.wasm %t.out.js
+;; RUN: python %S/../../../scripts/clusterfuzz/embed_wasms.py %t.js %t.1.wasm %t.2.wasm %t.out.js
 ;; RUN: cat %t.out.js | filecheck %s
 ;;
-;; CHECK: good1(undefined /* extracted wasm */)
-;; CHECK  bad(undefinedey /* random wasm */)
-;; CHECK: good2(undefined /* extracted wasm */)
+;; CHECK: good1(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0]));
+;; CHECK: bad(undefinedey
+;; CHECK: good2(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 4, 1, 2, 0, 11]));
 


### PR DESCRIPTION
This is the inverse of `extract_wasms.py`: the previous script
extracted wasm files from JS, and this one can re-embed them
back in.

This can be useful when working with ClusterFuzz and Fuzzilli
testcases.