### PR TITLE
Add a custom descriptors feature

### DIFF
--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -106,6 +106,8 @@ struct ToolOptions : public Options {
       .addFeature(FeatureSet::StackSwitching, "stack switching")
       .addFeature(FeatureSet::SharedEverything, "shared-everything threads")
       .addFeature(FeatureSet::FP16, "float 16 operations")
+      .addFeature(FeatureSet::CustomDescriptors,
+                  "custom descriptors and exact references")
       .add("--enable-typed-function-references",
            "",
            "Deprecated compatibility flag",

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -107,7 +107,7 @@ struct ToolOptions : public Options {
       .addFeature(FeatureSet::SharedEverything, "shared-everything threads")
       .addFeature(FeatureSet::FP16, "float 16 operations")
       .addFeature(FeatureSet::CustomDescriptors,
-                  "custom descriptors and exact references")
+                  "custom descriptors (RTTs) and exact references")
       .add("--enable-typed-function-references",
            "",
            "Deprecated compatibility flag",

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -398,6 +398,7 @@ extern const char* SharedEverythingFeature;
 extern const char* FP16Feature;
 extern const char* BulkMemoryOptFeature;
 extern const char* CallIndirectOverlongFeature;
+extern const char* CustomDescriptorsFeature;
 
 enum Subsection {
   NameModule = 0,

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -54,11 +54,12 @@ struct FeatureSet {
     // that we can automatically generate tool flags that set it, but otherwise
     // it does nothing. Binaryen always accepts LEB call-indirect encodings.
     CallIndirectOverlong = 1 << 20,
+    CustomDescriptors = 1 << 21,
     MVP = None,
     // Keep in sync with llvm default features:
     // https://github.com/llvm/llvm-project/blob/c7576cb89d6c95f03968076e902d3adfd1996577/clang/lib/Basic/Targets/WebAssembly.cpp#L150-L153
     Default = SignExt | MutableGlobals,
-    All = (1 << 21) - 1,
+    All = (1 << 22) - 1,
   };
 
   static std::string toString(Feature f) {
@@ -105,9 +106,14 @@ struct FeatureSet {
         return "bulk-memory-opt";
       case CallIndirectOverlong:
         return "call-indirect-overlong";
-      default:
-        WASM_UNREACHABLE("unexpected feature");
+      case CustomDescriptors:
+        return "custom-descriptors";
+      case MVP:
+      case Default:
+      case All:
+        break;
     }
+    WASM_UNREACHABLE("unexpected feature");
   }
 
   std::string toString() const {
@@ -159,6 +165,9 @@ struct FeatureSet {
     assert(has || !hasBulkMemory());
     return has;
   }
+  bool hasCustomDescriptors() const {
+    return (features & CustomDescriptors) != 0;
+  }
   bool hasAll() const { return (features & All) != 0; }
 
   void set(FeatureSet f, bool v = true) {
@@ -184,6 +193,7 @@ struct FeatureSet {
   void setSharedEverything(bool v = true) { set(SharedEverything, v); }
   void setFP16(bool v = true) { set(FP16, v); }
   void setBulkMemoryOpt(bool v = true) { set(BulkMemoryOpt, v); }
+  void setCustomDescriptors(bool v = true) { set(CustomDescriptors, v); }
   void setMVP() { features = MVP; }
   void setAll() { features = All; }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1358,6 +1358,8 @@ void WasmBinaryWriter::writeFeaturesSection() {
         return BinaryConsts::CustomSections::BulkMemoryOptFeature;
       case FeatureSet::CallIndirectOverlong:
         return BinaryConsts::CustomSections::CallIndirectOverlongFeature;
+      case FeatureSet::CustomDescriptors:
+        return BinaryConsts::CustomSections::CustomDescriptorsFeature;
       case FeatureSet::None:
       case FeatureSet::Default:
       case FeatureSet::All:

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -28,8 +28,8 @@ Name RETURN_FLOW("*return:)*");
 Name RETURN_CALL_FLOW("*return-call:)*");
 Name NONCONSTANT_FLOW("*nonconstant:)*");
 
-namespace BinaryConsts {
-namespace CustomSections {
+namespace BinaryConsts::CustomSections {
+
 const char* Name = "name";
 const char* SourceMapUrl = "sourceMappingURL";
 const char* Dylink = "dylink";
@@ -59,8 +59,9 @@ const char* SharedEverythingFeature = "shared-everything";
 const char* FP16Feature = "fp16";
 const char* BulkMemoryOptFeature = "bulk-memory-opt";
 const char* CallIndirectOverlongFeature = "call-indirect-overlong";
-} // namespace CustomSections
-} // namespace BinaryConsts
+const char* CustomDescriptorsFeature = "custom-descriptors";
+
+} // namespace BinaryConsts::CustomSections
 
 Name STACK_POINTER("__stack_pointer");
 Name MODULE("module");

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -33,7 +33,7 @@ Features.RelaxedSIMD: 4096
 Features.ExtendedConst: 8192
 Features.Strings: 16384
 Features.MultiMemory: 32768
-Features.All: 2097151
+Features.All: 4194303
 InvalidId: 0
 BlockId: 1
 IfId: 2

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -47,7 +47,7 @@ BinaryenFeatureMemory64: 2048
 BinaryenFeatureRelaxedSIMD: 4096
 BinaryenFeatureExtendedConst: 8192
 BinaryenFeatureStrings: 16384
-BinaryenFeatureAll: 2097151
+BinaryenFeatureAll: 4194303
 (f32.neg
  (f32.const -33.61199951171875)
 )

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -128,11 +128,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -128,6 +128,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -135,6 +135,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -135,11 +135,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -121,11 +121,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -121,6 +121,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -163,6 +163,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -163,11 +163,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -151,11 +151,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -151,6 +151,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -775,11 +775,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                                Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors and
-;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors (RTTs)
+;; CHECK-NEXT:                                                 and exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors and
-;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors
+;; CHECK-NEXT:                                                 (RTTs) and exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -775,6 +775,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                                Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors and
+;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors and
+;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -787,11 +787,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                                Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors and
-;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors (RTTs)
+;; CHECK-NEXT:                                                 and exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors and
-;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors
+;; CHECK-NEXT:                                                 (RTTs) and exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -787,6 +787,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                                Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors and
+;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors and
+;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -160,11 +160,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -160,6 +160,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -260,6 +260,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
+;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -260,11 +260,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                       Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --enable-custom-descriptors          Enable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors and exact
-;; CHECK-NEXT:                                        references
+;; CHECK-NEXT:   --disable-custom-descriptors         Disable custom descriptors (RTTs) and
+;; CHECK-NEXT:                                        exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -738,11 +738,11 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                                Disable float 16 operations
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors and
-;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors (RTTs)
+;; CHECK-NEXT:                                                 and exact references
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors and
-;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors
+;; CHECK-NEXT:                                                 (RTTs) and exact references
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -738,6 +738,12 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-fp16                                Disable float 16 operations
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-custom-descriptors                   Enable custom descriptors and
+;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-custom-descriptors                  Disable custom descriptors and
+;; CHECK-NEXT:                                                 exact references
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
+++ b/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
@@ -19,6 +19,7 @@
 --enable-fp16
 --enable-bulk-memory-opt
 --enable-call-indirect-overlong
+--enable-custom-descriptors
 (module
  (type $0 (func (result v128 externref)))
  (func $foo (type $0) (result v128 externref)


### PR DESCRIPTION
Although the proposal is called "Custom RTTs," the more precise term for
its main feature is "custom descriptors." To decrease long-term
confusion at the expense of some possible short-term confusion, name the
corresponding new feature "custom descriptors." This feature will guard
the use of both descriptor/describes clauses and exact reference types.
