### PR TITLE
Gate LTO in the Emscripten build behind the BYN_ENABLE_LTO CMake flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 # more useful error reports from users.
 option(BYN_ENABLE_ASSERTIONS "Enable assertions" ON)
 
-option(BYN_ENABLE_LTO "Build with LTO" Off)
+option(BYN_ENABLE_LTO "Build with LTO" ${EMSCRIPTEN})
 
 # Turn this off to avoid the dependency on gtest.
 option(BUILD_TESTS "Build GTest-based tests" ON)
@@ -341,8 +341,10 @@ if(EMSCRIPTEN)
     # On Node.js, make the tools immediately usable.
     add_link_flag("-sNODERAWFS")
   endif()
+  if (BYN_ENABLE_LTO)
     # in opt builds, LTO helps so much (>20%) it's worth slow compile times
     add_nondebug_compile_flag("-flto")
+  endif()
     if(EMSCRIPTEN_ENABLE_WASM64)
       add_compile_flag("-sMEMORY64 -Wno-experimental")
       add_link_flag("-sMEMORY64")
@@ -523,7 +525,9 @@ if(EMSCRIPTEN)
   target_link_libraries(binaryen_wasm PRIVATE optimized "--closure=1")
   # TODO: Fix closure warnings! (#5062)
   target_link_libraries(binaryen_wasm PRIVATE optimized "-Wno-error=closure")
-  target_link_libraries(binaryen_wasm PRIVATE optimized "-flto")
+  if (BYN_ENABLE_LTO)
+    target_link_libraries(binaryen_wasm PRIVATE optimized "-flto")
+  endif()
   target_link_libraries(binaryen_wasm PRIVATE debug "--profiling")
   # Avoid catching exit as that can confuse error reporting in Node,
   # see https://github.com/emscripten-core/emscripten/issues/17228
@@ -575,7 +579,9 @@ if(EMSCRIPTEN)
   endif()
   # TODO: Fix closure warnings! (#5062)
   target_link_libraries(binaryen_js PRIVATE optimized "-Wno-error=closure")
-  target_link_libraries(binaryen_js PRIVATE optimized "-flto")
+  if(BYN_ENABLE_LTO)
+    target_link_libraries(binaryen_js PRIVATE optimized "-flto")
+  endif()
   target_link_libraries(binaryen_js PRIVATE debug "--profiling")
   target_link_libraries(binaryen_js PRIVATE debug "-sASSERTIONS")
   # Avoid catching exit as that can confuse error reporting in Node,


### PR DESCRIPTION
Make it default to ON when using emscripten
