### PR TITLE
Add all features to C API

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -427,20 +427,20 @@ BinaryenFeatures BinaryenFeatureMVP(void) {
 BinaryenFeatures BinaryenFeatureAtomics(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::Atomics);
 }
-BinaryenFeatures BinaryenFeatureBulkMemory(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::BulkMemory);
-}
 BinaryenFeatures BinaryenFeatureMutableGlobals(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::MutableGlobals);
 }
 BinaryenFeatures BinaryenFeatureNontrappingFPToInt(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::TruncSat);
 }
-BinaryenFeatures BinaryenFeatureSignExt(void) {
-  return static_cast<BinaryenFeatures>(FeatureSet::SignExt);
-}
 BinaryenFeatures BinaryenFeatureSIMD128(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::SIMD);
+}
+BinaryenFeatures BinaryenFeatureBulkMemory(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::BulkMemory);
+}
+BinaryenFeatures BinaryenFeatureSignExt(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::SignExt);
 }
 BinaryenFeatures BinaryenFeatureExceptionHandling(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::ExceptionHandling);
@@ -471,6 +471,21 @@ BinaryenFeatures BinaryenFeatureStrings(void) {
 }
 BinaryenFeatures BinaryenFeatureMultiMemory(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::MultiMemory);
+}
+BinaryenFeatures BinaryenFeatureStackSwitching(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::StackSwitching);
+}
+BinaryenFeatures BinaryenFeatureSharedEverything(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::SharedEverything);
+}
+BinaryenFeatures BinaryenFeatureFP16(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::FP16);
+}
+BinaryenFeatures BinaryenFeatureBulkMemoryOpt(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::BulkMemoryOpt);
+}
+BinaryenFeatures BinaryenFeatureCallIndirectOverlong(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::CallIndirectOverlong);
 }
 BinaryenFeatures BinaryenFeatureAll(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::All);

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -210,11 +210,11 @@ typedef uint32_t BinaryenFeatures;
 
 BINARYEN_API BinaryenFeatures BinaryenFeatureMVP(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureAtomics(void);
-BINARYEN_API BinaryenFeatures BinaryenFeatureBulkMemory(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureMutableGlobals(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureNontrappingFPToInt(void);
-BINARYEN_API BinaryenFeatures BinaryenFeatureSignExt(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureSIMD128(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureBulkMemory(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureSignExt(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureExceptionHandling(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureTailCall(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureReferenceTypes(void);
@@ -225,6 +225,11 @@ BINARYEN_API BinaryenFeatures BinaryenFeatureRelaxedSIMD(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureExtendedConst(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureStrings(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureMultiMemory(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureStackSwitching(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureSharedEverything(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureFP16(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureBulkMemoryOpt(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureCallIndirectOverlong(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureAll(void);
 
 // Modules

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -145,11 +145,11 @@ function initializeConstants() {
   Module['Features'] = {};
   [ 'MVP',
     'Atomics',
-    'BulkMemory',
     'MutableGlobals',
     'NontrappingFPToInt',
-    'SignExt',
     'SIMD128',
+    'BulkMemory',
+    'SignExt',
     'ExceptionHandling',
     'TailCall',
     'ReferenceTypes',
@@ -160,6 +160,11 @@ function initializeConstants() {
     'ExtendedConst',
     'Strings',
     'MultiMemory',
+    'StackSwitching',
+    'SharedEverything',
+    'FP16',
+    'BulkMemoryOpt',
+    'CallIndirectOverlong',
     'All'
   ].forEach(name => {
     Module['Features'][name] = Module['_BinaryenFeature' + name]();


### PR DESCRIPTION
This PR adds all current features to the C API. I reordered `BulkMemory` and `SignExt` to match the order defined in `wasm-features.h`.

Fixes #7361
