### PR TITLE
Disable stack switching when GC is disabled in the fuzzer

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2403,7 +2403,7 @@ print('FEATURE_DISABLE_FLAGS:', FEATURE_DISABLE_FLAGS)
 # disabled, its dependent features need to be disabled as well.
 IMPLIED_FEATURE_OPTS = {
     '--disable-reference-types': ['--disable-gc', '--disable-exception-handling', '--disable-strings'],
-    '--disable-gc': ['--disable-strings'],
+    '--disable-gc': ['--disable-strings', '--disable-stack-switching'],
 }
 
 print('''


### PR DESCRIPTION
Stack switching depends on part of GC, at least atm.

See

https://github.com/WebAssembly/binaryen/pull/7827#discussion_r2277970620