### PR TITLE
[Outlining] Improve logging

### DIFF
--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -435,8 +435,7 @@ struct Outlining : public Pass {
                Sequences seqByFunc,
                const HashStringifyWalker& stringify) {
 #else
-  void outline(Module* module,
-               Sequences seqByFunc) {
+  void outline(Module* module, Sequences seqByFunc) {
 #endif
     // TODO: Make this a function-parallel sub-pass.
     std::vector<Name> keys(seqByFunc.size());

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -51,15 +51,18 @@ struct OutliningSequence {
                     Name func,
                     bool endsTypeUnreachable
 #if OUTLINING_DEBUG
-                    , unsigned programIdx
+                    ,
+                    unsigned programIdx
 #endif
                     )
     : startIdx(startIdx), endIdx(endIdx), func(func),
       endsTypeUnreachable(endsTypeUnreachable)
 #if OUTLINING_DEBUG
-      , programIdx(programIdx)
+      ,
+      programIdx(programIdx)
 #endif
-    {}
+  {
+  }
 };
 
 // Instances of this walker are intended to walk a function at a time, at the
@@ -349,11 +352,13 @@ struct Outlining : public Pass {
     // are relative to the enclosing function while substrings have indices
     // relative to the entire program.
     auto sequences = makeSequences(module, substrings, stringify);
-    outline(module, sequences
+    outline(module,
+            sequences
 #if OUTLINING_DEBUG
-            , stringify
+            ,
+            stringify
 #endif
-           );
+    );
     // Position the outlined functions first in the functions vector to make
     // the outlining lit tests far more readable.
     moveOutlinedFunctions(module, substrings.size());
@@ -409,9 +414,10 @@ struct Outlining : public Pass {
           stringify.exprs[seqIdx + substring.Length - 1]->type ==
             Type::unreachable
 #if OUTLINING_DEBUG
-          , seqIdx
+          ,
+          seqIdx
 #endif
-          );
+        );
         seqByFunc[existingFunc].push_back(seq);
       }
     }
@@ -421,9 +427,10 @@ struct Outlining : public Pass {
   void outline(Module* module,
                Sequences seqByFunc
 #if OUTLINING_DEBUG
-               , const HashStringifyWalker& stringify
+               ,
+               const HashStringifyWalker& stringify
 #endif
-              ) {
+  ) {
     // TODO: Make this a function-parallel sub-pass.
     std::vector<Name> keys(seqByFunc.size());
     std::transform(seqByFunc.begin(),
@@ -492,7 +499,8 @@ struct Outlining : public Pass {
     std::cerr << "moving sequences: "
               << "\n";
     for (auto& seq : seqs) {
-      for (Index idx = seq.programIdx; idx < seq.programIdx + (seq.endIdx - seq.startIdx);
+      for (Index idx = seq.programIdx;
+           idx < seq.programIdx + (seq.endIdx - seq.startIdx);
            idx++) {
         Expression* expr = exprs[idx];
         if (expr == nullptr) {

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -295,6 +295,7 @@ struct Outlining : public Pass {
     HashStringifyWalker stringify;
     // Walk the module and create a "string representation" of the program.
     stringify.walkModule(module);
+    ODBG(printHashString(stringify.hashString, stringify.exprs));
     // Collect all of the substrings of the string representation that appear
     // more than once in the program.
     auto substrings =
@@ -435,6 +436,19 @@ struct Outlining : public Pass {
   }
 
 #if OUTLINING_DEBUG
+  void printHashString(const std::vector<uint32_t>& hashString,
+                       const std::vector<Expression*>& exprs) {
+    std::cerr << "\n\n";
+    for (Index idx = 0; idx < hashString.size(); idx++) {
+      Expression* expr = exprs[idx];
+      if (expr) {
+        std::cerr << idx << " - " << hashString[idx] << ": "
+                  << ShallowExpression{expr} << "\n";
+      } else {
+        std::cerr << idx << ": unique symbol\n";
+      }
+    }
+  }
   void printReconstruct(Module* module,
                         const std::vector<uint32_t>& hashString,
                         const std::vector<Expression*>& exprs,

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -455,7 +455,8 @@ struct Outlining : public Pass {
                         Name existingFunc,
                         const std::vector<OutliningSequence>& seqs) {
     std::cerr << "\n\nReconstructing existing fn: " << existingFunc << "\n";
-    std::cerr << "moving sequences: " << "\n";
+    std::cerr << "moving sequences: "
+              << "\n";
     for (auto& seq : seqs) {
       for (Index idx = seq.originalIdx; idx < seq.originalIdx + seq.length;
            idx++) {

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -254,25 +254,6 @@ private:
   std::map<uint32_t, Name> idxToFuncName;
 };
 
-struct OutliningSequence {
-  unsigned startIdx;
-  unsigned endIdx;
-  Name func;
-  bool endsTypeUnreachable;
-  unsigned originalIdx;
-  unsigned length;
-
-  OutliningSequence(unsigned startIdx,
-                    unsigned endIdx,
-                    Name func,
-                    bool endsTypeUnreachable,
-                    unsigned originalIdx,
-                    unsigned length)
-    : startIdx(startIdx), endIdx(endIdx), func(func),
-      endsTypeUnreachable(endsTypeUnreachable), originalIdx(originalIdx),
-      length(length) {}
-};
-
 using Substrings = std::vector<SuffixTree::RepeatedSubstring>;
 
 // Functions that filter vectors of SuffixTree::RepeatedSubstring

--- a/src/passes/stringify-walker.h
+++ b/src/passes/stringify-walker.h
@@ -259,13 +259,18 @@ struct OutliningSequence {
   unsigned endIdx;
   Name func;
   bool endsTypeUnreachable;
+  unsigned originalIdx;
+  unsigned length;
 
   OutliningSequence(unsigned startIdx,
                     unsigned endIdx,
                     Name func,
-                    bool endsTypeUnreachable)
+                    bool endsTypeUnreachable,
+                    unsigned originalIdx,
+                    unsigned length)
     : startIdx(startIdx), endIdx(endIdx), func(func),
-      endsTypeUnreachable(endsTypeUnreachable) {}
+      endsTypeUnreachable(endsTypeUnreachable), originalIdx(originalIdx),
+      length(length) {}
 };
 
 using Substrings = std::vector<SuffixTree::RepeatedSubstring>;


### PR DESCRIPTION
Improve the quality of debug logs during outlining by:

- reorder logs to occur before corresponding asserts
- rename the debug logging macro used in Outlining.cpp so its not defined twice
- add a parameter to function outline to thread the data needed for logging
- add a parameters to struct OutliningSequence to connect the sequence back to its location in the stringified binary