### PR TITLE
[Custom Descriptors] Fix ref.cast_desc branching descriptors

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -1658,7 +1658,7 @@ public:
     }
     Flow desc = self()->visit(curr->desc);
     if (desc.breaking()) {
-      return typename Cast::Breaking{ref};
+      return typename Cast::Breaking{desc};
     }
     auto expected = desc.getSingleValue().getGCData();
     if (!expected) {

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -2936,7 +2936,8 @@ void FunctionValidator::visitRefTest(RefTest* curr) {
 void FunctionValidator::visitRefCast(RefCast* curr) {
   shouldBeTrue(
     getModule()->features.hasGC(), curr, "ref.cast requires gc [--enable-gc]");
-  if (curr->ref->type == Type::unreachable) {
+  if (curr->ref->type == Type::unreachable ||
+      (curr->desc && curr->desc->type == Type::unreachable)) {
     return;
   }
   if (!shouldBeTrue(

--- a/test/spec/ref.cast_desc.wast
+++ b/test/spec/ref.cast_desc.wast
@@ -145,6 +145,25 @@
       )
     )
   )
+
+  (func (export "cast-branch-ref") (result i32)
+    (drop
+      (ref.cast_desc (ref $super)
+        (return (i32.const 1))
+        (ref.null none)
+      )
+    )
+    (i32.const 0)
+  )
+  (func (export "cast-branch-desc") (result i32)
+    (drop
+      (ref.cast_desc (ref $super)
+        (ref.null none)
+        (return (i32.const 1))
+      )
+    )
+    (i32.const 0)
+  )
 )
 
 (assert_return (invoke "cast-success"))
@@ -157,6 +176,8 @@
 (assert_trap (invoke "cast-nn-fail-null") "cast error")
 (assert_trap (invoke "cast-nn-fail-wrong-desc") "cast error")
 (assert_trap (invoke "cast-nn-fail-null-desc") "null descriptor")
+(assert_return (invoke "cast-branch-ref") (i32.const 1))
+(assert_return (invoke "cast-branch-desc") (i32.const 1))
 
 (assert_malformed
   ;; Cast type must be a reference.


### PR DESCRIPTION
The interpreter was returning the wrong value when evaluating a
branching descriptor operand to a descriptor cast. Adding tests for this
fix also exposed a bug where the validator did not allow for unreachable
descriptor operands without also having unreachable ref operands.
