### PR TITLE
[NFC] Test we error at runtime on subtyping errors

### DIFF
--- a/test/lit/exec/runtime-nonexact.wast
+++ b/test/lit/exec/runtime-nonexact.wast
@@ -1,0 +1,24 @@
+;; Disable validation and see that we error at runtime when an exact
+;; reference contains a subtype. (We disable validation so that the error is
+;; caught only at runtime; this would allow us to catch bugs that validation
+;; misses.)
+
+;; RUN: not wasm-opt %s -all --no-validation --fuzz-exec 2>&1 | filecheck %s
+
+;; CHECK: Fatal: expected (ref (exact $A)), seeing (ref (exact $B)) from
+
+(module
+  (rec
+    (type $A (sub (struct)))
+    (type $B (sub $A (struct)))
+  )
+
+  (func $test (export "test")
+    (drop
+      (block (result (ref (exact $A)))
+        (struct.new $B)
+      )
+    )
+  )
+)
+


### PR DESCRIPTION
The test verifies that even if validation accepts something, the interpreter
checks subtyping at runtime, allowing us to detect (in principle) bugs in
validation (or missing/incorrect validation rules).