### PR TITLE
[NFC] Clean up pick<HeapType>() calls in fuzzer

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3426,9 +3426,8 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       // Choose a subtype we can materialize a constant for. We cannot
       // materialize non-nullable refs to func or i31 in global contexts.
       Nullability nullability = getSubType(type.getNullability());
-      auto subtype = pick(HeapType::i31,
-        HeapType::struct_,
-        HeapType::array).getBasic(share);
+      auto subtype =
+        pick(HeapType::i31, HeapType::struct_, HeapType::array).getBasic(share);
       return makeConst(Type(subtype, nullability));
     }
     case HeapType::eq: {
@@ -5425,11 +5424,12 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
         assert(wasm.features.hasReferenceTypes());
         assert(wasm.features.hasGC());
         return pick(HeapType::any,
-                                                      HeapType::eq,
-                                                      HeapType::i31,
-                                                      HeapType::struct_,
-                                                      HeapType::array,
-                                                      HeapType::none).getBasic(share);
+                    HeapType::eq,
+                    HeapType::i31,
+                    HeapType::struct_,
+                    HeapType::array,
+                    HeapType::none)
+          .getBasic(share);
       }
       case HeapType::eq:
         assert(wasm.features.hasReferenceTypes());

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3426,11 +3426,10 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       // Choose a subtype we can materialize a constant for. We cannot
       // materialize non-nullable refs to func or i31 in global contexts.
       Nullability nullability = getSubType(type.getNullability());
-      auto subtypeOpts = FeatureOptions<HeapType>().add(
-        FeatureSet::ReferenceTypes | FeatureSet::GC,
+      auto subtypeOpts = {
         HeapType::i31,
         HeapType::struct_,
-        HeapType::array);
+        HeapType::array};
       auto subtype = pick(subtypeOpts).getBasic(share);
       return makeConst(Type(subtype, nullability));
     }

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3427,9 +3427,9 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       // materialize non-nullable refs to func or i31 in global contexts.
       Nullability nullability = getSubType(type.getNullability());
       assert(wasm.features.hasGC());
