### PR TITLE
use Owi to check for equivalence of the fuzzer-generated programs

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1806,22 +1806,47 @@ class PreserveImportsExports(TestCaseHandler):
 
         compare(get_relevant_lines(original), get_relevant_lines(processed), 'Preserve')
 
+class Owi(TestCaseHandler):
+    frequency = 1
+
+    def can_run_on_wasm(self, wasm):
+        if JSPI:
+            return False
+        return all_disallowed(['exception-handling', 'simd', 'threads', 'gc', 'multimemory', 'memory64', 'custom-descriptors', 'shared-everything'])
+
+    def handle_pair(self, input, before_wasm, after_wasm, opts):
+        completed_process = subprocess.run(["owi", "iso", before_wasm, after_wasm, "--fail-on-assertion-only"])
+        code = completed_process.returncode
+
+        # 20: incompatible import type due to log-i64 being unreliable
+        if code == 20:
+            return True
+        # illegal opcode, needs to be investigated
+        elif code == 30:
+            return True
+        # unknown import, needs to be fixed in Owi (table-get and table-set)
+        elif code == 45:
+            return True
+        else:
+            print("found a bug: return code of Owi was: ", code)
+            return code == 0
 
 # The global list of all test case handlers
 testcase_handlers = [
-    FuzzExec(),
-    CompareVMs(),
-    CheckDeterminism(),
-    Wasm2JS(),
-    TrapsNeverHappen(),
-    CtorEval(),
-    Merge(),
+    #FuzzExec(),
+    #CompareVMs(),
+    #CheckDeterminism(),
+    #Wasm2JS(),
+    #TrapsNeverHappen(),
+    #CtorEval(),
+    #Merge(),
     # TODO: enable when stable enough, and adjust |frequency| (see above)
     # Split(),
-    RoundtripText(),
-    ClusterFuzz(),
-    Two(),
-    PreserveImportsExports(),
+    #RoundtripText(),
+    #ClusterFuzz(),
+    #Two(),
+    #PreserveImportsExports(),
+    Owi(),
 ]
 
 


### PR DESCRIPTION
Hi,

This PR adds the possibility to use [Owi](https://github.com/OCamlPro/owi) to check for the equivalence of programs generated by the fuzzer before and after optimization.

Owi performs symbolic execution, which allows to compare the output of two given functions "for any input value", rather than with concrete inputs (like `0`, or `1`, as it is currently done IIUC what @tlively told me). Owi can perform symbolic execution *in parallel* and has been shown to be the best symbolic execution tool for Wasm (disclaimer: I am one of the author of the tool, you can have a look at [the paper](https://arxiv.org/abs/2412.06391) if you want more details, but I am also happy to answer any question you might have).

This is implemented by using the `owi iso file1.wasm file2.wasm` subcommand. This command will get the list of all common imports between the two modules (same name and signature). Then, for each of them, it'll build a harness to invoke the two functions with symbols and check if the (symbolic) outputs can be shown to be equivalent.

For now, this is does not handle Wasm traps (as shown by the use of the `--fail-on-assertion-only`), but I plan to extend it later. It needs the development version of Owi and the following PR: https://github.com/OCamlPro/owi/pull/582/files

There are a few things left to do.

First, I don't understand why sometimes `log-i64` is imported with the following signature:

```wat
  (import "fuzzing-support" "log-i64" (func  (param i32) (param i32)))
```

And sometimes with the following one:

```wat
  (import "fuzzing-support" "log-i64" (func  (param i64)))
```

I also noticed some error happening during Owi's parsing of binary files. Is binaryen still generating non-standard binaries? If not, it may simply be a bug in Owi, or an unhandled Wasm proposal that I forgot in `all_disallowed` (is there a full list of the proposals somewhere?).

Finally, a few imports are missing in Owi (`table-get` and `table-set`).

(I commented out the other handlers, but this is of course only temporary to make testing easier).