### PR TITLE
[NFC] Move optimal-LEB emitting logic to a shared place

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -275,7 +275,7 @@ public:
   // backwards if we used fewer bytes, and return the number of bytes we moved.
   // (Thus, if we return >0, we moved code backwards, and the caller may need to
   // adjust things.)
-  BinaryLocation emitRetroactiveLEB(BinaryLocation start) {
+  BinaryLocation emitRetroactiveSectionSizeLEB(BinaryLocation start) {
     // Do not include the LEB itself in the section size.
     auto sectionSize = size() - start - MaxLEB32Bytes;
     auto sizeFieldSize = writeAt(start, U32LEB(sectionSize));

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -295,6 +295,15 @@ public:
 
     return adjustmentForLEBShrinking;
   }
+
+  void writeInlineString(std::string_view name) {
+    auto size = name.size();
+    auto data = name.data();
+    *this << U32LEB(size);
+    for (size_t i = 0; i < size; i++) {
+      *this << int8_t(data[i]);
+    }
+  }
 };
 
 namespace BinaryConsts {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -139,7 +139,7 @@ template<typename T> int32_t WasmBinaryWriter::startSection(T code) {
 }
 
 void WasmBinaryWriter::finishSection(int32_t start) {
-  auto adjustmentForLEBShrinking = o.emitRetroactiveLEB(start);
+  auto adjustmentForLEBShrinking = o.emitRetroactiveSectionSizeLEB(start);
   if (adjustmentForLEBShrinking && sourceMap) {
     for (auto i = sourceMapLocationsSizeAtSectionStart;
          i < sourceMapLocations.size();

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1525,8 +1525,7 @@ void WasmBinaryWriter::writeData(const char* data, size_t size) {
 }
 
 void WasmBinaryWriter::writeInlineString(std::string_view name) {
-  o << U32LEB(name.size());
-  writeData(name.data(), name.size());
+  o.writeInlineString(name);
 }
 
 static bool isHexDigit(char ch) {


### PR DESCRIPTION
This allows generating sections in side buffers, rather than just on the
main output buffer ("o"). This will help code annotations, where it is
useful to emit them to a side buffer, then copy them into the right
place (which is before the code section, but we must emit the code
first, to know the offsets for the annotations, so reordering is
unavoidable).