### PR TITLE
Allow JS and C to read the start function of a module

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5289,6 +5289,10 @@ void BinaryenSetStart(BinaryenModuleRef module, BinaryenFunctionRef start) {
   ((Module*)module)->addStart(((Function*)start)->name);
 }
 
+BinaryenFunctionRef BinaryenGetStart(BinaryenModuleRef module) {
+  return ((Module*)module)->getFunctionOrNull(((Module*)module)->start);
+}
+
 // Features
 
 BinaryenFeatures BinaryenModuleGetFeatures(BinaryenModuleRef module) {

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2869,6 +2869,8 @@ BINARYEN_API void BinaryenAddDataSegment(BinaryenModuleRef module,
 BINARYEN_API void BinaryenSetStart(BinaryenModuleRef module,
                                    BinaryenFunctionRef start);
 
+BINARYEN_API BinaryenFunctionRef BinaryenGetStart(BinaryenModuleRef module);
+
 // Features
 
 // These control what features are allowed when validation and in passes.

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2594,6 +2594,9 @@ function wrapModule(module, self = {}) {
   self['setStart'] = function(start) {
     return Module['_BinaryenSetStart'](module, start);
   };
+  self['getStart'] = function() {
+    return Module['_BinaryenGetStart'](module);
+  };
   self['getFeatures'] = function() {
     return Module['_BinaryenModuleGetFeatures'](module);
   };

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -760,6 +760,7 @@ function test_core() {
   // Start function. One per module
   var starter = module.addFunction("starter", binaryen.none, binaryen.none, [], module.nop());
   module.setStart(starter);
+  assert(module.getStart() == starter);
 
   var features = binaryen.Features.All;
   module.setFeatures(features);

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -1376,6 +1376,7 @@ void test_core() {
                                                     0,
                                                     BinaryenNop(module));
   BinaryenSetStart(module, starter);
+  assert(BinaryenGetStart(module) == starter);
 
   BinaryenFeatures features = BinaryenFeatureAll();
   BinaryenModuleSetFeatures(module, features);


### PR DESCRIPTION
This PR adds `BinaryenGetStart` to the C api and the corresponding `module.getStart` JS wrapper.