### PR TITLE
Print tables for call_indirects for nonzero table index

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -504,7 +504,7 @@ struct PrintExpressionContents
     }
 
     // Even if reference-types is not enabled because the features section or
-    // the matching command-line flags are not present, , if the table index is
+    // the matching command-line flags are not present, if the table index is
     // greater than 0, we print the table because otherwise the results will be
     // incorrect.
     if (features.hasReferenceTypes() ||

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -503,7 +503,13 @@ struct PrintExpressionContents
       printMedium(o, "call_indirect ");
     }
 
-    if (features.hasReferenceTypes()) {
+    // Even if reference-types is not enabled because the features section or
+    // the matching command-line flags are not present, , if the table index is
+    // greater than 0, we print the table because otherwise the results will be
+    // incorrect.
+    if (features.hasReferenceTypes() ||
+        (wasm && !wasm->tables.empty() &&
+         wasm->tables[0]->name != curr->table)) {
       curr->table.print(o);
       o << ' ';
     }


### PR DESCRIPTION
Rather than always printing the table like in #7839, this prints the table only when either reference types is enabled or the table index is not 0 (even if the features section or `--enable-reference-types` is not provided)

This addresses the concern in #7802, while not printing table when it is not necessary.

There is no test changes because
- At the moment wasm-dis enables all features so wasm-dis always prints tables in `call_indirect`s. This will change in #7840.
- wasm-opt results didn't print table so far when reference-types is not enabled, and all `call_indirect`s in those tests have table index 0.