### PR TITLE
Allow funcref literals to have inexact types

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -157,7 +157,7 @@ Literal fromBinaryenLiteral(BinaryenLiteral x) {
     }
   }
   if (heapType.isSignature()) {
-    return Literal::makeFunc(Name(x.func), heapType);
+    return Literal::makeFunc(Name(x.func), type);
   }
   assert(heapType.isData());
   WASM_UNREACHABLE("TODO: gc data");

--- a/src/ir/possible-contents.cpp
+++ b/src/ir/possible-contents.cpp
@@ -27,6 +27,7 @@
 #include "ir/module-utils.h"
 #include "ir/possible-contents.h"
 #include "support/insert_ordered.h"
+#include "wasm-type.h"
 #include "wasm.h"
 
 namespace std {
@@ -641,9 +642,9 @@ struct InfoCollector
     addRoot(curr);
   }
   void visitRefFunc(RefFunc* curr) {
-    addRoot(curr,
-            PossibleContents::literal(
-              Literal::makeFunc(curr->func, curr->type.getHeapType())));
+    addRoot(
+      curr,
+      PossibleContents::literal(Literal::makeFunc(curr->func, *getModule())));
 
     // The presence of a RefFunc indicates the function may be called
     // indirectly, so add the relevant connections for this particular function.
@@ -1859,8 +1860,8 @@ void TNHOracle::infer() {
         //       as other opts will make this call direct later, after which a
         //       lot of other optimizations become possible anyhow.
         auto target = possibleTargets[0]->name;
-        info.inferences[call->target] = PossibleContents::literal(
-          Literal::makeFunc(target, wasm.getFunction(target)->type));
+        info.inferences[call->target] =
+          PossibleContents::literal(Literal::makeFunc(target, wasm));
         continue;
       }
 

--- a/src/ir/properties.h
+++ b/src/ir/properties.h
@@ -116,7 +116,7 @@ inline Literal getLiteral(const Expression* curr) {
   } else if (auto* n = curr->dynCast<RefNull>()) {
     return Literal(n->type);
   } else if (auto* r = curr->dynCast<RefFunc>()) {
-    return Literal::makeFunc(r->func, r->type.getHeapType());
+    return Literal::makeFunc(r->func, r->type);
   } else if (auto* i = curr->dynCast<RefI31>()) {
     if (auto* c = i->value->dynCast<Const>()) {
       return Literal::makeI31(c->value.geti32(),

--- a/src/literal.h
+++ b/src/literal.h
@@ -30,6 +30,7 @@
 
 namespace wasm {
 
+class Module;
 class Literals;
 struct FuncData;
 struct GCData;
@@ -70,6 +71,9 @@ class Literal {
 
 public:
   // Type of the literal. Immutable because the literal's payload depends on it.
+  // For references to defined heap types, this is almost always an exact type.
+  // The exception is references to imported functions, since the function
+  // provided at instantiation time may have a subtype of the import type.
   const Type type;
 
   Literal() : v128(), type(Type::none) {}
@@ -90,7 +94,7 @@ public:
   explicit Literal(const std::array<Literal, 8>&);
   explicit Literal(const std::array<Literal, 4>&);
   explicit Literal(const std::array<Literal, 2>&);
-  explicit Literal(std::shared_ptr<FuncData> funcData, HeapType type);
+  explicit Literal(std::shared_ptr<FuncData> funcData, Type type);
   explicit Literal(std::shared_ptr<GCData> gcData, HeapType type);
   explicit Literal(std::shared_ptr<ExnData> exnData);
   explicit Literal(std::shared_ptr<ContData> contData);
@@ -252,7 +256,8 @@ public:
   }
   // Simple way to create a function from the name and type, without a full
   // FuncData.
-  static Literal makeFunc(Name func, HeapType type);
+  static Literal makeFunc(Name func, Type type);
+  static Literal makeFunc(Name func, Module& wasm);
   static Literal makeI31(int32_t value, Shareability share) {
     auto lit = Literal(Type(HeapTypes::i31.getBasic(share), NonNullable));
     lit.i32 = value | 0x80000000;

--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -148,7 +148,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
                                      }
                                      return Flow();
                                    }),
-        import->type);
+        Type(import->type, NonNullable, Exact));
     } else if (import->module == ENV && import->base == EXIT) {
       return Literal(std::make_shared<FuncData>(import->name,
                                                 nullptr,
@@ -157,7 +157,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
                                                   std::cout << "exit()\n";
                                                   throw ExitException();
                                                 }),
-                     import->type);
+                     Type(import->type, NonNullable, Exact));
     } else if (auto* inst = getImportInstance(import)) {
       return inst->getExportedFunction(import->base);
     }

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -202,7 +202,7 @@ public:
     };
     // Use a null instance because this is a host function.
     return Literal(std::make_shared<FuncData>(import->name, nullptr, f),
-                   import->type);
+                   Type(import->type, NonNullable, Exact));
   }
 
   void throwJSException() {

--- a/src/tools/wasm-ctor-eval.cpp
+++ b/src/tools/wasm-ctor-eval.cpp
@@ -103,7 +103,7 @@ public:
   }
 
   // This needs to be duplicated from ModuleRunner, unfortunately.
