### PR TITLE
Fix Branch Hinting iostream printing

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -2679,11 +2679,11 @@ void PrintSExpression::printCodeAnnotations(Expression* curr) {
     if (annotation.inline_) {
       Colors::grey(o);
       std::ofstream saved;
-      saved.copyfmt(std::cout);
+      saved.copyfmt(o);
       o << "(@" << Annotations::InlineHint << " \"\\" << std::hex
         << std::setfill('0') << std::setw(2) << int(*annotation.inline_)
         << "\")\n";
-      std::cout.copyfmt(saved);
+      o.copyfmt(saved);
       restoreNormalColor(o);
       doIndent(o, indent);
     }

--- a/test/lit/branch-hinting-printing.wast
+++ b/test/lit/branch-hinting-printing.wast
@@ -1,0 +1,21 @@
+;; The branch hint should not cause the later constant to print incorrectly
+;; (branch hints are printed in hex, and we should clear that state so later
+;; things are not affected).
+
+(module
+ (type $0 (func))
+ (func $0 (type $0)
+  (@metadata.code.inline "\00")
+  (call $0)
+ )
+ (func $1 (type $0)
+  (drop
+   (i32.const -18428)
+  )
+ )
+)
+
+;; RUN: wasm-opt %s -o %t.wasm -g
+;; RUN: wasm-dis %t.wasm | filecheck %s
+
+;; CHECK: (i32.const -18428)


### PR DESCRIPTION
The code saved and restored `std::cout`, not the current stream... and the
current stream is `std::cout` in most tests, so this went unnoticed. Printing
from `wasm-dis` works otherwise apparently, and the bug showed up there.