### PR TITLE
Fix wabt setup script

### DIFF
--- a/third_party/setup.py
+++ b/third_party/setup.py
@@ -184,9 +184,10 @@ def wabt_determine_platform():
 
 
 def wabt_determine_release(platform):
+    platform_regex = re.compile(r"^wabt-.*-ubuntu-.*.tar.gz$")
     data = fetch_json('https://api.github.com/repos/WebAssembly/wabt/releases/latest')
     for asset in data['assets']:
-        if asset['name'].endswith('-' + platform + '.tar.gz'):
+        if platform_regex.match(asset['name']):
             return asset['browser_download_url']
     print('Cannot determine release')
     return ''


### PR DESCRIPTION
On Linux we use "ubuntu" as the platform string when searching for a wabt release tarball and search for a file that ends with "-ubuntu.tar.gz".

However wabt release tarballs mention Ubuntu version as well, e.g. the current release name is "wabt-1.0.37-ubuntu-20.04.tar.gz". The current check with `endswith` does not match the current release tarball names.

Update the name matching to use the regex `^wabt-.*-ubuntu-.*.tar.gz$`, which matches version numbers after the "ubuntu" part.