### PR TITLE
Allow emcc-tests.sh to be invoked from outside the Binaryen source directory

### DIFF
--- a/scripts/emcc-tests.sh
+++ b/scripts/emcc-tests.sh
@@ -3,16 +3,18 @@
 set -o errexit
 set -o pipefail
 
+SRCDIR="$(dirname $(dirname ${BASH_SOURCE[0]}))"
+
 mkdir -p emcc-build
 echo "emcc-tests: build:wasm"
-emcmake cmake -B emcc-build -DCMAKE_BUILD_TYPE=Release -G Ninja
+emcmake cmake -S $SRCDIR -B emcc-build -DCMAKE_BUILD_TYPE=Release -G Ninja
 ninja -C emcc-build binaryen_wasm
 echo "emcc-tests: test:wasm"
-./check.py --binaryen-bin=emcc-build/bin binaryenjs_wasm
+$SRCDIR/check.py --binaryen-bin=emcc-build/bin binaryenjs_wasm
 echo "emcc-tests: done:wasm"
 
 echo "emcc-tests: build:js"
 ninja -C emcc-build  binaryen_js
 echo "emcc-tests: test:js"
-./check.py --binaryen-bin=emcc-build/bin binaryenjs
+$SRCDIR/check.py --binaryen-bin=emcc-build/bin binaryenjs
 echo "emcc-tests: done:js"


### PR DESCRIPTION
This makes it easier to run the tests while keeping the source tree clean.
