### PR TITLE
[NFC] Make public type collection more efficient

### DIFF
--- a/src/ir/module-utils.cpp
+++ b/src/ir/module-utils.cpp
@@ -621,8 +621,9 @@ std::vector<HeapType> collectHeapTypes(Module& wasm) {
 }
 
 std::vector<HeapType> getPublicHeapTypes(Module& wasm) {
-  // We will need to traverse the types used by public types and mark them
-  // public as well.
+  // Look at the types of imports as exports to get an initial set of public
+  // types, then traverse the types used by public types and collect the
+  // transitively reachable public types as well.
   std::vector<HeapType> workList;
   std::unordered_set<RecGroup> publicGroups;
 


### PR DESCRIPTION
Previously public type collection worked by collecting all types in the
module, classifying their visibility, then picking out all the public
types to return. However, visibility classification requires directly
finding the public types from the imports and exports in the first
place, so the initial step of collecting all the types was unnecessary.

Refactor the code so `getPublicHeapTypes` calculates the public types
directly from the imports and exports and `classifyTypes` uses those
results to classify visibility only when collecting all types from the
module anyway.
