### PR TITLE
Do not pass C++-only flag to C compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ CMakeFiles
 /*.ninja
 /.ninja_deps
 /.ninja_log
+/.ninja_log.last_upload
 /bin/
 /lib/
 /_deps/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,9 +114,14 @@ find_package(Threads REQUIRED)
 
 function(add_compile_flag value)
   message(STATUS "Building with ${value}")
-  foreach(variable CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
-  endforeach(variable)
+  # You can use the optional second argument to suppress passing C++-only flags to the C compiler.
+  if(ARGV1 STREQUAL "CXX_ONLY")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${value}" PARENT_SCOPE)
+  else()
+    foreach(variable CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+      set(${variable} "${${variable}} ${value}" PARENT_SCOPE)
+    endforeach(variable)
+  endif()
 endfunction()
 
 function(add_debug_compile_flag value)
@@ -269,7 +274,7 @@ else() # MSVC
   add_compile_flag("-fno-omit-frame-pointer")
   if(NOT BUILD_FUZZTEST)
     # fuzztest depends on RTTIs.
-    add_compile_flag("-fno-rtti")
+    add_compile_flag("-fno-rtti" "CXX_ONLY")
   endif()
   if(WIN32)
     add_compile_flag("-D_GNU_SOURCE")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -17,8 +17,6 @@ if(BUILD_LLVM_DWARF)
 endif()
 
 if(MIMALLOC_STATIC)
-  # Using a C++ compiler avoids warnings about -fno-rtti with a C compiler.
-  set(MI_USE_CXX ON)
   # We only need the static library, nothing else.
   set(MI_BUILD_STATIC ON)
   set(MI_BUILD_SHARED OFF)


### PR DESCRIPTION
and some minor drive-by fixes: gitignore Ninja in-tree build file, update mimalloc to latest stable release.

This gets rid of warnings in the mimalloc cmake/make step. See https://github.com/microsoft/mimalloc/issues/1031#issuecomment-2740351301 and https://github.com/microsoft/mimalloc/issues/1038.