### PR TITLE
[Debug Info] Prioritize optimization over debug info in metadata comparisons

### DIFF
--- a/src/ir/metadata.cpp
+++ b/src/ir/metadata.cpp
@@ -105,8 +105,14 @@ bool equal(Function* a, Function* b) {
     return false;
   }
 
-  if (a->debugLocations.empty() && b->debugLocations.empty() &&
-      a->codeAnnotations.empty() && b->codeAnnotations.empty()) {
+  // TODO: We do not consider debug locations here. This is often what is
+  //       desired in optimized builds (e.g. if we are trying to fold two
+  //       pieces of code together, that benefit outweighs slightly inaccurate
+  //       debug info). If we find that non-optimizer locations call this in
+  //       ways that lead to degraded debug info, we could add an option to
+  //       control it.
+
+  if (a->codeAnnotations.empty() && b->codeAnnotations.empty()) {
     // Nothing to compare; no differences.
     return true;
   }
@@ -121,11 +127,6 @@ bool equal(Function* a, Function* b) {
   assert(aList.list.size() == bList.list.size());
   for (Index i = 0; i < aList.list.size(); i++) {
     if (!compare(aList.list[i],
-                 bList.list[i],
-                 a->debugLocations,
-                 b->debugLocations,
-                 Function::DebugLocation()) ||
-        !compare(aList.list[i],
                  bList.list[i],
                  a->codeAnnotations,
                  b->codeAnnotations,

--- a/test/lit/passes/duplicate-function-elimination_branch-hints.wast
+++ b/test/lit/passes/duplicate-function-elimination_branch-hints.wast
@@ -218,3 +218,43 @@
  )
 )
 
+;; Source file location (debug info) does *not* prevent optimization. We
+;; prioritize optimization over debug info quality.
+(module
+ ;; CHECK:      (type $0 (func (param i32)))
+
+ ;; CHECK:      (export "a" (func $a))
+
+ ;; CHECK:      (export "b" (func $a))
+
+ ;; CHECK:      (func $a (type $0) (param $x i32)
+ ;; CHECK-NEXT:  ;;@ src.cpp:10:1
+ ;; CHECK-NEXT:  (if
+ ;; CHECK-NEXT:   (local.get $x)
+ ;; CHECK-NEXT:   (then
+ ;; CHECK-NEXT:    (unreachable)
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $a (export "a") (param $x i32)
+  ;; After we merge, this hint will remain in the single function.
+  ;;@ src.cpp:10:1
+  (if
+   (local.get $x)
+   (then
+    (unreachable)
+   )
+  )
+ )
+
+ (func $b (export "b") (param $x i32)
+  ;;@ src.cpp:20:1
+  (if
+   (local.get $x)
+   (then
+    (unreachable)
+   )
+  )
+ )
+)
+


### PR DESCRIPTION
Ignore debug info there, allowing e.g. DuplicateFunctionElimination to
merge functions identical in all ways but for debug info.