### PR TITLE
Fix clang-tidy

### DIFF
--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -o errexit
 set -o pipefail
 
 if [ -n "$1" ]; then

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -o errexit
 set -o pipefail
 
 if [ -n "$1" ]; then
@@ -28,7 +29,7 @@ if [ ! -e "$CLANG_TIDY_DIFF" ]; then
   echo "Failed to find clang-tidy-diff.py ($CLANG_TIDY_DIFF)"
   exit 1
 fi
-TIDY_MSG=$(git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF $ARG 2> /dev/null)
+TIDY_MSG=$(git diff -U0 $BRANCH... | $CLANG_TIDY_DIFF $ARG 2> /dev/null || true)
 if [ -n "$TIDY_MSG" -a "$TIDY_MSG" != "No relevant changes found." ]; then
   echo "Please fix clang-tidy errors before committing"
   echo

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -21,8 +21,6 @@
 #include <map>
 #include <vector>
 
-#include "wasm-features.h"
-
 namespace wasm {
 
 class Random {
@@ -160,10 +158,9 @@ public:
   template<typename T> std::vector<T> items(FeatureOptions<T>& picker) {
     std::vector<T> matches;
     for (const auto& item : picker.options) {
-      if (features.has(item.first)) {
+      if (features.has(item.first))
         matches.reserve(matches.size() + item.second.size());
-        matches.insert(matches.end(), item.second.begin(), item.second.end());
-      }
+      matches.insert(matches.end(), item.second.begin(), item.second.end());
     }
     return matches;
   }

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -21,6 +21,9 @@
 #include <map>
 #include <vector>
 
+#include "wasm-features.h"
+#include "wasm-type.h"
+
 namespace wasm {
 
 class Random {
@@ -158,9 +161,10 @@ public:
   template<typename T> std::vector<T> items(FeatureOptions<T>& picker) {
     std::vector<T> matches;
     for (const auto& item : picker.options) {
-      if (features.has(item.first))
+      if (features.has(item.first)) {
         matches.reserve(matches.size() + item.second.size());
-      matches.insert(matches.end(), item.second.begin(), item.second.end());
+        matches.insert(matches.end(), item.second.begin(), item.second.end());
+      }
     }
     return matches;
   }

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "wasm-features.h"
-#include "wasm-type.h"
+//#include "wasm-type.h"
 
 namespace wasm {
 

--- a/src/tools/fuzzing/random.h
+++ b/src/tools/fuzzing/random.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "wasm-features.h"
-//#include "wasm-type.h"
 
 namespace wasm {
 


### PR DESCRIPTION
Setting error-on-exit just makes it exit with error 1 after writing to `/dev/null`
(see line 31). After removing that, it properly continues and shows the
error.

See the last 3 commits in https://github.com/WebAssembly/binaryen/pull/7475  for an example. Without this fix, no diff is shown.