### PR TITLE
[Interpreter] I64

### DIFF
--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -119,16 +119,19 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     // TODO: add support for all operations.
     switch (curr->op) {
       case AddInt32:
+      case AddInt64:
       case AddFloat32:
       case AddFloat64:
         push(lhs.add(rhs));
         return {};
       case SubInt32:
+      case SubInt64:
       case SubFloat32:
       case SubFloat64:
         push(lhs.sub(rhs));
         return {};
       case MulInt32:
+      case MulInt64:
       case MulFloat32:
       case MulFloat64:
         push(lhs.mul(rhs));
@@ -136,6 +139,28 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
       case DivFloat32:
       case DivFloat64:
         push(lhs.div(rhs));
+        return {};
+      case EqInt32:
+      case EqInt64:
+      case EqFloat32:
+      case EqFloat64:
+        push(lhs.eq(rhs));
+        return {};
+      case LtSInt32:
+      case LtSInt64:
+        push(lhs.ltS(rhs));
+        return {};
+      case LtUInt32:
+      case LtUInt64:
+        push(lhs.ltU(rhs));
+        return {};
+      case GtSInt32:
+      case GtSInt64:
+        push(lhs.gtS(rhs));
+        return {};
+      case GtUInt32:
+      case GtUInt64:
+        push(lhs.gtU(rhs));
         return {};
       case MinFloat32:
       case MinFloat64:

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -90,18 +90,23 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     auto value = pop();
     switch (curr->op) {
       case SqrtFloat32:
+      case SqrtFloat64:
         push(value.sqrt());
         return {};
       case CeilFloat32:
+      case CeilFloat64:
         push(value.ceil());
         return {};
       case FloorFloat32:
+      case FloorFloat64:
         push(value.floor());
         return {};
       case TruncFloat32:
+      case TruncFloat64:
         push(value.trunc());
         return {};
       case NearestFloat32:
+      case NearestFloat64:
         push(value.nearbyint());
         return {};
       default:
@@ -115,23 +120,29 @@ struct ExpressionInterpreter : OverriddenVisitor<ExpressionInterpreter, Flow> {
     switch (curr->op) {
       case AddInt32:
       case AddFloat32:
+      case AddFloat64:
         push(lhs.add(rhs));
         return {};
       case SubInt32:
       case SubFloat32:
+      case SubFloat64:
         push(lhs.sub(rhs));
         return {};
       case MulInt32:
       case MulFloat32:
+      case MulFloat64:
         push(lhs.mul(rhs));
         return {};
       case DivFloat32:
+      case DivFloat64:
         push(lhs.div(rhs));
         return {};
       case MinFloat32:
+      case MinFloat64:
         push(lhs.min(rhs));
         return {};
       case MaxFloat32:
+      case MaxFloat64:
         push(lhs.max(rhs));
         return {};
       default:

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -25,6 +25,7 @@
 
 using namespace wasm;
 
+// uInt32
 TEST(InterpreterTest, AddI32) {
   Module wasm;
   IRBuilder builder(wasm);
@@ -76,6 +77,7 @@ TEST(InterpreterTest, MulI32) {
   EXPECT_EQ(results, expected);
 }
 
+// Float32
 TEST(InterpreterTest, AddF32) {
   Module wasm;
   IRBuilder builder(wasm);
@@ -220,6 +222,155 @@ TEST(InterpreterTest, NearF32) {
 
   auto results = Interpreter{}.run(*expr);
   std::vector<Literal> expected{Literal(float(2.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+// Float 64
+TEST(InterpreterTest, AddF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(0.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(double(1.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(AddFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(1.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, SubF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(1.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(double(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(SubFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(-1.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, MulF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(1.5))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(double(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(MulFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(3.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, DivF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(5.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(double(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(DivFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(2.5))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, SqrtF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(5.0))).getErr());
+  ASSERT_FALSE(builder.makeUnary(SqrtFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(2.23606797749979))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, CeilF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(1.5))).getErr());
+  ASSERT_FALSE(builder.makeUnary(CeilFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(2.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, FloorF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(1.5))).getErr());
+  ASSERT_FALSE(builder.makeUnary(FloorFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(1.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, TruncF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(2.017281))).getErr());
+  ASSERT_FALSE(builder.makeUnary(TruncFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(2.0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, NearF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(2.5))).getErr());
+  ASSERT_FALSE(builder.makeUnary(NearestFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(double(2.0))};
 
   EXPECT_EQ(results, expected);
 }

--- a/test/gtest/interpreter.cpp
+++ b/test/gtest/interpreter.cpp
@@ -77,6 +77,230 @@ TEST(InterpreterTest, MulI32) {
   EXPECT_EQ(results, expected);
 }
 
+TEST(InterpreterTest, EqI32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(EqInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, LtUI32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(LtUInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(1))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, GtUI32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint32_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(GtUInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+// sInt32
+TEST(InterpreterTest, LtSI32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(int32_t(-1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(int32_t(-2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(LtSInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(int32_t(0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, GtSI32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(int32_t(-3))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(int32_t(-4))).getErr());
+  ASSERT_FALSE(builder.makeBinary(GtSInt32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(int32_t(1))};
+
+  EXPECT_EQ(results, expected);
+}
+
+// uInt64
+TEST(InterpreterTest, AddI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(AddInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint64_t(3))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, SubI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(SubInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint64_t(-1))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, MulI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(MulInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint64_t(2))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, EqI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(EqInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, LtUI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(LtSInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(1))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, GtUI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(uint64_t(2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(GtSInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+// sInt64
+TEST(InterpreterTest, LtSI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(int64_t(-1))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(int64_t(-2))).getErr());
+  ASSERT_FALSE(builder.makeBinary(LtSInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(int32_t(0))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, GtSI64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(int64_t(-3))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(int64_t(-4))).getErr());
+  ASSERT_FALSE(builder.makeBinary(GtSInt64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(int32_t(1))};
+
+  EXPECT_EQ(results, expected);
+}
+
 // Float32
 TEST(InterpreterTest, AddF32) {
   Module wasm;
@@ -142,6 +366,23 @@ TEST(InterpreterTest, DivF32) {
 
   auto results = Interpreter{}.run(*expr);
   std::vector<Literal> expected{Literal(float(2.5))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, EqF32) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(float(1.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(float(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(EqFloat32).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(0))};
 
   EXPECT_EQ(results, expected);
 }
@@ -291,6 +532,23 @@ TEST(InterpreterTest, DivF64) {
 
   auto results = Interpreter{}.run(*expr);
   std::vector<Literal> expected{Literal(double(2.5))};
+
+  EXPECT_EQ(results, expected);
+}
+
+TEST(InterpreterTest, EqF64) {
+  Module wasm;
+  IRBuilder builder(wasm);
+
+  ASSERT_FALSE(builder.makeConst(Literal(double(1.0))).getErr());
+  ASSERT_FALSE(builder.makeConst(Literal(double(2.0))).getErr());
+  ASSERT_FALSE(builder.makeBinary(EqFloat64).getErr());
+
+  auto expr = builder.build();
+  ASSERT_FALSE(expr.getErr());
+
+  auto results = Interpreter{}.run(*expr);
+  std::vector<Literal> expected{Literal(uint32_t(0))};
 
   EXPECT_EQ(results, expected);
 }


### PR DESCRIPTION
Building on top of #7227, the following are implemented and tested:
- i64.add
- i64.sub
- i64.mul
- i64.eq
- i64.ltS
- i64.ltU
- i64.gtS
- i64.gtU

While here, I added in relevant cases that leveraged the code added for the above instructions.
- i32.eq
- f32.eq
- f64.eq

- i32.ltS
- i32.ltU
- i32.gtS
- i32.ltU