### PR TITLE
Revert part of #7715: Ignore metadata in function comparisons

### DIFF
--- a/src/ir/function-utils.h
+++ b/src/ir/function-utils.h
@@ -17,7 +17,6 @@
 #ifndef wasm_ir_function_h
 #define wasm_ir_function_h
 
-#include "ir/metadata.h"
 #include "ir/utils.h"
 #include "wasm.h"
 
@@ -38,9 +37,10 @@ inline bool equal(Function* left, Function* right) {
       return false;
     }
   }
-  if (!metadata::equal(left, right)) {
-    return false;
-  }
+  // We could in principle compare metadata here, but intentionally do not, as
+  // for optimization purposes we do want to e.g. merge functions that differ
+  // only in metadata (following LLVM's example). If we have a non-optimization
+  // reason for comparing metadata here then we could add a flag for it.
   if (left->imported() && right->imported()) {
     return true;
   }

--- a/test/lit/passes/duplicate-function-elimination_branch-hints.wast
+++ b/test/lit/passes/duplicate-function-elimination_branch-hints.wast
@@ -3,7 +3,10 @@
 
 ;; RUN: foreach %s %t wasm-opt --duplicate-function-elimination --all-features -S -o - | filecheck %s
 
-;; The functions here differ in branch hints, and should not be merged.
+;; Test that we merge functions even if they differ in branch hints. This is
+;; good for code size, and follows what LLVM does.
+
+;; The functions here differ in branch hints (but we still merge).
 (module
  ;; CHECK:      (type $0 (func (param i32)))
 
@@ -50,8 +53,7 @@
  )
 )
 
-;; These also differ, now one is missing a hint, and they should not be merged.
-;; TODO: Perhaps when optimizing for size, we should merge and drop the hint?
+;; These also differ, now one is missing a hint (but we still merge).
 (module
  ;; CHECK:      (type $0 (func (param i32)))
 
@@ -97,7 +99,7 @@
 )
 
 ;; Flipped case of the above, now the other one is the only one with a hint,
-;; and that hint is flipped.
+;; and that hint is flipped (but we still merge).
 (module
  ;; CHECK:      (type $0 (func (param i32)))
 
@@ -142,7 +144,7 @@
  )
 )
 
-;; Identical branch hints: We can merge here.
+;; Identical branch hints: We can definitely merge here.
 (module
  ;; CHECK:      (type $0 (func (param i32)))
 
@@ -218,8 +220,9 @@
  )
 )
 
-;; Source file location (debug info) does *not* prevent optimization. We
-;; prioritize optimization over debug info quality.
+;; Source file location (debug info) does not prevent optimization (and has
+;; even less reason to do so than branch hints, as we prioritize optimization
+;; over debug info quality).
 (module
  ;; CHECK:      (type $0 (func (param i32)))
 

--- a/test/lit/passes/duplicate-function-elimination_branch-hints.wast
+++ b/test/lit/passes/duplicate-function-elimination_branch-hints.wast
@@ -12,7 +12,7 @@
 
  ;; CHECK:      (export "a" (func $a))
 
- ;; CHECK:      (export "b" (func $b))
+ ;; CHECK:      (export "b" (func $a))
 
  ;; CHECK:      (func $a (type $0) (param $x i32)
  ;; CHECK-NEXT:  (@metadata.code.branch_hint "\00")
@@ -33,15 +33,6 @@
   )
  )
 
- ;; CHECK:      (func $b (type $0) (param $x i32)
- ;; CHECK-NEXT:  (@metadata.code.branch_hint "\01")
- ;; CHECK-NEXT:  (if
- ;; CHECK-NEXT:   (local.get $x)
- ;; CHECK-NEXT:   (then
- ;; CHECK-NEXT:    (unreachable)
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT: )
  (func $b (export "b") (param $x i32)
   (@metadata.code.branch_hint "\01")
   (if
@@ -59,7 +50,7 @@
 
  ;; CHECK:      (export "a" (func $a))
 
- ;; CHECK:      (export "b" (func $b))
+ ;; CHECK:      (export "b" (func $a))
 
  ;; CHECK:      (func $a (type $0) (param $x i32)
  ;; CHECK-NEXT:  (@metadata.code.branch_hint "\00")
@@ -80,14 +71,6 @@
   )
  )
 
- ;; CHECK:      (func $b (type $0) (param $x i32)
- ;; CHECK-NEXT:  (if
- ;; CHECK-NEXT:   (local.get $x)
- ;; CHECK-NEXT:   (then
- ;; CHECK-NEXT:    (unreachable)
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT: )
  (func $b (export "b") (param $x i32)
   (if
    (local.get $x)
@@ -105,7 +88,7 @@
 
  ;; CHECK:      (export "a" (func $a))
 
- ;; CHECK:      (export "b" (func $b))
+ ;; CHECK:      (export "b" (func $a))
 
  ;; CHECK:      (func $a (type $0) (param $x i32)
  ;; CHECK-NEXT:  (if
@@ -124,15 +107,6 @@
   )
  )
 
- ;; CHECK:      (func $b (type $0) (param $x i32)
- ;; CHECK-NEXT:  (@metadata.code.branch_hint "\01")
- ;; CHECK-NEXT:  (if
- ;; CHECK-NEXT:   (local.get $x)
- ;; CHECK-NEXT:   (then
- ;; CHECK-NEXT:    (unreachable)
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT: )
  (func $b (export "b") (param $x i32)
   (@metadata.code.branch_hint "\01")
   (if


### PR DESCRIPTION
Our comparisons are only used in optimization atm, and we decided not to
consider metadata when merging functions, as that is what LLVM does: it
will fold code together without carefully checking if profiling info matches,
and without even trying to fix up that profiling info later.

For more on LLVM, see

https://github.com/WebAssembly/binaryen/pull/7733#discussion_r2214579266

but basically it will just merge two instructions with different branch_weights
and keep the first of the two, no matter what.