### PR TITLE
Add PublicTypeValidator for use in fuzzer

### DIFF
--- a/src/ir/CMakeLists.txt
+++ b/src/ir/CMakeLists.txt
@@ -16,6 +16,7 @@ set(ir_SOURCES
   properties.cpp
   LocalGraph.cpp
   LocalStructuralDominance.cpp
+  public-type-validator.cpp
   ReFinalize.cpp
   return-utils.cpp
   stack-utils.cpp

--- a/src/ir/public-type-validator.cpp
+++ b/src/ir/public-type-validator.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/public-type-validator.h"
+#include "wasm-type.h"
+
+namespace wasm {
+
+bool PublicTypeValidator::isValidPublicTypeImpl(HeapType type) {
+  // If custom descriptors is not enabled and exposing this type would make an
+  // exact reference public, then this type is not valid to make public.
+  assert(!features.hasCustomDescriptors());
+  assert(!type.isBasic());
+  // Traverse the heap types reachable from this one, looking for exact
+  // references. Cache the findings for each group along the way to minimize
+  // future work.
+  struct Task {
+    RecGroup group;
+    bool finished;
+  };
+  std::vector<Task> workList{Task{type.getRecGroup(), false}};
+  std::unordered_set<RecGroup> visiting;
+
+  auto findInvalid = [&]() {
+    for (auto group : visiting) {
+      auto [_, inserted] = allowedPublicGroupCache.insert({group, false});
+      assert(inserted);
+    }
+  };
+
+  while (!workList.empty()) {
+    auto task = workList.back();
+    workList.pop_back();
+    if (task.finished) {
+      // We finished searching this group and the groups it reaches without
+      // finding a problem.
+      visiting.erase(task.group);
+      auto [_, inserted] = allowedPublicGroupCache.insert({task.group, true});
+      assert(inserted);
+      continue;
+    }
+    if (auto it = allowedPublicGroupCache.find(task.group);
+        it != allowedPublicGroupCache.end()) {
+      if (it->second) {
+        // We already know this group is valid. Move on to the next group.
+        continue;
+      } else {
+        // This group is invalid!
+        findInvalid();
+        return false;
+      }
+    }
+    // Check whether we are already in the process of searching this group.
+    if (!visiting.insert(task.group).second) {
+      continue;
+    }
+    // We have never seen this group before. Search it. Push a completion task
+    // first so we will know when we have finished searching.
+    workList.push_back({task.group, true});
+    for (auto heapType : task.group) {
+      // Look for invalid exact references.
+      for (auto t : heapType.getTypeChildren()) {
+        if (t.isExact()) {
+          findInvalid();
+          return false;
+        }
+      }
+      // Search the referenced groups as well.
+      for (auto t : heapType.getReferencedHeapTypes()) {
+        if (!t.isBasic()) {
+          workList.push_back({t.getRecGroup(), false});
+        }
+      }
+    }
+  }
+
+  // We searched all the reachable types and never found an exact reference.
+  return true;
+}
+
+} // namespace wasm

--- a/src/ir/public-type-validator.h
+++ b/src/ir/public-type-validator.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef wasm_ir_public_type_validator_h
+#define wasm_ir_public_type_validator_h
+
+#include "wasm-features.h"
+#include "wasm-type.h"
+
+#include <unordered_map>
+
+namespace wasm {
+
+// Utility for determining whether it is valid to make a given type public given
+// some enabled feature set. Used in the fuzzer for determining whether a
+// function can be exported, for instance.
+class PublicTypeValidator {
+public:
+  explicit PublicTypeValidator(FeatureSet features) : features(features) {}
+
+  bool isValidPublicType(HeapType type) {
+    if (features.hasCustomDescriptors()) {
+      return true;
+    }
+    if (type.isBasic()) {
+      return true;
+    }
+    return isValidPublicTypeImpl(type);
+  }
+
+  bool isValidPublicType(Type type) {
+    if (features.hasCustomDescriptors()) {
+      return true;
+    }
+    if (type.isBasic()) {
+      return true;
+    }
+    if (type.isTuple()) {
+      for (auto t : type) {
+        if (!isValidPublicType(t)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    assert(type.isRef());
+    if (type.isExact()) {
+      return false;
+    }
+    return isValidPublicType(type.getHeapType());
+  }
+
+private:
+  FeatureSet features;
+  std::unordered_map<RecGroup, bool> allowedPublicGroupCache;
+  bool isValidPublicTypeImpl(HeapType type);
+};
+
+} // namespace wasm
+
+#endif // wasm_ir_public_type_validator_h

--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -28,6 +28,7 @@
 #include <ir/literal-utils.h>
 #include <ir/manipulation.h>
 #include <ir/names.h>
+#include <ir/public-type-validator.h>
 #include <ir/utils.h>
 #include <support/file.h>
 #include <tools/optimization-options.h>
@@ -340,6 +341,13 @@ private:
   Expression* makeImportCallCode(Type type);
   Expression* makeImportSleep(Type type);
   Expression* makeMemoryHashLogging();
+
+  // We must be careful not to add exports that have invalid public types, such
+  // as those that reach exact types when custom descriptors is disabled.
+  PublicTypeValidator publicTypeValidator;
+  bool isValidPublicType(Type type) {
+    return publicTypeValidator.isValidPublicType(type);
+  }
 
   // Function operations. The main processFunctions() loop will call addFunction
   // as well as modFunction().

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -18,6 +18,7 @@ set(unittest_SOURCES
   local-graph.cpp
   possible-contents.cpp
   printing.cpp
+  public-type-validator.cpp
   scc.cpp
   stringify.cpp
   suffix_tree.cpp

--- a/test/gtest/public-type-validator.cpp
+++ b/test/gtest/public-type-validator.cpp
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ir/public-type-validator.h"
+#include "wasm-type.h"
+
+#include "gtest/gtest.h"
+
+using namespace wasm;
+
+class PublicTypeValidatorTest : public ::testing::Test {
+protected:
+  HeapType EmptyStruct;
+  HeapType RecursiveStruct;
+  HeapType InvalidStruct;
+  HeapType IndirectlyInvalidStruct;
+  HeapType RecursiveInvalidStruct;
+  HeapType EmptyStructInGroupWithInvalid;
+
+  void SetUp() override {
+    TypeBuilder builder(8);
+
+    // Empty struct
+    HeapType empty = builder[0];
+    builder[0] = Struct();
+
+    // Recursive struct
+    HeapType recursive = builder[1];
+    builder[1] = Struct({Field(Type(recursive, Nullable), Mutable)});
+
+    // Invalid struct
+    HeapType invalid = builder[2];
+    builder[2] = Struct({Field(Type(empty, Nullable, Exact), Mutable)});
+
+    // Indirectly invalid struct
+    builder[3] = Struct({Field(Type(invalid, Nullable), Mutable)});
+
+    // Mutually recursive, indirectly invalid struct
+    builder[4] = Struct({Field(Type(builder[5], Nullable), Mutable)});
+    builder[5] = Struct({Field(Type(builder[4], Nullable, Exact), Mutable)});
+    builder.createRecGroup(4, 2);
+
+    // Empty struct in group with invalid struct
+    builder[6] = Struct();
+    builder[7] = Struct({Field(Type(invalid, Nullable), Mutable)});
+    builder.createRecGroup(6, 2);
+
+    auto result = builder.build();
+    auto& built = *result;
+
+    EmptyStruct = built[0];
+    RecursiveStruct = built[1];
+    InvalidStruct = built[2];
+    IndirectlyInvalidStruct = built[3];
+    RecursiveInvalidStruct = built[4];
+    EmptyStructInGroupWithInvalid = built[6];
+  }
+
+  void TearDown() override { wasm::destroyAllTypesForTestingPurposesOnly(); }
+};
+
+TEST_F(PublicTypeValidatorTest, CustomDescriptorsEnabled) {
+  PublicTypeValidator validator(FeatureSet::CustomDescriptors);
+
+  EXPECT_TRUE(validator.isValidPublicType(EmptyStruct));
+  EXPECT_TRUE(validator.isValidPublicType(RecursiveStruct));
+  EXPECT_TRUE(validator.isValidPublicType(InvalidStruct));
+  EXPECT_TRUE(validator.isValidPublicType(IndirectlyInvalidStruct));
+  EXPECT_TRUE(validator.isValidPublicType(RecursiveInvalidStruct));
+  EXPECT_TRUE(validator.isValidPublicType(EmptyStructInGroupWithInvalid));
+}
+
+TEST_F(PublicTypeValidatorTest, CustomDescriptorsDisabled) {
+  PublicTypeValidator validator(FeatureSet::MVP);
+
+  EXPECT_TRUE(validator.isValidPublicType(EmptyStruct));
+  EXPECT_TRUE(validator.isValidPublicType(RecursiveStruct));
+  EXPECT_FALSE(validator.isValidPublicType(InvalidStruct));
+  EXPECT_FALSE(validator.isValidPublicType(IndirectlyInvalidStruct));
+  EXPECT_FALSE(validator.isValidPublicType(RecursiveInvalidStruct));
+  EXPECT_FALSE(validator.isValidPublicType(EmptyStructInGroupWithInvalid));
+}
+
+TEST_F(PublicTypeValidatorTest, CachedResult) {
+  PublicTypeValidator validator(FeatureSet::MVP);
+
+  // Check the indirectly invalid type first, then serve the query for the
+  // directly invalid type from the cache.
+  EXPECT_FALSE(validator.isValidPublicType(IndirectlyInvalidStruct));
+  EXPECT_FALSE(validator.isValidPublicType(InvalidStruct));
+
+  // We can serve repeated queries from the cache, too.
+  EXPECT_FALSE(validator.isValidPublicType(IndirectlyInvalidStruct));
+}
+
+TEST_F(PublicTypeValidatorTest, BasicHeapTypes) {
+  PublicTypeValidator validator(FeatureSet::MVP);
+
+  EXPECT_TRUE(validator.isValidPublicType(HeapTypes::any));
+  EXPECT_TRUE(validator.isValidPublicType(HeapTypes::eq));
+  EXPECT_TRUE(validator.isValidPublicType(HeapTypes::ext));
+  EXPECT_TRUE(validator.isValidPublicType(HeapTypes::func));
+  EXPECT_TRUE(validator.isValidPublicType(HeapTypes::none));
+}
+
+TEST_F(PublicTypeValidatorTest, Types) {
+  PublicTypeValidator validator(FeatureSet::MVP);
+
+  EXPECT_TRUE(validator.isValidPublicType(Type::i32));
+  EXPECT_TRUE(validator.isValidPublicType(Type::i64));
+  EXPECT_TRUE(validator.isValidPublicType(Type::f32));
+  EXPECT_TRUE(validator.isValidPublicType(Type::f64));
+  EXPECT_TRUE(validator.isValidPublicType(Type::v128));
+
+  EXPECT_TRUE(validator.isValidPublicType(Type(HeapType::any, Nullable)));
+  EXPECT_TRUE(validator.isValidPublicType(Type(EmptyStruct, Nullable)));
+  EXPECT_FALSE(validator.isValidPublicType(Type(EmptyStruct, Nullable, Exact)));
+  EXPECT_FALSE(validator.isValidPublicType(Type(InvalidStruct, Nullable)));
+}


### PR DESCRIPTION
When custom descriptors is not enabled, we consider it a validation
error for a public type to include an exact reference because the
identity of that type will change when the binary is written and that
reference becomes inexact. Once the fuzzer observes functions signatures
with exact references, it will have to be careful not to export those
functions and make the exact reference public when custom descriptors is
disabled.

Add a utility to efficiently determine whether a type is valid to be
made public, memoizing results to avoid traversing any type definition
more than once. Use this utility in the fuzzer.
