### PR TITLE
[NFC] Update ChildTyper callback for unknown constaints

### DIFF
--- a/src/ir/child-typer.h
+++ b/src/ir/child-typer.h
@@ -893,6 +893,8 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
     switch (curr->op) {
       case BrOnNull:
       case BrOnNonNull:
+        // br_on(_non)_null is polymorphic over reference types and does not
+        // take a type immediate.
         assert(!target);
         noteAnyReference(&curr->ref);
         return;

--- a/src/passes/TypeSSA.cpp
+++ b/src/passes/TypeSSA.cpp
@@ -238,9 +238,8 @@ struct Analyzer
 
       Type getLabelType(Name label) { WASM_UNREACHABLE("unexpected branch"); }
 
-      // Skip unreachable code. If we cannot compute a constraint due to
-      // unreachability, we can ignore it.
-      bool skipUnreachable() { return true; }
+      // We don't mind if we cannot compute a constraint due to unreachability.
+      void noteUnknown() {}
     } typer(*this);
     typer.visit(curr);
   }

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -401,6 +401,11 @@ struct IRBuilder::ChildPopper
       // condition.
       children.push_back({&curr->condition, {Subtype{Type::i32}}});
     }
+
+    // It is a bug if we ever have insufficient type information.
+    void noteUnknown() {
+      WASM_UNREACHABLE("unexpected insufficient type information");
+    }
   };
 
   IRBuilder& builder;


### PR DESCRIPTION
When ChildTyper does not have enough type information to generate type
constraints (for example, because a child whose type provides crucial
information is unreachable), it previously allowed the user to determine
whether to return early or not. But not returning early would then lead
to an assertion failure or other bad behavior, so it is never a
reasonable choice. The only real choice a user has is to return early
and ignore the situation (which is what TypeSSA wants) or to fail loudly
because this should never happen (which is what IRBuilder wants).
Simplify the callback to allow customizing this behavior but not whether
the early return ocurrs.
