### PR TITLE
Fix missing Exact type ReFinalization in TypeMerging

### DIFF
--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -171,7 +171,7 @@ struct TypeMerging : public Pass {
   // in a single step would be unsound because a type might be merged into its
   // parent's sibling without being merged with its parent.
   enum MergeKind { Supertypes, Siblings };
-  void merge(MergeKind kind);
+  bool merge(MergeKind kind);
 
   // Split a partition into potentially multiple partitions for each
   // disconnected group of types it contains.
@@ -242,13 +242,7 @@ void TypeMerging::run(Module* module_) {
   // Merging can unlock more sibling merging opportunities because two identical
   // types cannot be merged until their respective identical parents have been
   // merged in a previous step, making them siblings.
-  merge(Supertypes);
-  for (int i = 0; i < MAX_ITERATIONS; ++i) {
-    merge(Siblings);
-  }
-
-  applyMerges();
-
+  //
   // If we merge siblings, we also need to refinalize because the LUB of merged
   // siblings is the merged type rather than their common supertype after the
   // merge. This can happen in merge(Siblings), but also in merge(Supertypes),
@@ -266,10 +260,22 @@ void TypeMerging::run(Module* module_) {
   //   (A) ;; now A
   //  )
   //
-  ReFinalize().run(getPassRunner(), module);
+  bool refinalize = merge(Supertypes);
+  for (int i = 0; i < MAX_ITERATIONS; ++i) {
+    if (!merge(Siblings)) {
+      break;
+    }
+    refinalize = true;
+  }
+
+  applyMerges();
+
+  if (refinalize) {
+    ReFinalize().run(getPassRunner(), module);
+  }
 }
 
-void TypeMerging::merge(MergeKind kind) {
+bool TypeMerging::merge(MergeKind kind) {
   // Initial partitions are formed by grouping types with their structurally
   // similar supertypes or siblings, according to the `kind`.
   Partitions partitions;
@@ -439,12 +445,14 @@ void TypeMerging::merge(MergeKind kind) {
   // will accidentally set that subtype to be its own supertype. Also keep track
   // of the remaining types.
   std::vector<HeapType> newMergeable;
+  bool merged = false;
   for (const auto& partition : refinedPartitions) {
     auto target = mergeableSupertypesFirst(partition).front();
     newMergeable.push_back(target);
     for (auto type : partition) {
       if (type != target) {
         merges[type] = target;
+        merged = true;
       }
     }
   }
@@ -464,6 +472,8 @@ void TypeMerging::merge(MergeKind kind) {
     std::cerr << "\n";
   }
 #endif // TYPE_MERGING_DEBUG
+
+  return merged;
 }
 
 std::vector<std::vector<HeapType>>

--- a/src/passes/TypeMerging.cpp
+++ b/src/passes/TypeMerging.cpp
@@ -253,7 +253,19 @@ void TypeMerging::run(Module* module_) {
   // siblings is the merged type rather than their common supertype after the
   // merge. This can happen in merge(Siblings), but also in merge(Supertypes),
   // since we may end up merging B1 to its super A, and also B2 to the same
-  // super A, ending up with B1 and B2 now equal.
+  // super A, ending up with B1 and B2 now equal - in that case the siblings are
+  // now both equal (to the parent), allowing an exact LUB:
+  //
+  //  (select (result A))
+  //   (B1)
+  //   (B2)
+  //  )
+  // =>
+  //  (select (result (exact A))) ;; result is now exact
+  //   (A) ;; both are
+  //   (A) ;; now A
+  //  )
+  //
   ReFinalize().run(getPassRunner(), module);
 }
 

--- a/test/lit/passes/type-merging-exact.wast
+++ b/test/lit/passes/type-merging-exact.wast
@@ -131,3 +131,44 @@
     )
   )
 )
+
+;; Merge two siblings to their parent. We must refinalize here.
+(module
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $A (sub (array i8)))
+    (type $A (sub (array i8)))
+    (type $B1 (sub $A (array i8)))
+    (type $B2 (sub $A (array i8)))
+  )
+
+  ;; CHECK:      (func $test (type $1)
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (select (result (ref (exact $A)))
+  ;; CHECK-NEXT:    (array.new_default $A
+  ;; CHECK-NEXT:     (i32.const 0)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (array.new_default $A
+  ;; CHECK-NEXT:     (i32.const 1)
+  ;; CHECK-NEXT:    )
+  ;; CHECK-NEXT:    (i32.const 2)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $test
+    ;; B1 and B2 will turn into A, after which the select can be refined to an
+    ;; exact type.
+    (drop
+      (select (result (ref $A))
+        (array.new_default $B1
+          (i32.const 0)
+        )
+        (array.new_default $B2
+          (i32.const 1)
+        )
+        (i32.const 2)
+      )
+    )
+  )
+)
+

--- a/test/lit/passes/type-merging.wast
+++ b/test/lit/passes/type-merging.wast
@@ -890,7 +890,7 @@
  )
 
  ;; CHECK:      (func $test (type $D) (result (ref any) (ref $B))
- ;; CHECK-NEXT:  (block $l (type $A) (result (ref any) (ref $B))
+ ;; CHECK-NEXT:  (block $l
  ;; CHECK-NEXT:   (unreachable)
  ;; CHECK-NEXT:  )
  ;; CHECK-NEXT: )


### PR DESCRIPTION
If we merge siblings to their parent, they may end up equal:
```wat
(select (result A))
 (B1)
 (B2)
)

=>

(select (result (exact A))) ;; result is now exact
 (A) ;; both are
 (A) ;; now A
)
```
In such cases we must refinalize, as the LUB is now exact.