### PR TITLE
Fix operator precedence in Binaryen.js tests

### DIFF
--- a/test/binaryen.js/sideffects.js
+++ b/test/binaryen.js/sideffects.js
@@ -88,7 +88,7 @@ assert(
     module
   )
   ==
-  binaryen.SideEffects.ReadsMemory | binaryen.SideEffects.ImplicitTrap
+  (binaryen.SideEffects.ReadsMemory | binaryen.SideEffects.ImplicitTrap)
 );
 assert(
   binaryen.getSideEffects(
@@ -99,7 +99,7 @@ assert(
     module
   )
   ==
-  binaryen.SideEffects.WritesMemory | binaryen.SideEffects.ImplicitTrap
+  (binaryen.SideEffects.WritesMemory | binaryen.SideEffects.ImplicitTrap)
 );
 assert(
   binaryen.getSideEffects(
@@ -121,7 +121,7 @@ assert(
     module
   )
   ==
-  binaryen.SideEffects.Calls | binaryen.SideEffects.Throws
+  (binaryen.SideEffects.Calls | binaryen.SideEffects.Throws)
 );
 
 assert(


### PR DESCRIPTION
The equality operator (`==`) has higher operator precedence than bitwise OR (`|`), meaning that `a == b | c` is interpreted like `(a == b) | c` and not `a == (b | c)`, how it was intended.