### PR TITLE
[NFC] Use some C macros to reduce boilerplate in wasm-interpreter.h

### DIFF
--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -278,8 +278,8 @@ protected:
   }
 
   // As above, but reuse an existing |flow|.
-#define VISIT_REUSE(flow, expr)                                                      \
-  flow = self()->visit(expr);                                             \
+#define VISIT_REUSE(flow, expr)                                                \
+  flow = self()->visit(expr);                                                  \
   if (flow.breaking()) {                                                       \
     return flow;                                                               \
   }

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -270,8 +270,16 @@ protected:
   // Maximum iterations before giving up on a loop.
   Index maxLoopIterations;
 
+  // Helper for visiting: Visit and handle breaking.
 #define VISIT(flow, expr)                                                      \
   Flow flow = self()->visit(expr);                                             \
+  if (flow.breaking()) {                                                       \
+    return flow;                                                               \
+  }
+
+  // As above, but reuse an existing |flow|.
+#define VISIT_REUSE(flow, expr)                                                      \
+  flow = self()->visit(expr);                                             \
   if (flow.breaking()) {                                                       \
     return flow;                                                               \
   }
@@ -285,6 +293,7 @@ protected:
     return Flow();
   }
 
+  // As above, but for generateArguments.
 #define VISIT_ARGUMENTS(flow, operands, arguments)                             \
   Flow flow = self()->generateArguments(operands, arguments);                  \
   if (flow.breaking()) {                                                       \

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -270,10 +270,10 @@ protected:
   // Maximum iterations before giving up on a loop.
   Index maxLoopIterations;
 
-#define VISIT(flow, expr) \
-  Flow flow = self()->visit(expr); \
-  if (flow.breaking()) { \
-    return flow; \
+#define VISIT(flow, expr)                                                      \
+  Flow flow = self()->visit(expr);                                             \
+  if (flow.breaking()) {                                                       \
+    return flow;                                                               \
   }
 
   Flow generateArguments(const ExpressionList& operands, Literals& arguments) {
@@ -4915,4 +4915,3 @@ public:
 } // namespace wasm
 
 #endif // wasm_wasm_interpreter_h
-


### PR DESCRIPTION
Removes 447 lines (9%)