### PR TITLE
[Outlining] Separating Filter Branch & Return Tests

### DIFF
--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -365,14 +365,10 @@ TEST_F(StringifyTest, FilterBranches) {
   parseWast(wasm, branchesModuleText);
   HashStringifyWalker stringify = HashStringifyWalker();
   stringify.walkModule(&wasm);
-  auto substrings =
-  StringifyProcessor::repeatSubstrings(stringify.hashString);
-  auto result =
-  StringifyProcessor::filterBranches(substrings, stringify.exprs);
+  auto substrings = StringifyProcessor::repeatSubstrings(stringify.hashString);
+  auto result = StringifyProcessor::filterBranches(substrings, stringify.exprs);
 
-  EXPECT_EQ(
-    result,
-    (std::vector<SuffixTree::RepeatedSubstring>{}));
+  EXPECT_EQ(result, (std::vector<SuffixTree::RepeatedSubstring>{}));
 }
 
 TEST_F(StringifyTest, FilterReturn) {
@@ -390,12 +386,8 @@ TEST_F(StringifyTest, FilterReturn) {
   parseWast(wasm, branchesModuleText);
   HashStringifyWalker stringify = HashStringifyWalker();
   stringify.walkModule(&wasm);
-  auto substrings =
-  StringifyProcessor::repeatSubstrings(stringify.hashString);
-  auto result =
-  StringifyProcessor::filterBranches(substrings, stringify.exprs);
+  auto substrings = StringifyProcessor::repeatSubstrings(stringify.hashString);
+  auto result = StringifyProcessor::filterBranches(substrings, stringify.exprs);
 
-  EXPECT_EQ(
-    result,
-    (std::vector<SuffixTree::RepeatedSubstring>{}));
+  EXPECT_EQ(result, (std::vector<SuffixTree::RepeatedSubstring>{}));
 }

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -374,10 +374,10 @@ TEST_F(StringifyTest, FilterBranches) {
 TEST_F(StringifyTest, FilterReturn) {
   static auto branchesModuleText = R"wasm(
   (module
-    (func $a
+    (func $a (result i32)
       (return (i32.const 0))
     )
-    (func $b
+    (func $b (result i32)
       (return (i32.const 0))
     )
    )

--- a/test/gtest/stringify.cpp
+++ b/test/gtest/stringify.cpp
@@ -375,10 +375,10 @@ TEST_F(StringifyTest, FilterReturn) {
   static auto branchesModuleText = R"wasm(
   (module
     (func $a
-      (return)
+      (return (i32.const 0))
     )
     (func $b
-      (return)
+      (return (i32.const 0))
     )
    )
   )wasm";


### PR DESCRIPTION
In the interest of improved test readability, moved the return part of the FilterBranches test into its own test. Also condensed the test to remove the unnecessary consts.