### PR TITLE
OptimizeInstructions: Optimize (unsigned)x <= -1  ==>   i32(1) even with side effects

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -4025,10 +4025,10 @@ private:
       return right;
     }
     // (unsigned)x <= -1  ==>   i32(1)
-    if (matches(curr, binary(LeU, pure(&left), ival(-1)))) {
+    if (matches(curr, binary(LeU, any(&left), ival(-1)))) {
       right->value = Literal::makeOne(Type::i32);
       right->type = Type::i32;
-      return right;
+      return getDroppedChildrenAndAppend(curr, right);
     }
     // (unsigned)x > -1   ==>   i32(0)
     if (matches(curr, binary(GtU, pure(&left), ival(-1)))) {

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11132,7 +11132,27 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i64.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.lt_s
@@ -11246,8 +11266,20 @@
       (local.get $x)
       (i32.const -1)
     ))
+    (drop (i32.le_u
+      (i32.load 
+        (i32.const 0)
+      )
+      (i32.const -1)
+    ))
     (drop (i64.le_u
       (local.get $y)
+      (i64.const -1)
+    ))
+    (drop (i64.le_u
+      (i64.load 
+        (i32.const 0)
+      )
       (i64.const -1)
     ))
     (drop (i32.le_s


### PR DESCRIPTION
Current peephole optimization for unsigned(x) <= -1 => i32(1) is restrictive—actually we could replace the condition with const (1 here), while preserving any necessary side effects from the original expression or its children(by getDroppedChildrenAndAppend).

Fixes #7434 