### PR TITLE
SimplifyGlobals: Fix folding of exports

### DIFF
--- a/src/passes/SimplifyGlobals.cpp
+++ b/src/passes/SimplifyGlobals.cpp
@@ -738,10 +738,11 @@ struct SimplifyGlobals : public Pass {
 
       void visitGlobalGet(GlobalGet* curr) {
         // If this is a get of a global with a single get and no sets, then we
-        // can fold that code into here.
+        // can fold that code into here. We must also avoid an export, as it can
+        // have additional gets and sets that we do not see.
         auto name = curr->name;
         auto& info = infos[name];
-        if (info.written == 0 && info.read == 1) {
+        if (info.written == 0 && info.read == 1 && !info.exported) {
           auto* global = wasm.getGlobal(name);
           if (global->init) {
             // Copy that global's code. For simplicity we copy it as we have to

--- a/test/lit/passes/simplify-globals-gc.wast
+++ b/test/lit/passes/simplify-globals-gc.wast
@@ -58,6 +58,8 @@
 ;; One global reads another, and should contain the same value. We should not
 ;; erroneously optimize the global.get to a struct.new, as struct.new generates
 ;; a new value each time, and the export allows that difference to be noticed.
+;; TODO: We could flip the export to read $B instead, basically considering it
+;;       a use that we can modify, like global.gets that we already do.
 (module
  ;; CHECK:      (type $struct (struct))
  (type $struct (struct))


### PR DESCRIPTION
An exported global can have extra uses, which prevent folding its value
into others.