-  Literal makeFuncData(Name name, HeapType type) {
+  Literal makeFuncData(Name name, Type type) {
     auto allocation =
       std::make_shared<FuncData>(name, this, [this, name](Literals arguments) {
         return callFunction(name, arguments);
@@ -319,8 +319,9 @@ struct CtorEvalExternalInterface : EvallingModuleRunner::ExternalInterface {
     };
     // Use a null instance because these are either host functions or imported
     // from unknown sources.
+    // TODO: Be more precise about the types we allow these imports to have.
     return Literal(std::make_shared<FuncData>(import->name, nullptr, f),
-                   import->type);
+                   Type(import->type, NonNullable, Exact));
   }
 
   // We assume the table is not modified FIXME

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -346,7 +346,7 @@ public:
     Execute,
   };
 
-  Literal makeFuncData(Name name, HeapType type) {
+  Literal makeFuncData(Name name, Type type) {
     // Identify the interpreter, but do not provide a way to actually call the
     // function.
     auto allocation = std::make_shared<FuncData>(name, this);
@@ -1870,7 +1870,7 @@ public:
     return Literal(int32_t(value.isNull()));
   }
   Flow visitRefFunc(RefFunc* curr) {
-    return self()->makeFuncData(curr->func, curr->type.getHeapType());
+    return self()->makeFuncData(curr->func, curr->type);
   }
   Flow visitRefEq(RefEq* curr) {
     VISIT(flow, curr->left)
@@ -3177,7 +3177,7 @@ public:
                      [this, func](const Literals& arguments) -> Flow {
                        return callFunction(func->name, arguments);
                      }),
-                   func->type);
+                   Type(func->type, NonNullable, Exact));
   }
 
   // get an exported global
@@ -3459,12 +3459,12 @@ public:
     Literals arguments;
     VISIT_ARGUMENTS(flow, curr->operands, arguments);
     auto* func = wasm.getFunction(curr->target);
-    auto funcType = func->type;
+    auto funcType = Type(func->type, NonNullable, Exact);
     if (Intrinsics(*self()->getModule()).isCallWithoutEffects(func)) {
       // The call.without.effects intrinsic is a call to an import that actually
       // calls the given function reference that is the final argument.
       target = arguments.back().getFunc();
-      funcType = arguments.back().type.getHeapType();
+      funcType = funcType.with(arguments.back().type.getHeapType());
       arguments.pop_back();
     }
 
@@ -4419,8 +4419,9 @@ public:
     }
     auto funcName = funcValue.getFunc();
     auto* func = self()->getModule()->getFunction(funcName);
+    auto funcType = Type(func->type, NonNullable, Exact);
     return Literal(std::make_shared<ContData>(
-      self()->makeFuncData(func->name, func->type), curr->type.getHeapType()));
+      self()->makeFuncData(funcName, funcType), curr->type.getHeapType()));
   }
   Flow visitContBind(ContBind* curr) {
     Literals arguments;
@@ -4767,7 +4768,8 @@ public:
         // not the original function that was called, and the original has been
         // returned from already; we should call the last return_called
         // function).
-        auto target = self()->makeFuncData(name, function->type);
+        auto funcType = Type(function->type, NonNullable, Exact);
+        auto target = self()->makeFuncData(name, funcType);
         self()->pushResumeEntry({target}, "function-target");
       }
 
@@ -4916,7 +4918,7 @@ public:
     std::map<Name, std::shared_ptr<ModuleRunner>> linkedInstances = {})
     : ModuleRunnerBase(wasm, externalInterface, linkedInstances) {}
 
-  Literal makeFuncData(Name name, HeapType type) {
+  Literal makeFuncData(Name name, Type type) {
     // As the super's |makeFuncData|, but here we also provide a way to
     // actually call the function.
     auto allocation =

--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -71,15 +71,21 @@ Literal::Literal(const uint8_t init[16]) : type(Type::v128) {
   memcpy(&v128, init, 16);
 }
 
-Literal::Literal(std::shared_ptr<FuncData> funcData, HeapType type)
-  : funcData(funcData), type(type, NonNullable, Exact) {
+Literal::Literal(std::shared_ptr<FuncData> funcData, Type type)
+  : funcData(funcData), type(type) {
   assert(funcData);
   assert(type.isSignature());
 }
 
-Literal Literal::makeFunc(Name func, HeapType type) {
+Literal Literal::makeFunc(Name func, Type type) {
   // Provide only the name of the function, without execution info.
   return Literal(std::make_shared<FuncData>(func), type);
+}
+
+Literal Literal::makeFunc(Name func, Module& wasm) {
+  auto* f = wasm.getFunction(func);
+  auto exact = f->imported() ? Inexact : Exact;
+  return makeFunc(func, Type(f->type, NonNullable, exact));
 }
 
 Literal::Literal(std::shared_ptr<GCData> gcData, HeapType type)

--- a/test/gtest/possible-contents.cpp
+++ b/test/gtest/possible-contents.cpp
@@ -89,8 +89,8 @@ protected:
   PossibleContents nonNullFuncGlobal =
     PossibleContents::global("funcGlobal", Type(HeapType::func, NonNullable));
 
-  PossibleContents nonNullFunc = PossibleContents::literal(
-    Literal::makeFunc("func", Signature(Type::none, Type::none)));
+  PossibleContents nonNullFunc = PossibleContents::literal(Literal::makeFunc(
+    "func", Type(Signature(Type::none, Type::none), NonNullable, Exact)));
 
   PossibleContents exactI32 = PossibleContents::exactType(Type::i32);
   PossibleContents exactAnyref = PossibleContents::exactType(anyref);


### PR DESCRIPTION
Update the Literal constructors for funcrefs to take Type instead of
HeapType to allow them to be given inexact function references types
when the referenced function is an import. Use the new capability to
give references to imported functions inexact types in GUFA. Add a test
where this change fixes a misoptimization as well as tests where this
change simply changes the nature of the misoptimization. Future PRs will
fix these tests.
