### PR TITLE
Make code less demanding on STL iterators.

### DIFF
--- a/src/passes/Metrics.cpp
+++ b/src/passes/Metrics.cpp
@@ -195,16 +195,17 @@ struct Metrics
     keys.push_back("[total]");
     counts["[total]"] = total;
     // sort
-    sort(keys.begin(), keys.end(), [](const char* a, const char* b) -> bool {
-      // Sort the [..] ones first.
-      if (a[0] == '[' && b[0] != '[') {
-        return true;
-      }
-      if (a[0] != '[' && b[0] == '[') {
-        return false;
-      }
-      return strcmp(b, a) > 0;
-    });
+    std::sort(
+      keys.begin(), keys.end(), [](const char* a, const char* b) -> bool {
+        // Sort the [..] ones first.
+        if (a[0] == '[' && b[0] != '[') {
+          return true;
+        }
+        if (a[0] != '[' && b[0] == '[') {
+          return false;
+        }
+        return strcmp(b, a) > 0;
+      });
     o << title << "\n";
     for (auto* key : keys) {
       auto value = counts[key];

--- a/src/passes/ReorderLocals.cpp
+++ b/src/passes/ReorderLocals.cpp
@@ -67,7 +67,7 @@ struct ReorderLocals : public WalkerPass<PostWalker<ReorderLocals>> {
       newToOld[i] = i;
     }
     // sort, keeping params in front (where they will not be moved)
-    sort(
+    std::sort(
       newToOld.begin(), newToOld.end(), [this, curr](Index a, Index b) -> bool {
         if (curr->isParam(a) && !curr->isParam(b)) {
           return true;

--- a/src/support/strongly_connected_components.h
+++ b/src/support/strongly_connected_components.h
@@ -39,7 +39,7 @@ template<typename It, typename Class> struct SCCs {
   SCCs(It inputIt, It inputEnd) : inputIt(inputIt), inputEnd(inputEnd) {}
 
 private:
-  using T = typename It::value_type;
+  using T = typename std::iterator_traits<It>::value_type;
 
   // The iterators over the graph we are calculating the SCCs for.
   It inputIt;

--- a/src/support/topological_sort.h
+++ b/src/support/topological_sort.h
@@ -53,7 +53,8 @@ std::vector<Index> minSort(const Graph& graph, F cmp = std::less<Index>{});
 // their children.
 template<typename It, typename SortT, SortT Sort, typename... Args>
 decltype(auto) sortOfImpl(It begin, It end, Args... args) {
-  using T = std::remove_cv_t<typename It::value_type::first_type>;
+  using T =
+    std::remove_cv_t<typename std::iterator_traits<It>::value_type::first_type>;
   std::unordered_map<T, Index> indices;
   std::vector<T> elements;
   // Assign indices to each element.


### PR DESCRIPTION
This allows compilation of this library with non-standard STL variant, where vector iterator is implemented as pointer.