### PR TITLE
[Wasm GC] Fix GUFA on trampled params in TrapsNeverHappens mode

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1553,11 +1553,11 @@ void TNHOracle::scan(Function* func,
     //    (ref.cast (local.get $x)) ;; this is no longer casting the actual
     //                              ;; parameter
     //
-    std::unordered_set<Index> writtenLocals;
+    std::unordered_set<Index> writtenParams;
 
     void visitLocalSet(LocalSet* curr) {
       if (getFunction()->isParam(curr->index)) {
-        writtenLocals.insert(curr->index);
+        writtenParams.insert(curr->index);
       }
     }
 
@@ -1594,7 +1594,7 @@ void TNHOracle::scan(Function* func,
         // the only one to exist there, so it's ok to keep things simple here.
         if (getFunction()->isParam(get->index) && type != get->type &&
             info.castParams.count(get->index) == 0 &&
-            !writtenLocals.count(get->index)) {
+            !writtenParams.count(get->index)) {
           info.castParams[get->index] = type;
         }
       }

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -1545,6 +1545,22 @@ void TNHOracle::scan(Function* func,
       self->inEntryBlock = false;
     }
 
+    // We note params that are written to, as local changes prevent us from
+    // inferences:
+    //
+    //  (func $foo (param $x)
+    //    (local.set $x ..)
+    //    (ref.cast (local.get $x)) ;; this is no longer casting the actual
+    //                              ;; parameter
+    //
+    std::unordered_set<Index> writtenLocals;
+
+    void visitLocalSet(LocalSet* curr) {
+      if (getFunction()->isParam(curr->index)) {
+        writtenLocals.insert(curr->index);
+      }
+    }
+
     void visitCall(Call* curr) { info.calls.push_back(curr); }
 
     void visitCallRef(CallRef* curr) {
@@ -1570,13 +1586,15 @@ void TNHOracle::scan(Function* func,
 
       auto* fallthrough = Properties::getFallthrough(expr, options, wasm);
       if (auto* get = fallthrough->dynCast<LocalGet>()) {
-        // To optimize, this needs to be a param, and of a useful type.
+        // To optimize, this needs to be an unmodified param, and of a useful
+        // type.
         //
         // Note that if we see more than one cast we keep the first one. This is
         // not important in optimized code, as the most refined cast would be
         // the only one to exist there, so it's ok to keep things simple here.
         if (getFunction()->isParam(get->index) && type != get->type &&
-            info.castParams.count(get->index) == 0) {
+            info.castParams.count(get->index) == 0 &&
+            !writtenLocals.count(get->index)) {
           info.castParams[get->index] = type;
         }
       }


### PR DESCRIPTION
GUFA in TNH mode will infer that this will trap:
```wat
(func $foo (param $x)
  (ref.cast $T (local.get $x))
)

(func $bar
  (call $foo (X))
)
```
If X's type will cause a trap when cast to T, then we infer that the call
will trap, and optimize. However, we were missing a check for the
param being trampled,
```wat
(func $foo (param $x)
  (local.set $x (Y))     ;; !!!!!!!!!!
  (ref.cast $T (local.get $x))
)
```
Then if Y can be cast, we should not actually trap.

Fix this by just tracking which params are written to. We only look
in the first basic block anyhow, and traverse it in order, so that is
enough.

Fixes #7366