### PR TITLE
Add reorder-types-real.wast to fuzzer block list

### DIFF
--- a/scripts/test/fuzzing.py
+++ b/scripts/test/fuzzing.py
@@ -105,6 +105,8 @@ unfuzzable = [
     'exact-references.wast',
     # We do not have full suppor for these imports in all parts of the fuzzer.
     'instrument-branch-hints.wast',
+    # Contains a subtype chain that exceeds depth limits.
+    'reorder-types-real.wast',
 ]
 
 


### PR DESCRIPTION
The subtype chains in that test exceed the limits on subtyping depth in real engines.