### PR TITLE
[NFC] Avoiding huge output in validator messages

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -42,16 +42,27 @@ template<typename T,
            Expression,
            typename std::remove_pointer<T>::type>::value>::type* = nullptr>
 inline std::ostream&
-printModuleComponent(T curr, std::ostream& stream, Module& wasm) {
+printModuleComponent(T curr, std::ostringstream& stream, Module& wasm) {
   stream << curr << std::endl;
   return stream;
 }
 
 // Extra overload for Expressions, to print their contents.
 inline std::ostream&
-printModuleComponent(Expression* curr, std::ostream& stream, Module& wasm) {
+printModuleComponent(Expression* curr, std::ostringstream& stream, Module& wasm) {
   if (curr) {
-    stream << ModuleExpression(wasm, curr) << '\n';
+    // Print the full expression if we can, but avoid doing so if the output is
+    // already very large. This avoids quadratic output in some cases (e.g. if
+    // we have many nested expressions in each other, all of which fail to
+    // validate).
+    const std::ostringstream::pos_type MAX_OUTPUT = 1024 * 1024;
+    if (stream.tellp() < MAX_OUTPUT) {
+      stream << ModuleExpression(wasm, curr) << '\n';
+    } else {
+      // Print something, at least.
+      stream << "[not printing " << getExpressionName(curr)
+             << " because output is already very large\n";
+    }
   }
   return stream;
 }
@@ -98,7 +109,7 @@ struct ValidationInfo {
     return printModuleComponent(curr, ret, wasm);
   }
 
-  std::ostream& printFailureHeader(Function* func) {
+  std::ostringstream& printFailureHeader(Function* func) {
     auto& stream = getStream(func);
     if (quiet) {
       return stream;

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -55,13 +55,13 @@ printModuleComponent(Expression* curr, std::ostringstream& stream, Module& wasm)
     // already very large. This avoids quadratic output in some cases (e.g. if
     // we have many nested expressions in each other, all of which fail to
     // validate).
-    const std::ostringstream::pos_type MAX_OUTPUT = 1024 * 1024;
+    const std::ostringstream::pos_type MAX_OUTPUT = 100 * 1024;
     if (stream.tellp() < MAX_OUTPUT) {
       stream << ModuleExpression(wasm, curr) << '\n';
     } else {
       // Print something, at least.
       stream << "[not printing " << getExpressionName(curr)
-             << " because output is already very large\n";
+             << " because output is already very large]\n";
     }
   }
   return stream;


### PR DESCRIPTION
Nested expressions that all fail to validate can lead to quadratic output
and OOMs. Instead, put a limit on the size we print, and after it only
emit truncated error messages of fixed size.

Also make some of the types more precise in this code, which makes
it easier to read.

Fixes #7333