### PR TITLE
[NFC] Use ParentIndexIterator in SmallVector

### DIFF
--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -24,8 +24,9 @@
 
 #include <array>
 #include <cassert>
-#include <iterator>
 #include <vector>
+
+#include "support/parent_index_iterator.h"
 
 namespace wasm {
 
@@ -183,63 +184,28 @@ public:
 
   // iteration
 
-  template<typename Parent, typename Iterator> struct IteratorBase {
-    // TODO: Add remaining things from
-    //       https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
-    using iterator_category = std::random_access_iterator_tag;
+  struct Iterator : ParentIndexIterator<SmallVector<T, N>*, Iterator> {
     using value_type = T;
-    using difference_type = long;
-    using reference = T&;
     using pointer = T*;
+    using reference = T&;
 
-    Parent* parent;
-    size_t index;
-
-    IteratorBase(Parent* parent, size_t index) : parent(parent), index(index) {}
-
-    bool operator!=(const Iterator& other) const {
-      return index != other.index || parent != other.parent;
-    }
-
-    Iterator& operator++() {
-      Iterator& self = *static_cast<Iterator*>(this);
-      index++;
-      return self;
-    }
-    Iterator operator++(int) {
-      Iterator self = *static_cast<Iterator*>(this);
-      index++;
-      return self;
-    }
-
-    Iterator& operator+=(difference_type off) {
-      index += off;
-      return *this;
-    }
-
-    const Iterator operator+(difference_type off) const {
-      return Iterator(*this) += off;
-    }
-
-    difference_type operator-(const Iterator& other) const {
-      return index - other.index;
-    }
-
-    bool operator==(const Iterator& other) const {
-      return parent == other.parent && index == other.index;
-    }
-  };
-
-  struct Iterator : IteratorBase<SmallVector<T, N>, Iterator> {
     Iterator(SmallVector<T, N>* parent, size_t index)
-      : IteratorBase<SmallVector<T, N>, Iterator>(parent, index) {}
-    value_type& operator*() { return (*this->parent)[this->index]; }
+      : ParentIndexIterator<SmallVector<T, N>*, Iterator>{parent, index} {}
+
+    T& operator*() { return (*this->parent)[this->index]; }
   };
 
-  struct ConstIterator : IteratorBase<const SmallVector<T, N>, ConstIterator> {
+  struct ConstIterator
+    : ParentIndexIterator<const SmallVector<T, N>*, ConstIterator> {
+    using value_type = const T;
+    using pointer = const T*;
+    using reference = const T&;
+
     ConstIterator(const SmallVector<T, N>* parent, size_t index)
-      : IteratorBase<const SmallVector<T, N>, ConstIterator>(parent, index) {}
-    const value_type& operator*() const { return (*this->parent)[this->index]; }
+      : ParentIndexIterator<const SmallVector<T, N>*, ConstIterator>{parent,
+                                                                     index} {}
+
+    const T& operator*() const { return (*this->parent)[this->index]; }
   };
 
   Iterator begin() { return Iterator(this, 0); }


### PR DESCRIPTION
SmallVector previously (partially) implemented its own random access
iterators using a pointer to the parent SmallVector and an index, but
ParentIndexIterator is a more complete implementation of the same
iterator design. Reduce duplication and fix missing iterator
functionality by using ParentIndexIterator.
