### PR TITLE
[NFC] Add type.with(...) API to update reference types

### DIFF
--- a/src/ir/type-updating.cpp
+++ b/src/ir/type-updating.cpp
@@ -205,9 +205,7 @@ void GlobalTypeRewriter::mapTypes(const TypeMap& oldToNewTypes) {
 
     Type getNew(Type type) {
       if (type.isRef()) {
-        return Type(getNew(type.getHeapType()),
-                    type.getNullability(),
-                    type.getExactness());
+        return type.with(getNew(type.getHeapType()));
       }
       if (type.isTuple()) {
         auto tuple = type.getTuple();
@@ -467,7 +465,7 @@ void handleNonDefaultableLocals(Function* func, Module& wasm) {
 Type getValidLocalType(Type type, FeatureSet features) {
   assert(type.isConcrete());
   if (type.isNonNullable()) {
-    return Type(type.getHeapType(), Nullable, type.getExactness());
+    return type.with(Nullable);
   }
   if (type.isTuple()) {
     std::vector<Type> elems(type.size());

--- a/src/passes/LocalSubtyping.cpp
+++ b/src/passes/LocalSubtyping.cpp
@@ -152,8 +152,7 @@ struct LocalSubtyping : public WalkerPass<PostWalker<LocalSubtyping>> {
         // Remove non-nullability if we disallow that in locals.
         if (newType.isNonNullable()) {
           if (cannotBeNonNullable.count(i)) {
-            newType =
-              Type(newType.getHeapType(), Nullable, newType.getExactness());
+            newType = newType.with(Nullable);
           }
         } else if (!newType.isDefaultable()) {
           // Aside from the case we just handled of allowed non-nullability, we

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -398,6 +398,17 @@ public:
     return isExact() ? Exact : Inexact;
   }
 
+  // Return a new reference type with some part updated to the specified value.
+  Type with(HeapType heapType) {
+    return Type(heapType, getNullability(), getExactness());
+  }
+  Type with(Nullability nullability) {
+    return Type(getHeapType(), nullability, getExactness());
+  }
+  Type with(Exactness exactness) {
+    return Type(getHeapType(), getNullability(), exactness);
+  }
+
 private:
   template<bool (Type::*pred)() const> bool hasPredicate() {
     for (const auto& type : *this) {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1076,8 +1076,7 @@ void BrOn::finalize() {
   switch (op) {
     case BrOnNull:
       // If we do not branch, we flow out the existing value as non-null.
-      type =
-        Type(ref->type.getHeapType(), NonNullable, ref->type.getExactness());
+      type = ref->type.with(NonNullable);
       break;
     case BrOnNonNull:
       // If we do not branch, we flow out nothing (the spec could also have had
@@ -1087,8 +1086,7 @@ void BrOn::finalize() {
     case BrOnCast:
       if (castType.isNullable()) {
         // Nulls take the branch, so the result is non-nullable.
-        type =
-          Type(ref->type.getHeapType(), NonNullable, ref->type.getExactness());
+        type = ref->type.with(NonNullable);
       } else {
         // Nulls do not take the branch, so the result is non-nullable only if
         // the input is.
@@ -1099,9 +1097,7 @@ void BrOn::finalize() {
       if (castType.isNullable()) {
         // Nulls do not take the branch, so the result is non-nullable only if
         // the input is.
-        type = Type(castType.getHeapType(),
-                    ref->type.getNullability(),
-                    castType.getExactness());
+        type = castType.with(ref->type.getNullability());
       } else {
         // Nulls take the branch, so the result is non-nullable.
         type = castType;
@@ -1124,14 +1120,11 @@ Type BrOn::getSentType() {
         return Type::unreachable;
       }
       // BrOnNonNull sends the non-nullable type on the branch.
-      return Type(
-        ref->type.getHeapType(), NonNullable, ref->type.getExactness());
+      return ref->type.with(NonNullable);
     case BrOnCast:
       // The same as the result type of br_on_cast_fail.
       if (castType.isNullable()) {
-        return Type(castType.getHeapType(),
-                    ref->type.getNullability(),
-                    castType.getExactness());
+        return castType.with(ref->type.getNullability());
       } else {
         return castType;
       }
@@ -1141,8 +1134,7 @@ Type BrOn::getSentType() {
         return Type::unreachable;
       }
       if (castType.isNullable()) {
-        return Type(
-          ref->type.getHeapType(), NonNullable, ref->type.getExactness());
+        return ref->type.with(NonNullable);
       } else {
         return ref->type;
       }
@@ -1317,7 +1309,7 @@ void RefAs::finalize() {
   auto valHeapType = value->type.getHeapType();
   switch (op) {
     case RefAsNonNull:
-      type = Type(valHeapType, NonNullable, value->type.getExactness());
+      type = value->type.with(NonNullable);
       break;
     case AnyConvertExtern:
       type = Type(HeapTypes::any.getBasic(valHeapType.getShared()),


### PR DESCRIPTION
There are many places where we have to copy a reference type with some
modification, for example to make it refer to a different heap type or
to make it non-nullable or nullable. Previously the only way to do this
was with the `Type` constructor, retrieving and passing in the
unmodified fields of the old type explicitly.

With the addition of exact types, all of these sites have to be updated
to additionally propagate the old type's exactness. To simplify these
call sites and make them more robust against future additions to the
structure of reference types, introduce new APIs to update just a single
part of a reference type at a time.
