### PR TITLE
Fix build failure with Xcode/AppleClang 17

### DIFF
--- a/src/wasm/wasm-debug.cpp
+++ b/src/wasm/wasm-debug.cpp
@@ -18,7 +18,18 @@
 #include "wasm.h"
 
 #ifdef BUILD_LLVM_DWARF
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic warning "-Wdeprecated-declarations"
+#endif
+
 #include "llvm/ObjectYAML/DWARFEmitter.h"
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 #include "llvm/ObjectYAML/DWARFYAML.h"
 #include "llvm/include/llvm/DebugInfo/DWARFContext.h"
 


### PR DESCRIPTION
Addresses the issue reported in #7606, which appears to have been deleted.

A header included from LLVM includes a reference to `std::iterator` which is deprecated in C++17; this trips a deprecated-declarations warning which becomes a compile error via `-Werror`. This patch selectively causes that warning to be ignored.