### PR TITLE
Fix elem.drop interpretation

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3654,9 +3654,8 @@ public:
   }
 
   Flow visitElemDrop(ElemDrop* curr) {
-    Module& wasm = *self()->getModule();
     ElementSegment* seg = wasm.getElementSegment(curr->segment);
-    seg->data.clear();
+    droppedElementSegments.insert(seg->name);
     return {};
   }
 


### PR DESCRIPTION
Don't drop the segment in the module as the module can be used again later.

Instead add the segment to the dropped segments set.

Fixes the fuzzing issue described in https://github.com/WebAssembly/binaryen/pull/7658#issuecomment-2985124026.