### PR TITLE
[NFC] Add getFallthrough* helpers in OptimizeInstructions

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2608,7 +2608,7 @@ private:
     // on the second, however, as there could be effects in the middle.
     // TODO: Use effects here perhaps.
     auto& passOptions = getPassOptions();
-    left = getFallthrough(left, Properties::FallthroughBehavior::NoTeeBrIf);
+    left = Properties::getFallthrough(left, getPassOptions(), *getModule(), Properties::FallthroughBehavior::NoTeeBrIf);
     if (areMatchingTeeAndGet(left, right)) {
       return true;
     }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -299,7 +299,7 @@ struct OptimizeInstructions
     return Properties::getFallthrough(curr, getPassOptions(), *getModule());
   }
 
-  Expression* getFallthroughType(Expression* curr) {
+  Type getFallthroughType(Expression* curr) {
     return Properties::getFallthroughType(curr, getPassOptions(), *getModule());
   }
 
@@ -1824,7 +1824,6 @@ struct OptimizeInstructions
       return;
     }
 
-    auto& passOptions = getPassOptions();
     const auto& fields = curr->type.getHeapType().getStruct().fields;
     assert(fields.size() == curr->operands.size());
 
@@ -2109,7 +2108,6 @@ struct OptimizeInstructions
     }
 
     // The value must be the default/zero.
-    auto& passOptions = getPassOptions();
     auto zero = Literal::makeZero(type);
     auto* value = getFallthrough(curr->init);
     if (!Properties::isSingleConstantExpression(value) ||
@@ -2135,8 +2133,6 @@ struct OptimizeInstructions
       //       can use ArrayNew or ArrayNewFixed there. Measure which is best.
       return;
     }
-
-    auto& passOptions = getPassOptions();
 
     // If all the values are equal then we can optimize, either to
     // array.new_default (if they are all equal to the default) or array.new (if
@@ -2607,7 +2603,6 @@ private:
     // NoTeeBrIf as we do not want to look through the tee). We cannot do this
     // on the second, however, as there could be effects in the middle.
     // TODO: Use effects here perhaps.
-    auto& passOptions = getPassOptions();
     left =
       Properties::getFallthrough(left,
                                  getPassOptions(),

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2608,7 +2608,11 @@ private:
     // on the second, however, as there could be effects in the middle.
     // TODO: Use effects here perhaps.
     auto& passOptions = getPassOptions();
-    left = Properties::getFallthrough(left, getPassOptions(), *getModule(), Properties::FallthroughBehavior::NoTeeBrIf);
+    left =
+      Properties::getFallthrough(left,
+                                 getPassOptions(),
+                                 *getModule(),
+                                 Properties::FallthroughBehavior::NoTeeBrIf);
     if (areMatchingTeeAndGet(left, right)) {
       return true;
     }

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -295,6 +295,14 @@ struct OptimizeInstructions
     return EffectAnalyzer(getPassOptions(), *getModule(), expr);
   }
 
