### PR TITLE
[Custom Descriptors] Handle traps in instantiation in Merge fuzz handler

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1488,6 +1488,10 @@ class Merge(TestCaseHandler):
         merged_output = run_bynterp(merged, ['--fuzz-exec-before', '-all'])
         merged_output = fix_output(merged_output)
 
+        # If the second module traps in instantiation, then the merged module
+        # must do so as well, regardless of what the first module does. (In
+        # contrast, if the first module traps in instantiation, then the normal
+        # checks below will ensure the merged module does as well.)
         if traps_in_instantiation(second_output) and \
                 not traps_in_instantiation(output):
             # The merged module should also trap in instantiation, but the


### PR DESCRIPTION
With custom descriptors, it's possible for instantiation to trap when
a `struct.new` in a global initialiizer receives a null descriptor.
Update the Merge fuzz handler so that if the randomly generated second
module traps in instantion, it checks that the merged module also traps
in instantiation.

As a drive-by, remove some unnecessary feature flags passed to
wasm-merge and wasm-opt.
