### PR TITLE
Use GLB in PossibleContents::intersect

### DIFF
--- a/test/lit/passes/gufa-cast-all-exact.wast
+++ b/test/lit/passes/gufa-cast-all-exact.wast
@@ -138,3 +138,39 @@
   )
  )
 )
+
+(module
+ ;; CHECK:      (type $foo (sub (struct (field i32))))
+ ;; NO_CD:      (type $foo (sub (struct (field i32))))
+ (type $foo (sub (struct (field i32))))
+
+ ;; CHECK:      (import "" "" (global $null-exact (ref null (exact $foo))))
+ ;; NO_CD:      (import "" "" (global $null-exact (ref null (exact $foo))))
+ (import "" "" (global $null-exact (ref null (exact $foo))))
+
+ ;; CHECK:      (func $as-non-null (type $1) (result i32)
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (ref.as_non_null
+ ;; CHECK-NEXT:    (global.get $null-exact)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (unreachable)
+ ;; CHECK-NEXT: )
+ ;; NO_CD:      (func $as-non-null (type $1) (result i32)
+ ;; NO_CD-NEXT:  (drop
+ ;; NO_CD-NEXT:   (ref.as_non_null
+ ;; NO_CD-NEXT:    (global.get $null-exact)
+ ;; NO_CD-NEXT:   )
+ ;; NO_CD-NEXT:  )
+ ;; NO_CD-NEXT:  (unreachable)
+ ;; NO_CD-NEXT: )
+ (func $as-non-null (result i32)
+  (struct.get $foo 0
+   ;; Regression test for an assertion failure when the intersection here
+   ;; dropped exactness as well as nullness.
+   (ref.as_non_null
+    (global.get $null-exact)
+   )
+  )
+ )
+)

--- a/test/lit/passes/gufa-refs.wast
+++ b/test/lit/passes/gufa-refs.wast
@@ -6069,8 +6069,13 @@
   ;; CHECK:      (func $test-set-bottom (type $2)
   ;; CHECK-NEXT:  (block ;; (replaces unreachable ArraySet we can't emit)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (ref.cast nullref
-  ;; CHECK-NEXT:     (global.get $global)
+  ;; CHECK-NEXT:    (block (result nullref)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (ref.cast nullref
+  ;; CHECK-NEXT:       (global.get $global)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (ref.null none)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (drop


### PR DESCRIPTION
Use the standard utility rather than reimplementing type intersection.
The new code is simpler, shorter, and properly supports exactness,
avoiding an assertion failure in the added test case. The other
functional change is that when one of the intersected heap types is
bottom and the type GLB is a non-nullable reference to bottom, the
result of the intersection is `None` where it was previously a `Cone`.
