### PR TITLE
[Custom Descriptors] Keep trapping initializers

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1852,7 +1852,7 @@ testcase_handlers = [
     Wasm2JS(),
     TrapsNeverHappen(),
     CtorEval(),
-    Merge(),
+    # Merge(),
     # TODO: enable when stable enough, and adjust |frequency| (see above)
     # Split(),
     RoundtripText(),

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1852,7 +1852,7 @@ testcase_handlers = [
     Wasm2JS(),
     TrapsNeverHappen(),
     CtorEval(),
-    # Merge(),
+    Merge(),
     # TODO: enable when stable enough, and adjust |frequency| (see above)
     # Split(),
     RoundtripText(),

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -772,8 +772,9 @@ struct RemoveUnusedModuleElements : public Pass {
       // See TODO in addReferences - we may be able to do better here.
       return !needed({ModuleElementKind::Global, curr->name});
     });
-    module->removeTags(
-      [&](Tag* curr) { return !needed({ModuleElementKind::Tag, curr->name}); });
+    module->removeTags([&](Tag* curr) {
+      return !needed({ModuleElementKind::Tag, curr->name});
+    });
     module->removeMemories([&](Memory* curr) {
       return !needed(ModuleElement(ModuleElementKind::Memory, curr->name));
     });

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -870,7 +870,6 @@ struct RemoveUnusedModuleElements : public Pass {
       void visitStructNew(StructNew* curr) {
         if (curr->desc && curr->desc->type.isNullable()) {
           mayTrap = true;
-          return;
         }
       }
     };

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -887,7 +887,6 @@ struct RemoveUnusedModuleElements : public Pass {
           // allocation. Cache the results to avoid searching the same globals
           // again in the future.
           auto* global = wasm.getGlobal(get->name);
-          std::vector<std::unordered_map<Name, bool>::iterator> cacheEntries;
           while (true) {
             if (global->type.isNonNullable()) {
               // Only a null can cause a trap. Further globals must also be


### PR DESCRIPTION
Update RemoveUnusedModuleElements to preserve traps in global and
element segment initializers due to null or possibly-null descriptors
passed to struct.new. For every struct.new that appears with a
descriptor in an initializer, find the origin of the descrpitor value.
If it is a null literal or a nullable import, keep the global containing
the struct.new because it either will or will possibly trap.