-      auto subtype =
-        pick(HeapType::i31, HeapType::struct_, HeapType::array).getBasic(share);
-      return makeConst(Type(subtype, nullability));
+      HeapType subtype =
+        pick(HeapType::i31, HeapType::struct_, HeapType::array);
+      return makeConst(Type(subtype.getBasic(share), nullability));
     }
     case HeapType::eq: {
       if (!wasm.features.hasGC()) {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3426,6 +3426,7 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       // Choose a subtype we can materialize a constant for. We cannot
       // materialize non-nullable refs to func or i31 in global contexts.
       Nullability nullability = getSubType(type.getNullability());
+      assert(wasm.features.hasGC());
       auto subtype =
         pick(HeapType::i31, HeapType::struct_, HeapType::array).getBasic(share);
       return makeConst(Type(subtype, nullability));

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -5404,16 +5404,16 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
         // TODO: Typed function references.
         assert(wasm.features.hasReferenceTypes());
         return pick(FeatureOptions<HeapType>()
-                      .add(HeapType::func)
-                      .add(FeatureSet::GC, HeapType::nofunc))
+                      .add(HeapTypes::func)
+                      .add(FeatureSet::GC, HeapTypes::nofunc))
           .getBasic(share);
       case HeapType::cont:
         return pick(HeapTypes::cont, HeapTypes::nocont).getBasic(share);
       case HeapType::ext: {
         assert(wasm.features.hasReferenceTypes());
         auto options = FeatureOptions<HeapType>()
-                         .add(HeapType::ext)
-                         .add(FeatureSet::GC, HeapType::noext);
+                         .add(HeapTypes::ext)
+                         .add(FeatureSet::GC, HeapTypes::noext);
         if (share == Unshared) {
           // Shared strings not yet supported.
           options.add(FeatureSet::Strings, HeapType::string);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3427,8 +3427,7 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       // materialize non-nullable refs to func or i31 in global contexts.
       Nullability nullability = getSubType(type.getNullability());
       assert(wasm.features.hasGC());
-      auto subtype =
-        pick(HeapTypes::i31, HeapTypes::struct_, HeapTypes::array);
+      auto subtype = pick(HeapTypes::i31, HeapTypes::struct_, HeapTypes::array);
       return makeConst(Type(subtype.getBasic(share), nullability));
     }
     case HeapType::eq: {

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3427,8 +3427,8 @@ Expression* TranslateToFuzzReader::makeBasicRef(Type type) {
       // materialize non-nullable refs to func or i31 in global contexts.
       Nullability nullability = getSubType(type.getNullability());
       assert(wasm.features.hasGC());
-      HeapType subtype =
-        pick(HeapType::i31, HeapType::struct_, HeapType::array);
+      auto subtype =
+        pick(HeapTypes::i31, HeapTypes::struct_, HeapTypes::array);
       return makeConst(Type(subtype.getBasic(share), nullability));
     }
     case HeapType::eq: {
@@ -5424,12 +5424,12 @@ HeapType TranslateToFuzzReader::getSubType(HeapType type) {
       case HeapType::any: {
         assert(wasm.features.hasReferenceTypes());
         assert(wasm.features.hasGC());
-        return pick(HeapType::any,
-                    HeapType::eq,
-                    HeapType::i31,
-                    HeapType::struct_,
-                    HeapType::array,
-                    HeapType::none)
+        return pick(HeapTypes::any,
+                    HeapTypes::eq,
+                    HeapTypes::i31,
+                    HeapTypes::struct_,
+                    HeapTypes::array,
+                    HeapTypes::none)
           .getBasic(share);
       }
       case HeapType::eq:

--- a/src/tools/fuzzing/heap-types.cpp
+++ b/src/tools/fuzzing/heap-types.cpp
@@ -424,6 +424,9 @@ struct HeapTypeGeneratorImpl {
           return HeapTypes::none.getBasic(share);
         }
       }
+      // If we had no candidates then the oneIn() above us should have returned
+      // true, since oneIn(0) => true.
+      assert(!candidates.empty());
       return rand.pick(candidates);
     } else {
       // This is not a constructed type, so it must be a basic type.

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -115,6 +115,12 @@ public:
 #endif
 
   template<typename T> struct FeatureOptions {
+    // An option without a feature is applied in all cases.
+    FeatureOptions<T>& add(T option) {
+      options[FeatureSet::MVP].push_back(option);
+      return *this;
+    }
+
     template<typename... Ts>
     FeatureOptions<T>& add(FeatureSet feature, T option, Ts... rest) {
       options[feature].push_back(option);

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -115,6 +115,13 @@ public:
 #endif
 
   template<typename T> struct FeatureOptions {
+    FeatureOptions<T>& add(HeapType::BasicHeapType option) {
+      // Using FeatureOptions with BasicHeapTypes is risky as BasicHeapType
+      // is an enum, which can convert into FeatureSet implicitly (which would
+      // then be ambiguous with add(FeatureSet) below). Use HeapType instead.
+      static_assert(false);
+    }
+
     // An option without a feature is applied in all cases.
     FeatureOptions<T>& add(T option) {
       options[FeatureSet::MVP].push_back(option);

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -53,8 +53,9 @@ public:
   double getDouble();
 
   // Choose an integer value in [0, x). This doesn't use a perfectly uniform
-  // distribution, but it's fast and reasonable.
+  // distribution, but it's fast and reasonable. upTo(0) is defined as 0.
   uint32_t upTo(uint32_t x);
+  // Returns true with probability 1 in x. oneIn(0) is defined as true.
   bool oneIn(uint32_t x) { return upTo(x) == 0; }
 
   // Apply upTo twice, generating a skewed distribution towards


### PR DESCRIPTION
* Add some assertions on features being properly enabled.
* Simplify code to avoid `FeatureOptions` when unnecessary (feature known to be enabled).
* Add comments on the definition of `upTo/oneIn` of zero.
* Add a FeatureOptions overload to handle an option without a feature.

The motivation here is to figure out an assertion on `pick<HeapType>` being
given an empty array. The extra assertions might help.