### PR TITLE
GUFA: Fix a nondeterminism bug by pre-filtering

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -2456,7 +2456,7 @@ bool Flower::updateContents(LocationIndex locationIndex,
 #endif
     }
 
-    // The outcome of this filtering does not affect wether it is worth sending
+    // The outcome of this filtering does not affect whether it is worth sending
     // more later (we compute that at the end), so use a temp out var for that.
     bool worthSendingMoreTemp = true;
     filterExpressionContents(newContents, *exprLoc, worthSendingMoreTemp);

--- a/test/lit/passes/gufa-cast-all.wast
+++ b/test/lit/passes/gufa-cast-all.wast
@@ -327,25 +327,26 @@
     ;; taken, of course, but GUFA does see all branches; later optimizations
     ;; would optimize the branch away).
     ;;
-    ;; We see the ref.func first, so the block $block begins with that type.
+    ;; We see the ref.func first, so the block $block begins with that content.
     ;; Then we see the null arrive. Immediately combining the null with a
-    ;; ref.func gives us a cone - the best shape we have that can allow both a
-    ;; null and a ref.func. We later filter the result to the block, which is
-    ;; non-nullable, making the cone-non-nullable too - but it is a cone now,
+    ;; ref.func would give a cone - the best shape we have that can allow both a
+    ;; null and a ref.func. If we later filter the result to the block, which is
+    ;; non-nullable, the cone becomes non-nullable too - but it is a cone now,
     ;; and not the original ref.func, preventing us from applying the constant
     ;; value of the ref.func in the output. Early filtering of the arriving
     ;; content fixes this: the null is immediately filtered into nothing, since
-    ;; it is null and the location can only contain non-nullable contents.
+    ;; it is null and the location can only contain non-nullable contents. As a
+    ;; result, we can optimize the block (and the br_if) to return a ref.func.
     (drop
       (block $block (result (ref $A))
-        (br_on_non_null $block
-          (ref.null nofunc)
-        )
         (drop
           (br_if $block
             (ref.func $test)
             (global.get $global)
           )
+        )
+        (br_on_non_null $block
+          (ref.null nofunc)
         )
         (unreachable)
       )

--- a/test/lit/passes/gufa-cast-all.wast
+++ b/test/lit/passes/gufa-cast-all.wast
@@ -296,22 +296,27 @@
 
   ;; CHECK:      (func $test (type $A)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block $block (result (ref $A))
+  ;; CHECK-NEXT:   (block (result (ref $A))
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result (ref $A))
+  ;; CHECK-NEXT:     (block $block (result (ref $A))
   ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (br_if $block
+  ;; CHECK-NEXT:       (block (result (ref $A))
+  ;; CHECK-NEXT:        (drop
+  ;; CHECK-NEXT:         (br_if $block
+  ;; CHECK-NEXT:          (ref.func $test)
+  ;; CHECK-NEXT:          (global.get $global)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:        )
   ;; CHECK-NEXT:        (ref.func $test)
-  ;; CHECK-NEXT:        (global.get $global)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (ref.func $test)
+  ;; CHECK-NEXT:      (br_on_non_null $block
+  ;; CHECK-NEXT:       (ref.null nofunc)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (br_on_non_null $block
-  ;; CHECK-NEXT:     (ref.null nofunc)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:    (ref.func $test)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )

--- a/test/lit/passes/gufa-cast-all.wast
+++ b/test/lit/passes/gufa-cast-all.wast
@@ -289,6 +289,9 @@
   ;; CHECK:      (type $A (func))
   (type $A (func))
 
+  ;; CHECK:      (import "a" "b" (global $global i32))
+  (import "a" "b" (global $global i32))
+
   ;; CHECK:      (elem declare func $test)
 
   ;; CHECK:      (func $test (type $A)
@@ -299,9 +302,18 @@
   ;; CHECK-NEXT:      (br_on_non_null $block
   ;; CHECK-NEXT:       (ref.null nofunc)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (br $block
-  ;; CHECK-NEXT:       (ref.func $test)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (block (result (ref $A))
+  ;; CHECK-NEXT:        (drop
+  ;; CHECK-NEXT:         (br_if $block
+  ;; CHECK-NEXT:          (ref.func $test)
+  ;; CHECK-NEXT:          (global.get $global)
+  ;; CHECK-NEXT:         )
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:        (ref.func $test)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (unreachable)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (ref.func $test)
@@ -326,11 +338,14 @@
     ;; it is null and the location can only contain non-nullable contents.
     (drop
       (block $block (result (ref $A))
-        (br $block
-          (ref.func $test)
-        )
         (br_on_non_null $block
           (ref.null nofunc)
+        )
+        (drop
+          (br_if $block
+            (ref.func $test)
+            (global.get $global)
+          )
         )
         (unreachable)
       )

--- a/test/lit/passes/gufa-cast-all.wast
+++ b/test/lit/passes/gufa-cast-all.wast
@@ -296,27 +296,22 @@
 
   ;; CHECK:      (func $test (type $A)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (block (result (ref $A))
+  ;; CHECK-NEXT:   (block $block (result (ref $A))
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block $block (result (ref $A))
-  ;; CHECK-NEXT:      (br_on_non_null $block
-  ;; CHECK-NEXT:       (ref.null nofunc)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (block (result (ref $A))
   ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:       (block (result (ref $A))
-  ;; CHECK-NEXT:        (drop
-  ;; CHECK-NEXT:         (br_if $block
-  ;; CHECK-NEXT:          (ref.func $test)
-  ;; CHECK-NEXT:          (global.get $global)
-  ;; CHECK-NEXT:         )
-  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       (br_if $block
   ;; CHECK-NEXT:        (ref.func $test)
+  ;; CHECK-NEXT:        (global.get $global)
   ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (unreachable)
+  ;; CHECK-NEXT:      (ref.func $test)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (ref.func $test)
+  ;; CHECK-NEXT:    (br_on_non_null $block
+  ;; CHECK-NEXT:     (ref.null nofunc)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (unreachable)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )


### PR DESCRIPTION
The repeated "merge new content in, and filter based on the location it
arrives to" operation is non-commutative, and it turns out there was a
corner case we missed. Filtering before and after is enough to make us
return the same result with the ordering swapped.

This does make GUFA 5% slower, unfortunately. But this does result
in better code in some cases aside from fixing the nondeterminism.

Also add clearer comments about the problem here. We likely need to
just make the order of operations here deterministic (though a downside
of that is that the fuzzer wouldn't find bugs like this, and it would be
slower).
