### PR TITLE
add missing maybe_unused annotation

### DIFF
--- a/src/ir/public-type-validator.cpp
+++ b/src/ir/public-type-validator.cpp
@@ -36,7 +36,8 @@ bool PublicTypeValidator::isValidPublicTypeImpl(HeapType type) {
 
   auto markVisitingInvalid = [&]() {
     for (auto group : visiting) {
-      auto [_, inserted] = allowedPublicGroupCache.insert({group, false});
+      [[maybe_unused]] auto [_, inserted] =
+        allowedPublicGroupCache.insert({group, false});
       assert(inserted);
     }
   };


### PR DESCRIPTION
this fixes an unused variable warning in opt mode.