### PR TITLE
[Strings] Handle encoding in JSON parsing so StringLifting can handle arbitrary custom section content

### DIFF
--- a/src/passes/StringLifting.cpp
+++ b/src/passes/StringLifting.cpp
@@ -66,7 +66,14 @@ struct StringLifting : public Pass {
         continue;
       }
       if (global->module == stringConstsModule) {
-        importedStrings[global->name] = global->base;
+        // Encode from WTF-8 to WTF-16.
+        auto wtf8 = global->base;
+        std::stringstream wtf16;
+        bool valid = String::convertWTF8ToWTF16(wtf16, wtf8.str);
+        if (!valid) {
+          Fatal() << "Bad string to lift: " << wtf8;
+        }
+        importedStrings[global->name] = wtf16.str();
         found = true;
       }
     }
@@ -203,15 +210,8 @@ struct StringLifting : public Pass {
         // Replace global.gets of imported strings with string.const.
         auto iter = parent.importedStrings.find(curr->name);
         if (iter != parent.importedStrings.end()) {
-          // Encode from WTF-8 to WTF-16.
-          auto wtf8 = iter->second;
-          std::stringstream wtf16;
-          bool valid = String::convertWTF8ToWTF16(wtf16, wtf8.str);
-          if (!valid) {
-            Fatal() << "Bad string to lift: " << wtf8;
-          }
-
-          replaceCurrent(Builder(*getModule()).makeStringConst(wtf16.str()));
+          auto wtf16 = iter->second;
+          replaceCurrent(Builder(*getModule()).makeStringConst(wtf16.str));
           modified = true;
         }
       }

