### PR TITLE
[NFC] Speed up Unsubtyping

### DIFF
--- a/src/passes/Unsubtyping.cpp
+++ b/src/passes/Unsubtyping.cpp
@@ -133,8 +133,13 @@ struct TypeTree {
     // Remove sub from its old supertype if necessary.
     if (auto oldParentIndex = nodes[subIndex].parent;
         oldParentIndex != subIndex) {
+      // Move sub to the back of its parent's children and then pop it.
       auto& children = nodes[oldParentIndex].children;
+      auto& swapped = nodes[children.back()];
+      // Swap the indices in the parent's child vector.
       std::swap(children[nodes[subIndex].indexInParent], children.back());
+      // Swap the indices in the children.
+      std::swap(nodes[subIndex].indexInParent, swapped.indexInParent);
       children.pop_back();
     }
     nodes[subIndex].parent = superIndex;

--- a/test/lit/passes/unsubtyping.wast
+++ b/test/lit/passes/unsubtyping.wast
@@ -1850,3 +1850,25 @@
   )
  )
 )
+
+;; Regression test for assertion failure on incorrect updating of type tree
+;; state.
+(module
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $0 (sub (struct)))
+    (type $0 (sub (struct)))
+    ;; CHECK:       (type $1 (sub $0 (struct (field (ref null $0)))))
+    (type $1 (sub $0 (struct (field (ref null $0)))))
+    ;; CHECK:       (type $2 (sub $1 (struct (field (ref null $3)))))
+    (type $2 (sub $1 (struct (field (ref null $3)))))
+    ;; CHECK:       (type $3 (sub $0 (struct)))
+    (type $3 (sub $0 (struct)))
+   )
+   ;; CHECK:      (global $g (ref struct) (struct.new_default $2))
+   (global $g (ref struct) (struct.new_default $2))
+   ;; CHECK:      (global $g2 (ref null $1) (ref.null none))
+   (global $g2 (ref null $1) (ref.null none))
+   ;; CHECK:      (export "" (global $g2))
+   (export "" (global $g2))
+)


### PR DESCRIPTION
Speed up Unsubtyping by over 2x via algorithmic and other improvements.

The most expensive part of the Unsubtyping analysis is the handling of
casts. For each cast source and destination pair, each type that remains
a subtype of the source and was originally a subtype of the destination
must remain a subtype of the destination for the cast to continue
succeeding.

Previously, Unsubtyping analyzed these cast relationships for all types
as a single unit of work whenever it reached a fixed point from
examining other sources of subtyping constraints. This led to duplicated
work because the subtype, cast source, and cast destination triples
analyzed once would be analyzed again the next time casts were
considered.

Avoid this duplicated cast analysis by incrementally analyzing casts
whenever a new subtyping is discovered. Maintain the invariant that each
new subtyping either joins a subtyping tree rooted at the discovered
subtype into the discovered supertype's tree, or reparents the subtype
below some (possibly indirect) subtype of its old parent. In the former
case, the subtype and all of its descendents are evaluated against all
casts originating from all their new supertypes in the tree they have
joined. In the latter case, they must already have been evaluated
against all casts originating at the old supertype and its ancestors, so
they need only to be evaluated against their new supertypes up to the
old supertype. Once a particular type is evaluated against casts
originating from a particular supertype, that type will never be
evaluated against those casts again.

This algorithmic improvement accounts for most of the speedup. The rest
of the speedup is from doing less work while collecting the initial
subtyping constraints in a parallel function analysis. The old
implementation used an instance of Unsubtyping to collect constraints in
each function, which would end up doing some analysis to find additional
constraints. The new implementation does not do any analysis of
transitively required constraints during the initial parallel function
analysis.
