### PR TITLE
[NFC] Add an explicit ModuleRunner.start()

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5651,7 +5651,7 @@ BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize) {
 void BinaryenModuleInterpret(BinaryenModuleRef module) {
   ShellExternalInterface interface;
   ModuleRunner instance(*(Module*)module, &interface, {});
-  instance.start();
+  instance.instantiate();
 }
 
 BinaryenIndex BinaryenModuleAddDebugInfoFileName(BinaryenModuleRef module,

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -5651,6 +5651,7 @@ BinaryenModuleRef BinaryenModuleRead(char* input, size_t inputSize) {
 void BinaryenModuleInterpret(BinaryenModuleRef module) {
   ShellExternalInterface interface;
   ModuleRunner instance(*(Module*)module, &interface, {});
+  instance.start();
 }
 
 BinaryenIndex BinaryenModuleAddDebugInfoFileName(BinaryenModuleRef module,

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -271,7 +271,7 @@ struct ExecutionResults {
     LoggingExternalInterface interface(loggings, wasm);
     try {
       ModuleRunner instance(wasm, &interface);
-      instance.start();
+      instance.instantiate();
       interface.setModuleRunner(&instance);
       // execute all exported methods (that are therefore preserved through
       // opts)
@@ -431,7 +431,7 @@ struct ExecutionResults {
     LoggingExternalInterface interface(loggings, wasm);
     try {
       ModuleRunner instance(wasm, &interface);
-      instance.start();
+      instance.instantiate();
       interface.setModuleRunner(&instance);
       return run(func, wasm, instance);
     } catch (const TrapException&) {

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -271,6 +271,7 @@ struct ExecutionResults {
     LoggingExternalInterface interface(loggings, wasm);
     try {
       ModuleRunner instance(wasm, &interface);
+      instance.start();
       interface.setModuleRunner(&instance);
       // execute all exported methods (that are therefore preserved through
       // opts)
@@ -430,6 +431,7 @@ struct ExecutionResults {
     LoggingExternalInterface interface(loggings, wasm);
     try {
       ModuleRunner instance(wasm, &interface);
+      instance.start();
       interface.setModuleRunner(&instance);
       return run(func, wasm, instance);
     } catch (const TrapException&) {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1287,6 +1287,7 @@ void evalCtors(Module& wasm,
   try {
     // create an instance for evalling
     EvallingModuleRunner instance(wasm, &interface, linkedInstances);
+    instance.start();
     interface.instanceInitialized = true;
     // go one by one, in order, until we fail
     // TODO: if we knew priorities, we could reorder?

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -1287,7 +1287,7 @@ void evalCtors(Module& wasm,
   try {
     // create an instance for evalling
     EvallingModuleRunner instance(wasm, &interface, linkedInstances);
-    instance.start();
+    instance.instantiate();
     interface.instanceInitialized = true;
     // go one by one, in order, until we fail
     // TODO: if we knew priorities, we could reorder?

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -139,7 +139,7 @@ struct Shell {
         std::make_shared<ShellExternalInterface>(linkedInstances);
       auto instance =
         std::make_shared<ModuleRunner>(wasm, interface.get(), linkedInstances);
-      instance->start();
+      instance->instantiate();
       return {{std::move(interface), std::move(instance)}};
     } catch (...) {
       return Err{"failed to instantiate module"};

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -139,6 +139,7 @@ struct Shell {
         std::make_shared<ShellExternalInterface>(linkedInstances);
       auto instance =
         std::make_shared<ModuleRunner>(wasm, interface.get(), linkedInstances);
+      instance->start();
       return {{std::move(interface), std::move(instance)}};
     } catch (...) {
       return Err{"failed to instantiate module"};

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2900,7 +2900,12 @@ public:
     ExternalInterface* externalInterface,
     std::map<Name, std::shared_ptr<SubType>> linkedInstances_ = {})
     : ExpressionRunner<SubType>(&wasm), wasm(wasm),
-      externalInterface(externalInterface), linkedInstances(linkedInstances_) {
+      externalInterface(externalInterface), linkedInstances(linkedInstances_) {}
+
+  // Start up this instance. This must be called before doing anything else.
+  // (This is separate from the constructor so that it does not occur
+  // synchronously, which makes some code patterns harder to write.)
+  void start() {
     // import globals from the outside
     externalInterface->importGlobals(globals, wasm);
     // generate internal (non-imported) globals

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -2905,7 +2905,7 @@ public:
   // Start up this instance. This must be called before doing anything else.
   // (This is separate from the constructor so that it does not occur
   // synchronously, which makes some code patterns harder to write.)
-  void start() {
+  void instantiate() {
     // import globals from the outside
     externalInterface->importGlobals(globals, wasm);
     // generate internal (non-imported) globals


### PR DESCRIPTION
Previously the constructor ran the start method and other initialization. Doing
that in an explicit function that the user calls makes it possible to do things in
the middle. The specific thing I would like to do in the middle is have a function
to change the interpreter instance's mode to "reject as nonconstant relaxed SIMD",
but I've wanted this in the past too, and worked around it - seems best to just
fix it.

Adding more flags to the constructor is another option, but there are already
several, and more in the parent classes, and several levels of inheritance through
which all such options must be forwarded, which is annoying.