### PR TITLE
Fuzzer: Fix root cause of emitting non-constant expressions in global positions

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2100,7 +2100,10 @@ Expression* TranslateToFuzzReader::make(Type type) {
   }
   nesting++;
   Expression* ret = nullptr;
-  if (type.isConcrete()) {
+  if (!funcContext) {
+    // We are in a global init or similar, and can only emit constants.
+    ret = makeConst(type);
+  } else if (type.isConcrete()) {
     ret = _makeConcrete(type);
   } else if (type == Type::none) {
     ret = _makenone();


### PR DESCRIPTION
When we create a global we properly do `value = makeConst()`. However, if
we have nested structs, we ended up possibly calling `make(field.type)`,
which could emit anything.

To fix that, check for a function context in the core `make()`.

Replaces #7817 