### PR TITLE
Pause requires shared-everything

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -451,6 +451,7 @@ public:
   void visitAtomicWait(AtomicWait* curr);
   void visitAtomicNotify(AtomicNotify* curr);
   void visitAtomicFence(AtomicFence* curr);
+  void visitPause(Pause* curr);
   void visitSIMDExtract(SIMDExtract* curr);
   void visitSIMDReplace(SIMDReplace* curr);
   void visitSIMDShuffle(SIMDShuffle* curr);
@@ -1267,6 +1268,12 @@ void FunctionValidator::visitAtomicFence(AtomicFence* curr) {
                curr,
                "Currently only sequentially consistent atomics are supported, "
                "so AtomicFence's order should be 0");
+}
+
+void FunctionValidator::visitPause(Pause* curr) {
+  shouldBeTrue(getModule()->features.hasSharedEverything(),
+               curr,
+               "pause requires shared-everything [--enable-shared-everything]");
 }
 
 void FunctionValidator::visitSIMDExtract(SIMDExtract* curr) {

--- a/test/lit/validation/pause.wast
+++ b/test/lit/validation/pause.wast
@@ -1,0 +1,11 @@
+;; Test that shared pause requires shared-everything threads
+
+;; RUN: not wasm-opt %s 2>&1 | filecheck %s --check-prefix NO-SHARED
+;; RUN: wasm-opt %s --enable-reference-types --enable-gc --enable-shared-everything -o - -S | filecheck %s --check-prefix SHARED
+
+;; NO-SHARED: pause requires shared-everything [--enable-shared-everything]
+;; SHARED: (pause)
+
+(module
+  (func (pause))
+)


### PR DESCRIPTION
Validate that shared-everything is enabled when the module contains a
pause instruction. This will keep the fuzzer from trying to execute
pauses on V8 and failing because we don't yet enable shared-everything
on V8.
