### PR TITLE
Extend getMaxbits to handle Block type

### DIFF
--- a/src/ir/bits.h
+++ b/src/ir/bits.h
@@ -456,6 +456,12 @@ Index getMaxBits(Expression* curr,
     if (LoadUtils::isSignRelevant(load) && !load->signed_) {
       return 8 * load->bytes;
     }
+  } else if (auto* block = curr->dynCast<Block>()) {
+    // TODO: getFallthrough(block, ..., ...) is needed,
+    //   because the localset also need it
+    if (!block->name.is() && block->list.size() > 0) {
+      return getMaxBits(block->list.back(), localInfoProvider);
+    }
   }
   switch (curr->type.getBasic()) {
     case Type::i32:

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -8412,23 +8412,72 @@
       (i32.const 0)
     )
   )
-  ;; CHECK:      (func $andZero (param $0 i32) (result i32)
+  ;; CHECK:      (func $andZero (param $0 i32) (param $1 i64) (result i32)
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (i32.const 0)
   ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i64.const 0)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result i32)
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (call $andZero
-  ;; CHECK-NEXT:      (i32.const 1234)
+  ;; CHECK-NEXT:     (local.tee $0
+  ;; CHECK-NEXT:      (i32.const 1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (i32.const 0)
   ;; CHECK-NEXT:   )
   ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i64)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $1
+  ;; CHECK-NEXT:      (i64.const 1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i32)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $0
+  ;; CHECK-NEXT:      (i32.const 1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (local.set $0
+  ;; CHECK-NEXT:       (i32.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i32.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (block (result i64)
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (local.tee $1
+  ;; CHECK-NEXT:      (i64.const 1)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (block (result i64)
+  ;; CHECK-NEXT:      (local.set $1
+  ;; CHECK-NEXT:       (i64.const 1)
+  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:      (i64.const 0)
+  ;; CHECK-NEXT:     )
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i64.const 0)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
   ;; CHECK-NEXT:  (unreachable)
   ;; CHECK-NEXT: )
-  (func $andZero (param $0 i32) (result i32)
+  (func $andZero (param $0 i32) (param $1 i64) (result i32)
     (drop
       (i32.and
         (local.get $0)
@@ -8436,10 +8485,53 @@
       )
     )
     (drop
+      (i64.and
+        (local.get $1)
+        (i64.const 0)
+      )
+    )
+    ;; side effects, we must keep this, but
+    ;; can drop it.
+    (drop
       (i32.and
-        (call $andZero (i32.const 1234)) ;; side effects, we must keep this, but
-                                         ;; can drop it.
+        (local.tee $0
+          (i32.const 1)
+        )
         (i32.const 0)
+      )
+    )
+    (drop
+      (i64.and
+        (local.tee $1
+          (i64.const 1)
+        )
+        (i64.const 0)
+      )
+    )
+    (drop
+      (i32.and
+        (local.tee $0
+          (i32.const 1)
+        )
+        (block (result i32)
+          (local.set $0
+            (i32.const 1)
+          )
+          (i32.const 0)
+        )
+      )
+    )
+    (drop
+      (i64.and
+        (local.tee $1
+          (i64.const 1)
+        )
+        (block (result i64)
+          (local.set $1
+            (i64.const 1)
+          )
+          (i64.const 0)
+        )
       )
     )
     (unreachable)


### PR DESCRIPTION
There is a need to extend the getMaxBits to handle the `Block`.

For example, wasm-opt (95808a7d) cannot optimize the following code snippet

``` webassembly
   (i32.and
    (i32.load
     (i32.const 0)
    )
    (block (result i32)
     (i32.store
      (i32.const 0)
      (i32.const 0)
     )
     (i32.const 0)
    )
```

to zero, the root cause is that `getMaxBits` cannot identifes the block to zero.

Fixes: #7559