### PR TITLE
wasm-merge: Avoid quadratic time in validatoin

### DIFF
--- a/src/tools/wasm-merge.cpp
+++ b/src/tools/wasm-merge.cpp
@@ -490,13 +490,14 @@ void fuseImportsAndExports(const PassOptions& options) {
         if (export_->type != import->type) {
           reportTypeMismatch(valid, "table", import);
           std::cerr << "export type " << export_->type
-                    << " is different from import type " << import->type << ".\n";
+                    << " is different from import type " << import->type
+                    << ".\n";
         }
       }
     });
     ModuleUtils::iterImportedMemories(merged, [&](Memory* import) {
-      auto internalName =
-        kindModuleExportMaps[ExternalKind::Memory][import->module][import->base];
+      auto internalName = kindModuleExportMaps[ExternalKind::Memory]
+                                              [import->module][import->base];
       if (internalName.is()) {
         auto* export_ = merged.getMemory(internalName);
         if (export_->is64() != import->is64()) {
@@ -507,8 +508,8 @@ void fuseImportsAndExports(const PassOptions& options) {
       }
     });
     ModuleUtils::iterImportedGlobals(merged, [&](Global* import) {
-      auto internalName =
-        kindModuleExportMaps[ExternalKind::Global][import->module][import->base];
+      auto internalName = kindModuleExportMaps[ExternalKind::Global]
+                                              [import->module][import->base];
       if (internalName.is()) {
         auto* export_ = merged.getGlobal(internalName);
         if (export_->mutable_ != import->mutable_) {
@@ -518,9 +519,11 @@ void fuseImportsAndExports(const PassOptions& options) {
         if (export_->mutable_ && export_->type != import->type) {
           reportTypeMismatch(valid, "global", import);
           std::cerr << "export type " << export_->type
-                    << " is different from import type " << import->type << ".\n";
+                    << " is different from import type " << import->type
+                    << ".\n";
         }
-        if (!export_->mutable_ && !Type::isSubType(export_->type, import->type)) {
+        if (!export_->mutable_ &&
+            !Type::isSubType(export_->type, import->type)) {
           reportTypeMismatch(valid, "global", import);
           std::cerr << "type " << export_->type << " is not a subtype of "
                     << import->type << ".\n";
@@ -535,7 +538,8 @@ void fuseImportsAndExports(const PassOptions& options) {
         if (export_->type != import->type) {
           reportTypeMismatch(valid, "tag", import);
           std::cerr << "export type " << export_->type
-                    << " is different from import type " << import->type << ".\n";
+                    << " is different from import type " << import->type
+                    << ".\n";
         }
       }
     });


### PR DESCRIPTION
The actual merging logic in `wasm-merge` is careful to run in linear time
(since #5709). However, validation could actually be quadratic, since we do
it after each module that we merge in. Since we validate by default, this
made `wasm-merge` very slow sometimes.

To fix that, validate by default once at the very end. When in pass-debug
mode, which validates after each pass, validate after each module (so we
keep the option for precise debugging of problems).

On a large testcase I am investigating (350 modules, 41 MB wasm after
merge), this makes us go from 5 minutes down to just 19 seconds. With
`--no-validation`, we drop to 17. (That final number is about how long it
takes to run `wasm-opt` 350 times to round-trip each of those modules,
so it is shows `wasm-merge`'s merging is very fast.)

Actual diff is quite small, read without whitespace to avoid noise.
