### PR TITLE
Avoid overflow UB in random.cpp

### DIFF
--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -35,7 +35,7 @@ class Random {
   bool finishedInput = false;
   // After we finish the input, we start going through it again, but xoring
   // so it's not identical.
-  int xorFactor = 0;
+  unsigned int xorFactor = 0;
   // Features used for picking among FeatureOptions.
   FeatureSet features;
 


### PR DESCRIPTION
The random number generator adds into `xorFactor` in various places.
This variable was previously signed, so overflows from these adds were
UB. Make it unsigned to avoid UB.
