### PR TITLE
Validate descriptor declarations

### DIFF
--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -816,6 +816,20 @@ struct TypeBuilder {
     InvalidFuncType,
     // A non-shared field of a shared heap type.
     InvalidUnsharedField,
+    // A describes clause on a non-struct type.
+    NonStructDescribes,
+    // The described type is an invalid forward reference.
+    ForwardDescribesReference,
+    // The described type does not have this type as a descriptor.
+    MismatchedDescribes,
+    // A descriptor clause on a non-struct type.
+    NonStructDescriptor,
+    // The descriptor type does not describe this type.
+    MismatchedDescriptor,
+    // A non-shared descriptor on a shared type.
+    InvalidUnsharedDescriptor,
+    // A non-shared type described by a shared type.
+    InvalidUnsharedDescribes,
   };
 
   struct Error {

--- a/test/spec/descriptors.wast
+++ b/test/spec/descriptors.wast
@@ -1,0 +1,158 @@
+(module
+  (rec
+    (type (descriptor 1 (struct)))
+    (type (describes 0 (struct)))
+  )
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1 (struct)))
+      (type (struct))
+    )
+  )
+  "descriptor with no matching describes"
+)
+
+
+(assert_invalid
+  (module
+    (rec
+      (type (struct))
+      (type (describes 0 (struct)))
+    )
+  )
+  "describes with no matching descriptor"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (describes 1 (struct)))
+      (type (descriptor 0 (struct)))
+    )
+  )
+  "forward describes reference"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1 (array i8)))
+      (type (describes 0 (struct)))
+    )
+  )
+  "descriptor clause on non-struct type"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1 (struct)))
+      (type (describes 0 (array i8)))
+    )
+  )
+  "describes clause on non-struct type"
+)
+
+(module
+  (rec
+    (type (shared (descriptor 1 (struct))))
+    (type (shared (describes 0 (struct))))
+  )
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (shared (descriptor 1 (struct))))
+      (type (describes 0 (struct)))
+    )
+  )
+  "unshared descriptor type"
+)
+
+;; TODO: allow this?
+(assert_invalid
+  (module
+    (rec
+      (type (descriptor 1 (struct)))
+      (type (shared (describes 0 (struct))))
+    )
+  )
+  "unshared described types"
+)
+
+(module
+  (rec
+    (type $super (sub (descriptor $super-desc (struct))))
+    (type $super-desc (sub (describes $super (struct))))
+  )
+  (rec
+    (type $sub (sub $super (descriptor $sub-desc (struct))))
+    (type $sub-desc (sub $super-desc (describes $sub (struct))))
+  )
+)
+
+(module
+  (type $super (sub (struct)))
+  (rec
+    (type $other (sub (descriptor $super-desc (struct))))
+    (type $super-desc (sub (describes $other (struct))))
+  )
+  (rec
+    (type $sub (sub $super (descriptor $sub-desc (struct))))
+    (type $sub-desc (sub $super-desc (describes $sub (struct))))
+  )
+)
+
+(assert_invalid
+  (module
+    (type $super (sub (struct)))
+    (type $super-desc (sub (struct)))
+    (rec
+      (type $sub (sub $super (descriptor $sub-desc (struct))))
+      (type $sub-desc (sub $super-desc (describes $sub (struct))))
+    )
+  )
+  "supertype of descriptor must be a descriptor"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type $other (sub (descriptor $super-desc (struct))))
+      (type $super-desc (sub (describes $other (struct))))
+      (type $super (sub (descriptor $other-desc (struct))))
+      (type $other-desc (sub (describes $super (struct))))
+    )
+    (rec
+      (type $sub (sub $super (descriptor $sub-desc (struct))))
+      (type $sub-desc (sub $super-desc (describes $sub (struct))))
+    )
+  )
+  "supertype of described type must be described by supertype of descriptor"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type $super (sub (descriptor $super-desc (struct))))
+      (type $super-desc (sub (describes $super (struct))))
+    )
+    (type $sub (sub $super (struct)))
+  )
+  "supertype of type without descriptor cannot have descriptor"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type $super (sub (descriptor $super-desc (struct))))
+      (type $super-desc (sub (describes $super (struct))))
+    )
+    (type $sub (sub $super-desc (struct)))
+  )
+  "supertype of non-descriptor type cannot be a descriptor"
+)


### PR DESCRIPTION
To ensure soundness, there are very particular rules about how described
and descriptor type declarations must relate to one another and their
supertypes. Implement and test these rules.
