### PR TITLE
[Metadce] Report removed imports due to RemoveUnusedModuleElements

### DIFF
--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -337,7 +337,7 @@ public:
     // signatures work, traps-never-happen, etc.) which can lead to even more
     // things vanishing. Anything it removes, we can remove from our graph.
     //
-    // The only thing of interest are imports: exports are never removed by that
+    // The only things of interest are imports: exports are not removed by that
     // pass, but imports might no longer have any uses. To find imports that
     // were removed, scan the nodes and see what is no longer in the module.
     for (auto& [_, dceName] : importIdToDCENode) {

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -356,9 +356,11 @@ public:
       // If all uses of this import went away, we can remove it.
       bool used = false;
       for (auto [kind, internalName] : iter->second) {
-        // Only function imports are important here, as we do things like generate
-        // minification maps for them, etc., but we could add others as well.
-        // TODO: use something like iterImportable, abstracted over ExternalKind,
+        // Only function imports are important here, as we do things like
+        // generate minification maps for them, etc., but we could add others as
+        // well.
+        // TODO: use something like iterImportable, abstracted over
+        // ExternalKind,
         //       to get*OrNull(), and to remove*().
         if (kind != ModuleItemKind::Function ||
             wasm.getFunctionOrNull(internalName)) {

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -341,9 +341,15 @@ public:
     // pass, but imports might no longer have any uses. To find imports that
     // were removed, scan the nodes and see what is no longer in the module.
     for (auto& [_, dceName] : importIdToDCENode) {
-      auto [kind, internalName] = DCENodeToImport[dceName];
-      // The item must appear in the map.
-      assert(!internalName.isNull());
+      auto iter = DCENodeToImport.find(dceName);
+      if (iter == DCENodeToImport.end()) {
+        // This appears in the graph, but did not even begin in the wasm. That
+        // is, the outside was sending it to the wasm, but the wasm never
+        // imported it, which means the graph was not very optimized. Just
+        // ignore this.
+        continue;
+      }
+      auto [kind, internalName] = iter->second;
       // Only function imports are important here, as we do things like generate
       // minification maps for them, etc., but we could add others as well.
       // TODO: use something like iterImportable, abstracted over ExternalKind,

--- a/src/tools/wasm-metadce.cpp
+++ b/src/tools/wasm-metadce.cpp
@@ -360,8 +360,7 @@ public:
         // generate minification maps for them, etc., but we could add others as
         // well.
         // TODO: use something like iterImportable, abstracted over
-        // ExternalKind,
-        //       to get*OrNull(), and to remove*().
+        //       ExternalKind, to get*OrNull(), and to remove*().
         if (kind != ModuleItemKind::Function ||
             wasm.getFunctionOrNull(internalName)) {
           used = true;

--- a/test/lit/metadce/remove-unused-module-elements.wat
+++ b/test/lit/metadce/remove-unused-module-elements.wat
@@ -7,7 +7,7 @@
 ;; The export "used" is used, based on the graph file, while the other export
 ;; "unused" is not. Metadce itself can remove $unused. After that,
 ;; remove-unused-module-elements sees that no call_indirect exists that can
-;; reach $A, even though it is in the table, and we remove remove $A. Removing
+;; reach $A, even though it is in the table, and we can remove $A. Removing
 ;; $A then removes the import, which we should report.
 (module
  (type $A (func))

--- a/test/lit/metadce/remove-unused-module-elements.wat
+++ b/test/lit/metadce/remove-unused-module-elements.wat
@@ -1,0 +1,40 @@
+;; RUN: wasm-metadce %s --graph-file %s.json -all -S -o - | filecheck %s
+
+;; A testcase where after metadce removes things from the graph,
+;; remove-unused-module-elements (which is run internally) manages to remove an
+;; additional import. We should report that import is removed as well.
+
+;; The export "used" is used, based on the graph file, while the other export
+;; "unused" is not. Metadce itself can remove $unused. After that,
+;; remove-unused-module-elements sees that no call_indirect exists that can
+;; reach $A, even though it is in the table, and we remove remove $A. Removing
+;; $A then removes the import, which we should report.
+(module
+ (type $A (func))
+
+ (import "module" "base" (func $import))
+
+ (table $t 60 60 funcref)
+
+ (elem $elem (table $t) (i32.const 0) func $A)
+
+ (func $used (export "used")
+  (drop
+   (i32.const 42)
+  )
+ )
+
+ (func $unused (export "unused")
+  (call_indirect $t (type $A)
+   (i32.const -1)
+  )
+ )
+
+ (func $A (type $A)
+  (call $import)
+ )
+)
+
+;; CHECK: unused: export$unused
+;; CHECK: unused: importId$import
+

--- a/test/lit/metadce/remove-unused-module-elements.wat.json
+++ b/test/lit/metadce/remove-unused-module-elements.wat.json
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "root",
+    "reaches": [
+      "used"
+    ],
+    "root": true
+  },
+  {
+    "name": "used",
+    "export": "used"
+  }
+]


### PR DESCRIPTION
wasm-metadce does a graph analysis to find unreached things, and then
cleans up using RemoveUnusedModuleElements. That pass become more
powerful in #7728, which led to a situation where an import was removed
from the wasm, but wasm-metadce did not report that it had removed it.
This led to unneeded code in the JS (it kept sending that import,
unnecessarily). This was a harmless minor waste of JS size, but it did cause
a test error on Emscripten (#7747), as it parses that JS to check some
things, and it found an import in JS without a use in wasm.

To fix that, check if that pass removed imports, and report them.