### PR TITLE
[GC] Use cfp-reftest pass

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2228,6 +2228,7 @@ opt_choices = [
     ('-O1',), ('-O2',), ('-O3',), ('-O4',), ('-Os',), ('-Oz',),
     ("--abstract-type-refining",),
     ("--cfp",),
+    ("--cfp-reftest",),
     ("--coalesce-locals",),
     # XXX slow, non-default ("--coalesce-locals-learning",),
     ("--code-pushing",),

--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -771,7 +771,12 @@ void PassRunner::addDefaultGlobalOptimizationPrePasses() {
     addIfNoDWARFIssues("remove-unused-module-elements");
     if (options.closedWorld) {
       addIfNoDWARFIssues("remove-unused-types");
-      addIfNoDWARFIssues("cfp");
+      // Allow ref.tests in cfp if we are aggressively optimizing for speed.
+      if (options.optimizeLevel >= 3) {
+        addIfNoDWARFIssues("cfp-reftest");
+      } else {
+        addIfNoDWARFIssues("cfp");
+      }
       addIfNoDWARFIssues("gsi");
       addIfNoDWARFIssues("abstract-type-refining");
       addIfNoDWARFIssues("unsubtyping");


### PR DESCRIPTION
This pass has been used by j2wasm for a while, and is useful there, so
enable it for general use.

This pass can grow code size in some cases, if it emits a `ref.test` that is not
later optimized out. For that reason only enable it in `-O3+`, that is, when
optimizing aggressively for size.

Also fuzz this pass more.