### PR TITLE
Add missing `const` in one of IString::startsWith methods

### DIFF
--- a/src/support/istring.h
+++ b/src/support/istring.h
@@ -84,7 +84,7 @@ public:
   bool startsWith(IString str) const { return startsWith(str.str); }
 
   // Disambiguate for string literals.
-  template<int N> bool startsWith(const char (&str)[N]) {
+  template<int N> bool startsWith(const char (&str)[N]) const {
     return startsWith(std::string_view(str));
   }
 


### PR DESCRIPTION
Other `IString::startsWith` methods all have it but this doesn't, making this code not able to compile,
```cpp
Name n;
const Name& n2 = n;
if (n2.startsWith("abc"))
  ...
```
because `n` here is a const reference. This situation can be easily created when using containers:
```cpp
std::set<Name> names;
for (auto &n : names)
  if (n.startswith("abc"))
    ...
```
Because `set`'s iterator gives a constant reference, this does not compile currently.