### PR TITLE
[Fuzzing] Simplify V8 fuzzing flags: use --fuzzing over specific EH flag

### DIFF
--- a/scripts/clusterfuzz/run.py
+++ b/scripts/clusterfuzz/run.py
@@ -33,9 +33,7 @@ import sys
 
 # The V8 flags we put in the "fuzzer flags" files, which tell ClusterFuzz how to
 # run V8. By default we apply all staging flags.
-#
-# We also allow mixed EH, see the comment on the same flag in fuzz_opt.py
-FUZZER_FLAGS_FILE_CONTENTS = '--wasm-staging --wasm-allow-mixed-eh-for-testing'
+FUZZER_FLAGS_FILE_CONTENTS = '--wasm-staging'
 
 # Maximum size of the random data that we feed into wasm-opt -ttf. This is
 # smaller than fuzz_opt.py's INPUT_SIZE_MAX because that script is tuned for

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -673,7 +673,7 @@ def get_v8_extra_flags():
     # It is important to use the --fuzzing flag because it does things like
     # enable mixed old and new EH (which is an issue since
     # https://github.com/WebAssembly/exception-handling/issues/344 )
-    flags += ['--fuzzing']
+    flags = ['--fuzzing']
 
     # Sometimes add --future, which may enable new JITs and such, which is good
     # to fuzz for V8's sake.

--- a/test/unit/test_cluster_fuzz.py
+++ b/test/unit/test_cluster_fuzz.py
@@ -186,7 +186,7 @@ class ClusterFuzz(utils.BinaryenTestCase):
 
             # The flags file must contain --wasm-staging
             with open(flags_file) as f:
-                self.assertEqual(f.read(), '--wasm-staging --wasm-allow-mixed-eh-for-testing')
+                self.assertEqual(f.read(), '--wasm-staging')
 
             # Extract the wasm file(s) from the JS. Make sure to not notice
             # stale files.


### PR DESCRIPTION
ClusterFuzz already applies this flag, and it implies the EH flag, so we might
as well do it the way V8 does it. This is simpler, though it does mean we are
testing something even more different than production - but in the way V8
believes is best for fuzzing, at least.