### PR TITLE
add `evaluateFunctionExit` for backward analyzer in `monotone-analyzer`

### DIFF
--- a/src/analysis/monotone-analyzer-impl.h
+++ b/src/analysis/monotone-analyzer-impl.h
@@ -21,6 +21,15 @@ inline void
 MonotoneCFGAnalyzer<L, TxFn>::evaluateFunctionEntry(Function* func) {
   txfn.evaluateFunctionEntry(func, states[0]);
 }
+template<Lattice L, TransferFunction TxFn>
+inline void MonotoneCFGAnalyzer<L, TxFn>::evaluateFunctionExit(Function* func) {
+  for (size_t i = 0; i < cfg.size(); i++) {
+    if (cfg[i].isExit()) {
+      txfn.evaluateFunctionExit(func, states[i]);
+      break;
+    }
+  }
+}
 
 template<Lattice L, TransferFunction TxFn>
 inline void MonotoneCFGAnalyzer<L, TxFn>::evaluate() {

--- a/src/analysis/monotone-analyzer.h
+++ b/src/analysis/monotone-analyzer.h
@@ -34,6 +34,11 @@ public:
   // entry block depends on no other blocks, and hence cannot be changed by
   // them.
   void evaluateFunctionEntry(Function* func);
+  // This modifies the state of the CFG's exit block, with function
+  // information. This cannot be done otherwise in a backward analysis, as the
+  // exit block depends on no other blocks, and hence cannot be changed by
+  // them.
+  void evaluateFunctionExit(Function* func);
 
   // Iterates over all of the BlockStates after evaluate() is completed for the
   // transfer function to collect the finalized intermediate states from each


### PR DESCRIPTION
For backward analyzer, it is helpful to have a function to init state in the "entry point" (exit block).