### PR TITLE
[Custom Descriptors] Ensure descriptor validity in Unsubtyping

### DIFF
--- a/src/passes/Unsubtyping.cpp
+++ b/src/passes/Unsubtyping.cpp
@@ -492,6 +492,7 @@ struct Unsubtyping : Pass {
       }
       if (HeapType::isSubType(*oldSuper, super)) {
         // sub <: oldSuper <: super
+        processDescribed(sub, *oldSuper, super);
         noteSubtype(*oldSuper, super);
         // We already handled sub <: oldSuper, so we're done.
         return;
@@ -501,6 +502,7 @@ struct Unsubtyping : Pass {
       // super will already be in the same tree when we process them below, so
       // when we process casts we will know that we only need to process up to
       // oldSuper.
+      processDescribed(sub, super, *oldSuper);
       process(super, *oldSuper);
     }
 
@@ -510,6 +512,42 @@ struct Unsubtyping : Pass {
     // definitions and casts.
     processDefinitions(sub, super);
     processCasts(sub, super, oldSuper);
+  }
+
+  void processDescribed(HeapType sub, HeapType mid, HeapType super) {
+    // We are establishing sub <: mid <: super. If super describes the immediate
+    // supertype of the type sub describes. Then once we insert mid between them
+    // we would have this:
+    //
+    // A -> super
+    // ^     ^
+    // |    mid
+    // |     ^
+    // C -> sub
+    //
+    // This violates the requirement that the descriptor of C's immediate
+    // supertype must be the immediate supertype of C's descriptor. To fix it,
+    // we have to find the type B that mid describes and insert it between A and
+    // C:
+    //
+    // A -> super
+    // ^     ^
+    // B -> mid
+    // ^     ^
+    // C -> sub
+    //
+    // We do this eagerly before we establish sub <: mid <: super so that if
+    // establishing that subtyping requires recursively establishing other
+    // subtypings, we can depend on the invariant that the described types are
+    // always set up correctly beforehand.
+    auto subDescribed = sub.getDescribedType();
+    auto superDescribed = super.getDescribedType();
+    if (subDescribed && superDescribed &&
+        types.getSupertype(*subDescribed) == superDescribed) {
+      auto midDescribed = mid.getDescribedType();
+      assert(midDescribed);
+      process(*subDescribed, *midDescribed);
+    }
   }
 
   void processDefinitions(HeapType sub, HeapType super) {

--- a/src/passes/Unsubtyping.cpp
+++ b/src/passes/Unsubtyping.cpp
@@ -516,7 +516,7 @@ struct Unsubtyping : Pass {
 
   void processDescribed(HeapType sub, HeapType mid, HeapType super) {
     // We are establishing sub <: mid <: super. If super describes the immediate
-    // supertype of the type sub describes. Then once we insert mid between them
+    // supertype of the type sub describes, then once we insert mid between them
     // we would have this:
     //
     // A -> super


### PR DESCRIPTION
We already partially handled the interaction between descriptors and
subtyping by ensuring that B <: A implies B.desc <: A.desc if B.desc and
A.desc both exist. However, there was a subtler situation we did not
handle:

A -> A.desc
^      ^
|    B.desc
|      ^
C -> C.desc

This subtyping violates the constraint that the descriptor of C's
immediate supertype must be the immediate supertype of C's descriptor.
To fix this, find the described type B to insert between C and A before
establishing C.desc <: B.desc <: A.desc.
