### PR TITLE
[Fuzzer] Compare V8 variants

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -807,7 +807,7 @@ class CompareVMs(TestCaseHandler):
             def can_compare_to_self(self):
                 return True
 
-            def can_compare_to_others(self):
+            def can_compare_to_other(self, other):
                 return True
 
         class D8:
@@ -828,12 +828,15 @@ class CompareVMs(TestCaseHandler):
                 # can compare to themselves after opts in that case.
                 return not NANS
 
-            def can_compare_to_others(self):
+            def can_compare_to_other(self, other):
+                # Relaxed SIMD allows different behavior between VMs, so only
+                # allow comparisons to other d8 variants if it is enabled.
+                if not all_disallowed(['relaxed-simd']) and not other.name.startswith('d8'):
+                    return False
+
                 # If not legalized, the JS will fail immediately, so no point to
-                # compare to others. Relaxed SIMD allows different behavior
-                # between VMs (in principle we could compare to other D8
-                # variants, though TODO).
-                return self.can_compare_to_self() and LEGALIZE and all_disallowed(['relaxed-simd'])
+                # compare to others.
+                return self.can_compare_to_self() and LEGALIZE
 
         class D8Liftoff(D8):
             name = 'd8_liftoff'
@@ -887,7 +890,7 @@ class CompareVMs(TestCaseHandler):
                 # expects, but that's not quite what C has
                 return not NANS
 
-            def can_compare_to_others(self):
+            def can_compare_to_other(self, other):
                 # C won't trap on OOB, and NaNs can differ from wasm VMs
                 return not OOB and not NANS
 
@@ -934,7 +937,7 @@ class CompareVMs(TestCaseHandler):
                 return super(Wasm2C2Wasm, self).can_run(wasm) and self.has_emcc and \
                     os.path.getsize(wasm) <= INPUT_SIZE_MEAN
 
-            def can_compare_to_others(self):
+            def can_compare_to_other(self, other):
                 # NaNs can differ from wasm VMs
                 return not NANS
 
@@ -962,10 +965,12 @@ class CompareVMs(TestCaseHandler):
         ignored_before = ignored_vm_runs
 
         # vm_results will map vms to their results
+        relevant_vms = []
         vm_results = {}
         for vm in self.vms:
             if vm.can_run(wasm):
                 print(f'[CompareVMs] running {vm.name}')
+                relevant_vms.append(vm)
                 vm_results[vm] = fix_output(vm.run(wasm))
 
                 # If the binaryen interpreter hit a host limitation then do not
@@ -986,13 +991,13 @@ class CompareVMs(TestCaseHandler):
                     return vm_results
 
         # compare between the vms on this specific input
-        first_vm = None
-        for vm in vm_results.keys():
-            if vm.can_compare_to_others():
-                if first_vm is None:
-                    first_vm = vm
-                else:
-                    compare_between_vms(vm_results[first_vm], vm_results[vm], 'CompareVMs between VMs: ' + first_vm.name + ' and ' + vm.name)
+        num_vms = len(relevant_vms)
+        for i in range(0, num_vms):
+            for j in range(i + 1, num_vms):
+                vm1 = relevant_vms[i]
+                vm2 = relevant_vms[j]
+                if vm1.can_compare_to_other(vm2) and vm2.can_compare_to_other(vm1):
+                    compare_between_vms(vm_results[vm1], vm_results[vm2], 'CompareVMs between VMs: ' + vm1.name + ' and ' + vm2.name)
 
         return vm_results
 


### PR DESCRIPTION
Relaxed SIMD prevents comparisons between VMs, but v8-liftoff can be
compared to v8-turboshaft for example, as it is the same VM in another
mode.

To do this, replace the `can_compare_to_others` with a function that
considers a specific other VM.