### PR TITLE
RemoveUnusedBrs: optimize unreachable control flow mixed with side-effecting branches

### DIFF
--- a/test/lit/passes/remove-unused-brs.wast
+++ b/test/lit/passes/remove-unused-brs.wast
@@ -472,7 +472,12 @@
   ;; CHECK-NEXT:   (drop
   ;; CHECK-NEXT:    (br_if $block
   ;; CHECK-NEXT:     (local.get $temp)
-  ;; CHECK-NEXT:     (local.tee $temp
+  ;; CHECK-NEXT:     (block (result i32)
+  ;; CHECK-NEXT:      (drop
+  ;; CHECK-NEXT:       (local.tee $temp
+  ;; CHECK-NEXT:        (i32.const 1)
+  ;; CHECK-NEXT:       )
+  ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (i32.const 1)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -2897,7 +2897,12 @@
     (i32.const 1026)
     (then
      (br_if $label$1
-      (local.tee $0
+      (block (result i32)
+       (drop
+        (local.tee $0
+         (i32.const -7)
+        )
+       )
        (i32.const -7)
       )
      )


### PR DESCRIPTION
Currently wasm-opt cannot optimize unused branch complexed with side-effect operations, such as

``` webassembly
 (func $_start
  (local $0 i32)
  (block $block
   (br_if $block
    (local.tee $0
     (i32.const 1)
    )
   )
   (br_if $block
    (i32.load
     (i32.const 0)
    )
   )
   (local.set $0
    (i32.const 0)
   )
  )
  (i32.store
   (i32.const 0)
   (local.get $0)
  )
 )
```

Actually, the whole block can be removed. However, O3 cannot optimize it (while O2 could).

Fixes: #7637