### PR TITLE
OptimizeInstructions: Optimize `unsigned(x) >= 0 => i32(1)` even with side effects

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -553,8 +553,6 @@ struct OptimizeInstructions
       }
       {
         // unsigned(x) >= 0   =>   i32(1)
-        // TODO: Use getDroppedChildrenAndAppend() here, so we can optimize even
-        //       if pure.
         Const* c;
         Expression* x;
         if (matches(curr, binary(GeU, any(&x), ival(&c))) &&

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -557,11 +557,11 @@ struct OptimizeInstructions
         //       if pure.
         Const* c;
         Expression* x;
-        if (matches(curr, binary(GeU, pure(&x), ival(&c))) &&
+        if (matches(curr, binary(GeU, any(&x), ival(&c))) &&
             c->value.isZero()) {
           c->value = Literal::makeOne(Type::i32);
           c->type = Type::i32;
-          return replaceCurrent(c);
+          return replaceCurrent(getDroppedChildrenAndAppend(curr, c));
         }
         // unsigned(x) < 0   =>   i32(0)
         if (matches(curr, binary(LtU, pure(&x), ival(&c))) &&

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17351,8 +17351,8 @@
   ;; CHECK-NEXT:  (i32.const 1)
   ;; CHECK-NEXT: )
   (func $skip-added-constants-zero-b (result i32)
-    ;; Parallel case to the above, with a zero in the added constant. We do not
-    ;; optimize.
+    ;; Parallel case to the above, with a zero in the added constant, but we
+    ;; do optimize the outer i32.ge_u away.
     (i32.ge_u
       (i32.add
         (i32.shr_u

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11366,7 +11366,27 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i64.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
@@ -11575,8 +11595,20 @@
       (local.get $x)
       (i32.const 0)
     ))
+    (drop (i32.ge_u
+      (i32.load
+       (i32.const 0)
+      )
+      (i32.const 0)
+    ))
     (drop (i64.ge_u
       (local.get $y)
+      (i64.const 0)
+    ))
+    (drop (i64.ge_u
+      (i64.load
+       (i32.const 0)
+      )
       (i64.const 0)
     ))
 
@@ -17304,20 +17336,20 @@
     )
   )
 
-  ;; CHECK:      (func $skip-added-constants-zero-b (result i32)
-  ;; CHECK-NEXT:  (i32.ge_u
-  ;; CHECK-NEXT:   (i32.add
-  ;; CHECK-NEXT:    (i32.shr_u
-  ;; CHECK-NEXT:     (i32.load
-  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK:       (func $skip-added-constants-zero-b (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (i32.add
+  ;; CHECK-NEXT:     (i32.shr_u
+  ;; CHECK-NEXT:      (i32.load
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
   (func $skip-added-constants-zero-b (result i32)
     ;; Parallel case to the above, with a zero in the added constant. We do not
     ;; optimize.

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17336,20 +17336,20 @@
     )
   )
 
-  ;; CHECK:       (func $skip-added-constants-zero-b (result i32)
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (i32.add
-  ;; CHECK-NEXT:     (i32.shr_u
-  ;; CHECK-NEXT:      (i32.load
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK:      (func $skip-added-constants-zero-b (result i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.add
+  ;; CHECK-NEXT:    (i32.shr_u
+  ;; CHECK-NEXT:     (i32.load
+  ;; CHECK-NEXT:      (i32.const 0)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (i32.const 1)
+  ;; CHECK-NEXT: )
   (func $skip-added-constants-zero-b (result i32)
     ;; Parallel case to the above, with a zero in the added constant. We do not
     ;; optimize.


### PR DESCRIPTION
Current peephole optimization for unsigned(x) >= 0 => i32(1) is restrictive—actually we could replace the condition with const (1 here), while preserving any necessary side effects from the original expression or its children(by getDroppedChildrenAndAppend).

![Image](https://github.com/user-attachments/assets/f2424153-c923-4622-8067-ff9a09af0c16)

Fixes #7425 