### PR TITLE
MergeSimilarFunctions: do a return_call when possible

### DIFF
--- a/test/lit/passes/merge-similar-functions_all-features.wast
+++ b/test/lit/passes/merge-similar-functions_all-features.wast
@@ -103,7 +103,7 @@
   ;; CHECK:      (elem declare func $return_a $return_b)
 
   ;; CHECK:      (func $return_call_a (type $0) (result i32)
-  ;; CHECK-NEXT:  (call $byn$mgfn-shared$return_call_a
+  ;; CHECK-NEXT:  (return_call $byn$mgfn-shared$return_call_a
   ;; CHECK-NEXT:   (ref.func $return_a)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -115,7 +115,7 @@
   )
 
   ;; CHECK:      (func $return_call_b (type $0) (result i32)
-  ;; CHECK-NEXT:  (call $byn$mgfn-shared$return_call_a
+  ;; CHECK-NEXT:  (return_call $byn$mgfn-shared$return_call_a
   ;; CHECK-NEXT:   (ref.func $return_b)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )

--- a/test/lit/passes/merge-similar-functions_types.wast
+++ b/test/lit/passes/merge-similar-functions_types.wast
@@ -17,7 +17,7 @@
  ;; CHECK:      (elem declare func $2 $3)
 
  ;; CHECK:      (func $0 (type $type$0)
- ;; CHECK-NEXT:  (call $byn$mgfn-shared$0
+ ;; CHECK-NEXT:  (return_call $byn$mgfn-shared$0
  ;; CHECK-NEXT:   (ref.func $2)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -41,7 +41,7 @@
   (nop)
  )
  ;; CHECK:      (func $1 (type $type$0)
- ;; CHECK-NEXT:  (call $byn$mgfn-shared$0
+ ;; CHECK-NEXT:  (return_call $byn$mgfn-shared$0
  ;; CHECK-NEXT:   (ref.func $3)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -126,7 +126,7 @@
  ;; CHECK:      (elem declare func $2 $3)
 
  ;; CHECK:      (func $0 (type $type$0)
- ;; CHECK-NEXT:  (call $byn$mgfn-shared$0
+ ;; CHECK-NEXT:  (return_call $byn$mgfn-shared$0
  ;; CHECK-NEXT:   (ref.func $2)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
@@ -150,7 +150,7 @@
   (nop)
  )
  ;; CHECK:      (func $1 (type $type$0)
- ;; CHECK-NEXT:  (call $byn$mgfn-shared$0
+ ;; CHECK-NEXT:  (return_call $byn$mgfn-shared$0
  ;; CHECK-NEXT:   (ref.func $3)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )


### PR DESCRIPTION
This patch makes MergeSimilarFunctions do a return_call when the module has tail-call enabled. This is not merely an optimization, but is crucial for correctness when optimizing wasm modules produced by GHC that relies on tail-call to do control flow transfers. Previously, -Oz would break tail-call enabled modules by making the control stack grow where it shouldn't.