### PR TITLE
[NFC] Refactor a generic function for binary writing of a code annotations section

### DIFF
--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1410,6 +1410,9 @@ public:
   // must then insert before the code (as the spec requires that).
   std::optional<BufferWithRandomAccess> writeCodeAnnotations();
 
+  std::optional<BufferWithRandomAccess> writeBranchHints();
+  std::optional<BufferWithRandomAccess> writeCompilationHints();
+
   // helpers
   void writeInlineString(std::string_view name);
   void writeEscapedName(std::string_view name);
@@ -1679,8 +1682,12 @@ public:
   // hint position and size in the first pass, and handle it later.
   size_t branchHintsPos = 0;
   size_t branchHintsLen = 0;
-
   void readBranchHints(size_t payloadLen);
+
+  // Compilation hints, like branch hints, are read after the code.
+  size_t compilationHintsPos = 0;
+  size_t compilationHintsLen = 0;
+  void readCompilationHints(size_t payloadLen);
 
   Index readMemoryAccess(Address& alignment, Address& offset);
   std::tuple<Name, Address, Address> getMemarg();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1709,13 +1709,6 @@ private:
   // Scans ahead in the binary to check certain conditions like
   // needCodeLocations.
   void preScan();
-
-  // Internal helper for reading a code annotation section for a hint that is
-  // expression offset based. Receives the section name, payload length of the
-  // section and a function to read a single hint (receiving the annotation to
-  // update).
-  template<typename ReadFunc>
-  void readExpressionHints(Name sectionName, size_t payloadLen, ReadFunc read);
 };
 
 } // namespace wasm

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1410,7 +1410,7 @@ public:
   // must then insert before the code (as the spec requires that).
   std::optional<BufferWithRandomAccess> writeCodeAnnotations();
 
-  std::optional<BufferWithRandomAccess> writeBranchHints();
+  std::optional<BufferWithRandomAccess> getBranchHintsBuffer();
 
   // helpers
   void writeInlineString(std::string_view name);

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1501,7 +1501,8 @@ private:
   // the annotation), and another to emit it (receiving the annotation and the
   // buffer to write in).
   template<typename HasFunc, typename EmitFunc>
-  std::optional<BufferWithRandomAccess> writeExpressionHints(Name sectionName, HasFunc has, EmitFunc emit);
+  std::optional<BufferWithRandomAccess>
+  writeExpressionHints(Name sectionName, HasFunc has, EmitFunc emit);
 };
 
 extern std::vector<char> defaultEmptySourceMap;

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1709,6 +1709,13 @@ private:
   // Scans ahead in the binary to check certain conditions like
   // needCodeLocations.
   void preScan();
+
+  // Internal helper for reading a code annotation section for a hint that is
+  // expression offset based. Receives the section name, payload length of the
+  // section and a function to read a single hint (receiving the annotation to
+  // update).
+  template<typename ReadFunc>
+  void readExpressionHints(Name sectionName, size_t payloadLen, ReadFunc read);
 };
 
 } // namespace wasm

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1411,7 +1411,6 @@ public:
   std::optional<BufferWithRandomAccess> writeCodeAnnotations();
 
   std::optional<BufferWithRandomAccess> writeBranchHints();
-  std::optional<BufferWithRandomAccess> writeCompilationHints();
 
   // helpers
   void writeInlineString(std::string_view name);
@@ -1683,11 +1682,6 @@ public:
   size_t branchHintsPos = 0;
   size_t branchHintsLen = 0;
   void readBranchHints(size_t payloadLen);
-
-  // Compilation hints, like branch hints, are read after the code.
-  size_t compilationHintsPos = 0;
-  size_t compilationHintsLen = 0;
-  void readCompilationHints(size_t payloadLen);
 
   Index readMemoryAccess(Address& alignment, Address& offset);
   std::tuple<Name, Address, Address> getMemarg();

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1494,6 +1494,14 @@ private:
   std::unordered_map<Name, Index> stringIndexes;
 
   void prepare();
