### PR TITLE
Improve ReFinalize::replaceUntaken

### DIFF
--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include "ir/branch-utils.h"
-#include "ir/find_all.h"
 #include "ir/utils.h"
 
 namespace wasm {
@@ -60,7 +58,8 @@ void ReFinalize::visitLoop(Loop* curr) { curr->finalize(); }
 void ReFinalize::visitBreak(Break* curr) {
   curr->finalize();
   auto valueType = getValueType(curr->value);
-  if (valueType == Type::unreachable) {
+  if (valueType == Type::unreachable ||
+      getValueType(curr->condition) == Type::unreachable) {
     replaceUntaken(curr->value, curr->condition);
   } else {
     updateBreakValueType(curr->name, valueType);
@@ -69,7 +68,8 @@ void ReFinalize::visitBreak(Break* curr) {
 void ReFinalize::visitSwitch(Switch* curr) {
   curr->finalize();
   auto valueType = getValueType(curr->value);
-  if (valueType == Type::unreachable) {
+  if (valueType == Type::unreachable ||
+      getValueType(curr->condition) == Type::unreachable) {
     replaceUntaken(curr->value, curr->condition);
   } else {
     for (auto target : curr->targets) {
@@ -221,29 +221,26 @@ void ReFinalize::updateBreakValueType(Name name, Type type) {
   }
 }
 
-// Replace an untaken branch/switch with an unreachable value.
-// Another child may also exist and may or may not be unreachable.
+// Replace an branch/switch that is untaken because it is unreachable with an
+// unreachable non-branching expression. There is one or both of a value and
+// condition/descriptor, at least one of which is unreachable.
 void ReFinalize::replaceUntaken(Expression* value, Expression* otherChild) {
-  assert(value->type == Type::unreachable);
-  auto* replacement = value;
-  if (otherChild) {
-    Builder builder(*getModule());
-    // Even if we have
-    //  (block
-    //   (unreachable)
-    //   (i32.const 1)
-    //  )
-    // we want the block type to be unreachable. That is valid as
-    // the value is unreachable, and necessary since the type of
-    // the condition did not have an impact before (the break/switch
-    // type was unreachable), and might not fit in.
-    if (otherChild->type.isConcrete()) {
+  assert((value && value->type == Type::unreachable) ||
+         (otherChild && otherChild->type == Type::unreachable));
+  Builder builder(*getModule());
+  if (value && otherChild) {
+    if (value->type.isConcrete()) {
+      value = builder.makeDrop(value);
+    } else if (otherChild->type.isConcrete()) {
       otherChild = builder.makeDrop(otherChild);
     }
-    replacement = builder.makeSequence(value, otherChild);
-    assert(replacement->type.isBasic() && "Basic type expected");
+    replaceCurrent(builder.makeBlock({value, otherChild}, Type::unreachable));
+  } else if (value) {
+    replaceCurrent(value);
+  } else {
+    assert(otherChild);
+    replaceCurrent(otherChild);
   }
-  replaceCurrent(replacement);
 }
 
 } // namespace wasm

--- a/src/ir/ReFinalize.cpp
+++ b/src/ir/ReFinalize.cpp
@@ -221,7 +221,7 @@ void ReFinalize::updateBreakValueType(Name name, Type type) {
   }
 }
 
-// Replace an branch/switch that is untaken because it is unreachable with an
+// Replace a branch/switch that is untaken because it is unreachable with an
 // unreachable non-branching expression. There is one or both of a value and
 // condition/descriptor, at least one of which is unreachable.
 void ReFinalize::replaceUntaken(Expression* value, Expression* otherChild) {

--- a/test/lit/passes/vacuum_all-features.wast
+++ b/test/lit/passes/vacuum_all-features.wast
@@ -982,10 +982,8 @@
   ;; CHECK-NEXT:  (block $label$0
   ;; CHECK-NEXT:   (loop $label$1
   ;; CHECK-NEXT:    (drop
-  ;; CHECK-NEXT:     (br_if $label$0
-  ;; CHECK-NEXT:      (loop $label$9
-  ;; CHECK-NEXT:       (br $label$9)
-  ;; CHECK-NEXT:      )
+  ;; CHECK-NEXT:     (loop $label$9
+  ;; CHECK-NEXT:      (br $label$9)
   ;; CHECK-NEXT:     )
   ;; CHECK-NEXT:    )
   ;; CHECK-NEXT:   )

--- a/test/passes/fuzz_metrics_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_noprint.bin.txt
@@ -9,11 +9,11 @@ total
  [table-data]   : 25      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 6800    
+ [total]        : 6791    
  [vars]         : 256     
  Binary         : 454     
  Block          : 1201    
- Break          : 196     
+ Break          : 188     
  Call           : 205     
  CallIndirect   : 61      
  Const          : 1131    
@@ -30,6 +30,5 @@ total
  Return         : 58      
  Select         : 52      
  Store          : 41      
- Switch         : 1       
  Unary          : 451     
  Unreachable    : 246     

--- a/test/passes/fuzz_metrics_passes_noprint.bin.txt
+++ b/test/passes/fuzz_metrics_passes_noprint.bin.txt
@@ -9,15 +9,15 @@ total
  [table-data]   : 28      
  [tables]       : 1       
  [tags]         : 0       
- [total]        : 9402    
+ [total]        : 9390    
  [vars]         : 189     
  Binary         : 651     
- Block          : 1534    
- Break          : 332     
+ Block          : 1536    
+ Break          : 316     
  Call           : 296     
  CallIndirect   : 91      
  Const          : 1666    
- Drop           : 64      
+ Drop           : 66      
  GlobalGet      : 650     
  GlobalSet      : 582     
  If             : 506     

--- a/test/passes/precompute_all-features.txt
+++ b/test/passes/precompute_all-features.txt
@@ -123,9 +123,7 @@
  (func $refinalize-br-condition-unreachable (type $1)
   (block $label$1
    (drop
-    (br_if $label$1
-     (unreachable)
-    )
+    (unreachable)
    )
   )
  )
@@ -133,8 +131,10 @@
   (drop
    (block $label$1 (result i32)
     (drop
-     (br_if $label$1
-      (i32.const 100)
+     (block
+      (drop
+       (i32.const 100)
+      )
       (block $label$3
        (unreachable)
       )

--- a/test/passes/remove-unused-brs_enable-multivalue.txt
+++ b/test/passes/remove-unused-brs_enable-multivalue.txt
@@ -1154,9 +1154,7 @@
   (block $label$8
    (block $label$11
     (block $label$14
-     (br_if $label$8
-      (br $label$8)
-     )
+     (br $label$8)
     )
    )
   )
@@ -2199,13 +2197,9 @@
      (block $label$2
       (local.tee $0
        (loop $label$5
-        (br_if $label$5
-         (block
-          (unreachable)
-          (drop
-           (i32.const 0)
-          )
-         )
+        (unreachable)
+        (drop
+         (i32.const 0)
         )
        )
       )
@@ -2433,17 +2427,15 @@
    (else
     (drop
      (loop $label$3 (result i64)
-      (br_if $label$3
-       (if
-        (i32.const 0)
-        (then
-         (block $label$4
-          (unreachable)
-         )
-        )
-        (else
+      (if
+       (i32.const 0)
+       (then
+        (block $label$4
          (unreachable)
         )
+       )
+       (else
+        (unreachable)
        )
       )
       (i64.const -9)

--- a/test/passes/remove-unused-brs_generate-stack-ir_print-stack-ir.txt
+++ b/test/passes/remove-unused-brs_generate-stack-ir_print-stack-ir.txt
@@ -2,17 +2,15 @@
  (type $0 (func (param i64)))
  (func $0 (param $var$0 i64)
   (block $label$1
-   (br_if $label$1
-    (block $label$2
-     (loop $label$3
-      (local.tee $var$0
-       (block $label$4
-        (unreachable)
-       )
+   (block $label$2
+    (loop $label$3
+     (local.tee $var$0
+      (block $label$4
+       (unreachable)
       )
      )
-     (unreachable)
     )
+    (unreachable)
    )
   )
  )
@@ -20,17 +18,15 @@
 (module
  (type $0 (func (param i64)))
  (func $0 (param $var$0 i64)
-  block $label$1
-   block $label$2
-    loop $label$3
-     block $label$4
-      unreachable
-     end
+  block $label$2
+   loop $label$3
+    block $label$4
      unreachable
     end
     unreachable
    end
    unreachable
   end
+  unreachable
  )
 )


### PR DESCRIPTION
ReFinalize replaces unreachable branches with unreachable blocks so that
it can possibly propagate the unreachability up to the former branch
target. It previously only did this for branches whose sent values (as
opposed to their conditions) were unreachable, except for BrOn, where it
could erroneously optimize when the sent value was reachable and the
descriptor was unreachable. This was incorrect because `replaceUntaken`
assumed that the sent value was unreachable.

Rather than fix the bug for BrOn, generalize `replaceUntaken` to work
no matter whether the sent value or the other child exists or is the
source of unreachability.
