### PR TITLE
[NFC] Fix help text for tools that emit binary

### DIFF
--- a/src/tools/wasm-as.cpp
+++ b/src/tools/wasm-as.cpp
@@ -44,7 +44,7 @@ int main(int argc, const char* argv[]) {
   options
     .add("--output",
          "-o",
-         "Output file (stdout if not specified)",
+         "Output file",
          WasmAsOption,
          Options::Arguments::One,
          [](Options* o, const std::string& argument) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1374,7 +1374,7 @@ int main(int argc, const char* argv[]) {
   options
     .add("--output",
          "-o",
-         "Output file (stdout if not specified)",
+         "Output file",
          WasmCtorEvalOption,
          Options::Arguments::One,
          [](Options* o, const std::string& argument) {

--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -590,7 +590,7 @@ Input source maps can be specified by adding an -ism option right after the modu
   options
     .add("--output",
          "-o",
-         "Output file (stdout if not specified)",
+         "Output file",
          WasmMergeOption,
          Options::Arguments::One,
          [](Options* o, const std::string& argument) {

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -423,7 +423,7 @@ int main(int argc, const char* argv[]) {
   options
     .add("--output",
          "-o",
-         "Output file (stdout if not specified)",
+         "Output file",
          WasmMetaDCEOption,
          Options::Arguments::One,
          [](Options* o, const std::string& argument) {

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -99,7 +99,7 @@ int main(int argc, const char* argv[]) {
   options
     .add("--output",
          "-o",
-         "Output file (stdout if not specified)",
+         "Output file",
          WasmOptOption,
          Options::Arguments::One,
          [](Options* o, const std::string& argument) {

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -10,7 +10,7 @@
 ;; CHECK-NEXT: wasm-as options:
 ;; CHECK-NEXT: ----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --validate,-v                        Control validation of the output module
 ;; CHECK-NEXT:

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -9,7 +9,7 @@
 ;; CHECK-NEXT: wasm-ctor-eval options:
 ;; CHECK-NEXT: -----------------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --emit-text,-S                       Emit text instead of binary for the
 ;; CHECK-NEXT:                                        output file

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -25,7 +25,7 @@
 ;; CHECK-NEXT: wasm-merge options:
 ;; CHECK-NEXT: -------------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                          Output file (stdout if not specified)
+;; CHECK-NEXT:   --output,-o                          Output file
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --input-source-map,-ism              Consume source maps from the specified
 ;; CHECK-NEXT:                                        files

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -51,8 +51,7 @@
 ;; CHECK-NEXT: wasm-opt options:
 ;; CHECK-NEXT: -----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                                   Output file (stdout if not
-;; CHECK-NEXT:                                                 specified)
+;; CHECK-NEXT:   --output,-o                                   Output file
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --input-source-map,-ism                       Consume source map from the
 ;; CHECK-NEXT:                                                 specified file

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -9,8 +9,7 @@
 ;; CHECK-NEXT: wasm-opt options:
 ;; CHECK-NEXT: -----------------
 ;; CHECK-NEXT:
-;; CHECK-NEXT:   --output,-o                                   Output file (stdout if not
-;; CHECK-NEXT:                                                 specified)
+;; CHECK-NEXT:   --output,-o                                   Output file
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --emit-text,-S                                Emit text instead of binary for
 ;; CHECK-NEXT:                                                 the output file


### PR DESCRIPTION
Our tools all stated that if `-o` is not provided, we write to stdout by default.
But that is not true - we do nothing in that case. I believe the rationale is
that we write text to stdout by default in say wasm2js, but for wasm-opt etc.
we don't want to write binary to stdout (as that is dangerous).

It might be worth rethinking this in theory, but this has been the behavior
for many many years, so seems safest to update the help text.