### PR TITLE
Convert JSON parsing failures from assertions to exceptions

### DIFF
--- a/src/source-map.h
+++ b/src/source-map.h
@@ -19,14 +19,15 @@
 
 #include <optional>
 
+#include "support/json.h"
 #include "wasm.h"
 
 namespace wasm {
 
 struct MapParseException {
-  std::string text;
-
-  MapParseException(std::string text) : text(text) {}
+  std::string errorText;
+  MapParseException(std::string errorText) : errorText(errorText) {};
+  MapParseException(json::JsonParseException ex) : errorText(ex.errorText) {};
   void dump(std::ostream& o) const;
 };
 

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -45,6 +45,18 @@ namespace json {
 
 using IString = wasm::IString;
 
+struct JsonParseException {
+  std::string errorText;
+
+  JsonParseException(std::string errorText) : errorText(errorText) {}
+  void dump(std::ostream& o) const { o << "JSON parse error: " << errorText; }
+};
+
+#define THROW_IF(expr, message)                                                \
+  if (expr) {                                                                  \
+    throw JsonParseException(message);                                         \
+  }
+
 // Main value type
 struct Value {
   struct Ref : public std::shared_ptr<Value> {
@@ -277,7 +289,7 @@ struct Value {
       do {
         close = strchr(close + 1, '"');
       } while (*(close - 1) == '\\');
-      assert(close);
+      THROW_IF(!close, "malformed JSON string");
       *close = 0; // end this string, and reuse it straight from the input
       char* raw = curr + 1;
       if (stringEncoding == ASCII) {
@@ -301,24 +313,24 @@ struct Value {
         if (*curr == ']') {
           break;
         }
-        assert(*curr == ',');
+        THROW_IF(*curr != ',', "malformed JSON array");
         curr++;
         skip();
       }
       curr++;
     } else if (*curr == 'n') {
       // Null
-      assert(strncmp(curr, "null", 4) == 0);
+      THROW_IF(strncmp(curr, "null", 4) != 0, "unexpected JSON literal");
       setNull();
       curr += 4;
     } else if (*curr == 't') {
       // Bool true
-      assert(strncmp(curr, "true", 4) == 0);
+      THROW_IF(strncmp(curr, "true", 4) != 0, "unexpected JSON literal");
       setBool(true);
       curr += 4;
     } else if (*curr == 'f') {
       // Bool false
-      assert(strncmp(curr, "false", 5) == 0);
+      THROW_IF(strncmp(curr, "false", 5) != 0, "unexpected JSON literal");
       setBool(false);
       curr += 5;
     } else if (*curr == '{') {
@@ -327,15 +339,15 @@ struct Value {
       skip();
       setObject();
       while (*curr != '}') {
-        assert(*curr == '"');
+        THROW_IF(*curr != '"', "malformed key in JSON object");
         curr++;
         char* close = strchr(curr, '"');
-        assert(close);
+        THROW_IF(!close, "malformed key in JSON object");
         *close = 0; // end this string, and reuse it straight from the input
         IString key(curr);
         curr = close + 1;
         skip();
-        assert(*curr == ':');
+        THROW_IF(*curr != ':', "missing ':', in JSON object");
         curr++;
         skip();
         Ref value = Ref(new Value());
@@ -345,7 +357,7 @@ struct Value {
         if (*curr == '}') {
           break;
         }
-        assert(*curr == ',');
+        THROW_IF(*curr != ',', "malformed value in JSON object");
         curr++;
         skip();
       }

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -2,6 +2,7 @@ if(BUILD_FUZZTEST)
   include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third_party/fuzztest)
 else()
   include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include)
+  include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third_party/googletest/googlemock/include)
 endif()
 
 set(unittest_SOURCES


### PR DESCRIPTION
This allows some useful error reporting with bad source maps.
The JSON exception is converted to the existing map parse exception by the
source map parser, allowing a unified interface. Also add several tests of
bogus source maps.
