### PR TITLE
Optimize eqz by general getFallthrough in computing condition

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -2891,6 +2891,17 @@ private:
             }
           }
         }
+        if (unary->op == EqZInt32 || unary->op == EqZInt64) {
+          if (auto* c = getFallthrough(unary->value)->dynCast<Const>()) {
+            if (c->value.isZero()) {
+              return getDroppedChildrenAndAppend(unary,
+                                                 Literal::makeOne(Type::i32));
+            } else {
+              return getDroppedChildrenAndAppend(unary,
+                                                 Literal::makeZero(Type::i32));
+            }
+          }
+        }
       }
     } else if (auto* binary = boolean->dynCast<Binary>()) {
       if (binary->op == SubInt32) {

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -113,6 +113,68 @@
       )
     )
   )
+  ;; CHECK:      (func $if-eqz-one-arm-effect-condition-1 (param $i1 i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $i1
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 10)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-eqz-one-arm-effect-condition-1 (param $i1 i32)
+    (if
+      (i32.eqz
+        (local.tee $i1
+          (i32.const 0)
+        )
+      )
+      (then
+        (drop
+          (i32.const 10)
+        )
+      )
+    )
+  )
+  ;; CHECK:      (func $if-eqz-one-arm-effect-condition-2 (param $i1 i32)
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $i1
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 10)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-eqz-one-arm-effect-condition-2 (param $i1 i32)
+    (if
+      (i32.eqz
+        (local.tee $i1
+          (i32.const 1)
+        )
+      )
+      (then
+        (drop
+          (i32.const 10)
+        )
+      )
+    )
+  )
   ;; CHECK:      (func $if-eqz-two-arms (param $i1 i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (if (result i32)
@@ -130,6 +192,84 @@
     (if
       (i32.eqz
         (local.get $i1)
+      )
+      (then
+        (drop
+          (i32.const 11)
+        )
+      )
+      (else
+        (drop
+          (i32.const 12)
+        )
+      )
+    )
+  )
+  ;; CHECK:      (func $if-eqz-two-arms-effect-condition-1 (param $i1 i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (local.tee $i1
+  ;; CHECK-NEXT:       (i32.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 11)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (i32.const 12)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-eqz-two-arms-effect-condition-1 (param $i1 i32)
+    (if
+      (i32.eqz
+        (local.tee $i1
+          (i32.const 0)
+        )
+      )
+      (then
+        (drop
+          (i32.const 11)
+        )
+      )
+      (else
+        (drop
+          (i32.const 12)
+        )
+      )
+    )
+  )
+  ;; CHECK:      (func $if-eqz-two-arms-effect-condition-2 (param $i1 i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (local.tee $i1
+  ;; CHECK-NEXT:       (i32.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 11)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (i32.const 12)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-eqz-two-arms-effect-condition-2 (param $i1 i32)
+    (if
+      (i32.eqz
+        (local.tee $i1
+          (i32.const 1)
+        )
       )
       (then
         (drop
@@ -162,6 +302,84 @@
     (if
       (i64.eqz
         (local.get $i2)
+      )
+      (then
+        (drop
+          (i32.const 11)
+        )
+      )
+      (else
+        (drop
+          (i32.const 12)
+        )
+      )
+    )
+  )
+  ;; CHECK:      (func $if-eqz-two-arms-i64-effect-condition-1 (param $i2 i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (local.tee $i2
+  ;; CHECK-NEXT:       (i64.const 0)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 11)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (i32.const 12)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-eqz-two-arms-i64-effect-condition-1 (param $i2 i64)
+    (if
+      (i64.eqz
+        (local.tee $i2
+          (i64.const 0)
+        )
+      )
+      (then
+        (drop
+          (i32.const 11)
+        )
+      )
+      (else
+        (drop
+          (i32.const 12)
+        )
+      )
+    )
+  )
+  ;; CHECK:      (func $if-eqz-two-arms-i64-effect-condition-2 (param $i2 i64)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (block (result i32)
+  ;; CHECK-NEXT:     (drop
+  ;; CHECK-NEXT:      (local.tee $i2
+  ;; CHECK-NEXT:       (i64.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 11)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (i32.const 12)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $if-eqz-two-arms-i64-effect-condition-2 (param $i2 i64)
+    (if
+      (i64.eqz
+        (local.tee $i2
+          (i64.const 1)
+        )
       )
       (then
         (drop
@@ -9681,22 +9899,10 @@
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (select
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 0)
-  ;; CHECK-NEXT:    (i64.eqz
-  ;; CHECK-NEXT:     (i64.const 0)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $y)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
-  ;; CHECK-NEXT:   (select
-  ;; CHECK-NEXT:    (local.get $y)
-  ;; CHECK-NEXT:    (i64.const 2)
-  ;; CHECK-NEXT:    (i64.eqz
-  ;; CHECK-NEXT:     (i64.const 2)
-  ;; CHECK-NEXT:    )
-  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (i64.const 2)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT: )
   (func $select-on-const (param $x i32) (param $y i64)


### PR DESCRIPTION
Currently precompute doesn't do math computations with side-effect like seeing `eqz(x) == 0` (x is 1 but has effect) and `eqz(y) == 1` (y is 0 but has effect). 

For example, it cannot replace

```
(local.tee $x
 (i32.const 1)
)

=>

(block
 (local.tee $x
  (i32.const 1)
 )
 (i32.const 1)
)
```
It only replaces entire expressions.

As discussed in #7492 
> -O3 --gufa -O3 -O3 has the same result as -O2, as does --flatten -O3. It is unfortunate that so much effort is needed. Yes, this should be improved.

So we let OptimizeInstructions to do more here.

Fixes: #7492 