### PR TITLE
Remove BinaryenStringNewSetTry from C API

### DIFF
--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -2643,8 +2643,6 @@ BINARYEN_API BinaryenExpressionRef
 BinaryenStringNewGetEnd(BinaryenExpressionRef expr);
 BINARYEN_API void BinaryenStringNewSetEnd(BinaryenExpressionRef expr,
                                           BinaryenExpressionRef endExpr);
-BINARYEN_API void BinaryenStringNewSetTry(BinaryenExpressionRef expr,
-                                          bool try_);
 
 // StringConst
 


### PR DESCRIPTION
The definition for this function was removed in #6589.