### PR TITLE
[GC] Precompute: Fix ref.eq comparisons of structs with nested effects

### DIFF
--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -79,7 +79,8 @@ struct HeapValues {
   // precomputed), and we do not want to mix results between the two modes (if
   // we did, we might cache a result when we ignore effects that we later use
   // when not ignoring them, which would forget the effects).
-  std::unordered_map<Expression*, std::shared_ptr<GCData>> withEffects, withoutEffects;
+  std::unordered_map<Expression*, std::shared_ptr<GCData>> withEffects,
+    withoutEffects;
 
   void clear() {
     withEffects.clear();
@@ -201,7 +202,9 @@ public:
 
   // Generates heap info for a heap-allocating expression.
   Flow getGCAllocation(Expression* curr, std::function<Flow()> visitFunc) {
-    auto& heapValuesMap = (flags & FlagValues::PRESERVE_SIDEEFFECTS) ? heapValues.withEffects : heapValues.withoutEffects;
+    auto& heapValuesMap = (flags & FlagValues::PRESERVE_SIDEEFFECTS)
+                            ? heapValues.withEffects
+                            : heapValues.withoutEffects;
     // We must return a literal that refers to the canonical location for this
     // source expression, so that each time we compute a specific *.new then
     // we get the same identity.

--- a/src/passes/Precompute.cpp
+++ b/src/passes/Precompute.cpp
@@ -79,8 +79,7 @@ struct HeapValues {
   // precomputed), and we do not want to mix results between the two modes (if
   // we did, we might cache a result when we ignore effects that we later use
   // when not ignoring them, which would forget the effects).
-  std::unordered_map<Expression*, std::shared_ptr<GCData>> withEffects,
-    withoutEffects;
+  std::unordered_map<Expression*, std::shared_ptr<GCData>> withEffects, withoutEffects;
 
   void clear() {
     withEffects.clear();
@@ -202,9 +201,7 @@ public:
 
   // Generates heap info for a heap-allocating expression.
   Flow getGCAllocation(Expression* curr, std::function<Flow()> visitFunc) {
-    auto& heapValuesMap = (flags & FlagValues::PRESERVE_SIDEEFFECTS)
-                            ? heapValues.withEffects
-                            : heapValues.withoutEffects;
+    auto& heapValuesMap = (flags & FlagValues::PRESERVE_SIDEEFFECTS) ? heapValues.withEffects : heapValues.withoutEffects;
     // We must return a literal that refers to the canonical location for this
     // source expression, so that each time we compute a specific *.new then
     // we get the same identity.

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -13,9 +13,13 @@
  ;; two incompatible struct types
  (type $A (struct (field (mut f32))))
 
+ ;; type that referes to another
  ;; CHECK:      (type $func-return-i32 (func (result i32)))
 
  ;; CHECK:      (type $array-i32 (array (mut i32)))
+
+ ;; CHECK:      (type $referrer (struct (field (mut (ref null $empty)))))
+ (type $referrer (struct (field (mut (ref null $empty)))))
 
  ;; CHECK:      (type $B (struct (field (mut f64))))
  (type $B (struct (field (mut f64))))
@@ -175,7 +179,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $modify-gc-heap (type $6) (param $x (ref null $struct))
+ ;; CHECK:      (func $modify-gc-heap (type $7) (param $x (ref null $struct))
  ;; CHECK-NEXT:  (struct.set $struct 0
  ;; CHECK-NEXT:   (local.get $x)
  ;; CHECK-NEXT:   (i32.add
@@ -229,7 +233,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $load-from-struct-bad-arrive (type $6) (param $x (ref null $struct))
+ ;; CHECK:      (func $load-from-struct-bad-arrive (type $7) (param $x (ref null $struct))
  ;; CHECK-NEXT:  (call $log
  ;; CHECK-NEXT:   (struct.get $struct 0
  ;; CHECK-NEXT:    (local.get $x)
@@ -242,7 +246,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $ref-comparisons (type $12) (param $x (ref null $struct)) (param $y (ref null $struct))
+ ;; CHECK:      (func $ref-comparisons (type $13) (param $x (ref null $struct)) (param $y (ref null $struct))
  ;; CHECK-NEXT:  (local $z (ref null $struct))
  ;; CHECK-NEXT:  (local $w (ref null $struct))
  ;; CHECK-NEXT:  (call $log
@@ -395,7 +399,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-uncertain-param (type $7) (param $input (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-uncertain-param (type $8) (param $input (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local $tempref (ref null $empty))
  ;; CHECK-NEXT:  (local.set $tempresult
@@ -420,7 +424,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-different-params (type $13) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-different-params (type $14) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -442,7 +446,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-same-param (type $7) (param $input (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-same-param (type $8) (param $input (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -744,7 +748,7 @@
   )
  )
 
- ;; CHECK:      (func $helper (type $14) (param $0 i32) (result i32)
+ ;; CHECK:      (func $helper (type $15) (param $0 i32) (result i32)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $helper (param i32) (result i32)
@@ -822,14 +826,14 @@
   )
  )
 
- ;; CHECK:      (func $receive-f64 (type $15) (param $0 f64)
+ ;; CHECK:      (func $receive-f64 (type $16) (param $0 f64)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $receive-f64 (param f64)
   (unreachable)
  )
 
- ;; CHECK:      (func $odd-cast-and-get-non-null (type $16) (param $temp (ref $func-return-i32))
+ ;; CHECK:      (func $odd-cast-and-get-non-null (type $17) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.cast (ref nofunc)
  ;; CHECK-NEXT:    (ref.func $receive-f64)
@@ -857,7 +861,7 @@
   )
  )
 
- ;; CHECK:      (func $new_block_unreachable (type $9) (result anyref)
+ ;; CHECK:      (func $new_block_unreachable (type $10) (result anyref)
  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block
@@ -878,7 +882,7 @@
   )
  )
 
- ;; CHECK:      (func $br_on_cast-on-creation (type $17) (result (ref $empty))
+ ;; CHECK:      (func $br_on_cast-on-creation (type $18) (result (ref $empty))
  ;; CHECK-NEXT:  (block $label (result (ref (exact $empty)))
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (br_on_cast $label (ref (exact $empty)) (ref (exact $empty))
@@ -977,7 +981,7 @@
   )
  )
 
- ;; CHECK:      (func $remove-set (type $18) (result (ref func))
+ ;; CHECK:      (func $remove-set (type $19) (result (ref func))
  ;; CHECK-NEXT:  (local $nn funcref)
  ;; CHECK-NEXT:  (local $i i32)
  ;; CHECK-NEXT:  (loop $loop
@@ -1020,7 +1024,7 @@
   )
  )
 
- ;; CHECK:      (func $strings (type $19) (param $param (ref string))
+ ;; CHECK:      (func $strings (type $20) (param $param (ref string))
  ;; CHECK-NEXT:  (local $s (ref string))
  ;; CHECK-NEXT:  (local.set $s
  ;; CHECK-NEXT:   (string.const "hello, world")
@@ -1059,7 +1063,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable (type $9) (result anyref)
+ ;; CHECK:      (func $get-nonnullable-in-unreachable (type $10) (result anyref)
  ;; CHECK-NEXT:  (local $x (ref any))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
@@ -1096,7 +1100,7 @@
   (local.get $x)
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $10) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $11) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (local.set $0
@@ -1130,7 +1134,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $10) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $11) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (local.get $x)
@@ -1175,7 +1179,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $20) (result anyref i32)
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $21) (result anyref i32)
  ;; CHECK-NEXT:  (local $x (tuple (ref any) i32))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
@@ -1281,5 +1285,56 @@
    )
   )
  )
-)
 
+ ;; CHECK:      (func $nested-struct-ref.eq (type $2)
+ ;; CHECK-NEXT:  (local $A (ref $referrer))
+ ;; CHECK-NEXT:  (local $B (ref $empty))
+ ;; CHECK-NEXT:  (local $A2 (ref $referrer))
+ ;; CHECK-NEXT:  (local $temp i32)
+ ;; CHECK-NEXT:  (local.set $A2
+ ;; CHECK-NEXT:   (local.tee $A
+ ;; CHECK-NEXT:    (struct.new $referrer
+ ;; CHECK-NEXT:     (local.tee $B
+ ;; CHECK-NEXT:      (struct.new_default $empty)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $nested-struct-ref.eq
+  (local $A (ref $referrer))
+  (local $B (ref $empty))
+  (local $A2 (ref $referrer))
+  (local $temp i32)
+  ;; Create $A, and copy to $A2.
+  (local.set $A2
+   (local.tee $A
+    (struct.new $referrer
+     (local.tee $B
+      (struct.new_default $empty)
+     )
+    )
+   )
+  )
+  ;; They should be equal, so this can be 1.
+  (local.set $temp
+   (ref.eq
+    (local.get $A)
+    (local.get $A2)
+   )
+  )
+  ;; $A and $B are of course different.
+  (local.set $temp
+   (ref.eq
+    (local.get $A)
+    (local.get $B)
+   )
+  )
+ )
+)

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -13,12 +13,12 @@
  ;; two incompatible struct types
  (type $A (struct (field (mut f32))))
 
- ;; type that referes to another
- (type $referrer (struct (field (mut (ref null $empty)))))
-
  ;; CHECK:      (type $func-return-i32 (func (result i32)))
 
  ;; CHECK:      (type $array-i32 (array (mut i32)))
+
+ ;; CHECK:      (type $referrer (struct (field (mut (ref null $empty)))))
+ (type $referrer (struct (field (mut (ref null $empty)))))
 
  ;; CHECK:      (type $B (struct (field (mut f64))))
  (type $B (struct (field (mut f64))))
@@ -178,7 +178,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $modify-gc-heap (type $6) (param $x (ref null $struct))
+ ;; CHECK:      (func $modify-gc-heap (type $7) (param $x (ref null $struct))
  ;; CHECK-NEXT:  (struct.set $struct 0
  ;; CHECK-NEXT:   (local.get $x)
  ;; CHECK-NEXT:   (i32.add
@@ -232,7 +232,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $load-from-struct-bad-arrive (type $6) (param $x (ref null $struct))
+ ;; CHECK:      (func $load-from-struct-bad-arrive (type $7) (param $x (ref null $struct))
  ;; CHECK-NEXT:  (call $log
  ;; CHECK-NEXT:   (struct.get $struct 0
  ;; CHECK-NEXT:    (local.get $x)
@@ -245,7 +245,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $ref-comparisons (type $12) (param $x (ref null $struct)) (param $y (ref null $struct))
+ ;; CHECK:      (func $ref-comparisons (type $13) (param $x (ref null $struct)) (param $y (ref null $struct))
  ;; CHECK-NEXT:  (local $z (ref null $struct))
  ;; CHECK-NEXT:  (local $w (ref null $struct))
  ;; CHECK-NEXT:  (call $log
@@ -398,7 +398,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-uncertain-param (type $7) (param $input (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-uncertain-param (type $8) (param $input (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local $tempref (ref null $empty))
  ;; CHECK-NEXT:  (local.set $tempresult
@@ -423,7 +423,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-different-params (type $13) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-different-params (type $14) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -445,7 +445,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-same-param (type $7) (param $input (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-same-param (type $8) (param $input (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -747,7 +747,7 @@
   )
  )
 
- ;; CHECK:      (func $helper (type $14) (param $0 i32) (result i32)
+ ;; CHECK:      (func $helper (type $15) (param $0 i32) (result i32)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $helper (param i32) (result i32)
@@ -825,14 +825,14 @@
   )
  )
 
- ;; CHECK:      (func $receive-f64 (type $15) (param $0 f64)
+ ;; CHECK:      (func $receive-f64 (type $16) (param $0 f64)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $receive-f64 (param f64)
   (unreachable)
  )
 
- ;; CHECK:      (func $odd-cast-and-get-non-null (type $16) (param $temp (ref $func-return-i32))
+ ;; CHECK:      (func $odd-cast-and-get-non-null (type $17) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.cast (ref nofunc)
  ;; CHECK-NEXT:    (ref.func $receive-f64)
@@ -860,7 +860,7 @@
   )
  )
 
- ;; CHECK:      (func $new_block_unreachable (type $9) (result anyref)
+ ;; CHECK:      (func $new_block_unreachable (type $10) (result anyref)
  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block
@@ -881,7 +881,7 @@
   )
  )
 
- ;; CHECK:      (func $br_on_cast-on-creation (type $17) (result (ref $empty))
+ ;; CHECK:      (func $br_on_cast-on-creation (type $18) (result (ref $empty))
  ;; CHECK-NEXT:  (block $label (result (ref (exact $empty)))
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (br_on_cast $label (ref (exact $empty)) (ref (exact $empty))
@@ -980,7 +980,7 @@
   )
  )
 
- ;; CHECK:      (func $remove-set (type $18) (result (ref func))
+ ;; CHECK:      (func $remove-set (type $19) (result (ref func))
  ;; CHECK-NEXT:  (local $nn funcref)
  ;; CHECK-NEXT:  (local $i i32)
  ;; CHECK-NEXT:  (loop $loop
@@ -1023,7 +1023,7 @@
   )
  )
 
- ;; CHECK:      (func $strings (type $19) (param $param (ref string))
+ ;; CHECK:      (func $strings (type $20) (param $param (ref string))
  ;; CHECK-NEXT:  (local $s (ref string))
  ;; CHECK-NEXT:  (local.set $s
  ;; CHECK-NEXT:   (string.const "hello, world")
@@ -1062,7 +1062,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable (type $9) (result anyref)
+ ;; CHECK:      (func $get-nonnullable-in-unreachable (type $10) (result anyref)
  ;; CHECK-NEXT:  (local $x (ref any))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
@@ -1099,7 +1099,7 @@
   (local.get $x)
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $10) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $11) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (local.set $0
@@ -1133,7 +1133,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $10) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $11) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (local.get $x)
@@ -1178,7 +1178,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $20) (result anyref i32)
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $21) (result anyref i32)
  ;; CHECK-NEXT:  (local $x (tuple (ref any) i32))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
@@ -1285,6 +1285,27 @@
   )
  )
 
+ ;; CHECK:      (func $nested-struct-ref.eq (type $2)
+ ;; CHECK-NEXT:  (local $A (ref $referrer))
+ ;; CHECK-NEXT:  (local $B (ref $empty))
+ ;; CHECK-NEXT:  (local $A2 (ref $referrer))
+ ;; CHECK-NEXT:  (local $temp i32)
+ ;; CHECK-NEXT:  (local.set $A2
+ ;; CHECK-NEXT:   (local.tee $A
+ ;; CHECK-NEXT:    (struct.new $referrer
+ ;; CHECK-NEXT:     (local.tee $B
+ ;; CHECK-NEXT:      (struct.new_default $empty)
+ ;; CHECK-NEXT:     )
+ ;; CHECK-NEXT:    )
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (i32.const 1)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (local.set $temp
+ ;; CHECK-NEXT:   (i32.const 0)
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
  (func $nested-struct-ref.eq
   (local $A (ref $referrer))
   (local $B (ref $empty))

--- a/test/lit/passes/precompute-gc.wast
+++ b/test/lit/passes/precompute-gc.wast
@@ -14,12 +14,11 @@
  (type $A (struct (field (mut f32))))
 
  ;; type that referes to another
+ (type $referrer (struct (field (mut (ref null $empty)))))
+
  ;; CHECK:      (type $func-return-i32 (func (result i32)))
 
  ;; CHECK:      (type $array-i32 (array (mut i32)))
-
- ;; CHECK:      (type $referrer (struct (field (mut (ref null $empty)))))
- (type $referrer (struct (field (mut (ref null $empty)))))
 
  ;; CHECK:      (type $B (struct (field (mut f64))))
  (type $B (struct (field (mut f64))))
@@ -179,7 +178,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $modify-gc-heap (type $7) (param $x (ref null $struct))
+ ;; CHECK:      (func $modify-gc-heap (type $6) (param $x (ref null $struct))
  ;; CHECK-NEXT:  (struct.set $struct 0
  ;; CHECK-NEXT:   (local.get $x)
  ;; CHECK-NEXT:   (i32.add
@@ -233,7 +232,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $load-from-struct-bad-arrive (type $7) (param $x (ref null $struct))
+ ;; CHECK:      (func $load-from-struct-bad-arrive (type $6) (param $x (ref null $struct))
  ;; CHECK-NEXT:  (call $log
  ;; CHECK-NEXT:   (struct.get $struct 0
  ;; CHECK-NEXT:    (local.get $x)
@@ -246,7 +245,7 @@
    (struct.get $struct 0 (local.get $x))
   )
  )
- ;; CHECK:      (func $ref-comparisons (type $13) (param $x (ref null $struct)) (param $y (ref null $struct))
+ ;; CHECK:      (func $ref-comparisons (type $12) (param $x (ref null $struct)) (param $y (ref null $struct))
  ;; CHECK-NEXT:  (local $z (ref null $struct))
  ;; CHECK-NEXT:  (local $w (ref null $struct))
  ;; CHECK-NEXT:  (call $log
@@ -399,7 +398,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-uncertain-param (type $8) (param $input (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-uncertain-param (type $7) (param $input (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local $tempref (ref null $empty))
  ;; CHECK-NEXT:  (local.set $tempresult
@@ -424,7 +423,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-different-params (type $14) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-different-params (type $13) (param $input1 (ref $empty)) (param $input2 (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -446,7 +445,7 @@
   (local.get $tempresult)
  )
 
- ;; CHECK:      (func $propagate-same-param (type $8) (param $input (ref $empty)) (result i32)
+ ;; CHECK:      (func $propagate-same-param (type $7) (param $input (ref $empty)) (result i32)
  ;; CHECK-NEXT:  (local $tempresult i32)
  ;; CHECK-NEXT:  (local.set $tempresult
  ;; CHECK-NEXT:   (ref.eq
@@ -748,7 +747,7 @@
   )
  )
 
- ;; CHECK:      (func $helper (type $15) (param $0 i32) (result i32)
+ ;; CHECK:      (func $helper (type $14) (param $0 i32) (result i32)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $helper (param i32) (result i32)
@@ -826,14 +825,14 @@
   )
  )
 
- ;; CHECK:      (func $receive-f64 (type $16) (param $0 f64)
+ ;; CHECK:      (func $receive-f64 (type $15) (param $0 f64)
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT: )
  (func $receive-f64 (param f64)
   (unreachable)
  )
 
- ;; CHECK:      (func $odd-cast-and-get-non-null (type $17) (param $temp (ref $func-return-i32))
+ ;; CHECK:      (func $odd-cast-and-get-non-null (type $16) (param $temp (ref $func-return-i32))
  ;; CHECK-NEXT:  (local.set $temp
  ;; CHECK-NEXT:   (ref.cast (ref nofunc)
  ;; CHECK-NEXT:    (ref.func $receive-f64)
@@ -861,7 +860,7 @@
   )
  )
 
- ;; CHECK:      (func $new_block_unreachable (type $10) (result anyref)
+ ;; CHECK:      (func $new_block_unreachable (type $9) (result anyref)
  ;; CHECK-NEXT:  (block ;; (replaces unreachable StructNew we can't emit)
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (block
@@ -882,7 +881,7 @@
   )
  )
 
- ;; CHECK:      (func $br_on_cast-on-creation (type $18) (result (ref $empty))
+ ;; CHECK:      (func $br_on_cast-on-creation (type $17) (result (ref $empty))
  ;; CHECK-NEXT:  (block $label (result (ref (exact $empty)))
  ;; CHECK-NEXT:   (drop
  ;; CHECK-NEXT:    (br_on_cast $label (ref (exact $empty)) (ref (exact $empty))
@@ -981,7 +980,7 @@
   )
  )
 
- ;; CHECK:      (func $remove-set (type $19) (result (ref func))
+ ;; CHECK:      (func $remove-set (type $18) (result (ref func))
  ;; CHECK-NEXT:  (local $nn funcref)
  ;; CHECK-NEXT:  (local $i i32)
  ;; CHECK-NEXT:  (loop $loop
@@ -1024,7 +1023,7 @@
   )
  )
 
- ;; CHECK:      (func $strings (type $20) (param $param (ref string))
+ ;; CHECK:      (func $strings (type $19) (param $param (ref string))
  ;; CHECK-NEXT:  (local $s (ref string))
  ;; CHECK-NEXT:  (local.set $s
  ;; CHECK-NEXT:   (string.const "hello, world")
@@ -1063,7 +1062,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable (type $10) (result anyref)
+ ;; CHECK:      (func $get-nonnullable-in-unreachable (type $9) (result anyref)
  ;; CHECK-NEXT:  (local $x (ref any))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
@@ -1100,7 +1099,7 @@
   (local.get $x)
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $11) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-entry (type $10) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (unreachable)
  ;; CHECK-NEXT:  (local.set $0
@@ -1134,7 +1133,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $11) (param $x i32) (param $y (ref any))
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-later-loop (type $10) (param $x i32) (param $y (ref any))
  ;; CHECK-NEXT:  (local $0 (ref any))
  ;; CHECK-NEXT:  (if
  ;; CHECK-NEXT:   (local.get $x)
@@ -1179,7 +1178,7 @@
   )
  )
 
- ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $21) (result anyref i32)
+ ;; CHECK:      (func $get-nonnullable-in-unreachable-tuple (type $20) (result anyref i32)
  ;; CHECK-NEXT:  (local $x (tuple (ref any) i32))
  ;; CHECK-NEXT:  (local.tee $x
  ;; CHECK-NEXT:   (unreachable)
@@ -1286,27 +1285,6 @@
   )
  )
 
- ;; CHECK:      (func $nested-struct-ref.eq (type $2)
- ;; CHECK-NEXT:  (local $A (ref $referrer))
- ;; CHECK-NEXT:  (local $B (ref $empty))
- ;; CHECK-NEXT:  (local $A2 (ref $referrer))
- ;; CHECK-NEXT:  (local $temp i32)
- ;; CHECK-NEXT:  (local.set $A2
- ;; CHECK-NEXT:   (local.tee $A
- ;; CHECK-NEXT:    (struct.new $referrer
- ;; CHECK-NEXT:     (local.tee $B
- ;; CHECK-NEXT:      (struct.new_default $empty)
- ;; CHECK-NEXT:     )
- ;; CHECK-NEXT:    )
- ;; CHECK-NEXT:   )
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (i32.const 1)
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (local.set $temp
- ;; CHECK-NEXT:   (i32.const 0)
- ;; CHECK-NEXT:  )
- ;; CHECK-NEXT: )
  (func $nested-struct-ref.eq
   (local $A (ref $referrer))
   (local $B (ref $empty))


### PR DESCRIPTION
In the testcase here, the nested `tee` make the outer struct not precomputable
when we care about effects (`tee` is an effect). But we could precompute it
otherwise, and that ended up causing confusion, with no caching being done
of the canonical allocation for it, meaning each time we scanned it we saw
another struct, different in identity.

To fix this, implement the TODO to cache in both modes. I thought that would
be useful only for speed, but turns out it is necessary for correctness. Luckily
doing so is quite simple.