### PR TITLE
[NFC] Take a HeapType instead of Type in RefFunc::finalize

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -313,7 +313,7 @@ struct Precompute
           if (auto* r = curr->value->template dynCast<RefFunc>()) {
             r->func = singleValue.getFunc();
             auto heapType = getModule()->getFunction(r->func)->type;
-            r->finalize(Type(heapType, NonNullable));
+            r->finalize(heapType);
             curr->finalize();
             return;
           }

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -688,7 +688,7 @@ public:
   RefFunc* makeRefFunc(Name func, HeapType heapType) {
     auto* ret = wasm.allocator.alloc<RefFunc>();
     ret->func = func;
-    ret->finalize(Type(heapType, NonNullable));
+    ret->finalize(heapType);
     return ret;
   }
   RefEq* makeRefEq(Expression* left, Expression* right) {

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -1364,7 +1364,7 @@ public:
   Name func;
 
   void finalize();
-  void finalize(Type type_);
+  void finalize(HeapType heapType);
 };
 
 class RefEq : public SpecificExpression<Expression::RefEqId> {

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -821,7 +821,9 @@ void RefFunc::finalize() {
   assert(type.isSignature());
 }
 
-void RefFunc::finalize(Type type_) { type = type_; }
+void RefFunc::finalize(HeapType heapType) {
+  type = Type(heapType, NonNullable);
+}
 
 void RefEq::finalize() {
   if (left->type == Type::unreachable || right->type == Type::unreachable) {


### PR DESCRIPTION
This removes from the callers the burden of constructing the type with
the correct nullability and other future attributes.
