### PR TITLE
Use standard type printing for BINARYEN_PRINT_FULL

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -82,20 +82,20 @@ std::ostream& printLocal(Index index, Function* func, std::ostream& o) {
 // Print a name from the type section, if available. Otherwise print the type
 // normally.
 void printTypeOrName(Type type, std::ostream& o, Module* wasm) {
-  if (type.isRef() && wasm) {
-    auto heapType = type.getHeapType();
-    auto iter = wasm->typeNames.find(heapType);
-    if (iter != wasm->typeNames.end()) {
-      o << iter->second.name;
-      if (type.isNullable()) {
-        o << " null";
+  struct Printer : TypeNameGeneratorBase<Printer> {
+    Module* wasm;
+    DefaultTypeNameGenerator fallback;
+    Printer(Module* wasm) : wasm(wasm) {}
+    TypeNames getNames(HeapTypeDef type) {
+      if (wasm) {
+        if (auto it = wasm->typeNames.find(type); it != wasm->typeNames.end()) {
+          return it->second;
+        }
       }
-      return;
+      return fallback.getNames(type);
     }
-  }
-
-  // No luck with a name, just print the test as best we can.
-  o << type;
+  } print{wasm};
+  o << print(type);
 }
 
 } // anonymous namespace

--- a/test/lit/passes/gsi-debug.wast
+++ b/test/lit/passes/gsi-debug.wast
@@ -47,10 +47,10 @@
   ;; CHECK-NEXT:     ;;@
   ;; CHECK-NEXT:     (ref.as_non_null
   ;; CHECK-NEXT:      ;;@ local.c:30:3
-  ;; CHECK-NEXT:      (local.get $struct) (; struct null ;)
-  ;; CHECK-NEXT:     ) (; struct ;)
+  ;; CHECK-NEXT:      (local.get $struct) (; (ref null $struct) ;)
+  ;; CHECK-NEXT:     ) (; (ref $struct) ;)
   ;; CHECK-NEXT:     ;;@
-  ;; CHECK-NEXT:     (global.get $global1) (; struct ;)
+  ;; CHECK-NEXT:     (global.get $global1) (; (ref $struct) ;)
   ;; CHECK-NEXT:    ) (; i32 ;)
   ;; CHECK-NEXT:   ) (; i32 ;)
   ;; CHECK-NEXT:  ) (; none ;)


### PR DESCRIPTION
`printTypeOrName`, used to print types for BINARYEN_PRINT_FULL and a few
other niche use cases, previously had bespoke printing for references
that did not follow the standard format. To improve the output and
reduce the number of ways we print types, change it to use the standard
printing utility.
