### PR TITLE
Reduce interpreter max depth to 150

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4904,7 +4904,7 @@ public:
   }
 
   // The maximum call stack depth to evaluate into.
-  static const Index maxDepth = 200;
+  static const Index maxDepth = 150;
 
 protected:
   void trapIfGt(uint64_t lhs, uint64_t rhs, const char* msg) {

--- a/test/spec/call_indirect.wast
+++ b/test/spec/call_indirect.wast
@@ -550,7 +550,7 @@
 (assert_return (invoke "even" (i32.const 77)) (i32.const 99))
 (assert_return (invoke "odd" (i32.const 0)) (i32.const 99))
 (assert_return (invoke "odd" (i32.const 1)) (i32.const 44))
-(assert_return (invoke "odd" (i32.const 200)) (i32.const 99))
+(assert_return (invoke "odd" (i32.const 150)) (i32.const 99))
 (assert_return (invoke "odd" (i32.const 77)) (i32.const 44))
 
 (assert_exhaustion (invoke "runaway") "call stack exhausted")


### PR DESCRIPTION
The previous max depth of 200 was not enough to prevent the fuzzer from
encountering a stack overflow on an LTO build with 8MB of stack.
