### PR TITLE
[wasm-split] Remove ANSI codes from wast output

### DIFF
--- a/src/tools/wasm-split/split-options.cpp
+++ b/src/tools/wasm-split/split-options.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "split-options.h"
+#include "support/colors.h"
 #include <fstream>
 
 namespace wasm {
@@ -339,7 +340,10 @@ WasmSplitOptions::WasmSplitOptions()
          WasmSplitOption,
          {Mode::Split, Mode::Instrument},
          Options::Arguments::Zero,
-         [&](Options* o, const std::string& argument) { emitBinary = false; })
+         [&](Options* o, const std::string& argument) {
+           emitBinary = false;
+           Colors::setEnabled(false);
+         })
     .add("--debuginfo",
          "-g",
          "Emit names section in wasm binary (or full debuginfo in wast)",


### PR DESCRIPTION
Without this, wast files emitted by `-S` contain extra ANSI codes like
```wast
(^[[31m^[[1mmodule^[[0m
 (^[[31m^[[1mfunc ^[[0m$bar (^[[33mparam ^[[0m$0 i32) (result i32)
  (^[[35m^[[1mcall ^[[0m$foo
   (i32.const ^[[33m777^[[0m)
  )
 )
)
```