### PR TITLE
[NFC] Refactor code annotations to make using them easier

### DIFF
--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -258,7 +258,7 @@ struct ReconstructStringifyWalker
     // call will replace the instructions moved to the outlined function.
     ODBG(std::cerr << "\nadding call " << outlinedFunc->name << " to "
                    << &existingBuilder << "\n");
-    ASSERT_OK(existingBuilder.makeCall(outlinedFunc->name, false));
+    ASSERT_OK(existingBuilder.makeCall(outlinedFunc->name, false, CodeAnnotation::AlwaysInline));
 
     // If the last instruction of the outlined sequence is unreachable, insert
     // an unreachable instruction immediately after the call to the outlined

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -258,7 +258,8 @@ struct ReconstructStringifyWalker
     // call will replace the instructions moved to the outlined function.
     ODBG(std::cerr << "\nadding call " << outlinedFunc->name << " to "
                    << &existingBuilder << "\n");
-    ASSERT_OK(existingBuilder.makeCall(outlinedFunc->name, false, CodeAnnotation::AlwaysInline));
+    ASSERT_OK(existingBuilder.makeCall(
+      outlinedFunc->name, false, CodeAnnotation::AlwaysInline));
 
     // If the last instruction of the outlined sequence is unreachable, insert
     // an unreachable instruction immediately after the call to the outlined

--- a/src/passes/Outlining.cpp
+++ b/src/passes/Outlining.cpp
@@ -258,8 +258,7 @@ struct ReconstructStringifyWalker
     // call will replace the instructions moved to the outlined function.
     ODBG(std::cerr << "\nadding call " << outlinedFunc->name << " to "
                    << &existingBuilder << "\n");
-    ASSERT_OK(existingBuilder.makeCall(
-      outlinedFunc->name, false, CodeAnnotation::AlwaysInline));
+    ASSERT_OK(existingBuilder.makeCall(outlinedFunc->name, false));
 
     // If the last instruction of the outlined sequence is unreachable, insert
     // an unreachable instruction immediately after the call to the outlined

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -116,8 +116,9 @@ public:
   // signatures ensure that there are no missing fields.
   Result<> makeNop();
   Result<> makeBlock(Name label, Signature sig);
-  Result<>
-  makeIf(Name label, Signature sig, CodeAnnotation::BranchLikely likely = std::nullopt);
+  Result<> makeIf(Name label,
+                  Signature sig,
+                  CodeAnnotation::BranchLikely likely = std::nullopt);
   Result<> makeLoop(Name label, Signature sig);
   Result<> makeBreak(Index label,
                      bool isConditional,

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -117,20 +117,20 @@ public:
   Result<> makeNop();
   Result<> makeBlock(Name label, Signature sig);
   Result<>
-  makeIf(Name label, Signature sig, std::optional<bool> likely = std::nullopt);
+  makeIf(Name label, Signature sig, CodeAnnotation::BranchLikely likely = std::nullopt);
   Result<> makeLoop(Name label, Signature sig);
   Result<> makeBreak(Index label,
                      bool isConditional,
-                     std::optional<bool> likely = std::nullopt);
+                     CodeAnnotation::BranchLikely likely = std::nullopt);
   Result<> makeSwitch(const std::vector<Index>& labels, Index defaultLabel);
   // Unlike Builder::makeCall, this assumes the function already exists.
   Result<> makeCall(Name func,
                     bool isReturn,
-                    std::optional<std::uint8_t> inline_ = std::nullopt);
+                    CodeAnnotation::Inline inline_ = std::nullopt);
   Result<> makeCallIndirect(Name table,
                             HeapType type,
                             bool isReturn,
-                            std::optional<std::uint8_t> inline_ = std::nullopt);
+                            CodeAnnotation::Inline inline_ = std::nullopt);
   Result<> makeLocalGet(Index local);
   Result<> makeLocalSet(Index local);
   Result<> makeLocalTee(Index local);
@@ -206,14 +206,14 @@ public:
   Result<> makeI31Get(bool signed_);
   Result<> makeCallRef(HeapType type,
                        bool isReturn,
-                       std::optional<std::uint8_t> inline_ = std::nullopt);
+                       CodeAnnotation::Inline inline_ = std::nullopt);
   Result<> makeRefTest(Type type);
   Result<> makeRefCast(Type type);
   Result<> makeBrOn(Index label,
                     BrOnOp op,
                     Type in = Type::none,
                     Type out = Type::none,
-                    std::optional<bool> likely = std::nullopt);
+                    CodeAnnotation::BranchLikely likely = std::nullopt);
   Result<> makeStructNew(HeapType type);
   Result<> makeStructNewDefault(HeapType type);
   Result<>
