### PR TITLE
[Stack Switching] Ignore attempts to stash resume info for suspends without a continuation

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -463,11 +463,19 @@ protected:
   // Add an entry to help us resume this continuation later. Instructions call
   // this as we unwind.
   void pushResumeEntry(const Literals& entry, const char* what) {
+    auto currContinuation = getCurrContinuationOrNull();
+    if (!currContinuation) {
+      // We are suspending outside of a continuation. This will trap as an
+      // unhandled suspension when we reach the host, so we don't need to save
+      // any resume entries (it would be simpler to just trap when we suspend in
+      // such a situation, but spec tests want to differentiate traps from
+      // suspends).
+      return;
+    }
 #if WASM_INTERPRETER_DEBUG
     std::cout << indent() << "push resume entry [" << what << "]: " << entry
               << "\n";
 #endif
-    auto currContinuation = getCurrContinuation();
     currContinuation->resumeInfo.push_back(entry);
   }
 

--- a/test/lit/exec/cont_simple.wast
+++ b/test/lit/exec/cont_simple.wast
@@ -864,4 +864,14 @@
     ;; This will be reached.
     (call $log (i32.const 42))
   )
+
+  ;; CHECK:      [fuzz-exec] calling suspend-unhandled-block
+  ;; CHECK-NEXT: [exception thrown: unhandled suspend]
+  (func $suspend-unhandled-block (export "suspend-unhandled-block")
+    ;; The nop here means that we are inside a block. The block will try to save
+    ;; resume data, but we should skip that without erroring, and just report an
+    ;; unhandled suspend.
+    (suspend $more)
+    (nop)
+  )
 )


### PR DESCRIPTION
When there is no continuation (we are not running in one), then a
suspend will lead to a trap on the host side, of "unhandled
suspend". We do need to make sure not to error on the way, so
any attempt to save resume info must be skipped.

Spec tests did not catch this because they did not have an
enclosing block, and the block tries to save resume info.