### PR TITLE
[emscripten] Enable WASM_BIGINT by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,21 +313,6 @@ else() # MSVC
 endif()
 
 if(EMSCRIPTEN)
-  # Note: to debug with DWARF you will usually want to enable BIGINT support, as
-  # that helps avoid running Binaryen on the wasm after link. Binaryen's DWARF
-  # rewriting has known limitations, so avoiding it during link is recommended
-  # where possible (like local debugging).
-  #
-  # Note that this is debug info for Binaryen itself, that is, when you are
-  # debugging Binaryen source code. This flag has no impact on what Binaryen
-  # does when run on wasm files.
-  option(ENABLE_BIGINT "Enable wasm BigInt support" OFF)
-  if(ENABLE_BIGINT)
-    add_link_flag("-sWASM_BIGINT")
-   else()
-    add_link_flag("-sWASM_BIGINT=0")
-  endif()
-
   if("${CMAKE_BUILD_TYPE}" MATCHES "Release")
     # Extra check that cmake has set -O3 in its release flags.
     # This is really as an assertion that cmake is behaving as we expect.

--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -2844,34 +2844,6 @@ void BinaryenConstSetValueI64(BinaryenExpressionRef expr, int64_t value) {
   assert(expression->is<Const>());
   static_cast<Const*>(expression)->value = Literal(value);
 }
