### PR TITLE
[Stack Switching] Handle nested continuations

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4926,7 +4926,8 @@ public:
       self()->pushCurrContinuation(contData);
       self()->continuationStore->resuming = true;
 #if WASM_INTERPRETER_DEBUG
-      std::cout << self()->indent() << "resuming func " << func.getFunc() << '\n';
+      std::cout << self()->indent() << "resuming func " << func.getFunc()
+                << '\n';
 #endif
     }
 
@@ -4941,7 +4942,8 @@ public:
     }
 #if WASM_INTERPRETER_DEBUG
     if (!self()->isResuming()) {
-      std::cout << self()->indent() << "finished resuming, with " << ret << '\n';
+      std::cout << self()->indent() << "finished resuming, with " << ret
+                << '\n';
     }
 #endif
     if (!ret.suspendTag) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -4910,8 +4910,8 @@ public:
     auto contData = flow.getSingleValue().getContData();
     auto func = contData->func;
 
-    // If we are resuming a nested suspend, should just rewind the call stack,
-    // and therefore do not change or test the state here.
+    // If we are resuming a nested suspend then we should just rewind the call
+    // stack, and therefore do not change or test the state here.
     if (!self()->isResuming()) {
       if (contData->executed) {
         trap("continuation already executed");

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -735,7 +735,7 @@ std::ostream& operator<<(std::ostream& o, Literal literal) {
       auto data = literal.getContData();
       o << "cont(" << data->func << ' ' << data->type;
       if (data->resumeExpr) {
-        o << " resumeExpr=" << getExpressionName(data->resumeExpr);
+        o << " resumeExpr=" << reinterpret_cast<size_t>(data->resumeExpr);
       }
       if (!data->resumeInfo.empty()) {
         o << " |resumeInfo|=" << data->resumeInfo.size();


### PR DESCRIPTION
The key fix here is that we don't know what the continuation
function (the thing to call, to continue onwards) is, at the time of
suspending. Rather, that function is called from a resume, to
resume execution from there, so do so when we handle a
suspend in a Resume.

And, when we resume "through" a suspend (due to a nested
suspend), then we should just rewind the call stack.

With this, the next big spec testcase passes.

Also fix a minor issue with trying to put breaking values on
the value stack - only value stack values go there. The new
testcase enabled here trips on that.

Also improve some debug logging.