### PR TITLE
OptimizeInstructions: Fix max bits of a local with an unreachable set

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -129,6 +129,7 @@ struct LocalScanner : PostWalker<LocalScanner> {
       Properties::getFallthrough(curr->value, passOptions, *getModule());
     auto& info = localInfo[curr->index];
     info.maxBits = std::max(info.maxBits, Bits::getMaxBits(value, this));
+    info.maxBits = std::min(info.maxBits, getBitsForType(type));
     auto signExtBits = LocalInfo::kUnknown;
     if (Properties::getSignExtValue(value)) {
       signExtBits = Properties::getSignExtBits(value);

--- a/test/lit/passes/optimize-instructions-mvp.wast
+++ b/test/lit/passes/optimize-instructions-mvp.wast
@@ -18410,4 +18410,41 @@
       )
     )
   )
+
+  ;; CHECK:      (func $local-unreachable-size-matters
+  ;; CHECK-NEXT:  (local $temp i32)
+  ;; CHECK-NEXT:  (local.set $temp
+  ;; CHECK-NEXT:   (i32.const 1)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (drop
+  ;; CHECK-NEXT:   (i32.and
+  ;; CHECK-NEXT:    (local.get $temp)
+  ;; CHECK-NEXT:    (i32.const 1)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT:  (local.tee $temp
+  ;; CHECK-NEXT:   (unreachable)
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $local-unreachable-size-matters
+    ;; The local is written 1, then later down we have an unreachable. That
+    ;; should not confuse us as to the max bits in the local. This is a test for
+    ;; a bug where any local with an unreachable set got assigned 64 bits, which
+    ;; is wrong in this case and led to a misoptimization of the |and|. We
+    ;; should not optimize it away to a 0 (we could in theory optimize it to a
+    ;; 1, but this pass does not infer locals that precisely).
+    (local $temp i32)
+    (local.set $temp
+      (i32.const 1)
+    )
+    (drop
+      (i32.and
+        (local.get $temp)
+        (i32.const 1)
+      )
+    )
+    (local.tee $temp
+      (unreachable)
+    )
+  )
 )


### PR DESCRIPTION
Previously we set such locals to 64 bits, even if they were i32. This
interacted with #7505 which compared the bits to the true bits of
the type, which led to 64 != 32, which suggested we knew something
nontrivial about the bits.