### PR TITLE
[Custom Descriptors] Fix Unsubtyping on soon-to-be-invalid types

### DIFF
--- a/src/passes/Unsubtyping.cpp
+++ b/src/passes/Unsubtyping.cpp
@@ -582,7 +582,10 @@ struct Unsubtyping : Pass {
     }
     if (auto desc = sub.getDescribedType()) {
       if (auto superDesc = super.getDescribedType()) {
-        noteSubtype(*desc, *superDesc);
+        // We will be able to assume this once we fix the validation rules.
+        if (HeapType::isSubType(*desc, *superDesc)) {
+          noteSubtype(*desc, *superDesc);
+        }
       }
     }
   }

--- a/test/lit/passes/unsubtyping-desc.wast
+++ b/test/lit/passes/unsubtyping-desc.wast
@@ -206,3 +206,22 @@
   ;; CHECK-NEXT: ))
   (global $bot-mid (ref null $mid) (struct.new $bot (ref.null none)))
 )
+
+;; This will be invalid soon, but in the meantime we should not be confused when
+;; the types described by two related descriptors are unrelated.
+(module
+  (rec
+    ;; CHECK:      (rec
+    ;; CHECK-NEXT:  (type $A (descriptor $super (struct)))
+    (type $A (descriptor $super (struct)))
+    ;; CHECK:       (type $B (descriptor $sub (struct)))
+    (type $B (descriptor $sub (struct)))
+    ;; CHECK:       (type $super (sub (describes $A (struct))))
+    (type $super (sub (describes $A (struct))))
+    ;; CHECK:       (type $sub (sub $super (describes $B (struct))))
+    (type $sub (sub $super (describes $B (struct))))
+  )
+  ;; CHECK:      (global $public (ref null $B) (ref.null none))
+  (global $public (export "public") (ref null $B) (ref.null none))
+)
+;; CHECK:      (export "public" (global $public))


### PR DESCRIPTION
We've updated Unsubtyping so that it will be correct once we update the
descriptor type validation rules, but in doing so we introduced an
assertion failure when it encounters types that will no longer be valid
in the future but are still valid now. Add a workaround and test.
