### PR TITLE
[wasm-reduce] Fix time calculation

### DIFF
--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -196,7 +196,7 @@ struct ProgramResult {
     }
     code = pclose(stream);
     timer.stop();
-    time = timer.getTotal() / 2;
+    time = timer.getTotal();
   }
 #endif // _WIN32
 


### PR DESCRIPTION
Now that we only run the reduction command once per candidate rather
than twice, we don't need to divide the measured execution time in half.
