### PR TITLE
Reduce max interpreter depth from 250 to 200

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4428,7 +4428,7 @@ public:
   }
 
   // The maximum call stack depth to evaluate into.
-  static const Index maxDepth = 250;
+  static const Index maxDepth = 200;
 
 protected:
   void trapIfGt(uint64_t lhs, uint64_t rhs, const char* msg) {


### PR DESCRIPTION
This is an arbitrary limit, and it seems some LTO builds may start to
hit the old limit after #7767

200 should still be enough for anybody