### PR TITLE
[Interpreter] Float32

### DIFF
--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -86,7 +86,28 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     push(curr->value);
     return {};
   }
-  Flow visitUnary(Unary* curr) { WASM_UNREACHABLE("TODO"); }
+  Flow visitUnary(Unary* curr) {
+    auto value = pop();
+    switch (curr->op) {
+      case SqrtFloat32:
+        push(value.sqrt());
+        return {};
+      case CeilFloat32:
+        push(value.ceil());
+        return {};
+      case FloorFloat32:
+        push(value.floor());
+        return {};
+      case TruncFloat32:
+        push(value.trunc());
+        return {};
+      case NearestFloat32:
+        push(value.nearbyint());
+        return {};
+      default:
+        WASM_UNREACHABLE("TODO");
+    }
+  }
   Flow visitBinary(Binary* curr) {
     auto rhs = pop();
     auto lhs = pop();
@@ -106,6 +127,12 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
         return {};
       case DivFloat32:
         push(lhs.div(rhs));
+        return {};
+      case MinFloat32:
+        push(lhs.min(rhs));
+        return {};
+      case MaxFloat32:
+        push(lhs.max(rhs));
         return {};
       default:
         WASM_UNREACHABLE("TODO");

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -93,13 +93,19 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     // TODO: add support for all operations.
     switch (curr->op) {
       case AddInt32:
+      case AddFloat32:
         push(lhs.add(rhs));
         return {};
       case SubInt32:
+      case SubFloat32:
         push(lhs.sub(rhs));
         return {};
       case MulInt32:
+      case MulFloat32:
         push(lhs.mul(rhs));
+        return {};
+      case DivFloat32:
+        push(lhs.div(rhs));
         return {};
       default:
         WASM_UNREACHABLE("TODO");

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -144,6 +144,22 @@ TEST(InterpreterTest, DivF32) {
   EXPECT_EQ(results, expected);
 }
 
+TEST(InterpreterTest, SqrtF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(5.0))).getErr());
+  ASSERT_FALSE(builder.makeUnary(SqrtFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(2.2360679775))};
+
+  EXPECT_EQ(results, expected);
+}
+
 TEST(InterpreterTest, CeilF32) {
   Module wasm;
   IRBuilder builder(wasm);

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -75,3 +75,135 @@ TEST(InterpreterTest, MulI32) {
 
   EXPECT_EQ(results, expected);
 }
+
+TEST(InterpreterTest, AddF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(0.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(float(1.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(AddFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(1.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, SubF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(1.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(float(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(SubFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(-1.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, MulF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(1.5))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(float(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(MulFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(3.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, DivF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(5.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(float(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(DivFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(2.5))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, CeilF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(1.5))).getErr());
+  ASSERT_FALSE(builder.makeUnary(CeilFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(2.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, FloorF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(1.5))).getErr());
+  ASSERT_FALSE(builder.makeUnary(FloorFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(1.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, TruncF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(2.017281))).getErr());
+  ASSERT_FALSE(builder.makeUnary(TruncFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(2.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, NearF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(2.5))).getErr());
+  ASSERT_FALSE(builder.makeUnary(NearestFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(float(2.0))};
+
+  EXPECT_EQ(results, expected);
+}


### PR DESCRIPTION
Building on top of #7227, the following are implemented and tested:
- f32.add
- f32.sub
- f32.mul
- f32.div
- f32.sqrt
- f32.ceil
- f32.floor
- f32.trunc
- f32.nearbyint
