### PR TITLE
Add Windows 11 arm to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest,windows-11-arm]
+        os: [windows-latest, windows-11-arm]
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,11 +368,8 @@ jobs:
 
   # Windows + gcc needs work before the tests will run, so just test the compile
   build-mingw:
-    name: mingw-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, windows-11-arm]
+    name: mingw
+    runs-on: windows-latest
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
     steps:
     - uses: actions/setup-python@v5
       with:
@@ -77,7 +77,7 @@ jobs:
 
     - name: install ninja (win)
       run: choco install ninja
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
 
     - name: install v8
       run: |
@@ -98,7 +98,7 @@ jobs:
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
       run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out/install
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
 
     - name: build
       run: cmake --build out --config Release -v
@@ -108,7 +108,7 @@ jobs:
 
     - name: strip
       run: find out/install/ -type f -perm -u=x -exec strip -x {} +
-      if: matrix.os != 'windows-latest'
+      if: ${{ !startsWith(matrix.os, 'windows') }}
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
@@ -368,8 +368,11 @@ jobs:
 
   # Windows + gcc needs work before the tests will run, so just test the compile
   build-mingw:
-    name: mingw
-    runs-on: windows-latest
+    name: mingw-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest,windows-11-arm]
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest,windows-11-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, windows-11-arm]
     steps:
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -78,6 +78,7 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
         echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
+      if: ${{ matrix.os != 'macos-latest' & matrix.os != 'windows-11-arm' }} 
 
     - name: archive-arm64
       id: archive-arm64

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -83,7 +83,7 @@ jobs:
     - name: archive-arm64
       id: archive-arm64
       run: |
-        OSNAME=$(echo ${{ matrix.os }} | sed 's/-latest//')
+        OSNAME=$(echo ${{ matrix.os }} | sed 's/-latest//' | sed 's/-11-arm//')
         VERSION=$GITHUB_REF_NAME
         PKGNAME="binaryen-$VERSION-arm64-$OSNAME"
         TARBALL=$PKGNAME.tar.gz

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest,windows-11-arm]
     defaults:
       run:
         shell: bash
@@ -31,7 +31,7 @@ jobs:
 
     - name: install ninja (win)
       run: choco install ninja
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
 
     - name: mkdir
       run: mkdir -p out
@@ -45,7 +45,7 @@ jobs:
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
       run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out/install
-      if: matrix.os == 'windows-latest'
+      if: startsWith(matrix.os, 'windows')
 
     - name: build
       run: cmake --build out -v --config Release --target install
@@ -56,7 +56,7 @@ jobs:
 
     - name: strip
       run: find out*/install/ -type f -perm -u=x -exec strip -x {} +
-      if: matrix.os != 'windows-latest'
+      if: ${{ !startsWith(matrix.os, 'windows') }}
 
     - name: archive
       id: archive

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: strip
       run: find out*/install/ -type f -perm -u=x -exec strip -x {} +
-      if: !startsWith(matrix.os, 'windows')
+      if: ${{ !startsWith(matrix.os, 'windows') }}
 
     - name: archive
       id: archive

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -45,7 +45,12 @@ jobs:
     - name: cmake (win)
       # -G "Visual Studio 15 2017"
       run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out/install
-      if: startsWith(matrix.os, 'windows')
+      if: matrix.os == 'windows-latest'
+
+    - name: cmake (win arm64)
+      # -G "Visual Studio 15 2017"
+      run: cmake -S . -B out -DCMAKE_INSTALL_PREFIX=out-arm64/install 
+      if: matrix.os == 'windows-11-arm'
 
     - name: build
       run: cmake --build out -v --config Release --target install

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -78,7 +78,7 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
         echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
-      if: ${{ matrix.os != 'macos-latest' & matrix.os != 'windows-11-arm' }} 
+      if: ${{ matrix.os != 'macos-latest' && matrix.os != 'windows-11-arm' }} 
 
     - name: archive-arm64
       id: archive-arm64

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -78,7 +78,7 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
         echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
-      if: ${{ matrix.os != 'macos-latest' && matrix.os != 'windows-11-arm' }} 
+      if: matrix.os != 'windows-11-arm'
 
     - name: archive-arm64
       id: archive-arm64

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest,windows-11-arm]
+        os: [macos-latest, windows-latest, windows-11-arm]
     defaults:
       run:
         shell: bash
@@ -61,7 +61,7 @@ jobs:
 
     - name: strip
       run: find out*/install/ -type f -perm -u=x -exec strip -x {} +
-      if: ${{ !startsWith(matrix.os, 'windows') }}
+      if: !startsWith(matrix.os, 'windows')
 
     - name: archive
       id: archive

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -89,7 +89,7 @@ jobs:
         cmake -E sha256sum $TARBALL > $SHASUM
         echo "TARBALL=$TARBALL" >> $GITHUB_OUTPUT
         echo "SHASUM=$SHASUM" >> $GITHUB_OUTPUT
-      if: matrix.os == 'macos-latest'
+      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'windows-11-arm' }} 
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
According to https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/ Windows arm Github runners are now available for free for public repositories. Therefore I have added them to binaryen ci.