### PR TITLE
Add CMakeUserPresets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ CMakeFiles
 /emcc-build
 compile_commands.json
 test/lit/lit.site.cfg.py
+CMakeUserPresets.json
 
 # files related to bulding in-tree on windows
 /.vs/


### PR DESCRIPTION
This is a standard CMake file used to configure builds in IDEs.
