### PR TITLE
Avoid repeated work in RemoveUnusedModuleElements::addReferences() [NFC]

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -546,8 +546,8 @@ struct Analyzer {
     for (auto element : finder.elements) {
       // Avoid repeated work. Note that globals with multiple references to
       // previous globals can lead to exponential work, so this is important.
-      // (If C refers twice to B, and B refers twice to C, then when we process
-      // C we would, naively, scan B twice and C four times.)
+      // (If C refers twice to B, and B refers twice to A, then when we process
+      // C we would, naively, scan B twice and A four times.)
       auto [_, inserted] = referenced.insert(element);
       if (!inserted) {
         continue;

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -544,7 +544,10 @@ struct Analyzer {
     finder.walk(curr);
 
     for (auto element : finder.elements) {
-      referenced.insert(element);
+      auto [_, inserted] = referenced.insert(element);
+      if (!inserted) {
+        continue;
+      }
 
       auto& [kind, value] = element;
       if (kind == ModuleElementKind::Global) {

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -544,6 +544,10 @@ struct Analyzer {
     finder.walk(curr);
 
     for (auto element : finder.elements) {
+      // Avoid repeated work. Note that globals with multiple references to
+      // previous globals can lead to exponential work, so this is important.
+      // (If C refers twice to B, and B refers twice to C, then when we process
+      // C we would, naively, scan B twice and C four times.)
       auto [_, inserted] = referenced.insert(element);
       if (!inserted) {
         continue;


### PR DESCRIPTION
Globals that refer to globals lead to more work. This work cannot be
infinite, as globals only refer to previous ones, but  this can end up as
exponential time, so this is actually important to optimize here.

For exponential time, it is enough to have a chain of these:
```wat
 (global $global$N+1 (ref $A) (struct.new $A
  (global.get $global$N)
  (global.get $global$N)
 ))
```
That is, two references from each global to its predecessor, causing
us to double the work each time we scan back.

Fixes #7405 (where the above pattern appears)