### PR TITLE
Fix JSON parsing of escaped strings

### DIFF
--- a/src/support/json.h
+++ b/src/support/json.h
@@ -272,12 +272,17 @@ struct Value {
       // String
       // Start |close| at the opening ", and in the loop below we will always
       // begin looking at the first character after.
-      char* close = curr;
-      // Skip escaped "
-      do {
-        close = strchr(close + 1, '"');
-      } while (*(close - 1) == '\\');
-      assert(close);
+      char* close = curr + 1;
+      // Skip escaped ", which appears as \". We need to be careful though, as
+      // \" might also be \\" which would be an escaped " and an *un*escaped ".
+      while (*close && *close != '"') {
+        if (*close == '\\') {
+          // Skip the \ and the character after it, which it escapes.
+          close++;
+          assert(*close);
+        }
+        close++;
+      }
       *close = 0; // end this string, and reuse it straight from the input
       char* raw = curr + 1;
       if (stringEncoding == ASCII) {

--- a/src/support/json.h
+++ b/src/support/json.h
@@ -274,7 +274,7 @@ struct Value {
       // begin looking at the first character after.
       char* close = curr + 1;
       // Skip escaped ", which appears as \". We need to be careful though, as
-      // \" might also be \\" which would be an escaped " and an *un*escaped ".
+      // \" might also be \\" which would be an escaped \ and an *un*escaped ".
       while (*close && *close != '"') {
         if (*close == '\\') {
           // Skip the \ and the character after it, which it escapes.

--- a/test/lit/passes/string-lifting-section.wast
+++ b/test/lit/passes/string-lifting-section.wast
@@ -2,7 +2,7 @@
 
 ;; Lower first to generate the string.consts custom section, then lift it back.
 
-;; RUN: foreach %s %t wasm-opt -all --string-lowering --string-lifting -S -o - | filecheck %s
+;; RUN: wasm-opt %s -all --string-lowering --string-lifting -S -o - | filecheck %s
 
 (module
   ;; CHECK:      (type $0 (array (mut i16)))
@@ -36,6 +36,8 @@
   ;; CHECK:      (import "string.const" "4" (global $"string.const_\"unpaired high surrogate \\ed\\a0\\80 \"" (ref extern)))
 
   ;; CHECK:      (import "string.const" "5" (global $"string.const_\"unpaired low surrogate \\ed\\bd\\88 \"" (ref extern)))
+
+  ;; CHECK:      (import "string.const" "6" (global $"string.const_\"z\\\\\"" (ref extern)))
 
   ;; CHECK:      (import "wasm:js-string" "fromCharCodeArray" (func $fromCharCodeArray (type $3) (param (ref null $0) i32 i32) (result (ref extern))))
 
@@ -94,6 +96,9 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (string.const "unpaired low surrogate \ed\bd\88 ")
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (string.const "z\\")
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $tricky-consts
     ;; These tricky strings should remain exactly the same after lowering and
@@ -109,6 +114,10 @@
     )
     (drop
       (string.const "unpaired low surrogate \ED\BD\88 ")
+    )
+    ;; A string with \", but the " is not escaped, as the \ is part of \\.
+    (drop
+      (string.const "z\\")
     )
   )
 )


### PR DESCRIPTION
To find the end of a string, we must be more careful of escaping - we assumed
any `\"` was an escaped double-quote, but it might be part of `\\"`, that is, where
there is an escaped `\` before us, and the double-quote is not escaped itself.

This fixes StringLifting on real-world Java code I am testing on.