+  Expression* getFallthrough(Expression* curr) {
+    return Properties::getFallthrough(curr, getPassOptions(), *getModule());
+  }
+
+  Expression* getFallthroughType(Expression* curr) {
+    return Properties::getFallthroughType(curr, getPassOptions(), *getModule());
+  }
+
   decltype(auto) pure(Expression** binder) {
     using namespace Match::Internal;
     return Matcher<PureMatcherKind<OptimizeInstructions>>(binder, this);
@@ -574,9 +582,7 @@ struct OptimizeInstructions
       Index extraLeftShifts;
       auto bits = Properties::getAlmostSignExtBits(curr, extraLeftShifts);
       if (extraLeftShifts == 0) {
-        if (auto* load =
-              Properties::getFallthrough(ext, getPassOptions(), *getModule())
-                ->dynCast<Load>()) {
+        if (auto* load = getFallthrough(ext)->dynCast<Load>()) {
           // pattern match a load of 8 bits and a sign extend using a shl of
           // 24 then shr_s of 24 as well, etc.
           if (LoadUtils::canBeSigned(load) &&
@@ -1348,9 +1354,7 @@ struct OptimizeInstructions
     // the fallthrough value there. It takes more work to optimize this case,
     // but it is pretty important to allow a call_ref to become a fast direct
     // call, so make the effort.
-    if (auto* ref = Properties::getFallthrough(
-                      curr->target, getPassOptions(), *getModule())
-                      ->dynCast<RefFunc>()) {
+    if (auto* ref = getFallthrough(curr->target)->dynCast<RefFunc>()) {
       // Check if the fallthrough make sense. We may have cast it to a different
       // type, which would be a problem - we'd be replacing a call_ref to one
       // type with a direct call to a function of another type. That would trap
@@ -1748,8 +1752,7 @@ struct OptimizeInstructions
       }
     }
 
-    auto fallthrough =
-      Properties::getFallthrough(ref, getPassOptions(), *getModule());
+    auto fallthrough = getFallthrough(ref);
 
     if (fallthrough->type.isNull()) {
       replaceCurrent(
@@ -1833,8 +1836,7 @@ struct OptimizeInstructions
       }
 
       // The field must be written the default value.
-      auto* value = Properties::getFallthrough(
-        curr->operands[i], passOptions, *getModule());
+      auto* value = getFallthrough(curr->operands[i]);
       if (!Properties::isSingleConstantExpression(value) ||
           Properties::getLiteral(value) != Literal::makeZero(type)) {
         return;
@@ -1913,8 +1915,7 @@ struct OptimizeInstructions
     // this location in the total order of seqcst ops would have to be
     // considered to be reading from this RMW and therefore would synchronize
     // with it.
-    auto* value =
-      Properties::getFallthrough(curr->value, getPassOptions(), *getModule());
+    auto* value = getFallthrough(curr->value);
     if (Properties::isSingleConstantExpression(value)) {
       auto val = Properties::getLiteral(value);
       bool canOptimize = false;
@@ -2110,8 +2111,7 @@ struct OptimizeInstructions
     // The value must be the default/zero.
     auto& passOptions = getPassOptions();
     auto zero = Literal::makeZero(type);
-    auto* value =
-      Properties::getFallthrough(curr->init, passOptions, *getModule());
+    auto* value = getFallthrough(curr->init);
     if (!Properties::isSingleConstantExpression(value) ||
         Properties::getLiteral(value) != zero) {
       return;
@@ -2155,8 +2155,7 @@ struct OptimizeInstructions
     // See if they are equal to a constant, and if that constant is the default.
     auto type = curr->type.getHeapType().getArray().element.type;
     if (type.isDefaultable()) {
-      auto* value =
-        Properties::getFallthrough(curr->values[0], passOptions, *getModule());
+      auto* value = getFallthrough(curr->values[0]);
 
       if (Properties::isSingleConstantExpression(value) &&
           Properties::getLiteral(value) == Literal::makeZero(type)) {
@@ -2254,8 +2253,7 @@ struct OptimizeInstructions
     // of the value we are casting. local.tee, br_if, and blocks can all "lose"
     // type information, so looking at all the fallthrough values can give us a
     // more precise type than is stored in the IR.
-    Type refType =
-      Properties::getFallthroughType(curr->ref, getPassOptions(), *getModule());
+    Type refType = getFallthroughType(curr->ref);
 
     // As a first step, we can tighten up the cast type to be the greatest lower
     // bound of the original cast type and the type we know the cast value to
@@ -2425,8 +2423,7 @@ struct OptimizeInstructions
 
     // Parallel to the code in visitRefCast: we look not just at the final type
     // we are given, but at fallthrough values as well.
-    Type refType =
-      Properties::getFallthroughType(curr->ref, getPassOptions(), *getModule());
+    Type refType = getFallthroughType(curr->ref);
 
     // Improve the cast type as much as we can without changing the results.
     auto glb = Type::getGreatestLowerBound(curr->castType, refType);
@@ -2611,20 +2608,16 @@ private:
     // on the second, however, as there could be effects in the middle.
     // TODO: Use effects here perhaps.
     auto& passOptions = getPassOptions();
-    left =
-      Properties::getFallthrough(left,
-                                 passOptions,
-                                 *getModule(),
-                                 Properties::FallthroughBehavior::NoTeeBrIf);
+    left = getFallthrough(left, Properties::FallthroughBehavior::NoTeeBrIf);
     if (areMatchingTeeAndGet(left, right)) {
       return true;
     }
 
     // Ignore extraneous things and compare them syntactically. We can also
     // look at the full fallthrough for both sides now.
-    left = Properties::getFallthrough(left, passOptions, *getModule());
+    left = getFallthrough(left);
     auto* originalRight = right;
-    right = Properties::getFallthrough(right, passOptions, *getModule());
+    right = getFallthrough(right);
     if (!ExpressionAnalyzer::equal(left, right)) {
       return false;
     }


### PR DESCRIPTION
Just to simplify code a little. We have similar helpers for `effects()` etc.