### PR TITLE
[EH] Use V8 flag to allow mixed old and new EH [NFC]

### DIFF
--- a/scripts/clusterfuzz/run.py
+++ b/scripts/clusterfuzz/run.py
@@ -33,7 +33,9 @@ import sys
 
 # The V8 flags we put in the "fuzzer flags" files, which tell ClusterFuzz how to
 # run V8. By default we apply all staging flags.
-FUZZER_FLAGS_FILE_CONTENTS = '--wasm-staging'
+#
+# We also allow mixed EH, see the comment on the same flag in fuzz_opt.py
+FUZZER_FLAGS_FILE_CONTENTS = '--wasm-staging --wasm-allow-mixed-eh-for-testing'
 
 # Maximum size of the random data that we feed into wasm-opt -ttf. This is
 # smaller than fuzz_opt.py's INPUT_SIZE_MAX because that script is tuned for

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -667,13 +667,25 @@ def run_bynterp(wasm, args):
         del os.environ['BINARYEN_MAX_INTERPRETER_DEPTH']
 
 
-# Enable even more staged things than V8_OPTS. V8_OPTS are the flags we want to
-# use when testing, and enable all features we test against, while --future may
-# also enable non-feature things like new JITs and such (which are never needed
-# for our normal tests, but do make sense to fuzz for V8's sake). We do this
-# randomly for more variety.
+# Enable even more things than V8_OPTS. V8_OPTS are the flags we want to use
+# when testing, on our fixed test suite, but when fuzzing we may want more.
 def get_v8_extra_flags():
-    return ['--future'] if random.random() < 0.5 else []
+    # Due to https://github.com/WebAssembly/exception-handling/issues/344 , VMs
+    # do not allow mixed old and new wasm EH. Our fuzzer will very frequently
+    # mix those instructions in a module, so we must use the flag to allow that.
+    # FIXME This is not great, as the majority of the wasm files we test on are
+    #       not actually valid in VMs. We do get coverage this way for runtime
+    #       linking of old and new EH (which VMs allow), that is, our compile-
+    #       time combination of old and new simulates runtime linking to some
+    #       extent.
+    flags = ['--wasm-allow-mixed-eh-for-testing']
+
+    # Sometimes add --future, which may enable new JITs and such, which is good
+    # to fuzz for V8's sake.
+    if random.random() < 0.5:
+        flags += ['--future']
+
+    return flags
 
 
 V8_LIFTOFF_ARGS = ['--liftoff']
@@ -1650,7 +1662,7 @@ class ClusterFuzz(TestCaseHandler):
         # flags here!
         with open(flags_file, 'r') as f:
             flags = f.read()
-        cmd.append(flags)
+        cmd += flags.split(' ')
         # Run the fuzz file, which contains a modified fuzz_shell.js - we do
         # *not* run fuzz_shell.js normally.
         cmd.append(os.path.abspath(fuzz_file))

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -674,7 +674,7 @@ def get_v8_extra_flags():
     # do not allow mixed old and new wasm EH. Our fuzzer will very frequently
     # mix those instructions in a module, so we must use the flag to allow that.
     # FIXME This is not great, as the majority of the wasm files we test on are
-    #       not actually valid in VMs. We do get coverage this way for runtime
+    #       not actually valid in VMs. But we get coverage this way for runtime
     #       linking of old and new EH (which VMs allow), that is, our compile-
     #       time combination of old and new simulates runtime linking to some
     #       extent.

--- a/test/unit/test_cluster_fuzz.py
+++ b/test/unit/test_cluster_fuzz.py
@@ -186,7 +186,7 @@ class ClusterFuzz(utils.BinaryenTestCase):
 
             # The flags file must contain --wasm-staging
             with open(flags_file) as f:
-                self.assertEqual(f.read(), '--wasm-staging')
+                self.assertEqual(f.read(), '--wasm-staging --wasm-allow-mixed-eh-for-testing')
 
             # Extract the wasm file(s) from the JS. Make sure to not notice
             # stale files.


### PR DESCRIPTION
This is necessary with latest V8, since

https://github.com/v8/v8/commit/af887e07511cce2831b96edf7e3d9a13bc8c9df8

This is not ideal, see comment in the source, but also seems hard to
improve on.