### PR TITLE
[GC] Fix global handling in TypeRefiningGUFA

### DIFF
--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -221,9 +221,7 @@ struct TypeRefining : public Pass {
           // To avoid ending up requiring a cast later, the type of our child
           // must fit perfectly in the field it is written to.
           auto childType = structNew->operands[i]->type;
-std::cout << "pre  " << infos[i].getLUB() << '\n';
           infos[i].note(childType);
-std::cout << "post " << infos[i].getLUB() << '\n';
         }
       }
     }

--- a/test/lit/passes/type-refining-gufa.wast
+++ b/test/lit/passes/type-refining-gufa.wast
@@ -296,10 +296,10 @@
   )
 )
 
-;; We can infer the first global contains a null, so the struct type's field
-;; can be a null. However, doing so would require adding a cast from the
-;; global's declared type (funcref) to the refined type, so that the struct.new
-;; validates. (Alternatively, we could need to refine the global's type at the
+;; GUFA can infer the first global contains a $func, so the struct type's field
+;; can be refined. However, doing so would require adding a cast from the
+;; global's declared type (ref func) to the refined type, so that the struct.new
+;; validates. (Alternatively, we would need to refine the global's type at the
 ;; same time we refine the struct, but this pass only refines structs.) The type
 ;; of the struct's field should only refine as much as is valid, which is the
 ;; type of the global, (ref func), and not the declared type $func. Both GUFA
@@ -338,22 +338,21 @@
   )
 )
 
