### PR TITLE
[Parser] Error properly on br_on* going to a target without a value

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1974,6 +1974,9 @@ Result<> IRBuilder::makeBrOn(Index label, BrOnOp op, Type in, Type out) {
     case BrOnCast:
     case BrOnCastFail:
       // Modeled as sending one value.
+      if (extraArity == 0) {
+        return Err{"br_on target does not expect a value"};
+      }
       extraArity -= 1;
       break;
   }

--- a/test/lit/parse-bad-gc-br_on-novalue.wast
+++ b/test/lit/parse-bad-gc-br_on-novalue.wast
@@ -1,0 +1,17 @@
+;; RUN: not wasm-opt %s -all 2>&1 | filecheck %s
+
+;; Check we error properly when a block has no value, but a br_on with a value
+;; targets it.
+
+(module
+  ;; CHECK: 10:7: error: br_on target does not expect a value
+  (func $f
+    (block $foo
+      (br_on_cast $foo (ref eq) (ref eq)
+        (ref.i31
+          (i32.const 0)
+        )
+      )
+    )
+  )
+)

--- a/test/lit/parse-bad-gc-cmpxchg-orders.wast
+++ b/test/lit/parse-bad-gc-cmpxchg-orders.wast
@@ -1,17 +1,14 @@
 ;; RUN: not wasm-opt %s -all 2>&1 | filecheck %s
 
-;; Check we error properly when a block has no value, but a br_on with a value
-;; targets it.
-
 (module
-  ;; CHECK: 10:7: error: br_on target does not expect a value
-  (func $f
-    (block $foo
-      (br_on_cast $foo (ref eq) (ref eq)
-        (ref.i31
-          (i32.const 0)
-        )
-      )
+  (type $struct (struct (field (mut i32))))
+
+  ;; CHECK: 8:5: error: struct.atomic.rmw memory orders must be identical
+  (func $cmpxchg (param (ref null $struct))
+    (struct.atomic.rmw.cmpxchg seqcst acqrel 0
+      (local.get 0)
+      (i32.const 1)
+      (i32.const 2)
     )
   )
 )

--- a/test/lit/parse-bad-gc-cmpxchg-orders.wast
+++ b/test/lit/parse-bad-gc-cmpxchg-orders.wast
@@ -1,14 +1,17 @@
 ;; RUN: not wasm-opt %s -all 2>&1 | filecheck %s
 
-(module
-  (type $struct (struct (field (mut i32))))
+;; Check we error properly when a block has no value, but a br_on with a value
+;; targets it.
 
-  ;; CHECK: 8:5: error: struct.atomic.rmw memory orders must be identical
-  (func $cmpxchg (param (ref null $struct))
-    (struct.atomic.rmw.cmpxchg seqcst acqrel 0
-      (local.get 0)
-      (i32.const 1)
-      (i32.const 2)
+(module
+  ;; CHECK: 10:7: error: br_on target does not expect a value
+  (func $f
+    (block $foo
+      (br_on_cast $foo (ref eq) (ref eq)
+        (ref.i31
+          (i32.const 0)
+        )
+      )
     )
   )
 )


### PR DESCRIPTION
Internally we subtract 1 from the number of values while
processing such things, but if we start with 0 we'd overflow
and hit a confusing error later.

Fixes the last part of #7337