### PR TITLE
Do not fuzz on V8 with custom descriptors enabled

### DIFF
--- a/scripts/bundle_clusterfuzz.py
+++ b/scripts/bundle_clusterfuzz.py
@@ -106,6 +106,7 @@ features = [
     '-all',
     '--disable-shared-everything',
     '--disable-fp16',
+    '--disable-custom-descriptors',
 ]
 
 with tarfile.open(output_file, "w:gz") as tar:

--- a/scripts/clusterfuzz/run.py
+++ b/scripts/clusterfuzz/run.py
@@ -87,6 +87,7 @@ FUZZER_ARGS = [
     '-all',
     '--disable-shared-everything',
     '--disable-fp16',
+    '--disable-custom-descriptors',
 ]
 
 


### PR DESCRIPTION
V8 does not yet support custom descriptors, so update all fuzz handlers
that use it to avoid running when the feature is enabled. Since running
V8 is important, though, disable the feature most of the time, just like
we do for shared-everything.