@@ -706,10 +706,10 @@ private:
   void fixLoopWithInput(Loop* loop, Type inputType, Index scratch);
 
   // Add a branch hint, if |likely| is present.
-  void addBranchHint(Expression* expr, std::optional<bool> likely);
+  void addBranchHint(Expression* expr, CodeAnnotation::BranchLikely likely);
 
   // Add an inlining hint, if |inline_| is present.
-  void addInlineHint(Expression* expr, std::optional<std::uint8_t> inline_);
+  void addInlineHint(Expression* expr, CodeAnnotation::Inline inline_);
 
   void dump();
 };

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2137,6 +2137,21 @@ struct BinaryLocations {
   std::unordered_map<Function*, FunctionLocations> functions;
 };
 
+// Code annotations for VMs. As with debug info, we do not store these on
+// Expressions as we assume most instances are unannotated, and do not want to
+// add constant memory overhead.
+struct CodeAnnotation {
+  // Branch Hinting proposal: Whether the branch is likely, or unlikely.
+  using BranchLikely = std::optional<bool>;
+  BranchLikely branchLikely;
+
+  // Compilation Hints proposal.
+  static const uint8_t NeverInline = 0;
+  static const uint8_t AlwaysInline = 127;
+  using Inline = std::optional<uint8_t>;
+  Inline inline_;
+};
+
 // Forward declaration for FuncEffectsMap.
 class EffectAnalyzer;
 
@@ -2190,19 +2205,6 @@ public:
   std::unordered_map<Expression*, BinaryLocations::DelimiterLocations>
     delimiterLocations;
   BinaryLocations::FunctionLocations funcLocation;
