### PR TITLE
[wasm-split] Reorder comments

### DIFF
--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -45,6 +45,9 @@
 //   8. Export globals, tags, tables, and memories from the primary module and
 //      import them in the secondary module.
 //
+//   9. Run RemoveUnusedModuleElements pass on the secondary module in order to
+//      remove unused imports.
+//
 // Functions can be used or referenced three ways in a WebAssembly module: they
 // can be exported, called, or referenced with ref.func. The above procedure
 // introduces a layer of indirection to each of those mechanisms that removes

--- a/src/ir/module-splitting.cpp
+++ b/src/ir/module-splitting.cpp
@@ -46,10 +46,10 @@
 //      import them in the secondary module.
 //
 // Functions can be used or referenced three ways in a WebAssembly module: they
-// can be exported, called, or placed in a table. The above procedure introduces
-// a layer of indirection to each of those mechanisms that removes all
-// references to secondary functions from the primary module but restores the
-// original program's semantics once the secondary module is instantiated.
+// can be exported, called, or referenced with ref.func. The above procedure
+// introduces a layer of indirection to each of those mechanisms that removes
+// all references to secondary functions from the primary module but restores
+// the original program's semantics once the secondary module is instantiated.
 //
 // The code as currently written makes a couple assumptions about the module
 // that is being split:


### PR DESCRIPTION
This reorders the numbered list in the beginning of the file that describes the process so that the order matches the actual process.

Also removes a few outdated lines of comments and an unnecessarily include.