### PR TITLE
[wasm-split] Fix Split fuzzer

### DIFF
--- a/scripts/fuzz_shell.js
+++ b/scripts/fuzz_shell.js
@@ -419,6 +419,11 @@ if (secondBinary) {
 
 // Compile and instantiate a wasm file.
 function build(binary) {
+  if (secondBinary) {
+    // Provide the primary module's exports to the secondary.
+    imports['primary'] = exports;
+  }
+
   var module = new WebAssembly.Module(binary);
 
   var instance;


### PR DESCRIPTION
#7096 refactored things and broke the un-enabled wasm-split fuzzer.

After this, that fuzzer can run successfully for quite a while, but then it
finds stuff, so this does not enable it.