--- a/src/passes/StringLifting.cpp
+++ b/src/passes/StringLifting.cpp
@@ -84,7 +84,7 @@ struct StringLifting : public Pass {
         // We found the string consts section. Parse it.
         auto copy = section.data;
         json::Value array;
-        array.parse(copy.data());
+        array.parse(copy.data(), json::Value::WTF16);
         if (!array.isArray()) {
           Fatal()
             << "StringLifting: string.const section should be a JSON array";

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -422,7 +422,7 @@ private:
       return;
     }
 
-    auto unescaped = wasm::String::unescapeJSONToWTF8(str);
+    auto unescaped = wasm::String::unescapeJSONToWTF16(str);
 
     setString(
       IString(std::string_view(unescaped.data(), unescaped.size()), false));

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -412,18 +412,11 @@ struct Value {
   }
 
 private:
-  // If the string has no escaped characters, setString() the char* directly. If
-  // it does require escaping, do that and intern a new string with those
-  // contents.
+  // Unescape the input (UTF8) string into one of our internal strings (WTF16).
   void unescapeAndSetString(char* str) {
-    if (!strchr(str, '\\')) {
-      // No escaping slash.
-      setString(str);
-      return;
-    }
-
+    // TODO: Optimize the unescaped path? But it is impossible to avoid an
+    //       allocation here.
     auto unescaped = wasm::String::unescapeJSONToWTF16(str);
-
     setString(
       IString(std::string_view(unescaped.data(), unescaped.size()), false));
   }

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -431,7 +431,7 @@ private:
   void unescapeIntoWTF16(char* str) {
     // TODO: Optimize the unescaped path? But it is impossible to avoid an
     //       allocation here.
-    auto unescaped = wasm::String::unescapeJSONToWTF16(str);
+    auto unescaped = wasm::String::unescapeUTF8JSONtoWTF16(str);
     setString(
       IString(std::string_view(unescaped.data(), unescaped.size()), false));
   }

--- a/src/support/string.cpp
+++ b/src/support/string.cpp
@@ -432,6 +432,7 @@ bool isUTF8(std::string_view str) {
   return true;
 }
 
+//std::vector<char> unescapeJSONinUTF8toWTF16(const char* str) {
 std::vector<char> unescapeJSONToWTF16(const char* str) {
   std::vector<char> unescaped;
   size_t i = 0;
@@ -439,6 +440,7 @@ std::vector<char> unescapeJSONToWTF16(const char* str) {
     if (str[i] != '\\') {
       // Normal character.
       unescaped.push_back(str[i]);
+      unescaped.push_back(0);
       i++;
       continue;
     }
@@ -466,6 +468,7 @@ std::vector<char> unescapeJSONToWTF16(const char* str) {
           Fatal() << "Invalid escaped JSON ends in slash";
       }
       unescaped.push_back(c);
+      unescaped.push_back(0);
       i += 2;
       continue;
     }
@@ -482,9 +485,7 @@ std::vector<char> unescapeJSONToWTF16(const char* str) {
     // Write out the results.
     unescaped.push_back(x & 0xff);
     x >>= 8;
-    if (x) {
-      unescaped.push_back(x);
-    }
+    unescaped.push_back(x);
 
     i += 6;
   }

--- a/src/support/string.cpp
+++ b/src/support/string.cpp
@@ -432,8 +432,7 @@ bool isUTF8(std::string_view str) {
   return true;
 }
 
-//std::vector<char> unescapeJSONinUTF8toWTF16(const char* str) {
-std::vector<char> unescapeJSONToWTF16(const char* str) {
+std::vector<char> unescapeUTF8JSONtoWTF16(const char* str) {
   std::vector<char> unescaped;
   size_t i = 0;
   while (str[i]) {

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -102,8 +102,8 @@ bool convertUTF16ToUTF8(std::ostream& os, std::string_view str);
 // Whether the string is valid UTF-8.
 bool isUTF8(std::string_view str);
 
-// Given a string of properly-escaped JSON, unescape it.
-std::vector<char> unescapeJSONToWTF16(const char* str);
+// Given a string of properly-escaped JSON in UTF8, unescape it into WTF16.
+std::vector<char> unescapeUTF8JSONtoWTF16(const char* str);
 
 } // namespace wasm::String
 

--- a/src/support/string.h
+++ b/src/support/string.h
@@ -103,7 +103,7 @@ bool convertUTF16ToUTF8(std::ostream& os, std::string_view str);
 bool isUTF8(std::string_view str);
 
 // Given a string of properly-escaped JSON, unescape it.
-std::vector<char> unescapeJSONToWTF8(const char* str);
+std::vector<char> unescapeJSONToWTF16(const char* str);
 
 } // namespace wasm::String
 

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -518,7 +518,7 @@ int main(int argc, const char* argv[]) {
   auto graphInput(read_file<std::string>(graphFile, Flags::Text));
   auto* copy = strdup(graphInput.c_str());
   json::Value outside;
-  outside.parse(copy);
+  outside.parse(copy, json::Value::ASCII);
 
   // parse the JSON into our graph, doing all the JSON parsing here, leaving
   // the abstract computation for the class itself

--- a/test/gtest/json.cpp
+++ b/test/gtest/json.cpp
@@ -8,7 +8,7 @@ TEST_F(JSONTest, Stringify) {
   auto input = "[\"hello\",\"world\"]";
   auto* copy = strdup(input);
   json::Value value;
-  value.parse(copy);
+  value.parse(copy, json::Value::ASCII);
   std::stringstream ss;
   value.stringify(ss);
   EXPECT_EQ(ss.str(), input);

--- a/test/lit/passes/string-lifting-section.wast
+++ b/test/lit/passes/string-lifting-section.wast
@@ -91,7 +91,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $tricky-consts
-    ;; This tricky string should remain exactly the same after lowering and
+    ;; These tricky strings should remain exactly the same after lowering and
     ;; lifting.
     (drop
       (string.const "needs\tescaping\00.'#%\"- .\r\n\\08\0C\0A\0D\09.ꙮ")

--- a/test/lit/passes/string-lifting-section.wast
+++ b/test/lit/passes/string-lifting-section.wast
@@ -29,7 +29,11 @@
 
   ;; CHECK:      (import "string.const" "1" (global $"string.const_\"foo\"" (ref extern)))
 
-  ;; CHECK:      (import "string.const" "2" (global $"string.const_\"needs\\tescaping\\00.\\\'#%\\\"\"" (ref extern)))
+  ;; CHECK:      (import "string.const" "2" (global $"string.const_\"needs\\tescaping\\00.\\\'#%\\\"- .\\r\\n\\\\08\\0c\\n\\r\\t.\\ea\\99\\ae\"" (ref extern)))
+
+  ;; CHECK:      (import "string.const" "3" (global $"string.const_\"unpaired high surrogate \\ed\\a0\\80 \"" (ref extern)))
+
+  ;; CHECK:      (import "string.const" "4" (global $"string.const_\"unpaired low surrogate \\ed\\bd\\88 \"" (ref extern)))
 
   ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $3) (param (ref null $0) i32 i32) (result (ref extern))))
 
@@ -77,14 +81,26 @@
 
   ;; CHECK:      (func $tricky-consts (type $1)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (string.const "needs\tescaping\00.\'#%\"")
+  ;; CHECK-NEXT:   (string.const "needs\tescaping\00.\'#%\"- .\r\n\\08\0c\n\r\t.\ea\99\ae")
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (string.const "unpaired high surrogate \ed\a0\80 ")
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (string.const "unpaired low surrogate \ed\bd\88 ")
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $tricky-consts
     ;; This tricky string should remain exactly the same after lowering and
     ;; lifting.
     (drop
-      (string.const "needs\tescaping\00.'#%\"")
+      (string.const "needs\tescaping\00.'#%\"- .\r\n\\08\0C\0A\0D\09.ꙮ")
+    )
+    (drop
+      (string.const "unpaired high surrogate \ED\A0\80 ")
+    )
+    (drop
+      (string.const "unpaired low surrogate \ED\BD\88 ")
     )
   )
 )


### PR DESCRIPTION
Rather than encode to WTF8 and re-encode, instead make the unescaping logic go
from UTF8 straight to WTF16. That makes it simpler and more efficient.

Make the JSON parser get a parameter for which encoding to use for strings, so
we can use ascii in old places.