### PR TITLE
Assert unreachable cases in getBasicHeapTypeLUB

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -407,15 +407,13 @@ std::optional<HeapType> getBasicHeapTypeLUB(HeapType::BasicHeapType a,
   HeapType lubUnshared;
   switch (HeapType(a).getBasic(Unshared)) {
     case HeapType::ext:
-      if (bUnshared != HeapType::string) {
-        return std::nullopt;
-      }
+      assert(bUnshared == HeapType::string);
       lubUnshared = HeapType::ext;
       break;
     case HeapType::func:
     case HeapType::cont:
     case HeapType::exn:
-      return std::nullopt;
+      WASM_UNREACHABLE("Unexpected non-bottom type in same hierarchy");
     case HeapType::any:
       lubUnshared = HeapType::any;
       break;


### PR DESCRIPTION
This currently seems to be a bit inconsistent with the null types that already use assertions / unreachable for cases that are already handled above:
```c++
      // Bottom types already handled.
      WASM_UNREACHABLE("unexpected basic type");
```
It isn't a very meaningful change, I'd just like to verify that I don't misunderstand the implementation. :face_with_peeking_eye: 
