### PR TITLE
[ci] Update Ubuntu 20.04 ci job to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,3 +421,37 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         gcov: true
+
+  # Duplicates build-asan.  Please keep in sync
+  build-cxx20:
+    name: c++20
+    # Make sure we can still build on older Ubuntu
+    runs-on: ubuntu-22.04
+    env:
+      CC: "gcc"
+      CXX: "g++"
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: install ninja
+      run: sudo apt-get install ninja-build
+    - name: install v8
+      run: |
+        npm install jsvu -g
+        jsvu --os=default --engines=v8
+    - name: install Python dev dependencies
+      run: pip3 install -r requirements-dev.txt
+    - name: cmake
+      run: |
+        mkdir -p out
+        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20
+    - name: build
+      run: cmake --build out
+    - name: test
+      run: |
+        python check.py --binaryen-bin=out/bin lit
+        python check.py --binaryen-bin=out/bin gtest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,37 +421,3 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         gcov: true
-
-  # Duplicates build-asan.  Please keep in sync
-  build-cxx20:
-    name: c++20
-    # Make sure we can still build on older Ubuntu
-    runs-on: ubuntu-20.04
-    env:
-      CC: "gcc"
-      CXX: "g++"
-    steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - name: install ninja
-      run: sudo apt-get install ninja-build
-    - name: install v8
-      run: |
-        npm install jsvu -g
-        jsvu --os=default --engines=v8
-    - name: install Python dev dependencies
-      run: pip3 install -r requirements-dev.txt
-    - name: cmake
-      run: |
-        mkdir -p out
-        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER="$CC" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20
-    - name: build
-      run: cmake --build out
-    - name: test
-      run: |
-        python check.py --binaryen-bin=out/bin lit
-        python check.py --binaryen-bin=out/bin gtest


### PR DESCRIPTION
If you pick a recent workflow run (here is the latest run on main https://github.com/WebAssembly/binaryen/actions/runs/13530775040 as of writing this PR) you'll see following at the bottom 
![image](https://github.com/user-attachments/assets/81f93f61-28f8-4346-9b8f-f50b239457bf)

If you click of the link for this warning you'll be taken here https://github.com/actions/runner-images/issues/11101 . It states that the Ubuntu 20.04 runner was deprecated at the start of this month, and will be fully unsupported by the 1st April . Therefore in my opinion is worth removing the Ubuntu 20.04 job from the ci rather than risk trying to run on an unsupported runner. If you need to keep supporting this version of Ubuntu then a job could be created in a separate PR, which builds inside a Docker container with a Ubuntu 20.04 base image.