### PR TITLE
fix: segf with empty dwarf .debug_loc

### DIFF
--- a/third_party/llvm-project/dwarf2yaml.cpp
+++ b/third_party/llvm-project/dwarf2yaml.cpp
@@ -120,7 +120,7 @@ void dumpDebugLoc(DWARFContext &DCtx, DWARFYAML::Data &Y) { // XXX BINARYEN
   // the same address size?
   auto CUS = DCtx.normal_units();
   if (CUS.empty()) {
-    return ;
+    return;
   }
   auto CU = CUS.begin()->get();
   uint8_t savedAddressByteSize = CU->getFormParams().AddrSize;  // XXX BINARYEN

--- a/third_party/llvm-project/dwarf2yaml.cpp
+++ b/third_party/llvm-project/dwarf2yaml.cpp
@@ -118,7 +118,11 @@ void dumpDebugRanges(DWARFContext &DCtx, DWARFYAML::Data &Y) { // XXX BINARYEN
 void dumpDebugLoc(DWARFContext &DCtx, DWARFYAML::Data &Y) { // XXX BINARYEN
   // This blindly grabs the first CU, which should be ok since they all have
   // the same address size?
-  auto CU = DCtx.normal_units().begin()->get();
+  auto CUS = DCtx.normal_units();
+  if (CUS.empty()) {
+    return ;
+  }
+  auto CU = CUS.begin()->get();
   uint8_t savedAddressByteSize = CU->getFormParams().AddrSize;  // XXX BINARYEN
   DWARFDataExtractor locsData(DCtx.getDWARFObj(), DCtx.getDWARFObj().getLocSection(),
                               DCtx.isLittleEndian(), savedAddressByteSize);


### PR DESCRIPTION
Hello,
I'm getting a segfault while running wasm-opt on my wasm (it started with version 123)
```bash
$> wasm-opt --enable-threads -g -O4 -ol 100 -s 0 -all -o out.wasm in.wasm
fish: Job 1, 'wasm-opt --enable-threads -g -O…' terminated by signal SIGSEGV (Address boundary error)
```
After a little sesion with gdb, found out in `third_party/llvm-project/dwarf2yaml.cpp:122` **the `CU` variables equals the end of the iterator**.

WASM analysis:
```bash
$> wasm-objdump -h in.wasm
[...]
   Custom start=0x037bac4b end=0x0508e814 (size=0x018d3bc9) "name"
   Custom start=0x0508e816 end=0x0508e822 (size=0x0000000c) ".debug_info"
   Custom start=0x0508e824 end=0x0508e82f (size=0x0000000b) ".debug_loc"
   Custom start=0x0508e831 end=0x0508e83f (size=0x0000000e) ".debug_ranges"
[...]

$>  wasm-objdump -j .debug_loc -s in.wasm
in.wasm:	file format wasm 0x1

Contents of section Custom:
508e824: 0a2e 6465 6275 675f 6c6f 63              ..debug_loc
```
So it look like it is an empty `.debug_loc` causing the crash
