### PR TITLE
Fix incorrect result in getMaxBits for 0 / 0

### DIFF
--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -187,7 +187,9 @@ Index getMaxBits(Expression* curr,
             return 32;
           }
           int32_t bitsRight = getMaxBits(c);
-          return std::max(0, maxBitsLeft - bitsRight + 1);
+          // Apply std::min: Result bits cannot exceed dividend bits
+          return std::min(maxBitsLeft,
+                          std::max(0, maxBitsLeft - bitsRight + 1));
         }
         return 32;
       }
@@ -195,7 +197,9 @@ Index getMaxBits(Expression* curr,
         int32_t maxBitsLeft = getMaxBits(binary->left, localInfoProvider);
         if (auto* c = binary->right->dynCast<Const>()) {
           int32_t bitsRight = getMaxBits(c);
-          return std::max(0, maxBitsLeft - bitsRight + 1);
+          // Apply std::min: Result bits cannot exceed dividend bits
+          return std::min(maxBitsLeft,
+                          std::max(0, maxBitsLeft - bitsRight + 1));
         }
         return maxBitsLeft;
       }
@@ -282,7 +286,9 @@ Index getMaxBits(Expression* curr,
             return 64;
           }
           int32_t bitsRight = getMaxBits(c);
-          return std::max(0, maxBitsLeft - bitsRight + 1);
+          // Apply std::min: Result bits cannot exceed dividend bits
+          return std::min(maxBitsLeft,
+                          std::max(0, maxBitsLeft - bitsRight + 1));
         }
         return 64;
       }
@@ -290,7 +296,9 @@ Index getMaxBits(Expression* curr,
         int32_t maxBitsLeft = getMaxBits(binary->left, localInfoProvider);
         if (auto* c = binary->right->dynCast<Const>()) {
           int32_t bitsRight = getMaxBits(c);
-          return std::max(0, maxBitsLeft - bitsRight + 1);
+          // Apply std::min: Result bits cannot exceed dividend bits
+          return std::min(maxBitsLeft,
+                          std::max(0, maxBitsLeft - bitsRight + 1));
         }
         return maxBitsLeft;
       }

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11395,6 +11395,17 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.div_u
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.extend_i32_u
   ;; CHECK-NEXT:    (i64.eq
   ;; CHECK-NEXT:     (local.get $y)
@@ -11406,6 +11417,17 @@
   ;; CHECK-NEXT:   (i64.div_s
   ;; CHECK-NEXT:    (local.get $y)
   ;; CHECK-NEXT:    (i64.const -2147483648)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i64)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i64.div_u
+  ;; CHECK-NEXT:      (i64.const 0)
+  ;; CHECK-NEXT:      (i64.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -11433,6 +11455,17 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.div_u
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i64.extend_i32_u
   ;; CHECK-NEXT:    (i64.eq
   ;; CHECK-NEXT:     (local.get $y)
@@ -11444,6 +11477,17 @@
   ;; CHECK-NEXT:   (i64.shr_u
   ;; CHECK-NEXT:    (local.get $y)
   ;; CHECK-NEXT:    (i64.const 63)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i64)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i64.div_u
+  ;; CHECK-NEXT:      (i64.const 0)
+  ;; CHECK-NEXT:      (i64.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i64.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -11683,6 +11727,11 @@
       (local.get $x)
       (i32.const -2147483648)
     ))
+    ;; i32(0) / i32(0) => i32(0) but still traps
+    (drop (i32.div_s
+      (i32.const 0)
+      (i32.const 0)
+    ))
     ;; i64(x) / -9223372036854775808  ->  x == -9223372036854775808
     (drop (i64.div_s
       (local.get $y)
@@ -11692,6 +11741,11 @@
     (drop (i64.div_s
       (local.get $y)
       (i64.const -2147483648)
+    ))
+    ;; i64(0) / i64(0) => i64(0) but still traps
+    (drop (i64.div_s
+      (i64.const 0)
+      (i64.const 0)
     ))
 
     ;; unsigned divs
@@ -11715,6 +11769,11 @@
       (local.get $x)
       (i32.const -2147483648)
     ))
+    ;; i32(0) / i32(0) => i32(0) but still traps
+    (drop (i32.div_u
+      (i32.const 0)
+      (i32.const 0)
+    ))
     ;; u64(x) / -1  =>  u64(x == -1)
     (drop (i64.div_u
       (local.get $y)
@@ -11724,6 +11783,11 @@
     (drop (i64.div_u
       (local.get $y)
       (i64.const -9223372036854775808)
+    ))
+    ;; i64(0) / i64(0) => i64(0) but still traps
+    (drop (i64.div_u
+      (i64.const 0)
+      (i64.const 0)
     ))
 
     ;; bool(x) | 1  ==>  1


### PR DESCRIPTION
The result of integer division cannot have more bits than the dividend. However, currently rule for `div` doesn't cover the `0 / 0`. It returns `1` for `0 / 0` binary operation (line 198 below).

https://github.com/WebAssembly/binaryen/blob/e6f1c53a2052d7c1e9e06ace64c7c2833aa82a7d/src/ir/bits.h#L194-L201

Fixes bug, and missed optimization in #7471 