### PR TITLE
[NFC] Cleanly separate expression tracking from source maps

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1452,6 +1452,7 @@ class WasmBinaryReader {
   // Settings.
 
   bool debugInfo = true;
+  bool DWARF = false;
   bool skipFunctionBodies = false;
 
   // Internal state.
@@ -1474,7 +1475,7 @@ public:
                    std::vector<char>& sourceMap = defaultEmptySourceMap);
 
   void setDebugInfo(bool value) { debugInfo = value; }
-  void setDWARF(bool value) {} // TODO: rmoof
+  void setDWARF(bool value) { DWARF = value; }
   void setSkipFunctionBodies(bool skipFunctionBodies_) {
     skipFunctionBodies = skipFunctionBodies_;
   }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1352,11 +1352,11 @@ public:
   void writeDebugLocation(const Function::DebugLocation& loc);
   void writeNoDebugLocation();
   void writeSourceMapLocation(Expression* curr, Function* func);
-  void writeExtraDebugLocation(Expression* curr, Function* func, size_t id);
 
   // Track where expressions go in the binary format.
   void trackExpressionStart(Expression* curr, Function* func);
   void trackExpressionEnd(Expression* curr, Function* func);
+  void trackExpressionDelimiter(Expression* curr, Function* func, size_t id);
 
   // helpers
   void writeInlineString(std::string_view name);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1620,7 +1620,6 @@ public:
   void readFeatures(size_t payloadLen);
   void readDylink(size_t payloadLen);
   void readDylink0(size_t payloadLen);
-  void readBranchHints(size_t payloadLen);
 
   Index readMemoryAccess(Address& alignment, Address& offset);
   std::tuple<Name, Address, Address> getMemarg();

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -95,10 +95,7 @@ public:
                    Function* func,
                    bool sourceMap,
                    bool DWARF)
-    : parent(parent), o(o), func(func), sourceMap(sourceMap), DWARF(DWARF) {}
-
-  // TODO: trackExpressions bool? for speeed
-  // and do we need sourceMap?
+    : parent(parent), o(o), func(func), DWARF(DWARF) {}
 
   void visit(Expression* curr) {
     if (func) {
@@ -139,7 +136,6 @@ private:
   WasmBinaryWriter& parent;
   BufferWithRandomAccess& o;
   Function* func = nullptr;
-  bool sourceMap;
   bool DWARF;
 
   std::vector<Name> breakStack;

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -93,7 +93,6 @@ public:
   BinaryInstWriter(WasmBinaryWriter& parent,
                    BufferWithRandomAccess& o,
                    Function* func,
-                   bool sourceMap,
                    bool DWARF)
     : parent(parent), o(o), func(func), DWARF(DWARF) {}
 
@@ -451,7 +450,7 @@ public:
                            bool sourceMap = false,
                            bool DWARF = false)
     : BinaryenIRWriter<BinaryenIRToBinaryWriter>(func), parent(parent),
-      writer(parent, o, func, sourceMap, DWARF), sourceMap(sourceMap) {}
+      writer(parent, o, func, DWARF), sourceMap(sourceMap) {}
 
   void emit(Expression* curr) { writer.visit(curr); }
   void emitHeader() {
@@ -520,7 +519,7 @@ public:
                         StackIR& stackIR,
                         bool sourceMap = false,
                         bool DWARF = false)
-    : parent(parent), writer(parent, o, func, sourceMap, DWARF), func(func),
+    : parent(parent), writer(parent, o, func, DWARF), func(func),
       stackIR(stackIR), sourceMap(sourceMap) {}
 
   void write();

--- a/src/wasm-stack.h
+++ b/src/wasm-stack.h
@@ -97,13 +97,16 @@ public:
                    bool DWARF)
     : parent(parent), o(o), func(func), sourceMap(sourceMap), DWARF(DWARF) {}
 