+
+  // Internal helper for emitting a code annotation section for a hint that is
+  // expression offset based. Receives the name of the section and two
+  // functions, one to check if the annotation we care about exists (receiving
+  // the annotation), and another to emit it (receiving the annotation and the
+  // buffer to write in).
+  template<typename HasFunc, typename EmitFunc>
+  std::optional<BufferWithRandomAccess> writeExpressionHints(Name sectionName, HasFunc has, EmitFunc emit);
 };
 
 extern std::vector<char> defaultEmptySourceMap;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1651,7 +1651,7 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(Nam
     for (auto& exprHint : funcHints.exprHints) {
       buffer << U32LEB(exprHint.offset);
 
-      emit(*exprHint.hint);
+      emit(*exprHint.hint, buffer);
     }
   }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1665,8 +1665,6 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(Nam
 
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeBranchHints() {
   return writeExpressionHints(
-    *wasm,
-    binaryLocations,
     Annotations::BranchHint,
     [](const Function::CodeAnnotation& annotation) {
       return annotation.branchLikely;

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1563,7 +1563,7 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeCodeAnnotations() {
     }
   };
 
-  append(writeBranchHints());
+  append(getBranchHintsBuffer());
   return ret;
 }
 
@@ -1664,7 +1664,7 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(
   return buffer;
 }
 
-std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeBranchHints() {
+std::optional<BufferWithRandomAccess> WasmBinaryWriter::getBranchHintsBuffer() {
   return writeExpressionHints(
     Annotations::BranchHint,
     [](const Function::CodeAnnotation& annotation) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1568,7 +1568,8 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeCodeAnnotations() {
 }
 
 template<typename HasFunc, typename EmitFunc>
-std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(Name sectionName, HasFunc has, EmitFunc emit) {
+std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(
+  Name sectionName, HasFunc has, EmitFunc emit) {
   // Assemble the info: for each function, a vector of the hints.
   struct ExprHint {
     Expression* expr;
@@ -1669,7 +1670,8 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeBranchHints() {
     [](const Function::CodeAnnotation& annotation) {
       return annotation.branchLikely;
     },
-    [](const Function::CodeAnnotation& annotation, BufferWithRandomAccess& buffer) {
+    [](const Function::CodeAnnotation& annotation,
+       BufferWithRandomAccess& buffer) {
       // Hint size, always 1 for now.
       buffer << U32LEB(1);
 
@@ -1678,8 +1680,7 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeBranchHints() {
 
       // Hint contents: likely or not.
       buffer << U32LEB(int(*annotation.branchLikely));
-    }
-  );
+    });
 }
 
 void WasmBinaryWriter::writeData(const char* data, size_t size) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1549,6 +1549,25 @@ void WasmBinaryWriter::trackExpressionDelimiter(Expression* curr,
 }
 
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeCodeAnnotations() {
+  std::optional<BufferWithRandomAccess> ret;
+
+  auto append = [&](std::optional<BufferWithRandomAccess>&& temp) {
+    if (temp) {
+      if (!ret) {
+        // This is the first section.
+        ret = std::move(temp);
+      } else {
+        // This is a later section, append.
+        ret->insert(ret->end(), temp->begin(), temp->end());
+      }
+    }
+  };
+
+  append(writeBranchHints());
+  return ret;
+}
+
+std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeBranchHints() {
   // Assemble the info for Branch Hinting: for each function, a vector of the
   // hints.
   struct ExprHint {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1567,14 +1567,8 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeCodeAnnotations() {
   return ret;
 }
 
-namespace {
-
-// Writes a code annotation section for a hint that is expression offset based.
-// Receives the name of the section and two functions, one to check of the
-// annotation we care about exists (receiving the annotation), and another to
-// emit it (receiving the annotation and the buffer to write in).
 template<typename HasFunc, typename EmitFunc>
-std::optional<BufferWithRandomAccess> writeExpressionHints(Module& wasm, BinaryLocations& binaryLocations, Name sectionName, HasFunc has, EmitFunc emit) {
+std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(Name sectionName, HasFunc has, EmitFunc emit) {
   // Assemble the info: for each function, a vector of the hints.
   struct ExprHint {
     Expression* expr;
@@ -1590,7 +1584,7 @@ std::optional<BufferWithRandomAccess> writeExpressionHints(Module& wasm, BinaryL
 
   std::vector<FuncHints> funcHintsVec;
 
-  for (auto& func : wasm.functions) {
+  for (auto& func : wasm->functions) {
     // Collect the hints for this function.
     FuncHints funcHints;
 
@@ -1668,8 +1662,6 @@ std::optional<BufferWithRandomAccess> writeExpressionHints(Module& wasm, BinaryL
 
   return buffer;
 }
-
-} // anonymous namespace
 
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeBranchHints() {
   return writeExpressionHints(


### PR DESCRIPTION
This will allow 95% of the code to be shared for binary writing, between
branch hints and inline hints for example. They have almost identical
formats in structure, differing only in the hint itself and section name.

Also prepare for multiple code annotations sections.