### PR TITLE
Switch source map parsing to use the JSON parser

### DIFF
--- a/src/source-map.h
+++ b/src/source-map.h
@@ -67,7 +67,7 @@ private:
   char peek() {
     if (pos == mappings.size()) {
       return '"';
-    }  else if (pos > mappings.size()) {
+    } else if (pos > mappings.size()) {
       throw MapParseException("unexpected end of source map");
     }
     return mappings[pos];

--- a/src/source-map.h
+++ b/src/source-map.h
@@ -18,7 +18,6 @@
 #define wasm_source_map_h
 
 #include <optional>
-#include <unordered_map>
 
 #include "wasm.h"
 
@@ -32,7 +31,8 @@ struct MapParseException {
 };
 
 class SourceMapReader {
-  const std::vector<char>& buffer;
+  std::vector<char>& buffer;
+  std::string_view mappings;
 
   // Current position in the source map buffer.
   size_t pos = 0;
@@ -53,9 +53,9 @@ class SourceMapReader {
   bool hasSymbol = false;
 
 public:
-  SourceMapReader(const std::vector<char>& buffer) : buffer(buffer) {}
+  SourceMapReader(std::vector<char>& buffer) : buffer(buffer) {}
 
-  void readHeader(Module& wasm);
+  void parse(Module& wasm);
 
   std::optional<Function::DebugLocation>
   readDebugLocationAt(size_t currLocation);
@@ -65,32 +65,18 @@ public:
 
 private:
   char peek() {
-    if (pos >= buffer.size()) {
+    if (pos == mappings.size()) {
+      return '"';
+    }  else if (pos > mappings.size()) {
       throw MapParseException("unexpected end of source map");
     }
-    return buffer[pos];
+    return mappings[pos];
   }
 
   char get() {
     char c = peek();
     ++pos;
     return c;
-  }
-
-  bool maybeGet(char c) {
-    if (pos < buffer.size() && peek() == c) {
-      ++pos;
-      return true;
-    }
-    return false;
-  }
-
-  void expect(char c) {
-    using namespace std::string_literals;
-    char got = get();
-    if (got != c) {
-      throw MapParseException("expected '"s + c + "', got '" + got + "'");
-    }
   }
 
   int32_t readBase64VLQ();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1464,7 +1464,7 @@ public:
   WasmBinaryReader(Module& wasm,
                    FeatureSet features,
                    const std::vector<char>& input,
-                   const std::vector<char>& sourceMap = defaultEmptySourceMap);
+                   std::vector<char>& sourceMap = defaultEmptySourceMap);
 
   void setDebugInfo(bool value) { debugInfo = value; }
   void setDWARF(bool value) { DWARF = value; }

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2173,6 +2173,10 @@ public:
                ? columnNumber < other.columnNumber
                : symbolNameIndex < other.symbolNameIndex;
     }
+    void dump() {
+      std::cerr << (symbolNameIndex ? symbolNameIndex.value() : -1) <<
+       " @ " << fileIndex << ":" << lineNumber << ":" << columnNumber << "\n";
+    }
   };
   // One can explicitly set the debug location of an expression to
   // nullopt to stop the propagation of debug locations.

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2174,8 +2174,9 @@ public:
                : symbolNameIndex < other.symbolNameIndex;
     }
     void dump() {
-      std::cerr << (symbolNameIndex ? symbolNameIndex.value() : -1) <<
-       " @ " << fileIndex << ":" << lineNumber << ":" << columnNumber << "\n";
+      std::cerr << (symbolNameIndex ? symbolNameIndex.value() : -1) << " @ "
+                << fileIndex << ":" << lineNumber << ":" << columnNumber
+                << "\n";
     }
   };
   // One can explicitly set the debug location of an expression to

