### PR TITLE
[Strings] Erase the strings section after StringLifting

### DIFF
--- a/src/passes/StringLifting.cpp
+++ b/src/passes/StringLifting.cpp
@@ -79,13 +79,13 @@ struct StringLifting : public Pass {
     }
 
     // Imported strings may also be found in the string section.
-    auto iter = std::find_if(
+    auto stringSectionIter = std::find_if(
       module->customSections.begin(),
       module->customSections.end(),
       [&](CustomSection& section) { return section.name == "string.consts"; });
-    if (iter != module->customSections.end()) {
+    if (stringSectionIter != module->customSections.end()) {
       // We found the string consts section. Parse it.
-      auto& section = *iter;
+      auto& section = *stringSectionIter;
       auto copy = section.data;
       json::Value array;
       array.parse(copy.data(), json::Value::WTF16);
@@ -117,7 +117,7 @@ struct StringLifting : public Pass {
 
       // Remove the custom section: After lifting it has no purpose (and could
       // cause problems with repeated lifting/lowering).
-      module->customSections.erase(iter);
+      module->customSections.erase(stringSectionIter);
     }
 
     auto array16 = Type(Array(Field(Field::i16, Mutable)), Nullable);

--- a/src/passes/StringLifting.cpp
+++ b/src/passes/StringLifting.cpp
@@ -79,11 +79,10 @@ struct StringLifting : public Pass {
     }
 
     // Imported strings may also be found in the string section.
-    auto iter = std::find_if(module->customSections.begin(),
-                             module->customSections.end(),
-                             [&](CustomSection& section) {
-      return section.name == "string.consts";
-    });
+    auto iter = std::find_if(
+      module->customSections.begin(),
+      module->customSections.end(),
+      [&](CustomSection& section) { return section.name == "string.consts"; });
     if (iter != module->customSections.end()) {
       // We found the string consts section. Parse it.
       auto& section = *iter;
@@ -91,8 +90,7 @@ struct StringLifting : public Pass {
       json::Value array;
       array.parse(copy.data(), json::Value::WTF16);
       if (!array.isArray()) {
-        Fatal()
-          << "StringLifting: string.const section should be a JSON array";
+        Fatal() << "StringLifting: string.const section should be a JSON array";
       }
 
       // We have the array of constants from the section. Find globals that
@@ -112,8 +110,7 @@ struct StringLifting : public Pass {
             << "StringLifting: string.const section entry is not a string";
         }
         if (importedStrings.count(global->name)) {
-          Fatal()
-            << "StringLifting: string.const section tramples other const";
+          Fatal() << "StringLifting: string.const section tramples other const";
         }
         importedStrings[global->name] = item->getIString();
       }

--- a/test/lit/passes/string-lifting-section-erase.wast
+++ b/test/lit/passes/string-lifting-section-erase.wast
@@ -1,0 +1,23 @@
+;; Test that the section vanishes after lifting.
+
+(module
+  (func $strings
+    ;; These strings cannot appear as magic imports, and will definitely go in
+    ;; the strings section.
+    (drop
+      (string.const "unpaired high surrogate \ED\A0\80 ")
+    )
+    (drop
+      (string.const "unpaired low surrogate \ED\BD\88 ")
+    )
+  )
+)
+
+;; Lower into the section. We should see the section.
+;; RUN: wasm-opt %s -all --string-lowering                  -S -o - | filecheck %s
+;; CHECK: custom section
+
+;; Also lift. Now no section should appear.
+;; RUN: wasm-opt %s -all --string-lowering --string-lifting -S -o - | filecheck %s
+;; CHECK-NOT: custom section
+

--- a/test/lit/passes/string-lifting-section-erase.wast
+++ b/test/lit/passes/string-lifting-section-erase.wast
@@ -14,10 +14,10 @@
 )
 
 ;; Lower into the section. We should see the section.
-;; RUN: wasm-opt %s -all --string-lowering                  -S -o - | filecheck %s
-;; CHECK: custom section
+;; RUN: wasm-opt %s -all --string-lowering                  -S -o - | filecheck %s --check-prefix=LOWER
+;; LOWER: custom section
 
 ;; Also lift. Now no section should appear.
-;; RUN: wasm-opt %s -all --string-lowering --string-lifting -S -o - | filecheck %s
-;; CHECK-NOT: custom section
+;; RUN: wasm-opt %s -all --string-lowering --string-lifting -S -o - | filecheck %s --check-prefix=AND_LIFT
+;; AND_LIFT-NOT: custom section
 


### PR DESCRIPTION
After we lift the strings section into stringref, we don't need the section any
more, and leaving it around could cause problems with repeated lifting/
lowering operations (which would be very much possible with #7540). In
particular, without erasing it, we'd accumulate such sections over time.

Diff without whitespace is smaller.
