### PR TITLE
Use fallthrough in optimizeInstructions to further optimize (unsigned)x < 0 ==> i32(0)

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -573,9 +573,10 @@ struct OptimizeInstructions
         if (curr->op == Abstract::getBinary(curr->left->type, Abstract::LtU) &&
             (c = getFallthrough(curr->right)->dynCast<Const>()) &&
             c->value.isZero()) {
-          c->value = Literal::makeZero(Type::i32);
-          c->type = Type::i32;
-          return replaceCurrent(getDroppedChildrenAndAppend(curr, c));
+          // We could reuse c here, if we checked it had no more uses
+          auto zero =
+            Builder(*getModule()).makeConst(Literal::makeZero(Type::i32));
+          return replaceCurrent(getDroppedChildrenAndAppend(curr, zero));
         }
       }
     }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2922,18 +2922,17 @@ private:
             return binary;
           }
         }
-      } else if (binary->op == LtUInt32) {
-        auto value = Properties::getFallthrough(
-          binary->right, getPassOptions(), *getModule());
-        if (Properties::isConstantExpression(value)) {
-          if (Properties::getLiteral(value).isZero()) {
-            // Hoist potential zero to be good for constant propagation
-            // in case of being blocked by side effect.
-            // (unsigned)x < 0   ==>  i32(0)
-            Builder builder(*getModule());
-            return getDroppedChildrenAndAppend(
-              binary, LiteralUtils::makeZero(Type::i32, *getModule()));
-          }
+      }
+      if (auto* block = binary->right->dynCast<Block>()) {
+        auto fallthrough =
+          Properties::getFallthrough(block, getPassOptions(), *getModule());
+        if (auto* c = fallthrough->dynCast<Const>()) {
+          Builder builder(*getModule());
+          auto ret = getDroppedChildrenAndAppend(
+            binary,
+            LiteralUtils::makeFromInt32(
+              c->value.geti32(), Type::i32, *getModule()));
+          return ret;
         }
       }
       if (auto* ext = Properties::getSignExtValue(binary)) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2928,10 +2928,8 @@ private:
           Properties::getFallthrough(block, getPassOptions(), *getModule());
         if (auto* c = fallthrough->dynCast<Const>()) {
           Builder builder(*getModule());
-          return getDroppedChildrenAndAppend(
-            binary,
-            LiteralUtils::makeFromInt32(
-              c->value.geti32(), Type::i32, *getModule()));
+          return getDroppedChildrenAndAppend(binary,
+                                             builder.makeConst(c->value));
         }
       }
       if (auto* ext = Properties::getSignExtValue(binary)) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -570,7 +570,8 @@ struct OptimizeInstructions
           return replaceCurrent(getDroppedChildrenAndAppend(curr, c));
         }
         // unsigned(x) < 0   =>   i32(0)
-        if (matches(curr, binary(LtU, any(&x), ival(&c))) &&
+        if (curr->op == Abstract::getBinary(curr->left->type, Abstract::LtU) &&
+            (c = getFallthrough(curr->right)->dynCast<Const>()) &&
             c->value.isZero()) {
           c->value = Literal::makeZero(Type::i32);
           c->type = Type::i32;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2922,6 +2922,19 @@ private:
             return binary;
           }
         }
+      } else if (binary->op == LtUInt32) {
+        auto value = Properties::getFallthrough(
+          binary->right, getPassOptions(), *getModule());
+        if (Properties::isConstantExpression(value)) {
+          if (Properties::getLiteral(value).isZero()) {
+            // Hoist potential zero to be good for constant propagation
+            // in case of being blocked by side effect.
+            // (unsigned)x < 0   ==>  i32(0)
+            Builder builder(*getModule());
+            return getDroppedChildrenAndAppend(
+              binary, LiteralUtils::makeZero(Type::i32, *getModule()));
+          }
+        }
       }
       if (auto* ext = Properties::getSignExtValue(binary)) {
         // use a cheaper zero-extent, we just care about the boolean value

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2924,15 +2924,6 @@ private:
           }
         }
       }
