### PR TITLE
Fix RefFunc type updating in I64ToI32Lowering

### DIFF
--- a/test/lit/passes/flatten_i64-to-i32-lowering.wast
+++ b/test/lit/passes/flatten_i64-to-i32-lowering.wast
@@ -665,3 +665,26 @@
   )
  )
 )
+
+;; Make sure we update the ref.func in the table with the correct return type.
+(module
+ (table 1 1 funcref)
+
+ (elem (i32.const 0) $f)
+
+ ;; CHECK:      (type $0 (func (result i32)))
+
+ ;; CHECK:      (global $i64toi32_i32$HIGH_BITS (mut i32) (i32.const 0))
+
+ ;; CHECK:      (table $0 1 1 funcref)
+
+ ;; CHECK:      (elem $0 (i32.const 0) $f)
+
+ ;; CHECK:      (func $f (type $0) (result i32)
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
+ (func $f (result i64)
+  (unreachable)
+ )
+)


### PR DESCRIPTION
We recently started updating RefFunc types in I64ToI32Lowering to ensure
that their types matched the updated types of their functions. But the
way we updated the types of RefFunc expressions and Functions were not
the same. When updating Functions that return i64, we replace the result
type with i32 and use a global to propagate the remaining bits to the
caller. Previously when updating RefFunc result types, we would instead
split i64s into pairs of i32s, depending on multivalue to lower the
type. Update the logic for updating RefFunc results to match the
existing logic for updating Functions.
