### PR TITLE
[Relaxed SIMD] Add missing relaxed entries in features.h

### DIFF
--- a/src/ir/features.h
+++ b/src/ir/features.h
@@ -79,6 +79,7 @@ inline FeatureSet get(UnaryOp op) {
     case RelaxedTruncZeroUVecF64x2ToVecI32x4: {
       ret.setSIMD();
       ret.setRelaxedSIMD();
+      break;
     }
     default: {}
   }

--- a/src/ir/features.h
+++ b/src/ir/features.h
@@ -73,6 +73,13 @@ inline FeatureSet get(UnaryOp op) {
       ret.setSignExt();
       break;
     }
+    case RelaxedTruncSVecF32x4ToVecI32x4:
+    case RelaxedTruncUVecF32x4ToVecI32x4:
+    case RelaxedTruncZeroSVecF64x2ToVecI32x4:
+    case RelaxedTruncZeroUVecF64x2ToVecI32x4: {
+      ret.setSIMD();
+      ret.setRelaxedSIMD();
+    }
     default: {}
   }
   return ret;
@@ -157,6 +164,16 @@ inline FeatureSet get(BinaryOp op) {
     case MinVecF64x2:
     case MaxVecF64x2: {
       ret.setSIMD();
+      break;
+    }
+    case RelaxedMinVecF32x4:
+    case RelaxedMaxVecF32x4:
+    case RelaxedMinVecF64x2:
+    case RelaxedMaxVecF64x2:
+    case RelaxedSwizzleVecI8x16:
+    case RelaxedQ15MulrSVecI16x8: {
+      ret.setSIMD();
+      ret.setRelaxedSIMD();
       break;
     }
     default: {}


### PR DESCRIPTION
This is needed to prevent fuzzer errors.