### PR TITLE
[NFC] Share the "simple combinable bool" logic among StructValues users

### DIFF
--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -39,7 +39,7 @@ struct CombinableBool {
 
   operator bool() const { return value; }
 
-  bool combine(const DescriptorInfo& other) {
+  bool combine(const CombinableBool& other) {
     if (!value && other.value) {
       value = true;
       return true;

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -29,6 +29,25 @@ using StructField = std::pair<HeapType, Index>;
 
 namespace StructUtils {
 
+// A value that has a single bool, and implements combine() so it can be used in
+// StructValues.
+struct CombinableBool {
+  bool value = false;
+
+  CombinableBool() {}
+  CombinableBool(bool value) : value(value) {}
+
+  operator bool() const { return value; }
+
+  bool combine(const DescriptorInfo& other) {
+    if (!value && other.value) {
+      value = true;
+      return true;
+    }
+    return false;
+  }
+};
+
 // A vector of a template type's values. One such vector will be used per struct
 // type, where each element in the vector represents a field. We always assume
 // that the vectors are pre-initialized to the right length before accessing any

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -71,19 +71,6 @@ using PCVStructValuesMap = StructUtils::StructValuesMap<PossibleConstantValues>;
 using PCVFunctionStructValuesMap =
   StructUtils::FunctionStructValuesMap<PossibleConstantValues>;
 
-// A wrapper for a boolean value that provides a combine() method as is used in
-// the StructUtils propagation logic.
-struct Bool {
-  bool value = false;
-
-  Bool() {}
-  Bool(bool value) : value(value) {}
-
-  operator bool() const { return value; }
-
-  bool combine(bool other) { return value = value || other; }
-};
-
 using BoolStructValuesMap = StructUtils::StructValuesMap<Bool>;
 using BoolFunctionStructValuesMap = StructUtils::FunctionStructValuesMap<Bool>;
 

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -71,8 +71,8 @@ using PCVStructValuesMap = StructUtils::StructValuesMap<PossibleConstantValues>;
 using PCVFunctionStructValuesMap =
   StructUtils::FunctionStructValuesMap<PossibleConstantValues>;
 
-using BoolStructValuesMap = StructUtils::StructValuesMap<Bool>;
-using BoolFunctionStructValuesMap = StructUtils::FunctionStructValuesMap<Bool>;
+using BoolStructValuesMap = StructUtils::StructValuesMap<CombinableBool>;
+using BoolFunctionStructValuesMap = StructUtils::FunctionStructValuesMap<CombinableBool>;
 
 // Optimize struct gets based on what we've learned about writes.
 //

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -71,9 +71,9 @@ using PCVStructValuesMap = StructUtils::StructValuesMap<PossibleConstantValues>;
 using PCVFunctionStructValuesMap =
   StructUtils::FunctionStructValuesMap<PossibleConstantValues>;
 
-using BoolStructValuesMap = StructUtils::StructValuesMap<CombinableBool>;
+using BoolStructValuesMap = StructUtils::StructValuesMap<StructUtils::CombinableBool>;
 using BoolFunctionStructValuesMap =
-  StructUtils::FunctionStructValuesMap<CombinableBool>;
+  StructUtils::FunctionStructValuesMap<StructUtils::CombinableBool>;
 
 // Optimize struct gets based on what we've learned about writes.
 //
@@ -548,7 +548,7 @@ struct ConstantFieldPropagation : public Pass {
     // of subtypes must be taken into account (that is, A or a subtype is being
     // copied, so we want to do the same thing for B and C as well as A, since
     // a copy of A means it could be a copy of B or C).
-    StructUtils::TypeHierarchyPropagator<Bool> boolPropagator(subTypes);
+    StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool> boolPropagator(subTypes);
     boolPropagator.propagateToSubTypes(combinedCopyInfos);
     for (auto& [type, copied] : combinedCopyInfos) {
       for (Index i = 0; i < copied.size(); i++) {

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -71,7 +71,8 @@ using PCVStructValuesMap = StructUtils::StructValuesMap<PossibleConstantValues>;
 using PCVFunctionStructValuesMap =
   StructUtils::FunctionStructValuesMap<PossibleConstantValues>;
 
-using BoolStructValuesMap = StructUtils::StructValuesMap<StructUtils::CombinableBool>;
+using BoolStructValuesMap =
+  StructUtils::StructValuesMap<StructUtils::CombinableBool>;
 using BoolFunctionStructValuesMap =
   StructUtils::FunctionStructValuesMap<StructUtils::CombinableBool>;
 
@@ -548,7 +549,8 @@ struct ConstantFieldPropagation : public Pass {
     // of subtypes must be taken into account (that is, A or a subtype is being
     // copied, so we want to do the same thing for B and C as well as A, since
     // a copy of A means it could be a copy of B or C).
-    StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool> boolPropagator(subTypes);
+    StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool>
+      boolPropagator(subTypes);
     boolPropagator.propagateToSubTypes(combinedCopyInfos);
     for (auto& [type, copied] : combinedCopyInfos) {
       for (Index i = 0; i < copied.size(); i++) {

--- a/src/passes/ConstantFieldPropagation.cpp
+++ b/src/passes/ConstantFieldPropagation.cpp
@@ -72,7 +72,8 @@ using PCVFunctionStructValuesMap =
   StructUtils::FunctionStructValuesMap<PossibleConstantValues>;
 
 using BoolStructValuesMap = StructUtils::StructValuesMap<CombinableBool>;
-using BoolFunctionStructValuesMap = StructUtils::FunctionStructValuesMap<CombinableBool>;
+using BoolFunctionStructValuesMap =
+  StructUtils::FunctionStructValuesMap<CombinableBool>;
 
 // Optimize struct gets based on what we've learned about writes.
 //

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -427,31 +427,17 @@ struct GlobalTypeOptimization : public Pass {
     // remove A's descriptor without also removing $B's, so we need to propagate
     // that "must remain a descriptor" property among descriptors.
     if (!haveUnneededDescriptors.empty()) {
-
-      struct DescriptorInfo {
-        // Whether this descriptor is needed - it must keep describing.
-        bool needed = false;
-
-        bool combine(const DescriptorInfo& other) {
-          if (!needed && other.needed) {
-            needed = true;
-            return true;
-          }
-          return false;
-        }
-      };
-
-      StructUtils::TypeHierarchyPropagator<DescriptorInfo> descPropagator(
+      StructUtils::TypeHierarchyPropagator<CombinableBool> descPropagator(
         subTypes);
 
       // Populate the initial data: Any descriptor we did not see was unneeded,
       // is needed.
-      StructUtils::TypeHierarchyPropagator<DescriptorInfo>::StructMap map;
+      StructUtils::TypeHierarchyPropagator<CombinableBool>::StructMap map;
       for (auto type : subTypes.types) {
         if (auto desc = type.getDescriptorType()) {
           if (!haveUnneededDescriptors.count(type)) {
             // This descriptor type is needed.
-            map[*desc].needed = true;
+            map[*desc].value = true;
           }
         }
       }
@@ -471,7 +457,7 @@ struct GlobalTypeOptimization : public Pass {
       // keep subtyping working for the descriptors, and later passes could
       // remove the unused A2.
       for (auto& [type, info] : map) {
-        if (info.needed) {
+        if (info.value) {
           auto described = type.getDescribedType();
           assert(described);
           haveUnneededDescriptors.erase(*described);

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -427,12 +427,13 @@ struct GlobalTypeOptimization : public Pass {
     // remove A's descriptor without also removing $B's, so we need to propagate
     // that "must remain a descriptor" property among descriptors.
     if (!haveUnneededDescriptors.empty()) {
-      StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool> descPropagator(
-        subTypes);
+      StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool>
+        descPropagator(subTypes);
 
       // Populate the initial data: Any descriptor we did not see was unneeded,
       // is needed.
-      StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool>::StructMap map;
+      StructUtils::TypeHierarchyPropagator<
+        StructUtils::CombinableBool>::StructMap map;
       for (auto type : subTypes.types) {
         if (auto desc = type.getDescriptorType()) {
           if (!haveUnneededDescriptors.count(type)) {

--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -427,12 +427,12 @@ struct GlobalTypeOptimization : public Pass {
     // remove A's descriptor without also removing $B's, so we need to propagate
     // that "must remain a descriptor" property among descriptors.
     if (!haveUnneededDescriptors.empty()) {
-      StructUtils::TypeHierarchyPropagator<CombinableBool> descPropagator(
+      StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool> descPropagator(
         subTypes);
 
       // Populate the initial data: Any descriptor we did not see was unneeded,
       // is needed.
-      StructUtils::TypeHierarchyPropagator<CombinableBool>::StructMap map;
+      StructUtils::TypeHierarchyPropagator<StructUtils::CombinableBool>::StructMap map;
       for (auto type : subTypes.types) {
         if (auto desc = type.getDescriptorType()) {
           if (!haveUnneededDescriptors.count(type)) {


### PR DESCRIPTION
This mostly just avoids code duplication, but the CFP version was
actually also inefficient (combine returned true more than it
should, possibly leading to wasted work).