-      if (auto* block = binary->right->dynCast<Block>()) {
-        auto fallthrough =
-          Properties::getFallthrough(block, getPassOptions(), *getModule());
-        if (auto* c = fallthrough->dynCast<Const>()) {
-          Builder builder(*getModule());
-          return getDroppedChildrenAndAppend(binary,
-                                             builder.makeConst(c->value));
-        }
-      }
       if (auto* ext = Properties::getSignExtValue(binary)) {
         // use a cheaper zero-extent, we just care about the boolean value
         // anyhow

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2928,11 +2928,10 @@ private:
           Properties::getFallthrough(block, getPassOptions(), *getModule());
         if (auto* c = fallthrough->dynCast<Const>()) {
           Builder builder(*getModule());
-          auto ret = getDroppedChildrenAndAppend(
+          return getDroppedChildrenAndAppend(
             binary,
             LiteralUtils::makeFromInt32(
               c->value.geti32(), Type::i32, *getModule()));
-          return ret;
         }
       }
       if (auto* ext = Properties::getSignExtValue(binary)) {

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11558,12 +11558,12 @@
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:     (block (result i64)
   ;; CHECK-NEXT:      (i64.store
   ;; CHECK-NEXT:       (i32.const 0)
   ;; CHECK-NEXT:       (i64.const 0)
   ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (i64.const 0)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (i32.const 0)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11551,6 +11551,25 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i64.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (i64.store
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (i64.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.ne
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:    (i32.const 0)
@@ -11833,6 +11852,19 @@
             (i32.const 0)
           )
           (i32.const 0)
+        )
+      )
+    )
+    (drop (i64.lt_u
+        (i64.load
+          (i32.const 0)
+        )
+        (block (result i64)
+          (i64.store
+            (i32.const 0)
+            (i64.const 0)
+          )
+          (i64.const 0)
         )
       )
     )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -175,6 +175,63 @@
       )
     )
   )
+
+  ;; CHECK:      (func $if-lt_u-side-effect (param $i1 i32) (param $i2 i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (i32.load
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (block (result i32)
+  ;; CHECK-NEXT:       (i32.store
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:        (i32.const 0)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-lt_u-side-effect (param $i1 i32) (param $i2 i32)
+    (if
+      (i32.lt_u
+        (i32.load
+          (i32.const 0)
+        )
+        (block (result i32)
+          (i32.store
+            (i32.const 0)
+            (i32.const 0)
+          )
+          (i32.const 0)
+        )
+      )
+      (then
+        (drop
+          (i32.const 1)
+        )
+      )
+      (else
+        (drop
+          (i32.const 0)
+        )
+      )
+    )
+  )
+
   ;; CHECK:      (func $eqz-gt_s (result i32)
   ;; CHECK-NEXT:  (i32.eqz
   ;; CHECK-NEXT:   (i32.const 0)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -176,62 +176,6 @@
     )
   )
 
-  ;; CHECK:      (func $if-lt_u-side-effect (param $i1 i32) (param $i2 i32)
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (if (result i32)
-  ;; CHECK-NEXT:    (block (result i32)
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (i32.load
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (drop
-  ;; CHECK-NEXT:      (block (result i32)
-  ;; CHECK-NEXT:       (i32.store
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:        (i32.const 0)
-  ;; CHECK-NEXT:       )
-  ;; CHECK-NEXT:       (i32.const 0)
-  ;; CHECK-NEXT:      )
-  ;; CHECK-NEXT:     )
-  ;; CHECK-NEXT:     (i32.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (then
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (else
-  ;; CHECK-NEXT:     (i32.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT: )
-  (func $if-lt_u-side-effect (param $i1 i32) (param $i2 i32)
-    (if
-      (i32.lt_u
-        (i32.load
-          (i32.const 0)
-        )
-        (block (result i32)
-          (i32.store
-            (i32.const 0)
-            (i32.const 0)
-          )
-          (i32.const 0)
-        )
-      )
-      (then
-        (drop
-          (i32.const 1)
-        )
-      )
-      (else
-        (drop
-          (i32.const 0)
-        )
-      )
-    )
-  )
-
   ;; CHECK:      (func $eqz-gt_s (result i32)
   ;; CHECK-NEXT:  (i32.eqz
   ;; CHECK-NEXT:   (i32.const 0)
@@ -11588,6 +11532,25 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (i32.store
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.ne
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:    (i32.const 0)
@@ -11860,6 +11823,20 @@
       )
       (i64.const 0)
     ))
+    (drop (i32.lt_u
+        (i32.load
+          (i32.const 0)
+        )
+        (block (result i32)
+          (i32.store
+            (i32.const 0)
+            (i32.const 0)
+          )
+          (i32.const 0)
+        )
+      )
+    )
+
 
     ;; (unsigned)x > 0  =>  x != 0
     (drop (i32.gt_u


### PR DESCRIPTION
Currently, `wasm-opt` cannot optimize the code as expected: `(unsigned)x < 0 ==> i32(0)`.

```webassembly
(i32.lt_u
 (i32.load $0 (i32.const 0) )
 (block (result i32)
  (i32.store $0
   (i32.const 0)
   (i32.const 0)
  )
  (i32.const 0)
 )
)
```

It should have been optimized after `merge-blocks`, as the `store` could have been hoisted. However, the load and store cannot be reordered, preventing `wasm-opt` from doing so. 

This can be addressed in `optimizeInstructions` by using `fallthrough` to hoist the constant zero, enabling further optimizations.

Fixes: #7455 