### PR TITLE
Exclude the mimalloc files from the Binaryen install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ if(BUILD_LLVM_DWARF)
 endif()
 
 if(MIMALLOC_STATIC)
-  if(NOT(LINUX AND BUILD_STATIC_LIB) OR EMSCRIPTEN)
+  if(NOT(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND BUILD_STATIC_LIB) OR EMSCRIPTEN)
     message(FATAL_ERROR "Statically linking mimalloc is only supported when building as a native, statically linked library on Linux.")
   endif()
   message(STATUS "Building with statically linked mimalloc allocator.")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -26,5 +26,5 @@ if(MIMALLOC_STATIC)
   # (They can still be enabled via MIMALLOC_VERBOSE=1 wasm-opt ...)
   add_compile_definitions(MI_DEBUG=0)
   
-  add_subdirectory(mimalloc)
+  add_subdirectory(mimalloc EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
Since mimalloc is linked statically into the Binaryen tools, none of its
files need to be installed with Binaryen.

Also use CMAKE_SYSTEM_NAME instead of LINUX, as the latter was introduced in CMake 3.25
