### PR TITLE
[emscripten] Avoid copying binaryen.js for each test. NFC

### DIFF
--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import shutil
 import subprocess
 
 from . import shared
@@ -37,15 +36,10 @@ function assert(x) {
 
 
 def make_js_test(input_js_file, binaryen_js):
-    # Copy the binaryen.js file to binaryen.mjs for now since file
-    # extensions matter under node.
-    # TODO(sbc): Should binaryen build as a `.mjs` file itself?
-    shutil.copyfile(binaryen_js, 'binaryen.mjs')
-
     basename = os.path.basename(input_js_file)
     outname = os.path.splitext(basename)[0] + '.mjs'
     with open(outname, 'w') as f:
-        f.write(make_js_test_header('./binaryen.mjs'))
+        f.write(make_js_test_header(binaryen_js))
         test_src = open(input_js_file).read()
         f.write(test_src)
     return outname


### PR DESCRIPTION
Turns out you can import a `.js` just fine under node.  It doesn't need to be called `.mjs`, despite the comment.