### PR TITLE
[Custom Descriptors] Validate features in TypeBuilder

### DIFF
--- a/src/parser/parse-2-typedefs.cpp
+++ b/src/parser/parse-2-typedefs.cpp
@@ -24,7 +24,7 @@ Result<> parseTypeDefs(
   IndexMap& typeIndices,
   std::vector<HeapType>& types,
   std::unordered_map<HeapType, std::unordered_map<Name, Index>>& typeNames) {
-  TypeBuilder builder(decls.typeDefs.size());
+  TypeBuilder builder(decls.typeDefs.size(), decls.wasm.features);
   ParseTypeDefsCtx ctx(input, builder, typeIndices);
   for (auto& recType : decls.recTypeDefs) {
     WithPosition with(ctx, recType.pos);

--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -21,6 +21,7 @@
 #include "source-map.h"
 #include "support/colors.h"
 #include "support/file.h"
+#include "wasm-features.h"
 #include "wasm-io.h"
 
 #include "tool-options.h"
@@ -66,6 +67,11 @@ int main(int argc, const char* argv[]) {
   }
   Module wasm;
   options.applyOptionsBeforeParse(wasm);
+  // Temporarily apply all features during parsing to avoid any errors. See note
+  // below on skipping validation.
+  auto enabledFeatures = wasm.features;
+  wasm.features = FeatureSet::All;
+
   try {
     ModuleReader().readBinary(options.extra["infile"], wasm, sourceMapFilename);
   } catch (ParseException& p) {
@@ -91,6 +97,7 @@ int main(int argc, const char* argv[]) {
   //       better to have an "autodetect" code path that enables used features
   //       eventually.
 
+  wasm.features = enabledFeatures;
   if (options.debug) {
     std::cerr << "Printing..." << std::endl;
   }

--- a/src/tools/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce.cpp
@@ -379,6 +379,9 @@ struct Reducer
 
     toolOptions.applyOptionsBeforeParse(*module);
 
+    // Assume we may need all features.
+    module->features = FeatureSet::All;
+
     ModuleReader reader;
     try {
       reader.read(working, *module);
@@ -390,12 +393,6 @@ struct Reducer
 
     toolOptions.applyOptionsAfterParse(*module);
 
-    // If there is no features section, assume we may need them all (without
-    // this, a module with no features section but that uses e.g. atomics and
-    // bulk memory would not work).
-    if (!module->hasFeaturesSection) {
-      module->features = FeatureSet::All;
-    }
     builder = std::make_unique<Builder>(*module);
     setModule(module.get());
   }

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -1705,7 +1705,7 @@ public:
 
   static Name escape(Name name);
   void readNames(size_t sectionPos, size_t payloadLen);
-  void readFeatures(size_t payloadLen);
+  void readFeatures(size_t sectionPos, size_t payloadLen);
   void readDylink(size_t payloadLen);
   void readDylink0(size_t payloadLen);
 

--- a/src/wasm-type.h
+++ b/src/wasm-type.h
@@ -717,7 +717,7 @@ struct TypeBuilder {
   struct Impl;
   std::unique_ptr<Impl> impl;
 
-  TypeBuilder(size_t n);
+  TypeBuilder(size_t n, FeatureSet features = FeatureSet::All);
   TypeBuilder() : TypeBuilder(0) {}
   ~TypeBuilder();
 
@@ -862,6 +862,8 @@ struct TypeBuilder {
     InvalidUnsharedDescriptor,
     // A non-shared type described by a shared type.
     InvalidUnsharedDescribes,
+    // The custom descriptors feature is missing.
+    RequiresCustomDescriptors,
   };
 
   struct Error {

--- a/test/lit/validation/unused-descriptors.wast
+++ b/test/lit/validation/unused-descriptors.wast
@@ -1,0 +1,21 @@
+;; Test that we reject descriptor types when custom descriptors are not enabled,
+;; even if they are not directly used.
+
+;; RUN: not wasm-opt -all --disable-custom-descriptors %s 2>&1 | filecheck %s
+
+;; Check the binary parser, too.
+
+;; RUN: wasm-opt -all %s -o %t.wasm
+;; RUN: not wasm-opt -all --disable-custom-descriptors %t.wasm 2>&1 | filecheck %s
+
+;; CHECK: invalid type: custom descriptors required but not enabled
+
+(module
+  (rec
+    (type $struct (descriptor $desc (struct)))
+    (type $desc (describes $struct (struct)))
+    (type $used (struct))
+  )
+
+  (global $use (ref null $used) (ref.null none))
+)


### PR DESCRIPTION
The Binaryen validator does not validate all types because it does not
want to pay the cost of walking the module to gather the types.
Furthermore, even if it did walk the module to gather types, it would
still have no way of validating completely unused types. However,
correctly validating that a module's types use only the allowed features
can be important, for example to prevent the fuzzer from using initial
contents that use a feature with a handler that cannot handle that
feature. To achieve this validation without paying the cost in the
validator, validate features used by types in TypeBuilder instead. For
now the only feature validated is custom descriptors.

To avoid introducing new errors, ensure that all features are available
when parsing in wasm-dis and wasm-reduce. Also tweak error messages to
make the binary and text parsers consistent so we can simplify the test.
