### PR TITLE
Fuzzer: Fix branching instructions in non-function scopes

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -4342,11 +4342,8 @@ Expression* TranslateToFuzzReader::makeSelect(Type type) {
 
 Expression* TranslateToFuzzReader::makeSwitch(Type type) {
   assert(type == Type::unreachable);
-  if (!funcContext) {
+  if (!funcContext || funcContext->breakableStack.empty()) {
     return makeTrivial(type);
-  }
-  if (funcContext->breakableStack.empty()) {
-    return make(type);
   }
   // we need to find proper targets to break to; try a bunch
   int tries = fuzzParams->TRIES;

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2472,7 +2472,7 @@ Expression* TranslateToFuzzReader::makeTry(Type type) {
 Expression* TranslateToFuzzReader::makeTryTable(Type type) {
   auto* body = make(type);
 
-  if (funcContext->breakableStack.empty()) {
+  if (!funcContext || funcContext->breakableStack.empty()) {
     // Nothing to break to, emit a trivial TryTable.
     // TODO: Perhaps generate a block wrapping us?
     return builder.makeTryTable(body, {}, {}, {});
@@ -2535,7 +2535,7 @@ Expression* TranslateToFuzzReader::makeTryTable(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeBreak(Type type) {
-  if (funcContext->breakableStack.empty()) {
+  if (!funcContext || funcContext->breakableStack.empty()) {
     return makeTrivial(type);
   }
   Expression* condition = nullptr;
@@ -4340,7 +4340,7 @@ Expression* TranslateToFuzzReader::makeSelect(Type type) {
 
 Expression* TranslateToFuzzReader::makeSwitch(Type type) {
   assert(type == Type::unreachable);
-  if (funcContext->breakableStack.empty()) {
+  if (!funcContext || funcContext->breakableStack.empty()) {
     return make(type);
   }
   // we need to find proper targets to break to; try a bunch
@@ -4855,7 +4855,7 @@ Expression* TranslateToFuzzReader::makeRefCast(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeBrOn(Type type) {
-  if (funcContext->breakableStack.empty()) {
+  if (!funcContext || funcContext->breakableStack.empty()) {
     return makeTrivial(type);
   }
   // We need to find a proper target to break to; try a few times. Finding the

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2471,11 +2471,9 @@ Expression* TranslateToFuzzReader::makeTry(Type type) {
 
 Expression* TranslateToFuzzReader::makeTryTable(Type type) {
   auto* body = make(type);
-
   if (!funcContext) {
     return makeTrivial(type);
   }
-
   if (funcContext->breakableStack.empty()) {
     // Nothing to break to, emit a trivial TryTable.
     // TODO: Perhaps generate a block wrapping us?

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2472,7 +2472,11 @@ Expression* TranslateToFuzzReader::makeTry(Type type) {
 Expression* TranslateToFuzzReader::makeTryTable(Type type) {
   auto* body = make(type);
 
-  if (!funcContext || funcContext->breakableStack.empty()) {
+  if (!funcContext) {
+    return makeTrivial(type);
+  }
+
+  if (funcContext->breakableStack.empty()) {
     // Nothing to break to, emit a trivial TryTable.
     // TODO: Perhaps generate a block wrapping us?
     return builder.makeTryTable(body, {}, {}, {});
@@ -4340,7 +4344,10 @@ Expression* TranslateToFuzzReader::makeSelect(Type type) {
 
 Expression* TranslateToFuzzReader::makeSwitch(Type type) {
   assert(type == Type::unreachable);
-  if (!funcContext || funcContext->breakableStack.empty()) {
+  if (!funcContext) {
+    return makeTrivial(type);
+  }
+  if (funcContext->breakableStack.empty()) {
     return make(type);
   }
   // we need to find proper targets to break to; try a bunch


### PR DESCRIPTION
Not sure why this wasn't an issue before, but perhaps we emit more
code in global scopes now?