### PR TITLE
[Custom Descriptors] Fix shared GTO placeholders

### DIFF
--- a/src/passes/GlobalTypeOptimization.cpp
+++ b/src/passes/GlobalTypeOptimization.cpp
@@ -578,7 +578,9 @@ struct GlobalTypeOptimization : public Pass {
         // Until we've created all the placeholders, create a placeholder
         // describee type for the next descriptor that needs one.
         if (placeholderIt != parent.descriptorsOfPlaceholders.end()) {
-          typeBuilder[i].descriptor(getTempHeapType(placeholderIt->first));
+          auto descriptor = placeholderIt->first;
+          typeBuilder[i].descriptor(getTempHeapType(descriptor));
+          typeBuilder[i].setShared(descriptor.getShared());
           ++placeholderIt;
           return;
         }


### PR DESCRIPTION
When we optimize a descriptor to describe a placeholder type because the
original described type no longer needs a descriptor, we were not
previously ensuring that the sharedness of the placeholder matched the
sharedness of the descriptor type. Make sure the shareness matches to
avoid validation errors when rebuilding the types.
