### PR TITLE
OptimizeInstructions: Optimize `unsigned(x) < 0 => i32(0)` even with side effects

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -564,11 +564,11 @@ struct OptimizeInstructions
           return replaceCurrent(c);
         }
         // unsigned(x) < 0   =>   i32(0)
-        if (matches(curr, binary(LtU, pure(&x), ival(&c))) &&
+        if (matches(curr, binary(LtU, any(&x), ival(&c))) &&
             c->value.isZero()) {
           c->value = Literal::makeZero(Type::i32);
           c->type = Type::i32;
-          return replaceCurrent(c);
+          return replaceCurrent(getDroppedChildrenAndAppend(curr, c));
         }
       }
     }

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11372,18 +11372,28 @@
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (block (result i32)
   ;; CHECK-NEXT:      (drop
-  ;; CHECK-NEXT:        (i32.load
-  ;; CHECK-NEXT:          (i32.const 0)
-  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:       (i32.load
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (i64.load
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.ne
   ;; CHECK-NEXT:    (local.get $x)
@@ -11603,6 +11613,12 @@
     ))
     (drop (i64.lt_u
       (local.get $y)
+      (i64.const 0)
+    ))
+    (drop (i64.lt_u
+      (i64.load
+       (i32.const 0)
+      )
       (i64.const 0)
     ))
 

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11372,6 +11372,16 @@
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:        (i32.load
+  ;; CHECK-NEXT:          (i32.const 0)
+  ;; CHECK-NEXT:        )
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -11583,6 +11593,12 @@
     ;; (unsigned)x < 0  =>  i32(0)
     (drop (i32.lt_u
       (local.get $x)
+      (i32.const 0)
+    ))
+    (drop (i32.lt_u
+      (i32.load
+       (i32.const 0)
+      )
       (i32.const 0)
     ))
     (drop (i64.lt_u


### PR DESCRIPTION
Current peephole optimization for `unsigned(x) < 0 => i32(0)` is restrictive—actually we could replace the condition with const (zero here), while preserving any necessary side effects from the original expression or its children(by `getDroppedChildrenAndAppend`).

![Image](https://github.com/user-attachments/assets/57bf13f8-d851-46fd-87c5-0185236c188c)


Fixes #7418 