### PR TITLE
[CI] Add a no-asserts build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,8 +457,8 @@ jobs:
         python check.py --binaryen-bin=out/bin gtest
 
   # Ensures we can build in no-asserts mode (just building)
-  build-debug:
-    name: debug
+  build-noasserts:
+    name: noasserts
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,3 +455,23 @@ jobs:
       run: |
         python check.py --binaryen-bin=out/bin lit
         python check.py --binaryen-bin=out/bin gtest
+
+  # Ensures we can build in no-asserts mode (just building)
+  build-debug:
+    name: debug
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: install ninja
+      run: sudo apt-get install ninja-build
+    - name: cmake
+      run: |
+        mkdir -p out
+        cmake -S . -B out -G Ninja -DCMAKE_INSTALL_PREFIX=out/install -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DBYN_ENABLE_ASSERTIONS=OFF
+    - name: build
+      run: cmake --build out -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,7 @@ jobs:
         python check.py --binaryen-bin=out/bin lit
         python check.py --binaryen-bin=out/bin gtest
 
-  # Ensures we can build in no-asserts mode (just building)
+  # Ensures we can build in no-asserts mode (just building).
   build-noasserts:
     name: noasserts
     runs-on: ubuntu-latest

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -974,7 +974,7 @@ struct Reducer
     return maxSkip > 2;
   }
 
-  void visitModule(Module* curr) {
+  void visitModule([[maybe_unused]] Module* curr) {
     // The initial module given to us is our global object. As we continue to
     // process things here, we may replace the module, so we should never again
     // refer to curr.

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -947,7 +947,7 @@ void WasmBinaryWriter::writeNames() {
       auto substart =
         startSubsection(BinaryConsts::CustomSections::Subsection::NameLocal);
       o << U32LEB(functionsWithLocalNames.size());
-      Index emitted = 0;
+      [[maybe_unused]] Index emitted = 0;
       for (auto& [index, func] : functionsWithLocalNames) {
         // Pairs of (local index in IR, name).
         std::vector<std::pair<Index, Name>> localsWithNames;


### PR DESCRIPTION
All our testing has asserts enabled, to catch issues. This adds a build mode
for no-asserts, just to catch compile errors like #7610