### PR TITLE
Use fallthrough in optimizeInstructions to further optimize (unsigned)x >= 0 ==> i32(0)

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -562,12 +562,13 @@ struct OptimizeInstructions
       {
         // unsigned(x) >= 0   =>   i32(1)
         Const* c;
-        Expression* x;
-        if (matches(curr, binary(GeU, any(&x), ival(&c))) &&
+        if (curr->op == Abstract::getBinary(curr->left->type, Abstract::GeU) &&
+            (c = getFallthrough(curr->right)->dynCast<Const>()) &&
             c->value.isZero()) {
-          c->value = Literal::makeOne(Type::i32);
-          c->type = Type::i32;
-          return replaceCurrent(getDroppedChildrenAndAppend(curr, c));
+          // We could reuse c here, if we checked it had no more uses
+          auto one =
+            Builder(*getModule()).makeConst(Literal::makeOne(Type::i32));
+          return replaceCurrent(getDroppedChildrenAndAppend(curr, one));
         }
         // unsigned(x) < 0   =>   i32(0)
         if (curr->op == Abstract::getBinary(curr->left->type, Abstract::LtU) &&

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -11550,6 +11550,44 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (i32.store
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i64.load
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i64)
+  ;; CHECK-NEXT:      (i64.store
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:       (i64.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i64.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
@@ -11884,6 +11922,32 @@
       )
       (i64.const 0)
     ))
+    (drop (i32.ge_u
+        (i32.load
+          (i32.const 0)
+        )
+        (block (result i32)
+          (i32.store
+            (i32.const 0)
+            (i32.const 0)
+          )
+          (i32.const 0)
+        )
+      )
+    )
+    (drop (i64.ge_u
+        (i64.load
+          (i32.const 0)
+        )
+        (block (result i64)
+          (i64.store
+            (i32.const 0)
+            (i64.const 0)
+          )
+          (i64.const 0)
+        )
+      )
+    )
 
     ;; (unsigned)x < 0  =>  i32(0)
     (drop (i32.lt_u


### PR DESCRIPTION
Currently, `wasm-opt` cannot optimize the code as expected: `(unsigned)x >= 0 ==> i32(0)`.

```webassembly
   (i32.ge_u
    (i32.load
     (i32.const 0)
    )
    (block (result i32)
     (i32.store
      (i32.const 0)
      (i32.const 0)
     )
     (i32.const 0)
    )
   )
```

It should have been optimized after `merge-blocks`, as the `store` could have been hoisted. However, the load and store cannot be reordered, preventing `wasm-opt` from doing so. 

This can be addressed in `optimizeInstructions` by using `fallthrough` to hoist the constant zero, enabling further optimizations.

Fixes: #7556