### PR TITLE
Fix determinism of Clusterfuzz fuzz handler

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1629,7 +1629,19 @@ class ClusterFuzz(TestCaseHandler):
     # for each iteration (once for each of the wasm files we ignore), which is
     # confusing.
     def handle_pair(self, input, before_wasm, after_wasm, opts):
+        # Do not run ClusterFuzz in the first seconds of fuzzing: the first time
+        # it runs is very slow (to build the bundle), which is annoying when you
+        # are just starting the fuzzer and looking for any obvious problems.
+        # Check this here as opposed to in e.g. can_run_on_wasm to avoid
+        # changing the observed sequence of random numbers before and after this
+        # threshold, which could interfere with bug reproduction.
+        seconds = 30
+        if time.time() - start_time < seconds:
+            return
+
         self.ensure()
+
+        # NO RANDOM DATA SHOULD BE USED BELOW THIS POINT
 
         # run.py() should emit these two files. Delete them to make sure they
         # are created by run.py() in the next step.
@@ -1710,13 +1722,6 @@ class ClusterFuzz(TestCaseHandler):
         tar = tarfile.open(bundle, "r:gz")
         tar.extractall(path=self.clusterfuzz_dir)
         tar.close()
-
-    def can_run_on_wasm(self, wasm):
-        # Do not run ClusterFuzz in the first seconds of fuzzing: the first time
-        # it runs is very slow (to build the bundle), which is annoying when you
-        # are just starting the fuzzer and looking for any obvious problems.
-        seconds = 30
-        return time.time() - start_time > seconds
 
 
 # Tests linking two wasm files at runtime, and that optimizations do not break


### PR DESCRIPTION
The first time the Clusterfuzz handler runs, it does a lot of setup work
that can be annoying when trying to run the fuzzer briefly to smoke out
very obvious problems. To avoid that annoyance, we do not run the
Clusterfuzz handler until we have already fuzzed for at least 30
seconds. However, we used to control this in the `can_run_on_wasm`
method, which caused reproducibility issues because the number of calls
to `random` functions would differ before and after that 30-second
cutoff. Specifically, `relevant_handlers` would have a different size
before and after that cutoff, so the number of `random` calls to compute
`filtered_handlers` would be different.

To avoid these reproducibility problems, simply return early from the
`handle` method of the Clusterfuzz handler if it has not yet been 30
seconds.
