### PR TITLE
[Stack Switching] Implement the simple case of cont.bind

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3499,9 +3499,10 @@ public:
       parent.functionStack.push_back(function->name);
       locals.resize(function->getNumLocals());
 
-      if (parent.resuming) {
-        // Nothing more to do here: we are resuming execution, so there is old
-        // locals state that will be restored.
+      if (parent.resuming && parent.currContinuation->resumeExpr) {
+        // Nothing more to do here: we are resuming execution to some
+        // suspended expression (resumeExpr), so there is old locals state that
+        // will be restored.
         return;
       }
 
@@ -4709,7 +4710,29 @@ public:
     Name func = funcFlow.getSingleValue().getFunc();
     return Literal(std::make_shared<ContData>(func, curr->type.getHeapType()));
   }
-  Flow visitContBind(ContBind* curr) { return Flow(NONCONSTANT_FLOW); }
+  Flow visitContBind(ContBind* curr) {
+    Literals arguments;
+    Flow flow = self()->generateArguments(curr->operands, arguments);
+    if (flow.breaking()) {
+      return flow;
+    }
+    Flow cont = self()->visit(curr->cont);
+    if (cont.breaking()) {
+      return cont;
+    }
+
+    // Create a new continuation, copying the old but with the new type +
+    // arguments.
+    auto old = cont.getSingleValue().getContData();
+    auto newData = *old;
+    newData.type = curr->type.getHeapType();
+    newData.resumeArguments = arguments;
+    // We handle only the simple case of applying all parameters, for now. TODO
+    assert(old->resumeArguments.empty());
+    // The old one is done.
+    old->executed = true;
+    return Literal(std::make_shared<ContData>(newData));
+  }
   Flow visitSuspend(Suspend* curr) {
     // Process the arguments, whether or not we are resuming. If we are resuming
     // then we don't need these values (we sent them as part of the suspension),
@@ -4771,7 +4794,12 @@ public:
       trap("continuation already executed");
     }
     contData->executed = true;
-    contData->resumeArguments = arguments;
+    if (contData->resumeArguments.empty()) {
+      // The continuation has no bound arguments. For now, we just handle the
+      // simple case of binding all of them, so that means we can just use all
+      // the immediate ones here. TODO
+      contData->resumeArguments = arguments;
+    }
     Name func = contData->func;
     self()->currContinuation = contData;
     if (contData->resumeExpr) {
@@ -4895,6 +4923,19 @@ public:
   Flow callFunction(Name name, Literals arguments) {
     if (callDepth > maxDepth) {
       hostLimit("stack limit");
+    }
+
+    if (self()->resuming) {
+      // The arguments are in the continuation data.
+      arguments = self()->currContinuation->resumeArguments;
+
+      if (!self()->currContinuation->resumeExpr) {
+        // This is the first time we resume, that is, there is no suspend which
+        // is the resume expression that we need to execute up to. All we need
+        // to do is just start calling this function (with the arguments we've
+        // set), so resuming is done
+        self()->resuming = false;
+      }
     }
 
     Flow flow;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4802,12 +4802,7 @@ public:
     }
     Name func = contData->func;
     self()->currContinuation = contData;
-    if (contData->resumeExpr) {
-      // There is an expression to resume execution at, so this is not the first
-      // time we run this function. Mark us as resuming, until we reach that
-      // expression.
-      self()->resuming = true;
-    }
+    self()->resuming = true;
 #if WASM_INTERPRETER_DEBUG
     std::cout << self()->indent() << "resuming func " << func << '\n';
 #endif

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -740,6 +740,9 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
       if (!data->resumeInfo.empty()) {
         o << " |resumeInfo|=" << data->resumeInfo.size();
       }
+      if (!data->resumeArguments.empty()) {
+        o << " resumeArguments=" << data->resumeArguments;
+      }
       o << " executed=" << data->executed << ')';
     } else {
       assert(literal.isData());

--- a/test/lit/exec/cont_simple.wast
+++ b/test/lit/exec/cont_simple.wast
@@ -813,12 +813,27 @@
     (suspend $more)
     (call $log (local.get $x))
     (suspend $more)
+    ;; Test that the bound arguments do not get applied to child calls.
+    (call $bind-child
+      (i32.const 1337)
+    )
+    (suspend $more)
+  )
+
+  (func $bind-child (param $x i32)
+    (suspend $more)
+    (call $log (local.get $x))
+    (suspend $more)
   )
 
   ;; CHECK:      [fuzz-exec] calling run-bind
   ;; CHECK-NEXT: [LoggingExternalInterface logging 100]
   ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
   ;; CHECK-NEXT: [LoggingExternalInterface logging 42]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 1337]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
   ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
   ;; CHECK-NEXT: [LoggingExternalInterface logging 300]
   (func $run-bind (export "run-bind")

--- a/test/lit/exec/cont_simple.wast
+++ b/test/lit/exec/cont_simple.wast
@@ -815,6 +815,12 @@
     (suspend $more)
   )
 
+  ;; CHECK:      [fuzz-exec] calling run-bind
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 100]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 42]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 200]
+  ;; CHECK-NEXT: [LoggingExternalInterface logging 300]
   (func $run-bind (export "run-bind")
     (call $run
       (cont.bind $k-get-i32 $k

--- a/test/lit/exec/cont_simple.wast
+++ b/test/lit/exec/cont_simple.wast
@@ -807,4 +807,20 @@
       (cont.new $k (ref.func $call_ref))
     )
   )
+
+  (func $bind (param $x i32)
+    ;; Test that cont.bind works when used on this.
+    (suspend $more)
+    (call $log (local.get $x))
+    (suspend $more)
+  )
+
+  (func $run-bind (export "run-bind")
+    (call $run
+      (cont.bind $k-get-i32 $k
+        (i32.const 42)
+        (cont.new $k-get-i32 (ref.func $bind))
+      )
+    )
+  )
 )

--- a/test/spec/cont.wast
+++ b/test/spec/cont.wast
@@ -130,7 +130,7 @@
 (assert_trap (invoke "non-linear-1") "continuation already consumed")
 (assert_trap (invoke "non-linear-2") "continuation already consumed")
 (assert_trap (invoke "non-linear-3") "continuation already consumed")
-;; TODO: cont.bind (assert_trap (invoke "non-linear-4") "continuation already consumed")
+(assert_trap (invoke "non-linear-4") "continuation already consumed")
 
 (assert_invalid
   (module


### PR DESCRIPTION
In the simple case, all parameters are bound. This is common in the
spec test, and will unblock a bunch of stuff there.

To do this, add full support for resuming without a resume expression,
that is, without a Suspend that we need to unwind back to. Specifically,
when we resume a bound continuation, the only thing we need to do
when resuming is to apply the bound arguments, and then
continue execution normally.