### PR TITLE
Fix optimization of casts to exact null types

### DIFF
--- a/test/lit/passes/optimize-instructions-exact.wast
+++ b/test/lit/passes/optimize-instructions-exact.wast
@@ -6,19 +6,27 @@
 ;; RUN: wasm-opt %s -all --optimize-instructions -S -o - | filecheck %s
 
 (module
- ;; CHECK:      (func $cast-to-exact-none (type $0) (param $0 anyref)
- ;; CHECK-NEXT:  (drop
- ;; CHECK-NEXT:   (ref.cast (exact nullref)
- ;; CHECK-NEXT:    (local.get $0)
- ;; CHECK-NEXT:   )
+ ;; CHECK:      (func $cast-any-to-exact-none (type $0) (param $0 anyref) (result (exact nullref))
+ ;; CHECK-NEXT:  (ref.cast (exact nullref)
+ ;; CHECK-NEXT:   (local.get $0)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )
- (func $cast-to-exact-none (param anyref)
-  (drop
-   ;; This will not be changed, but should not trigger an assertion.
-   (ref.cast (exact nullref)
-    (local.get 0)
-   )
+ (func $cast-any-to-exact-none (param anyref) (result (exact nullref))
+  ;; This will not be changed, but should not trigger an assertion.
+  (ref.cast (exact nullref)
+   (local.get 0)
+  )
+ )
+ ;; CHECK:      (func $cast-null-to-exact-none (type $1) (result (exact nullref))
+ ;; CHECK-NEXT:  (local $0 nullref)
+ ;; CHECK-NEXT:  (ref.cast (exact nullref)
+ ;; CHECK-NEXT:   (local.get $0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $cast-null-to-exact-none (result (exact nullref))
+  (local nullref)
+  (ref.cast (exact nullref)
+   (local.get 0)
   )
  )
 )


### PR DESCRIPTION
The logic for optimizing ref.casts that are known to succeed did not
account for possible casts to exact null types, leading to it producing
invalid IR. Fix it and add a test.
