### PR TITLE
Update test after recent landings conflict

### DIFF
--- a/test/lit/exec/tag-cross-module.wast
+++ b/test/lit/exec/tag-cross-module.wast
@@ -18,6 +18,7 @@
 
 ;; CHECK: [fuzz-exec] calling func
 ;; CHECK-NEXT: [exception thrown: tag nullref]
+;; CHECK-NEXT: [fuzz-exec] running second module
 ;; CHECK-NEXT: [fuzz-exec] calling func2-internal
 ;; CHECK-NEXT: [exception thrown: tag nullref]
 ;; CHECK-NEXT: [fuzz-exec] calling func2-imported


### PR DESCRIPTION
One PR added this extra logging, the other added this test, and
the test needs an update.