### PR TITLE
Propagate exactness when combining GUFA possible contents

### DIFF
--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -102,7 +102,7 @@ PossibleContents PossibleContents::combine(const PossibleContents& a,
     // just add in nullability. For example, a literal of type T and a null
     // becomes an exact type of T that allows nulls, and so forth.
     auto mixInNull = [](ConeType cone) {
-      cone.type = Type(cone.type.getHeapType(), Nullable);
+      cone.type = cone.type.with(Nullable);
       return cone;
     };
     if (!a.isNull()) {

--- a/test/lit/passes/gufa-cast-all-exact.wast
+++ b/test/lit/passes/gufa-cast-all-exact.wast
@@ -109,3 +109,32 @@
   )
  )
 )
+
+(module
+ ;; CHECK:      (type $foo (struct (field i32)))
+ ;; NO_CD:      (type $foo (struct (field i32)))
+ (type $foo (struct (field i32)))
+
+ ;; CHECK:      (import "" "" (global $exact (ref (exact $foo))))
+ ;; NO_CD:      (import "" "" (global $exact (ref (exact $foo))))
+ (import "" "" (global $exact (ref (exact $foo))))
+
+ ;; CHECK:      (func $get (type $1) (result i32)
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
+ ;; NO_CD:      (func $get (type $1) (result i32)
+ ;; NO_CD-NEXT:  (unreachable)
+ ;; NO_CD-NEXT: )
+ (func $get (result i32)
+  ;; Regression test for a bug where exactness was not preserved when combining
+  ;; nullness into cone types, resulting in a later assertion failure on the
+  ;; StructGet.
+  (struct.get $foo 0
+   (select (result (ref null (exact $foo)))
+    (global.get $exact)
+    (ref.null none)
+    (i32.const 0)
+   )
+  )
+ )
+)


### PR DESCRIPTION
The logic for joining nullability into a PossibleContents cone value did
not previously preserve the exactness of the type in the cone value,
causing assertion failures.
