### PR TITLE
[Outlining] Insert Unreachable

### DIFF
--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -208,13 +208,6 @@ struct ReconstructStringifyWalker
     Function* outlinedFunc =
       getModule()->getFunction(sequences[seqCounter].func);
     ASSERT_OK(outlinedBuilder.visitFunctionStart(outlinedFunc));
-    // If the last instruction of the outlined sequence is unreachable, insert
-    // an unreachable instruction immediately after the call to the outlined
-    // function. This maintains the unreachable type in the original scope
-    // of the outlined sequence.
-    if (sequences[seqCounter].endsTypeUnreachable) {
-      ASSERT_OK(existingBuilder.makeUnreachable());
-    }
 
     // Add a local.get instruction for every parameter of the outlined function.
     Signature sig = outlinedFunc->type.getSignature();
@@ -226,6 +219,14 @@ struct ReconstructStringifyWalker
     // call will replace the instructions moved to the outlined function.
     ASSERT_OK(existingBuilder.makeCall(outlinedFunc->name, false));
     DBG(std::cerr << "\ncreated outlined fn: " << outlinedFunc->name << "\n");
+
+    // If the last instruction of the outlined sequence is unreachable, insert
+    // an unreachable instruction immediately after the call to the outlined
+    // function. This maintains the unreachable type in the original scope
+    // of the outlined sequence.
+    if (sequences[seqCounter].endsTypeUnreachable) {
+      ASSERT_OK(existingBuilder.makeUnreachable());
+    }
   }
 
   void transitionToInSkipSeq() {

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -350,12 +350,6 @@ struct Outlining : public Pass {
   using Sequences =
     std::unordered_map<Name, std::vector<wasm::OutliningSequence>>;
 
-  bool endsTypeUnreachable(unsigned hashIdx,
-                           const HashStringifyWalker& stringify) {
-    Expression* expr = stringify.exprs[hashIdx - 1];
-    return expr->type == Type::unreachable;
-  }
-
   // Converts an array of SuffixTree::RepeatedSubstring to a mapping of original
   // functions to repeated sequences they contain. These sequences are ordered
   // by start index by construction because the substring's start indices are
@@ -375,7 +369,8 @@ struct Outlining : public Pass {
           relativeIdx,
           relativeIdx + substring.Length,
           func,
-          endsTypeUnreachable(seqIdx + substring.Length, stringify));
+          stringify.exprs[seqIdx + substring.Length - 1]->type ==
+            Type::unreachable);
         seqByFunc[existingFunc].push_back(seq);
       }
     }

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -208,7 +208,6 @@ struct ReconstructStringifyWalker
     Function* outlinedFunc =
       getModule()->getFunction(sequences[seqCounter].func);
     ASSERT_OK(outlinedBuilder.visitFunctionStart(outlinedFunc));
-
     // If the last instruction of the outlined sequence is unreachable, insert
     // an unreachable instruction immediately after the call to the outlined
     // function. This maintains the unreachable type in the original scope

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -254,9 +254,10 @@ struct OutliningSequence {
   unsigned startIdx;
   unsigned endIdx;
   Name func;
+  bool endsUnreachable;
 
-  OutliningSequence(unsigned startIdx, unsigned endIdx, Name func)
-    : startIdx(startIdx), endIdx(endIdx), func(func) {}
+  OutliningSequence(unsigned startIdx, unsigned endIdx, Name func, bool endsUnreachable)
+    : startIdx(startIdx), endIdx(endIdx), func(func), endsUnreachable(endsUnreachable) {}
 };
 
 using Substrings = std::vector<SuffixTree::RepeatedSubstring>;

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -254,10 +254,14 @@ struct OutliningSequence {
   unsigned startIdx;
   unsigned endIdx;
   Name func;
-  bool endsUnreachable;
+  bool endsTypeUnreachable;
 
-  OutliningSequence(unsigned startIdx, unsigned endIdx, Name func, bool endsUnreachable)
-    : startIdx(startIdx), endIdx(endIdx), func(func), endsUnreachable(endsUnreachable) {}
+  OutliningSequence(unsigned startIdx,
+                    unsigned endIdx,
+                    Name func,
+                    bool endsTypeUnreachable)
+    : startIdx(startIdx), endIdx(endIdx), func(func),
+      endsTypeUnreachable(endsTypeUnreachable) {}
 };
 
 using Substrings = std::vector<SuffixTree::RepeatedSubstring>;

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1015,6 +1015,7 @@
 ;; to warrant outlining.
 (module
   ;; CHECK:      (type $0 (func))
+
   ;; CHECK:      (func $outline$ (type $0)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
@@ -1073,6 +1074,19 @@
     drop        ;; End substring 2 repeat
   )
 )
+
+;; Tests unreachable type handling
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (type $1 (func (result f32)))
+
+  ;; CHECK:      (type $2 (func (result i32)))
+
+  ;; CHECK:      (func $outline$ (type $0)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
 
@@ -1080,7 +1094,6 @@
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
-(module
   (func $a (result f32)
     i32.const 0
     drop

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1100,7 +1100,6 @@
     unreachable
   )
   ;; CHECK:      (func $b (type $2) (result i32)
-  ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT:  (call $outline$)
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1015,7 +1015,6 @@
 ;; to warrant outlining.
 (module
   ;; CHECK:      (type $0 (func))
-
   ;; CHECK:      (func $outline$ (type $0)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
@@ -1072,5 +1071,29 @@
     drop
     i32.const 2
     drop        ;; End substring 2 repeat
+  )
+)
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+
+  ;; CHECK:      (func $a (type $1) (result f32)
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+(module
+  (func $a (result f32)
+    i32.const 0
+    drop
+    unreachable
+  )
+  ;; CHECK:      (func $b (type $2) (result i32)
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT:  (call $outline$)
+  ;; CHECK-NEXT:  (unreachable)
+  ;; CHECK-NEXT: )
+  (func $b (result i32)
+    i32.const 0
+    drop
+    unreachable
   )
 )


### PR DESCRIPTION
When the last instruction of the outlined sequence is unreachable, we need to insert an unreachable instruction immediately after the call to the outlined function. This maintains the unreachable type in the original scope of the outlined sequence.