### PR TITLE
Precompute: Skip RefGetDesc for now

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -240,6 +240,12 @@ public:
     // string.encode_wtf16_array anyhow.)
     return Flow(NONCONSTANT_FLOW);
   }
+
+  Flow visitRefGetDesc(RefGetDesc* curr) {
+    // TODO: Implement this. For now, return nonconstant so that we skip it and
+    //       do not error.
+    return Flow(NONCONSTANT_FLOW);
+  }
 };
 
 struct Precompute


### PR DESCRIPTION
This allows users to optimize custom descriptors content without erroring, at
least, for now.