### PR TITLE
[wasm-dis] Enable all features for printing

### DIFF
--- a/src/tools/wasm-dis.cpp
+++ b/src/tools/wasm-dis.cpp
@@ -67,9 +67,6 @@ int main(int argc, const char* argv[]) {
   }
   Module wasm;
   options.applyOptionsBeforeParse(wasm);
-  // Temporarily apply all features during parsing to avoid any errors. See note
-  // below on skipping validation.
-  auto enabledFeatures = wasm.features;
   wasm.features = FeatureSet::All;
 
   try {
@@ -91,13 +88,6 @@ int main(int argc, const char* argv[]) {
 
   options.applyOptionsAfterParse(wasm);
 
-  // TODO: Validation. However, validating would mean that users are forced to
-  //       run with  wasm-dis -all  or such, to enable the features (unless the
-  //       features section is present, but that's rare in general). It would be
-  //       better to have an "autodetect" code path that enables used features
-  //       eventually.
-
-  wasm.features = enabledFeatures;
   if (options.debug) {
     std::cerr << "Printing..." << std::endl;
   }

--- a/test/br_to_exit.wasm.fromBinary
+++ b/test/br_to_exit.wasm.fromBinary
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (func $0
+ (func $0 (type $0)
   (block $label
    (br $label)
   )

--- a/test/br_to_try.wasm.fromBinary
+++ b/test/br_to_try.wasm.fromBinary
@@ -2,7 +2,7 @@
  (type $0 (func (param i32)))
  (type $1 (func))
  (tag $tag$0 (type $0) (param i32))
- (func $0
+ (func $0 (type $1)
   (block $label
    (try
     (do

--- a/test/break-to-return.wasm.fromBinary
+++ b/test/break-to-return.wasm.fromBinary
@@ -2,7 +2,7 @@
  (type $0 (func (param i32 i32) (result i32)))
  (memory $0 256 256)
  (export "add" (func $0))
- (func $0 (param $0 i32) (param $1 i32) (result i32)
+ (func $0 (type $0) (param $0 i32) (param $1 i32) (result i32)
   (block $label (result i32)
    (br $label
     (i32.add

--- a/test/break-within-catch.wasm.fromBinary
+++ b/test/break-within-catch.wasm.fromBinary
@@ -2,7 +2,7 @@
  (type $0 (func (param i32)))
  (type $1 (func))
  (tag $tag$0 (type $0) (param i32))
- (func $0
+ (func $0 (type $1)
   (block $label
    (try
     (do

--- a/test/complexBinaryNames.wasm.fromBinary
+++ b/test/complexBinaryNames.wasm.fromBinary
@@ -1,10 +1,10 @@
 (module
  (type $0 (func))
  (export "$zoo (.bar)" (func $1))
- (func $foo\20\28.bar\29
+ (func $foo\20\28.bar\29 (type $0)
   (nop)
  )
- (func $1
+ (func $1 (type $0)
   (call $foo\20\28.bar\29)
  )
 )

--- a/test/consume-stacky.wasm.fromBinary
+++ b/test/consume-stacky.wasm.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func (result i32)))
  (memory $0 1 1)
- (func $0 (result i32)
+ (func $0 (type $0) (result i32)
   (local $scratch i32)
   (local.set $scratch
    (i32.const 1)

--- a/test/dylib.wasm.fromBinary
+++ b/test/dylib.wasm.fromBinary
@@ -5,10 +5,10 @@
  (type $3 (func (param i32 i32) (result i32)))
  (import "env" "memory" (memory $mimport$0 0))
  (import "env" "__memory_base" (global $gimport$0 i32))
- (import "env" "g$waka_mine" (func $fimport$0 (result i32)))
- (import "env" "g$waka_others" (func $fimport$1 (result i32)))
- (import "env" "fp$_Z16waka_func_theirsi$ii" (func $fimport$2 (result i32)))
- (import "env" "fp$_Z14waka_func_minei$ii" (func $fimport$3 (result i32)))
+ (import "env" "g$waka_mine" (func $fimport$0 (type $0) (result i32)))
+ (import "env" "g$waka_others" (func $fimport$1 (type $0) (result i32)))
+ (import "env" "fp$_Z16waka_func_theirsi$ii" (func $fimport$2 (type $0) (result i32)))
+ (import "env" "fp$_Z14waka_func_minei$ii" (func $fimport$3 (type $0) (result i32)))
  (global $global$0 (mut i32) (i32.const 0))
  (global $global$1 (mut i32) (i32.const 0))
  (global $global$2 (mut i32) (i32.const 0))
@@ -23,16 +23,16 @@
  (export "main" (func $3))
  (export "__dso_handle" (global $global$5))
  (export "__post_instantiate" (func $4))
- (func $0
+ (func $0 (type $1)
   (nop)
  )
- (func $1 (param $0 i32) (result i32)
+ (func $1 (type $2) (param $0 i32) (result i32)
   (i32.add
    (local.get $0)
    (i32.const 1)
   )
  )
- (func $2 (result i32)
+ (func $2 (type $0) (result i32)
   (i32.add
    (i32.load
     (global.get $global$3)
@@ -48,7 +48,7 @@
    )
   )
  )
- (func $3 (param $0 i32) (param $1 i32) (result i32)
+ (func $3 (type $3) (param $0 i32) (param $1 i32) (result i32)
   (i32.add
    (i32.load
     (global.get $global$3)
@@ -64,7 +64,7 @@
    )
   )
  )
- (func $4
+ (func $4 (type $1)
   (global.set $global$2
    (call $fimport$0)
   )

--- a/test/elided-br.wasm.fromBinary
+++ b/test/elided-br.wasm.fromBinary
@@ -1,6 +1,6 @@
 (module
  (type $0 (func))
- (func $0
+ (func $0 (type $0)
   (block $block
    (unreachable)
    (block

--- a/test/fib-dbg.wasm.fromBinary
+++ b/test/fib-dbg.wasm.fromBinary
@@ -48,7 +48,7 @@
  (export "stackRestore" (func $stackRestore))
  (export "_fib" (func $_fib))
  (export "stackAlloc" (func $stackAlloc))
- (func $stackAlloc (param $0 i32) (result i32)
+ (func $stackAlloc (type $0) (param $0 i32) (result i32)
   (local $1 i32)
   (block
    (local.set $1
@@ -76,17 +76,17 @@
   )
   (unreachable)
  )
- (func $stackSave (result i32)
+ (func $stackSave (type $2) (result i32)
   (return
    (global.get $global$3)
   )
  )
- (func $stackRestore (param $0 i32)
+ (func $stackRestore (type $3) (param $0 i32)
   (global.set $global$3
    (local.get $0)
   )
  )
- (func $establishStackSpace (param $0 i32) (param $1 i32)
+ (func $establishStackSpace (type $1) (param $0 i32) (param $1 i32)
   (global.set $global$3
    (local.get $0)
   )
@@ -94,7 +94,7 @@
    (local.get $1)
   )
  )
- (func $setThrew (param $0 i32) (param $1 i32)
+ (func $setThrew (type $1) (param $0 i32) (param $1 i32)
   (if
    (i32.eq
     (global.get $global$7)
@@ -110,7 +110,7 @@
    )
   )
  )
- (func $_fib (param $0 i32) (result i32)
+ (func $_fib (type $0) (param $0 i32) (result i32)
   (local $1 i32)
   (local $2 i32)
   (local $3 i32)
@@ -222,7 +222,7 @@
   (unreachable)
   ;;@ fib.c:8:0
  )
- (func $runPostSets
+ (func $runPostSets (type $4)
   (local $0 i32)
   (nop)
  )

--- a/test/fn_prolog_epilog.debugInfo.wasm.fromBinary
+++ b/test/fn_prolog_epilog.debugInfo.wasm.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  ;;@ src.cpp:1:1
- (func $0
+ (func $0 (type $0)
   (nop)
   ;;@ src.cpp:2:1
   (block

--- a/test/lit/merge/sourcemap.wat
+++ b/test/lit/merge/sourcemap.wat
@@ -40,13 +40,13 @@
 
 ;; CHECK-BIN:      (export "g" (func $1))
 
-;; CHECK-BIN:      (func $0
+;; CHECK-BIN:      (func $0 (type $0)
 ;; CHECK-BIN-NEXT:  ;;@ a:3:4:myFunction
 ;; CHECK-BIN-NEXT:  (nop)
 ;; CHECK-BIN-NEXT:  ;;@ a:5:6
 ;; CHECK-BIN-NEXT: )
 
-;; CHECK-BIN:      (func $1
+;; CHECK-BIN:      (func $1 (type $0)
 ;; CHECK-BIN-NEXT:  ;;@ b:9:10:MyClass::g
 ;; CHECK-BIN-NEXT:  (nop)
 ;; CHECK-BIN-NEXT:  ;;@ b:11:12

--- a/test/lit/metadce/sourcemap.wat
+++ b/test/lit/metadce/sourcemap.wat
@@ -27,7 +27,7 @@
 
 ;; BIN:      (export "f" (func $0))
 
-;; BIN:      (func $0
+;; BIN:      (func $0 (type $0)
 ;; BIN-NEXT:  ;;@ a:7:8:someSymbol
 ;; BIN-NEXT:  (nop)
 ;; BIN-NEXT:  ;;@ a:9:10

--- a/test/lit/wasm-split/basic.wast
+++ b/test/lit/wasm-split/basic.wast
@@ -70,7 +70,7 @@
 
 ;; KEEP-NONE-PRIMARY:      (module
 ;; KEEP-NONE-PRIMARY-NEXT:  (type $0 (func (param i32) (result i32)))
-;; KEEP-NONE-PRIMARY-NEXT:  (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+;; KEEP-NONE-PRIMARY-NEXT:  (import "placeholder" "0" (func $placeholder_0 (type $0) (param i32) (result i32)))
 ;; KEEP-NONE-PRIMARY-NEXT:  (table $table 1 1 funcref)
 ;; KEEP-NONE-PRIMARY-NEXT:  (elem $0 (i32.const 0) $placeholder_0)
 ;; KEEP-NONE-PRIMARY-NEXT:  (export "%table" (table $table))
@@ -80,12 +80,12 @@
 ;; KEEP-NONE-SECONDARY-NEXT:  (type $0 (func (param i32) (result i32)))
 ;; KEEP-NONE-SECONDARY-NEXT:  (import "primary" "%table" (table $table 1 1 funcref))
 ;; KEEP-NONE-SECONDARY-NEXT:  (elem $0 (i32.const 0) $foo)
-;; KEEP-NONE-SECONDARY-NEXT:  (func $bar (param $0 i32) (result i32)
+;; KEEP-NONE-SECONDARY-NEXT:  (func $bar (type $0) (param $0 i32) (result i32)
 ;; KEEP-NONE-SECONDARY-NEXT:   (call $foo
 ;; KEEP-NONE-SECONDARY-NEXT:    (i32.const 1)
 ;; KEEP-NONE-SECONDARY-NEXT:   )
 ;; KEEP-NONE-SECONDARY-NEXT:  )
-;; KEEP-NONE-SECONDARY-NEXT:  (func $foo (param $0 i32) (result i32)
+;; KEEP-NONE-SECONDARY-NEXT:  (func $foo (type $0) (param $0 i32) (result i32)
 ;; KEEP-NONE-SECONDARY-NEXT:   (call $bar
 ;; KEEP-NONE-SECONDARY-NEXT:    (i32.const 0)
 ;; KEEP-NONE-SECONDARY-NEXT:   )
@@ -97,13 +97,13 @@
 
 ;; KEEP-FOO-PRIMARY:      (module
 ;; KEEP-FOO-PRIMARY-NEXT:  (type $0 (func (param i32) (result i32)))
-;; KEEP-FOO-PRIMARY-NEXT:  (import "placeholder" "1" (func $placeholder_1 (param i32) (result i32)))
+;; KEEP-FOO-PRIMARY-NEXT:  (import "placeholder" "1" (func $placeholder_1 (type $0) (param i32) (result i32)))
 ;; KEEP-FOO-PRIMARY-NEXT:  (table $table 2 2 funcref)
 ;; KEEP-FOO-PRIMARY-NEXT:  (elem $0 (i32.const 0) $foo $placeholder_1)
 ;; KEEP-FOO-PRIMARY-NEXT:  (export "%foo" (func $foo))
 ;; KEEP-FOO-PRIMARY-NEXT:  (export "%table" (table $table))
-;; KEEP-FOO-PRIMARY-NEXT:  (func $foo (param $0 i32) (result i32)
-;; KEEP-FOO-PRIMARY-NEXT:   (call_indirect (type $0)
+;; KEEP-FOO-PRIMARY-NEXT:  (func $foo (type $0) (param $0 i32) (result i32)
+;; KEEP-FOO-PRIMARY-NEXT:   (call_indirect $table (type $0)
 ;; KEEP-FOO-PRIMARY-NEXT:    (i32.const 0)
 ;; KEEP-FOO-PRIMARY-NEXT:    (i32.const 1)
 ;; KEEP-FOO-PRIMARY-NEXT:   )
@@ -113,9 +113,9 @@
 ;; KEEP-FOO-SECONDARY:      (module
 ;; KEEP-FOO-SECONDARY-NEXT:  (type $0 (func (param i32) (result i32)))
 ;; KEEP-FOO-SECONDARY-NEXT:  (import "primary" "%table" (table $table 2 2 funcref))
-;; KEEP-FOO-SECONDARY-NEXT:  (import "primary" "%foo" (func $foo (param i32) (result i32)))
+;; KEEP-FOO-SECONDARY-NEXT:  (import "primary" "%foo" (func $foo (type $0) (param i32) (result i32)))
 ;; KEEP-FOO-SECONDARY-NEXT:  (elem $0 (i32.const 1) $bar)
-;; KEEP-FOO-SECONDARY-NEXT:  (func $bar (param $0 i32) (result i32)
+;; KEEP-FOO-SECONDARY-NEXT:  (func $bar (type $0) (param $0 i32) (result i32)
 ;; KEEP-FOO-SECONDARY-NEXT:   (call $foo
 ;; KEEP-FOO-SECONDARY-NEXT:    (i32.const 1)
 ;; KEEP-FOO-SECONDARY-NEXT:   )
@@ -127,13 +127,13 @@
 
 ;; KEEP-BAR-PRIMARY:      (module
 ;; KEEP-BAR-PRIMARY-NEXT:  (type $0 (func (param i32) (result i32)))
-;; KEEP-BAR-PRIMARY-NEXT:  (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+;; KEEP-BAR-PRIMARY-NEXT:  (import "placeholder" "0" (func $placeholder_0 (type $0) (param i32) (result i32)))
 ;; KEEP-BAR-PRIMARY-NEXT:  (table $table 1 1 funcref)
 ;; KEEP-BAR-PRIMARY-NEXT:  (elem $0 (i32.const 0) $placeholder_0)
 ;; KEEP-BAR-PRIMARY-NEXT:  (export "%bar" (func $bar))
 ;; KEEP-BAR-PRIMARY-NEXT:  (export "%table" (table $table))
-;; KEEP-BAR-PRIMARY-NEXT:  (func $bar (param $0 i32) (result i32)
-;; KEEP-BAR-PRIMARY-NEXT:   (call_indirect (type $0)
+;; KEEP-BAR-PRIMARY-NEXT:  (func $bar (type $0) (param $0 i32) (result i32)
+;; KEEP-BAR-PRIMARY-NEXT:   (call_indirect $table (type $0)
 ;; KEEP-BAR-PRIMARY-NEXT:    (i32.const 1)
 ;; KEEP-BAR-PRIMARY-NEXT:    (i32.const 0)
 ;; KEEP-BAR-PRIMARY-NEXT:   )
@@ -143,9 +143,9 @@
 ;; KEEP-BAR-SECONDARY:      (module
 ;; KEEP-BAR-SECONDARY-NEXT:  (type $0 (func (param i32) (result i32)))
 ;; KEEP-BAR-SECONDARY-NEXT:  (import "primary" "%table" (table $table 1 1 funcref))
-;; KEEP-BAR-SECONDARY-NEXT:  (import "primary" "%bar" (func $bar (param i32) (result i32)))
+;; KEEP-BAR-SECONDARY-NEXT:  (import "primary" "%bar" (func $bar (type $0) (param i32) (result i32)))
 ;; KEEP-BAR-SECONDARY-NEXT:  (elem $0 (i32.const 0) $foo)
-;; KEEP-BAR-SECONDARY-NEXT:  (func $foo (param $0 i32) (result i32)
+;; KEEP-BAR-SECONDARY-NEXT:  (func $foo (type $0) (param $0 i32) (result i32)
 ;; KEEP-BAR-SECONDARY-NEXT:   (call $bar
 ;; KEEP-BAR-SECONDARY-NEXT:    (i32.const 0)
 ;; KEEP-BAR-SECONDARY-NEXT:   )
@@ -161,12 +161,12 @@
 ;; KEEP-BOTH-PRIMARY-NEXT:  (table $table 1 1 funcref)
 ;; KEEP-BOTH-PRIMARY-NEXT:  (elem $0 (i32.const 0) $foo)
 ;; KEEP-BOTH-PRIMARY-NEXT:  (export "%table" (table $table))
-;; KEEP-BOTH-PRIMARY-NEXT:  (func $foo (param $0 i32) (result i32)
+;; KEEP-BOTH-PRIMARY-NEXT:  (func $foo (type $0) (param $0 i32) (result i32)
 ;; KEEP-BOTH-PRIMARY-NEXT:   (call $bar
 ;; KEEP-BOTH-PRIMARY-NEXT:    (i32.const 0)
 ;; KEEP-BOTH-PRIMARY-NEXT:   )
 ;; KEEP-BOTH-PRIMARY-NEXT:  )
-;; KEEP-BOTH-PRIMARY-NEXT:  (func $bar (param $0 i32) (result i32)
+;; KEEP-BOTH-PRIMARY-NEXT:  (func $bar (type $0) (param $0 i32) (result i32)
 ;; KEEP-BOTH-PRIMARY-NEXT:   (call $foo
 ;; KEEP-BOTH-PRIMARY-NEXT:    (i32.const 1)
 ;; KEEP-BOTH-PRIMARY-NEXT:   )

--- a/test/lit/wasm-split/jspi-secondary-export.wast
+++ b/test/lit/wasm-split/jspi-secondary-export.wast
@@ -11,9 +11,9 @@
 
  ;; PRIMARY:      (type $1 (func))
 
- ;; PRIMARY:      (import "env" "__load_secondary_module" (func $fimport$0))
+ ;; PRIMARY:      (import "env" "__load_secondary_module" (func $fimport$0 (type $1)))
 
- ;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+ ;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (type $0) (param i32) (result i32)))
 
  ;; PRIMARY:      (global $global$0 (mut i32) (i32.const 0))
 
@@ -27,7 +27,7 @@
 
  ;; PRIMARY:      (export "%table" (table $0))
 
- ;; PRIMARY:      (func $foo (param $0 i32) (result i32)
+ ;; PRIMARY:      (func $foo (type $0) (param $0 i32) (result i32)
  ;; PRIMARY-NEXT:  (if
  ;; PRIMARY-NEXT:   (i32.eqz
  ;; PRIMARY-NEXT:    (global.get $global$0)
@@ -36,7 +36,7 @@
  ;; PRIMARY-NEXT:    (call $fimport$0)
  ;; PRIMARY-NEXT:   )
  ;; PRIMARY-NEXT:  )
- ;; PRIMARY-NEXT:  (call_indirect (type $0)
+ ;; PRIMARY-NEXT:  (call_indirect $0 (type $0)
  ;; PRIMARY-NEXT:   (local.get $0)
  ;; PRIMARY-NEXT:   (i32.const 0)
  ;; PRIMARY-NEXT:  )
@@ -50,7 +50,7 @@
 
  ;; SECONDARY:      (elem $0 (i32.const 0) $bar)
 
- ;; SECONDARY:      (func $bar (param $0 i32) (result i32)
+ ;; SECONDARY:      (func $bar (type $0) (param $0 i32) (result i32)
  ;; SECONDARY-NEXT:  (i32.const 0)
  ;; SECONDARY-NEXT: )
  (func $bar (param i32) (result i32)

--- a/test/lit/wasm-split/jspi.wast
+++ b/test/lit/wasm-split/jspi.wast
@@ -11,9 +11,9 @@
 
  ;; PRIMARY:      (type $1 (func))
 
- ;; PRIMARY:      (import "env" "__load_secondary_module" (func $fimport$0))
+ ;; PRIMARY:      (import "env" "__load_secondary_module" (func $fimport$0 (type $1)))
 
- ;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (param i32) (result i32)))
+ ;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (type $0) (param i32) (result i32)))
 
  ;; PRIMARY:      (global $global$0 (mut i32) (i32.const 0))
 
@@ -27,7 +27,7 @@
 
  ;; PRIMARY:      (export "%table" (table $0))
 
- ;; PRIMARY:      (func $foo (param $0 i32) (result i32)
+ ;; PRIMARY:      (func $foo (type $0) (param $0 i32) (result i32)
  ;; PRIMARY-NEXT:  (if
  ;; PRIMARY-NEXT:   (i32.eqz
  ;; PRIMARY-NEXT:    (global.get $global$0)
@@ -36,7 +36,7 @@
  ;; PRIMARY-NEXT:    (call $fimport$0)
  ;; PRIMARY-NEXT:   )
  ;; PRIMARY-NEXT:  )
- ;; PRIMARY-NEXT:  (call_indirect (type $0)
+ ;; PRIMARY-NEXT:  (call_indirect $0 (type $0)
  ;; PRIMARY-NEXT:   (i32.const 0)
  ;; PRIMARY-NEXT:   (i32.const 0)
  ;; PRIMARY-NEXT:  )
@@ -48,11 +48,11 @@
 
  ;; SECONDARY:      (import "primary" "%table" (table $timport$0 1 funcref))
 
- ;; SECONDARY:      (import "primary" "foo" (func $foo (param i32) (result i32)))
+ ;; SECONDARY:      (import "primary" "foo" (func $foo (type $0) (param i32) (result i32)))
 
  ;; SECONDARY:      (elem $0 (i32.const 0) $bar)
 
- ;; SECONDARY:      (func $bar (param $0 i32) (result i32)
+ ;; SECONDARY:      (func $bar (type $0) (param $0 i32) (result i32)
  ;; SECONDARY-NEXT:  (call $foo
  ;; SECONDARY-NEXT:   (i32.const 1)
  ;; SECONDARY-NEXT:  )

--- a/test/lit/wasm-split/minimized-exports.wast
+++ b/test/lit/wasm-split/minimized-exports.wast
@@ -17,7 +17,7 @@
 ;; PRIMARY-NEXT:     (nop)
 ;; PRIMARY-NEXT:   )
 ;; PRIMARY-NEXT:   (func $2
-;; PRIMARY-NEXT:     (call_indirect (type $0)
+;; PRIMARY-NEXT:     (call_indirect $0 (type $0)
 ;; PRIMARY-NEXT:       (i32.const 0)
 ;; PRIMARY-NEXT:     )
 ;; PRIMARY-NEXT:   )
@@ -26,8 +26,8 @@
 ;; SECONDARY:      (module
 ;; SECONDARY-NEXT:   (type $0 (func))
 ;; SECONDARY-NEXT:   (import "primary" "%c" (table $timport$0 1 funcref))
-;; SECONDARY-NEXT:   (import "primary" "%a" (func $fimport$0))
-;; SECONDARY-NEXT:   (import "primary" "%b" (func $fimport$1))
+;; SECONDARY-NEXT:   (import "primary" "%a" (func $fimport$0 (type $0)))
+;; SECONDARY-NEXT:   (import "primary" "%b" (func $fimport$1 (type $0)))
 ;; SECONDARY-NEXT:   (elem $0 (i32.const 0) $0)
 ;; SECONDARY-NEXT:   (func $0
 ;; SECONDARY-NEXT:     (call $fimport$1)

--- a/test/lit/wasm-split/multi-split.wast
+++ b/test/lit/wasm-split/multi-split.wast
@@ -34,13 +34,15 @@
 
  ;; MOD1:      (import "" "table" (table $timport$0 1 funcref))
 
- ;; MOD1:      (import "" "B" (func $B (result i64)))
+ ;; MOD1:      (import "" "B" (func $B (type $0) (result i64)))
 
- ;; MOD1:      (import "" "C" (func $C (result f32)))
+ ;; MOD1:      (import "" "C" (func $C (type $1) (result f32)))
 
  ;; MOD1:      (elem $0 (i32.const 0) $A)
 
- ;; MOD1:      (func $A (result i32)
+ ;; MOD1:      (elem declare func $B $C)
+
+ ;; MOD1:      (func $A (type $2) (result i32)
  ;; MOD1-NEXT:  (drop
  ;; MOD1-NEXT:   (call_ref $2
  ;; MOD1-NEXT:    (ref.func $A)
@@ -66,13 +68,15 @@
 
  ;; MOD1-OPTIONS:      (import "custom_env" "table" (table $timport$0 1 funcref))
 
- ;; MOD1-OPTIONS:      (import "custom_env" "B" (func $B (result i64)))
+ ;; MOD1-OPTIONS:      (import "custom_env" "B" (func $B (type $0) (result i64)))
 
- ;; MOD1-OPTIONS:      (import "custom_env" "C" (func $C (result f32)))
+ ;; MOD1-OPTIONS:      (import "custom_env" "C" (func $C (type $1) (result f32)))
 
  ;; MOD1-OPTIONS:      (elem $0 (i32.const 0) $A)
 
- ;; MOD1-OPTIONS:      (func $A (result i32)
+ ;; MOD1-OPTIONS:      (elem declare func $B $C)
+
+ ;; MOD1-OPTIONS:      (func $A (type $2) (result i32)
  ;; MOD1-OPTIONS-NEXT:  (drop
  ;; MOD1-OPTIONS-NEXT:   (call_ref $2
  ;; MOD1-OPTIONS-NEXT:    (ref.func $A)
@@ -117,13 +121,15 @@
 
  ;; MOD2:      (import "" "table_4" (table $timport$0 1 funcref))
 
- ;; MOD2:      (import "" "C" (func $C (result f32)))
+ ;; MOD2:      (import "" "C" (func $C (type $0) (result f32)))
 
- ;; MOD2:      (import "" "trampoline_A" (func $fimport$1 (result i32)))
+ ;; MOD2:      (import "" "trampoline_A" (func $fimport$1 (type $1) (result i32)))
 
  ;; MOD2:      (elem $0 (i32.const 0) $B)
 
- ;; MOD2:      (func $B (result i64)
+ ;; MOD2:      (elem declare func $C $fimport$1)
+
+ ;; MOD2:      (func $B (type $2) (result i64)
  ;; MOD2-NEXT:  (drop
  ;; MOD2-NEXT:   (call_ref $1
  ;; MOD2-NEXT:    (ref.func $fimport$1)
@@ -149,13 +155,15 @@
 
  ;; MOD2-OPTIONS:      (import "custom_env" "table_4" (table $timport$0 1 funcref))
 
- ;; MOD2-OPTIONS:      (import "custom_env" "C" (func $C (result f32)))
+ ;; MOD2-OPTIONS:      (import "custom_env" "C" (func $C (type $0) (result f32)))
 
- ;; MOD2-OPTIONS:      (import "custom_env" "trampoline_A" (func $fimport$1 (result i32)))
+ ;; MOD2-OPTIONS:      (import "custom_env" "trampoline_A" (func $fimport$1 (type $1) (result i32)))
 
  ;; MOD2-OPTIONS:      (elem $0 (i32.const 0) $B)
 
- ;; MOD2-OPTIONS:      (func $B (result i64)
+ ;; MOD2-OPTIONS:      (elem declare func $C $fimport$1)
+
+ ;; MOD2-OPTIONS:      (func $B (type $2) (result i64)
  ;; MOD2-OPTIONS-NEXT:  (drop
  ;; MOD2-OPTIONS-NEXT:   (call_ref $1
  ;; MOD2-OPTIONS-NEXT:    (ref.func $fimport$1)
@@ -200,13 +208,15 @@
 
  ;; MOD3:      (import "" "table_6" (table $timport$0 1 funcref))
 
- ;; MOD3:      (import "" "trampoline_A" (func $fimport$0 (result i32)))
+ ;; MOD3:      (import "" "trampoline_A" (func $fimport$0 (type $0) (result i32)))
 
- ;; MOD3:      (import "" "trampoline_B" (func $fimport$1 (result i64)))
+ ;; MOD3:      (import "" "trampoline_B" (func $fimport$1 (type $1) (result i64)))
 
  ;; MOD3:      (elem $0 (i32.const 0) $C)
 
- ;; MOD3:      (func $C (result f32)
+ ;; MOD3:      (elem declare func $fimport$0 $fimport$1)
+
+ ;; MOD3:      (func $C (type $2) (result f32)
  ;; MOD3-NEXT:  (drop
  ;; MOD3-NEXT:   (call_ref $0
  ;; MOD3-NEXT:    (ref.func $fimport$0)
@@ -232,13 +242,15 @@
 
  ;; MOD3-OPTIONS:      (import "custom_env" "table_6" (table $timport$0 1 funcref))
 
- ;; MOD3-OPTIONS:      (import "custom_env" "trampoline_A" (func $fimport$0 (result i32)))
+ ;; MOD3-OPTIONS:      (import "custom_env" "trampoline_A" (func $fimport$0 (type $0) (result i32)))
 
- ;; MOD3-OPTIONS:      (import "custom_env" "trampoline_B" (func $fimport$1 (result i64)))
+ ;; MOD3-OPTIONS:      (import "custom_env" "trampoline_B" (func $fimport$1 (type $1) (result i64)))
 
  ;; MOD3-OPTIONS:      (elem $0 (i32.const 0) $C)
 
- ;; MOD3-OPTIONS:      (func $C (result f32)
+ ;; MOD3-OPTIONS:      (elem declare func $fimport$0 $fimport$1)
+
+ ;; MOD3-OPTIONS:      (func $C (type $2) (result f32)
  ;; MOD3-OPTIONS-NEXT:  (drop
  ;; MOD3-OPTIONS-NEXT:   (call_ref $0
  ;; MOD3-OPTIONS-NEXT:    (ref.func $fimport$0)
@@ -275,11 +287,11 @@
   (f32.const 0)
  )
 )
-;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (result i32)))
+;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (type $ret-i32) (result i32)))
 
-;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0_5 (result i64)))
+;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0_5 (type $ret-i64) (result i64)))
 
-;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0_6 (result f32)))
+;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0_6 (type $ret-f32) (result f32)))
 
 ;; PRIMARY:      (table $0 1 funcref)
 
@@ -307,26 +319,26 @@
 
 ;; PRIMARY:      (export "table_6" (table $2))
 
-;; PRIMARY:      (func $0 (result i32)
-;; PRIMARY-NEXT:  (call_indirect (type $ret-i32)
+;; PRIMARY:      (func $0 (type $ret-i32) (result i32)
+;; PRIMARY-NEXT:  (call_indirect $0 (type $ret-i32)
 ;; PRIMARY-NEXT:   (i32.const 0)
 ;; PRIMARY-NEXT:  )
 ;; PRIMARY-NEXT: )
 
-;; PRIMARY:      (func $1 (result i64)
-;; PRIMARY-NEXT:  (call_indirect (type $ret-i64)
+;; PRIMARY:      (func $1 (type $ret-i64) (result i64)
+;; PRIMARY-NEXT:  (call_indirect $1 (type $ret-i64)
 ;; PRIMARY-NEXT:   (i32.const 0)
 ;; PRIMARY-NEXT:  )
 ;; PRIMARY-NEXT: )
 
-;; PRIMARY:      (func $2 (result i64)
-;; PRIMARY-NEXT:  (call_indirect (type $ret-i64)
+;; PRIMARY:      (func $2 (type $ret-i64) (result i64)
+;; PRIMARY-NEXT:  (call_indirect $1 (type $ret-i64)
 ;; PRIMARY-NEXT:   (i32.const 0)
 ;; PRIMARY-NEXT:  )
 ;; PRIMARY-NEXT: )
 
-;; PRIMARY:      (func $3 (result f32)
-;; PRIMARY-NEXT:  (call_indirect (type $ret-f32)
+;; PRIMARY:      (func $3 (type $ret-f32) (result f32)
+;; PRIMARY-NEXT:  (call_indirect $2 (type $ret-f32)
 ;; PRIMARY-NEXT:   (i32.const 0)
 ;; PRIMARY-NEXT:  )
 ;; PRIMARY-NEXT: )
@@ -357,26 +369,26 @@
 
 ;; PRIMARY-OPTIONS:      (export "table_6" (table $2))
 
-;; PRIMARY-OPTIONS:      (func $0 (result i32)
-;; PRIMARY-OPTIONS-NEXT:  (call_indirect (type $ret-i32)
+;; PRIMARY-OPTIONS:      (func $0 (type $ret-i32) (result i32)
+;; PRIMARY-OPTIONS-NEXT:  (call_indirect $0 (type $ret-i32)
 ;; PRIMARY-OPTIONS-NEXT:   (i32.const 0)
 ;; PRIMARY-OPTIONS-NEXT:  )
 ;; PRIMARY-OPTIONS-NEXT: )
 
-;; PRIMARY-OPTIONS:      (func $1 (result i64)
-;; PRIMARY-OPTIONS-NEXT:  (call_indirect (type $ret-i64)
+;; PRIMARY-OPTIONS:      (func $1 (type $ret-i64) (result i64)
+;; PRIMARY-OPTIONS-NEXT:  (call_indirect $1 (type $ret-i64)
 ;; PRIMARY-OPTIONS-NEXT:   (i32.const 0)
 ;; PRIMARY-OPTIONS-NEXT:  )
 ;; PRIMARY-OPTIONS-NEXT: )
 
-;; PRIMARY-OPTIONS:      (func $2 (result i64)
-;; PRIMARY-OPTIONS-NEXT:  (call_indirect (type $ret-i64)
+;; PRIMARY-OPTIONS:      (func $2 (type $ret-i64) (result i64)
+;; PRIMARY-OPTIONS-NEXT:  (call_indirect $1 (type $ret-i64)
 ;; PRIMARY-OPTIONS-NEXT:   (i32.const 0)
 ;; PRIMARY-OPTIONS-NEXT:  )
 ;; PRIMARY-OPTIONS-NEXT: )
 
-;; PRIMARY-OPTIONS:      (func $3 (result f32)
-;; PRIMARY-OPTIONS-NEXT:  (call_indirect (type $ret-f32)
+;; PRIMARY-OPTIONS:      (func $3 (type $ret-f32) (result f32)
+;; PRIMARY-OPTIONS-NEXT:  (call_indirect $2 (type $ret-f32)
 ;; PRIMARY-OPTIONS-NEXT:   (i32.const 0)
 ;; PRIMARY-OPTIONS-NEXT:  )
 ;; PRIMARY-OPTIONS-NEXT: )

--- a/test/lit/wasm-split/no-active-segment.wast
+++ b/test/lit/wasm-split/no-active-segment.wast
@@ -15,7 +15,7 @@
 
  ;; SECONDARY:      (elem $0 (i32.const 0) $foo)
 
- ;; SECONDARY:      (func $foo
+ ;; SECONDARY:      (func $foo (type $0)
  ;; SECONDARY-NEXT:  (nop)
  ;; SECONDARY-NEXT: )
  (func $foo
@@ -24,7 +24,7 @@
 )
 ;; PRIMARY:      (type $0 (func))
 
-;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0))
+;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (type $0)))
 
 ;; PRIMARY:      (table $0 1 funcref)
 
@@ -34,8 +34,8 @@
 
 ;; PRIMARY:      (export "table" (table $0))
 
-;; PRIMARY:      (func $0
-;; PRIMARY-NEXT:  (call_indirect (type $0)
+;; PRIMARY:      (func $0 (type $0)
+;; PRIMARY-NEXT:  (call_indirect $0 (type $0)
 ;; PRIMARY-NEXT:   (i32.const 0)
 ;; PRIMARY-NEXT:  )
 ;; PRIMARY-NEXT: )

--- a/test/lit/wasm-split/no-placeholders.wast
+++ b/test/lit/wasm-split/no-placeholders.wast
@@ -15,11 +15,11 @@
 
  ;; PRIMARY:      (export "table" (table $0))
 
- ;; PRIMARY:      (func $foo
- ;; PRIMARY-NEXT:  (call_indirect (type $0)
+ ;; PRIMARY:      (func $foo (type $0)
+ ;; PRIMARY-NEXT:  (call_indirect $0 (type $0)
  ;; PRIMARY-NEXT:   (i32.const 0)
  ;; PRIMARY-NEXT:  )
- ;; PRIMARY-NEXT:  (call_indirect (type $0)
+ ;; PRIMARY-NEXT:  (call_indirect $0 (type $0)
  ;; PRIMARY-NEXT:   (i32.const 1)
  ;; PRIMARY-NEXT:  )
  ;; PRIMARY-NEXT: )
@@ -31,11 +31,11 @@
 
  ;; SECONDARY:      (import "primary" "table" (table $timport$0 2 funcref))
 
- ;; SECONDARY:      (import "primary" "foo" (func $foo))
+ ;; SECONDARY:      (import "primary" "foo" (func $foo (type $0)))
 
  ;; SECONDARY:      (elem $0 (i32.const 0) $bar $baz)
 
- ;; SECONDARY:      (func $bar
+ ;; SECONDARY:      (func $bar (type $0)
  ;; SECONDARY-NEXT:  (call $foo)
  ;; SECONDARY-NEXT:  (call $baz)
  ;; SECONDARY-NEXT: )
@@ -43,7 +43,7 @@
   (call $foo)
   (call $baz)
  )
- ;; SECONDARY:      (func $baz
+ ;; SECONDARY:      (func $baz (type $0)
  ;; SECONDARY-NEXT:  (call $foo)
  ;; SECONDARY-NEXT:  (call $bar)
  ;; SECONDARY-NEXT: )

--- a/test/lit/wasm-split/segments.wast
+++ b/test/lit/wasm-split/segments.wast
@@ -14,7 +14,7 @@
  ;; PRIMARY:      (type $elem-array (array externref))
  (type $elem-array (array externref))
 
- ;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0))
+ ;; PRIMARY:      (import "placeholder" "0" (func $placeholder_0 (type $0)))
 
  ;; PRIMARY:      (memory $mem 0)
  (memory $mem 0)
@@ -33,14 +33,14 @@
 
  ;; PRIMARY:      (export "table" (table $0))
 
- ;; PRIMARY:      (func $data.drop
+ ;; PRIMARY:      (func $data.drop (type $0)
  ;; PRIMARY-NEXT:  (data.drop $data)
  ;; PRIMARY-NEXT: )
  (func $data.drop
   (data.drop $data)
  )
 
- ;; PRIMARY:      (func $memory.init
+ ;; PRIMARY:      (func $memory.init (type $0)
  ;; PRIMARY-NEXT:  (memory.init $data
  ;; PRIMARY-NEXT:   (i32.const 0)
  ;; PRIMARY-NEXT:   (i32.const 0)
@@ -55,7 +55,7 @@
   )
  )
 
- ;; PRIMARY:      (func $array.new_data
+ ;; PRIMARY:      (func $array.new_data (type $0)
  ;; PRIMARY-NEXT:  (drop
  ;; PRIMARY-NEXT:   (array.new_data $data-array $data
  ;; PRIMARY-NEXT:    (i32.const 0)
@@ -72,7 +72,7 @@
   )
  )
 
- ;; PRIMARY:      (func $array.new_elem
+ ;; PRIMARY:      (func $array.new_elem (type $0)
  ;; PRIMARY-NEXT:  (drop
  ;; PRIMARY-NEXT:   (array.new_elem $elem-array $elem
  ;; PRIMARY-NEXT:    (i32.const 0)
@@ -95,19 +95,19 @@
 
  ;; SECONDARY:      (elem $0 (i32.const 0) $no-segment)
 
- ;; SECONDARY:      (func $no-segment
+ ;; SECONDARY:      (func $no-segment (type $0)
  ;; SECONDARY-NEXT:  (nop)
  ;; SECONDARY-NEXT: )
  (func $no-segment
   (nop)
  )
 
- ;; PRIMARY:      (func $use-funcs
+ ;; PRIMARY:      (func $use-funcs (type $0)
  ;; PRIMARY-NEXT:  (call $data.drop)
  ;; PRIMARY-NEXT:  (call $memory.init)
  ;; PRIMARY-NEXT:  (call $array.new_data)
  ;; PRIMARY-NEXT:  (call $array.new_elem)
- ;; PRIMARY-NEXT:  (call_indirect (type $0)
+ ;; PRIMARY-NEXT:  (call_indirect $0 (type $0)
  ;; PRIMARY-NEXT:   (i32.const 0)
  ;; PRIMARY-NEXT:  )
  ;; PRIMARY-NEXT: )

--- a/test/metadatas.wasm.fromBinary
+++ b/test/metadatas.wasm.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (export "a" (func $0))
- (func $0
+ (func $0 (type $0)
   (nop)
  )
  ;; custom section "emscripten_metadata", size 7

--- a/test/mutable-global.wasm.fromBinary
+++ b/test/mutable-global.wasm.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (import "env" "global-mut" (global $gimport$0 (mut i32)))
- (func $0
+ (func $0 (type $0)
   (global.set $gimport$0
    (i32.add
     (global.get $gimport$0)

--- a/test/reduce/atomics-and-bulk-memory.wast.txt
+++ b/test/reduce/atomics-and-bulk-memory.wast.txt
@@ -2,7 +2,7 @@
  (type $0 (func (result i32)))
  (memory $0 1 1)
  (export "foo" (func $0))
- (func $0 (result i32)
+ (func $0 (type $0) (result i32)
   (i32.atomic.store8
    (i32.const 0)
    (i32.const 99)

--- a/test/reduce/destructive.wast.txt
+++ b/test/reduce/destructive.wast.txt
@@ -1,7 +1,7 @@
 (module
  (type $0 (func (param i32) (result i32)))
  (export "x" (func $0))
- (func $0 (param $0 i32) (result i32)
+ (func $0 (type $0) (param $0 i32) (result i32)
   (i32.const 100)
  )
 )

--- a/test/reduce/gc.wast.txt
+++ b/test/reduce/gc.wast.txt
@@ -3,7 +3,7 @@
  (type $1 (func (result i32)))
  (global $global$0 (ref null $0) (struct.new_default $0))
  (export "use-global" (func $0))
- (func $0 (result i32)
+ (func $0 (type $1) (result i32)
   (struct.set $0 0
    (global.get $global$0)
    (i32.const 42)

--- a/test/reduce/imports.wast.txt
+++ b/test/reduce/imports.wast.txt
@@ -1,7 +1,7 @@
 (module
  (type $0 (func (result i32)))
  (export "x" (func $0))
- (func $0 (result i32)
+ (func $0 (type $0) (result i32)
   (i32.const 5678)
  )
 )

--- a/test/reduce/memory_table.wast.txt
+++ b/test/reduce/memory_table.wast.txt
@@ -12,9 +12,9 @@
  (export "f2" (func $1))
  (export "f4" (func $2))
  (export "f5" (func $3))
- (func $0
+ (func $0 (type $1)
  )
- (func $1 (result i32)
+ (func $1 (type $0) (result i32)
   (i32.store
    (i32.const 0)
    (i32.const 65530)
@@ -23,13 +23,13 @@
    (i32.const 0)
   )
  )
- (func $2 (result i32)
+ (func $2 (type $0) (result i32)
   (i32.add
    (call $1)
    (i32.const 1234)
   )
  )
- (func $3 (result i32)
+ (func $3 (type $0) (result i32)
   (i31.get_u
    (table.get $0
     (i32.const 1)

--- a/test/reduce/simple.wast.txt
+++ b/test/reduce/simple.wast.txt
@@ -1,7 +1,7 @@
 (module
  (type $0 (func (result i32)))
  (export "x" (func $0))
- (func $0 (result i32)
+ (func $0 (type $0) (result i32)
   (i32.const 5678)
  )
 )

--- a/test/stacky.wasm.fromBinary
+++ b/test/stacky.wasm.fromBinary
@@ -2,7 +2,7 @@
  (type $0 (func (param i32 i32) (result i32)))
  (memory $0 256 256)
  (export "add" (func $0))
- (func $0 (param $0 i32) (param $1 i32) (result i32)
+ (func $0 (type $0) (param $0 i32) (param $1 i32) (result i32)
   (local $scratch i32)
   (i32.add
    (block (result i32)

--- a/test/try-delegate.wasm.fromBinary
+++ b/test/try-delegate.wasm.fromBinary
@@ -1,7 +1,7 @@
 (module
  (type $0 (func))
  (tag $tag$0 (type $0))
- (func $0
+ (func $0 (type $0)
   (try $label
    (do
     (try
@@ -14,7 +14,7 @@
    )
   )
  )
- (func $1
+ (func $1 (type $0)
   (try $label
    (do
     (try

--- a/test/unreachable-pops.wasm.fromBinary
+++ b/test/unreachable-pops.wasm.fromBinary
@@ -1,6 +1,6 @@
 (module
  (type $0 (func (result i32)))
- (func $0 (result i32)
+ (func $0 (type $0) (result i32)
   (i32.add
    (unreachable)
    (unreachable)


### PR DESCRIPTION
This enables all features for wasm-dis for printing.

wasm-dis currently enables all features at parsing time and restores the originally enabled features at printing time, but doesn't do any validation, so there's no point restoring the original features:
https://github.com/WebAssembly/binaryen/blob/e81f964d9cc70c71c4339e6558f57ebe8eb5cc32/src/tools/wasm-dis.cpp#L70-L73 https://github.com/WebAssembly/binaryen/blob/e81f964d9cc70c71c4339e6558f57ebe8eb5cc32/src/tools/wasm-dis.cpp#L94-L100
And even if we do validation, I'm not sure how many people would use wasm-dis for validation anyway.

And it's easy to be misused. For example, running `wasm-dis` without any options on a binary that has reference types enabled and has multiple tables will not print any indices for `call_indirect`s and does not even error out, happily producing a wast file that has incorrect semantics, because without table references they will all mean whatever table at index 0.
https://github.com/WebAssembly/binaryen/blob/21464e7533ef235634c8d62442a8a10cafff6568/src/passes/Print.cpp#L506-L509
Note that without `-all` you can even disassemble GC binaries with `struct`s, because there's no validation. But we still don't print table references for `call_indirect`s.

This PR removes that restoring and validation and enables all features at all times for wasm-dis.

The test changes are two kinds:
- We now have a table reference for all `call_indirect`s
- We now have a type index for all `func`s

At least the first change is not compatible with MVP. (Not sure about the second one.) But our wast parser doesn't seem to have any problems with parsing these without `-all` of `--enable-reference-types` at the moment. (@tlively [confirms](https://github.com/WebAssembly/binaryen/pull/7798#issuecomment-3161638044) that)

What do you think?

Companion change: https://github.com/emscripten-core/emscripten/pull/24876