### PR TITLE
Prepare for type exports

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -4893,50 +4893,35 @@ WASM_DEPRECATED BinaryenExportRef BinaryenAddExport(BinaryenModuleRef module,
 BinaryenExportRef BinaryenAddFunctionExport(BinaryenModuleRef module,
                                             const char* internalName,
                                             const char* externalName) {
-  auto* ret = new Export();
-  ret->value = internalName;
-  ret->name = externalName;
-  ret->kind = ExternalKind::Function;
+  auto* ret = new Export(externalName, ExternalKind::Function, internalName);
   ((Module*)module)->addExport(ret);
   return ret;
 }
 BinaryenExportRef BinaryenAddTableExport(BinaryenModuleRef module,
                                          const char* internalName,
                                          const char* externalName) {
-  auto* ret = new Export();
-  ret->value = internalName;
-  ret->name = externalName;
-  ret->kind = ExternalKind::Table;
+  auto* ret = new Export(externalName, ExternalKind::Table, internalName);
   ((Module*)module)->addExport(ret);
   return ret;
 }
 BinaryenExportRef BinaryenAddMemoryExport(BinaryenModuleRef module,
                                           const char* internalName,
                                           const char* externalName) {
-  auto* ret = new Export();
-  ret->value = internalName;
-  ret->name = externalName;
-  ret->kind = ExternalKind::Memory;
+  auto* ret = new Export(externalName, ExternalKind::Memory, internalName);
   ((Module*)module)->addExport(ret);
   return ret;
 }
 BinaryenExportRef BinaryenAddGlobalExport(BinaryenModuleRef module,
                                           const char* internalName,
                                           const char* externalName) {
-  auto* ret = new Export();
-  ret->value = internalName;
-  ret->name = externalName;
-  ret->kind = ExternalKind::Global;
+  auto* ret = new Export(externalName, ExternalKind::Global, internalName);
   ((Module*)module)->addExport(ret);
   return ret;
 }
 BinaryenExportRef BinaryenAddTagExport(BinaryenModuleRef module,
                                        const char* internalName,
                                        const char* externalName) {
-  auto* ret = new Export();
-  ret->value = internalName;
-  ret->name = externalName;
-  ret->kind = ExternalKind::Tag;
+  auto* ret = new Export(externalName, ExternalKind::Tag, internalName);
   ((Module*)module)->addExport(ret);
   return ret;
 }
@@ -5087,11 +5072,8 @@ void BinaryenSetMemory(BinaryenModuleRef module,
   memory->shared = shared;
   memory->addressType = memory64 ? Type::i64 : Type::i32;
   if (exportName) {
-    auto memoryExport = std::make_unique<Export>();
-    memoryExport->name = exportName;
-    memoryExport->value = memory->name;
-    memoryExport->kind = ExternalKind::Memory;
-    ((Module*)module)->addExport(memoryExport.release());
+    ((Module*)module)
+      ->addExport(new Export(exportName, ExternalKind::Memory, memory->name));
   }
   ((Module*)module)->removeDataSegments([&](DataSegment* curr) {
     return true;

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5925,7 +5925,7 @@ const char* BinaryenExportGetName(BinaryenExportRef export_) {
   return ((Export*)export_)->name.str.data();
 }
 const char* BinaryenExportGetValue(BinaryenExportRef export_) {
-  return ((Export*)export_)->value.str.data();
+  return ((Export*)export_)->getInternalName().str.data();
 }
 
 //

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5925,7 +5925,7 @@ const char* BinaryenExportGetName(BinaryenExportRef export_) {
   return ((Export*)export_)->name.str.data();
 }
 const char* BinaryenExportGetValue(BinaryenExportRef export_) {
-  return ((Export*)export_)->getInternalName().str.data();
+  return ((Export*)export_)->getInternalName()->str.data();
 }
 
 //

--- a/src/ir/export-utils.cpp
+++ b/src/ir/export-utils.cpp
@@ -29,7 +29,7 @@ std::vector<T*> getExportedByKind(Module& wasm, G getModuleItem) {
   for (auto& ex : wasm.exports) {
     if (ex->kind == K) {
       // The kind is either ExternalKind::Function or ExternalKind::Global
-      ret.push_back(getModuleItem(ex->getInternalName()));
+      ret.push_back(getModuleItem(*ex->getInternalName()));
     }
   }
   return ret;

--- a/src/ir/export-utils.cpp
+++ b/src/ir/export-utils.cpp
@@ -28,7 +28,8 @@ std::vector<T*> getExportedByKind(Module& wasm, G getModuleItem) {
   std::vector<T*> ret;
   for (auto& ex : wasm.exports) {
     if (ex->kind == K) {
-      ret.push_back(getModuleItem(ex->value));
+      // The kind is either ExternalKind::Function or ExternalKind::Global
+      ret.push_back(getModuleItem(ex->getInternalName()));
     }
   }
   return ret;

--- a/src/ir/export-utils.h
+++ b/src/ir/export-utils.h
@@ -27,7 +27,7 @@ std::vector<Global*> getExportedGlobals(Module& wasm);
 inline bool isExported(const Module& module, const Function& func) {
   for (auto& exportFunc : module.exports) {
     if (exportFunc->kind == ExternalKind::Function &&
-        exportFunc->getInternalName() == func.name) {
+        *exportFunc->getInternalName() == func.name) {
       return true;
     }
   }

--- a/src/ir/export-utils.h
+++ b/src/ir/export-utils.h
@@ -27,7 +27,7 @@ std::vector<Global*> getExportedGlobals(Module& wasm);
 inline bool isExported(const Module& module, const Function& func) {
   for (auto& exportFunc : module.exports) {
     if (exportFunc->kind == ExternalKind::Function &&
-        exportFunc->value == func.name) {
+        exportFunc->getInternalName() == func.name) {
       return true;
     }
   }

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -355,11 +355,9 @@ void ModuleSplitter::setupJSPI() {
   // Support the first version of JSPI, where the JSPI pass added the load
   // secondary module export.
   // TODO: remove this when the new JSPI API is only supported.
-  if (primary.getExportOrNull(LOAD_SECONDARY_MODULE) &&
-      primary.getExport(LOAD_SECONDARY_MODULE)->kind ==
-        ExternalKind::Function) {
-    internalLoadSecondaryModule =
-      *primary.getExport(LOAD_SECONDARY_MODULE)->getInternalName();
+  if (auto* loadSecondary = primary.getExportOrNull(LOAD_SECONDARY_MODULE);
+      loadSecondary && loadSecondary->kind == ExternalKind::Function) {
+    internalLoadSecondaryModule = *loadSecondary->getInternalName();
     // Remove the exported LOAD_SECONDARY_MODULE function since it's only needed
     // internally.
     primary.removeExport(LOAD_SECONDARY_MODULE);

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -822,12 +822,12 @@ void ModuleSplitter::shareImportableItems() {
   // Map internal names to (one of) their corresponding export names. Don't
   // consider functions because they have already been imported and exported as
   // necessary.
-  std::unordered_map<std::pair<ExternalKind, std::variant<Name, HeapType>>,
-                     Name>
-    exports;
+  std::unordered_map<std::pair<ExternalKind, Name>, Name> exports;
   for (auto& ex : primary.exports) {
     if (ex->kind != ExternalKind::Function) {
-      exports[std::make_pair(ex->kind, ex->value)] = ex->name;
+      if (auto* name = ex->getInternalName()) {
+        exports[std::make_pair(ex->kind, *name)] = ex->name;
+      }
     }
   }
 
@@ -847,7 +847,7 @@ void ModuleSplitter::shareImportableItems() {
                                     ? minified.getName()
                                     : genericExportName);
       Name exportName = Names::getValidExportName(primary, baseName);
-      primary.addExport(new Export{exportName, primaryItem.name, kind});
+      primary.addExport(new Export(exportName, kind, primaryItem.name));
       secondaryItem.base = exportName;
     }
   };

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -355,9 +355,9 @@ void ModuleSplitter::setupJSPI() {
   // Support the first version of JSPI, where the JSPI pass added the load
   // secondary module export.
   // TODO: remove this when the new JSPI API is only supported.
-  if (primary.getExportOrNull(LOAD_SECONDARY_MODULE)) {
-    assert(primary.getExport(LOAD_SECONDARY_MODULE)->kind ==
-           ExternalKind::Function);
+  if (primary.getExportOrNull(LOAD_SECONDARY_MODULE) &&
+      primary.getExport(LOAD_SECONDARY_MODULE)->kind ==
+        ExternalKind::Function) {
     internalLoadSecondaryModule =
       *primary.getExport(LOAD_SECONDARY_MODULE)->getInternalName();
     // Remove the exported LOAD_SECONDARY_MODULE function since it's only needed

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -359,7 +359,7 @@ void ModuleSplitter::setupJSPI() {
     assert(primary.getExport(LOAD_SECONDARY_MODULE)->kind ==
            ExternalKind::Function);
     internalLoadSecondaryModule =
-      primary.getExport(LOAD_SECONDARY_MODULE)->getInternalName();
+      *primary.getExport(LOAD_SECONDARY_MODULE)->getInternalName();
     // Remove the exported LOAD_SECONDARY_MODULE function since it's only needed
     // internally.
     primary.removeExport(LOAD_SECONDARY_MODULE);
@@ -473,7 +473,7 @@ ModuleSplitter::initExportedPrimaryFuncs(const Module& primary) {
   std::map<Name, Name> functionExportNames;
   for (auto& ex : primary.exports) {
     if (ex->kind == ExternalKind::Function) {
-      functionExportNames[ex->getInternalName()] = ex->name;
+      functionExportNames[*ex->getInternalName()] = ex->name;
     }
   }
   return functionExportNames;
@@ -529,10 +529,10 @@ void ModuleSplitter::thunkExportedSecondaryFunctions() {
   Builder builder(primary);
   for (auto& ex : primary.exports) {
     if (ex->kind != ExternalKind::Function ||
-        !secondaryFuncs.count(ex->getInternalName())) {
+        !secondaryFuncs.count(*ex->getInternalName())) {
       continue;
     }
-    Name secondaryFunc = ex->getInternalName();
+    Name secondaryFunc = *ex->getInternalName();
     if (primary.getFunctionOrNull(secondaryFunc)) {
       // We've already created a thunk for this function
       continue;

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -632,12 +632,12 @@ void classifyTypeVisibility(Module& wasm,
   for (auto& ex : wasm.exports) {
     switch (ex->kind) {
       case ExternalKind::Function: {
-        auto* func = wasm.getFunction(ex->getInternalName());
+        auto* func = wasm.getFunction(*ex->getInternalName());
         notePublic(func->type);
         continue;
       }
       case ExternalKind::Table: {
-        auto* table = wasm.getTable(ex->getInternalName());
+        auto* table = wasm.getTable(*ex->getInternalName());
         assert(table->type.isRef());
         notePublic(table->type.getHeapType());
         continue;
@@ -646,14 +646,14 @@ void classifyTypeVisibility(Module& wasm,
         // Never a reference type.
         continue;
       case ExternalKind::Global: {
-        auto* global = wasm.getGlobal(ex->getInternalName());
+        auto* global = wasm.getGlobal(*ex->getInternalName());
         if (global->type.isRef()) {
           notePublic(global->type.getHeapType());
         }
         continue;
       }
       case ExternalKind::Tag:
-        notePublic(wasm.getTag(ex->getInternalName())->type);
+        notePublic(wasm.getTag(*ex->getInternalName())->type);
         continue;
       case ExternalKind::Invalid:
         break;

--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -632,12 +632,12 @@ void classifyTypeVisibility(Module& wasm,
   for (auto& ex : wasm.exports) {
     switch (ex->kind) {
       case ExternalKind::Function: {
-        auto* func = wasm.getFunction(ex->value);
+        auto* func = wasm.getFunction(ex->getInternalName());
         notePublic(func->type);
         continue;
       }
       case ExternalKind::Table: {
-        auto* table = wasm.getTable(ex->value);
+        auto* table = wasm.getTable(ex->getInternalName());
         assert(table->type.isRef());
         notePublic(table->type.getHeapType());
         continue;
@@ -646,14 +646,14 @@ void classifyTypeVisibility(Module& wasm,
         // Never a reference type.
         continue;
       case ExternalKind::Global: {
-        auto* global = wasm.getGlobal(ex->value);
+        auto* global = wasm.getGlobal(ex->getInternalName());
         if (global->type.isRef()) {
           notePublic(global->type.getHeapType());
         }
         continue;
       }
       case ExternalKind::Tag:
-        notePublic(wasm.getTag(ex->value)->type);
+        notePublic(wasm.getTag(ex->getInternalName())->type);
         continue;
       case ExternalKind::Invalid:
         break;

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -2165,7 +2165,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
 
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Table) {
-      shared.publicTables.insert(ex->getInternalName());
+      shared.publicTables.insert(*ex->getInternalName());
     }
   }
 
@@ -2277,7 +2277,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
   // Exports can be modified from the outside.
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Function) {
-      calledFromOutside(ex->getInternalName());
+      calledFromOutside(*ex->getInternalName());
     } else if (ex->kind == ExternalKind::Table) {
       // If any table is exported, assume any function in any table (including
       // other tables) can be called from the outside.
@@ -2301,7 +2301,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
     } else if (ex->kind == ExternalKind::Global) {
       // Exported mutable globals are roots, since the outside may write any
       // value to them.
-      auto name = ex->getInternalName();
+      auto name = *ex->getInternalName();
       auto* global = wasm.getGlobal(name);
       if (global->mutable_) {
         roots[GlobalLocation{name}] = PossibleContents::fromType(global->type);
@@ -2319,7 +2319,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
   }
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Tag) {
-      publicTags.insert(ex->getInternalName());
+      publicTags.insert(*ex->getInternalName());
     }
   }
   for (auto tag : publicTags) {

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -2165,7 +2165,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
 
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Table) {
-      shared.publicTables.insert(ex->value);
+      shared.publicTables.insert(ex->getInternalName());
     }
   }
 
@@ -2277,7 +2277,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
   // Exports can be modified from the outside.
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Function) {
-      calledFromOutside(ex->value);
+      calledFromOutside(ex->getInternalName());
     } else if (ex->kind == ExternalKind::Table) {
       // If any table is exported, assume any function in any table (including
       // other tables) can be called from the outside.
@@ -2301,7 +2301,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
     } else if (ex->kind == ExternalKind::Global) {
       // Exported mutable globals are roots, since the outside may write any
       // value to them.
-      auto name = ex->value;
+      auto name = ex->getInternalName();
       auto* global = wasm.getGlobal(name);
       if (global->mutable_) {
         roots[GlobalLocation{name}] = PossibleContents::fromType(global->type);
@@ -2319,7 +2319,7 @@ Flower::Flower(Module& wasm, const PassOptions& options)
   }
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Tag) {
-      publicTags.insert(ex->value);
+      publicTags.insert(ex->getInternalName());
     }
   }
   for (auto tag : publicTags) {

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1668,7 +1668,7 @@ struct Asyncify : public Pass {
         for (auto& theExport : module->exports) {
           if (theExport->kind == ExternalKind::Memory &&
               theExport->name == asyncifyMemoryValue) {
-            asyncifyMemory = theExport->getInternalName();
+            asyncifyMemory = *theExport->getInternalName();
             break;
           }
         }
@@ -1903,7 +1903,7 @@ struct ModAsyncify
     auto* unwind = this->getModule()->getExport(ASYNCIFY_STOP_UNWIND);
     assert(unwind->kind == ExternalKind::Function);
     auto* unwindFunc =
-      this->getModule()->getFunction(unwind->getInternalName());
+      this->getModule()->getFunction(*unwind->getInternalName());
     FindAll<GlobalSet> sets(unwindFunc->body);
     assert(sets.list.size() == 1);
     asyncifyStateName = sets.list[0]->name;

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1668,7 +1668,7 @@ struct Asyncify : public Pass {
         for (auto& theExport : module->exports) {
           if (theExport->kind == ExternalKind::Memory &&
               theExport->name == asyncifyMemoryValue) {
-            asyncifyMemory = theExport->value;
+            asyncifyMemory = theExport->getInternalName();
             break;
           }
         }
@@ -1901,7 +1901,9 @@ struct ModAsyncify
   void doWalkFunction(Function* func) {
     // Find the asyncify state name.
     auto* unwind = this->getModule()->getExport(ASYNCIFY_STOP_UNWIND);
-    auto* unwindFunc = this->getModule()->getFunction(unwind->value);
+    assert(unwind->kind == ExternalKind::Function);
+    auto* unwindFunc =
+      this->getModule()->getFunction(unwind->getInternalName());
     FindAll<GlobalSet> sets(unwindFunc->body);
     assert(sets.list.size() == 1);
     asyncifyStateName = sets.list[0]->name;

--- a/src/passes/Asyncify.cpp
+++ b/src/passes/Asyncify.cpp
@@ -1901,9 +1901,9 @@ struct ModAsyncify
   void doWalkFunction(Function* func) {
     // Find the asyncify state name.
     auto* unwind = this->getModule()->getExport(ASYNCIFY_STOP_UNWIND);
-    assert(unwind->kind == ExternalKind::Function);
-    auto* unwindFunc =
-      this->getModule()->getFunction(*unwind->getInternalName());
+    auto* unwindFunc = this->getModule()->getFunction(
+      ((unwind->kind == ExternalKind::Function)) ? *unwind->getInternalName()
+                                                 : Name());
     FindAll<GlobalSet> sets(unwindFunc->body);
     assert(sets.list.size() == 1);
     asyncifyStateName = sets.list[0]->name;

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -260,7 +260,7 @@ struct DAE : public Pass {
     // Exports are considered unseen calls.
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        hasUnseenCalls.insert(curr->value);
+        hasUnseenCalls.insert(curr->getInternalName());
       }
     }
 

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -260,7 +260,7 @@ struct DAE : public Pass {
     // Exports are considered unseen calls.
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        hasUnseenCalls.insert(curr->getInternalName());
+        hasUnseenCalls.insert(*curr->getInternalName());
       }
     }
 

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -223,7 +223,7 @@ struct Directize : public Pass {
 
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Table) {
-        tables[ex->getInternalName()].mayBeModified = true;
+        tables[*ex->getInternalName()].mayBeModified = true;
       }
     }
 

--- a/src/passes/Directize.cpp
+++ b/src/passes/Directize.cpp
@@ -223,7 +223,7 @@ struct Directize : public Pass {
 
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Table) {
-        tables[ex->value].mayBeModified = true;
+        tables[ex->getInternalName()].mayBeModified = true;
       }
     }
 

--- a/src/passes/EncloseWorld.cpp
+++ b/src/passes/EncloseWorld.cpp
@@ -52,11 +52,12 @@ struct EncloseWorld : public Pass {
     std::vector<std::unique_ptr<Export>> newExports;
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
-        auto* func = module->getFunction(*ex->getInternalName());
+        auto* name = ex->getInternalName();
+        auto* func = module->getFunction(*name);
         // If this opens up types, replace it with an enclosed stub.
         if (opensTypes(func)) {
           auto stubName = makeStubStubForExport(func, module);
-          ex->value = stubName;
+          *name = stubName;
         }
       }
     }

--- a/src/passes/EncloseWorld.cpp
+++ b/src/passes/EncloseWorld.cpp
@@ -52,7 +52,7 @@ struct EncloseWorld : public Pass {
     std::vector<std::unique_ptr<Export>> newExports;
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
-        auto* func = module->getFunction(ex->value);
+        auto* func = module->getFunction(ex->getInternalName());
         // If this opens up types, replace it with an enclosed stub.
         if (opensTypes(func)) {
           auto stubName = makeStubStubForExport(func, module);

--- a/src/passes/EncloseWorld.cpp
+++ b/src/passes/EncloseWorld.cpp
@@ -52,7 +52,7 @@ struct EncloseWorld : public Pass {
     std::vector<std::unique_ptr<Export>> newExports;
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
-        auto* func = module->getFunction(ex->getInternalName());
+        auto* func = module->getFunction(*ex->getInternalName());
         // If this opens up types, replace it with an enclosed stub.
         if (opensTypes(func)) {
           auto stubName = makeStubStubForExport(func, module);

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -111,7 +111,7 @@ static void exportFunction(Module& wasm, Name name, bool must_export) {
     return; // Already exported
   }
   auto exp = new Export;
-  exp->name = exp->value = name;
+  exp->value = exp->name = name;
   exp->kind = ExternalKind::Function;
   wasm.addExport(exp);
 }

--- a/src/passes/GenerateDynCalls.cpp
+++ b/src/passes/GenerateDynCalls.cpp
@@ -110,10 +110,7 @@ static void exportFunction(Module& wasm, Name name, bool must_export) {
   if (wasm.getExportOrNull(name)) {
     return; // Already exported
   }
-  auto exp = new Export;
-  exp->value = exp->name = name;
-  exp->kind = ExternalKind::Function;
-  wasm.addExport(exp);
+  wasm.addExport(new Export(name, ExternalKind::Function, name));
 }
 
 void GenerateDynCalls::generateDynCallThunk(HeapType funcType) {

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1271,7 +1271,7 @@ struct Inlining : public Pass {
     }
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
-        infos[ex->value].usedGlobally = true;
+        infos[ex->getInternalName()].usedGlobally = true;
       }
     }
     if (module->start.is()) {

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1271,7 +1271,7 @@ struct Inlining : public Pass {
     }
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
-        infos[ex->getInternalName()].usedGlobally = true;
+        infos[*ex->getInternalName()].usedGlobally = true;
       }
     }
     if (module->start.is()) {

--- a/src/passes/JSPI.cpp
+++ b/src/passes/JSPI.cpp
@@ -126,7 +126,7 @@ struct JSPI : public Pass {
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function &&
           canChangeState(ex->name.toString(), listedExports)) {
-        auto* func = module->getFunction(ex->getInternalName());
+        auto* func = module->getFunction(*ex->getInternalName());
         Name wrapperName;
         auto iter = wrappedExports.find(func->name);
         if (iter == wrappedExports.end()) {

--- a/src/passes/JSPI.cpp
+++ b/src/passes/JSPI.cpp
@@ -126,7 +126,8 @@ struct JSPI : public Pass {
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function &&
           canChangeState(ex->name.toString(), listedExports)) {
-        auto* func = module->getFunction(*ex->getInternalName());
+        auto* name = ex->getInternalName();
+        auto* func = module->getFunction(*name);
         Name wrapperName;
         auto iter = wrappedExports.find(func->name);
         if (iter == wrappedExports.end()) {
@@ -135,7 +136,7 @@ struct JSPI : public Pass {
         } else {
           wrapperName = iter->second;
         }
-        ex->value = wrapperName;
+        *name = wrapperName;
       }
     }
 

--- a/src/passes/JSPI.cpp
+++ b/src/passes/JSPI.cpp
@@ -126,7 +126,7 @@ struct JSPI : public Pass {
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function &&
           canChangeState(ex->name.toString(), listedExports)) {
-        auto* func = module->getFunction(ex->value);
+        auto* func = module->getFunction(ex->getInternalName());
         Name wrapperName;
         auto iter = wrappedExports.find(func->name);
         if (iter == wrappedExports.end()) {

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -193,8 +193,9 @@ private:
     if (!setTempRet0) {
       if (exportedHelpers) {
         auto* ex = module->getExport(SET_TEMP_RET_EXPORT);
-        assert(ex->kind == ExternalKind::Function);
-        setTempRet0 = module->getFunction(*ex->getInternalName());
+        setTempRet0 = module->getFunction((ex->kind == ExternalKind::Function)
+                                            ? *ex->getInternalName()
+                                            : Name());
       } else {
         setTempRet0 = getFunctionOrImport(
           module, SET_TEMP_RET_IMPORT, Type::i32, Type::none);
@@ -207,8 +208,9 @@ private:
     if (!getTempRet0) {
       if (exportedHelpers) {
         auto* ex = module->getExport(GET_TEMP_RET_EXPORT);
-        assert(ex->kind == ExternalKind::Function);
-        getTempRet0 = module->getFunction(*ex->getInternalName());
+        getTempRet0 = module->getFunction((ex->kind == ExternalKind::Function)
+                                            ? *ex->getInternalName()
+                                            : Name());
       } else {
         getTempRet0 = getFunctionOrImport(
           module, GET_TEMP_RET_IMPORT, Type::none, Type::i32);

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -71,7 +71,7 @@ struct LegalizeJSInterface : public Pass {
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
         // if it's an import, ignore it
-        auto* func = module->getFunction(ex->getInternalName());
+        auto* func = module->getFunction(*ex->getInternalName());
         if (isIllegal(func)) {
           // Provide a legal function for the export.
           auto legalName = makeLegalStub(func, module);
@@ -194,7 +194,7 @@ private:
       if (exportedHelpers) {
         auto* ex = module->getExport(SET_TEMP_RET_EXPORT);
         assert(ex->kind == ExternalKind::Function);
-        setTempRet0 = module->getFunction(ex->getInternalName());
+        setTempRet0 = module->getFunction(*ex->getInternalName());
       } else {
         setTempRet0 = getFunctionOrImport(
           module, SET_TEMP_RET_IMPORT, Type::i32, Type::none);
@@ -208,7 +208,7 @@ private:
       if (exportedHelpers) {
         auto* ex = module->getExport(GET_TEMP_RET_EXPORT);
         assert(ex->kind == ExternalKind::Function);
-        getTempRet0 = module->getFunction(ex->getInternalName());
+        getTempRet0 = module->getFunction(*ex->getInternalName());
       } else {
         getTempRet0 = getFunctionOrImport(
           module, GET_TEMP_RET_IMPORT, Type::none, Type::i32);
@@ -363,7 +363,7 @@ struct LegalizeAndPruneJSInterface : public LegalizeJSInterface {
     std::unordered_map<Name, Name> exportedFunctions;
     for (auto& exp : module->exports) {
       if (exp->kind == ExternalKind::Function) {
-        exportedFunctions[exp->getInternalName()] = exp->name;
+        exportedFunctions[*exp->getInternalName()] = exp->name;
       }
     }
 

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -71,7 +71,7 @@ struct LegalizeJSInterface : public Pass {
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
         // if it's an import, ignore it
-        auto* func = module->getFunction(ex->value);
+        auto* func = module->getFunction(ex->getInternalName());
         if (isIllegal(func)) {
           // Provide a legal function for the export.
           auto legalName = makeLegalStub(func, module);
@@ -193,7 +193,8 @@ private:
     if (!setTempRet0) {
       if (exportedHelpers) {
         auto* ex = module->getExport(SET_TEMP_RET_EXPORT);
-        setTempRet0 = module->getFunction(ex->value);
+        assert(ex->kind == ExternalKind::Function);
+        setTempRet0 = module->getFunction(ex->getInternalName());
       } else {
         setTempRet0 = getFunctionOrImport(
           module, SET_TEMP_RET_IMPORT, Type::i32, Type::none);
@@ -206,7 +207,8 @@ private:
     if (!getTempRet0) {
       if (exportedHelpers) {
         auto* ex = module->getExport(GET_TEMP_RET_EXPORT);
-        getTempRet0 = module->getFunction(ex->value);
+        assert(ex->kind == ExternalKind::Function);
+        getTempRet0 = module->getFunction(ex->getInternalName());
       } else {
         getTempRet0 = getFunctionOrImport(
           module, GET_TEMP_RET_IMPORT, Type::none, Type::i32);
@@ -361,7 +363,7 @@ struct LegalizeAndPruneJSInterface : public LegalizeJSInterface {
     std::unordered_map<Name, Name> exportedFunctions;
     for (auto& exp : module->exports) {
       if (exp->kind == ExternalKind::Function) {
-        exportedFunctions[exp->value] = exp->name;
+        exportedFunctions[exp->getInternalName()] = exp->name;
       }
     }
 

--- a/src/passes/LegalizeJSInterface.cpp
+++ b/src/passes/LegalizeJSInterface.cpp
@@ -71,11 +71,12 @@ struct LegalizeJSInterface : public Pass {
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Function) {
         // if it's an import, ignore it
-        auto* func = module->getFunction(*ex->getInternalName());
+        auto* name = ex->getInternalName();
+        auto* func = module->getFunction(*name);
         if (isIllegal(func)) {
           // Provide a legal function for the export.
           auto legalName = makeLegalStub(func, module);
-          ex->value = legalName;
+          *name = legalName;
           if (exportOriginals) {
             // Also export the original function, before legalization. This is
             // not normally useful for JS, except in cases like dynamic linking

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -135,8 +135,8 @@ struct Metrics
       for (auto& exp : module->exports) {
         // Removing a type export will not remove any code
         if (auto* name = exp->getInternalName()) {
-          // create a test module where we remove the export and then see how much
-          // can be removed thanks to that
+          // create a test module where we remove the export and then see how
+          // much can be removed thanks to that
           Module test;
           ModuleUtils::copyModule(*module, test);
           test.removeExport(exp->name);

--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -133,6 +133,10 @@ struct Metrics
         baseline = sizeAfterGlobalCleanup(&test);
       }
       for (auto& exp : module->exports) {
+        if (!exp->hasInternalName()) {
+          // Removing a type export will not remove any code
+          continue;
+        }
         // create a test module where we remove the export and then see how much
         // can be removed thanks to that
         Module test;
@@ -142,7 +146,7 @@ struct Metrics
         counts["[removable-bytes-without-it]"] =
           baseline - sizeAfterGlobalCleanup(&test);
         printCounts(std::string("export: ") + exp->name.toString() + " (" +
-                    exp->value.toString() + ')');
+                    exp->getInternalName().toString() + ')');
       }
       // check how much size depends on the start method
       if (!module->start.isNull()) {

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -473,7 +473,7 @@ struct MultiMemoryLowering : public Pass {
     // Ensuring only the first memory is an exported memory
     for (auto& exp : wasm->exports) {
       if (exp->kind == ExternalKind::Memory &&
-          exp->value == getFirstMemory().name) {
+          exp->getInternalName() == getFirstMemory().name) {
         isExported = true;
       } else if (exp->kind == ExternalKind::Memory) {
         Fatal() << "MultiMemoryLowering: only the first memory can be exported";

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -473,7 +473,7 @@ struct MultiMemoryLowering : public Pass {
     // Ensuring only the first memory is an exported memory
     for (auto& exp : wasm->exports) {
       if (exp->kind == ExternalKind::Memory &&
-          exp->getInternalName() == getFirstMemory().name) {
+          *exp->getInternalName() == getFirstMemory().name) {
         isExported = true;
       } else if (exp->kind == ExternalKind::Memory) {
         Fatal() << "MultiMemoryLowering: only the first memory can be exported";

--- a/src/passes/MultiMemoryLowering.cpp
+++ b/src/passes/MultiMemoryLowering.cpp
@@ -706,7 +706,7 @@ struct MultiMemoryLowering : public Pass {
         // We checked in prepCombinedMemory that any memory exports are for
         // the first memory, so setting the exports to the combinedMemory means
         // calling JS will not have to worry about offsets
-        exp->value = combinedMemory;
+        *exp->getInternalName() = combinedMemory;
       }
     }
   }

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -372,7 +372,7 @@ struct OnceReduction : public Pass {
         // An exported global cannot be "once" since the outside may read and
         // write to it in ways we are unaware.
         // TODO: See comment above on mutability.
-        optInfo.onceGlobals[ex->value] = false;
+        optInfo.onceGlobals[ex->getInternalName()] = false;
       }
     }
 

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -372,7 +372,7 @@ struct OnceReduction : public Pass {
         // An exported global cannot be "once" since the outside may read and
         // write to it in ways we are unaware.
         // TODO: See comment above on mutability.
-        optInfo.onceGlobals[ex->getInternalName()] = false;
+        optInfo.onceGlobals[*ex->getInternalName()] = false;
       }
     }
 

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -134,7 +134,8 @@ static void removeSegment(Module& wasm, Name segment) {
 }
 
 static Address getExportedAddress(Module& wasm, Export* export_) {
-  Global* g = wasm.getGlobal(export_->value);
+  assert(export_->kind == ExternalKind::Global);
+  Global* g = wasm.getGlobal(export_->getInternalName());
   auto* addrConst = g->init->dynCast<Const>();
   return addrConst->value.getUnsigned();
 }
@@ -238,11 +239,12 @@ struct PostEmscripten : public Pass {
     auto sideModule = hasArgument("post-emscripten-side-module");
     EmJsWalker walker(sideModule);
     walker.walkModule(&module);
-    for (const Export& exp : walker.toRemove) {
+    for (Export& exp : walker.toRemove) {
       if (exp.kind == ExternalKind::Function) {
-        module.removeFunction(exp.value);
+        module.removeFunction(exp.getInternalName());
       } else {
-        module.removeGlobal(exp.value);
+        assert(exp.kind == ExternalKind::Global);
+        module.removeGlobal(exp.getInternalName());
       }
       module.removeExport(exp.name);
     }

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -134,8 +134,9 @@ static void removeSegment(Module& wasm, Name segment) {
 }
 
 static Address getExportedAddress(Module& wasm, Export* export_) {
-  assert(export_->kind == ExternalKind::Global);
-  Global* g = wasm.getGlobal(*export_->getInternalName());
+  Global* g = wasm.getGlobal((export_->kind == ExternalKind::Global)
+                               ? *export_->getInternalName()
+                               : Name());
   auto* addrConst = g->init->dynCast<Const>();
   return addrConst->value.getUnsigned();
 }

--- a/src/passes/PostEmscripten.cpp
+++ b/src/passes/PostEmscripten.cpp
@@ -135,7 +135,7 @@ static void removeSegment(Module& wasm, Name segment) {
 
 static Address getExportedAddress(Module& wasm, Export* export_) {
   assert(export_->kind == ExternalKind::Global);
-  Global* g = wasm.getGlobal(export_->getInternalName());
+  Global* g = wasm.getGlobal(*export_->getInternalName());
   auto* addrConst = g->init->dynCast<Const>();
   return addrConst->value.getUnsigned();
 }
@@ -241,10 +241,10 @@ struct PostEmscripten : public Pass {
     walker.walkModule(&module);
     for (Export& exp : walker.toRemove) {
       if (exp.kind == ExternalKind::Function) {
-        module.removeFunction(exp.getInternalName());
+        module.removeFunction(*exp.getInternalName());
       } else {
         assert(exp.kind == ExternalKind::Global);
-        module.removeGlobal(exp.getInternalName());
+        module.removeGlobal(*exp.getInternalName());
       }
       module.removeExport(exp.name);
     }

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3087,7 +3087,8 @@ void PrintSExpression::visitExport(Export* curr) {
       WASM_UNREACHABLE("invalid ExternalKind");
   }
   o << ' ';
-  curr->value.print(o) << "))";
+  // TODO: specific case for type exports
+  curr->getInternalName().print(o) << "))";
 }
 
 void PrintSExpression::emitImportHeader(Importable* curr) {

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3088,7 +3088,7 @@ void PrintSExpression::visitExport(Export* curr) {
   }
   o << ' ';
   // TODO: specific case for type exports
-  curr->getInternalName().print(o) << "))";
+  curr->getInternalName()->print(o) << "))";
 }
 
 void PrintSExpression::emitImportHeader(Importable* curr) {

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -65,7 +65,7 @@ struct PrintCallGraph : public Pass {
     // Exports
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        Function* func = module->getFunction(curr->value);
+        Function* func = module->getFunction(curr->getInternalName());
         o << "  \"" << func->name
           << "\" [style=\"filled\", fillcolor=\"gray\"];\n";
       }

--- a/src/passes/PrintCallGraph.cpp
+++ b/src/passes/PrintCallGraph.cpp
@@ -65,7 +65,7 @@ struct PrintCallGraph : public Pass {
     // Exports
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        Function* func = module->getFunction(curr->getInternalName());
+        Function* func = module->getFunction(*curr->getInternalName());
         o << "  \"" << func->name
           << "\" [style=\"filled\", fillcolor=\"gray\"];\n";
       }

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -786,7 +786,8 @@ struct RemoveUnusedModuleElements : public Pass {
         continue;
       }
 
-      auto* func = module->getFunction(*exp->getInternalName());
+      auto* name = exp->getInternalName();
+      auto* func = module->getFunction(*name);
       if (!func->body) {
         continue;
       }
@@ -813,7 +814,7 @@ struct RemoveUnusedModuleElements : public Pass {
         }
       }
       if (ok) {
-        exp->value = calledFunc->name;
+        *name = calledFunc->name;
       }
     }
   }

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -622,15 +622,15 @@ struct RemoveUnusedModuleElements : public Pass {
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
         roots.emplace_back(ModuleElementKind::Function,
-                           curr->getInternalName());
+                           *curr->getInternalName());
       } else if (curr->kind == ExternalKind::Global) {
-        roots.emplace_back(ModuleElementKind::Global, curr->getInternalName());
+        roots.emplace_back(ModuleElementKind::Global, *curr->getInternalName());
       } else if (curr->kind == ExternalKind::Tag) {
-        roots.emplace_back(ModuleElementKind::Tag, curr->getInternalName());
+        roots.emplace_back(ModuleElementKind::Tag, *curr->getInternalName());
       } else if (curr->kind == ExternalKind::Table) {
-        roots.emplace_back(ModuleElementKind::Table, curr->getInternalName());
+        roots.emplace_back(ModuleElementKind::Table, *curr->getInternalName());
       } else if (curr->kind == ExternalKind::Memory) {
-        roots.emplace_back(ModuleElementKind::Memory, curr->getInternalName());
+        roots.emplace_back(ModuleElementKind::Memory, *curr->getInternalName());
       }
     }
 
@@ -786,7 +786,7 @@ struct RemoveUnusedModuleElements : public Pass {
         continue;
       }
 
-      auto* func = module->getFunction(exp->getInternalName());
+      auto* func = module->getFunction(*exp->getInternalName());
       if (!func->body) {
         continue;
       }

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -621,15 +621,16 @@ struct RemoveUnusedModuleElements : public Pass {
     // Exports are roots.
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        roots.emplace_back(ModuleElementKind::Function, curr->value);
+        roots.emplace_back(ModuleElementKind::Function,
+                           curr->getInternalName());
       } else if (curr->kind == ExternalKind::Global) {
-        roots.emplace_back(ModuleElementKind::Global, curr->value);
+        roots.emplace_back(ModuleElementKind::Global, curr->getInternalName());
       } else if (curr->kind == ExternalKind::Tag) {
-        roots.emplace_back(ModuleElementKind::Tag, curr->value);
+        roots.emplace_back(ModuleElementKind::Tag, curr->getInternalName());
       } else if (curr->kind == ExternalKind::Table) {
-        roots.emplace_back(ModuleElementKind::Table, curr->value);
+        roots.emplace_back(ModuleElementKind::Table, curr->getInternalName());
       } else if (curr->kind == ExternalKind::Memory) {
-        roots.emplace_back(ModuleElementKind::Memory, curr->value);
+        roots.emplace_back(ModuleElementKind::Memory, curr->getInternalName());
       }
     }
 
@@ -785,7 +786,7 @@ struct RemoveUnusedModuleElements : public Pass {
         continue;
       }
 
-      auto* func = module->getFunction(exp->value);
+      auto* func = module->getFunction(exp->getInternalName());
       if (!func->body) {
         continue;
       }

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -77,7 +77,7 @@ struct ReorderFunctions : public Pass {
     }
     for (auto& curr : module->exports) {
       if (curr->kind == ExternalKind::Function) {
-        counts[curr->getInternalName()]++;
+        counts[*curr->getInternalName()]++;
       }
     }
     ElementUtils::iterAllElementFunctionNames(

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -76,7 +76,9 @@ struct ReorderFunctions : public Pass {
       counts[module->start]++;
     }
     for (auto& curr : module->exports) {
-      counts[curr->value]++;
+      if (curr->kind == ExternalKind::Function) {
+        counts[curr->getInternalName()]++;
+      }
     }
     ElementUtils::iterAllElementFunctionNames(
       module, [&](Name& name) { counts[name]++; });

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -161,7 +161,7 @@ struct SafeHeap : public Pass {
       getSbrkPtr = existing->name;
     } else if (auto* existing = module->getExportOrNull(GET_SBRK_PTR)) {
       assert(existing->kind == ExternalKind::Function);
-      getSbrkPtr = existing->getInternalName();
+      getSbrkPtr = *existing->getInternalName();
     } else if (auto* existing = info.getImportedFunction(ENV, SBRK)) {
       sbrk = existing->name;
     } else {

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -159,8 +159,8 @@ struct SafeHeap : public Pass {
     auto addressType = module->memories[0]->addressType;
     if (auto* existing = info.getImportedFunction(ENV, GET_SBRK_PTR)) {
       getSbrkPtr = existing->name;
-    } else if (auto* existing = module->getExportOrNull(GET_SBRK_PTR)) {
-      assert(existing->kind == ExternalKind::Function);
+    } else if (auto* existing = module->getExportOrNull(GET_SBRK_PTR);
+               existing && existing->kind == ExternalKind::Function) {
       getSbrkPtr = *existing->getInternalName();
     } else if (auto* existing = info.getImportedFunction(ENV, SBRK)) {
       sbrk = existing->name;

--- a/src/passes/SafeHeap.cpp
+++ b/src/passes/SafeHeap.cpp
@@ -160,7 +160,8 @@ struct SafeHeap : public Pass {
     if (auto* existing = info.getImportedFunction(ENV, GET_SBRK_PTR)) {
       getSbrkPtr = existing->name;
     } else if (auto* existing = module->getExportOrNull(GET_SBRK_PTR)) {
-      getSbrkPtr = existing->value;
+      assert(existing->kind == ExternalKind::Function);
+      getSbrkPtr = existing->getInternalName();
     } else if (auto* existing = info.getImportedFunction(ENV, SBRK)) {
       sbrk = existing->name;
     } else {

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -515,7 +515,7 @@ struct SimplifyGlobals : public Pass {
     }
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Global) {
-        map[ex->value].exported = true;
+        map[ex->getInternalName()].exported = true;
       }
     }
 

--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -515,7 +515,7 @@ struct SimplifyGlobals : public Pass {
     }
     for (auto& ex : module->exports) {
       if (ex->kind == ExternalKind::Global) {
-        map[ex->getInternalName()].exported = true;
+        map[*ex->getInternalName()].exported = true;
       }
     }
 

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -104,7 +104,7 @@ inline void replaceFunctions(PassRunner* runner,
   // replace in exports
   for (auto& exp : module.exports) {
     if (exp->kind == ExternalKind::Function) {
-      maybeReplace(exp->value);
+      maybeReplace(exp->getInternalName());
     }
   }
 }

--- a/src/passes/opt-utils.h
+++ b/src/passes/opt-utils.h
@@ -104,7 +104,7 @@ inline void replaceFunctions(PassRunner* runner,
   // replace in exports
   for (auto& exp : module.exports) {
     if (exp->kind == ExternalKind::Function) {
-      maybeReplace(exp->getInternalName());
+      maybeReplace(*exp->getInternalName());
     }
   }
 }

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -125,11 +125,11 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
     ModuleUtils::iterImportedGlobals(wasm, [&](Global* import) {
       auto inst = getImportInstance(import);
       auto* exportedGlobal = inst->wasm.getExportOrNull(import->base);
-      if (!exportedGlobal) {
+      if (!exportedGlobal || exportedGlobal->kind != ExternalKind::Global) {
         Fatal() << "importGlobals: unknown import: " << import->module.str
                 << "." << import->name.str;
       }
-      globals[import->name] = inst->globals[exportedGlobal->value];
+      globals[import->name] = inst->globals[exportedGlobal->getInternalName()];
     });
   }
 

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -129,7 +129,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
         Fatal() << "importGlobals: unknown import: " << import->module.str
                 << "." << import->name.str;
       }
-      globals[import->name] = inst->globals[exportedGlobal->getInternalName()];
+      globals[import->name] = inst->globals[*exportedGlobal->getInternalName()];
     });
   }
 

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -59,7 +59,7 @@ public:
     : loggings(loggings), wasm(wasm) {
     for (auto& exp : wasm.exports) {
       if (exp->kind == ExternalKind::Table && exp->name == "table") {
-        exportedTable = exp->getInternalName();
+        exportedTable = *exp->getInternalName();
         break;
       }
     }
@@ -205,7 +205,7 @@ public:
       // No callable export.
       throwJSException();
     }
-    return callFunctionAsJS(exp->getInternalName());
+    return callFunctionAsJS(*exp->getInternalName());
   }
 
   Literals callRefAsJS(Literal ref) {
@@ -279,7 +279,7 @@ struct ExecutionResults {
           continue;
         }
         std::cout << "[fuzz-exec] calling " << exp->name << "\n";
-        auto* func = wasm.getFunction(exp->getInternalName());
+        auto* func = wasm.getFunction(*exp->getInternalName());
         FunctionResult ret = run(func, wasm, instance);
         results[exp->name] = ret;
         if (auto* values = std::get_if<Literals>(&ret)) {

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -59,7 +59,7 @@ public:
     : loggings(loggings), wasm(wasm) {
     for (auto& exp : wasm.exports) {
       if (exp->kind == ExternalKind::Table && exp->name == "table") {
-        exportedTable = exp->value;
+        exportedTable = exp->getInternalName();
         break;
       }
     }
@@ -205,7 +205,7 @@ public:
       // No callable export.
       throwJSException();
     }
-    return callFunctionAsJS(exp->value);
+    return callFunctionAsJS(exp->getInternalName());
   }
 
   Literals callRefAsJS(Literal ref) {
@@ -279,7 +279,7 @@ struct ExecutionResults {
           continue;
         }
         std::cout << "[fuzz-exec] calling " << exp->name << "\n";
-        auto* func = wasm.getFunction(exp->value);
+        auto* func = wasm.getFunction(exp->getInternalName());
         FunctionResult ret = run(func, wasm, instance);
         results[exp->name] = ret;
         if (auto* values = std::get_if<Literals>(&ret)) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1411,7 +1411,7 @@ void TranslateToFuzzReader::processFunctions() {
     for (Index i = 0; i < numInitialExports; i++) {
       auto& exp = wasm.exports[i];
       if (exp->kind == ExternalKind::Function && upTo(RESOLUTION) < chance) {
-        auto* func = wasm.getFunction(exp->getInternalName());
+        auto* func = wasm.getFunction(*exp->getInternalName());
         if (!func->imported()) {
           auto* call =
             builder.makeCall(pick(noParamsOrResultFuncs), {}, Type::none);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1411,7 +1411,7 @@ void TranslateToFuzzReader::processFunctions() {
     for (Index i = 0; i < numInitialExports; i++) {
       auto& exp = wasm.exports[i];
       if (exp->kind == ExternalKind::Function && upTo(RESOLUTION) < chance) {
-        auto* func = wasm.getFunction(exp->value);
+        auto* func = wasm.getFunction(exp->getInternalName());
         if (!func->imported()) {
           auto* call =
             builder.makeCall(pick(noParamsOrResultFuncs), {}, Type::none);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -1482,11 +1482,7 @@ Function* TranslateToFuzzReader::addFunction() {
     });
   if (validExportParams && (numAddedFunctions == 0 || oneIn(2)) &&
       !wasm.getExportOrNull(func->name) && !preserveImportsAndExports) {
-    auto* export_ = new Export;
-    export_->name = func->name;
-    export_->value = func->name;
-    export_->kind = ExternalKind::Function;
-    wasm.addExport(export_);
+    wasm.addExport(new Export(func->name, ExternalKind::Function, func->name));
   }
   // add some to an elem segment
   while (oneIn(3) && !random.finished()) {

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -27,10 +27,10 @@ namespace wasm {
 inline std::string generateSpecWrapper(Module& wasm) {
   std::string ret;
   for (auto& exp : wasm.exports) {
-    auto* func = wasm.getFunctionOrNull(exp->value);
-    if (!func) {
+    if (exp->kind != ExternalKind::Function) {
       continue; // something exported other than a function
     }
+    auto* func = wasm.getFunctionOrNull(exp->getInternalName());
     ret += std::string("(invoke \"") + exp->name.toString() + "\" ";
     for (const auto& param : func->getParams()) {
       // zeros in arguments TODO more?

--- a/src/tools/spec-wrapper.h
+++ b/src/tools/spec-wrapper.h
@@ -30,7 +30,7 @@ inline std::string generateSpecWrapper(Module& wasm) {
     if (exp->kind != ExternalKind::Function) {
       continue; // something exported other than a function
     }
-    auto* func = wasm.getFunctionOrNull(exp->getInternalName());
+    auto* func = wasm.getFunctionOrNull(*exp->getInternalName());
     ret += std::string("(invoke \"") + exp->name.toString() + "\" ";
     for (const auto& param : func->getParams()) {
       // zeros in arguments TODO more?

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -215,7 +215,7 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
                                     global->module.toString() + "." +
                                     global->base.toString());
         }
-        globals[global->name] = inst->globals[globalExport->getInternalName()];
+        globals[global->name] = inst->globals[*globalExport->getInternalName()];
       } else {
         throw FailToEvalException(std::string("importGlobals: ") +
                                   global->module.toString() + "." +
@@ -1298,7 +1298,7 @@ void evalCtors(Module& wasm,
       if (!ex || ex->kind != ExternalKind::Function) {
         Fatal() << "export not found: " << ctor;
       }
-      auto funcName = ex->getInternalName();
+      auto funcName = *ex->getInternalName();
       auto outcome = evalCtor(instance, interface, funcName, ctor);
       if (!outcome) {
         if (!quiet) {
@@ -1320,7 +1320,7 @@ void evalCtors(Module& wasm,
         // We are keeping around the export, which should now refer to an
         // empty function since calling the export should do nothing.
         assert(exp->kind == ExternalKind::Function);
-        auto* func = wasm.getFunction(exp->getInternalName());
+        auto* func = wasm.getFunction(*exp->getInternalName());
         auto copyName = Names::getValidFunctionName(wasm, func->name);
         auto* copyFunc = ModuleUtils::copyFunction(func, wasm, copyName);
         if (func->getResults() == Type::none) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1319,8 +1319,9 @@ void evalCtors(Module& wasm,
       } else {
         // We are keeping around the export, which should now refer to an
         // empty function since calling the export should do nothing.
-        assert(exp->kind == ExternalKind::Function);
-        auto* func = wasm.getFunction(*exp->getInternalName());
+        auto* func = wasm.getFunction((exp->kind == ExternalKind::Function)
+                                        ? *exp->getInternalName()
+                                        : Name());
         auto copyName = Names::getValidFunctionName(wasm, func->name);
         auto* copyFunc = ModuleUtils::copyFunction(func, wasm, copyName);
         if (func->getResults() == Type::none) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1182,7 +1182,7 @@ start_eval:
          (localExprs.size() && func->getParams() != Type::none))) {
       auto originalFuncType = wasm.getFunction(funcName)->type;
       auto copyName = Names::getValidFunctionName(wasm, funcName);
-      wasm.getExport(exportName)->value = copyName;
+      *wasm.getExport(exportName)->getInternalName() = copyName;
 
       if (func->imported()) {
         // We must have return-called this imported function. Generate a new
@@ -1329,7 +1329,7 @@ void evalCtors(Module& wasm,
         } else {
           copyFunc->body = interface.getSerialization(*outcome);
         }
-        wasm.getExport(exp->name)->value = copyName;
+        *wasm.getExport(exp->name)->getInternalName() = copyName;
       }
     }
   } catch (FailToEvalException& fail) {

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -220,11 +220,10 @@ void updateNames(Module& wasm, KindNameUpdates& kindNameUpdates) {
     // the module scope.
     void mapModuleFields(Module& wasm) {
       for (auto& curr : wasm.exports) {
-        if (!curr->hasInternalName()) {
-          // skip type exports
-          continue;
+        // skip type exports
+        if (auto* name = curr->getInternalName()) {
+          mapName(ModuleItemKind(curr->kind), *name);
         }
-        mapName(ModuleItemKind(curr->kind), curr->getInternalName());
       }
       for (auto& curr : wasm.elementSegments) {
         mapName(ModuleItemKind::Table, curr->table);
@@ -444,14 +443,13 @@ void fuseImportsAndExports() {
   KindModuleExportMaps kindModuleExportMaps;
 
   for (auto& ex : merged.exports) {
-    if (!ex->hasInternalName()) {
-      // skip type exports
-      continue;
+    // skip type exports
+    if (auto* name = ex->getInternalName()) {
+      assert(exportModuleMap.count(ex.get()));
+      ExportInfo& exportInfo = exportModuleMap[ex.get()];
+      kindModuleExportMaps[ex->kind][exportInfo.moduleName]
+                          [exportInfo.baseName] = *name;
     }
-    assert(exportModuleMap.count(ex.get()));
-    ExportInfo& exportInfo = exportModuleMap[ex.get()];
-    kindModuleExportMaps[ex->kind][exportInfo.moduleName][exportInfo.baseName] =
-      ex->getInternalName();
   }
 
   // Find all the imports and see which have corresponding exports, which means

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -123,20 +123,18 @@ struct MetaDCEGraph {
       nodes[dceName] = DCENode(dceName);
     });
     for (auto& exp : wasm.exports) {
-      if (!exp->hasInternalName()) {
-        // skip type exports
-        // TODO: shall we keep track of type dependencies?
-        continue;
+      // skip type exports
+      // TODO: shall we keep track of type dependencies?
+      if (auto* name = exp->getInternalName()) {
+        if (exportToDCENode.find(exp->name) == exportToDCENode.end()) {
+          auto dceName = getName("export", exp->name.toString());
+          exportToDCENode[exp->name] = dceName;
+          nodes[dceName] = DCENode(dceName);
+        }
+        // we can also link the export to the thing being exported
+        auto& node = nodes[exportToDCENode[exp->name]];
+        node.reaches.push_back(getDCEName(ModuleItemKind(exp->kind), *name));
       }
-      if (exportToDCENode.find(exp->name) == exportToDCENode.end()) {
-        auto dceName = getName("export", exp->name.toString());
-        exportToDCENode[exp->name] = dceName;
-        nodes[dceName] = DCENode(dceName);
-      }
-      // we can also link the export to the thing being exported
-      auto& node = nodes[exportToDCENode[exp->name]];
-      node.reaches.push_back(
-        getDCEName(ModuleItemKind(exp->kind), exp->getInternalName()));
     }
     // Add initializer dependencies
     // if we provide a parent DCE name, that is who can reach what we see

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -123,6 +123,11 @@ struct MetaDCEGraph {
       nodes[dceName] = DCENode(dceName);
     });
     for (auto& exp : wasm.exports) {
+      if (!exp->hasInternalName()) {
+        // skip type exports
+        // TODO: shall we keep track of type dependencies?
+        continue;
+      }
       if (exportToDCENode.find(exp->name) == exportToDCENode.end()) {
         auto dceName = getName("export", exp->name.toString());
         exportToDCENode[exp->name] = dceName;
@@ -130,7 +135,8 @@ struct MetaDCEGraph {
       }
       // we can also link the export to the thing being exported
       auto& node = nodes[exportToDCENode[exp->name]];
-      node.reaches.push_back(getDCEName(ModuleItemKind(exp->kind), exp->value));
+      node.reaches.push_back(
+        getDCEName(ModuleItemKind(exp->kind), exp->getInternalName()));
     }
     // Add initializer dependencies
     // if we provide a parent DCE name, that is who can reach what we see

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1121,7 +1121,7 @@ struct Reducer
         }
       }
       void visitExport(Export* curr) {
-        if (curr->hasInternalName() && names.count(curr->getInternalName())) {
+        if (auto* name = curr->getInternalName(); name && names.count(*name)) {
           exportsToRemove.push_back(curr->name);
         }
       }

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -1121,7 +1121,7 @@ struct Reducer
         }
       }
       void visitExport(Export* curr) {
-        if (names.count(curr->value)) {
+        if (curr->hasInternalName() && names.count(curr->getInternalName())) {
           exportsToRemove.push_back(curr->name);
         }
       }

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
 
     ret += "        case " + std::to_string(functionExportIndex++) + ":\n";
 
-    auto* func = wasm.getFunction(exp->getInternalName());
+    auto* func = wasm.getFunction(*exp->getInternalName());
 
     ret += std::string("          puts(\"[fuzz-exec] calling ") +
            exp->name.toString() + "\");\n";

--- a/src/tools/wasm2c-wrapper.h
+++ b/src/tools/wasm2c-wrapper.h
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
 
     ret += "        case " + std::to_string(functionExportIndex++) + ":\n";
 
-    auto* func = wasm.getFunction(exp->value);
+    auto* func = wasm.getFunction(exp->getInternalName());
 
     ret += std::string("          puts(\"[fuzz-exec] calling ") +
            exp->name.toString() + "\");\n";

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -591,8 +591,9 @@ Expression* AssertionEmitter::translateInvoke(InvokeAction& invoke,
   for (auto& arg : invoke.args) {
     args.push_back(builder.makeConstantExpression(arg));
   }
-  Type type =
-    wasm.getFunction(wasm.getExport(invoke.name)->value)->getResults();
+  Export* exp = wasm.getExport(invoke.name);
+  assert(exp->kind == ExternalKind::Function);
+  Type type = wasm.getFunction(exp->getInternalName())->getResults();
   return builder.makeCall(invoke.name, args, type);
 }
 

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -592,8 +592,11 @@ Expression* AssertionEmitter::translateInvoke(InvokeAction& invoke,
     args.push_back(builder.makeConstantExpression(arg));
   }
   Export* exp = wasm.getExport(invoke.name);
-  assert(exp->kind == ExternalKind::Function);
-  Type type = wasm.getFunction(*exp->getInternalName())->getResults();
+  Type type = wasm
+                .getFunction((exp->kind == ExternalKind::Function)
+                               ? *exp->getInternalName()
+                               : Name())
+                ->getResults();
   return builder.makeCall(invoke.name, args, type);
 }
 

--- a/src/tools/wasm2js.cpp
+++ b/src/tools/wasm2js.cpp
@@ -593,7 +593,7 @@ Expression* AssertionEmitter::translateInvoke(InvokeAction& invoke,
   }
   Export* exp = wasm.getExport(invoke.name);
   assert(exp->kind == ExternalKind::Function);
-  Type type = wasm.getFunction(exp->getInternalName())->getResults();
+  Type type = wasm.getFunction(*exp->getInternalName())->getResults();
   return builder.makeCall(invoke.name, args, type);
 }
 

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -143,11 +143,7 @@ public:
 
   static std::unique_ptr<Export>
   makeExport(Name name, std::variant<Name, HeapType> value, ExternalKind kind) {
-    auto export_ = std::make_unique<Export>();
-    export_->name = name;
-    export_->value = value;
-    export_->kind = kind;
-    return export_;
+    return std::make_unique<Export>(name, kind, value);
   }
 
   enum Mutability { Mutable, Immutable };

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -142,7 +142,7 @@ public:
   }
 
   static std::unique_ptr<Export>
-  makeExport(Name name, Name value, ExternalKind kind) {
+  makeExport(Name name, std::variant<Name, HeapType> value, ExternalKind kind) {
     auto export_ = std::make_unique<Export>();
     export_->name = name;
     export_->value = value;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2910,10 +2910,10 @@ public:
   // call an exported function
   Literals callExport(Name name, const Literals& arguments) {
     Export* export_ = wasm.getExportOrNull(name);
-    if (!export_) {
+    if (!export_ || export_->kind != ExternalKind::Function) {
       externalInterface->trap("callExport not found");
     }
-    return callFunction(export_->value, arguments);
+    return callFunction(export_->getInternalName(), arguments);
   }
 
   Literals callExport(Name name) { return callExport(name, Literals()); }
@@ -2921,10 +2921,10 @@ public:
   // get an exported global
   Literals getExport(Name name) {
     Export* export_ = wasm.getExportOrNull(name);
-    if (!export_) {
+    if (!export_ || export_->kind != ExternalKind::Global) {
       externalInterface->trap("getExport external not found");
     }
-    Name internalName = export_->value;
+    Name internalName = export_->getInternalName();
     auto iter = globals.find(internalName);
     if (iter == globals.end()) {
       externalInterface->trap("getExport internal not found");
@@ -2966,7 +2966,8 @@ private:
     if (table->imported()) {
       auto& importedInstance = linkedInstances.at(table->module);
       auto* tableExport = importedInstance->wasm.getExport(table->base);
-      return importedInstance->getTableInstanceInfo(tableExport->value);
+      return importedInstance->getTableInstanceInfo(
+        tableExport->getInternalName());
     }
 
     return TableInstanceInfo{self(), name};
@@ -3021,7 +3022,8 @@ private:
     if (memory->imported()) {
       auto& importedInstance = linkedInstances.at(memory->module);
       auto* memoryExport = importedInstance->wasm.getExport(memory->base);
-      return importedInstance->getMemoryInstanceInfo(memoryExport->value);
+      return importedInstance->getMemoryInstanceInfo(
+        memoryExport->getInternalName());
     }
 
     return MemoryInstanceInfo{self(), name};
@@ -3161,7 +3163,7 @@ protected:
     while (global->imported()) {
       inst = inst->linkedInstances.at(global->module).get();
       Export* globalExport = inst->wasm.getExport(global->base);
-      global = inst->wasm.getGlobal(globalExport->value);
+      global = inst->wasm.getGlobal(globalExport->getInternalName());
     }
 
     return inst->globals[global->name];

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2913,7 +2913,7 @@ public:
     if (!export_ || export_->kind != ExternalKind::Function) {
       externalInterface->trap("callExport not found");
     }
-    return callFunction(export_->getInternalName(), arguments);
+    return callFunction(*export_->getInternalName(), arguments);
   }
 
   Literals callExport(Name name) { return callExport(name, Literals()); }
@@ -2924,7 +2924,7 @@ public:
     if (!export_ || export_->kind != ExternalKind::Global) {
       externalInterface->trap("getExport external not found");
     }
-    Name internalName = export_->getInternalName();
+    Name internalName = *export_->getInternalName();
     auto iter = globals.find(internalName);
     if (iter == globals.end()) {
       externalInterface->trap("getExport internal not found");
@@ -2967,7 +2967,7 @@ private:
       auto& importedInstance = linkedInstances.at(table->module);
       auto* tableExport = importedInstance->wasm.getExport(table->base);
       return importedInstance->getTableInstanceInfo(
-        tableExport->getInternalName());
+        *tableExport->getInternalName());
     }
 
     return TableInstanceInfo{self(), name};
@@ -3023,7 +3023,7 @@ private:
       auto& importedInstance = linkedInstances.at(memory->module);
       auto* memoryExport = importedInstance->wasm.getExport(memory->base);
       return importedInstance->getMemoryInstanceInfo(
-        memoryExport->getInternalName());
+        *memoryExport->getInternalName());
     }
 
     return MemoryInstanceInfo{self(), name};
@@ -3163,7 +3163,7 @@ protected:
     while (global->imported()) {
       inst = inst->linkedInstances.at(global->module).get();
       Export* globalExport = inst->wasm.getExport(global->base);
-      global = inst->wasm.getGlobal(globalExport->getInternalName());
+      global = inst->wasm.getGlobal(*globalExport->getInternalName());
     }
 
     return inst->globals[global->name];

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2255,11 +2255,14 @@ enum class ModuleItemKind {
 
 class Export {
 public:
-  // exported name - note that this is the key, as the internal name is
-  // non-unique (can have multiple exports for an internal, also over kinds)
+  // exported name - note that this is the key, as the internal name,
+  // or the exported type, is non-unique (can have multiple exports for an
+  // internal, also over kinds)
   Name name;
-  Name value; // internal name
+  std::variant<Name, HeapType> value; // internal name or exported type
   ExternalKind kind;
+  Name& getInternalName() { return std::get<Name>(value); }
+  bool hasInternalName() { return std::get_if<Name>(&value); }
 };
 
 class ElementSegment : public Named {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2259,8 +2259,16 @@ public:
   // or the exported type, is non-unique (can have multiple exports for an
   // internal, also over kinds)
   Name name;
-  std::variant<Name, HeapType> value; // internal name or exported type
   ExternalKind kind;
+
+private:
+  std::variant<Name, HeapType> value; // internal name or exported type
+
+public:
+  Export(Name name, ExternalKind kind, std::variant<Name, HeapType> value)
+    : name(name), kind(kind), value(value) {
+    assert(std::get_if<Name>(&value));
+  }
   Name* getInternalName() { return std::get_if<Name>(&value); }
 };
 

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2261,8 +2261,7 @@ public:
   Name name;
   std::variant<Name, HeapType> value; // internal name or exported type
   ExternalKind kind;
-  Name& getInternalName() { return std::get<Name>(value); }
-  bool hasInternalName() { return std::get_if<Name>(&value); }
+  Name* getInternalName() { return std::get_if<Name>(&value); }
 };
 
 class ElementSegment : public Named {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -603,19 +603,19 @@ void WasmBinaryWriter::writeExports() {
     o << U32LEB(int32_t(curr->kind));
     switch (curr->kind) {
       case ExternalKind::Function:
-        o << U32LEB(getFunctionIndex(curr->value));
+        o << U32LEB(getFunctionIndex(curr->getInternalName()));
         break;
       case ExternalKind::Table:
-        o << U32LEB(getTableIndex(curr->value));
+        o << U32LEB(getTableIndex(curr->getInternalName()));
         break;
       case ExternalKind::Memory:
-        o << U32LEB(getMemoryIndex(curr->value));
+        o << U32LEB(getMemoryIndex(curr->getInternalName()));
         break;
       case ExternalKind::Global:
-        o << U32LEB(getGlobalIndex(curr->value));
+        o << U32LEB(getGlobalIndex(curr->getInternalName()));
         break;
       case ExternalKind::Tag:
-        o << U32LEB(getTagIndex(curr->value));
+        o << U32LEB(getTagIndex(curr->getInternalName()));
         break;
       default:
         WASM_UNREACHABLE("unexpected extern kind");

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -603,19 +603,19 @@ void WasmBinaryWriter::writeExports() {
     o << U32LEB(int32_t(curr->kind));
     switch (curr->kind) {
       case ExternalKind::Function:
-        o << U32LEB(getFunctionIndex(curr->getInternalName()));
+        o << U32LEB(getFunctionIndex(*curr->getInternalName()));
         break;
       case ExternalKind::Table:
-        o << U32LEB(getTableIndex(curr->getInternalName()));
+        o << U32LEB(getTableIndex(*curr->getInternalName()));
         break;
       case ExternalKind::Memory:
-        o << U32LEB(getMemoryIndex(curr->getInternalName()));
+        o << U32LEB(getMemoryIndex(*curr->getInternalName()));
         break;
       case ExternalKind::Global:
-        o << U32LEB(getGlobalIndex(curr->getInternalName()));
+        o << U32LEB(getGlobalIndex(*curr->getInternalName()));
         break;
       case ExternalKind::Tag:
-        o << U32LEB(getTagIndex(curr->getInternalName()));
+        o << U32LEB(getTagIndex(*curr->getInternalName()));
         break;
       default:
         WASM_UNREACHABLE("unexpected extern kind");

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -36,19 +36,9 @@ namespace wasm {
 void addExportedFunction(Module& wasm, Function* function) {
   wasm.addFunction(function);
   auto export_ = new Export;
-  export_->name = export_->value = function->name;
+  export_->value = export_->name = function->name;
   export_->kind = ExternalKind::Function;
   wasm.addExport(export_);
-}
-
-// TODO(sbc): There should probably be a better way to do this.
-bool isExported(Module& wasm, Name name) {
-  for (auto& ex : wasm.exports) {
-    if (ex->value == name) {
-      return true;
-    }
-  }
-  return false;
 }
 
 Global* getStackPointerGlobal(Module& wasm) {

--- a/src/wasm/wasm-emscripten.cpp
+++ b/src/wasm/wasm-emscripten.cpp
@@ -35,10 +35,8 @@ namespace wasm {
 
 void addExportedFunction(Module& wasm, Function* function) {
   wasm.addFunction(function);
-  auto export_ = new Export;
-  export_->value = export_->name = function->name;
-  export_->kind = ExternalKind::Function;
-  wasm.addExport(export_);
+  wasm.addExport(
+    new Export(function->name, ExternalKind::Function, function->name));
 }
 
 Global* getStackPointerGlobal(Module& wasm) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3929,7 +3929,7 @@ static void validateExports(Module& module, ValidationInfo& info) {
   for (auto& curr : module.exports) {
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
-        Function* f = module.getFunction(curr->value);
+        Function* f = module.getFunction(curr->getInternalName());
         for (const auto& param : f->getParams()) {
           info.shouldBeUnequal(
             param,
@@ -3945,7 +3945,7 @@ static void validateExports(Module& module, ValidationInfo& info) {
         }
       }
     } else if (curr->kind == ExternalKind::Global) {
-      if (Global* g = module.getGlobalOrNull(curr->value)) {
+      if (Global* g = module.getGlobalOrNull(curr->getInternalName())) {
         if (!module.features.hasMutableGlobals()) {
           info.shouldBeFalse(g->mutable_,
                              g->name,
@@ -3959,24 +3959,28 @@ static void validateExports(Module& module, ValidationInfo& info) {
   }
   std::unordered_set<Name> exportNames;
   for (auto& exp : module.exports) {
-    Name name = exp->value;
     if (exp->kind == ExternalKind::Function) {
+      Name name = exp->getInternalName();
       info.shouldBeTrue(module.getFunctionOrNull(name),
                         name,
                         "module function exports must be found");
     } else if (exp->kind == ExternalKind::Global) {
+      Name name = exp->getInternalName();
       info.shouldBeTrue(module.getGlobalOrNull(name),
                         name,
                         "module global exports must be found");
     } else if (exp->kind == ExternalKind::Table) {
+      Name name = exp->getInternalName();
       info.shouldBeTrue(module.getTableOrNull(name),
                         name,
                         "module table exports must be found");
     } else if (exp->kind == ExternalKind::Memory) {
+      Name name = exp->getInternalName();
       info.shouldBeTrue(module.getMemoryOrNull(name),
                         name,
                         "module memory exports must be found");
     } else if (exp->kind == ExternalKind::Tag) {
+      Name name = exp->getInternalName();
       info.shouldBeTrue(
         module.getTagOrNull(name), name, "module tag exports must be found");
     } else {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -3929,7 +3929,7 @@ static void validateExports(Module& module, ValidationInfo& info) {
   for (auto& curr : module.exports) {
     if (curr->kind == ExternalKind::Function) {
       if (info.validateWeb) {
-        Function* f = module.getFunction(curr->getInternalName());
+        Function* f = module.getFunction(*curr->getInternalName());
         for (const auto& param : f->getParams()) {
           info.shouldBeUnequal(
             param,
@@ -3945,7 +3945,7 @@ static void validateExports(Module& module, ValidationInfo& info) {
         }
       }
     } else if (curr->kind == ExternalKind::Global) {
-      if (Global* g = module.getGlobalOrNull(curr->getInternalName())) {
+      if (Global* g = module.getGlobalOrNull(*curr->getInternalName())) {
         if (!module.features.hasMutableGlobals()) {
           info.shouldBeFalse(g->mutable_,
                              g->name,
@@ -3960,27 +3960,27 @@ static void validateExports(Module& module, ValidationInfo& info) {
   std::unordered_set<Name> exportNames;
   for (auto& exp : module.exports) {
     if (exp->kind == ExternalKind::Function) {
-      Name name = exp->getInternalName();
+      Name name = *exp->getInternalName();
       info.shouldBeTrue(module.getFunctionOrNull(name),
                         name,
                         "module function exports must be found");
     } else if (exp->kind == ExternalKind::Global) {
-      Name name = exp->getInternalName();
+      Name name = *exp->getInternalName();
       info.shouldBeTrue(module.getGlobalOrNull(name),
                         name,
                         "module global exports must be found");
     } else if (exp->kind == ExternalKind::Table) {
-      Name name = exp->getInternalName();
+      Name name = *exp->getInternalName();
       info.shouldBeTrue(module.getTableOrNull(name),
                         name,
                         "module table exports must be found");
     } else if (exp->kind == ExternalKind::Memory) {
-      Name name = exp->getInternalName();
+      Name name = *exp->getInternalName();
       info.shouldBeTrue(module.getMemoryOrNull(name),
                         name,
                         "module memory exports must be found");
     } else if (exp->kind == ExternalKind::Tag) {
-      Name name = exp->getInternalName();
+      Name name = *exp->getInternalName();
       info.shouldBeTrue(
         module.getTagOrNull(name), name, "module tag exports must be found");
     } else {

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -535,11 +535,8 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
                         {},
                         builder.makeReturn(builder.makeGlobalGet(
                           INT64_TO_32_HIGH_BITS, Type::i32))))));
-    auto e = new Export();
-    e->name = WASM_FETCH_HIGH_BITS;
-    e->value = WASM_FETCH_HIGH_BITS;
-    e->kind = ExternalKind::Function;
-    wasm->addExport(e);
+    wasm->addExport(new Export(
+      WASM_FETCH_HIGH_BITS, ExternalKind::Function, WASM_FETCH_HIGH_BITS));
   }
   if (flags.emscripten) {
     asmFunc[3]->push_back(ValueBuilder::makeName("// EMSCRIPTEN_END_FUNCS\n"));

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -89,7 +89,7 @@ bool isTableExported(Module& wasm) {
   }
   for (auto& ex : wasm.exports) {
     if (ex->kind == ExternalKind::Table &&
-        ex->getInternalName() == wasm.tables[0]->name) {
+        *ex->getInternalName() == wasm.tables[0]->name) {
       return true;
     }
   }
@@ -343,7 +343,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
   // Scan the wasm for important things.
   for (auto& exp : wasm->exports) {
     if (exp->kind == ExternalKind::Function) {
-      functionsCallableFromOutside.insert(exp->getInternalName());
+      functionsCallableFromOutside.insert(*exp->getInternalName());
     }
   }
   ElementUtils::iterAllElementFunctionNames(
@@ -767,7 +767,7 @@ void Wasm2JSBuilder::addExports(Ref ast, Module* wasm) {
           exports,
           fromName(export_->name, NameScope::Export),
           ValueBuilder::makeName(
-            fromName(export_->getInternalName(), NameScope::Top)));
+            fromName(*export_->getInternalName(), NameScope::Top)));
         break;
       }
       case ExternalKind::Memory: {
@@ -810,7 +810,7 @@ void Wasm2JSBuilder::addExports(Ref ast, Module* wasm) {
         Ref object = ValueBuilder::makeObject();
 
         IString identName =
-          fromName(export_->getInternalName(), NameScope::Top);
+          fromName(*export_->getInternalName(), NameScope::Top);
 
         // getter
         {

--- a/src/wasm2js.h
+++ b/src/wasm2js.h
@@ -88,7 +88,8 @@ bool isTableExported(Module& wasm) {
     return false;
   }
   for (auto& ex : wasm.exports) {
-    if (ex->kind == ExternalKind::Table && ex->value == wasm.tables[0]->name) {
+    if (ex->kind == ExternalKind::Table &&
+        ex->getInternalName() == wasm.tables[0]->name) {
       return true;
     }
   }
@@ -342,7 +343,7 @@ Ref Wasm2JSBuilder::processWasm(Module* wasm, Name funcName) {
   // Scan the wasm for important things.
   for (auto& exp : wasm->exports) {
     if (exp->kind == ExternalKind::Function) {
-      functionsCallableFromOutside.insert(exp->value);
+      functionsCallableFromOutside.insert(exp->getInternalName());
     }
   }
   ElementUtils::iterAllElementFunctionNames(
@@ -765,7 +766,8 @@ void Wasm2JSBuilder::addExports(Ref ast, Module* wasm) {
         ValueBuilder::appendToObjectWithQuotes(
           exports,
           fromName(export_->name, NameScope::Export),
-          ValueBuilder::makeName(fromName(export_->value, NameScope::Top)));
+          ValueBuilder::makeName(
+            fromName(export_->getInternalName(), NameScope::Top)));
         break;
       }
       case ExternalKind::Memory: {
@@ -807,7 +809,8 @@ void Wasm2JSBuilder::addExports(Ref ast, Module* wasm) {
       case ExternalKind::Global: {
         Ref object = ValueBuilder::makeObject();
 
-        IString identName = fromName(export_->value, NameScope::Top);
+        IString identName =
+          fromName(export_->getInternalName(), NameScope::Top);
 
         // getter
         {


### PR DESCRIPTION
Change the type of the field `value` in class `Export` to `std::variant<Name, HeapType>`, since a type export references a heap type and not a named component.