### PR TITLE
Fix RemoveUnusedBrs bug on removed br_if value where condition interferes

### DIFF
--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1298,7 +1298,7 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
               //
               //   (drop
               //     (br_if $block
-              //       (read a value)     ;; this original value is returned
+              //       (read a value)     ;; this original value is returned,
               //       (write that value) ;; if we branch
               //     )
               //   )

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1292,29 +1292,28 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
             if (auto* br = drop->value->dynCast<Break>();
                 br && br->value && br->condition && br->name == curr->name &&
                 ExpressionAnalyzer::equal(br->value, last)) {
-                // The value must have no effects, as we are removing one copy
-                // of it. Also, the condition must not interfere with that
-                // value, or it might change, e.g.
-                //
-                //   (drop
-                //     (br_if $block
-                //       (read a value)     ;; this original value is returned
-                //       (write that value) ;; if we branch
-                //     )
-                //   )
-                //   (read a value)
-                // =>
-                //   (drop
-                //     (write that value)
-                //   )
-                //   (read a value)         ;; now the written value is used
-                auto valueEffects = EffectAnalyzer(passOptions, *getModule(), br->value);
-                if (!valueEffects.hasUnremovableSideEffects()) {
-                  auto conditionEffects = EffectAnalyzer(passOptions, *getModule(), br->condition);
-                  if  (!conditionEffects.invalidates(valueEffects)) {
-                    // All conditions met, perform the update.
-                    drop->value = br->condition;
-                  }
+              // The value must have no effects, as we are removing one copy
+              // of it. Also, the condition must not interfere with that
+              // value, or it might change, e.g.
+              //
+              //   (drop
+              //     (br_if $block
+              //       (read a value)     ;; this original value is returned
+              //       (write that value) ;; if we branch
+              //     )
+              //   )
+              //   (read a value)
+              // =>
+              //   (drop
+              //     (write that value)
+              //   )
+              //   (read a value)         ;; now the written value is used
+              auto valueEffects = EffectAnalyzer(passOptions, *getModule(), br->value);
+              if (!valueEffects.hasUnremovableSideEffects()) {
+                auto conditionEffects = EffectAnalyzer(passOptions, *getModule(), br->condition);
+                if  (!conditionEffects.invalidates(valueEffects)) {
+                  // All conditions met, perform the update.
+                  drop->value = br->condition;
                 }
               }
             }

--- a/src/passes/RemoveUnusedBrs.cpp
+++ b/src/passes/RemoveUnusedBrs.cpp
@@ -1308,10 +1308,12 @@ struct RemoveUnusedBrs : public WalkerPass<PostWalker<RemoveUnusedBrs>> {
               //     (write that value)
               //   )
               //   (read a value)         ;; now the written value is used
-              auto valueEffects = EffectAnalyzer(passOptions, *getModule(), br->value);
+              auto valueEffects =
+                EffectAnalyzer(passOptions, *getModule(), br->value);
               if (!valueEffects.hasUnremovableSideEffects()) {
-                auto conditionEffects = EffectAnalyzer(passOptions, *getModule(), br->condition);
-                if  (!conditionEffects.invalidates(valueEffects)) {
+                auto conditionEffects =
+                  EffectAnalyzer(passOptions, *getModule(), br->condition);
+                if (!conditionEffects.invalidates(valueEffects)) {
                   // All conditions met, perform the update.
                   drop->value = br->condition;
                 }

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -470,8 +470,11 @@
   ;; CHECK-NEXT:  (local $temp i32)
   ;; CHECK-NEXT:  (block $block (result i32)
   ;; CHECK-NEXT:   (drop
-  ;; CHECK-NEXT:    (local.tee $temp
-  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    (br_if $block
+  ;; CHECK-NEXT:     (local.get $temp)
+  ;; CHECK-NEXT:     (local.tee $temp
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:   (local.get $temp)

--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -466,6 +466,34 @@
     )
   )
 
+  ;; CHECK:      (func $restructure-br_if-condition-invalidates-6 (type $2) (result i32)
+  ;; CHECK-NEXT:  (local $temp i32)
+  ;; CHECK-NEXT:  (block $block (result i32)
+  ;; CHECK-NEXT:   (drop
+  ;; CHECK-NEXT:    (local.tee $temp
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (local.get $temp)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $restructure-br_if-condition-invalidates-6 (result i32)
+    (local $temp i32)
+    ;; The br value is syntactically identical to the value at the end of the
+    ;; block, however, the local.tee changes that value so we cannot optimize.
+    (block $block (result i32)
+      (drop
+        (br_if $block
+          (local.get $temp)
+          (local.tee $temp
+            (i32.const 1)
+          )
+        )
+      )
+      (local.get $temp)
+    )
+  )
+
   ;; CHECK:      (func $restructure-select-no-multivalue (type $1)
   ;; CHECK-NEXT:  (tuple.drop 2
   ;; CHECK-NEXT:   (block $block (type $3) (result i32 i32)


### PR DESCRIPTION
Fixes a regression from #7506 . That PR checked for effects, but we forgot to
also check for interactions between effects, see comment in the code.

cc @xuruiyang2002 