### PR TITLE
Honor CPU affinity in ThreadPool::getNumCores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
     - name: install packages
       run: |
         ./alpine.sh apk update
-        ./alpine.sh apk add build-base cmake git python3 py3-pip clang ninja
+        ./alpine.sh apk add build-base cmake git python3 py3-pip clang ninja util-linux
 
     - name: avoid d8 tests (jsvu is not compatible with alpine)
       run: |

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -135,7 +135,7 @@ jobs:
     - name: install packages
       run: |
         ./alpine.sh apk update
-        ./alpine.sh apk add build-base cmake git python3 clang ninja py3-pip
+        ./alpine.sh apk add build-base cmake git python3 py3-pip clang ninja util-linux
 
     - name: avoid d8 tests (jsvu is not compatible with alpine)
       run: |

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import lit.formats
 
 config.name = "Binaryen lit tests"
@@ -25,6 +26,9 @@ for tool in ('not', 'foreach'):
     tool_file = config.binaryen_src_root + '/scripts/' + tool + '.py'
     python = sys.executable.replace('\\', '/')
     config.substitutions.append((tool, python + ' ' + tool_file))
+
+if 'linux' in sys.platform:
+    config.available_features.add('linux')
 
 # Finds the given executable 'program' in PATH.
 # Operates like the Unix tool 'which'.

--- a/test/lit/num_cores.wast
+++ b/test/lit/num_cores.wast
@@ -1,0 +1,13 @@
+;; REQUIRES: linux
+;; Test that getNumCores honors thread affinity on linux
+
+(module
+  (func $a)
+)
+
+;; RUN: taskset -c 0 wasm-opt -O1 --debug=threads %s 2>&1 | filecheck %s
+;; RUN: taskset -c 0,2 wasm-opt -O1 --debug=threads %s 2>&1 | filecheck %s --check-prefix=TWO
+
+;; CHECK: getNumCores: 1
+
+;; TWO: getNumCores: 2


### PR DESCRIPTION
This reports that number of CPUs that are actually usable by the current process.

This means that I can do something like `taskset -c 0 emcc hello.c -O2` and the internal call to `wasm-opt` within emcc will only use a single core.

Ideally this would work on macOS and windows too, but I'm not even sure how easy it is to control affinity on those OSes.