-;; As above, but now the global has a refined type. Now GUFA can optimize while
-;; normal type refining cannot.
+;; As above, but now the global has a refined type, so we can refine fully.
 (module
   ;; NRML:      (rec
-  ;; NRML-NEXT:  (type $struct (struct (field (ref func))))
+  ;; NRML-NEXT:  (type $struct (struct (field (ref $func))))
   ;; GUFA:      (rec
-  ;; GUFA-NEXT:  (type $struct (struct (field (ref func))))
+  ;; GUFA-NEXT:  (type $struct (struct (field (ref $func))))
   (type $struct (struct (field funcref)))
 
   ;; NRML:       (type $func (func))
   ;; GUFA:       (type $func (func))
   (type $func (func))
 
-  ;; NRML:      (global $A (ref func) (ref.func $func))
-  ;; GUFA:      (global $A (ref func) (ref.func $func))
-  (global $A (ref func) (ref.func $func))
+  ;; NRML:      (global $A (ref $func) (ref.func $func))
+  ;; GUFA:      (global $A (ref $func) (ref.func $func))
+  (global $A (ref $func) (ref.func $func))  ;; the type here changed
 
   ;; NRML:      (global $B (ref $struct) (struct.new $struct
   ;; NRML-NEXT:  (global.get $A)

--- a/test/lit/passes/type-refining-gufa.wast
+++ b/test/lit/passes/type-refining-gufa.wast
@@ -302,7 +302,9 @@
 ;; validates. (Alternatively, we could need to refine the global's type at the
 ;; same time we refine the struct, but this pass only refines structs.) The type
 ;; of the struct's field should only refine as much as is valid, which is the
-;; type of the global, (ref func), and not the declared type $func.
+;; type of the global, (ref func), and not the declared type $func. Both GUFA
+;; and normal type refining succeed here (-O3 removes the entire module, and is
+;; not interesting here).
 (module
   ;; NRML:      (rec
   ;; NRML-NEXT:  (type $struct (struct (field (ref func))))
@@ -336,6 +338,8 @@
   )
 )
 
+;; As above, but now the global has a refined type. Now GUFA can optimize while
+;; normal type refining cannot.
 (module
   ;; NRML:      (rec
   ;; NRML-NEXT:  (type $struct (struct (field (ref func))))

--- a/test/lit/passes/type-refining-gufa.wast
+++ b/test/lit/passes/type-refining-gufa.wast
@@ -296,3 +296,87 @@
   )
 )
 
+;; We can infer the first global contains a null, so the struct type's field
+;; can be a null. However, doing so would require adding a cast from the
+;; global's declared type (funcref) to the refined type, so that the struct.new
+;; validates. (Alternatively, we could need to refine the global's type at the
+;; same time we refine the struct, but this pass only refines structs.) The type
+;; of the struct's field should only refine as much as is valid, which is the
+;; type of the global, (ref func), and not the declared type $func.
+(module
+  ;; NRML:      (rec
+  ;; NRML-NEXT:  (type $struct (struct (field (ref func))))
+  ;; GUFA:      (rec
+  ;; GUFA-NEXT:  (type $struct (struct (field (ref func))))
+  (type $struct (struct (field funcref)))
+
+  ;; NRML:       (type $func (func))
+  ;; GUFA:       (type $func (func))
+  (type $func (func))
+
+  ;; NRML:      (global $A (ref func) (ref.func $func))
+  ;; GUFA:      (global $A (ref func) (ref.func $func))
+  (global $A (ref func) (ref.func $func))
+
+  ;; NRML:      (global $B (ref $struct) (struct.new $struct
+  ;; NRML-NEXT:  (global.get $A)
+  ;; NRML-NEXT: ))
+  ;; GUFA:      (global $B (ref $struct) (struct.new $struct
+  ;; GUFA-NEXT:  (global.get $A)
+  ;; GUFA-NEXT: ))
+  (global $B (ref $struct) (struct.new $struct
+    (global.get $A)
+  ))
+
+  ;; NRML:      (func $func (type $func)
+  ;; NRML-NEXT: )
+  ;; GUFA:      (func $func (type $func)
+  ;; GUFA-NEXT: )
+  (func $func (type $func)
+  )
+)
+
+(module
+  ;; NRML:      (rec
+  ;; NRML-NEXT:  (type $struct (struct (field (ref func))))
+  ;; GUFA:      (rec
+  ;; GUFA-NEXT:  (type $struct (struct (field (ref func))))
+  (type $struct (struct (field funcref)))
+
+  ;; NRML:       (type $func (func))
+  ;; GUFA:       (type $func (func))
+  (type $func (func))
+
+  ;; NRML:      (global $A (ref func) (ref.func $func))
+  ;; GUFA:      (global $A (ref func) (ref.func $func))
+  (global $A (ref func) (ref.func $func))
+
+  ;; NRML:      (global $B (ref $struct) (struct.new $struct
+  ;; NRML-NEXT:  (global.get $A)
+  ;; NRML-NEXT: ))
+  ;; GUFA:      (global $B (ref $struct) (struct.new $struct
+  ;; GUFA-NEXT:  (global.get $A)
+  ;; GUFA-NEXT: ))
+  (global $B (ref $struct) (struct.new $struct
+    (global.get $A)
+  ))
+
+  ;; NRML:      (func $func (type $func)
+  ;; NRML-NEXT: )
+  ;; GUFA:      (func $func (type $func)
+  ;; GUFA-NEXT: )
+  (func $func (type $func)
+  )
+)
+
+;; Check we do not error on struct.new_default in a global. Here we can refine
+;; the field to nullref.
+(module
+  ;; NRML:      (type $struct (struct (field nullfuncref)))
+  ;; GUFA:      (type $struct (struct (field nullfuncref)))
+  (type $struct (struct (field funcref)))
+
+  ;; NRML:      (global $C (ref $struct) (struct.new_default $struct))
+  ;; GUFA:      (global $C (ref $struct) (struct.new_default $struct))
+  (global $C (ref $struct) (struct.new_default $struct))
+)


### PR DESCRIPTION
TypeRefiningGUFA refines struct types based on the types that flow into fields,
and looks past the immediate types in the IR. As a result, it can require
casts when we end up storing something that appears not-sufficiently-
refined to wasm validation rules, in ways that cannot occur with normal
TypeRefining.

The specific problem that can happen is that casts are disallowed in
globals, so we must be careful to not refine too much there.