### PR TITLE
OptimizeInstruction: Optimize any boolean & (No overlap with boolean's LSB)  ==> 0

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3569,8 +3569,7 @@ private:
     // Check left's max bits and right is constant.
     auto leftMaxBits = Bits::getMaxBits(left, this);
     uint64_t maskLeft;
-    if (!left->type.isConcrete() ||
-        leftMaxBits == left->type.getByteSize() * 8) {
+    if (!left->type.isNumber() || leftMaxBits == left->type.getByteSize() * 8) {
       // If we know nothing useful about the bits on the left,
       // we cannot optimize.
       return nullptr;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3565,15 +3565,7 @@ private:
     auto* right = curr->right;
     auto leftMaxBits = Bits::getMaxBits(left, this);
 
-    if (leftMaxBits == 0) {
-      // Left is always zero, result is zero.
-      replaceCurrent(getDroppedChildrenAndAppend(
-        curr, LiteralUtils::makeZero(type, *getModule())));
-      return nullptr;
-    }
-
     uint64_t mask = (1ULL << leftMaxBits) - 1;
-
     if (auto* c = right->dynCast<Const>()) {
       uint64_t constantValue = c->value.getInteger();
       if ((constantValue & mask) == 0) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3569,8 +3569,8 @@ private:
     if (auto* c = right->dynCast<Const>()) {
       uint64_t constantValue = c->value.getInteger();
       if ((constantValue & mask) == 0) {
-        replaceCurrent(getDroppedChildrenAndAppend(
-          curr, LiteralUtils::makeZero(type, *getModule())));
+        getDroppedChildrenAndAppend(curr,
+                                    LiteralUtils::makeZero(type, *getModule()));
       }
     }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3569,7 +3569,7 @@ private:
     // Check left's max bits and right is constant.
     auto leftMaxBits = Bits::getMaxBits(left, this);
     uint64_t maskLeft;
-    if (left->type.isConcrete() &&
+    if (!left->type.isConcrete() ||
         leftMaxBits == left->type.getByteSize() * 8) {
       // If we know nothing useful about the bits on the left,
       // we cannot optimize.

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3569,7 +3569,7 @@ private:
     auto* left = curr->left;
     auto* right = curr->right;
 
-    // Check right as constant and left's max bits
+    // Check right is constant and left's max bits
     auto leftMaxBits = Bits::getMaxBits(left, this);
     uint64_t maskLeft;
     if (leftMaxBits == 64) {

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3563,14 +3563,26 @@ private:
 
     auto* left = curr->left;
     auto* right = curr->right;
-    auto leftMaxBits = Bits::getMaxBits(left, this);
 
-    uint64_t mask = (1ULL << leftMaxBits) - 1;
+    // Check right as constant and left's max bits
+    auto leftMaxBits = Bits::getMaxBits(left, this);
+    uint64_t maskLeft = (1ULL << leftMaxBits) - 1;
     if (auto* c = right->dynCast<Const>()) {
       uint64_t constantValue = c->value.getInteger();
-      if ((constantValue & mask) == 0) {
-        getDroppedChildrenAndAppend(curr,
-                                    LiteralUtils::makeZero(type, *getModule()));
+      if ((constantValue & maskLeft) == 0) {
+        return getDroppedChildrenAndAppend(
+          curr, LiteralUtils::makeZero(type, *getModule()));
+      }
+    }
+
+    // Check left as constant and right's max bits
+    auto rightMaxBits = Bits::getMaxBits(right, this);
+    uint64_t maskRight = (1ULL << rightMaxBits) - 1;
+    if (auto* c = left->dynCast<Const>()) {
+      uint64_t constantValue = c->value.getInteger();
+      if ((constantValue & maskRight) == 0) {
+        return getDroppedChildrenAndAppend(
+          curr, LiteralUtils::makeZero(type, *getModule()));
       }
     }
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3569,7 +3569,7 @@ private:
     // Check left's max bits and right is constant.
     auto leftMaxBits = Bits::getMaxBits(left, this);
     uint64_t maskLeft;
-    if (leftMaxBits == 64) {
+    if (leftMaxBits == left->type.getByteSize() * 8) {
       // If we know nothing useful about the bits on the left,
       // we can not optimize.
       return nullptr;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3571,7 +3571,7 @@ private:
     uint64_t maskLeft;
     if (leftMaxBits == left->type.getByteSize() * 8) {
       // If we know nothing useful about the bits on the left,
-      // we can not optimize.
+      // we cannot optimize.
       return nullptr;
     } else {
       maskLeft = (1ULL << leftMaxBits) - 1;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3569,7 +3569,8 @@ private:
     // Check left's max bits and right is constant.
     auto leftMaxBits = Bits::getMaxBits(left, this);
     uint64_t maskLeft;
-    if (leftMaxBits == left->type.getByteSize() * 8) {
+    if (left->type.isConcrete() &&
+        leftMaxBits == left->type.getByteSize() * 8) {
       // If we know nothing useful about the bits on the left,
       // we cannot optimize.
       return nullptr;

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -3563,9 +3563,6 @@ private:
   Expression* optimizeAndNoOverlappingBits(Binary* curr) {
     assert(curr->op == AndInt32 || curr->op == AndInt64);
 
-    using namespace Abstract;
-    using namespace Match;
-
     auto* left = curr->left;
     auto* right = curr->right;
 

--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -832,13 +832,11 @@ struct OptimizeInstructions
         return replaceCurrent(ret);
       }
     }
-    if (curr->op == AndInt32 || curr->op == AndInt64 || curr->op == OrInt32) {
+    if (curr->op == AndInt32 || curr->op == OrInt32) {
       if (curr->op == AndInt32) {
         if (auto* ret = combineAnd(curr)) {
           return replaceCurrent(ret);
         }
-      }
-      if (curr->op == AndInt32 || curr->op == AndInt64) {
         if (auto* ret = optimizeAndNoOverlappingBits(curr)) {
           return replaceCurrent(ret);
         }
@@ -855,6 +853,12 @@ struct OptimizeInstructions
         return replaceCurrent(ret);
       }
     }
+    if (curr->op == AndInt64) {
+      if (auto* ret = optimizeAndNoOverlappingBits(curr)) {
+        return replaceCurrent(ret);
+      }
+    }
+
     // relation/comparisons allow for math optimizations
     if (curr->isRelational()) {
       if (auto* ret = optimizeRelational(curr)) {

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -1371,10 +1371,7 @@
   ;; CHECK-NEXT:   (i32.const 100)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.const 100)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $and-neg1
@@ -1393,10 +1390,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.const 100)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 1)
@@ -1445,6 +1439,9 @@
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
   ;; CHECK-NEXT:    (local.get $x)
   ;; CHECK-NEXT:    (i32.const 3)
@@ -1479,6 +1476,7 @@
   ;; CHECK-NEXT: )
   (func $canonicalize-consts-vars (param $x i32) (param $y i32)
     (drop (i32.and (i32.const 1) (i32.const 2)))
+    (drop (i32.and (i32.const 2) (i32.const 1)))
     (drop (i32.and (local.get $x) (i32.const 3)))
     (drop (i32.and (i32.const 4) (local.get $x)))
     (drop (i32.and (local.get $x) (local.get $y)))

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17851,12 +17851,12 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $no-overlapping-bits-corner-case (param $x i32) (param $y i64)
-    ;; optimizeAndNoOverlappingBits will simplify AND operations where
-    ;; Bitwise AND of a value with bits in [0, n) and a constant with no bits in
-    ;; [0, n) always yields 0. Replace with zero.
-    ;; Note: after swapping the operands, it also satisfies the commutative law.
+    ;; optimizeAndNoOverlappingBits simplifies AND operations where
+    ;;  - the left value covers bits in [0, n)
+    ;;  - the right operand is a constant with no bits in [0, n)
+    ;; Result is simplified to zero.
 
-    ;; No any bit overlapping, optimized
+    ;; No any bit overlapped, optimized.
     (drop
       (i64.and
         (i64.const 1)
@@ -17927,7 +17927,7 @@
         (local.get $y)
       )
     )
-    ;; One bit overlapped, not optimized
+    ;; One bit overlapped, so we can not optimized.
     (drop
       (i32.and
         (i32.const 0x7fffffff)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17779,21 +17779,7 @@
       (i32.const 1)
     )
   )
-  ;; CHECK:      (func $no-overlapping-bits-corner-case (param $0 i32) (param $1 i64)
-  ;; CHECK-NEXT:  (local $x i32)
-  ;; CHECK-NEXT:  (local $y i64)
-  ;; CHECK-NEXT:  (local.set $x
-  ;; CHECK-NEXT:   (i32.const 1)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (local.set $y
-  ;; CHECK-NEXT:   (i64.const 1)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.const 0)
-  ;; CHECK-NEXT:  )
+  ;; CHECK:      (func $add-op-no-overlapping-bits-corner-case
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
@@ -17803,6 +17789,33 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.const 0)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $add-op-no-overlapping-bits-corner-case
+    ;; optimizeAndNoOverlappingBits simplifies AND operations where
+    ;;  - the left value covers bits in [0, n)
+    ;;  - the right operand is a constant with no bits in [0, n)
+    ;; Result is simplified to zero.
+    ;; No any bit overlapped, optimized.
+    (drop
+      (i32.and
+        (i32.const 1)
+        (i32.const 2)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 1)
+        (i64.const 2)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0x7fffffff)
+        (i64.const 0x80000000)
+      )
+    )
+  )
+  ;; CHECK:      (func $add-op-overlapping-bits-corner-case
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
   ;; CHECK-NEXT:    (i32.const 2147483647)
@@ -17815,6 +17828,23 @@
   ;; CHECK-NEXT:    (i64.const 2147483649)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $add-op-overlapping-bits-corner-case
+    ;; One bit overlapped, so we can not optimized.
+    (drop
+      (i32.and
+        (i32.const 0x7fffffff)
+        (i32.const 0x80000001)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0x7fffffff)
+        (i64.const 0x80000001)
+      )
+    )
+  )
+  ;; CHECK:      (func $add-op-no-overlapping-skipped
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
   ;; CHECK-NEXT:    (i32.const 2)
@@ -17833,6 +17863,30 @@
   ;; CHECK-NEXT:    (i64.const 2147483647)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $add-op-no-overlapping-skipped
+    ;; Both-constant cases which does not meets the condition are handled
+    ;; by Precompute, so they are skipped here.
+    (drop
+      (i32.and
+        (i32.const 2)
+        (i32.const 1)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 2)
+        (i64.const 1)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0x80000000)
+        (i64.const 0x7fffffff)
+      )
+    )
+  )
+  ;; CHECK:      (func $add-op-unknown-useful (param $0 i32) (param $1 i64)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
   ;; CHECK-NEXT:    (i32.const -2147483648)
@@ -17858,84 +17912,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $no-overlapping-bits-corner-case (param $0 i32) (param $1 i64)
-    ;; optimizeAndNoOverlappingBits simplifies AND operations where
-    ;;  - the left value covers bits in [0, n)
-    ;;  - the right operand is a constant with no bits in [0, n)
-    ;; Result is simplified to zero.
-    (local $x i32)
-    (local $y i64)
-    (local.set $x
-      (i32.const 1)
-    )
-    (local.set $y
-      (i64.const 1)
-    )
-    ;; No any bit overlapped, optimized.
-    (drop
-      (i32.and
-        (local.get $x)
-        (i32.const 2)
-      )
-    )
-    (drop
-      (i64.and
-        (local.get $y)
-        (i64.const 2)
-      )
-    )
-    ;; Both-constant cases which meets the condition are also optimized.
-    (drop
-      (i32.and
-        (i32.const 1)
-        (i32.const 2)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 1)
-        (i64.const 2)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 0x7fffffff)
-        (i64.const 0x80000000)
-      )
-    )
-    ;; One bit overlapped, so we can not optimized.
-    (drop
-      (i32.and
-        (i32.const 0x7fffffff)
-        (i32.const 0x80000001)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 0x7fffffff)
-        (i64.const 0x80000001)
-      )
-    )
-    ;; Both-constant cases which does not meets the condition are handled
-    ;; by Precompute, so they are skipped here.
-    (drop
-      (i32.and
-        (i32.const 2)
-        (i32.const 1)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 2)
-        (i64.const 1)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 0x80000000)
-        (i64.const 0x7fffffff)
-      )
-    )
+  (func $add-op-unknown-useful (param $0 i32) (param $1 i64)
     ;; Know nothing useful about the bits on the left, so we can not optimize.
     (drop
       (i32.and

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -6967,7 +6967,7 @@
     )
    )
   )
-  ;; CHECK:      (func $de-morgan-2 (param $x i32) (param $y i32)
+  ;; CHECK:      (func $de-morgan-2 (param $x i32) (param $y i32) (param $z i64)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
   ;; CHECK-NEXT:    (i32.or
@@ -7013,7 +7013,14 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.eqz
+  ;; CHECK-NEXT:     (local.get $x)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.wrap_i64
+  ;; CHECK-NEXT:     (local.get $z)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz
@@ -7021,7 +7028,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $de-morgan-2 (param $x i32) (param $y i32)
+  (func $de-morgan-2 (param $x i32) (param $y i32) (param $z i64)
     (drop
       (i32.and (i32.eqz (local.get $x)) (i32.eqz (local.get $y)))
     )
@@ -7038,7 +7045,7 @@
       (i32.and (local.get $x) (i32.eqz (local.get $y)))
     )
     (drop
-      (i32.and (i32.eqz (local.get $x)) (i32.wrap_i64 (i64.const 2)))
+      (i32.and (i32.eqz (local.get $x)) (i32.wrap_i64 (local.get $z)))
     )
     (drop
       (i32.and (i32.wrap_i64 (i64.const 1)) (i32.eqz (local.get $y)))

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17795,7 +17795,7 @@
     ;;  - the left value covers bits in [0, n)
     ;;  - the right operand is a constant with no bits in [0, n)
     ;; Result is simplified to zero.
-    ;; No any bit overlapped, optimized.
+    ;; No bit overlaps, so we optimize.
     (drop
       (i32.and
         (i32.const 1)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -2860,15 +2860,18 @@
       (i32.const 24)
     )
   )
-  ;; CHECK:      (func $sext-24-and-127-128 (result i32)
-  ;; CHECK-NEXT:  (i32.const 0)
+  ;; CHECK:      (func $sext-24-and-127-unknown (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (i32.and
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (i32.const 127)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $sext-24-and-127-128 (result i32)
+  (func $sext-24-and-127-unknown (param $x i32) (result i32)
     (i32.shr_s
       (i32.shl
         (i32.and ;; takes the min, here it is ok
           (i32.const 127)
-          (i32.const 128)
+          (local.get $x)
         )
         (i32.const 24)
       )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17779,7 +17779,18 @@
       (i32.const 1)
     )
   )
-  ;; CHECK:      (func $no-overlapping-bits-corner-case (param $x i32) (param $y i64)
+  ;; CHECK:      (func $no-overlapping-bits-corner-case (param $0 i32) (param $1 i64)
+  ;; CHECK-NEXT:  (local $x i32)
+  ;; CHECK-NEXT:  (local $y i64)
+  ;; CHECK-NEXT:  (local.set $x
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.set $y
+  ;; CHECK-NEXT:   (i64.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.const 0)
   ;; CHECK-NEXT:  )
@@ -17790,9 +17801,24 @@
   ;; CHECK-NEXT:   (i64.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.const -2147483648)
   ;; CHECK-NEXT:    (i32.const 2147483647)
+  ;; CHECK-NEXT:    (i32.const -2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (i64.const 2147483647)
+  ;; CHECK-NEXT:    (i64.const 2147483649)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -17808,55 +17834,63 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const -2147483648)
+  ;; CHECK-NEXT:    (i32.const 2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.and
   ;; CHECK-NEXT:    (i64.const -9223372036854775808)
   ;; CHECK-NEXT:    (i64.const 9223372036854775807)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (local.get $0)
   ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (local.get $1)
   ;; CHECK-NEXT:    (i64.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.const 2147483647)
-  ;; CHECK-NEXT:    (i32.const -2147483647)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (i64.const 2147483647)
-  ;; CHECK-NEXT:    (i64.const 2147483649)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $no-overlapping-bits-corner-case (param $x i32) (param $y i64)
+  (func $no-overlapping-bits-corner-case (param $0 i32) (param $1 i64)
     ;; optimizeAndNoOverlappingBits simplifies AND operations where
     ;;  - the left value covers bits in [0, n)
     ;;  - the right operand is a constant with no bits in [0, n)
     ;; Result is simplified to zero.
-
+    (local $x i32)
+    (local $y i64)
+    (local.set $x
+      (i32.const 1)
+    )
+    (local.set $y
+      (i64.const 1)
+    )
     ;; No any bit overlapped, optimized.
+    (drop
+      (i32.and
+        (local.get $x)
+        (i32.const 2)
+      )
+    )
+    (drop
+      (i64.and
+        (local.get $y)
+        (i64.const 2)
+      )
+    )
+    ;; Both-constant cases which meets the condition are also optimized.
+    (drop
+      (i32.and
+        (i32.const 1)
+        (i32.const 2)
+      )
+    )
     (drop
       (i64.and
         (i64.const 1)
@@ -17864,23 +17898,30 @@
       )
     )
     (drop
+      (i64.and
+        (i64.const 0x7fffffff)
+        (i64.const 0x80000000)
+      )
+    )
+    ;; One bit overlapped, so we can not optimized.
+    (drop
       (i32.and
-        (i32.const 0)
-        (local.get $x)
+        (i32.const 0x7fffffff)
+        (i32.const 0x80000001)
       )
     )
     (drop
       (i64.and
-        (i64.const 0)
-        (local.get $y)
+        (i64.const 0x7fffffff)
+        (i64.const 0x80000001)
       )
     )
-    ;; optimizeAndNoOverlappingBits focuses on the case where one side is constant,
-    ;; both-constant cases are handled by Precompute, so they are skipped here.
+    ;; Both-constant cases which does not meets the condition are handled
+    ;; by Precompute, so they are skipped here.
     (drop
       (i32.and
-        (i32.const 0x80000000)
-        (i32.const 0x7fffffff)
+        (i32.const 2)
+        (i32.const 1)
       )
     )
     (drop
@@ -17897,47 +17938,27 @@
     )
     ;; Know nothing useful about the bits on the left, so we can not optimize.
     (drop
+      (i32.and
+        (i32.const 0x80000000)
+        (i32.const 0x7fffffff)
+      )
+    )
+    (drop
       (i64.and
         (i64.const 0x8000000000000000)
         (i64.const 0x7fffffffffffffff)
       )
     )
     (drop
-      (i64.and
-        (local.get $y)
-        (i64.const 1)
-      )
-    )
-    ;; Know nothing useful about the value of the right, so we can not optimize.
-    (drop
       (i32.and
-        (i32.const 1)
-        (local.get $x)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 1)
-        (local.get $y)
-      )
-    )
-    ;; One bit overlapped, so we can not optimized.
-    (drop
-      (i32.and
-        (local.get $x)
+        (local.get $0)
         (i32.const 1)
       )
     )
     (drop
-      (i32.and
-        (i32.const 0x7fffffff)
-        (i32.const 0x80000001)
-      )
-    )
-    (drop
       (i64.and
-        (i64.const 0x7fffffff)
-        (i64.const 0x80000001)
+        (local.get $1)
+        (i64.const 1)
       )
     )
   )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -1371,7 +1371,10 @@
   ;; CHECK-NEXT:   (i32.const 100)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const 100)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $and-neg1
@@ -1390,7 +1393,10 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const 100)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 1)
@@ -1439,7 +1445,10 @@
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
@@ -17772,28 +17781,7 @@
   )
   ;; CHECK:      (func $no-overlapping-bits-corner-case (param $x i32) (param $y i64)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 1)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i64.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
@@ -17802,21 +17790,63 @@
   ;; CHECK-NEXT:   (i64.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.const 0)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i64.const 0)
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.const -2147483647)
+  ;; CHECK-NEXT:    (i32.const -2147483648)
   ;; CHECK-NEXT:    (i32.const 2147483647)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.and
-  ;; CHECK-NEXT:    (i64.const 2147483649)
+  ;; CHECK-NEXT:    (i64.const 2)
+  ;; CHECK-NEXT:    (i64.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (i64.const 2147483648)
   ;; CHECK-NEXT:    (i64.const 2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (i64.const -9223372036854775808)
+  ;; CHECK-NEXT:    (i64.const 9223372036854775807)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const 2147483647)
+  ;; CHECK-NEXT:    (i32.const -2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (i64.const 2147483647)
+  ;; CHECK-NEXT:    (i64.const 2147483649)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
@@ -17826,32 +17856,27 @@
     ;; [0, n) always yields 0. Replace with zero.
     ;; Note: after swapping the operands, it also satisfies the commutative law.
 
-    ;; Unknown, not optimized
-    (drop
-      (i32.and
-        (local.get $x)
-        (i32.const 1)
-      )
-    )
-    (drop
-      (i64.and
-        (local.get $y)
-        (i64.const 1)
-      )
-    )
-    (drop
-      (i32.and
-        (i32.const 1)
-        (local.get $x)
-      )
-    )
-    (drop
-      (i64.and
-        (i64.const 1)
-        (local.get $y)
-      )
-    )
     ;; No any bit overlapping, optimized
+    (drop
+      (i64.and
+        (i64.const 1)
+        (i64.const 2)
+      )
+    )
+    (drop
+      (i32.and
+        (i32.const 0)
+        (local.get $x)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0)
+        (local.get $y)
+      )
+    )
+    ;; optimizeAndNoOverlappingBits focuses on the case where one side is constant,
+    ;; both-constant cases are handled by Precompute, so they are skipped here.
     (drop
       (i32.and
         (i32.const 0x80000000)
@@ -17870,23 +17895,49 @@
         (i64.const 0x7fffffff)
       )
     )
+    ;; Know nothing useful about the bits on the left, so we can not optimize.
     (drop
       (i64.and
         (i64.const 0x8000000000000000)
         (i64.const 0x7fffffffffffffff)
       )
     )
-    ;; Just one bit overlapping, not optimized
     (drop
       (i32.and
-        (i32.const 0x80000001)
-        (i32.const 0x7fffffff)
+        (local.get $x)
+        (i32.const 1)
       )
     )
     (drop
       (i64.and
-        (i64.const 0x80000001)
+        (local.get $y)
+        (i64.const 1)
+      )
+    )
+    ;; Know nothing useful about the value of the right, so we can not optimize.
+    (drop
+      (i32.and
+        (i32.const 1)
+        (local.get $x)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 1)
+        (local.get $y)
+      )
+    )
+    ;; One bit overlapped, not optimized
+    (drop
+      (i32.and
+        (i32.const 0x7fffffff)
+        (i32.const 0x80000001)
+      )
+    )
+    (drop
+      (i64.and
         (i64.const 0x7fffffff)
+        (i64.const 0x80000001)
       )
     )
   )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -1442,10 +1442,7 @@
   )
   ;; CHECK:      (func $canonicalize-consts-vars (param $x i32) (param $y i32)
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.and
@@ -7018,12 +7015,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (i32.eqz
-  ;; CHECK-NEXT:     (local.get $x)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:    (i32.const 2)
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.eqz

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17779,7 +17779,7 @@
       (i32.const 1)
     )
   )
-  ;; CHECK:      (func $add-op-no-overlapping-bits-corner-case
+  ;; CHECK:      (func $add-op-no-overlapping-bits-corner-case (param $0 i32) (param $1 i64)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
@@ -17789,8 +17789,14 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.const 0)
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.const 0)
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $add-op-no-overlapping-bits-corner-case
+  (func $add-op-no-overlapping-bits-corner-case (param $0 i32) (param $1 i64)
     ;; optimizeAndNoOverlappingBits simplifies AND operations where
     ;;  - the left value covers bits in [0, n)
     ;;  - the right operand is a constant with no bits in [0, n)
@@ -17812,6 +17818,26 @@
       (i64.and
         (i64.const 0x7fffffff)
         (i64.const 0x80000000)
+      )
+    )
+    ;; We know something (but not constant) about the bits
+    ;; on the left, so we can optimize.
+    (drop
+      (i32.and
+        (i32.and
+          (local.get $0)
+          (i32.const 0xff)
+        )
+        (i32.const 0xff00)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.and
+          (local.get $1)
+          (i64.const 0xff)
+        )
+        (i64.const 0xff00)
       )
     )
   )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17913,7 +17913,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $add-op-unknown-useful (param $0 i32) (param $1 i64)
-    ;; Know nothing useful about the bits on the left, so we can not optimize.
+    ;; We know nothing useful about the bits on the left, so we cannot optimize.
     (drop
       (i32.and
         (i32.const 0x80000000)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17814,12 +17814,6 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (i32.and
-  ;; CHECK-NEXT:    (local.get $x)
-  ;; CHECK-NEXT:    (i32.const 1)
-  ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:  )
-  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.and
   ;; CHECK-NEXT:    (local.get $y)
   ;; CHECK-NEXT:    (i64.const 1)
@@ -17835,6 +17829,12 @@
   ;; CHECK-NEXT:   (i64.and
   ;; CHECK-NEXT:    (local.get $y)
   ;; CHECK-NEXT:    (i64.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -17903,12 +17903,6 @@
       )
     )
     (drop
-      (i32.and
-        (local.get $x)
-        (i32.const 1)
-      )
-    )
-    (drop
       (i64.and
         (local.get $y)
         (i64.const 1)
@@ -17928,6 +17922,12 @@
       )
     )
     ;; One bit overlapped, so we can not optimized.
+    (drop
+      (i32.and
+        (local.get $x)
+        (i32.const 1)
+      )
+    )
     (drop
       (i32.and
         (i32.const 0x7fffffff)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17770,4 +17770,124 @@
       (i32.const 1)
     )
   )
+  ;; CHECK:      (func $no-overlapping-bits-corner-case (param $x i32) (param $y i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (local.get $y)
+  ;; CHECK-NEXT:    (i64.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (i32.const -2147483647)
+  ;; CHECK-NEXT:    (i32.const 2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.and
+  ;; CHECK-NEXT:    (i64.const 2147483649)
+  ;; CHECK-NEXT:    (i64.const 2147483647)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $no-overlapping-bits-corner-case (param $x i32) (param $y i64)
+    ;; optimizeAndNoOverlappingBits will simplify AND operations where
+    ;; Bitwise AND of a value with bits in [0, n) and a constant with no bits in
+    ;; [0, n) always yields 0. Replace with zero.
+    ;; Note: after swapping the operands, it also satisfies the commutative law.
+
+    ;; Unknown, not optimized
+    (drop
+      (i32.and
+        (local.get $x)
+        (i32.const 1)
+      )
+    )
+    (drop
+      (i64.and
+        (local.get $y)
+        (i64.const 1)
+      )
+    )
+    (drop
+      (i32.and
+        (i32.const 1)
+        (local.get $x)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 1)
+        (local.get $y)
+      )
+    )
+    ;; No any bit overlapping, optimized
+    (drop
+      (i32.and
+        (i32.const 0x80000000)
+        (i32.const 0x7fffffff)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 2)
+        (i64.const 1)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0x80000000)
+        (i64.const 0x7fffffff)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0x8000000000000000)
+        (i64.const 0x7fffffffffffffff)
+      )
+    )
+    ;; Just one bit overlapping, not optimized
+    (drop
+      (i32.and
+        (i32.const 0x80000001)
+        (i32.const 0x7fffffff)
+      )
+    )
+    (drop
+      (i64.and
+        (i64.const 0x80000001)
+        (i64.const 0x7fffffff)
+      )
+    )
+  )
 )

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17865,8 +17865,8 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $add-op-no-overlapping-skipped
-    ;; Both-constant cases which does not meets the condition are handled
-    ;; by Precompute, so they are skipped here.
+    ;; Both-constant cases which do not meet the condition (mask of left has no
+    ;; overlap with right) is left for Precompute.
     (drop
       (i32.and
         (i32.const 2)

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -2863,10 +2863,7 @@
     )
   )
   ;; CHECK:      (func $sext-24-and-127-128 (result i32)
-  ;; CHECK-NEXT:  (i32.and
-  ;; CHECK-NEXT:   (i32.const 127)
-  ;; CHECK-NEXT:   (i32.const 128)
-  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (i32.const 0)
   ;; CHECK-NEXT: )
   (func $sext-24-and-127-128 (result i32)
     (i32.shr_s

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -17830,7 +17830,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $add-op-overlapping-bits-corner-case
-    ;; One bit overlapped, so we can not optimized.
+    ;; One bit overlaps, so we cannot optimize.
     (drop
       (i32.and
         (i32.const 0x7fffffff)


### PR DESCRIPTION
There are so many rules for `and`, but we still cannot optimize the following one:

```
(i32.and
 (i32.eqz
  (i32.load $0
   (i32.const 0)
  )
 )
 (i32.const 4)
)
```

to zero.

Adding rule for `add`: `any boolean & (No overlap with boolean's LSB)  ==> 0`

Fixes: #7481 