### PR TITLE
[Outlining] Filter in nested control flow

### DIFF
--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -204,9 +204,7 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filter(
     void walk(Expression* curr) {
       hasFilterValue = false;
       Super::walk(curr);
-      while (!controlFlowQueue.empty()) {
-        dequeueControlFlow();
-      }
+      flushControlFlowQueue();
     }
 
     void addUniqueSymbol(SeparatorReason reason) {}

--- a/src/passes/hash-stringify-walker.cpp
+++ b/src/passes/hash-stringify-walker.cpp
@@ -204,6 +204,9 @@ std::vector<SuffixTree::RepeatedSubstring> StringifyProcessor::filter(
     void walk(Expression* curr) {
       hasFilterValue = false;
       Super::walk(curr);
+      while (!controlFlowQueue.empty()) {
+        dequeueControlFlow();
+      }
     }
 
     void addUniqueSymbol(SeparatorReason reason) {}

--- a/src/passes/stringify-walker-impl.h
+++ b/src/passes/stringify-walker-impl.h
@@ -42,9 +42,7 @@ inline void StringifyWalker<SubType>::doWalkFunction(Function* func) {
   addUniqueSymbol(SeparatorReason::makeFuncStart(func));
   Super::walk(func->body);
   addUniqueSymbol(SeparatorReason::makeEnd());
-  while (!controlFlowQueue.empty()) {
-    dequeueControlFlow();
-  }
+  flushControlFlowQueue();
 }
 
 template<typename SubType>

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -191,6 +191,11 @@ struct StringifyWalker
   static void scan(SubType* self, Expression** currp);
   static void doVisitExpression(SubType* self, Expression** currp);
 
+  void flushControlFlowQueue() {
+    while (!controlFlowQueue.empty()) {
+      dequeueControlFlow();
+    }
+  }
   void dequeueControlFlow();
 };
 

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -191,7 +191,6 @@ struct StringifyWalker
   static void scan(SubType* self, Expression** currp);
   static void doVisitExpression(SubType* self, Expression** currp);
 
-private:
   void dequeueControlFlow();
 };
 

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1109,3 +1109,34 @@
     unreachable
   )
 )
+
+;; Tests that restricted expressions (local.set) are filtered from outlining
+;; even when nested within control flow.
+ (module
+   (func $a
+      (local $x i32)
+      (block
+        (if
+          (i32.const 0)
+          (then
+            (local.set $x
+              (i32.const 1)
+            )
+          )
+        )
+      )
+   )
+   (func $b
+      (local $x i32)
+      (block
+        (if
+          (i32.const 0)
+          (then
+            (local.set $x
+              (i32.const 1)
+            )
+          )
+        )
+      )
+     )
+)

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1113,6 +1113,17 @@
 ;; Tests that restricted expressions (local.set) are filtered from outlining
 ;; even when nested within control flow.
  (module
+   ;; CHECK:      (func $a (type $0)
+   ;; CHECK-NEXT:  (local $x i32)
+   ;; CHECK-NEXT:  (if
+   ;; CHECK-NEXT:   (i32.const 0)
+   ;; CHECK-NEXT:   (then
+   ;; CHECK-NEXT:    (local.set $x
+   ;; CHECK-NEXT:     (i32.const 1)
+   ;; CHECK-NEXT:    )
+   ;; CHECK-NEXT:   )
+   ;; CHECK-NEXT:  )
+   ;; CHECK-NEXT: )
    (func $a
       (local $x i32)
       (block
@@ -1126,6 +1137,17 @@
         )
       )
    )
+   ;; CHECK:      (func $b (type $0)
+   ;; CHECK-NEXT:  (local $x i32)
+   ;; CHECK-NEXT:  (if
+   ;; CHECK-NEXT:   (i32.const 0)
+   ;; CHECK-NEXT:   (then
+   ;; CHECK-NEXT:    (local.set $x
+   ;; CHECK-NEXT:     (i32.const 1)
+   ;; CHECK-NEXT:    )
+   ;; CHECK-NEXT:   )
+   ;; CHECK-NEXT:  )
+   ;; CHECK-NEXT: )
    (func $b
       (local $x i32)
       (block

--- a/test/lit/passes/outlining.wast
+++ b/test/lit/passes/outlining.wast
@@ -1112,53 +1112,55 @@
 
 ;; Tests that restricted expressions (local.set) are filtered from outlining
 ;; even when nested within control flow.
- (module
-   ;; CHECK:      (func $a (type $0)
-   ;; CHECK-NEXT:  (local $x i32)
-   ;; CHECK-NEXT:  (if
-   ;; CHECK-NEXT:   (i32.const 0)
-   ;; CHECK-NEXT:   (then
-   ;; CHECK-NEXT:    (local.set $x
-   ;; CHECK-NEXT:     (i32.const 1)
-   ;; CHECK-NEXT:    )
-   ;; CHECK-NEXT:   )
-   ;; CHECK-NEXT:  )
-   ;; CHECK-NEXT: )
-   (func $a
-      (local $x i32)
-      (block
-        (if
-          (i32.const 0)
-          (then
-            (local.set $x
-              (i32.const 1)
-            )
+(module
+  ;; CHECK:      (type $0 (func))
+
+  ;; CHECK:      (func $a (type $0)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (local.set $x
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $a
+    (local $x i32)
+    (block
+      (if
+        (i32.const 0)
+        (then
+          (local.set $x
+            (i32.const 1)
           )
         )
       )
-   )
-   ;; CHECK:      (func $b (type $0)
-   ;; CHECK-NEXT:  (local $x i32)
-   ;; CHECK-NEXT:  (if
-   ;; CHECK-NEXT:   (i32.const 0)
-   ;; CHECK-NEXT:   (then
-   ;; CHECK-NEXT:    (local.set $x
-   ;; CHECK-NEXT:     (i32.const 1)
-   ;; CHECK-NEXT:    )
-   ;; CHECK-NEXT:   )
-   ;; CHECK-NEXT:  )
-   ;; CHECK-NEXT: )
-   (func $b
-      (local $x i32)
-      (block
-        (if
-          (i32.const 0)
-          (then
-            (local.set $x
-              (i32.const 1)
-            )
+    )
+  )
+  ;; CHECK:      (func $b (type $0)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (local.set $x
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $b
+    (local $x i32)
+    (block
+      (if
+        (i32.const 0)
+        (then
+          (local.set $x
+            (i32.const 1)
           )
         )
       )
-     )
+    )
+  )
 )


### PR DESCRIPTION
Fixes a bug where stringify walker was not removing outlining candidates with restricted expressions because they were in nested control flow.