-int32_t BinaryenConstGetValueI64Low(BinaryenExpressionRef expr) {
-  auto* expression = (Expression*)expr;
-  assert(expression->is<Const>());
-  return (int32_t)(static_cast<Const*>(expression)->value.geti64() &
-                   0xffffffff);
-}
-void BinaryenConstSetValueI64Low(BinaryenExpressionRef expr, int32_t valueLow) {
-  auto* expression = (Expression*)expr;
-  assert(expression->is<Const>());
-  auto& value = static_cast<Const*>(expression)->value;
-  int64_t valueI64 = value.type == Type::i64 ? value.geti64() : 0;
-  static_cast<Const*>(expression)->value =
-    Literal((valueI64 & ~0xffffffff) | (int64_t(valueLow) & 0xffffffff));
-}
-int32_t BinaryenConstGetValueI64High(BinaryenExpressionRef expr) {
-  auto* expression = (Expression*)expr;
-  assert(expression->is<Const>());
-  return (int32_t)(static_cast<Const*>(expression)->value.geti64() >> 32);
-}
-void BinaryenConstSetValueI64High(BinaryenExpressionRef expr,
-                                  int32_t valueHigh) {
-  auto* expression = (Expression*)expr;
-  assert(expression->is<Const>());
-  auto& value = static_cast<Const*>(expression)->value;
-  int64_t valueI64 = value.type == Type::i64 ? value.geti64() : 0;
-  static_cast<Const*>(expression)->value =
-    Literal((int64_t(valueHigh) << 32) | (valueI64 & 0xffffffff));
-}
 float BinaryenConstGetValueF32(BinaryenExpressionRef expr) {
   auto* expression = (Expression*)expr;
   assert(expression->is<Const>());

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -1650,20 +1650,6 @@ BINARYEN_API int64_t BinaryenConstGetValueI64(BinaryenExpressionRef expr);
 // Sets the 64-bit integer value of an `i64.const` expression.
 BINARYEN_API void BinaryenConstSetValueI64(BinaryenExpressionRef expr,
                                            int64_t value);
-// Gets the low 32-bits of the 64-bit integer value of an `i64.const`
-// expression.
-BINARYEN_API int32_t BinaryenConstGetValueI64Low(BinaryenExpressionRef expr);
-// Sets the low 32-bits of the 64-bit integer value of an `i64.const`
-// expression.
-BINARYEN_API void BinaryenConstSetValueI64Low(BinaryenExpressionRef expr,
-                                              int32_t valueLow);
-// Gets the high 32-bits of the 64-bit integer value of an `i64.const`
-// expression.
-BINARYEN_API int32_t BinaryenConstGetValueI64High(BinaryenExpressionRef expr);
-// Sets the high 32-bits of the 64-bit integer value of an `i64.const`
-// expression.
-BINARYEN_API void BinaryenConstSetValueI64High(BinaryenExpressionRef expr,
-                                               int32_t valueHigh);
 // Gets the 32-bit float value of a `f32.const` expression.
 BINARYEN_API float BinaryenConstGetValueF32(BinaryenExpressionRef expr);
 // Sets the 32-bit float value of a `f32.const` expression.

--- a/test/binaryen.js/expressions.js
+++ b/test/binaryen.js/expressions.js
@@ -832,17 +832,14 @@ console.log("# Const");
   assert(info.type === theConst.type);
   assert(info.value === theConst.valueI32);
 
-  theConst.valueI64Low = 3;
-  assert(theConst.valueI64Low === 3);
-  theConst.valueI64High = 4;
-  assert(theConst.valueI64High === 4);
+  theConst.valueI64 = 3;
+  assert(theConst.valueI64 === 3n);
   theConst.finalize();
   assert(theConst.type == binaryen.i64);
 
   info = binaryen.getExpressionInfo(theConst);
   assert(info.type === theConst.type);
-  assert(info.value.low === theConst.valueI64Low);
-  assert(info.value.high === theConst.valueI64High);
+  assert(info.value === theConst.valueI64);
 
   theConst.valueF32 = 5;
   assert(theConst.valueF32 === 5);

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -24,8 +24,8 @@ function makeFloat32(x) {
   return module.f32.const(x);
 }
 
-function makeInt64(l, h) {
-  return module.i64.const(l, h);
+function makeInt64(x) {
+  return module.i64.const(x);
 }
 
 function makeFloat64(x) {
@@ -215,7 +215,7 @@ function test_core() {
       constF32 = module.f32.const(3.14),
       constF64 = module.f64.const(2.1828),
       constF32Bits = module.f32.const_bits(0xffff1234),
-      constF64Bits = module.f64.const_bits(0x5678abcd, 0xffff1234);
+      constF64Bits = module.f64.const_bits(0xffff1234_5678abcdn);
 
   var iIfF = binaryen.createType([binaryen.i32, binaryen.i64, binaryen.f32, binaryen.f64])
 
@@ -234,7 +234,7 @@ function test_core() {
   var valueList = [
     // Unary
     module.i32.clz(module.i32.const(-10)),
-    module.i64.ctz(module.i64.const(-22, -1)),
+    module.i64.ctz(module.i64.const(-23)),
     module.i32.popcnt(module.i32.const(-10)),
     module.f32.neg(module.f32.const(-33.612)),
     module.f64.abs(module.f64.const(-9005.841)),
@@ -246,7 +246,7 @@ function test_core() {
     module.i32.eqz(module.i32.const(-10)),
     module.i64.extend_s(module.i32.const(-10)),
     module.i64.extend_u(module.i32.const(-10)),
-    module.i32.wrap(module.i64.const(-22, -1)),
+    module.i32.wrap(module.i64.const(-23)),
     module.i32.trunc_s.f32(module.f32.const(-33.612)),
     module.i64.trunc_s.f32(module.f32.const(-33.612)),
     module.i32.trunc_u.f32(module.f32.const(-33.612)),
@@ -269,18 +269,18 @@ function test_core() {
     module.f64.convert_s.i32(module.i32.const(-10)),
     module.f32.convert_u.i32(module.i32.const(-10)),
     module.f64.convert_u.i32(module.i32.const(-10)),
-    module.f32.convert_s.i64(module.i64.const(-22, -1)),
-    module.f64.convert_s.i64(module.i64.const(-22, -1)),
-    module.f32.convert_u.i64(module.i64.const(-22, -1)),
-    module.f64.convert_u.i64(module.i64.const(-22, -1)),
+    module.f32.convert_s.i64(module.i64.const(-23)),
+    module.f64.convert_s.i64(module.i64.const(-23)),
+    module.f32.convert_u.i64(module.i64.const(-23)),
+    module.f64.convert_u.i64(module.i64.const(-23)),
     module.f64.promote(module.f32.const(-33.612)),
     module.f32.demote(module.f64.const(-9005.841)),
     module.f32.reinterpret(module.i32.const(-10)),
-    module.f64.reinterpret(module.i64.const(-22, -1)),
+    module.f64.reinterpret(module.i64.const(-23)),
     module.i8x16.splat(module.i32.const(42)),
     module.i16x8.splat(module.i32.const(42)),
     module.i32x4.splat(module.i32.const(42)),
-    module.i64x2.splat(module.i64.const(123, 456)),
+    module.i64x2.splat(module.i64.const(1_000_000_000_123n)),
     module.f32x4.splat(module.f32.const(42.0)),
     module.f64x2.splat(module.f64.const(42.0)),
     module.v128.not(module.v128.const(v128_bytes)),
@@ -338,17 +338,17 @@ function test_core() {
     module.i32.add(module.i32.const(-10), module.i32.const(-11)),
     module.f64.sub(module.f64.const(-9005.841), module.f64.const(-9007.333)),
     module.i32.div_s(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.div_u(module.i64.const(-22, 0), module.i64.const(-23, 0)),
-    module.i64.rem_s(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.div_u(module.i64.const(-22), module.i64.const(-23)),
+    module.i64.rem_s(module.i64.const(-22), module.i64.const(-23)),
     module.i32.rem_u(module.i32.const(-10), module.i32.const(-11)),
     module.i32.and(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.or(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.or(module.i64.const(-22), module.i64.const(-23)),
     module.i32.xor(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.shl(module.i64.const(-22, 0), module.i64.const(-23, 0)),
-    module.i64.shr_u(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.shl(module.i64.const(-22), module.i64.const(-23)),
+    module.i64.shr_u(module.i64.const(-22), module.i64.const(-23)),
     module.i32.shr_s(module.i32.const(-10), module.i32.const(-11)),
     module.i32.rotl(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.rotr(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.rotr(module.i64.const(-22), module.i64.const(-23)),
     module.f32.div(module.f32.const(-33.612), module.f32.const(-62.5)),
     module.f64.copysign(module.f64.const(-9005.841), module.f64.const(-9007.333)),
     module.f32.min(module.f32.const(-33.612), module.f32.const(-62.5)),
@@ -356,13 +356,13 @@ function test_core() {
     module.i32.eq(module.i32.const(-10), module.i32.const(-11)),
     module.f32.ne(module.f32.const(-33.612), module.f32.const(-62.5)),
     module.i32.lt_s(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.lt_u(module.i64.const(-22, 0), module.i64.const(-23, 0)),
-    module.i64.le_s(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.lt_u(module.i64.const(-22), module.i64.const(-23)),
+    module.i64.le_s(module.i64.const(-22), module.i64.const(-23)),
     module.i32.le_u(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.gt_s(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.gt_s(module.i64.const(-23), module.i64.const(-23)),
     module.i32.gt_u(module.i32.const(-10), module.i32.const(-11)),
     module.i32.ge_s(module.i32.const(-10), module.i32.const(-11)),
-    module.i64.ge_u(module.i64.const(-22, 0), module.i64.const(-23, 0)),
+    module.i64.ge_u(module.i64.const(-22), module.i64.const(-23)),
     module.f32.lt(module.f32.const(-33.612), module.f32.const(-62.5)),
     module.f64.le(module.f64.const(-9005.841), module.f64.const(-9007.333)),
     module.f64.gt(module.f64.const(-9005.841), module.f64.const(-9007.333)),
@@ -507,7 +507,7 @@ function test_core() {
     module.i16x8.replace_lane(module.v128.const(v128_bytes), 1, module.i32.const(42)),
     module.i8x16.replace_lane(module.v128.const(v128_bytes), 1, module.i32.const(42)),
     module.i32x4.replace_lane(module.v128.const(v128_bytes), 1, module.i32.const(42)),
-    module.i64x2.replace_lane(module.v128.const(v128_bytes), 1, module.i64.const(42, 43)),
+    module.i64x2.replace_lane(module.v128.const(v128_bytes), 1, module.i64.const(42)),
     module.f32x4.replace_lane(module.v128.const(v128_bytes), 1, module.f32.const(42)),
     module.f64x2.replace_lane(module.v128.const(v128_bytes), 1, module.f64.const(42)),
     // SIMD shift
@@ -710,15 +710,24 @@ function test_core() {
     }
   }
 
-  console.log("getExpressionInfo(i32.const)=" + JSON.stringify(binaryen.getExpressionInfo(module.i32.const(5))));
-  console.log("getExpressionInfo(i64.const)=" + JSON.stringify(binaryen.getExpressionInfo(module.i64.const(6, 7))));
-  console.log("getExpressionInfo(f32.const)=" + JSON.stringify(binaryen.getExpressionInfo(module.f32.const(8.5))));
-  console.log("getExpressionInfo(f64.const)=" + JSON.stringify(binaryen.getExpressionInfo(module.f64.const(9.5))));
+  function infoToString(info) {
+    // BigInt values cannot be passed through JSON.stringify so convert
+    // them to strings first.
+    if (typeof info.value === 'bigint') {
+      info.value = info.value.toString();
+    }
+    return JSON.stringify(info);
+  }
+
+  console.log("getExpressionInfo(i32.const)=" + infoToString(binaryen.getExpressionInfo(module.i32.const(5))));
+  console.log("getExpressionInfo(i64.const)=" + infoToString(binaryen.getExpressionInfo(module.i64.const(6))));
+  console.log("getExpressionInfo(f32.const)=" + infoToString(binaryen.getExpressionInfo(module.f32.const(8.5))));
+  console.log("getExpressionInfo(f64.const)=" + infoToString(binaryen.getExpressionInfo(module.f64.const(9.5))));
   var elements = binaryen.getExpressionInfo(
     module.tuple.make([ makeInt32(13), makeInt64(37, 0), makeFloat32(1.3), makeFloat64(3.7) ])
   ).operands;
   for (var i = 0; i < elements.length; i++) {
-    console.log("getExpressionInfo(tuple[" + i + "])=" + JSON.stringify(binaryen.getExpressionInfo(elements[i])));
+    console.log("getExpressionInfo(tuple[" + i + "])=" + infoToString(binaryen.getExpressionInfo(elements[i])));
   }
 
   // Make the main body of the function. and one block with a return value, one without

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -118,11 +118,11 @@ getExpressionInfo={"id":15,"type":4,"op":6}
 )
 
 getExpressionInfo(i32.const)={"id":14,"type":2,"value":5}
-getExpressionInfo(i64.const)={"id":14,"type":3,"value":{"low":6,"high":7}}
+getExpressionInfo(i64.const)={"id":14,"type":3,"value":"6"}
 getExpressionInfo(f32.const)={"id":14,"type":4,"value":8.5}
 getExpressionInfo(f64.const)={"id":14,"type":5,"value":9.5}
 getExpressionInfo(tuple[0])={"id":14,"type":2,"value":13}
-getExpressionInfo(tuple[1])={"id":14,"type":3,"value":{"low":37,"high":0}}
+getExpressionInfo(tuple[1])={"id":14,"type":3,"value":"37"}
 getExpressionInfo(tuple[2])={"id":14,"type":4,"value":1.2999999523162842}
 getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
 (module
@@ -163,7 +163,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.ctz
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -223,7 +223,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i32.wrap_i64
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -338,22 +338,22 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (f32.convert_i64_s
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
        (f64.convert_i64_s
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
        (f32.convert_i64_u
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
        (f64.convert_i64_u
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -373,7 +373,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (f64.reinterpret_i64
-        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -393,7 +393,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64x2.splat
-        (i64.const 1958505087099)
+        (i64.const 1000000000123)
        )
       )
       (drop
@@ -681,14 +681,14 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.div_u
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
        (i64.rem_s
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -705,8 +705,8 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.or
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -717,14 +717,14 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.shl
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
        (i64.shr_u
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -741,8 +741,8 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.rotr
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -789,14 +789,14 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.lt_u
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
        (i64.le_s
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -807,8 +807,8 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.gt_s
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -23)
+        (i64.const -23)
        )
       )
       (drop
@@ -825,8 +825,8 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       )
       (drop
        (i64.ge_u
-        (i64.const 4294967274)
-        (i64.const 4294967273)
+        (i64.const -22)
+        (i64.const -23)
        )
       )
       (drop
@@ -1674,7 +1674,7 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
       (drop
        (i64x2.replace_lane 1
         (v128.const i32x4 0x04030201 0x08070605 0x0c0b0a09 0x100f0e0d)
-        (i64.const 184683593770)
+        (i64.const 42)
        )
       )
       (drop


### PR DESCRIPTION
This flag has been enabled by default in emscripten for a while now so I don't think we need this here anymore.

Also remove the `-Wno-experimental` flag which is no longer needed for `-sMEMORY64`.

Also remove `-sMODULARIZE` which is implied by `-sEXPORT_ES6`.