### PR TITLE
[Custom Descriptors] Fix bug optimizing struct.new

### DIFF
--- a/src/passes/OptimizeInstructions.cpp
+++ b/src/passes/OptimizeInstructions.cpp
@@ -1863,9 +1863,15 @@ struct OptimizeInstructions
       }
     }
 
-    // Success! Drop the children and return a struct.new_with_default.
+    // Success! Drop the children and return a struct.new_with_default. We don't
+    // want the descriptor to be dropped, however, so temporarily remove it
+    // while we drop the other children. If the descriptor is null, this makes
+    // no difference.
+    auto* desc = curr->desc;
+    curr->desc = nullptr;
     auto* rep = getDroppedChildrenAndAppend(curr, curr);
     curr->operands.clear();
+    curr->desc = desc;
     assert(curr->isWithDefault());
     replaceCurrent(rep);
   }


### PR DESCRIPTION
When all of the non-descriptor operands to struct.new have default
values, we can optimize the struct.new to struct.new_default in
OptimizeInstructions. When we do this, we drop all the children with
side effects. This previously included the descriptor operand, even
though we did not clear the descriptor operand from the StructNew parent
expression, causing the descriptor operand to appear twice in the IR.
This is invalid and could lead to assertion failures elsewhere.

To avoid the problem, clear the descriptor operand while we call the
utility to drop the StructNew children and restore it afterward. This is
somewhat ugly, but better than duplicating the functionality of the
utility, except ignoring the descriptor.
