### PR TITLE
[NFC] Merge the two parts of RemoveUnusedModuleElements

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -359,6 +359,11 @@ struct Analyzer
   }
 
   void useRefFunc(Name func) {
+    if (walkingForReferencesOnly) {
+      reference({ModuleElementKind::Function, func});
+      return;
+    }
+
     if (!options.closedWorld) {
       // The world is open, so assume the worst and something (inside or outside
       // of the module) can call this.
@@ -500,6 +505,10 @@ struct Analyzer
   // Mark something as used, if it hasn't already been, and if so add it to the
   // queue so we can process the things it can reach.
   void use(ModuleElement element) {
+    if (walkingForReferencesOnly) {
+      reference(element);
+      return;
+    }
     auto [_, inserted] = used.emplace(element);
     if (inserted) {
       moduleQueue.emplace_back(element);
@@ -510,6 +519,8 @@ struct Analyzer
   }
 
   void use(Expression* curr) {
+    assert(!walkingForReferencesOnly);
+
     // For expressions we do not need to check if they have already been seen:
     // the tree structure guarantees that traversing children, recursively, will
     // only visit each expression once, since each expression has a single

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -68,8 +68,7 @@ using IndirectCall = std::pair<Name, HeapType>;
 
 // Visit or walk an expression to find what things are referenced.
 struct Analyzer
-  : public PostWalker<Analyzer,
-                      UnifiedExpressionVisitor<Analyzer>> {
+  : public PostWalker<Analyzer, UnifiedExpressionVisitor<Analyzer>> {
 
   // Visiting logic.
 
@@ -245,7 +244,8 @@ struct Analyzer
     }
 
     // Main loop on both the module and the expression queues.
-    while (processExpressions() || processModule() || processExpressionReferences()) {
+    while (processExpressions() || processModule() ||
+           processExpressionReferences()) {
     }
   }
 

--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -274,8 +274,10 @@ struct Analyzer
     return worked;
   }
 
+  // Like processExpressions, but for references only. This scans the entire
+  // expressions it receives and ensures a reference to all things appearing
+  // there.
   bool processExpressionReferences() {
-
     bool worked = false;
     while (expressionReferenceQueue.size()) {
       worked = true;
@@ -286,7 +288,7 @@ struct Analyzer
       // Find references anywhere in this expression so we can apply them.
       assert(!walkingForReferencesOnly);
       walkingForReferencesOnly = true;
-      walk(curr); // XXX
+      walk(curr);
       walkingForReferencesOnly = false;
     }
     return worked;
@@ -629,6 +631,8 @@ struct Analyzer
   // effects then we would have had to assume the worst earlier, and not get
   // here).
   void addReferences(Expression* curr) {
+    // We use a queue here, as doing a walk right now could recurse, depending
+    // on who called us, and we cannot nest walk()s.
     expressionReferenceQueue.push_back(curr);
   }
 


### PR DESCRIPTION
Followup investigation to https://github.com/WebAssembly/binaryen/pull/7728#issuecomment-3100201679 (see also https://github.com/WebAssembly/binaryen/pull/7745)

As @aheejin suggested there, we can just call `use()` etc. rather than store
those things on vectors, then call them from there.

To do this, merge the Finder and the Analyzer parts of the pass, so that when
we do a visit/walk we just end up calling `use()` etc. directly.

This is slightly faster on some testcases (4%), and no change on others.

I am not sure if this is worth landing, though: the small speedup is on one of
our faster passes anyhow (so little overall effect), and it turns out that making
this work adds more code than it removes: we have two forms of visiting, one
for uses and one for references. When we gather the vectors first, we can just
apply them differently; without them, with merged direct calls, we need a
mechanism to do two different things. We also need another queue to avoid
too much recursion.

@aheejin what do you think?