### PR TITLE
Fuzzer: Do not always add functions

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -219,6 +219,9 @@ private:
   // The name of an empty tag.
   Name trivialTag;
 
+  // Whether we were given initial functions.
+  bool haveInitialFunctions;
+
   // RAII helper for managing the state used to create a single function.
   struct FunctionCreationContext {
     TranslateToFuzzReader& parent;


### PR DESCRIPTION
Leaving a small chance to only modify existing functions, rather than
always add lots of new ones, opens opportunities for very precise
small testcases to not get overly-modified. E.g., if a small testcase
checks for turning a field immutable, adding many functions will
likely add sets to all fields, changing the global picture substantially.