### PR TITLE
[NFC] Use a SmallVector for HeapType children

### DIFF
--- a/src/passes/MinimizeRecGroups.cpp
+++ b/src/passes/MinimizeRecGroups.cpp
@@ -744,7 +744,9 @@ struct MinimizeRecGroups : Pass {
         if (seen.insert(curr).second) {
           dfsOrders[i].push_back(curr);
           auto children = curr.getReferencedHeapTypes();
-          workList.insert(workList.end(), children.rbegin(), children.rend());
+          for (auto child : children) {
+            workList.push_back(child);
+          }
         }
       }
       assert(dfsOrders[i].size() == types.size());

--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -361,7 +361,7 @@ private:
 };
 
 struct HeapTypeChildCollector : HeapTypeChildWalker<HeapTypeChildCollector> {
-  std::vector<HeapType> children;
+  HeapTypeChildren children;
   void noteChild(HeapType type) { children.push_back(type); }
 };
 
@@ -753,7 +753,7 @@ bool Type::isSubType(Type left, Type right) {
   return SubTyper().isSubType(left, right);
 }
 
-std::vector<HeapType> Type::getHeapTypeChildren() {
+HeapTypeChildren Type::getHeapTypeChildren() {
   HeapTypeChildCollector collector;
   collector.walkRoot(this);
   return collector.children;
@@ -1175,13 +1175,13 @@ std::vector<Type> HeapType::getTypeChildren() const {
   WASM_UNREACHABLE("unexpected kind");
 }
 
-std::vector<HeapType> HeapType::getHeapTypeChildren() const {
+HeapTypeChildren HeapType::getHeapTypeChildren() const {
   HeapTypeChildCollector collector;
   collector.walkRoot(const_cast<HeapType*>(this));
   return collector.children;
 }
 
-std::vector<HeapType> HeapType::getReferencedHeapTypes() const {
+HeapTypeChildren HeapType::getReferencedHeapTypes() const {
   auto types = getHeapTypeChildren();
   if (auto super = getDeclaredSuperType()) {
     types.push_back(*super);


### PR DESCRIPTION
This was one of @danleh 's top findings in the [mimalloc investigation](https://github.com/WebAssembly/binaryen/issues/5561#issuecomment-2714778022),
where this method accounted for 25% (!) of all allocations.

I measured various sizes of SmallVectors and indeed it is possible to
get noticeably faster here: this PR is a 5% speedup for `-O3` as a whole,
tested on a large Java testcase and a large Kotlin testcase.

The change to MinimizeRecGroups is NFC (the order is reversed, but I don't
think it matters?). This is needed to compile, as our current SmallVector
doesn't have reverse iteration support (I looked into that for a few minutes
but it was not trivial to add; anyhow, the new code is idiomatic in the
codebase, I think).

cc #4165