### PR TITLE
[Stack Switching] Handle imported tags properly

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -133,7 +133,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
     });
   }
 
-  Literals callImport(Function* import, const Literals& arguments) override {
+  Flow callImport(Function* import, const Literals& arguments) override {
     if (import->module == SPECTEST && import->base.startsWith(PRINT)) {
       for (auto argument : arguments) {
         std::cout << argument << " : " << argument.type << '\n';
@@ -144,9 +144,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
       std::cout << "exit()\n";
       throw ExitException();
     } else if (auto* inst = getImportInstance(import)) {
-      auto flow = inst->callExport(import->base, arguments);
-      assert(!flow.suspendTag); // TODO: support stack switching on calls
-      return flow.values;
+      return inst->callExport(import->base, arguments);
     }
     Fatal() << "callImport: unknown import: " << import->module.str << "."
             << import->name.str;

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -75,7 +75,7 @@ public:
     }
   }
 
-  Literals callImport(Function* import, const Literals& arguments) override {
+  Flow callImport(Function* import, const Literals& arguments) override {
     if (import->module == "fuzzing-support") {
       if (import->base.startsWith("log")) {
         // This is a logging function like log-i32 or log-f64

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -242,7 +242,7 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
     });
   }
 
-  Literals callImport(Function* import, const Literals& arguments) override {
+  Flow callImport(Function* import, const Literals& arguments) override {
     Name WASI("wasi_snapshot_preview1");
 
     if (ignoreExternalInput) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4775,7 +4775,9 @@ public:
     // We will resume from this precise spot, when the new continuation is
     // resumed.
     new_->resumeExpr = curr;
-    return Flow(SUSPEND_FLOW, self()->getModule()->getTag(curr->tag), std::move(arguments));
+    return Flow(SUSPEND_FLOW,
+                self()->getModule()->getTag(curr->tag),
+                std::move(arguments));
   }
   Flow visitResume(Resume* curr) {
     Literals arguments;

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3056,8 +3056,8 @@ public:
     virtual ~ExternalInterface() = default;
     virtual void init(Module& wasm, SubType& instance) {}
     virtual void importGlobals(GlobalValueSet& globals, Module& wasm) = 0;
-    virtual Literals callImport(Function* import,
-                                const Literals& arguments) = 0;
+    virtual Flow callImport(Function* import,
+                            const Literals& arguments) = 0;
     virtual bool growMemory(Name name, Address oldSize, Address newSize) = 0;
     virtual bool growTable(Name name,
                            const Literal& value,

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -3056,8 +3056,7 @@ public:
     virtual ~ExternalInterface() = default;
     virtual void init(Module& wasm, SubType& instance) {}
     virtual void importGlobals(GlobalValueSet& globals, Module& wasm) = 0;
-    virtual Flow callImport(Function* import,
-                            const Literals& arguments) = 0;
+    virtual Flow callImport(Function* import, const Literals& arguments) = 0;
     virtual bool growMemory(Name name, Address oldSize, Address newSize) = 0;
     virtual bool growTable(Name name,
                            const Literal& value,
@@ -4790,9 +4789,8 @@ public:
     // We will resume from this precise spot, when the new continuation is
     // resumed.
     new_->resumeExpr = curr;
-    return Flow(SUSPEND_FLOW,
-                self()->getCanonicalTag(curr->tag),
-                std::move(arguments));
+    return Flow(
+      SUSPEND_FLOW, self()->getCanonicalTag(curr->tag), std::move(arguments));
   }
   Flow visitResume(Resume* curr) {
     Literals arguments;

--- a/test/spec/tag_linked.wast
+++ b/test/spec/tag_linked.wast
@@ -1,0 +1,45 @@
+;; Test that we can properly use a tag from an imported module. The export name
+;; and the internal names all differ, to make sure we properly identify the tag.
+
+(module
+  (tag $suspend)
+
+  (export "suspendey" (tag $suspend))
+  (export "suspender" (func $suspender))
+
+  (func $suspender
+    (suspend $suspend)
+  )
+)
+
+(register "first")
+
+(module
+  (type $func (func))
+  (type $cont (cont $func))
+
+  (tag $imported-suspend (import "first" "suspendey"))
+
+  (import "first" "suspender" (func $suspender))
+
+  (tag $suspend) ;; name overlap
+
+  (func (export "run") (result i32)
+    (drop
+      (block $internal (result (ref $cont))
+        (block $imported (result (ref $cont))
+          (resume $cont (on $imported-suspend $imported) (on $suspend $internal)
+            (cont.new $cont (ref.func $suspender))
+          )
+          (unreachable)
+        )
+        (return (i32.const 42))
+      )
+      (return (i32.const 1337))
+    )
+    (unreachable)
+  )
+)
+
+(assert_return (invoke "run") (i32.const 42))
+


### PR DESCRIPTION
We were using Tag names, but the internal name in a module may
overlap with other modules etc. - we really need to look at the
actual imported Tag, if it is imported. To do that, store Tag* and
add a way to get the canonical Tag* - i.e., the imported one if
imported, so all references, including from other modules, all
refer to the same thing.

To be able to test this, make `callImport` return a Flow (so we can
suspend through import calls).

As a bonus, replacing `Name tag` with `Tag* tag` makes our data
structures smaller.