--- a/src/wasm/source-map.cpp
+++ b/src/wasm/source-map.cpp
@@ -43,7 +43,8 @@ void SourceMapReader::parse(Module& wasm) {
   if (!sm_json.isObject()) {
     throw MapParseException("Source map is not valid JSON");
   }
-  if (!(sm_json.has("version") && sm_json["version"]->isNumber() && sm_json["version"]->getInteger() == 3)) {
+  if (!(sm_json.has("version") && sm_json["version"]->isNumber() &&
+        sm_json["version"]->getInteger() == 3)) {
     throw MapParseException("Source map version missing or is not 3");
   }
   if (!(sm_json.has("sources") && sm_json["sources"]->isArray())) {

--- a/src/wasm/source-map.cpp
+++ b/src/wasm/source-map.cpp
@@ -38,19 +38,19 @@ void SourceMapReader::parse(Module& wasm) {
   if (buffer.empty()) {
     return;
   }
-  json::Value sm_json;
-  sm_json.parse(buffer.data(), json::Value::ASCII);
-  if (!sm_json.isObject()) {
+  json::Value json;
+  json.parse(buffer.data(), json::Value::ASCII);
+  if (!json.isObject()) {
     throw MapParseException("Source map is not valid JSON");
   }
-  if (!(sm_json.has("version") && sm_json["version"]->isNumber() &&
-        sm_json["version"]->getInteger() == 3)) {
+  if (!(json.has("version") && json["version"]->isNumber() &&
+        json["version"]->getInteger() == 3)) {
     throw MapParseException("Source map version missing or is not 3");
   }
-  if (!(sm_json.has("sources") && sm_json["sources"]->isArray())) {
+  if (!(json.has("sources") && json["sources"]->isArray())) {
     throw MapParseException("Source map sources missing or not an array");
   }
-  json::Ref s = sm_json["sources"];
+  json::Ref s = json["sources"];
   for (size_t i = 0; i < s->size(); i++) {
     json::Ref v = s[i];
     if (!(s[i]->isString())) {
@@ -59,8 +59,8 @@ void SourceMapReader::parse(Module& wasm) {
     wasm.debugInfoFileNames.push_back(v->getCString());
   }
 
-  if (sm_json.has("names")) {
-    json::Ref n = sm_json["names"];
+  if (json.has("names")) {
+    json::Ref n = json["names"];
     if (!n->isArray()) {
       throw MapParseException("Source map names is not an array");
     }
@@ -73,10 +73,10 @@ void SourceMapReader::parse(Module& wasm) {
     }
   }
 
-  if (!sm_json.has("mappings")) {
+  if (!json.has("mappings")) {
     throw MapParseException("Source map mappings missing");
   }
-  json::Ref m = sm_json["mappings"];
+  json::Ref m = json["mappings"];
   if (!m->isString()) {
     throw MapParseException("Source map mappings is not a string");
   }

--- a/src/wasm/source-map.cpp
+++ b/src/wasm/source-map.cpp
@@ -16,6 +16,7 @@
 
 #include "source-map.h"
 #include "support/colors.h"
+#include "support/json.h"
 
 namespace wasm {
 
@@ -33,96 +34,54 @@ void MapParseException::dump(std::ostream& o) const {
   Colors::normal(o);
 }
 
-void SourceMapReader::readHeader(Module& wasm) {
-  assert(pos == 0);
+void SourceMapReader::parse(Module& wasm) {
   if (buffer.empty()) {
     return;
   }
-
-  auto skipWhitespace = [&]() {
-    while (pos < buffer.size() && (buffer[pos] == ' ' || buffer[pos] == '\n')) {
-      ++pos;
+  json::Value sm_json;
+  sm_json.parse(buffer.data(), json::Value::ASCII);
+  if (!sm_json.isObject()) {
+    throw MapParseException("Source map is not valid JSON");
+  }
+  if (!(sm_json.has("version") && sm_json["version"]->isNumber() && sm_json["version"]->getInteger() == 3)) {
+    throw MapParseException("Source map version missing or is not 3");
+  }
+  if (!(sm_json.has("sources") && sm_json["sources"]->isArray())) {
+    throw MapParseException("Source map sources missing or not an array");
+  }
+  json::Ref s = sm_json["sources"];
+  for (size_t i = 0; i < s->size(); i++) {
+    json::Ref v = s[i];
+    if (!(s[i]->isString())) {
+      throw MapParseException("Source map sources contains non-string");
     }
-  };
+    wasm.debugInfoFileNames.push_back(v->getCString());
+  }
 
-  auto findField = [&](const char* name) {
-    bool matching = false;
-    size_t len = strlen(name);
-    size_t index = 0;
-    while (1) {
-      char ch = get();
-      if (ch == '\"') {
-        if (matching) {
-          if (index == len) {
-            // We matched a terminating quote.
-            break;
-          }
-          matching = false;
-        } else {
-          // Beginning of a new potential match.
-          matching = true;
-          index = 0;
-        }
-      } else if (matching && name[index] == ch) {
-        ++index;
-      } else if (matching) {
-        matching = false;
+  if (sm_json.has("names")) {
+    json::Ref n = sm_json["names"];
+    if (!n->isArray()) {
+      throw MapParseException("Source map names is not an array");
+    }
+    for (size_t i = 0; i < n->size(); i++) {
+      json::Ref v = n[i];
+      if (!v->isString()) {
+        throw MapParseException("Source map names contains non-string");
       }
-    }
-    skipWhitespace();
-    expect(':');
-    skipWhitespace();
-    return true;
-  };
-
-  auto readString = [&](std::string& str) {
-    std::vector<char> vec;
-    skipWhitespace();
-    expect('\"');
-    while (1) {
-      if (maybeGet('\"')) {
-        break;
-      }
-      vec.push_back(get());
-    }
-    skipWhitespace();
-    str = std::string(vec.begin(), vec.end());
-  };
-
-  if (!findField("sources")) {
-    throw MapParseException("cannot find the 'sources' field in map");
-  }
-
-  skipWhitespace();
-  expect('[');
-  if (!maybeGet(']')) {
-    do {
-      std::string file;
-      readString(file);
-      wasm.debugInfoFileNames.push_back(file);
-    } while (maybeGet(','));
-    expect(']');
-  }
-
-  if (findField("names")) {
-    skipWhitespace();
-    expect('[');
-    if (!maybeGet(']')) {
-      do {
-        std::string symbol;
-        readString(symbol);
-        wasm.debugInfoSymbolNames.push_back(symbol);
-      } while (maybeGet(','));
-      expect(']');
+      wasm.debugInfoSymbolNames.push_back(v->getCString());
     }
   }
 
-  if (!findField("mappings")) {
-    throw MapParseException("cannot find the 'mappings' field in map");
+  if (!sm_json.has("mappings")) {
+    throw MapParseException("Source map mappings missing");
+  }
+  json::Ref m = sm_json["mappings"];
+  if (!m->isString()) {
+    throw MapParseException("Source map mappings is not a string");
   }
 
-  expect('\"');
-  if (maybeGet('\"')) {
+  mappings = m->getCString();
+  if (mappings.empty()) {
     // There are no mappings.
     location = 0;
     return;
@@ -134,10 +93,6 @@ void SourceMapReader::readHeader(Module& wasm) {
 
 std::optional<Function::DebugLocation>
 SourceMapReader::readDebugLocationAt(size_t currLocation) {
-  if (pos >= buffer.size()) {
-    return std::nullopt;
-  }
-
   while (location && location <= currLocation) {
     do {
       char next = peek();
@@ -164,13 +119,13 @@ SourceMapReader::readDebugLocationAt(size_t currLocation) {
     } while (false);
 
     // Check whether there is another record to read the position for.
-    char next = get();
-    if (next == '\"') {
+
+    if (peek() == '\"') {
       // End of records.
       location = 0;
       break;
     }
-    if (next != ',') {
+    if (get() != ',') {
       throw MapParseException("Expected delimiter");
     }
 
@@ -181,7 +136,6 @@ SourceMapReader::readDebugLocationAt(size_t currLocation) {
   if (!hasInfo) {
     return std::nullopt;
   }
-
   auto sym = hasSymbol ? symbol : std::optional<uint32_t>{};
   return Function::DebugLocation{file, line, col, sym};
 }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1774,7 +1774,7 @@ void WasmBinaryWriter::writeMemoryOrder(MemoryOrder order, bool isRMW) {
 WasmBinaryReader::WasmBinaryReader(Module& wasm,
                                    FeatureSet features,
                                    const std::vector<char>& input,
-                                   const std::vector<char>& sourceMap)
+                                   std::vector<char>& sourceMap)
   : wasm(wasm), allocator(wasm.allocator), input(input), builder(wasm),
     sourceMapReader(sourceMap) {
   wasm.features = features;
@@ -1824,7 +1824,7 @@ void WasmBinaryReader::read() {
   }
 
   readHeader();
-  sourceMapReader.readHeader(wasm);
+  sourceMapReader.parse(wasm);
 
   // Read sections until the end
   while (more()) {

--- a/test/gtest/source-map.cpp
+++ b/test/gtest/source-map.cpp
@@ -33,7 +33,7 @@ protected:
     parseWast(wasm, "(module)");
   }
 
-  void ParseMap(std::string& sourceMap) {
+  void parseMap(std::string& sourceMap) {
     buffer = {sourceMap.begin(), sourceMap.end()};
     reader.reset(new SourceMapReader(buffer));
     reader->parse(wasm);
@@ -67,7 +67,7 @@ TEST_F(SourceMapTest, SourceMappingSingleSegment) {
           "mappings": "A"
       }
   )";
-  ParseMap(sourceMap);
+  parseMap(sourceMap);
 
   auto loc = reader->readDebugLocationAt(0);
   EXPECT_FALSE(loc.has_value());
@@ -82,7 +82,7 @@ TEST_F(SourceMapTest, BadSourceMap) {
       "mappings": "A"
     }
   )";
-  EXPECT_THROW(ParseMap(sourceMap), MapParseException);
+  EXPECT_THROW(parseMap(sourceMap), MapParseException);
 }
 
 TEST_F(SourceMapTest, SourcesAndNames) {
@@ -94,7 +94,7 @@ TEST_F(SourceMapTest, SourcesAndNames) {
       "mappings": ""
     }
   )";
-  ParseMap(sourceMap);
+  parseMap(sourceMap);
 
   EXPECT_EQ(wasm.debugInfoFileNames.size(), 2);
   EXPECT_EQ(wasm.debugInfoFileNames[0], "foo.c");
@@ -113,7 +113,7 @@ TEST_F(SourceMapTest, OptionalFields) {
       "mappings": "A"
     }
   )";
-  ParseMap(sourceMap);
+  parseMap(sourceMap);
 }
 
 // This map is taken from test/fib-dbg.wasm
@@ -127,7 +127,7 @@ TEST_F(SourceMapTest, Fibonacci) {
       "mappings": "moBAEA,4BAKA,QAJA,OADA,OAAA,uCAKA"
     }
   )";
-  ParseMap(sourceMap);
+  parseMap(sourceMap);
 
   // Location before the first record has no value
   auto loc = reader->readDebugLocationAt(642);

--- a/test/gtest/source-map.cpp
+++ b/test/gtest/source-map.cpp
@@ -40,8 +40,10 @@ protected:
   }
 
   void ExpectDbgLocEq(size_t location,
-    BinaryLocation file, BinaryLocation line, BinaryLocation col,
-    std::optional<BinaryLocation> sym) {
+                      BinaryLocation file,
+                      BinaryLocation line,
+                      BinaryLocation col,
+                      std::optional<BinaryLocation> sym) {
     auto loc_str = std::stringstream() << "location: " << location;
     SCOPED_TRACE(loc_str.str());
     auto loc = reader->readDebugLocationAt(location);
@@ -52,7 +54,6 @@ protected:
     EXPECT_EQ(loc->symbolNameIndex, sym);
   }
 };
-
 
 // Check that debug location parsers can handle single-segment mappings.
 TEST_F(SourceMapTest, SourceMappingSingleSegment) {
@@ -84,7 +85,6 @@ TEST_F(SourceMapTest, BadSourceMap) {
   EXPECT_THROW(ParseMap(sourceMap), MapParseException);
 }
 
-
 TEST_F(SourceMapTest, SourcesAndNames) {
   std::string sourceMap = R"(
     {
@@ -104,7 +104,6 @@ TEST_F(SourceMapTest, SourcesAndNames) {
   EXPECT_EQ(wasm.debugInfoSymbolNames[1], "bar");
 }
 
-
 TEST_F(SourceMapTest, OptionalFields) {
   // The "names" field is optional.
   std::string sourceMap = R"(
@@ -116,7 +115,6 @@ TEST_F(SourceMapTest, OptionalFields) {
   )";
   ParseMap(sourceMap);
 }
-
 
 // This map is taken from test/fib-dbg.wasm
 TEST_F(SourceMapTest, Fibonacci) {
@@ -140,7 +138,7 @@ TEST_F(SourceMapTest, Fibonacci) {
   // First location
   ExpectDbgLocEq(643, 0, 3, 0, std::nullopt);
   // locations in between records have the same value as the previous one.
-  for(size_t l = 644; l < 671; l++) {
+  for (size_t l = 644; l < 671; l++) {
     ExpectDbgLocEq(l, 0, 3, 0, std::nullopt);
   }
   // Subsequent ones are on record boundaries
@@ -151,6 +149,7 @@ TEST_F(SourceMapTest, Fibonacci) {
   ExpectDbgLocEq(732, 0, 8, 0, std::nullopt);
   // Entries after the last record have the same value as the last one.
   ExpectDbgLocEq(733, 0, 8, 0, std::nullopt);
-  // Should we return empty values for locations that are past the end of the program?
+  // Should we return empty values for locations that are past the end of the
+  // program?
   ExpectDbgLocEq(9999, 0, 8, 0, std::nullopt);
 }

--- a/test/gtest/source-map.cpp
+++ b/test/gtest/source-map.cpp
@@ -20,32 +20,137 @@
 
 using namespace wasm;
 
-using SourceMapTest = PrintTest;
+class SourceMapTest : public PrintTest {
+  std::vector<char> buffer;
+
+protected:
+  Module wasm;
+  std::unique_ptr<SourceMapReader> reader;
+
+  void SetUp() override {
+    PrintTest::SetUp();
+    reader.reset();
+    parseWast(wasm, "(module)");
+  }
+
+  void ParseMap(std::string& sourceMap) {
+    buffer = {sourceMap.begin(), sourceMap.end()};
+    reader.reset(new SourceMapReader(buffer));
+    reader->parse(wasm);
+  }
+
+  void ExpectDbgLocEq(size_t location,
+    BinaryLocation file, BinaryLocation line, BinaryLocation col,
+    std::optional<BinaryLocation> sym) {
+    auto loc_str = std::stringstream() << "location: " << location;
+    SCOPED_TRACE(loc_str.str());
+    auto loc = reader->readDebugLocationAt(location);
+    ASSERT_TRUE(loc.has_value());
+    EXPECT_EQ(loc->fileIndex, file);
+    EXPECT_EQ(loc->lineNumber, line);
+    EXPECT_EQ(loc->columnNumber, col);
+    EXPECT_EQ(loc->symbolNameIndex, sym);
+  }
+};
+
 
 // Check that debug location parsers can handle single-segment mappings.
 TEST_F(SourceMapTest, SourceMappingSingleSegment) {
-  auto text = "(module)";
-  Module wasm;
-  parseWast(wasm, text);
-
   // A single-segment mapping starting at offset 0.
   std::string sourceMap = R"(
       {
           "version": 3,
           "sources": [],
+          "sourcesContent": [],
           "names": [],
           "mappings": "A"
       }
   )";
-  std::vector<char> buffer(sourceMap.begin(), sourceMap.end());
+  ParseMap(sourceMap);
 
-  SourceMapReader reader(buffer);
+  auto loc = reader->readDebugLocationAt(0);
+  EXPECT_FALSE(loc.has_value());
+}
 
-  // Test `readSourceMapHeader` (only check for errors, as there is no mapping
-  // to print).
-  reader.readHeader(wasm);
+TEST_F(SourceMapTest, BadSourceMap) {
+  // This source map is missing the version field.
+  std::string sourceMap = R"(
+    {
+      "sources": [],
+      "names": [],
+      "mappings": "A"
+    }
+  )";
+  EXPECT_THROW(ParseMap(sourceMap), MapParseException);
+}
 
-  // Test `readNextDebugLocation`.
-  // TODO: Actually check the result.
-  reader.readDebugLocationAt(1);
+
+TEST_F(SourceMapTest, SourcesAndNames) {
+  std::string sourceMap = R"(
+    {
+      "version": 3,
+      "sources": ["foo.c", "bar.c"],
+      "names": ["foo", "bar"],
+      "mappings": ""
+    }
+  )";
+  ParseMap(sourceMap);
+
+  EXPECT_EQ(wasm.debugInfoFileNames.size(), 2);
+  EXPECT_EQ(wasm.debugInfoFileNames[0], "foo.c");
+  EXPECT_EQ(wasm.debugInfoFileNames[1], "bar.c");
+  EXPECT_EQ(wasm.debugInfoSymbolNames.size(), 2);
+  EXPECT_EQ(wasm.debugInfoSymbolNames[0], "foo");
+  EXPECT_EQ(wasm.debugInfoSymbolNames[1], "bar");
+}
+
+
+TEST_F(SourceMapTest, OptionalFields) {
+  // The "names" field is optional.
+  std::string sourceMap = R"(
+    {
+      "version": 3,
+      "sources": [],
+      "mappings": "A"
+    }
+  )";
+  ParseMap(sourceMap);
+}
+
+
+// This map is taken from test/fib-dbg.wasm
+TEST_F(SourceMapTest, Fibonacci) {
+  // Test mapping parsing and debug locs
+  std::string sourceMap = R"(
+    {
+      "version":3,
+      "sources":["fib.c"],
+      "names":[],
+      "mappings": "moBAEA,4BAKA,QAJA,OADA,OAAA,uCAKA"
+    }
+  )";
+  ParseMap(sourceMap);
+
+  // Location before the first record has no value
+  auto loc = reader->readDebugLocationAt(642);
+  EXPECT_FALSE(loc.has_value());
+
+  // TODO: These column numbers show as 0 but emsymbolizer.py prints them as 1.
+  // Figure out which is right.
+  // First location
+  ExpectDbgLocEq(643, 0, 3, 0, std::nullopt);
+  // locations in between records have the same value as the previous one.
+  for(size_t l = 644; l < 671; l++) {
+    ExpectDbgLocEq(l, 0, 3, 0, std::nullopt);
+  }
+  // Subsequent ones are on record boundaries
+  ExpectDbgLocEq(671, 0, 8, 0, std::nullopt);
+  ExpectDbgLocEq(679, 0, 4, 0, std::nullopt);
+  ExpectDbgLocEq(686, 0, 3, 0, std::nullopt);
+  ExpectDbgLocEq(693, 0, 3, 0, std::nullopt);
+  ExpectDbgLocEq(732, 0, 8, 0, std::nullopt);
+  // Entries after the last record have the same value as the last one.
+  ExpectDbgLocEq(733, 0, 8, 0, std::nullopt);
+  // Should we return empty values for locations that are past the end of the program?
+  ExpectDbgLocEq(9999, 0, 8, 0, std::nullopt);
 }


### PR DESCRIPTION
This is in preparation for fixing #6805.
Aside from cleaning up and reusing more code, it allows optional fields in the
source map and random access to those fields, rather than walking through
the whole JSON file just once. (It does keep the current behavior of
walking through the actual mappings in a single pass synchronized with reading
the binary). It also adds some unit tests.
