### PR TITLE
[NFC] Introduce HeapTypeDef and use it for printing

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -198,7 +198,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
       }
     }
 
-    TypeNames getNames(HeapType type) {
+    TypeNames getNames(HeapTypeDef type) {
       if (parent.currModule) {
         if (auto it = parent.currModule->typeNames.find(type);
             it != parent.currModule->typeNames.end()) {

--- a/src/tools/wasm-fuzz-types.cpp
+++ b/src/tools/wasm-fuzz-types.cpp
@@ -97,7 +97,7 @@ void Fuzzer::printTypes(const std::vector<HeapType>& types) {
   std::cout << "Built " << types.size() << " types:\n";
   struct FatalTypeNameGenerator
     : TypeNameGeneratorBase<FatalTypeNameGenerator> {
-    TypeNames getNames(HeapType type) {
+    TypeNames getNames(HeapTypeDef type) {
       Fatal() << "trying to print unknown heap type";
     }
   } fatalGenerator;

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -32,19 +32,21 @@ namespace wasm {
 // ability to use the generator as a function to print Types and HeapTypes to
 // streams.
 template<typename Subclass> struct TypeNameGeneratorBase {
-  TypeNames getNames(HeapType type) {
+  TypeNames getNames(HeapTypeDef type) {
     static_assert(&TypeNameGeneratorBase<Subclass>::getNames !=
                     &Subclass::getNames,
                   "Derived class must implement getNames");
     WASM_UNREACHABLE("Derived class must implement getNames");
   }
-  HeapType::Printed operator()(HeapType type) {
-    return type.print(
-      [&](HeapType ht) { return static_cast<Subclass*>(this)->getNames(ht); });
+  HeapType::Printed operator()(HeapTypeDef type) {
+    return type.print([&](HeapTypeDef ht) {
+      return static_cast<Subclass*>(this)->getNames(ht);
+    });
   }
   Type::Printed operator()(Type type) {
-    return type.print(
-      [&](HeapType ht) { return static_cast<Subclass*>(this)->getNames(ht); });
+    return type.print([&](HeapTypeDef ht) {
+      return static_cast<Subclass*>(this)->getNames(ht);
+    });
   }
 };
 
@@ -60,7 +62,7 @@ struct DefaultTypeNameGenerator
   // Cached names for types that have already been seen.
   std::unordered_map<HeapType, TypeNames> nameCache;
 
-  TypeNames getNames(HeapType type);
+  TypeNames getNames(HeapTypeDef type);
 };
 
 // Generates names based on the indices of types in some collection, falling

--- a/src/wasm-type-printing.h
+++ b/src/wasm-type-printing.h
@@ -50,12 +50,14 @@ template<typename Subclass> struct TypeNameGeneratorBase {
 
 private:
   constexpr void assertValidUsage() {
+#if !defined(__GNUC__) || __GNUC__ >= 14
     // Check that the subclass provides `getNames` with the correct type.
     using Self = TypeNameGeneratorBase<Subclass>;
     static_assert(
       static_cast<TypeNames (Self::*)(HeapTypeDef)>(&Self::getNames) !=
         static_cast<TypeNames (Self::*)(HeapTypeDef)>(&Subclass::getNames),
       "Derived class must implement getNames");
+#endif
   }
 };
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -50,6 +50,7 @@ void destroyAllTypesForTestingPurposesOnly();
 // data.
 class Type;
 class HeapType;
+class HeapTypeDef;
 class RecGroup;
 struct Signature;
 struct Continuation;
@@ -73,7 +74,7 @@ struct TypeNames {
 };
 
 // Used to generate HeapType names.
-using HeapTypeNameGenerator = std::function<TypeNames(HeapType)>;
+using HeapTypeNameGenerator = std::function<TypeNames(HeapTypeDef)>;
 
 // The type used for interning IDs in the public interfaces of Type and
 // HeapType.
@@ -292,6 +293,16 @@ public:
   }
 
   std::string toString() const;
+};
+
+// Like `HeapType`, but used to represent heap type definitions and abstract
+// heap types rather than arbitrary heap types. Use this whenever it would be a
+// category error to use an exact heap type.
+class HeapTypeDef : public HeapType {
+public:
+  // Allow implicit conversions from HeapType.
+  constexpr HeapTypeDef(HeapType type) : HeapType(type.with(Inexact)) {}
+  constexpr HeapTypeDef() = default;
 };
 
 class Type {
@@ -1006,6 +1017,10 @@ public:
 template<> class hash<wasm::HeapType> {
 public:
   size_t operator()(const wasm::HeapType&) const;
+};
+template<> class hash<wasm::HeapTypeDef> {
+public:
+  size_t operator()(const wasm::HeapTypeDef&) const;
 };
 template<> class hash<wasm::RecGroup> {
 public:

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2415,8 +2415,8 @@ public:
   // Module name, if specified. Serves a documentary role only.
   Name name;
 
-  std::unordered_map<HeapType, TypeNames> typeNames;
-  std::unordered_map<HeapType, Index> typeIndices;
+  std::unordered_map<HeapTypeDef, TypeNames> typeNames;
+  std::unordered_map<HeapTypeDef, Index> typeIndices;
 
   MixedArena allocator;
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -1369,7 +1369,7 @@ size_t RecGroup::size() const {
   }
 }
 
-TypeNames DefaultTypeNameGenerator::getNames(HeapType type) {
+TypeNames DefaultTypeNameGenerator::getNames(HeapTypeDef type) {
   auto [it, inserted] = nameCache.insert({type, {}});
   if (inserted) {
     // Generate a new name for this type we have not previously seen.
@@ -2766,6 +2766,10 @@ size_t hash<wasm::Array>::operator()(const wasm::Array& array) const {
 
 size_t hash<wasm::HeapType>::operator()(const wasm::HeapType& heapType) const {
   return wasm::hash(heapType.getID());
+}
+
+size_t hash<wasm::HeapTypeDef>::operator()(const wasm::HeapTypeDef& def) const {
+  return wasm::hash(def.getID());
 }
 
 size_t hash<wasm::RecGroup>::operator()(const wasm::RecGroup& group) const {


### PR DESCRIPTION
Now that we have exact heap types, non-abstract heap types no longer
correspond 1:1 with heap type definitions. We previously used a single
type, `HeapType`, to represent both heap types and heap type
definitions. Now that `HeapType` can represent multiple heap types
corresponding to the same definition, there is a new class of potential
bugs in which code that expects `HeapType` values to map 1:1 with heap
type definitions observes both an exact and inexact heap type for the
same definition.

To eliminate this class of bugs, introduce a new type, `HeapTypeDef`,
whose values do correspond 1:1 with heap type definitions. `HeapTypeDef`
is a subclass of `HeapType`, so it supports all the same functionality,
but it cannot represent exact heap types because its constructor clears
the exact bit.

As an initial proof-of-concept, use HeapTypeDef in the type printing
machinery, which only cares about heap type names corresponding to heap
type definitions. Future PRs will use HeapTypeDef in more places.
