### PR TITLE
[NFC] Use principal types in ChildTyper

### DIFF
--- a/src/ir/child-typer.h
+++ b/src/ir/child-typer.h
@@ -16,38 +16,26 @@
 #ifndef wasm_ir_child_typer_h
 #define wasm_ir_child_typer_h
 
+#include "ir/principal-type.h"
 #include "wasm-traversal.h"
 #include "wasm.h"
 
 namespace wasm {
 
-// CRTP visitor for determining constraints on the types of expression children.
-// For each child of the visited expression, calls a callback with a pointer to
-// the child and information on how the child is constrained. The possible
-// callbacks are:
+// CRTP visitor for determining constaints on the types of expression children.
+// For each child of the visited expression, calls a callback with the VarTypes
+// giving the constraint on the child:
 //
-//   noteSubtype(Expression** childp, Type type) - The child must be a subtype
-//   of `type`, which may be a tuple type. For children that must not produce
-//   values, this may be `Type::none`. This accounts for most type constraints.
+//   note(Expression** childp, SmallVector<VarType, 1> type)
 //
-//   noteAnyType(Expression** childp) - The child may have any non-tuple type.
-//   Used for the children of polymorphic instructions like `drop` and `select`.
-//
-//   noteAnyReferenceType(Expression** childp) - The child may have any
-//   reference type. Used for the children of polymorphic reference instructions
-//   like `ref.is_null`.
-//
-//   noteAnyTupleType(Expression** childp, size_t arity) - The child may have
-//   any tuple type with the given arity. Used for the children of polymorphic
-//   tuple instructions like `tuple.drop` and `tuple.extract`.
+// Multiple VarTypes if and only if the child must be a tuple. In that case,
+// each vartype gives the constraint on a single element of the tuple.
 //
 // Subclasses must additionally implement a callback for getting the type of a
-// branch target. This callback will only be used when the label type is not
-// passed directly as an argument to the branch visitor method (see below).
+// branch target. This callback will only be used when a the label type is not
+// passed directly as an argumnet to the branch visitor method (see below).
 //
 //   Type getLabelType(Name label)
-//
-// Children with type `unreachable` satisfy all constraints.
 //
 // Constraints are determined using information that would be present in the
 // binary, e.g. type annotation immediates. Many of the visitor methods take
@@ -70,6 +58,7 @@ namespace wasm {
 // information to generate constraints for all the children. Some users may wish
 // to ignore this situation and others may want to assert that it never occurs.
 template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
+  using Constraints = SmallVector<VarType, 1>;
   Module& wasm;
   Function* func;
 
@@ -77,8 +66,33 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
 
   Subtype& self() { return *static_cast<Subtype*>(this); }
 
+  void note(Expression** childp, VarType type) {
+    self().note(childp, Constraints{type});
+  }
+
   void note(Expression** childp, Type type) {
-    self().noteSubtype(childp, type);
+    if (type.isTuple()) {
+      Constraints tuple;
+      for (auto t : type.getTuple()) {
+        tuple.push_back(t);
+      }
+      self().note(childp, tuple);
+    } else {
+      note(childp, VarType{type});
+    }
+  }
+
+  // Disambiguate betwween Type and VarType.
+  void note(Expression** childp, Type::BasicType type) {
+    note(childp, VarType{Type(type)});
+  }
+
+  void noteAnyTuple(Expression** childp, size_t n) {
+    Constraints tuple;
+    for (; n != 0; --n) {
+      tuple.push_back(VarType{Index(n - 1)});
+    }
+    self().note(childp, tuple);
   }
 
   void notePointer(Expression** ptrp, Name mem) {
@@ -87,16 +101,6 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
 
   void noteTableIndex(Expression** indexp, Name table) {
     note(indexp, wasm.getTable(table)->addressType);
-  }
-
-  void noteAny(Expression** childp) { self().noteAnyType(childp); }
-
-  void noteAnyReference(Expression** childp) {
-    self().noteAnyReferenceType(childp);
-  }
-
-  void noteAnyTuple(Expression** childp, size_t arity) {
-    self().noteAnyTupleType(childp, arity);
   }
 
   Type getLabelType(Name label) { return self().getLabelType(label); }
@@ -115,6 +119,7 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
   }
 
   void visitIf(If* curr) {
+    // TODO: if the condition is unreachable, use a type variable for the arms?
     note(&curr->condition, Type::i32);
     note(&curr->ifTrue, curr->type);
     if (curr->ifFalse) {
@@ -200,8 +205,6 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
 
   void visitAtomicCmpxchg(AtomicCmpxchg* curr,
                           std::optional<Type> type = std::nullopt) {
-    assert(!type || *type == Type::i32 || *type == Type::i64);
-    notePointer(&curr->ptr, curr->memory);
     if (!type) {
       if (curr->expected->type == Type::i64 ||
           curr->replacement->type == Type::i64) {
@@ -210,6 +213,8 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
         type = Type::i32;
       }
     }
+    assert(*type == Type::i32 || *type == Type::i64);
+    notePointer(&curr->ptr, curr->memory);
     note(&curr->expected, *type);
     note(&curr->replacement, *type);
   }
@@ -701,8 +706,10 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
       note(&curr->ifTrue, *type);
       note(&curr->ifFalse, *type);
     } else {
-      noteAny(&curr->ifTrue);
-      noteAny(&curr->ifFalse);
+      // Polymorphic over types.
+      // TODO: Model the constraint that this must be a numeric or vector type.
+      note(&curr->ifTrue, VarType{0u});
+      note(&curr->ifFalse, VarType{0u});
     }
     note(&curr->condition, Type::i32);
   }
@@ -711,11 +718,9 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
     if (!arity) {
       arity = curr->value->type.size();
     }
-    if (*arity > 1) {
-      noteAnyTuple(&curr->value, *arity);
-    } else {
-      noteAny(&curr->value);
-    }
+    assert(*arity > 0);
+    // Might not actually be a tuple, but works either way.
+    noteAnyTuple(&curr->value, *arity);
   }
 
   void visitReturn(Return* curr) {
@@ -738,14 +743,19 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
 
   void visitRefNull(RefNull* curr) {}
 
-  void visitRefIsNull(RefIsNull* curr) { noteAnyReference(&curr->value); }
+  void visitRefIsNull(RefIsNull* curr) {
+    // Polymorphic over heap types.
+    note(&curr->value, VarRef{Nullable, VarHeapType{0u}});
+  }
 
   void visitRefFunc(RefFunc* curr) {}
 
   void visitRefEq(RefEq* curr) {
-    Type eqref(HeapType::eq, Nullable);
-    note(&curr->left, eqref);
-    note(&curr->right, eqref);
+    // Polymorphic over sharedness.
+    VarRef maybeShareEqref{Nullable,
+                           VarAbsHeapType{VarSharedness{0u}, HeapType::eq}};
+    note(&curr->left, maybeShareEqref);
+    note(&curr->right, maybeShareEqref);
   }
 
   void visitTableGet(TableGet* curr) {
@@ -815,8 +825,8 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
   }
 
   void visitTupleMake(TupleMake* curr) {
-    for (auto& expr : curr->operands) {
-      noteAny(&expr);
+    for (Index i = 0; i < curr->operands.size(); ++i) {
+      note(&curr->operands[i], VarType{Index(curr->operands.size() - i - 1)});
     }
   }
 
@@ -848,10 +858,7 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
       ht = curr->target->type.getHeapType().getSignature();
     }
     auto params = ht->getSignature().params;
-    assert(curr->operands.size() == params.size());
-    for (size_t i = 0; i < params.size(); ++i) {
-      note(&curr->operands[i], params[i]);
-    }
+    handleCall(curr, params);
     note(&curr->target, Type(*ht, Nullable));
   }
 
@@ -886,7 +893,9 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
       }
       ht = curr->ref->type.getHeapType();
     }
