### PR TITLE
[Custom Descriptors] Interpret ref.get_desc

### DIFF
--- a/src/literal.h
+++ b/src/literal.h
@@ -775,8 +775,13 @@ struct GCData {
   // The element or field values.
   Literals values;
 
-  GCData(HeapType type, Literals&& values)
-    : type(type), values(std::move(values)) {}
+  // The descriptor, if it exists, or null.
+  Literal desc;
+
+  GCData(HeapType type,
+         Literals&& values,
+         const Literal& desc = Literal::makeNull(HeapType::none))
+    : type(type), values(std::move(values)), desc(desc) {}
 };
 
 // The data of a (ref exn) literal.

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -1216,6 +1216,9 @@ void StructNew::finalize() {
   if (handleUnreachableOperands(this)) {
     return;
   }
+  if (descriptor && descriptor->type == Type::unreachable) {
+    type = Type::unreachable;
+  }
 }
 
 void StructGet::finalize() {


### PR DESCRIPTION
Add a descriptor to the GCData stored in a reference value. The
descriptor itself is another literal representing either a null if there
is no descriptor or otherwise a reference to the descriptor. Update
the interpretation of struct.new to set the descriptor when allocating
types with descriptors and then retrieve the descriptor when
interpreting ref.get_desc.
