### PR TITLE
[NFC] Simplify interpretation of casts

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1642,14 +1642,7 @@ public:
     }
     Literal val = ref.getSingleValue();
     Type castType = curr->getCastType();
-    if (val.isNull()) {
-      if (castType.isNullable()) {
-        return typename Cast::Success{val};
-      } else {
-        return typename Cast::Failure{val};
-      }
-    }
-    if (HeapType::isSubType(val.type.getHeapType(), castType.getHeapType())) {
+    if (Type::isSubType(val.type, castType)) {
       return typename Cast::Success{val};
     } else {
       return typename Cast::Failure{val};


### PR DESCRIPTION
The interpreter previously inspected subtyping for nullability and heap
types separately when executing casts. Simplify this to just check
subtyping on the combined type. This is NFC for now, but will have the
happy side effect of handling exactness correctly once we type
allocations as exact and interpret exact casts.