-    note(&curr->ref, Type(*ht, Nullable));
+    // Polymorphic over exactness.
+    assert(!ht->isBasic());
+    note(&curr->ref, VarRef{Nullable, VarDefHeapType{VarExactness{0u}, *ht}});
   }
 
   void visitBrOn(BrOn* curr, std::optional<Type> target = std::nullopt) {
@@ -896,7 +905,8 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
         // br_on(_non)_null is polymorphic over reference types and does not
         // take a type immediate.
         assert(!target);
-        noteAnyReference(&curr->ref);
+        // Polymorphic over heap types.
+        note(&curr->ref, VarRef{Nullable, VarHeapType{0u}});
         return;
       case BrOnCast:
       case BrOnCastFail:
@@ -931,8 +941,7 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
         note(&curr->operands[i], fields[i].type);
       }
     }
-    auto desc = curr->type.getHeapType().getDescriptorType();
-    if (desc) {
+    if (auto desc = curr->type.getHeapType().getDescriptorType()) {
       note(&curr->desc, Type(*desc, NonNullable, Exact));
     }
   }
@@ -992,6 +1001,7 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
     assert(curr->index < fields.size());
     note(&curr->ref, Type(*ht, Nullable));
     auto type = fields[curr->index].type;
+    // TODO: (shared eq) as appropriate.
     note(&curr->expected, type.isRef() ? Type(HeapType::eq, Nullable) : type);
     note(&curr->replacement, type);
   }
