### PR TITLE
Fix undefined behavior in construction of wasm::NameType

### DIFF
--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -29,7 +29,7 @@ namespace wasm {
 struct NameType {
   Name name;
   Type type;
-  NameType() : name(nullptr), type(Type::none) {}
+  NameType() : name(), type(Type::none) {}
   NameType(Name name, Type type) : name(name), type(type) {}
 };
 


### PR DESCRIPTION
`wasm::Name::Name(nullptr)` ends up calling `std::string_view(nullptr)`,
which is undefined and triggers an assertion in some standard libraries. 

https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view.html