### PR TITLE
[Custom Descriptors] Preserve trap in Heap2Local

### DIFF
--- a/src/passes/Heap2Local.cpp
+++ b/src/passes/Heap2Local.cpp
@@ -752,8 +752,13 @@ struct Struct2Local : PostWalker<Struct2Local> {
       }
     }
     if (curr->desc) {
-      contents.push_back(
-        builder.makeLocalSet(tempIndexes[numTemps - 1], curr->desc));
+      // Preserve the trapping on null descriptors by inserting a
+      // ref.as_non_null.
+      Expression* desc = curr->desc;
+      if (curr->desc->type.isNullable()) {
+        desc = builder.makeRefAs(RefAsNonNull, desc);
+      }
+      contents.push_back(builder.makeLocalSet(tempIndexes[numTemps - 1], desc));
     }
 
     // Store the values into the locals representing the fields.

--- a/test/lit/passes/heap2local-desc.wast
+++ b/test/lit/passes/heap2local-desc.wast
@@ -56,7 +56,9 @@
   ;; CHECK-NEXT:     (i32.const 1)
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (local.set $3
-  ;; CHECK-NEXT:     (global.get $desc)
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (global.get $desc)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (local.set $0
   ;; CHECK-NEXT:     (local.get $2)
@@ -84,7 +86,9 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result nullref)
   ;; CHECK-NEXT:    (local.set $2
-  ;; CHECK-NEXT:     (global.get $desc)
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (global.get $desc)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (local.set $0
   ;; CHECK-NEXT:     (i32.const 0)
@@ -240,7 +244,9 @@
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (local.set $2
-  ;; CHECK-NEXT:       (local.get $desc)
+  ;; CHECK-NEXT:       (ref.as_non_null
+  ;; CHECK-NEXT:        (local.get $desc)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (local.set $1
   ;; CHECK-NEXT:       (local.get $2)
@@ -328,7 +334,9 @@
   ;; CHECK-NEXT:    (drop
   ;; CHECK-NEXT:     (block (result nullref)
   ;; CHECK-NEXT:      (local.set $2
-  ;; CHECK-NEXT:       (local.get $desc)
+  ;; CHECK-NEXT:       (ref.as_non_null
+  ;; CHECK-NEXT:        (local.get $desc)
+  ;; CHECK-NEXT:       )
   ;; CHECK-NEXT:      )
   ;; CHECK-NEXT:      (local.set $1
   ;; CHECK-NEXT:       (local.get $2)
@@ -423,7 +431,9 @@
   ;; CHECK-NEXT:  (drop
   ;; CHECK-NEXT:   (block (result nullref)
   ;; CHECK-NEXT:    (local.set $3
-  ;; CHECK-NEXT:     (local.get $desc)
+  ;; CHECK-NEXT:     (ref.as_non_null
+  ;; CHECK-NEXT:      (local.get $desc)
+  ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:    (local.set $2
   ;; CHECK-NEXT:     (local.get $3)


### PR DESCRIPTION
Insert a ref.as_non_null when optimizing struct.new with a nullable
descriptor to preserve the trap if the descriptor is null.
