### PR TITLE
[Experimental] Print descriptors as vtable fields

### DIFF
--- a/src/wasm/wasm-type.cpp
+++ b/src/wasm/wasm-type.cpp
@@ -126,7 +126,7 @@ struct TypePrinter {
   std::ostream& print(const Field& field);
   std::ostream& print(const Signature& sig);
   std::ostream& print(const Continuation& cont);
-  std::ostream& print(const Struct& struct_,
+  std::ostream& print(HeapType type,
                       const std::unordered_map<Index, Name>& fieldNames);
   std::ostream& print(const Array& array);
 };
@@ -1656,9 +1656,9 @@ std::ostream& TypePrinter::print(Type type) {
   } else if (type.isRef()) {
     auto heapType = type.getHeapType();
     if (type.isNullable() && heapType.isBasic() && !heapType.isShared()) {
-      if (type.isExact()) {
-        os << "(exact ";
-      }
+      // if (type.isExact()) {
+      //   os << "(exact ";
+      // }
       // Print shorthands for certain basic heap types.
       switch (heapType.getBasic(Unshared)) {
         case HeapType::ext:
@@ -1707,22 +1707,22 @@ std::ostream& TypePrinter::print(Type type) {
           os << "nullexnref";
           break;
       }
-      if (type.isExact()) {
-        os << ')';
-      }
+      // if (type.isExact()) {
+      //   os << ')';
+      // }
       return os;
     }
     os << "(ref ";
     if (type.isNullable()) {
       os << "null ";
     }
-    if (type.isExact()) {
-      os << "(exact ";
-    }
+    // if (type.isExact()) {
+    //   os << "(exact ";
+    // }
     printHeapTypeName(heapType);
-    if (type.isExact()) {
-      os << ')';
-    }
+    // if (type.isExact()) {
+    //   os << ')';
+    // }
     os << ')';
   } else {
     WASM_UNREACHABLE("unexpected type");
@@ -1813,22 +1813,22 @@ std::ostream& TypePrinter::print(HeapType type) {
   if (type.isShared()) {
     os << "(shared ";
   }
-  if (auto desc = type.getDescribedType()) {
-    os << "(describes ";
-    printHeapTypeName(*desc);
-    os << ' ';
-  }
-  if (auto desc = type.getDescriptorType()) {
-    os << "(descriptor ";
-    printHeapTypeName(*desc);
-    os << ' ';
-  }
+  // if (auto desc = type.getDescribedType()) {
+  //   os << "(describes ";
+  //   printHeapTypeName(*desc);
+  //   os << ' ';
+  // }
+  // if (auto desc = type.getDescriptorType()) {
+  //   os << "(descriptor ";
+  //   printHeapTypeName(*desc);
+  //   os << ' ';
+  // }
   switch (type.getKind()) {
     case HeapTypeKind::Func:
       print(type.getSignature());
       break;
     case HeapTypeKind::Struct:
-      print(type.getStruct(), names.fieldNames);
+      print(type, names.fieldNames);
       break;
     case HeapTypeKind::Array:
       print(type.getArray());
@@ -1839,12 +1839,12 @@ std::ostream& TypePrinter::print(HeapType type) {
     case HeapTypeKind::Basic:
       WASM_UNREACHABLE("unexpected kind");
   }
-  if (type.getDescriptorType()) {
-    os << ')';
-  }
-  if (type.getDescribedType()) {
-    os << ')';
-  }
+  // if (type.getDescriptorType()) {
+  //   os << ')';
+  // }
+  // if (type.getDescribedType()) {
+  //   os << ')';
+  // }
   if (type.isShared()) {
     os << ')';
   }
@@ -1914,9 +1914,15 @@ std::ostream& TypePrinter::print(const Continuation& continuation) {
 }
 
 std::ostream&
-TypePrinter::print(const Struct& struct_,
+TypePrinter::print(HeapType type,
                    const std::unordered_map<Index, Name>& fieldNames) {
+  const auto& struct_ = type.getStruct();
   os << "(struct";
+  if (auto desc = type.getDescriptorType()) {
+    os << " (field $vtable ";
+    print(Type(*desc, NonNullable));
+    os << ')';
+  }
   for (Index i = 0; i < struct_.fields.size(); ++i) {
     // TODO: move this to the function for printing fields.
     os << " (field ";


### PR DESCRIPTION
Also print exact references as inexact references. This prints modules
using custom descriptors as if they were not using custom descriptors,
making it easier to identify optimization regressions by diffing modules
before and after enabling custom descriptors.
