### PR TITLE
Fix IRBuilder location tracking of If starts

### DIFF
--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -155,14 +155,14 @@ void IRBuilder::push(Expression* expr) {
     auto end = BinaryLocation(*binaryPos - codeSectionOffset);
     // Some expressions already have their start noted, and we are just seeing
     // their last segment (like an Else).
-    // TODO: does Try etc. need this too?
-    if (expr->is<If>()) {
-      auto iter = func->expressionLocations.find(expr);
-      assert(iter != func->expressionLocations.end());
+    auto iter = func->expressionLocations.find(expr);
+    if (iter != func->expressionLocations.end()) {
+      // Just update the end.
       iter->second.end = end;
       // The true start from before is before the start of the current segment.
       assert(iter->second.start < start);
     } else {
+      // Add a whole entry.
       func->expressionLocations[expr] = BinaryLocations::Span{start, end};
     }
     lastBinaryPos = *binaryPos;

--- a/test/lit/branch-hinting.wast
+++ b/test/lit/branch-hinting.wast
@@ -259,6 +259,54 @@
     )
   )
 
+  ;; CHECK:      (func $branch-hints-if-else (type $0) (param $x i32)
+  ;; CHECK-NEXT:  (@metadata.code.branch_hint "\01")
+  ;; CHECK-NEXT:  (if
+  ;; CHECK-NEXT:   (local.get $x)
+  ;; CHECK-NEXT:   (then
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:   (else
+  ;; CHECK-NEXT:    (drop
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; RTRIP:      (func $branch-hints-if-else (type $0) (param $x i32)
+  ;; RTRIP-NEXT:  (@metadata.code.branch_hint "\01")
+  ;; RTRIP-NEXT:  (if
+  ;; RTRIP-NEXT:   (local.get $x)
+  ;; RTRIP-NEXT:   (then
+  ;; RTRIP-NEXT:    (drop
+  ;; RTRIP-NEXT:     (i32.const 1)
+  ;; RTRIP-NEXT:    )
+  ;; RTRIP-NEXT:   )
+  ;; RTRIP-NEXT:   (else
+  ;; RTRIP-NEXT:    (drop
+  ;; RTRIP-NEXT:     (i32.const 0)
+  ;; RTRIP-NEXT:    )
+  ;; RTRIP-NEXT:   )
+  ;; RTRIP-NEXT:  )
+  ;; RTRIP-NEXT: )
+  ;; SRCMP:      (func $branch-hints-if-else (type $0) (param $x i32)
+  ;; SRCMP-NEXT:  (@metadata.code.branch_hint "\01")
+  ;; SRCMP-NEXT:  (if
+  ;; SRCMP-NEXT:   (local.get $x)
+  ;; SRCMP-NEXT:   (then
+  ;; SRCMP-NEXT:    (drop
+  ;; SRCMP-NEXT:     (i32.const 1)
+  ;; SRCMP-NEXT:    )
+  ;; SRCMP-NEXT:   )
+  ;; SRCMP-NEXT:   (else
+  ;; SRCMP-NEXT:    (drop
+  ;; SRCMP-NEXT:     (i32.const 0)
+  ;; SRCMP-NEXT:    )
+  ;; SRCMP-NEXT:   )
+  ;; SRCMP-NEXT:  )
+  ;; SRCMP-NEXT: )
   (func $branch-hints-if-else (param $x i32)
     (@metadata.code.branch_hint "\01")
     (if
@@ -276,6 +324,48 @@
     )
   )
 
+  ;; CHECK:      (func $branch-hints-if-else-result (type $0) (param $x i32)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (@metadata.code.branch_hint "\01")
+  ;; CHECK-NEXT:   (if (result i32)
+  ;; CHECK-NEXT:    (local.get $x)
+  ;; CHECK-NEXT:    (then
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (else
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  ;; RTRIP:      (func $branch-hints-if-else-result (type $0) (param $x i32)
+  ;; RTRIP-NEXT:  (drop
+  ;; RTRIP-NEXT:   (@metadata.code.branch_hint "\01")
+  ;; RTRIP-NEXT:   (if (result i32)
+  ;; RTRIP-NEXT:    (local.get $x)
+  ;; RTRIP-NEXT:    (then
+  ;; RTRIP-NEXT:     (i32.const 1)
+  ;; RTRIP-NEXT:    )
+  ;; RTRIP-NEXT:    (else
+  ;; RTRIP-NEXT:     (i32.const 0)
+  ;; RTRIP-NEXT:    )
+  ;; RTRIP-NEXT:   )
+  ;; RTRIP-NEXT:  )
+  ;; RTRIP-NEXT: )
+  ;; SRCMP:      (func $branch-hints-if-else-result (type $0) (param $x i32)
+  ;; SRCMP-NEXT:  (drop
+  ;; SRCMP-NEXT:   (@metadata.code.branch_hint "\01")
+  ;; SRCMP-NEXT:   (if (result i32)
+  ;; SRCMP-NEXT:    (local.get $x)
+  ;; SRCMP-NEXT:    (then
+  ;; SRCMP-NEXT:     (i32.const 1)
+  ;; SRCMP-NEXT:    )
+  ;; SRCMP-NEXT:    (else
+  ;; SRCMP-NEXT:     (i32.const 0)
+  ;; SRCMP-NEXT:    )
+  ;; SRCMP-NEXT:   )
+  ;; SRCMP-NEXT:  )
+  ;; SRCMP-NEXT: )
   (func $branch-hints-if-else-result (param $x i32)
     (drop
       (@metadata.code.branch_hint "\01")

--- a/test/lit/branch-hinting.wast
+++ b/test/lit/branch-hinting.wast
@@ -259,6 +259,38 @@
     )
   )
 
+  (func $branch-hints-if-else (param $x i32)
+    (@metadata.code.branch_hint "\01")
+    (if
+      (local.get $x)
+      (then
+        (drop
+          (i32.const 1)
+        )
+      )
+      (else
+        (drop
+          (i32.const 0)
+        )
+      )
+    )
+  )
+
+  (func $branch-hints-if-else-result (param $x i32)
+    (drop
+      (@metadata.code.branch_hint "\01")
+      (if (result i32)
+        (local.get $x)
+        (then
+          (i32.const 1)
+        )
+        (else
+          (i32.const 0)
+        )
+      )
+    )
+  )
+
   ;; CHECK:      (func $branch-hints-br_on (type $1) (param $x anyref)
   ;; CHECK-NEXT:  (block $out
   ;; CHECK-NEXT:   (drop


### PR DESCRIPTION
The old code forgot the If scope when it started the Else, so any if-else would get
a binary location span that started in the else (and ends in the right place).

To fix this, note the if start location when we have it, and don't trample.

Fixes branch hints on if-elses.