### PR TITLE
[NFC] Model imported and exported function values

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -78,124 +78,130 @@ public:
     }
   }
 
-  Flow callImport(Function* import, const Literals& arguments) override {
-    if (import->module == "fuzzing-support") {
-      if (import->base.startsWith("log")) {
-        // This is a logging function like log-i32 or log-f64
-        std::cout << "[LoggingExternalInterface ";
-        if (import->base == "log-branch") {
-          // Report this as a special logging, so we can differentiate it from
-          // the others in the fuzzer.
-          std::cout << "log-branch";
-        } else {
-          // All others are just reported as loggings.
-          std::cout << "logging";
-        }
-        loggings.push_back(Literal()); // buffer with a None between calls
-        for (auto argument : arguments) {
-          if (argument.type == Type::i64) {
-            // To avoid JS legalization changing logging results, treat a
-            // logging of an i64 as two i32s (which is what legalization would
-            // turn us into).
-            auto low = Literal(int32_t(argument.getInteger()));
-            auto high = Literal(int32_t(argument.getInteger() >> int32_t(32)));
-            std::cout << ' ' << low;
-            loggings.push_back(low);
-            std::cout << ' ' << high;
-            loggings.push_back(high);
+  Literal getImportedFunction(Function* import) override {
+    auto f = [import, this](const Literals& arguments) -> Flow {
+      if (import->module == "fuzzing-support") {
+        if (import->base.startsWith("log")) {
+          // This is a logging function like log-i32 or log-f64
+          std::cout << "[LoggingExternalInterface ";
+          if (import->base == "log-branch") {
+            // Report this as a special logging, so we can differentiate it
+            // from the others in the fuzzer.
+            std::cout << "log-branch";
           } else {
-            std::cout << ' ' << argument;
-            loggings.push_back(argument);
+            // All others are just reported as loggings.
+            std::cout << "logging";
           }
-        }
-        std::cout << "]\n";
-        return {};
-      } else if (import->base == "throw") {
-        // Throw something, depending on the value of the argument. 0 means we
-        // should throw a JS exception, and any other value means we should
-        // throw a wasm exception (with that value as the payload).
-        if (arguments[0].geti32() == 0) {
-          throwJSException();
-        } else {
-          auto payload = std::make_shared<ExnData>(wasmTag, arguments);
-          throwException(WasmException{Literal(payload)});
-        }
-      } else if (import->base == "table-get") {
-        // Check for errors here, duplicating tableLoad(), because that will
-        // trap, and we just want to throw an exception (the same as JS would).
-        if (!exportedTable) {
-          throwJSException();
-        }
-        auto index = arguments[0].getUnsigned();
-        if (index >= tables[exportedTable].size()) {
-          throwJSException();
-        }
-        return {tableLoad(exportedTable, index)};
-      } else if (import->base == "table-set") {
-        if (!exportedTable) {
-          throwJSException();
-        }
-        auto index = arguments[0].getUnsigned();
-        if (index >= tables[exportedTable].size()) {
-          throwJSException();
-        }
-        tableStore(exportedTable, index, arguments[1]);
-        return {};
-      } else if (import->base == "call-export") {
-        callExportAsJS(arguments[0].geti32());
-        // The second argument determines if we should catch and rethrow
-        // exceptions. There is no observable difference in those two modes in
-        // the binaryen interpreter, so we don't need to do anything.
-
-        // Return nothing. If we wanted to return a value we'd need to have
-        // multiple such functions, one for each signature.
-        return {};
-      } else if (import->base == "call-export-catch") {
-        try {
+          loggings.push_back(Literal()); // buffer with a None between calls
+          for (auto argument : arguments) {
+            if (argument.type == Type::i64) {
+              // To avoid JS legalization changing logging results, treat a
+              // logging of an i64 as two i32s (which is what legalization
+              // would turn us into).
+              auto low = Literal(int32_t(argument.getInteger()));
+              auto high =
+                Literal(int32_t(argument.getInteger() >> int32_t(32)));
+              std::cout << ' ' << low;
+              loggings.push_back(low);
+              std::cout << ' ' << high;
+              loggings.push_back(high);
+            } else {
+              std::cout << ' ' << argument;
+              loggings.push_back(argument);
+            }
+          }
+          std::cout << "]\n";
+          return {};
+        } else if (import->base == "throw") {
+          // Throw something, depending on the value of the argument. 0 means
+          // we should throw a JS exception, and any other value means we
+          // should throw a wasm exception (with that value as the payload).
+          if (arguments[0].geti32() == 0) {
+            throwJSException();
+          } else {
+            auto payload = std::make_shared<ExnData>(wasmTag, arguments);
+            throwException(WasmException{Literal(payload)});
+          }
+        } else if (import->base == "table-get") {
+          // Check for errors here, duplicating tableLoad(), because that will
+          // trap, and we just want to throw an exception (the same as JS
+          // would).
+          if (!exportedTable) {
+            throwJSException();
+          }
+          auto index = arguments[0].getUnsigned();
+          if (index >= tables[exportedTable].size()) {
+            throwJSException();
+          }
+          return {tableLoad(exportedTable, index)};
+        } else if (import->base == "table-set") {
+          if (!exportedTable) {
+            throwJSException();
+          }
+          auto index = arguments[0].getUnsigned();
+          if (index >= tables[exportedTable].size()) {
+            throwJSException();
+          }
+          tableStore(exportedTable, index, arguments[1]);
+          return {};
+        } else if (import->base == "call-export") {
           callExportAsJS(arguments[0].geti32());
-          return {Literal(int32_t(0))};
-        } catch (const WasmException& e) {
-          return {Literal(int32_t(1))};
-        }
-      } else if (import->base == "call-ref") {
-        // Similar to call-export*, but with a ref.
-        callRefAsJS(arguments[0]);
-        return {};
-      } else if (import->base == "call-ref-catch") {
-        try {
+          // The second argument determines if we should catch and rethrow
+          // exceptions. There is no observable difference in those two modes
+          // in the binaryen interpreter, so we don't need to do anything.
+
+          // Return nothing. If we wanted to return a value we'd need to have
+          // multiple such functions, one for each signature.
+          return {};
+        } else if (import->base == "call-export-catch") {
+          try {
+            callExportAsJS(arguments[0].geti32());
+            return {Literal(int32_t(0))};
+          } catch (const WasmException& e) {
+            return {Literal(int32_t(1))};
+          }
+        } else if (import->base == "call-ref") {
+          // Similar to call-export*, but with a ref.
           callRefAsJS(arguments[0]);
-          return {Literal(int32_t(0))};
-        } catch (const WasmException& e) {
-          return {Literal(int32_t(1))};
+          return {};
+        } else if (import->base == "call-ref-catch") {
+          try {
+            callRefAsJS(arguments[0]);
+            return {Literal(int32_t(0))};
+          } catch (const WasmException& e) {
+            return {Literal(int32_t(1))};
+          }
+        } else if (import->base == "sleep") {
+          // Do not actually sleep, just return the id.
+          return {arguments[1]};
+        } else {
+          WASM_UNREACHABLE("unknown fuzzer import");
         }
-      } else if (import->base == "sleep") {
-        // Do not actually sleep, just return the id.
-        return {arguments[1]};
-      } else {
-        WASM_UNREACHABLE("unknown fuzzer import");
-      }
-    } else if (import->module == ENV) {
-      if (import->base == "log_execution") {
-        std::cout << "[LoggingExternalInterface log-execution";
-        for (auto argument : arguments) {
-          std::cout << ' ' << argument;
+      } else if (import->module == ENV) {
+        if (import->base == "log_execution") {
+          std::cout << "[LoggingExternalInterface log-execution";
+          for (auto argument : arguments) {
+            std::cout << ' ' << argument;
+          }
+          std::cout << "]\n";
+          return {};
+        } else if (import->base == "setTempRet0") {
+          state.tempRet0 = arguments[0].geti32();
+          return {};
+        } else if (import->base == "getTempRet0") {
+          return {Literal(state.tempRet0)};
         }
-        std::cout << "]\n";
-        return {};
-      } else if (import->base == "setTempRet0") {
-        state.tempRet0 = arguments[0].geti32();
-        return {};
-      } else if (import->base == "getTempRet0") {
-        return {Literal(state.tempRet0)};
+      } else if (linkedInstances.count(import->module)) {
+        // This is from a recognized module.
+        return getImportInstance(import)->callExport(import->base, arguments);
       }
-    } else if (linkedInstances.count(import->module)) {
-      // This is from a recognized module.
-      return getImportInstance(import)->callExport(import->base, arguments);
-    }
-    // Anything else, we ignore.
-    std::cerr << "[LoggingExternalInterface ignoring an unknown import "
-              << import->module << " . " << import->base << '\n';
-    return {};
+      // Anything else, we ignore.
+      std::cerr << "[LoggingExternalInterface ignoring an unknown import "
+                << import->module << " . " << import->base << '\n';
+      return {};
+    };
+    return Literal(std::make_shared<FuncData>(import->base, nullptr, f),
+                   import->type);
   }
 
   void throwJSException() {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -251,68 +251,74 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
     });
   }
 
-  Flow callImport(Function* import, const Literals& arguments) override {
-    Name WASI("wasi_snapshot_preview1");
+  Literal getImportedFunction(Function* import) override {
+    auto f = [import, this](const Literals& arguments) -> Flow {
+      Name WASI("wasi_snapshot_preview1");
 
-    if (ignoreExternalInput) {
-      if (import->module == WASI) {
-        if (import->base == "environ_sizes_get") {
-          if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
-              import->getResults() != Type::i32) {
-            throw FailToEvalException("wasi environ_sizes_get has wrong sig");
+      if (ignoreExternalInput) {
+        if (import->module == WASI) {
+          if (import->base == "environ_sizes_get") {
+            if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
+                import->getResults() != Type::i32) {
+              throw FailToEvalException("wasi environ_sizes_get has wrong sig");
+            }
+
+            // Write out a count of i32(0) and return __WASI_ERRNO_SUCCESS
+            // (0).
+            store32(arguments[0].geti32(), 0, wasm->memories[0]->name);
+            return {Literal(int32_t(0))};
           }
 
-          // Write out a count of i32(0) and return __WASI_ERRNO_SUCCESS (0).
-          store32(arguments[0].geti32(), 0, wasm->memories[0]->name);
-          return {Literal(int32_t(0))};
-        }
+          if (import->base == "environ_get") {
+            if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
+                import->getResults() != Type::i32) {
+              throw FailToEvalException("wasi environ_get has wrong sig");
+            }
 
-        if (import->base == "environ_get") {
-          if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
-              import->getResults() != Type::i32) {
-            throw FailToEvalException("wasi environ_get has wrong sig");
+            // Just return __WASI_ERRNO_SUCCESS (0).
+            return {Literal(int32_t(0))};
           }
 
-          // Just return __WASI_ERRNO_SUCCESS (0).
-          return {Literal(int32_t(0))};
-        }
+          if (import->base == "args_sizes_get") {
+            if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
+                import->getResults() != Type::i32) {
+              throw FailToEvalException("wasi args_sizes_get has wrong sig");
+            }
 
-        if (import->base == "args_sizes_get") {
-          if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
-              import->getResults() != Type::i32) {
-            throw FailToEvalException("wasi args_sizes_get has wrong sig");
+            // Write out an argc of i32(0) and return a __WASI_ERRNO_SUCCESS
+            // (0).
+            store32(arguments[0].geti32(), 0, wasm->memories[0]->name);
+            return {Literal(int32_t(0))};
           }
 
-          // Write out an argc of i32(0) and return a __WASI_ERRNO_SUCCESS (0).
-          store32(arguments[0].geti32(), 0, wasm->memories[0]->name);
-          return {Literal(int32_t(0))};
-        }
+          if (import->base == "args_get") {
+            if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
+                import->getResults() != Type::i32) {
+              throw FailToEvalException("wasi args_get has wrong sig");
+            }
 
-        if (import->base == "args_get") {
-          if (arguments.size() != 2 || arguments[0].type != Type::i32 ||
-              import->getResults() != Type::i32) {
-            throw FailToEvalException("wasi args_get has wrong sig");
+            // Just return __WASI_ERRNO_SUCCESS (0).
+            return {Literal(int32_t(0))};
           }
 
-          // Just return __WASI_ERRNO_SUCCESS (0).
-          return {Literal(int32_t(0))};
+          // Otherwise, we don't recognize this import; continue normally to
+          // error.
         }
-
-        // Otherwise, we don't recognize this import; continue normally to
-        // error.
       }
-    }
 
-    std::string extra;
-    if (import->module == ENV && import->base == "___cxa_atexit") {
-      extra = RECOMMENDATION "build with -s NO_EXIT_RUNTIME=1 so that calls "
-                             "to atexit are not emitted";
-    } else if (import->module == WASI && !ignoreExternalInput) {
-      extra = RECOMMENDATION "consider --ignore-external-input";
-    }
-    throw FailToEvalException(std::string("call import: ") +
-                              import->module.toString() + "." +
-                              import->base.toString() + extra);
+      std::string extra;
+      if (import->module == ENV && import->base == "___cxa_atexit") {
+        extra = RECOMMENDATION "build with -s NO_EXIT_RUNTIME=1 so that calls "
+                               "to atexit are not emitted";
+      } else if (import->module == WASI && !ignoreExternalInput) {
+        extra = RECOMMENDATION "consider --ignore-external-input";
+      }
+      throw FailToEvalException(std::string("call import: ") +
+                                import->module.toString() + "." +
+                                import->base.toString() + extra);
+    };
+    return Literal(std::make_shared<FuncData>(import->base, nullptr, f),
+                   import->type);
   }
 
   // We assume the table is not modified FIXME

--- a/src/tools/wasm-shell.cpp
+++ b/src/tools/wasm-shell.cpp
@@ -245,7 +245,7 @@ struct Shell {
       }
       auto& instance = it->second;
       try {
-        return instance->getExport(get->name);
+        return instance->getExportedGlobal(get->name);
       } catch (TrapException&) {
         return TrapResult{};
       } catch (...) {

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -141,7 +141,7 @@ struct FuncData {
   void* self;
 
   // A way to execute this function. We use this when it is called.
-  using Call = std::function<Flow(Literals)>;
+  using Call = std::function<Flow(const Literals&)>;
   Call call;
 
   FuncData(Name name, void* self = nullptr, Call call = {})
@@ -151,7 +151,7 @@ struct FuncData {
     return name == other.name && self == other.self;
   }
 
-  Flow doCall(Literals arguments) {
+  Flow doCall(const Literals& arguments) {
     assert(call);
     return call(arguments);
   }
@@ -2896,7 +2896,7 @@ public:
     virtual ~ExternalInterface() = default;
     virtual void init(Module& wasm, SubType& instance) {}
     virtual void importGlobals(GlobalValueSet& globals, Module& wasm) = 0;
-    virtual Flow callImport(Function* import, const Literals& arguments) = 0;
+    virtual Literal getImportedFunction(Function* import) = 0;
     virtual bool growMemory(Name name, Address oldSize, Address newSize) = 0;
     virtual bool growTable(Name name,
                            const Literal& value,
@@ -3153,17 +3153,32 @@ public:
 
   // call an exported function
   Flow callExport(Name name, const Literals& arguments) {
-    Export* export_ = wasm.getExportOrNull(name);
-    if (!export_ || export_->kind != ExternalKind::Function) {
-      externalInterface->trap("callExport not found");
-    }
-    return callFunction(*export_->getInternalName(), arguments);
+    return getExportedFunction(name).getFuncData()->doCall(arguments);
   }
 
   Flow callExport(Name name) { return callExport(name, Literals()); }
 
+  Literal getExportedFunction(Name name) {
+    Export* export_ = wasm.getExportOrNull(name);
+    if (!export_ || export_->kind != ExternalKind::Function) {
+      externalInterface->trap("exported function not found");
+    }
+    Function* func = wasm.getFunctionOrNull(*export_->getInternalName());
+    assert(func);
+    if (func->imported()) {
+      return externalInterface->getImportedFunction(func);
+    }
+    return Literal(std::make_shared<FuncData>(
+                     func->name,
+                     nullptr,
+                     [this, func](const Literals& arguments) -> Flow {
+                       return callFunction(func->name, arguments);
+                     }),
+                   func->type);
+  }
+
   // get an exported global
-  Literals getExport(Name name) {
+  Literals getExportedGlobal(Name name) {
     Export* export_ = wasm.getExportOrNull(name);
     if (!export_ || export_->kind != ExternalKind::Global) {
       externalInterface->trap("getExport external not found");
@@ -4697,7 +4712,9 @@ public:
 
       if (function->imported()) {
         // TODO: Allow imported functions to tail call as well.
-        return externalInterface->callImport(function, arguments);
+        return externalInterface->getImportedFunction(function)
+          .getFuncData()
+          ->doCall(arguments);
       }
 
       FunctionScope scope(function, arguments, *self());


### PR DESCRIPTION
Update ExternalInterface to provide imported functions as values
rather than just exposing an interface to call them. Similarly, update
a ModuleRunner instance to provide exported functions as values rather
than just providing an interface to call them.

Dealing with imported and exported functions as values like this is a
prerequisite for fixing our interpretation of function reference casts
to reflect that fact that the runtime type of a reference to an imported
function may be a nontrivial subtype of the type of the corresponding
function import. Actually fixing this is left to a follow-on PR.