@@ -1154,9 +1164,10 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
       }
       ht = curr->ref->type.getHeapType();
     }
-    auto type = ht->getArray().element.type;
+    Type type = ht->getArray().element.type;
     note(&curr->ref, Type(*ht, Nullable));
     note(&curr->index, Type::i32);
+    // TODO: (shared eq) as appropriate.
     note(&curr->expected, type.isRef() ? Type(HeapType::eq, Nullable) : type);
     note(&curr->replacement, type);
   }
@@ -1164,7 +1175,8 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
   void visitRefAs(RefAs* curr) {
     switch (curr->op) {
       case RefAsNonNull:
-        noteAnyReference(&curr->value);
+        // Polymorphic over heap types.
+        note(&curr->value, VarRef{Nullable, VarHeapType{0u}});
         return;
       case AnyConvertExtern:
         note(&curr->value, Type(HeapType::ext, Nullable));
@@ -1200,6 +1212,7 @@ template<typename Subtype> struct ChildTyper : OverriddenVisitor<Subtype> {
   void visitStringConst(StringConst* curr) {}
 
   void visitStringMeasure(StringMeasure* curr) {
+    // TODO: extern instead of string? For other ops as well.
     note(&curr->ref, Type(HeapType::string, Nullable));
   }
 

--- a/src/ir/principal-type.cpp
+++ b/src/ir/principal-type.cpp
@@ -1069,6 +1069,11 @@ std::optional<Signature> PrincipalType::getSignature() const {
   return Signature(sigParams, sigResults);
 }
 
+bool PrincipalType::matches(Type type, VarType constraint) {
+  VarAssignments assignments;
+  return match(assignments, VarType{type}, constraint);
+}
+
 std::ostream& operator<<(std::ostream& o, const PrincipalType& type) {
   print(o, type);
   return o;

--- a/src/ir/principal-type.h
+++ b/src/ir/principal-type.h
@@ -130,6 +130,8 @@ struct PrincipalType {
   // variables.
   std::optional<Signature> getSignature() const;
 
+  static bool matches(Type type, VarType constraint);
+
   bool operator==(const PrincipalType& other) const {
     return rparams == other.rparams && results == other.results &&
            unreachable == other.unreachable;


### PR DESCRIPTION
Refactor ChildTyper to report type constraints using a single callback
that takes a sequence of VarTypes from principal-type.h rather than
using several callbacks for the various kinds of constraints. The
previous approach using several callbacks did not scale well to the
various kinds of polymorphism introduced in new Wasm proposals, such
as polymorphism over sharedness in `ref.eq` or polymorphism over
exactness in `ref.get_desc`.

NFC despite better modeling these contraints because ChildTyper is so
far only used from TypeSSA, which only uses it to look for exact types,
and from IRBuilder, which only uses it to control the construction of
unreachable IR. Follow-on changes will use ChildTyper in new ways that
require this improved precision.
