### PR TITLE
Fix assertion failure in TupleOptimization

### DIFF
--- a/src/passes/TupleOptimization.cpp
+++ b/src/passes/TupleOptimization.cpp
@@ -150,8 +150,11 @@ struct TupleOptimization : public WalkerPass<PostWalker<TupleOptimization>> {
 
   void visitTupleExtract(TupleExtract* curr) {
     // We need the input to be a local, either from a tee or a get.
-    if (auto* set = curr->tuple->dynCast<LocalSet>()) {
-      validUses[set->index]++;
+    if (auto* tee = curr->tuple->dynCast<LocalSet>()) {
+      // The tee might not be of a tuple local if it is unreachable.
+      if (getFunction()->getLocalType(tee->index).isTuple()) {
+        validUses[tee->index]++;
+      }
     } else if (auto* get = curr->tuple->dynCast<LocalGet>()) {
       validUses[get->index]++;
     }

--- a/test/lit/passes/tuple-optimization.wast
+++ b/test/lit/passes/tuple-optimization.wast
@@ -1064,4 +1064,23 @@
       )
     )
   )
+
+  ;; CHECK:      (func $unreachable.tuple.extract (type $3) (result i32)
+  ;; CHECK-NEXT:  (local $tuple (tuple i32 i64))
+  ;; CHECK-NEXT:  (local $non-tuple i32)
+  ;; CHECK-NEXT:  (tuple.extract 2 0
+  ;; CHECK-NEXT:   (local.tee $non-tuple
+  ;; CHECK-NEXT:    (unreachable)
+  ;; CHECK-NEXT:   )
+  ;; CHECK-NEXT:  )
+  ;; CHECK-NEXT: )
+  (func $unreachable.tuple.extract (result i32)
+    (local $tuple (tuple i32 i64))
+    (local $non-tuple i32)
+    (tuple.extract 2 0
+      (local.tee $non-tuple
+        (unreachable)
+      )
+    )
+  )
 )


### PR DESCRIPTION
We previously counted a local use for all `local.tee` operands to
`tuple.extract`, even if the `local.tee` was unreachable and had a
non-tuple local. This led to an assertion failure later. Fix the issue
by disregarding `local.tee` operands of `tuple.extract` if they don't
have tuple locals.
