### PR TITLE
[NFC] Use HeapTypeDef more widely

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -347,7 +347,7 @@ namespace {
 
 // Helper for collecting HeapTypes and their frequencies.
 struct TypeInfos {
-  InsertOrderedMap<HeapType, HeapTypeInfo> info;
+  InsertOrderedMap<HeapTypeDef, HeapTypeInfo> info;
 
   // Multivalue control flow structures need a function type, but the identity
   // of the function type (i.e. what recursion group it is in or whether it is
@@ -355,7 +355,7 @@ struct TypeInfos {
   // existing function type with the necessary signature.
   InsertOrderedMap<Signature, size_t> controlFlowSignatures;
 
-  void note(HeapType type) {
+  void note(HeapTypeDef type) {
     if (!type.isBasic()) {
       ++info[type].useCount;
     }
@@ -366,7 +366,7 @@ struct TypeInfos {
     }
   }
   // Ensure a type is included without increasing its count.
-  void include(HeapType type) {
+  void include(HeapTypeDef type) {
     if (!type.isBasic()) {
       info[type];
     }
@@ -388,7 +388,7 @@ struct TypeInfos {
       note(sig.results);
     }
   }
-  bool contains(HeapType type) { return info.count(type); }
+  bool contains(HeapTypeDef type) { return info.count(type); }
 };
 
 struct CodeScanner
@@ -468,11 +468,11 @@ struct CodeScanner
 };
 
 void classifyTypeVisibility(Module& wasm,
-                            InsertOrderedMap<HeapType, HeapTypeInfo>& types);
+                            InsertOrderedMap<HeapTypeDef, HeapTypeInfo>& types);
 
 } // anonymous namespace
 
-InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
+InsertOrderedMap<HeapTypeDef, HeapTypeInfo> collectHeapTypeInfo(
   Module& wasm, TypeInclusion inclusion, VisibilityHandling visibility) {
   // Collect module-level info.
   TypeInfos info;
@@ -523,9 +523,9 @@ InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
   // track which recursion groups we've already processed to avoid quadratic
   // behavior when there is a single large group.
   // TODO: Use a vector here, since we never try to add the same type twice.
-  UniqueNonrepeatingDeferredQueue<HeapType> newTypes;
-  std::unordered_map<Signature, HeapType> seenSigs;
-  auto noteNewType = [&](HeapType type) {
+  UniqueNonrepeatingDeferredQueue<HeapTypeDef> newTypes;
+  std::unordered_map<Signature, HeapTypeDef> seenSigs;
+  auto noteNewType = [&](HeapTypeDef type) {
     newTypes.push(type);
     if (type.isSignature()) {
       seenSigs.insert({type.getSignature(), type});
@@ -588,14 +588,14 @@ InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
 
 namespace {
 
-void classifyTypeVisibility(Module& wasm,
-                            InsertOrderedMap<HeapType, HeapTypeInfo>& types) {
+void classifyTypeVisibility(
+  Module& wasm, InsertOrderedMap<HeapTypeDef, HeapTypeInfo>& types) {
   // We will need to traverse the types used by public types and mark them
   // public as well.
-  std::vector<HeapType> workList;
+  std::vector<HeapTypeDef> workList;
   std::unordered_set<RecGroup> publicGroups;
 
-  auto notePublic = [&](HeapType type) {
+  auto notePublic = [&](HeapTypeDef type) {
     if (type.isBasic()) {
       return;
     }
@@ -694,9 +694,9 @@ void setIndices(IndexedHeapTypes& indexedTypes) {
 
 } // anonymous namespace
 
-std::vector<HeapType> collectHeapTypes(Module& wasm) {
+std::vector<HeapTypeDef> collectHeapTypes(Module& wasm) {
   auto info = collectHeapTypeInfo(wasm);
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
   types.reserve(info.size());
   for (auto& [type, _] : info) {
     types.push_back(type);
@@ -704,10 +704,10 @@ std::vector<HeapType> collectHeapTypes(Module& wasm) {
   return types;
 }
 
-std::vector<HeapType> getPublicHeapTypes(Module& wasm) {
+std::vector<HeapTypeDef> getPublicHeapTypes(Module& wasm) {
   auto info = collectHeapTypeInfo(
     wasm, TypeInclusion::BinaryTypes, VisibilityHandling::FindVisibility);
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
   types.reserve(info.size());
   for (auto& [type, typeInfo] : info) {
     if (typeInfo.visibility == Visibility::Public) {
@@ -717,10 +717,10 @@ std::vector<HeapType> getPublicHeapTypes(Module& wasm) {
   return types;
 }
 
-std::vector<HeapType> getPrivateHeapTypes(Module& wasm) {
+std::vector<HeapTypeDef> getPrivateHeapTypes(Module& wasm) {
   auto info = collectHeapTypeInfo(
     wasm, TypeInclusion::UsedIRTypes, VisibilityHandling::FindVisibility);
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
   types.reserve(info.size());
   for (auto& [type, typeInfo] : info) {
     if (typeInfo.visibility == Visibility::Private) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -470,26 +470,26 @@ struct HeapTypeInfo {
   Visibility visibility = Visibility::Unknown;
 };
 
-InsertOrderedMap<HeapType, HeapTypeInfo> collectHeapTypeInfo(
+InsertOrderedMap<HeapTypeDef, HeapTypeInfo> collectHeapTypeInfo(
   Module& wasm,
   TypeInclusion inclusion = TypeInclusion::AllTypes,
   VisibilityHandling visibility = VisibilityHandling::NoVisibility);
 
 // Helper function for collecting all the non-basic heap types used in the
 // module, i.e. the types that would appear in the type section.
-std::vector<HeapType> collectHeapTypes(Module& wasm);
+std::vector<HeapTypeDef> collectHeapTypes(Module& wasm);
 
 // Collect all the heap types visible on the module boundary that cannot be
 // changed. TODO: For open world use cases, this needs to include all subtypes
 // of public types as well.
-std::vector<HeapType> getPublicHeapTypes(Module& wasm);
+std::vector<HeapTypeDef> getPublicHeapTypes(Module& wasm);
 
 // getHeapTypes - getPublicHeapTypes
-std::vector<HeapType> getPrivateHeapTypes(Module& wasm);
+std::vector<HeapTypeDef> getPrivateHeapTypes(Module& wasm);
 
 struct IndexedHeapTypes {
-  std::vector<HeapType> types;
-  std::unordered_map<HeapType, Index> indices;
+  std::vector<HeapTypeDef> types;
+  std::unordered_map<HeapTypeDef, Index> indices;
 };
 
 // Similar to `collectHeapTypes`, but provides fast lookup of the index for each

--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -28,7 +28,7 @@ namespace wasm {
 //
 // This only scans user types, and not basic types like HeapType::eq.
 struct SubTypes {
-  SubTypes(const std::vector<HeapType>& types) : types(types) {
+  SubTypes(const std::vector<HeapTypeDef>& types) : types(types) {
     for (auto type : types) {
       note(type);
     }
@@ -198,11 +198,11 @@ struct SubTypes {
 
   // All the types in the program. This is computed here anyhow, and can be
   // useful for callers to iterate on, so it is public.
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
 
 private:
   // Add a type to the graph.
-  void note(HeapType type) {
+  void note(HeapTypeDef type) {
     if (auto super = type.getDeclaredSuperType()) {
       typeSubTypes[*super].push_back(type);
     }

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -1179,18 +1179,19 @@ struct ParseImplicitTypeDefsCtx : TypeParserCtx<ParseImplicitTypeDefsCtx> {
   Lexer in;
 
   // Types parsed so far.
-  std::vector<HeapType>& types;
+  std::vector<HeapTypeDef>& types;
 
   // Map typeuse positions without an explicit type to the correct type.
-  std::unordered_map<Index, HeapType>& implicitTypes;
+  std::unordered_map<Index, HeapTypeDef>& implicitTypes;
 
   // Map signatures to the first defined heap type they match.
-  std::unordered_map<Signature, HeapType> sigTypes;
+  std::unordered_map<Signature, HeapTypeDef> sigTypes;
 
-  ParseImplicitTypeDefsCtx(Lexer& in,
-                           std::vector<HeapType>& types,
-                           std::unordered_map<Index, HeapType>& implicitTypes,
-                           const IndexMap& typeIndices)
+  ParseImplicitTypeDefsCtx(
+    Lexer& in,
+    std::vector<HeapTypeDef>& types,
+    std::unordered_map<Index, HeapTypeDef>& implicitTypes,
+    const IndexMap& typeIndices)
     : TypeParserCtx<ParseImplicitTypeDefsCtx>(typeIndices), in(in),
       types(types), implicitTypes(implicitTypes) {
     for (auto type : types) {
@@ -1231,7 +1232,7 @@ struct ParseImplicitTypeDefsCtx : TypeParserCtx<ParseImplicitTypeDefsCtx> {
     }
 
     auto sig = Signature(Type(paramTypes), Type(resultTypes));
-    auto [it, inserted] = sigTypes.insert({sig, HeapType::func});
+    auto [it, inserted] = sigTypes.insert({sig, HeapType(HeapType::func)});
     if (inserted) {
       auto type = HeapType(sig);
       it->second = type;
@@ -1259,8 +1260,8 @@ struct ParseModuleTypesCtx : TypeParserCtx<ParseModuleTypesCtx>,
 
   Module& wasm;
 
-  const std::vector<HeapType>& types;
-  const std::unordered_map<Index, HeapType>& implicitTypes;
+  const std::vector<HeapTypeDef>& types;
+  const std::unordered_map<Index, HeapTypeDef>& implicitTypes;
   const std::unordered_map<Index, Index>& implicitElemIndices;
 
   // The index of the current type.
@@ -1269,8 +1270,8 @@ struct ParseModuleTypesCtx : TypeParserCtx<ParseModuleTypesCtx>,
   ParseModuleTypesCtx(
     Lexer& in,
     Module& wasm,
-    const std::vector<HeapType>& types,
-    const std::unordered_map<Index, HeapType>& implicitTypes,
+    const std::vector<HeapTypeDef>& types,
+    const std::unordered_map<Index, HeapTypeDef>& implicitTypes,
     const std::unordered_map<Index, Index>& implicitElemIndices,
     const IndexMap& typeIndices)
     : TypeParserCtx<ParseModuleTypesCtx>(typeIndices), in(in), wasm(wasm),
@@ -1308,7 +1309,7 @@ struct ParseModuleTypesCtx : TypeParserCtx<ParseModuleTypesCtx>,
     return TypeUse{it->second, ids};
   }
 
-  Result<HeapType> getBlockTypeFromTypeUse(Index pos, TypeUse use) {
+  Result<HeapTypeDef> getBlockTypeFromTypeUse(Index pos, TypeUse use) {
     return use.type;
   }
 
@@ -1448,9 +1449,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   Module& wasm;
   Builder builder;
 
-  const std::vector<HeapType>& types;
-  const std::unordered_map<Index, HeapType>& implicitTypes;
-  const std::unordered_map<HeapType, std::unordered_map<Name, Index>>&
+  const std::vector<HeapTypeDef>& types;
+  const std::unordered_map<Index, HeapTypeDef>& implicitTypes;
+  const std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>>&
     typeNames;
   const std::unordered_map<Index, Index>& implicitElemIndices;
 
@@ -1475,9 +1476,9 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
   ParseDefsCtx(
     Lexer& in,
     Module& wasm,
-    const std::vector<HeapType>& types,
-    const std::unordered_map<Index, HeapType>& implicitTypes,
-    const std::unordered_map<HeapType, std::unordered_map<Name, Index>>&
+    const std::vector<HeapTypeDef>& types,
+    const std::unordered_map<Index, HeapTypeDef>& implicitTypes,
+    const std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>>&
       typeNames,
     const std::unordered_map<Index, Index>& implicitElemIndices,
     const IndexMap& typeIndices)
@@ -1501,7 +1502,7 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx> {
     return HeapType(Signature(Type::none, results[0]));
   }
 
-  Result<HeapType> getBlockTypeFromTypeUse(Index pos, HeapType type) {
+  Result<HeapTypeDef> getBlockTypeFromTypeUse(Index pos, HeapType type) {
     assert(type.isSignature());
     // TODO: Error if block parameters are named
     return type;

--- a/src/parser/parse-2-typedefs.cpp
+++ b/src/parser/parse-2-typedefs.cpp
@@ -22,8 +22,8 @@ Result<> parseTypeDefs(
   ParseDeclsCtx& decls,
   Lexer& input,
   IndexMap& typeIndices,
-  std::vector<HeapType>& types,
-  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames) {
+  std::vector<HeapTypeDef>& types,
+  std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>>& typeNames) {
   TypeBuilder builder(decls.typeDefs.size());
   ParseTypeDefsCtx ctx(input, builder, typeIndices);
   for (auto& recType : decls.recTypeDefs) {

--- a/src/parser/parse-3-implicit-types.cpp
+++ b/src/parser/parse-3-implicit-types.cpp
@@ -22,8 +22,8 @@ Result<>
 parseImplicitTypeDefs(ParseDeclsCtx& decls,
                       Lexer& input,
                       IndexMap& typeIndices,
-                      std::vector<HeapType>& types,
-                      std::unordered_map<Index, HeapType>& implicitTypes) {
+                      std::vector<HeapTypeDef>& types,
+                      std::unordered_map<Index, HeapTypeDef>& implicitTypes) {
   ParseImplicitTypeDefsCtx ctx(input, types, implicitTypes, typeIndices);
   for (Index pos : decls.implicitTypeDefs) {
     WithPosition with(ctx, pos);

--- a/src/parser/parse-4-module-types.cpp
+++ b/src/parser/parse-4-module-types.cpp
@@ -18,11 +18,12 @@
 
 namespace wasm::WATParser {
 
-Result<> parseModuleTypes(ParseDeclsCtx& decls,
-                          Lexer& input,
-                          IndexMap& typeIndices,
-                          std::vector<HeapType>& types,
-                          std::unordered_map<Index, HeapType>& implicitTypes) {
+Result<>
+parseModuleTypes(ParseDeclsCtx& decls,
+                 Lexer& input,
+                 IndexMap& typeIndices,
+                 std::vector<HeapTypeDef>& types,
+                 std::unordered_map<Index, HeapTypeDef>& implicitTypes) {
   ParseModuleTypesCtx ctx(input,
                           decls.wasm,
                           types,

--- a/src/parser/parse-5-defs.cpp
+++ b/src/parser/parse-5-defs.cpp
@@ -22,9 +22,9 @@ Result<> parseDefinitions(
   ParseDeclsCtx& decls,
   Lexer& input,
   IndexMap& typeIndices,
-  std::vector<HeapType>& types,
-  std::unordered_map<Index, HeapType>& implicitTypes,
-  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames) {
+  std::vector<HeapTypeDef>& types,
+  std::unordered_map<Index, HeapTypeDef>& implicitTypes,
+  std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>>& typeNames) {
   // Parse definitions.
   // TODO: Parallelize this.
   ParseDefsCtx ctx(input,

--- a/src/parser/wat-parser-internal.h
+++ b/src/parser/wat-parser-internal.h
@@ -28,29 +28,30 @@ Result<> parseTypeDefs(
   ParseDeclsCtx& decls,
   Lexer& input,
   IndexMap& typeIndices,
-  std::vector<HeapType>& types,
-  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames);
+  std::vector<HeapTypeDef>& types,
+  std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>>& typeNames);
 
 Result<>
 parseImplicitTypeDefs(ParseDeclsCtx& decls,
                       Lexer& input,
                       IndexMap& typeIndices,
-                      std::vector<HeapType>& types,
-                      std::unordered_map<Index, HeapType>& implicitTypes);
+                      std::vector<HeapTypeDef>& types,
+                      std::unordered_map<Index, HeapTypeDef>& implicitTypes);
 
-Result<> parseModuleTypes(ParseDeclsCtx& decls,
-                          Lexer& input,
-                          IndexMap& typeIndices,
-                          std::vector<HeapType>& types,
-                          std::unordered_map<Index, HeapType>& implicitTypes);
+Result<>
+parseModuleTypes(ParseDeclsCtx& decls,
+                 Lexer& input,
+                 IndexMap& typeIndices,
+                 std::vector<HeapTypeDef>& types,
+                 std::unordered_map<Index, HeapTypeDef>& implicitTypes);
 
 Result<> parseDefinitions(
   ParseDeclsCtx& decls,
   Lexer& input,
   IndexMap& typeIndices,
-  std::vector<HeapType>& types,
-  std::unordered_map<Index, HeapType>& implicitTypes,
-  std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames);
+  std::vector<HeapTypeDef>& types,
+  std::unordered_map<Index, HeapTypeDef>& implicitTypes,
+  std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>>& typeNames);
 
 // RAII utility for temporarily changing the parsing position of a parsing
 // context.

--- a/src/parser/wat-parser.cpp
+++ b/src/parser/wat-parser.cpp
@@ -100,11 +100,11 @@ Result<> doParseModule(Module& wasm, Lexer& input, bool allowExtra) {
   auto typeIndices = createIndexMap(decls.in, decls.typeDefs);
   CHECK_ERR(typeIndices);
 
-  std::vector<HeapType> types;
-  std::unordered_map<HeapType, std::unordered_map<Name, Index>> typeNames;
+  std::vector<HeapTypeDef> types;
+  std::unordered_map<HeapTypeDef, std::unordered_map<Name, Index>> typeNames;
   CHECK_ERR(parseTypeDefs(decls, input, *typeIndices, types, typeNames));
 
-  std::unordered_map<Index, HeapType> implicitTypes;
+  std::unordered_map<Index, HeapTypeDef> implicitTypes;
   CHECK_ERR(
     parseImplicitTypeDefs(decls, input, *typeIndices, types, implicitTypes));
 

--- a/src/passes/NameTypes.cpp
+++ b/src/passes/NameTypes.cpp
@@ -32,7 +32,7 @@ struct NameTypes : public Pass {
 
   void run(Module* module) override {
     // Find all the types.
-    std::vector<HeapType> types = ModuleUtils::collectHeapTypes(*module);
+    std::vector<HeapTypeDef> types = ModuleUtils::collectHeapTypes(*module);
 
     std::unordered_set<Name> used;
 

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -141,7 +141,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
   // Used to print delegate's depth argument when it throws to the caller
   int controlFlowDepth = 0;
 
-  std::vector<HeapType> heapTypes;
+  std::vector<HeapTypeDef> heapTypes;
   std::unordered_map<Signature, HeapType> signatureTypes;
 
   // Track the print indent so that we can see when it changes. That affects how
@@ -173,7 +173,7 @@ struct PrintSExpression : public UnifiedExpressionVisitor<PrintSExpression> {
     DefaultTypeNameGenerator fallback;
     std::unordered_map<HeapType, TypeNames> fallbackNames;
 
-    TypePrinter(PrintSExpression& parent, const std::vector<HeapType>& types)
+    TypePrinter(PrintSExpression& parent, const std::vector<HeapTypeDef>& types)
       : parent(parent) {
       if (!parent.currModule) {
         return;

--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -69,11 +69,11 @@ namespace {
 // way to ensure that the new types are in fact in a new rec group.
 //
 // TODO: Move this outside if we find more uses.
-std::vector<HeapType> ensureTypesAreInNewRecGroup(RecGroup recGroup,
-                                                  Module& wasm) {
+std::vector<HeapTypeDef> ensureTypesAreInNewRecGroup(RecGroup recGroup,
+                                                     Module& wasm) {
   auto num = recGroup.size();
 
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
   types.reserve(num);
   for (auto type : recGroup) {
     types.push_back(type);
@@ -81,8 +81,8 @@ std::vector<HeapType> ensureTypesAreInNewRecGroup(RecGroup recGroup,
 
   // Find all the heap types present before we create the new ones. The new
   // types must not appear in |existingSet|.
-  std::vector<HeapType> existing = ModuleUtils::collectHeapTypes(wasm);
-  std::unordered_set<HeapType> existingSet(existing.begin(), existing.end());
+  std::vector<HeapTypeDef> existing = ModuleUtils::collectHeapTypes(wasm);
+  std::unordered_set<HeapTypeDef> existingSet(existing.begin(), existing.end());
 
   // Check for a collision with an existing rec group. Note that it is enough to
   // check one of the types: either the entire rec group gets merged, so they

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -191,11 +191,12 @@ private:
   std::vector<Type> loggableTypes;
 
   // The heap types we can pick from to generate instructions.
-  std::vector<HeapType> interestingHeapTypes;
+  std::vector<HeapTypeDef> interestingHeapTypes;
 
   // A mapping of a heap type to the subset of interestingHeapTypes that are
   // subtypes of it.
-  std::unordered_map<HeapType, std::vector<HeapType>> interestingHeapSubTypes;
+  std::unordered_map<HeapTypeDef, std::vector<HeapTypeDef>>
+    interestingHeapSubTypes;
 
   // Type => list of struct fields that have that type.
   std::unordered_map<Type, std::vector<StructField>> typeStructFields;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -484,11 +484,11 @@ void TranslateToFuzzReader::setupHeapTypes() {
     // Basic types must be handled directly, since subTypes doesn't look at
     // those.
     auto share = type.getShared();
-    auto struct_ = HeapTypes::struct_.getBasic(share);
-    auto array = HeapTypes::array.getBasic(share);
-    auto eq = HeapTypes::eq.getBasic(share);
-    auto any = HeapTypes::any.getBasic(share);
-    auto func = HeapTypes::func.getBasic(share);
+    HeapType struct_ = HeapTypes::struct_.getBasic(share);
+    HeapType array = HeapTypes::array.getBasic(share);
+    HeapType eq = HeapTypes::eq.getBasic(share);
+    HeapType any = HeapTypes::any.getBasic(share);
+    HeapType func = HeapTypes::func.getBasic(share);
     switch (type.getKind()) {
       case HeapTypeKind::Func:
         interestingHeapSubTypes[func].push_back(type);

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -669,7 +669,7 @@ namespace {
 // supertypes in which they appear.
 struct Inhabitator {
   // Uniquely identify fields as an index into a type.
-  using FieldPos = std::pair<HeapType, Index>;
+  using FieldPos = std::pair<HeapTypeDef, Index>;
 
   // When we make a reference nullable, we typically need to make the same
   // reference in other types nullable to maintain valid subtyping. Which types
@@ -682,14 +682,14 @@ struct Inhabitator {
   enum Variance { Invariant, Covariant };
 
   // The input types.
-  const std::vector<HeapType>& types;
+  const std::vector<HeapTypeDef>& types;
 
   // The fields we will make nullable.
   std::unordered_set<FieldPos> nullables;
 
   SubTypes subtypes;
 
-  Inhabitator(const std::vector<HeapType>& types)
+  Inhabitator(const std::vector<HeapTypeDef>& types)
     : types(types), subtypes(types) {}
 
   Variance getVariance(FieldPos fieldPos);
@@ -698,7 +698,7 @@ struct Inhabitator {
   void markExternRefsNullable();
   void breakNonNullableCycles();
 
-  std::vector<HeapType> build();
+  std::vector<HeapTypeDef> build();
 };
 
 Inhabitator::Variance Inhabitator::getVariance(FieldPos fieldPos) {
@@ -749,7 +749,7 @@ void Inhabitator::markNullable(FieldPos field) {
       // this extra `index` variable once we have C++20. It's a workaround for
       // lambdas being unable to capture structured bindings.
       const size_t index = idx;
-      subtypes.iterSubTypes(curr, [&](HeapType type, Index) {
+      subtypes.iterSubTypes(curr, [&](HeapTypeDef type, Index) {
         nullables.insert({type, index});
       });
       break;
@@ -800,13 +800,13 @@ void Inhabitator::markExternRefsNullable() {
 // the cycle to be made non-nullable.
 void Inhabitator::breakNonNullableCycles() {
   // Types we've finished visiting. We don't need to visit them again.
-  std::unordered_set<HeapType> visited;
+  std::unordered_set<HeapTypeDef> visited;
 
   // The path of types we are currently visiting. If one of them comes back up,
   // we've found a cycle. Map the types to the other types they reference and
   // our current index into that list so we can track where we are in each level
   // of the search.
-  InsertOrderedMap<HeapType, std::pair<std::vector<Type>, Index>> visiting;
+  InsertOrderedMap<HeapTypeDef, std::pair<std::vector<Type>, Index>> visiting;
 
   for (auto root : types) {
     if (visited.count(root)) {
@@ -881,8 +881,8 @@ void Inhabitator::breakNonNullableCycles() {
   }
 }
 
-std::vector<HeapType> Inhabitator::build() {
-  std::unordered_map<HeapType, size_t> typeIndices;
+std::vector<HeapTypeDef> Inhabitator::build() {
+  std::unordered_map<HeapTypeDef, size_t> typeIndices;
   for (size_t i = 0; i < types.size(); ++i) {
     typeIndices.insert({types[i], i});
   }
@@ -975,16 +975,16 @@ std::vector<HeapType> Inhabitator::build() {
 
 } // anonymous namespace
 
-std::vector<HeapType>
-HeapTypeGenerator::makeInhabitable(const std::vector<HeapType>& types) {
+std::vector<HeapTypeDef>
+HeapTypeGenerator::makeInhabitable(const std::vector<HeapTypeDef>& types) {
   if (types.empty()) {
     return {};
   }
 
   // Remove duplicate and basic types. We will insert them back at the end.
-  std::unordered_map<HeapType, size_t> typeIndices;
+  std::unordered_map<HeapTypeDef, size_t> typeIndices;
   std::vector<size_t> deduplicatedIndices;
-  std::vector<HeapType> deduplicated;
+  std::vector<HeapTypeDef> deduplicated;
   for (auto type : types) {
     if (type.isBasic()) {
       deduplicatedIndices.push_back(-1);
@@ -1006,7 +1006,7 @@ HeapTypeGenerator::makeInhabitable(const std::vector<HeapType>& types) {
   deduplicated = inhabitator.build();
 
   // Re-duplicate and re-insert basic types as necessary.
-  std::vector<HeapType> result;
+  std::vector<HeapTypeDef> result;
   for (size_t i = 0; i < types.size(); ++i) {
     if (deduplicatedIndices[i] == (size_t)-1) {
       assert(types[i].isBasic());
@@ -1021,14 +1021,14 @@ HeapTypeGenerator::makeInhabitable(const std::vector<HeapType>& types) {
 namespace {
 
 bool isUninhabitable(Type type,
-                     std::unordered_set<HeapType>& visited,
-                     std::unordered_set<HeapType>& visiting);
+                     std::unordered_set<HeapTypeDef>& visited,
+                     std::unordered_set<HeapTypeDef>& visiting);
 
 // Simple recursive DFS through non-nullable references to see if we find any
 // cycles.
-bool isUninhabitable(HeapType type,
-                     std::unordered_set<HeapType>& visited,
-                     std::unordered_set<HeapType>& visiting) {
+bool isUninhabitable(HeapTypeDef type,
+                     std::unordered_set<HeapTypeDef>& visited,
+                     std::unordered_set<HeapTypeDef>& visiting) {
   switch (type.getKind()) {
     case HeapTypeKind::Basic:
       return false;
@@ -1071,8 +1071,8 @@ bool isUninhabitable(HeapType type,
 }
 
 bool isUninhabitable(Type type,
-                     std::unordered_set<HeapType>& visited,
-                     std::unordered_set<HeapType>& visiting) {
+                     std::unordered_set<HeapTypeDef>& visited,
+                     std::unordered_set<HeapTypeDef>& visiting) {
   if (type.isRef() && type.isNonNullable()) {
     if (type.getHeapType().isBottom() ||
         type.getHeapType().isMaybeShared(HeapType::ext)) {
@@ -1085,10 +1085,10 @@ bool isUninhabitable(Type type,
 
 } // anonymous namespace
 
-std::vector<HeapType>
-HeapTypeGenerator::getInhabitable(const std::vector<HeapType>& types) {
-  std::unordered_set<HeapType> visited, visiting;
-  std::vector<HeapType> inhabitable;
+std::vector<HeapTypeDef>
+HeapTypeGenerator::getInhabitable(const std::vector<HeapTypeDef>& types) {
+  std::unordered_set<HeapTypeDef> visited, visiting;
+  std::vector<HeapTypeDef> inhabitable;
   for (auto type : types) {
     if (!isUninhabitable(type, visited, visiting)) {
       inhabitable.push_back(type);

--- a/src/tools/fuzzing/heap-types.h
+++ b/src/tools/fuzzing/heap-types.h
@@ -42,12 +42,12 @@ struct HeapTypeGenerator {
   // Given a sequence of newly-built heap types, produce a sequence of similar
   // or identical types that are all inhabitable, i.e. that are possible to
   // create values for.
-  static std::vector<HeapType>
-  makeInhabitable(const std::vector<HeapType>& types);
+  static std::vector<HeapTypeDef>
+  makeInhabitable(const std::vector<HeapTypeDef>& types);
 
   // Returns the types in the input that are inhabitable.
-  static std::vector<HeapType>
-  getInhabitable(const std::vector<HeapType>& types);
+  static std::vector<HeapTypeDef>
+  getInhabitable(const std::vector<HeapTypeDef>& types);
 };
 
 } // namespace wasm

--- a/src/tools/wasm-fuzz-types.cpp
+++ b/src/tools/wasm-fuzz-types.cpp
@@ -39,7 +39,7 @@ struct Fuzzer {
   bool verbose;
 
   // Initialized by `run` for checkers and possible later inspection
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
   std::vector<std::vector<Index>> subtypeIndices;
   Random rand;
 
@@ -48,7 +48,7 @@ struct Fuzzer {
   // Generate types and run checkers on them.
   void run(uint64_t seed);
 
-  static void printTypes(const std::vector<HeapType>&);
+  static void printTypes(const std::vector<HeapTypeDef>&);
 
   // Checkers for various properties.
   void checkSubtypes() const;
@@ -93,7 +93,7 @@ void Fuzzer::run(uint64_t seed) {
   checkRecGroupShapes();
 }
 
-void Fuzzer::printTypes(const std::vector<HeapType>& types) {
+void Fuzzer::printTypes(const std::vector<HeapTypeDef>& types) {
   std::cout << "Built " << types.size() << " types:\n";
   struct FatalTypeNameGenerator
     : TypeNameGeneratorBase<FatalTypeNameGenerator> {
@@ -233,7 +233,7 @@ void Fuzzer::checkCanonicalization() {
   // between canonical and temporary components.
   struct Copier {
     Random& rand;
-    const std::vector<HeapType>& types;
+    const std::vector<HeapTypeDef>& types;
     TypeBuilder& builder;
 
     // For each type, the indices in `types` at which it appears.
@@ -479,7 +479,8 @@ void Fuzzer::checkCanonicalization() {
 }
 
 void Fuzzer::checkInhabitable() {
-  std::vector<HeapType> inhabitable = HeapTypeGenerator::makeInhabitable(types);
+  std::vector<HeapTypeDef> inhabitable =
+    HeapTypeGenerator::makeInhabitable(types);
   if (verbose) {
     std::cout << "\nInhabitable types:\n\n";
     printTypes(inhabitable);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1458,7 +1458,7 @@ class WasmBinaryReader {
   SourceMapReader sourceMapReader;
 
   // All types defined in the type section
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
 
 public:
   WasmBinaryReader(Module& wasm,

--- a/src/wasm-type-ordering.h
+++ b/src/wasm-type-ordering.h
@@ -29,12 +29,12 @@ namespace wasm::HeapTypeOrdering {
 // type in the sequence comes only after its immediate supertype in the
 // collection is visited.
 template<typename T>
-std::vector<HeapType> supertypesFirst(
+std::vector<HeapTypeDef> supertypesFirst(
   const T& types,
-  std::function<std::optional<HeapType>(HeapType)> getSuper =
-    [](HeapType type) { return type.getDeclaredSuperType(); }) {
+  std::function<std::optional<HeapTypeDef>(HeapTypeDef)> getSuper =
+    [](HeapTypeDef type) { return type.getDeclaredSuperType(); }) {
 
-  InsertOrderedMap<HeapType, std::vector<HeapType>> subtypes;
+  InsertOrderedMap<HeapTypeDef, std::vector<HeapTypeDef>> subtypes;
   for (auto type : types) {
     subtypes.insert({type, {}});
   }

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -855,14 +855,14 @@ struct TypeBuilder {
     ErrorReason reason;
   };
 
-  struct BuildResult : std::variant<std::vector<HeapType>, Error> {
+  struct BuildResult : std::variant<std::vector<HeapTypeDef>, Error> {
     operator bool() const {
-      return bool(std::get_if<std::vector<HeapType>>(this));
+      return bool(std::get_if<std::vector<HeapTypeDef>>(this));
     }
-    const std::vector<HeapType>& operator*() const {
-      return std::get<std::vector<HeapType>>(*this);
+    const std::vector<HeapTypeDef>& operator*() const {
+      return std::get<std::vector<HeapTypeDef>>(*this);
     }
-    const std::vector<HeapType>* operator->() const { return &*(*this); }
+    const std::vector<HeapTypeDef>* operator->() const { return &*(*this); }
     const Error* getError() const { return std::get_if<Error>(this); }
   };
 

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -2574,7 +2574,7 @@ buildRecGroup(std::unique_ptr<RecGroupInfo>&& groupInfo,
       canonicalized.insert({group[i], canonical[i]});
     }
     // Return the canonical types.
-    return {std::vector<HeapType>(canonical.begin(), canonical.end())};
+    return {std::vector<HeapTypeDef>(canonical.begin(), canonical.end())};
   }
 
   // The group was successfully moved to the global rec group store, so it is
@@ -2588,7 +2588,7 @@ buildRecGroup(std::unique_ptr<RecGroupInfo>&& groupInfo,
     }
   }
 
-  std::vector<HeapType> results(group.begin(), group.end());
+  std::vector<HeapTypeDef> results(group.begin(), group.end());
 
   // We need to make the tuples canonical as well, but right now there is no way
   // to move them to their global store, so we have to create new tuples and
@@ -2622,7 +2622,7 @@ buildRecGroup(std::unique_ptr<RecGroupInfo>&& groupInfo,
 TypeBuilder::BuildResult TypeBuilder::build() {
   size_t entryCount = impl->entries.size();
 
-  std::vector<HeapType> results;
+  std::vector<HeapTypeDef> results;
   results.reserve(entryCount);
 
   // Map temporary HeapTypes to their canonicalized versions so they can be

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -349,7 +349,7 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
     std::vector<PossibleContents> vec(set.begin(), set.end());
 
     // Find the maximum depths for the normalized cone tests later down.
-    std::unordered_set<HeapType> heapTypes;
+    std::unordered_set<HeapTypeDef> heapTypes;
     for (auto& contents : set) {
       auto type = contents.getType();
       if (type.isRef()) {
@@ -359,7 +359,7 @@ TEST_F(PossibleContentsTest, TestIntersectWithCombinations) {
         }
       }
     }
-    std::vector<HeapType> heapTypesVec(heapTypes.begin(), heapTypes.end());
+    std::vector<HeapTypeDef> heapTypesVec(heapTypes.begin(), heapTypes.end());
     SubTypes subTypes(heapTypesVec);
     auto maxDepths = subTypes.getMaxDepths();
 

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -185,7 +185,7 @@ TEST_F(TypeTest, Basics) {
 
   auto result = builder.build();
   ASSERT_TRUE(result);
-  std::vector<HeapType> built = *result;
+  std::vector<HeapTypeDef> built = *result;
   ASSERT_EQ(built.size(), size_t{3});
 
   // The built types should have the correct kinds.

--- a/test/gtest/type-domains.h
+++ b/test/gtest/type-domains.h
@@ -134,7 +134,7 @@ struct TypeBuilderPlan {
   std::vector<TypeDefPlan> defs;
 
   // Built types.
-  std::vector<HeapType> types;
+  std::vector<HeapTypeDef> types;
 
   friend std::ostream& operator<<(std::ostream& o, const TypeBuilderPlan& plan);
 };


### PR DESCRIPTION
Update `TypeBuilder::build` to return a vector of `HeapTypeDef`.
Although `HeapTypeDef` is implicitly convertible to `HeapType`,
containers of `HeapTypeDef` are not implicitly convertible to containers
of `HeapType`, so this change requires several other utilities and
passes to start using `HeapTypeDef` directly and transitively.
