### PR TITLE
[Fuzzing] Add an env var to avoid modifying the given wasm file in fuzz_opt.py

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1878,9 +1878,9 @@ def test_one(random_input, given_wasm):
         # usual ways, like running DeNAN on it, which is important in many cases
         # (imagine the reducer generates a NAN, then we need to restore the
         # property of not having any). However, in some cases we do need to
-        # trust the wasm is correct, as any change may alter the properties we
-        # want there, so we have an env var to control that,
-        # BINARYEN_TRUST_GIVEN_WASM.
+        # trust the wasm is correct, or it is simpler to debug things without
+        # constant changes in each reduction cycle, so we have an env var to
+        # control that, BINARYEN_TRUST_GIVEN_WASM.
         if os.environ.get('BINARYEN_TRUST_GIVEN_WASM'):
             shutil.copyfile(given_wasm, abspath('a.wasm'))
         else:


### PR DESCRIPTION
Normally we want to fix it up (remove NaNs etc., as we do normally), but the
changes in each fuzzing iteration can make things hard to debug. Add an
env var to simply trust the given wasm file and use it without changes.

Diff without whitespace is a little smaller.