### PR TITLE
[Custom Descriptors] Fix TypeMerging sibling criteria

### DIFF
--- a/test/lit/passes/type-merging-desc.wast
+++ b/test/lit/passes/type-merging-desc.wast
@@ -307,23 +307,6 @@
 )
 
 (module
-  ;; We can merge the $B chain into the $A chain, but we cannot merge in the
-  ;; other direction because that would make $B.desc its own subtype.
-  (rec
-    ;; CHECK:      (rec
-    ;; CHECK-NEXT:  (type $A (sub (descriptor $A.desc (struct))))
-    (type $A (sub (descriptor $A.desc (struct))))
-    ;; CHECK:       (type $A.desc (sub (describes $A (struct))))
-    (type $A.desc (sub (describes $A (struct))))
-    (type $B (sub (descriptor $B.desc (struct))))
-    (type $B.desc (sub $A.desc (describes $B (struct))))
-  )
-
-  ;; CHECK:      (global $B.desc (ref null $A.desc) (ref.null none))
-  (global $B.desc (ref null $B.desc) (ref.null none))
-)
-
-(module
   ;; CHECK:      (type $public (sub (struct)))
   (type $public (sub (struct)))
 
@@ -367,4 +350,60 @@
 
   ;; CHECK:      (export "public" (global $public))
   (export "public" (global $public))
+)
+
+(module
+  ;; In principle we could merge the $B chain into the $A chain, because $A and
+  ;; $B are mergeable as siblings and $B.desc is mergeable into its supertype
+  ;; A.desc. However we do not currently do this kind of merge in either phase.
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $A (sub (descriptor $A.desc (struct))))
+    (type $A (sub (descriptor $A.desc (struct))))
+    ;; CHECK:       (type $A.desc (sub (describes $A (struct))))
+    (type $A.desc (sub (describes $A (struct))))
+    ;; CHECK:       (type $B (sub (descriptor $B.desc (struct))))
+    (type $B (sub (descriptor $B.desc (struct))))
+    ;; CHECK:       (type $B.desc (sub $A.desc (describes $B (struct))))
+    (type $B.desc (sub $A.desc (describes $B (struct))))
+  )
+
+  ;; CHECK:      (global $B.desc (ref null $B.desc) (ref.null none))
+  (global $B.desc (ref null $B.desc) (ref.null none))
+)
+
+(module
+  (rec
+    ;; Like above, but now we have an unrelated C chain. We have these chains:
+    ;;
+    ;; A -> A.desc
+    ;;        ^
+    ;; B -> B.desc
+    ;;
+    ;; C -> C.desc
+    ;;
+    ;; The C chain should not be considered a sibling of the B chain because
+    ;; C.desc is not a subtype of A.desc, even though they would look like
+    ;; siblings if you only considered the base type in the chain.
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $A (descriptor $A.desc (struct)))
+    (type $A (descriptor $A.desc (struct)))
+    ;; CHECK:       (type $A.desc (sub (describes $A (struct))))
+    (type $A.desc (sub (describes $A (struct))))
+    ;; CHECK:       (type $B (descriptor $B.desc (struct)))
+    (type $B (descriptor $B.desc (struct)))
+    ;; CHECK:       (type $B.desc (sub $A.desc (describes $B (struct))))
+    (type $B.desc (sub $A.desc (describes $B (struct))))
+    ;; CHECK:       (type $C (descriptor $C.desc (struct)))
+    (type $C (descriptor $C.desc (struct)))
+    ;; CHECK:       (type $C.desc (describes $C (struct)))
+    (type $C.desc (describes $C (struct)))
+  )
+
+  ;; CHECK:      (global $C (ref null $C) (ref.null none))
+  (global $C (ref null $C) (ref.null none))
+
+  ;; This would become invalid if $B.desc were merged into $C.desc.
+  ;; CHECK:      (global $A.desc (ref null $A.desc) (struct.new_default $B.desc))
+  (global $A.desc (ref null $A.desc) (struct.new_default $B.desc))
 )


### PR DESCRIPTION
When merging sibling types, we must first partition the types by their
supertypes and shapes. With custom descriptors, we consider full
descriptor chains as single units to be merged. We had updated the shape
partitioning to account for this, but not the supertype partitioning. As
a result, we were incorrectly merging chains with different descriptor
supertypes as long as the base described types had no supertype.

Fix the bug by partitioning not just on the base described type's
supertype, but the sequence of all supertypes in the chain.