-
-  // Code annotations for VMs. As with debug info, we do not store these on
-  // Expressions as we assume most instances are unannotated, and do not want to
-  // add constant memory overhead.
-  struct CodeAnnotation {
-    // Branch Hinting proposal: Whether the branch is likely, or unlikely.
-    std::optional<bool> branchLikely;
-
-    // Compilation Hints proposal.
-    static const uint8_t NeverInline = 0;
-    static const uint8_t AlwaysInline = 127;
-    std::optional<uint8_t> inline_;
-  };
 
   // Function-level annotations are implemented with a key of nullptr, matching
   // the 0 byte offset in the spec.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1668,11 +1668,8 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::getBranchHintsBuffer() {
   return writeExpressionHints(
     Annotations::BranchHint,
-    [](const CodeAnnotation& annotation) {
-      return annotation.branchLikely;
-    },
-    [](const CodeAnnotation& annotation,
-       BufferWithRandomAccess& buffer) {
+    [](const CodeAnnotation& annotation) { return annotation.branchLikely; },
+    [](const CodeAnnotation& annotation, BufferWithRandomAccess& buffer) {
       // Hint size, always 1 for now.
       buffer << U32LEB(1);
 
@@ -1687,11 +1684,8 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::getBranchHintsBuffer() {
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::getInlineHintsBuffer() {
   return writeExpressionHints(
     Annotations::InlineHint,
-    [](const CodeAnnotation& annotation) {
-      return annotation.inline_;
-    },
-    [](const CodeAnnotation& annotation,
-       BufferWithRandomAccess& buffer) {
+    [](const CodeAnnotation& annotation) { return annotation.inline_; },
+    [](const CodeAnnotation& annotation, BufferWithRandomAccess& buffer) {
       // Hint size, always 1 for now.
       buffer << U32LEB(1);
 
@@ -5323,39 +5317,37 @@ void WasmBinaryReader::readExpressionHints(Name sectionName,
 }
 
 void WasmBinaryReader::readBranchHints(size_t payloadLen) {
-  readExpressionHints(Annotations::BranchHint,
-                      payloadLen,
-                      [&](CodeAnnotation& annotation) {
-                        auto size = getU32LEB();
-                        if (size != 1) {
-                          throwError("bad BranchHint size");
-                        }
+  readExpressionHints(
+    Annotations::BranchHint, payloadLen, [&](CodeAnnotation& annotation) {
+      auto size = getU32LEB();
+      if (size != 1) {
+        throwError("bad BranchHint size");
+      }
 
-                        auto likely = getU32LEB();
-                        if (likely != 0 && likely != 1) {
-                          throwError("bad BranchHint value");
-                        }
+      auto likely = getU32LEB();
+      if (likely != 0 && likely != 1) {
+        throwError("bad BranchHint value");
+      }
 
-                        annotation.branchLikely = likely;
-                      });
+      annotation.branchLikely = likely;
+    });
 }
 
 void WasmBinaryReader::readInlineHints(size_t payloadLen) {
-  readExpressionHints(Annotations::InlineHint,
-                      payloadLen,
-                      [&](CodeAnnotation& annotation) {
-                        auto size = getU32LEB();
-                        if (size != 1) {
-                          throwError("bad InlineHint size");
-                        }
+  readExpressionHints(
+    Annotations::InlineHint, payloadLen, [&](CodeAnnotation& annotation) {
+      auto size = getU32LEB();
+      if (size != 1) {
+        throwError("bad InlineHint size");
+      }
 
-                        uint8_t inline_ = getInt8();
-                        if (inline_ > 127) {
-                          throwError("bad InlineHint value");
-                        }
+      uint8_t inline_ = getInt8();
+      if (inline_ > 127) {
+        throwError("bad InlineHint value");
+      }
 
-                        annotation.inline_ = inline_;
-                      });
+      annotation.inline_ = inline_;
+    });
 }
 
 Index WasmBinaryReader::readMemoryAccess(Address& alignment, Address& offset) {

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1576,7 +1576,7 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(
     Expression* expr;
     // The offset we will write in the custom section.
     BinaryLocation offset;
-    Function::CodeAnnotation* hint;
+    CodeAnnotation* hint;
   };
 
   struct FuncHints {
@@ -1668,10 +1668,10 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::writeExpressionHints(
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::getBranchHintsBuffer() {
   return writeExpressionHints(
     Annotations::BranchHint,
-    [](const Function::CodeAnnotation& annotation) {
+    [](const CodeAnnotation& annotation) {
       return annotation.branchLikely;
     },
-    [](const Function::CodeAnnotation& annotation,
+    [](const CodeAnnotation& annotation,
        BufferWithRandomAccess& buffer) {
       // Hint size, always 1 for now.
       buffer << U32LEB(1);
@@ -1687,10 +1687,10 @@ std::optional<BufferWithRandomAccess> WasmBinaryWriter::getBranchHintsBuffer() {
 std::optional<BufferWithRandomAccess> WasmBinaryWriter::getInlineHintsBuffer() {
   return writeExpressionHints(
     Annotations::InlineHint,
-    [](const Function::CodeAnnotation& annotation) {
+    [](const CodeAnnotation& annotation) {
       return annotation.inline_;
     },
-    [](const Function::CodeAnnotation& annotation,
+    [](const CodeAnnotation& annotation,
        BufferWithRandomAccess& buffer) {
       // Hint size, always 1 for now.
       buffer << U32LEB(1);
@@ -5325,7 +5325,7 @@ void WasmBinaryReader::readExpressionHints(Name sectionName,
 void WasmBinaryReader::readBranchHints(size_t payloadLen) {
   readExpressionHints(Annotations::BranchHint,
                       payloadLen,
-                      [&](Function::CodeAnnotation& annotation) {
+                      [&](CodeAnnotation& annotation) {
                         auto size = getU32LEB();
                         if (size != 1) {
                           throwError("bad BranchHint size");
@@ -5343,7 +5343,7 @@ void WasmBinaryReader::readBranchHints(size_t payloadLen) {
 void WasmBinaryReader::readInlineHints(size_t payloadLen) {
   readExpressionHints(Annotations::InlineHint,
                       payloadLen,
-                      [&](Function::CodeAnnotation& annotation) {
+                      [&](CodeAnnotation& annotation) {
                         auto size = getU32LEB();
                         if (size != 1) {
                           throwError("bad InlineHint size");

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1380,8 +1380,9 @@ Result<> IRBuilder::makeBlock(Name label, Signature sig) {
   return visitBlockStart(block, sig.params);
 }
 
-Result<>
-IRBuilder::makeIf(Name label, Signature sig, CodeAnnotation::BranchLikely likely) {
+Result<> IRBuilder::makeIf(Name label,
+                           Signature sig,
+                           CodeAnnotation::BranchLikely likely) {
   auto* iff = wasm.allocator.alloc<If>();
   iff->type = sig.results;
   addBranchHint(iff, likely);
@@ -1441,9 +1442,8 @@ Result<> IRBuilder::makeSwitch(const std::vector<Index>& labels,
   return Ok{};
 }
 
-Result<> IRBuilder::makeCall(Name func,
-                             bool isReturn,
-                             CodeAnnotation::Inline inline_) {
+Result<>
+IRBuilder::makeCall(Name func, bool isReturn, CodeAnnotation::Inline inline_) {
   auto sig = wasm.getFunction(func)->getSig();
   Call curr(wasm.allocator);
   curr.target = func;
@@ -1991,8 +1991,11 @@ Result<> IRBuilder::makeRefCast(Type type) {
   return Ok{};
 }
 
-Result<> IRBuilder::makeBrOn(
-  Index label, BrOnOp op, Type in, Type out, CodeAnnotation::BranchLikely likely) {
+Result<> IRBuilder::makeBrOn(Index label,
+                             BrOnOp op,
+                             Type in,
+                             Type out,
+                             CodeAnnotation::BranchLikely likely) {
   BrOn curr;
   curr.op = op;
   curr.castType = out;
@@ -2548,7 +2551,8 @@ Result<> IRBuilder::makeStackSwitch(HeapType ct, Name tag) {
   return Ok{};
 }
 
-void IRBuilder::addBranchHint(Expression* expr, CodeAnnotation::BranchLikely likely) {
+void IRBuilder::addBranchHint(Expression* expr,
+                              CodeAnnotation::BranchLikely likely) {
   if (likely) {
     // Branches are only possible inside functions.
     assert(func);

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1381,7 +1381,7 @@ Result<> IRBuilder::makeBlock(Name label, Signature sig) {
 }
 
 Result<>
-IRBuilder::makeIf(Name label, Signature sig, std::optional<bool> likely) {
+IRBuilder::makeIf(Name label, Signature sig, CodeAnnotation::BranchLikely likely) {
   auto* iff = wasm.allocator.alloc<If>();
   iff->type = sig.results;
   addBranchHint(iff, likely);
@@ -1397,7 +1397,7 @@ Result<> IRBuilder::makeLoop(Name label, Signature sig) {
 
 Result<> IRBuilder::makeBreak(Index label,
                               bool isConditional,
-                              std::optional<bool> likely) {
+                              CodeAnnotation::BranchLikely likely) {
   auto name = getLabelName(label);
   CHECK_ERR(name);
   auto labelType = getLabelType(label);
@@ -1443,7 +1443,7 @@ Result<> IRBuilder::makeSwitch(const std::vector<Index>& labels,
 
 Result<> IRBuilder::makeCall(Name func,
                              bool isReturn,
-                             std::optional<std::uint8_t> inline_) {
+                             CodeAnnotation::Inline inline_) {
   auto sig = wasm.getFunction(func)->getSig();
   Call curr(wasm.allocator);
   curr.target = func;
@@ -1459,7 +1459,7 @@ Result<> IRBuilder::makeCall(Name func,
 Result<> IRBuilder::makeCallIndirect(Name table,
                                      HeapType type,
                                      bool isReturn,
-                                     std::optional<std::uint8_t> inline_) {
+                                     CodeAnnotation::Inline inline_) {
   CallIndirect curr(wasm.allocator);
   curr.heapType = type;
   curr.operands.resize(type.getSignature().params.size());
@@ -1959,7 +1959,7 @@ Result<> IRBuilder::makeI31Get(bool signed_) {
 
 Result<> IRBuilder::makeCallRef(HeapType type,
                                 bool isReturn,
-                                std::optional<std::uint8_t> inline_) {
+                                CodeAnnotation::Inline inline_) {
   CallRef curr(wasm.allocator);
   if (!type.isSignature()) {
     return Err{"expected function type"};
@@ -1992,7 +1992,7 @@ Result<> IRBuilder::makeRefCast(Type type) {
 }
 
 Result<> IRBuilder::makeBrOn(
-  Index label, BrOnOp op, Type in, Type out, std::optional<bool> likely) {
+  Index label, BrOnOp op, Type in, Type out, CodeAnnotation::BranchLikely likely) {
   BrOn curr;
   curr.op = op;
   curr.castType = out;
@@ -2548,7 +2548,7 @@ Result<> IRBuilder::makeStackSwitch(HeapType ct, Name tag) {
   return Ok{};
 }
 
-void IRBuilder::addBranchHint(Expression* expr, std::optional<bool> likely) {
+void IRBuilder::addBranchHint(Expression* expr, CodeAnnotation::BranchLikely likely) {
   if (likely) {
     // Branches are only possible inside functions.
     assert(func);
@@ -2557,7 +2557,7 @@ void IRBuilder::addBranchHint(Expression* expr, std::optional<bool> likely) {
 }
 
 void IRBuilder::addInlineHint(Expression* expr,
-                              std::optional<uint8_t> inline_) {
+                              CodeAnnotation::Inline inline_) {
   if (inline_) {
     // Branches are only possible inside functions.
     assert(func);


### PR DESCRIPTION
Define aliases for their types, allowing users to do things like
```cpp
makeIf(.., .., CodeAnnotation::BranchLikely(true))
```
Also move this outside of Function. Annotations can, in principle,
appear on things outside of functions (e.g. code in globals, though
no use exists yet), and also this avoids extra typing of `Function::`

edit: diff without whitespace is smaller