+  // TODO: trackExpressions bool? for speeed
+  // and do we need sourceMap?
+
   void visit(Expression* curr) {
-    if (func && !sourceMap) {
-      parent.writeDebugLocation(curr, func);
+    if (func) {
+      parent.trackExpressionStart(curr, func);
     }
     OverriddenVisitor<BinaryInstWriter>::visit(curr);
-    if (func && !sourceMap) {
-      parent.writeDebugLocationEnd(curr, func);
+    if (func) {
+      parent.trackExpressionEnd(curr, func);
     }
   }
 
@@ -480,7 +483,7 @@ public:
   void emitUnreachable() { writer.emitUnreachable(); }
   void emitDebugLocation(Expression* curr) {
     if (sourceMap) {
-      parent.writeDebugLocation(curr, func);
+      parent.writeSourceMapLocation(curr, func);
     }
   }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1521,7 +1521,7 @@ void WasmBinaryWriter::trackExpressionEnd(Expression* curr, Function* func) {
   }
 }
 
-void WasmBinaryWriter::writeExtraDebugLocation(Expression* curr,
+void WasmBinaryWriter::trackExpressionDelimiter(Expression* curr,
                                                Function* func,
                                                size_t id) {
   if (func && !func->expressionLocations.empty()) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1505,8 +1505,6 @@ void WasmBinaryWriter::writeSourceMapLocation(Expression* curr,
 }
 
 void WasmBinaryWriter::trackExpressionStart(Expression* curr, Function* func) {
-  assert(needCodeLocations);
-
   // If this is an instruction in a function, and if the original wasm had
   // binary locations tracked, then track it in the output as well. We also
   // track locations of instructions that have code annotations, as their binary
@@ -1519,8 +1517,6 @@ void WasmBinaryWriter::trackExpressionStart(Expression* curr, Function* func) {
 }
 
 void WasmBinaryWriter::trackExpressionEnd(Expression* curr, Function* func) {
-  assert(needCodeLocations);
-
   if (func && !func->expressionLocations.empty()) {
     auto& span = binaryLocations.expressions.at(curr);
     span.end = o.size();
@@ -1530,8 +1526,6 @@ void WasmBinaryWriter::trackExpressionEnd(Expression* curr, Function* func) {
 void WasmBinaryWriter::trackExpressionDelimiter(Expression* curr,
                                                Function* func,
                                                size_t id) {
-  assert(needCodeLocations);
-
   if (func && !func->expressionLocations.empty()) {
     binaryLocations.delimiters[curr][id] = o.size();
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1524,8 +1524,8 @@ void WasmBinaryWriter::trackExpressionEnd(Expression* curr, Function* func) {
 }
 
 void WasmBinaryWriter::trackExpressionDelimiter(Expression* curr,
-                                               Function* func,
-                                               size_t id) {
+                                                Function* func,
+                                                size_t id) {
   if (func && !func->expressionLocations.empty()) {
     binaryLocations.delimiters[curr][id] = o.size();
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1818,7 +1818,7 @@ void WasmBinaryReader::preScan() {
     if (sectionCode == BinaryConsts::Section::Custom) {
       auto sectionName = getInlineString();
       // DWARF sections contain code offsets.
-      if (Debug::isDWARFSection(sectionName)) {
+      if (DWARF && Debug::isDWARFSection(sectionName)) {
         needCodeLocations = true;
         break;
       }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1491,6 +1491,8 @@ void WasmBinaryWriter::writeNoDebugLocation() {
 
 void WasmBinaryWriter::writeSourceMapLocation(Expression* curr,
                                               Function* func) {
+  assert(sourceMap);
+
   auto& debugLocations = func->debugLocations;
   auto iter = debugLocations.find(curr);
   if (iter != debugLocations.end() && iter->second) {
@@ -1503,6 +1505,8 @@ void WasmBinaryWriter::writeSourceMapLocation(Expression* curr,
 }
 
 void WasmBinaryWriter::trackExpressionStart(Expression* curr, Function* func) {
+  assert(needCodeLocations);
+
   // If this is an instruction in a function, and if the original wasm had
   // binary locations tracked, then track it in the output as well. We also
   // track locations of instructions that have code annotations, as their binary
@@ -1515,6 +1519,8 @@ void WasmBinaryWriter::trackExpressionStart(Expression* curr, Function* func) {
 }
 
 void WasmBinaryWriter::trackExpressionEnd(Expression* curr, Function* func) {
+  assert(needCodeLocations);
+
   if (func && !func->expressionLocations.empty()) {
     auto& span = binaryLocations.expressions.at(curr);
     span.end = o.size();
@@ -1524,6 +1530,8 @@ void WasmBinaryWriter::trackExpressionEnd(Expression* curr, Function* func) {
 void WasmBinaryWriter::trackExpressionDelimiter(Expression* curr,
                                                Function* func,
                                                size_t id) {
+  assert(needCodeLocations);
+
   if (func && !func->expressionLocations.empty()) {
     binaryLocations.delimiters[curr][id] = o.size();
   }

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1507,8 +1507,7 @@ void WasmBinaryWriter::trackExpressionStart(Expression* curr, Function* func) {
   // binary locations tracked, then track it in the output as well. We also
   // track locations of instructions that have code annotations, as their binary
   // location goes in the custom section.
-  if (func && (!func->expressionLocations.empty() ||
-               func->codeAnnotations.count(curr))) {
+  if (func && !func->expressionLocations.empty()) {
     binaryLocations.expressions[curr] =
       BinaryLocations::Span{BinaryLocation(o.size()), 0};
     binaryLocationTrackedExpressionsForFunc.push_back(curr);

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1838,7 +1838,7 @@ void WasmBinaryReader::preScan() {
   if (DWARF && !foundDWARF) {
     // The user asked for DWARF, but no DWARF sections exist in practice, so
     // disable the support.
-    DWARF = false;    
+    DWARF = false;
   }
 
   // Reset.

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -3212,12 +3212,10 @@ void StackIRToBinaryWriter::write() {
       case StackInst::IfBegin:
       case StackInst::LoopBegin:
       case StackInst::TryTableBegin: {
-        parent.trackExpressionStart(inst->origin, func);
         if (sourceMap) {
           parent.writeSourceMapLocation(inst->origin, func);
         }
         writer.visit(inst->origin);
-        parent.trackExpressionEnd(inst->origin, func);
         break;
       }
       case StackInst::TryEnd:

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -2736,8 +2736,8 @@ void BinaryInstWriter::emitScopeEnd(Expression* curr) {
   assert(!breakStack.empty());
   breakStack.pop_back();
   o << int8_t(BinaryConsts::End);
-  if (func && !sourceMap) {
-    parent.writeDebugLocationEnd(curr, func);
+  if (func) {
+    parent.trackExpressionEnd(curr, func);
   }
 }
 
@@ -3212,13 +3212,12 @@ void StackIRToBinaryWriter::write() {
       case StackInst::IfBegin:
       case StackInst::LoopBegin:
       case StackInst::TryTableBegin: {
+        parent.trackExpressionStart(inst->origin, func);
         if (sourceMap) {
-          parent.writeDebugLocation(inst->origin, func);
+          parent.writeSourceMapLocation(inst->origin, func);
         }
         writer.visit(inst->origin);
-        if (sourceMap) {
-          parent.writeDebugLocationEnd(inst->origin, func);
-        }
+        parent.trackExpressionEnd(inst->origin, func);
         break;
       }
       case StackInst::TryEnd:

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -51,7 +51,7 @@ void BinaryInstWriter::visitIf(If* curr) {
 
 void BinaryInstWriter::emitIfElse(If* curr) {
   if (func && !sourceMap) {
-    parent.writeExtraDebugLocation(curr, func, BinaryLocations::Else);
+    parent.trackExpressionDelimiter(curr, func, BinaryLocations::Else);
   }
   o << int8_t(BinaryConsts::Else);
 }
@@ -2157,7 +2157,7 @@ void BinaryInstWriter::visitTryTable(TryTable* curr) {
 
 void BinaryInstWriter::emitCatch(Try* curr, Index i) {
   if (func && !sourceMap) {
-    parent.writeExtraDebugLocation(curr, func, i);
+    parent.trackExpressionDelimiter(curr, func, i);
   }
   o << int8_t(BinaryConsts::Catch_Legacy)
     << U32LEB(parent.getTagIndex(curr->catchTags[i]));
@@ -2165,7 +2165,7 @@ void BinaryInstWriter::emitCatch(Try* curr, Index i) {
 
 void BinaryInstWriter::emitCatchAll(Try* curr) {
   if (func && !sourceMap) {
-    parent.writeExtraDebugLocation(curr, func, curr->catchBodies.size());
+    parent.trackExpressionDelimiter(curr, func, curr->catchBodies.size());
   }
   o << int8_t(BinaryConsts::CatchAll_Legacy);
 }

--- a/src/wasm/wasm-stack.cpp
+++ b/src/wasm/wasm-stack.cpp
@@ -50,7 +50,7 @@ void BinaryInstWriter::visitIf(If* curr) {
 }
 
 void BinaryInstWriter::emitIfElse(If* curr) {
-  if (func && !sourceMap) {
+  if (func) {
     parent.trackExpressionDelimiter(curr, func, BinaryLocations::Else);
   }
   o << int8_t(BinaryConsts::Else);
@@ -2156,7 +2156,7 @@ void BinaryInstWriter::visitTryTable(TryTable* curr) {
 }
 
 void BinaryInstWriter::emitCatch(Try* curr, Index i) {
-  if (func && !sourceMap) {
+  if (func) {
     parent.trackExpressionDelimiter(curr, func, i);
   }
   o << int8_t(BinaryConsts::Catch_Legacy)
@@ -2164,7 +2164,7 @@ void BinaryInstWriter::emitCatch(Try* curr, Index i) {
 }
 
 void BinaryInstWriter::emitCatchAll(Try* curr) {
-  if (func && !sourceMap) {
+  if (func) {
     parent.trackExpressionDelimiter(curr, func, curr->catchBodies.size());
   }
   o << int8_t(BinaryConsts::CatchAll_Legacy);


### PR DESCRIPTION
We track debug info in two ways: for source maps, and for DWARF. DWARF needs
more information, not just the start of each expression's location but also the end
and delimiters (else for an if) as well. The existing code slightly mixed the two
together, which is annoying because code annotations require the same tracking
DWARF does. To improve that, this PR refactors the code to cleanly separate the
two forms of tracking:

* writeSourceMapLocation is now the only method that source maps use
* trackExpressionStart|End|Delimiter is now used by DWARF (and soon code
  annotations).

As a result,

* BinaryInstWriter no longer needs a sourceMap param. It was using !sourceMap
  in the sense of "maybe DWARF", but given custom annotations we'll need more
  anyhow. Simplify the code by letting the parent decide what to do.
* Replace DWARF scanning ahead of sections with a "preScan" method. This will
  be extended for code annotations later.

Diff without whitespace is slightly smaller.