### PR TITLE
[Custom Descriptors] Fix GTO placeholders for unused types

### DIFF
--- a/test/lit/passes/gto-desc.wast
+++ b/test/lit/passes/gto-desc.wast
@@ -1173,8 +1173,33 @@
   )
 )
 
+;; Here we would optimize $unused with a placeholder, except that we don't
+;; include it in the output at all because it is unused. We should not get
+;; confused and try to emit a placeholder for it anyway.
+(module
+ (rec
+  ;; CHECK:      (rec
+  ;; CHECK-NEXT:  (type $public (sub (descriptor $public.desc (struct))))
+  (type $public (sub (descriptor $public.desc (struct))))
+  ;; CHECK:       (type $public.desc (sub (describes $public (struct))))
+  (type $public.desc (sub (describes $public (struct))))
+ )
+ (rec
+  (type $unused (descriptor $unused.desc (struct)))
+  (type $unused.desc (sub $public.desc (describes $unused (struct))))
+  ;; CHECK:      (type $private (struct))
+  (type $private (struct))
+ )
+
+ ;; CHECK:      (global $public (ref null $public) (ref.null none))
+ (global $public (export "public") (ref null $public) (ref.null none))
+ ;; CHECK:      (global $private (ref null $private) (ref.null none))
+ (global $private (ref null $private) (ref.null none))
+)
+
 ;; Sibling types $A and $B. The supertype that connects them should not stop us
 ;; from optimizing $B here, even though $A cannot be optimized.
+;; CHECK:      (export "public" (global $public))
 (module
   (rec
     ;; CHECK:      (rec


### PR DESCRIPTION
GTO emits placeholder describee types when it optimizes descriptor types
that must remain descriptors. However, it previously tried to emit a
placeholder describee type even for a descriptor type that is unused in
the module and therefore not included in the rebuilt types. These
dangling describees caused validation faillures when rebuilding the
types. Fix the problem by emitting placeholder describees only for
descriptors that will be rebuilt.
