### PR TITLE
Binary encoding and decoding of exact casts

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1126,6 +1126,8 @@ enum ASTNodes {
   I31GetS = 0x1d,
   I31GetU = 0x1e,
   RefI31Shared = 0x1f,
+  RefTestRT = 0x20,
+  RefCastRT = 0x21,
 
   // Shared GC Opcodes
 

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -304,6 +304,13 @@ enum SegmentFlag {
   UsesExpressions = 1 << 2
 };
 
+enum BrOnCastFlag {
+  InputNullable = 1 << 0,
+  OutputNullable = 1 << 1,
+  InputExact = 1 << 2,
+  OutputExact = 1 << 3,
+};
+
 enum EncodedType {
   // value types
   i32 = -0x1,  // 0x7f

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4251,16 +4251,24 @@ Result<> WasmBinaryReader::readInst() {
           return builder.makeRefTest(Type(getHeapType(), NonNullable));
         case BinaryConsts::RefTestNull:
           return builder.makeRefTest(Type(getHeapType(), Nullable));
+        case BinaryConsts::RefTestRT:
+          return builder.makeRefTest(getType());
         case BinaryConsts::RefCast:
           return builder.makeRefCast(Type(getHeapType(), NonNullable));
         case BinaryConsts::RefCastNull:
           return builder.makeRefCast(Type(getHeapType(), Nullable));
+        case BinaryConsts::RefCastRT:
+          return builder.makeRefCast(getType());
         case BinaryConsts::BrOnCast:
         case BinaryConsts::BrOnCastFail: {
           auto flags = getInt8();
           auto label = getU32LEB();
-          auto in = Type(getHeapType(), (flags & 1) ? Nullable : NonNullable);
-          auto cast = Type(getHeapType(), (flags & 2) ? Nullable : NonNullable);
+          auto srcNull = (flags & 1) ? Nullable : NonNullable;
+          auto dstNull = (flags & 2) ? Nullable : NonNullable;
+          auto srcExact = (flags & 4) ? Exact : Inexact;
+          auto dstExact = (flags & 8) ? Exact : Inexact;
+          auto in = Type(getHeapType(), srcNull, srcExact);
+          auto cast = Type(getHeapType(), dstNull, dstExact);
           auto kind = op == BinaryConsts::BrOnCast ? BrOnCast : BrOnCastFail;
           return builder.makeBrOn(label, kind, in, cast);
         }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4263,10 +4263,16 @@ Result<> WasmBinaryReader::readInst() {
         case BinaryConsts::BrOnCastFail: {
           auto flags = getInt8();
           auto label = getU32LEB();
-          auto srcNull = (flags & 1) ? Nullable : NonNullable;
-          auto dstNull = (flags & 2) ? Nullable : NonNullable;
-          auto srcExact = (flags & 4) ? Exact : Inexact;
-          auto dstExact = (flags & 8) ? Exact : Inexact;
+          auto srcNull = (flags & BinaryConsts::BrOnCastFlag::InputNullable)
+                           ? Nullable
+                           : NonNullable;
+          auto dstNull = (flags & BinaryConsts::BrOnCastFlag::OutputNullable)
+                           ? Nullable
+                           : NonNullable;
+          auto srcExact =
+            (flags & BinaryConsts::BrOnCastFlag::InputExact) ? Exact : Inexact;
+          auto dstExact =
+            (flags & BinaryConsts::BrOnCastFlag::OutputExact) ? Exact : Inexact;
           auto in = Type(getHeapType(), srcNull, srcExact);
           auto cast = Type(getHeapType(), dstNull, dstExact);
           auto kind = op == BinaryConsts::BrOnCast ? BrOnCast : BrOnCastFail;

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2260,7 +2260,8 @@ void BinaryInstWriter::visitCallRef(CallRef* curr) {
 
 void BinaryInstWriter::visitRefTest(RefTest* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
-  if (curr->castType.isExact()) {
+  if (curr->castType.isExact() &&
+      parent.getModule()->features.hasCustomDescriptors()) {
     // Fall back to the general form with a reftype immediate.
     o << U32LEB(BinaryConsts::RefTestRT);
     parent.writeType(curr->castType);
@@ -2277,7 +2278,8 @@ void BinaryInstWriter::visitRefTest(RefTest* curr) {
 
 void BinaryInstWriter::visitRefCast(RefCast* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
-  if (curr->type.isExact()) {
+  if (curr->type.isExact() &&
+      parent.getModule()->features.hasCustomDescriptors()) {
     // Fall back to the general form with a reftype immediate.
     o << U32LEB(BinaryConsts::RefCastRT);
     parent.writeType(curr->type);

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2279,7 +2279,7 @@ void BinaryInstWriter::visitRefCast(RefCast* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
   if (curr->type.isExact()) {
     // Fall back to the general form with a reftype immediate.
-    o << U32LEB(BinaryConsts::RefTestRT);
+    o << U32LEB(BinaryConsts::RefCastRT);
     parent.writeType(curr->type);
   } else {
     // Use the special-case form with heap type immediate.

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2260,22 +2260,36 @@ void BinaryInstWriter::visitCallRef(CallRef* curr) {
 
 void BinaryInstWriter::visitRefTest(RefTest* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
-  if (curr->castType.isNullable()) {
-    o << U32LEB(BinaryConsts::RefTestNull);
+  if (curr->castType.isExact()) {
+    // Fall back to the general form with a reftype immediate.
+    o << U32LEB(BinaryConsts::RefTestRT);
+    parent.writeType(curr->castType);
   } else {
-    o << U32LEB(BinaryConsts::RefTest);
+    // Use the special-case form with heap type immediate.
+    if (curr->castType.isNullable()) {
+      o << U32LEB(BinaryConsts::RefTestNull);
+    } else {
+      o << U32LEB(BinaryConsts::RefTest);
+    }
+    parent.writeHeapType(curr->castType.getHeapType());
   }
-  parent.writeHeapType(curr->castType.getHeapType());
 }
 
 void BinaryInstWriter::visitRefCast(RefCast* curr) {
   o << int8_t(BinaryConsts::GCPrefix);
-  if (curr->type.isNullable()) {
-    o << U32LEB(BinaryConsts::RefCastNull);
+  if (curr->type.isExact()) {
+    // Fall back to the general form with a reftype immediate.
+    o << U32LEB(BinaryConsts::RefTestRT);
+    parent.writeType(curr->type);
   } else {
-    o << U32LEB(BinaryConsts::RefCast);
+    // Use the special-case form with heap type immediate.
+    if (curr->type.isNullable()) {
+      o << U32LEB(BinaryConsts::RefCastNull);
+    } else {
+      o << U32LEB(BinaryConsts::RefCast);
+    }
+    parent.writeHeapType(curr->type.getHeapType());
   }
-  parent.writeHeapType(curr->type.getHeapType());
 }
 
 void BinaryInstWriter::visitBrOn(BrOn* curr) {
@@ -2298,8 +2312,15 @@ void BinaryInstWriter::visitBrOn(BrOn* curr) {
       }
       assert(curr->ref->type.isRef());
       assert(Type::isSubType(curr->castType, curr->ref->type));
+      bool srcExact = false;
+      bool dstExact = false;
+      if (parent.getModule()->features.hasCustomDescriptors()) {
+        srcExact = curr->ref->type.isExact();
+        dstExact = curr->castType.isExact();
+      }
       uint8_t flags = (curr->ref->type.isNullable() ? 1 : 0) |
-                      (curr->castType.isNullable() ? 2 : 0);
+                      (curr->castType.isNullable() ? 2 : 0) |
+                      (srcExact ? 4 : 0) | (dstExact ? 8 : 0);
       o << flags;
       o << U32LEB(getBreakIndex(curr->name));
       parent.writeHeapType(curr->ref->type.getHeapType());

--- a/test/lit/basic/exact-references.wast
+++ b/test/lit/basic/exact-references.wast
@@ -12,8 +12,8 @@
 ;; Also check that if we emit a binary without custom descriptors enabled, the
 ;; types are generalized to be inexact.
 
-;; RUN: wasm-opt %s -all --disable-custom-descriptors -g -o - | wasm-opt -all -S -o - \
-;; RUN:     | filecheck %s --check-prefix=NO-EXACT
+;; RUN: wasm-opt %s -all --disable-custom-descriptors -g -o %t.noexact.wasm
+;; RUN: wasm-opt %t.noexact.wasm -all -S -o - | filecheck %s --check-prefix=NO-EXACT
 
 (module
   ;; CHECK-TEXT:      (type $foo (struct (field (exact anyref)) (field (ref exact any)) (field (ref null exact $foo)) (field (ref exact $foo))))

--- a/test/lit/basic/exact-references.wast
+++ b/test/lit/basic/exact-references.wast
@@ -22,8 +22,26 @@
   (type $foo (struct (field (exact anyref) (ref exact any) (ref null exact $foo) (ref exact $foo))))
 
 
+  ;; CHECK-TEXT:      (type $1 (func (param anyref) (result anyref)))
+
+  ;; CHECK-TEXT:      (type $2 (func (param (exact i31ref))))
+
+  ;; CHECK-TEXT:      (type $3 (func (param (exact eqref))))
+
   ;; CHECK-TEXT:      (import "" "g1" (global $g1 (exact anyref)))
+  ;; CHECK-BIN:      (type $1 (func (param anyref) (result anyref)))
+
+  ;; CHECK-BIN:      (type $2 (func (param (exact i31ref))))
+
+  ;; CHECK-BIN:      (type $3 (func (param (exact eqref))))
+
   ;; CHECK-BIN:      (import "" "g1" (global $g1 (exact anyref)))
+  ;; NO-EXACT:      (type $1 (func (param anyref) (result anyref)))
+
+  ;; NO-EXACT:      (type $2 (func (param i31ref)))
+
+  ;; NO-EXACT:      (type $3 (func (param eqref)))
+
   ;; NO-EXACT:      (import "" "g1" (global $g1 anyref))
   (import "" "g1" (global $g1 (exact anyref)))
 
@@ -41,8 +59,290 @@
   ;; CHECK-BIN:      (import "" "g4" (global $g4 (ref exact $foo)))
   ;; NO-EXACT:      (import "" "g4" (global $g4 (ref $foo)))
   (import "" "g4" (global $g4 (ref exact $foo)))
+
+  ;; CHECK-TEXT:      (func $ref-test (type $2) (param $0 (exact i31ref))
+  ;; CHECK-TEXT-NEXT:  (drop
+  ;; CHECK-TEXT-NEXT:   (ref.test (ref exact i31)
+  ;; CHECK-TEXT-NEXT:    (local.get $0)
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT:  (drop
+  ;; CHECK-TEXT-NEXT:   (ref.test (exact i31ref)
+  ;; CHECK-TEXT-NEXT:    (local.get $0)
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT: )
+  ;; CHECK-BIN:      (func $ref-test (type $2) (param $0 (exact i31ref))
+  ;; CHECK-BIN-NEXT:  (drop
+  ;; CHECK-BIN-NEXT:   (ref.test (ref exact i31)
+  ;; CHECK-BIN-NEXT:    (local.get $0)
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT:  (drop
+  ;; CHECK-BIN-NEXT:   (ref.test (exact i31ref)
+  ;; CHECK-BIN-NEXT:    (local.get $0)
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT: )
+  ;; NO-EXACT:      (func $ref-test (type $2) (param $0 i31ref)
+  ;; NO-EXACT-NEXT:  (drop
+  ;; NO-EXACT-NEXT:   (ref.test (ref i31)
+  ;; NO-EXACT-NEXT:    (local.get $0)
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT:  (drop
+  ;; NO-EXACT-NEXT:   (ref.test i31ref
+  ;; NO-EXACT-NEXT:    (local.get $0)
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT: )
+  (func $ref-test (param (ref null exact i31))
+    (drop
+      (ref.test (ref exact i31)
+        (local.get 0)
+      )
+    )
+    (drop
+      (ref.test (ref null exact i31)
+        (local.get 0)
+      )
+    )
+  )
+
+  ;; CHECK-TEXT:      (func $ref-cast (type $3) (param $0 (exact eqref))
+  ;; CHECK-TEXT-NEXT:  (drop
+  ;; CHECK-TEXT-NEXT:   (ref.cast (ref exact eq)
+  ;; CHECK-TEXT-NEXT:    (local.get $0)
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT:  (drop
+  ;; CHECK-TEXT-NEXT:   (ref.cast (exact eqref)
+  ;; CHECK-TEXT-NEXT:    (local.get $0)
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT:  (drop
+  ;; CHECK-TEXT-NEXT:   (ref.cast (ref exact none)
+  ;; CHECK-TEXT-NEXT:    (local.get $0)
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT: )
+  ;; CHECK-BIN:      (func $ref-cast (type $3) (param $0 (exact eqref))
+  ;; CHECK-BIN-NEXT:  (drop
+  ;; CHECK-BIN-NEXT:   (ref.test (ref exact eq)
+  ;; CHECK-BIN-NEXT:    (local.get $0)
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT:  (drop
+  ;; CHECK-BIN-NEXT:   (ref.test (exact eqref)
+  ;; CHECK-BIN-NEXT:    (local.get $0)
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT:  (drop
+  ;; CHECK-BIN-NEXT:   (ref.test (ref exact none)
+  ;; CHECK-BIN-NEXT:    (local.get $0)
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT: )
+  ;; NO-EXACT:      (func $ref-cast (type $3) (param $0 eqref)
+  ;; NO-EXACT-NEXT:  (drop
+  ;; NO-EXACT-NEXT:   (ref.test (ref eq)
+  ;; NO-EXACT-NEXT:    (local.get $0)
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT:  (drop
+  ;; NO-EXACT-NEXT:   (ref.test eqref
+  ;; NO-EXACT-NEXT:    (local.get $0)
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT:  (drop
+  ;; NO-EXACT-NEXT:   (ref.test (ref none)
+  ;; NO-EXACT-NEXT:    (local.get $0)
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT: )
+  (func $ref-cast (param (ref null exact eq))
+    (drop
+      (ref.cast (ref exact eq)
+        (local.get 0)
+      )
+    )
+    (drop
+      (ref.cast (ref null exact eq)
+        (local.get 0)
+      )
+    )
+    (drop
+      (ref.cast (ref exact i31)
+        (local.get 0)
+      )
+    )
+  )
+
+  ;; CHECK-TEXT:      (func $br-on-cast (type $1) (param $0 anyref) (result anyref)
+  ;; CHECK-TEXT-NEXT:  (block $label (result anyref)
+  ;; CHECK-TEXT-NEXT:   (drop
+  ;; CHECK-TEXT-NEXT:    (br_on_cast $label anyref (exact eqref)
+  ;; CHECK-TEXT-NEXT:     (local.get $0)
+  ;; CHECK-TEXT-NEXT:    )
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:   (drop
+  ;; CHECK-TEXT-NEXT:    (br_on_cast $label anyref (ref exact eq)
+  ;; CHECK-TEXT-NEXT:     (local.get $0)
+  ;; CHECK-TEXT-NEXT:    )
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:   (drop
+  ;; CHECK-TEXT-NEXT:    (br_on_cast $label anyref (exact i31ref)
+  ;; CHECK-TEXT-NEXT:     (local.get $0)
+  ;; CHECK-TEXT-NEXT:    )
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:   (local.get $0)
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT: )
+  ;; CHECK-BIN:      (func $br-on-cast (type $1) (param $0 anyref) (result anyref)
+  ;; CHECK-BIN-NEXT:  (block $block (result anyref)
+  ;; CHECK-BIN-NEXT:   (drop
+  ;; CHECK-BIN-NEXT:    (br_on_cast $block anyref (exact eqref)
+  ;; CHECK-BIN-NEXT:     (local.get $0)
+  ;; CHECK-BIN-NEXT:    )
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:   (drop
+  ;; CHECK-BIN-NEXT:    (br_on_cast $block anyref (ref exact eq)
+  ;; CHECK-BIN-NEXT:     (local.get $0)
+  ;; CHECK-BIN-NEXT:    )
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:   (drop
+  ;; CHECK-BIN-NEXT:    (br_on_cast $block anyref (exact i31ref)
+  ;; CHECK-BIN-NEXT:     (local.get $0)
+  ;; CHECK-BIN-NEXT:    )
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:   (local.get $0)
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT: )
+  ;; NO-EXACT:      (func $br-on-cast (type $1) (param $0 anyref) (result anyref)
+  ;; NO-EXACT-NEXT:  (block $block (result anyref)
+  ;; NO-EXACT-NEXT:   (drop
+  ;; NO-EXACT-NEXT:    (br_on_cast $block anyref eqref
+  ;; NO-EXACT-NEXT:     (local.get $0)
+  ;; NO-EXACT-NEXT:    )
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:   (drop
+  ;; NO-EXACT-NEXT:    (br_on_cast $block anyref (ref eq)
+  ;; NO-EXACT-NEXT:     (local.get $0)
+  ;; NO-EXACT-NEXT:    )
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:   (drop
+  ;; NO-EXACT-NEXT:    (br_on_cast $block anyref i31ref
+  ;; NO-EXACT-NEXT:     (local.get $0)
+  ;; NO-EXACT-NEXT:    )
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:   (local.get $0)
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT: )
+  (func $br-on-cast (param anyref) (result anyref)
+    (drop
+      (br_on_cast 0 anyref (ref null exact eq)
+        (local.get 0)
+      )
+    )
+    (drop
+      (br_on_cast 0 anyref (ref exact eq)
+        (local.get 0)
+      )
+    )
+    (drop
+      (br_on_cast 0 anyref (ref null exact i31)
+        (local.get 0)
+      )
+    )
+    (local.get 0)
+  )
+
+  ;; CHECK-TEXT:      (func $br-on-cast-fail (type $1) (param $0 anyref) (result anyref)
+  ;; CHECK-TEXT-NEXT:  (block $label (result anyref)
+  ;; CHECK-TEXT-NEXT:   (drop
+  ;; CHECK-TEXT-NEXT:    (br_on_cast_fail $label anyref (exact eqref)
+  ;; CHECK-TEXT-NEXT:     (local.get $0)
+  ;; CHECK-TEXT-NEXT:    )
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:   (drop
+  ;; CHECK-TEXT-NEXT:    (br_on_cast_fail $label anyref (ref exact eq)
+  ;; CHECK-TEXT-NEXT:     (local.get $0)
+  ;; CHECK-TEXT-NEXT:    )
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:   (drop
+  ;; CHECK-TEXT-NEXT:    (br_on_cast_fail $label anyref (exact i31ref)
+  ;; CHECK-TEXT-NEXT:     (local.get $0)
+  ;; CHECK-TEXT-NEXT:    )
+  ;; CHECK-TEXT-NEXT:   )
+  ;; CHECK-TEXT-NEXT:   (local.get $0)
+  ;; CHECK-TEXT-NEXT:  )
+  ;; CHECK-TEXT-NEXT: )
+  ;; CHECK-BIN:      (func $br-on-cast-fail (type $1) (param $0 anyref) (result anyref)
+  ;; CHECK-BIN-NEXT:  (block $block (result anyref)
+  ;; CHECK-BIN-NEXT:   (drop
+  ;; CHECK-BIN-NEXT:    (br_on_cast_fail $block anyref (exact eqref)
+  ;; CHECK-BIN-NEXT:     (local.get $0)
+  ;; CHECK-BIN-NEXT:    )
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:   (drop
+  ;; CHECK-BIN-NEXT:    (br_on_cast_fail $block anyref (ref exact eq)
+  ;; CHECK-BIN-NEXT:     (local.get $0)
+  ;; CHECK-BIN-NEXT:    )
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:   (drop
+  ;; CHECK-BIN-NEXT:    (br_on_cast_fail $block anyref (exact i31ref)
+  ;; CHECK-BIN-NEXT:     (local.get $0)
+  ;; CHECK-BIN-NEXT:    )
+  ;; CHECK-BIN-NEXT:   )
+  ;; CHECK-BIN-NEXT:   (local.get $0)
+  ;; CHECK-BIN-NEXT:  )
+  ;; CHECK-BIN-NEXT: )
+  ;; NO-EXACT:      (func $br-on-cast-fail (type $1) (param $0 anyref) (result anyref)
+  ;; NO-EXACT-NEXT:  (block $block (result anyref)
+  ;; NO-EXACT-NEXT:   (drop
+  ;; NO-EXACT-NEXT:    (br_on_cast_fail $block anyref eqref
+  ;; NO-EXACT-NEXT:     (local.get $0)
+  ;; NO-EXACT-NEXT:    )
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:   (drop
+  ;; NO-EXACT-NEXT:    (br_on_cast_fail $block anyref (ref eq)
+  ;; NO-EXACT-NEXT:     (local.get $0)
+  ;; NO-EXACT-NEXT:    )
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:   (drop
+  ;; NO-EXACT-NEXT:    (br_on_cast_fail $block anyref i31ref
+  ;; NO-EXACT-NEXT:     (local.get $0)
+  ;; NO-EXACT-NEXT:    )
+  ;; NO-EXACT-NEXT:   )
+  ;; NO-EXACT-NEXT:   (local.get $0)
+  ;; NO-EXACT-NEXT:  )
+  ;; NO-EXACT-NEXT: )
+  (func $br-on-cast-fail (param anyref) (result anyref)
+    (drop
+      (br_on_cast_fail 0 anyref (ref null exact eq)
+        (local.get 0)
+      )
+    )
+    (drop
+      (br_on_cast_fail 0 anyref (ref exact eq)
+        (local.get 0)
+      )
+    )
+    (drop
+      (br_on_cast_fail 0 anyref (ref null exact i31)
+        (local.get 0)
+      )
+    )
+    (local.get 0)
+  )
 )
 ;; CHECK-BIN-NODEBUG:      (type $0 (struct (field (exact anyref)) (field (ref exact any)) (field (ref null exact $0)) (field (ref exact $0))))
+
+;; CHECK-BIN-NODEBUG:      (type $1 (func (param anyref) (result anyref)))
+
+;; CHECK-BIN-NODEBUG:      (type $2 (func (param (exact i31ref))))
+
+;; CHECK-BIN-NODEBUG:      (type $3 (func (param (exact eqref))))
 
 ;; CHECK-BIN-NODEBUG:      (import "" "g1" (global $gimport$0 (exact anyref)))
 
@@ -51,3 +351,76 @@
 ;; CHECK-BIN-NODEBUG:      (import "" "g3" (global $gimport$2 (ref null exact $0)))
 
 ;; CHECK-BIN-NODEBUG:      (import "" "g4" (global $gimport$3 (ref exact $0)))
+
+;; CHECK-BIN-NODEBUG:      (func $0 (type $2) (param $0 (exact i31ref))
+;; CHECK-BIN-NODEBUG-NEXT:  (drop
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (ref exact i31)
+;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT:  (drop
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (exact i31ref)
+;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT: )
+
+;; CHECK-BIN-NODEBUG:      (func $1 (type $3) (param $0 (exact eqref))
+;; CHECK-BIN-NODEBUG-NEXT:  (drop
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (ref exact eq)
+;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT:  (drop
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (exact eqref)
+;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT:  (drop
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (ref exact none)
+;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT: )
+
+;; CHECK-BIN-NODEBUG:      (func $2 (type $1) (param $0 anyref) (result anyref)
+;; CHECK-BIN-NODEBUG-NEXT:  (block $block (result anyref)
+;; CHECK-BIN-NODEBUG-NEXT:   (drop
+;; CHECK-BIN-NODEBUG-NEXT:    (br_on_cast $block anyref (exact eqref)
+;; CHECK-BIN-NODEBUG-NEXT:     (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:    )
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:   (drop
+;; CHECK-BIN-NODEBUG-NEXT:    (br_on_cast $block anyref (ref exact eq)
+;; CHECK-BIN-NODEBUG-NEXT:     (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:    )
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:   (drop
+;; CHECK-BIN-NODEBUG-NEXT:    (br_on_cast $block anyref (exact i31ref)
+;; CHECK-BIN-NODEBUG-NEXT:     (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:    )
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:   (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT: )
+
+;; CHECK-BIN-NODEBUG:      (func $3 (type $1) (param $0 anyref) (result anyref)
+;; CHECK-BIN-NODEBUG-NEXT:  (block $block (result anyref)
+;; CHECK-BIN-NODEBUG-NEXT:   (drop
+;; CHECK-BIN-NODEBUG-NEXT:    (br_on_cast_fail $block anyref (exact eqref)
+;; CHECK-BIN-NODEBUG-NEXT:     (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:    )
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:   (drop
+;; CHECK-BIN-NODEBUG-NEXT:    (br_on_cast_fail $block anyref (ref exact eq)
+;; CHECK-BIN-NODEBUG-NEXT:     (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:    )
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:   (drop
+;; CHECK-BIN-NODEBUG-NEXT:    (br_on_cast_fail $block anyref (exact i31ref)
+;; CHECK-BIN-NODEBUG-NEXT:     (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:    )
+;; CHECK-BIN-NODEBUG-NEXT:   )
+;; CHECK-BIN-NODEBUG-NEXT:   (local.get $0)
+;; CHECK-BIN-NODEBUG-NEXT:  )
+;; CHECK-BIN-NODEBUG-NEXT: )

--- a/test/lit/basic/exact-references.wast
+++ b/test/lit/basic/exact-references.wast
@@ -128,34 +128,34 @@
   ;; CHECK-TEXT-NEXT: )
   ;; CHECK-BIN:      (func $ref-cast (type $3) (param $0 (exact eqref))
   ;; CHECK-BIN-NEXT:  (drop
-  ;; CHECK-BIN-NEXT:   (ref.test (ref exact eq)
+  ;; CHECK-BIN-NEXT:   (ref.cast (ref exact eq)
   ;; CHECK-BIN-NEXT:    (local.get $0)
   ;; CHECK-BIN-NEXT:   )
   ;; CHECK-BIN-NEXT:  )
   ;; CHECK-BIN-NEXT:  (drop
-  ;; CHECK-BIN-NEXT:   (ref.test (exact eqref)
+  ;; CHECK-BIN-NEXT:   (ref.cast (exact eqref)
   ;; CHECK-BIN-NEXT:    (local.get $0)
   ;; CHECK-BIN-NEXT:   )
   ;; CHECK-BIN-NEXT:  )
   ;; CHECK-BIN-NEXT:  (drop
-  ;; CHECK-BIN-NEXT:   (ref.test (ref exact none)
+  ;; CHECK-BIN-NEXT:   (ref.cast (ref exact none)
   ;; CHECK-BIN-NEXT:    (local.get $0)
   ;; CHECK-BIN-NEXT:   )
   ;; CHECK-BIN-NEXT:  )
   ;; CHECK-BIN-NEXT: )
   ;; NO-EXACT:      (func $ref-cast (type $3) (param $0 eqref)
   ;; NO-EXACT-NEXT:  (drop
-  ;; NO-EXACT-NEXT:   (ref.test (ref eq)
+  ;; NO-EXACT-NEXT:   (ref.cast (ref eq)
   ;; NO-EXACT-NEXT:    (local.get $0)
   ;; NO-EXACT-NEXT:   )
   ;; NO-EXACT-NEXT:  )
   ;; NO-EXACT-NEXT:  (drop
-  ;; NO-EXACT-NEXT:   (ref.test eqref
+  ;; NO-EXACT-NEXT:   (ref.cast eqref
   ;; NO-EXACT-NEXT:    (local.get $0)
   ;; NO-EXACT-NEXT:   )
   ;; NO-EXACT-NEXT:  )
   ;; NO-EXACT-NEXT:  (drop
-  ;; NO-EXACT-NEXT:   (ref.test (ref none)
+  ;; NO-EXACT-NEXT:   (ref.cast (ref none)
   ;; NO-EXACT-NEXT:    (local.get $0)
   ;; NO-EXACT-NEXT:   )
   ;; NO-EXACT-NEXT:  )
@@ -367,17 +367,17 @@
 
 ;; CHECK-BIN-NODEBUG:      (func $1 (type $3) (param $0 (exact eqref))
 ;; CHECK-BIN-NODEBUG-NEXT:  (drop
-;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (ref exact eq)
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.cast (ref exact eq)
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:   )
 ;; CHECK-BIN-NODEBUG-NEXT:  )
 ;; CHECK-BIN-NODEBUG-NEXT:  (drop
-;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (exact eqref)
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.cast (exact eqref)
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:   )
 ;; CHECK-BIN-NODEBUG-NEXT:  )
 ;; CHECK-BIN-NODEBUG-NEXT:  (drop
-;; CHECK-BIN-NODEBUG-NEXT:   (ref.test (ref exact none)
+;; CHECK-BIN-NODEBUG-NEXT:   (ref.cast (ref exact none)
 ;; CHECK-BIN-NODEBUG-NEXT:    (local.get $0)
 ;; CHECK-BIN-NODEBUG-NEXT:   )
 ;; CHECK-BIN-NODEBUG-NEXT:  )


### PR DESCRIPTION
The binary format for casts needs to be extended to support exact
references. In particular, add new opcodes for `ref.test` and `ref.cast`
that take reference type immediates instead of heap type immediates. Use
two more bits in the flags immediate of `br_on_cast` and
`br_on_cast_fail` to encode the source and destination exactness.
