### PR TITLE
Optimize block tails where a dropped br_if's value is redundant

### DIFF
--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1284,14 +1284,14 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           auto* secondLast = curr->list[size - 2];
           auto* last = curr->list[size - 1];
           if (auto* drop = secondLast->dynCast<Drop>()) {
-            if (auto* brk = drop->value->dynCast<Break>(); brk && brk->value) {
+            if (auto* br = drop->value->dynCast<Break>(); br && br->value) {
               bool hasNoSideEffects =
-                !EffectAnalyzer(passOptions, *getModule(), brk->value)
+                !EffectAnalyzer(passOptions, *getModule(), br->value)
                    .hasSideEffects();
-              bool isEqual = ExpressionAnalyzer::equal(brk->value, last);
+              bool isEqual = ExpressionAnalyzer::equal(br->value, last);
               if (hasNoSideEffects && isEqual) {
                 // All conditions met, perform the update
-                drop->value = brk->condition;
+                drop->value = br->condition;
               }
             }
           }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1283,7 +1283,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           const size_t size = curr->list.size();
           auto* secondLast = curr->list[size - 2];
           auto* last = curr->list[size - 1];
-          if (auto* drop = secondLast->dynCast<Drop>(); drop && drop->value) {
+          if (auto* drop = secondLast->dynCast<Drop>()) {
             if (auto* brk = drop->value->dynCast<Break>(); brk && brk->value) {
               bool hasNoSideEffects =
                 !EffectAnalyzer(passOptions, *getModule(), brk->value)

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1285,13 +1285,12 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           auto* last = curr->list[size - 1];
           if (auto* drop = secondLast->dynCast<Drop>()) {
             if (auto* br = drop->value->dynCast<Break>(); br && br->value) {
-              bool hasNoSideEffects =
-                !EffectAnalyzer(passOptions, *getModule(), br->value)
-                   .hasUnremovableSideEffects();
-              bool isEqual = ExpressionAnalyzer::equal(br->value, last);
-              if (hasNoSideEffects && isEqual) {
-                // All conditions met, perform the update
-                drop->value = br->condition;
+              if (!EffectAnalyzer(passOptions, *getModule(), br->value)
+                     .hasUnremovableSideEffects()) {
+                if (ExpressionAnalyzer::equal(br->value, last)) {
+                  // All conditions met, perform the update
+                  drop->value = br->condition;
+                }
               }
             }
           }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1281,7 +1281,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           //   )
           //   (value)
           // )
-          const size_t size = curr->list.size();
+          size_t size = curr->list.size();
           auto* secondLast = curr->list[size - 2];
           auto* last = curr->list[size - 1];
           if (auto* drop = secondLast->dynCast<Drop>()) {

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1287,7 +1287,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
             if (auto* br = drop->value->dynCast<Break>(); br && br->value) {
               bool hasNoSideEffects =
                 !EffectAnalyzer(passOptions, *getModule(), br->value)
-                   .hasSideEffects();
+                   .hasUnremovableSideEffects();
               bool isEqual = ExpressionAnalyzer::equal(br->value, last);
               if (hasNoSideEffects && isEqual) {
                 // All conditions met, perform the update

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1283,15 +1283,15 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           const size_t size = curr->list.size();
           auto* secondLast = curr->list[size - 2];
           auto* last = curr->list[size - 1];
-
-          if (auto* drop = secondLast->dynCast<Drop>()) {
-            if (auto* brk = drop->value->dynCast<Break>()) {
-              if (!EffectAnalyzer(passOptions, *getModule(), brk->value)
-                     .hasSideEffects()) {
-                if (ExpressionAnalyzer::equal(brk->value, last)) {
-                  // All conditions met, perform the update
-                  drop->value = brk->condition;
-                }
+          if (auto* drop = secondLast->dynCast<Drop>(); drop && drop->value) {
+            if (auto* brk = drop->value->dynCast<Break>(); brk && brk->value) {
+              bool hasNoSideEffects =
+                !EffectAnalyzer(passOptions, *getModule(), brk->value)
+                   .hasSideEffects();
+              bool isEqual = ExpressionAnalyzer::equal(brk->value, last);
+              if (hasNoSideEffects && isEqual) {
+                // All conditions met, perform the update
+                drop->value = brk->condition;
               }
             }
           }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1284,17 +1284,14 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           auto* secondLast = curr->list[size - 2];
           auto* last = curr->list[size - 1];
           if (auto* drop = secondLast->dynCast<Drop>()) {
-            if (auto* br = drop->value->dynCast<Break>(); br && br->value) {
+            if (auto* br = drop->value->dynCast<Break>();
+                br && br->value && br->condition) {
               if (br->name == curr->name) {
                 if (!EffectAnalyzer(passOptions, *getModule(), br->value)
                        .hasUnremovableSideEffects()) {
                   if (ExpressionAnalyzer::equal(br->value, last)) {
                     // All conditions met, perform the update.
-                    if (br->condition) {
-                      drop->value = br->condition;
-                    } else {
-                      curr->list.removeAt(size - 2);
-                    }
+                    drop->value = br->condition;
                   }
                 }
               }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1290,7 +1290,11 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                        .hasUnremovableSideEffects()) {
                   if (ExpressionAnalyzer::equal(br->value, last)) {
                     // All conditions met, perform the update.
-                    drop->value = br->condition;
+                    if (br->condition) {
+                      drop->value = br->condition;
+                    } else {
+                      curr->list.removeAt(size - 2);
+                    }
                   }
                 }
               }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1289,7 +1289,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
                 if (!EffectAnalyzer(passOptions, *getModule(), br->value)
                        .hasUnremovableSideEffects()) {
                   if (ExpressionAnalyzer::equal(br->value, last)) {
-                    // All conditions met, perform the update
+                    // All conditions met, perform the update.
                     drop->value = br->condition;
                   }
                 }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1260,8 +1260,8 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           restructureIf(curr);
 
           // Optimize block tails where a dropped `br_if`'s value is redundant
-          // when the br_if targets the block itself.
-          // consider for example:
+          // when the br_if targets the block itself:
+          //
           // (block $block (result i32)
           // ..
           //   (drop

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1259,7 +1259,6 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
           // Pattern-patch ifs, recreating them when it makes sense.
           restructureIf(curr);
 
-          // A potential optimization opportunity:
           // Optimize block tails where a dropped `br_if`'s value is redundant
           // when the br_if targets the block itself.
           // consider for example:

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -30,7 +30,7 @@
     )
   )
 
-  ;; CHECK:      (func $selectify-simple (type $1) (param $0 i32) (result i32)
+  ;; CHECK:      (func $selectify-simple (type $0) (param $0 i32) (result i32)
   ;; CHECK-NEXT:  (select
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:   (i32.lt_u
@@ -73,7 +73,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (if (result i32)
   ;; CHECK-NEXT:   (local.get $x)
   ;; CHECK-NEXT:   (then
@@ -104,12 +104,12 @@
     )
   )
 
-  ;; CHECK:      (func $nothing (type $0)
+  ;; CHECK:      (func $nothing (type $1)
   ;; CHECK-NEXT: )
   (func $nothing)
 
 
-  ;; CHECK:      (func $restructure-br_if-condition-reorderable (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-condition-reorderable (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (if (result i32)
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (call $nothing)
@@ -146,7 +146,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-effectful (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-effectful (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (select
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (call $nothing)
@@ -188,7 +188,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-1 (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-1 (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (block $x (result i32)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (br_if $x
@@ -233,7 +233,7 @@
     (i32.const 400)
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-2 (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-2 (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (block $x (result i32)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (br_if $x
@@ -272,7 +272,7 @@
       (call $get-i32)
     )
   )
-  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-3 (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-3 (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (block $x (result i32)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (br_if $x
@@ -305,7 +305,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-4 (type $1) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-effectful-corner-case-4 (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (block $x (result i32)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (br_if $x
@@ -340,7 +340,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-target-parent-block (type $2) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-1 (type $2) (result i32)
   ;; CHECK-NEXT:  (block $parent (result i32)
   ;; CHECK-NEXT:   (call $nothing)
   ;; CHECK-NEXT:   (drop
@@ -349,7 +349,7 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-target-parent-block (result i32)
+  (func $restructure-br_if-value-redudant-in-block-tail-1 (result i32)
     ;; The br_if's value is equal to the value right after it, so we can remove it.
     (block $parent (result i32)
       (call $nothing)
@@ -363,7 +363,59 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-target-outer-block (type $2) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-2 (type $2) (result i32)
+  ;; CHECK-NEXT:  (block $parent (result i32)
+  ;; CHECK-NEXT:   (call $nothing)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $parent
+  ;; CHECK-NEXT:     (i32.const 2)
+  ;; CHECK-NEXT:     (call $get-i32)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-value-redudant-in-block-tail-2 (result i32)
+    ;; As above, but now the value is different, so we do not optimize
+    (block $parent (result i32)
+      (call $nothing)
+      (drop
+        (br_if $parent
+          (i32.const 2)
+          (call $get-i32)
+        )
+      )
+      (i32.const 1)
+    )
+  )
+
+  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-3 (type $0) (param $x i32) (result i32)
+  ;; CHECK-NEXT:  (block $parent (result i32)
+  ;; CHECK-NEXT:   (call $nothing)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br_if $parent
+  ;; CHECK-NEXT:     (call $get-i32)
+  ;; CHECK-NEXT:     (call $get-i32)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-value-redudant-in-block-tail-3 (param $x i32) (result i32)
+    ;; As above, but now the value has effects, so we do not optimize
+    (block $parent (result i32)
+      (call $nothing)
+      (drop
+        (br_if $parent
+          (call $get-i32)
+          (call $get-i32)
+        )
+      )
+      (i32.const 1)
+    )
+  )
+
+  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-4 (type $2) (result i32)
   ;; CHECK-NEXT:  (block $outer (result i32)
   ;; CHECK-NEXT:   (block $inner (result i32)
   ;; CHECK-NEXT:    (call $nothing)
@@ -377,7 +429,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-target-outer-block (result i32)
+  (func $restructure-br_if-value-redudant-in-block-tail-4 (result i32)
     ;; As above, but the br_if targets another block, so we do not optimize.
     (block $outer (result i32)
       (block $inner (result i32)
@@ -394,7 +446,7 @@
   )
 
 
-  ;; CHECK:      (func $restructure-select-no-multivalue (type $0)
+  ;; CHECK:      (func $restructure-select-no-multivalue (type $1)
   ;; CHECK-NEXT:  (tuple.drop 2
   ;; CHECK-NEXT:   (block $block (type $3) (result i32 i32)
   ;; CHECK-NEXT:    (tuple.drop 2
@@ -441,7 +493,7 @@
     )
   )
 
-  ;; CHECK:      (func $if-of-if (type $0)
+  ;; CHECK:      (func $if-of-if (type $1)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (select
@@ -475,7 +527,7 @@
     )
   )
 
-  ;; CHECK:      (func $if-of-if-but-side-effects (type $0)
+  ;; CHECK:      (func $if-of-if-but-side-effects (type $1)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (local.tee $x
@@ -514,7 +566,7 @@
     )
   )
 
-  ;; CHECK:      (func $if-of-if-but-too-costly (type $0)
+  ;; CHECK:      (func $if-of-if-but-too-costly (type $1)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (local.tee $x
@@ -569,7 +621,7 @@
     )
   )
 
-  ;; CHECK:      (func $if-of-if-but-inner-else (type $0)
+  ;; CHECK:      (func $if-of-if-but-inner-else (type $1)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (local.tee $x
@@ -609,7 +661,7 @@
     )
   )
 
-  ;; CHECK:      (func $if-of-if-but-outer-else (type $0)
+  ;; CHECK:      (func $if-of-if-but-outer-else (type $1)
   ;; CHECK-NEXT:  (local $x i32)
   ;; CHECK-NEXT:  (if
   ;; CHECK-NEXT:   (local.tee $x
@@ -649,7 +701,7 @@
     )
   )
 
-  ;; CHECK:      (func $unreachable-if (type $0)
+  ;; CHECK:      (func $unreachable-if (type $1)
   ;; CHECK-NEXT:  (block $block
   ;; CHECK-NEXT:   (if (result i32)
   ;; CHECK-NEXT:    (unreachable)
@@ -679,7 +731,7 @@
     )
   )
 
-  ;; CHECK:      (func $loop-with-unreachable-if (type $0)
+  ;; CHECK:      (func $loop-with-unreachable-if (type $1)
   ;; CHECK-NEXT:  (loop $label
   ;; CHECK-NEXT:   (if (result i32)
   ;; CHECK-NEXT:    (unreachable)

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -398,7 +398,7 @@
   ;; CHECK-NEXT:     (call $get-i32)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
-  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:   (call $get-i32)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $restructure-br_if-value-redundant-in-block-tail-3 (param $x i32) (result i32)

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -340,8 +340,8 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-redundant (type $2) (result i32)
-  ;; CHECK-NEXT:  (block $x (result i32)
+  ;; CHECK:      (func $restructure-br_if-target-parent-block (type $2) (result i32)
+  ;; CHECK-NEXT:  (block $parent (result i32)
   ;; CHECK-NEXT:   (call $nothing)
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (call $get-i32)
@@ -349,16 +349,46 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-value-redundant (result i32)
-    (block $x (result i32)
+  (func $restructure-br_if-target-parent-block (result i32)
+    (block $parent (result i32)
       (call $nothing)
       (drop
-        (br_if $x
+        (br_if $parent
           (i32.const 1)
           (call $get-i32)
         )
       )
       (i32.const 1)
+    )
+  )
+
+  ;; CHECK:      (func $restructure-br_if-target-outer-block (type $2) (result i32)
+  ;; CHECK-NEXT:  (block $outer (result i32)
+  ;; CHECK-NEXT:   (block $inner (result i32)
+  ;; CHECK-NEXT:    (call $nothing)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (br_if $outer
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:      (call $get-i32)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-target-outer-block (result i32)
+    ;;Perform optimize only when br_if target its parent block
+    (block $outer (result i32)
+      (block $inner (result i32)
+        (call $nothing)
+        (drop
+          (br_if $outer
+            (i32.const 1)
+            (call $get-i32)
+          )
+        )
+        (i32.const 1)
+      )
     )
   )
 

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -340,6 +340,29 @@
     )
   )
 
+  ;; CHECK:      (func $restructure-br_if-value-redundant (type $2) (result i32)
+  ;; CHECK-NEXT:  (block $x (result i32)
+  ;; CHECK-NEXT:   (call $nothing)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (call $get-i32)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-value-redundant (result i32)
+    (block $x (result i32)
+      (call $nothing)
+      (drop
+        (br_if $x
+          (i32.const 1)
+          (call $get-i32)
+        )
+      )
+      (i32.const 1)
+    )
+  )
+
+
   ;; CHECK:      (func $restructure-select-no-multivalue (type $0)
   ;; CHECK-NEXT:  (tuple.drop 2
   ;; CHECK-NEXT:   (block $block (type $2) (result i32 i32)

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -350,6 +350,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $restructure-br_if-target-parent-block (result i32)
+    ;; The br_if's value is equal to the value right after it, so we can remove it.
     (block $parent (result i32)
       (call $nothing)
       (drop

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -448,10 +448,8 @@
   ;; CHECK:      (func $restructure-br_if-value-redundant-in-block-tail-5 (type $2) (result i32)
   ;; CHECK-NEXT:  (block $parent (result i32)
   ;; CHECK-NEXT:   (call $nothing)
-  ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (br $parent
-  ;; CHECK-NEXT:     (i32.const 1)
-  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   (br $parent
+  ;; CHECK-NEXT:    (i32.const 1)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -461,10 +461,8 @@
     ;; the dead code after it, but also should not error here.
     (block $parent (result i32)
       (call $nothing)
-      (drop
-        (br $parent
-          (i32.const 1)
-        )
+      (br $parent
+        (i32.const 1)
       )
       (i32.const 1)
     )

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -445,6 +445,30 @@
     )
   )
 
+  ;; CHECK:      (func $restructure-br_if-value-redundant-in-block-tail-5 (type $2) (result i32)
+  ;; CHECK-NEXT:  (block $parent (result i32)
+  ;; CHECK-NEXT:   (call $nothing)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (br $parent
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-value-redundant-in-block-tail-5 (result i32)
+    ;; As above, but the br lacks a condition. We do not bother to optimize
+    ;; the dead code after it, but also should not error here.
+    (block $parent (result i32)
+      (call $nothing)
+      (drop
+        (br $parent
+          (i32.const 1)
+        )
+      )
+      (i32.const 1)
+    )
+  )
 
   ;; CHECK:      (func $restructure-select-no-multivalue (type $1)
   ;; CHECK-NEXT:  (tuple.drop 2

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -340,7 +340,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-1 (type $2) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-redundant-in-block-tail-1 (type $2) (result i32)
   ;; CHECK-NEXT:  (block $parent (result i32)
   ;; CHECK-NEXT:   (call $nothing)
   ;; CHECK-NEXT:   (drop
@@ -349,7 +349,7 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-value-redudant-in-block-tail-1 (result i32)
+  (func $restructure-br_if-value-redundant-in-block-tail-1 (result i32)
     ;; The br_if's value is equal to the value right after it, so we can remove it.
     (block $parent (result i32)
       (call $nothing)
@@ -363,7 +363,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-2 (type $2) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-redundant-in-block-tail-2 (type $2) (result i32)
   ;; CHECK-NEXT:  (block $parent (result i32)
   ;; CHECK-NEXT:   (call $nothing)
   ;; CHECK-NEXT:   (drop
@@ -375,7 +375,7 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-value-redudant-in-block-tail-2 (result i32)
+  (func $restructure-br_if-value-redundant-in-block-tail-2 (result i32)
     ;; As above, but now the value is different, so we do not optimize
     (block $parent (result i32)
       (call $nothing)
@@ -389,7 +389,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-3 (type $0) (param $x i32) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-redundant-in-block-tail-3 (type $0) (param $x i32) (result i32)
   ;; CHECK-NEXT:  (block $parent (result i32)
   ;; CHECK-NEXT:   (call $nothing)
   ;; CHECK-NEXT:   (drop
@@ -401,7 +401,7 @@
   ;; CHECK-NEXT:   (i32.const 1)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-value-redudant-in-block-tail-3 (param $x i32) (result i32)
+  (func $restructure-br_if-value-redundant-in-block-tail-3 (param $x i32) (result i32)
     ;; As above, but now the value has effects, so we do not optimize
     (block $parent (result i32)
       (call $nothing)
@@ -415,7 +415,7 @@
     )
   )
 
-  ;; CHECK:      (func $restructure-br_if-value-redudant-in-block-tail-4 (type $2) (result i32)
+  ;; CHECK:      (func $restructure-br_if-value-redundant-in-block-tail-4 (type $2) (result i32)
   ;; CHECK-NEXT:  (block $outer (result i32)
   ;; CHECK-NEXT:   (block $inner (result i32)
   ;; CHECK-NEXT:    (call $nothing)
@@ -429,7 +429,7 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
-  (func $restructure-br_if-value-redudant-in-block-tail-4 (result i32)
+  (func $restructure-br_if-value-redundant-in-block-tail-4 (result i32)
     ;; As above, but the br_if targets another block, so we do not optimize.
     (block $outer (result i32)
       (block $inner (result i32)

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -5,7 +5,7 @@
 
 (module
   ;; Regression test in which we need to calculate a proper LUB.
-  ;; CHECK:      (func $selectify-fresh-lub (type $3) (param $x i32) (result anyref)
+  ;; CHECK:      (func $selectify-fresh-lub (type $4) (param $x i32) (result anyref)
   ;; CHECK-NEXT:  (select (result i31ref)
   ;; CHECK-NEXT:   (ref.null none)
   ;; CHECK-NEXT:   (ref.i31
@@ -226,7 +226,7 @@
     )
   )
 
-  ;; CHECK:      (func $get-i32 (type $4) (result i32)
+  ;; CHECK:      (func $get-i32 (type $2) (result i32)
   ;; CHECK-NEXT:  (i32.const 400)
   ;; CHECK-NEXT: )
   (func $get-i32 (result i32)
@@ -365,7 +365,7 @@
 
   ;; CHECK:      (func $restructure-select-no-multivalue (type $0)
   ;; CHECK-NEXT:  (tuple.drop 2
-  ;; CHECK-NEXT:   (block $block (type $2) (result i32 i32)
+  ;; CHECK-NEXT:   (block $block (type $3) (result i32 i32)
   ;; CHECK-NEXT:    (tuple.drop 2
   ;; CHECK-NEXT:     (br_if $block
   ;; CHECK-NEXT:      (tuple.make 2

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -411,7 +411,7 @@
           (call $get-i32)
         )
       )
-      (i32.const 1)
+      (call $get-i32)
     )
   )
 

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -378,7 +378,7 @@
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $restructure-br_if-target-outer-block (result i32)
-    ;;Perform optimize only when br_if target its parent block
+    ;; As above, but the br_if targets another block, so we do not optimize.
     (block $outer (result i32)
       (block $inner (result i32)
         (call $nothing)


### PR DESCRIPTION
If a block ends with a `br_if` followed by a value that is the same as the `br_if`'s value (and has no side effects), the value of `br_if` and `br_if` itself are redundant and can be removed. For example:

``` webassembly
(block $block (result i32)
 ..
 (drop
  (br_if $block
   (value)
   (condition)
  )
 )
 (value)
)

=>

(block $block (result i32)
 ..
 (drop
  (condition)
 )
 (value)
)
```

Fixes: #7489 

