### PR TITLE
[emscripten] Drop `-sWASM=0` variant build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ CMakeFiles
 /dist/
 /config.h
 /emcc-build
+/emcc-build-dbg
 compile_commands.json
 test/lit/lit.site.cfg.py
 CMakeUserPresets.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - The emscripten build of binaryen no longer targets pure JS (via wasm2js) by
+   default.  In the long run this will allow us to enable WASM_BIGINT and other
+   features that wasm2js does not support.  There is now just a single
+   binaryen_js target.  It should still be possible to inject `-sWASM=0` as a
+   linker flag but this is not officially supported. (#7995)
 
 v126
 ----

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,99 +545,45 @@ endif()
 # binaryen.js
 #
 # Note that we can't emit binaryen.js directly, as there is libbinaryen already
-# declared earlier, so we create binaryen_wasm/js.js, which must then be copied.
+# declared earlier, so we create binaryen_js.js, which must then be copied.
 if(EMSCRIPTEN)
-  # binaryen.js WebAssembly variant
-  add_executable(binaryen_wasm ${binaryen_HEADERS})
+  add_executable(binaryen_js ${binaryen_HEADERS})
   # For the emscripten build we link against libbinaryen wih `--whole-archive`.
   # Without this, the EMSCRIPTEN_KEEPALIVE symbols within the library would
   # be ignored.
-  target_link_libraries(binaryen_wasm PRIVATE binaryen)
-  target_link_libraries(binaryen_wasm PRIVATE "-sFILESYSTEM")
-  target_link_libraries(binaryen_wasm PRIVATE "-sEXPORT_NAME=Binaryen")
-  target_link_libraries(binaryen_wasm PRIVATE "-sNODERAWFS=0")
-  # Do not error on the repeated NODERAWFS argument
-  target_link_libraries(binaryen_wasm PRIVATE "-Wno-unused-command-line-argument")
-  # Emit a single file for convenience of people using binaryen.js as a library,
-  # so they only need to distribute a single file.
-  if(EMSCRIPTEN_ENABLE_SINGLE_FILE)
-    target_link_libraries(binaryen_wasm PRIVATE "-sSINGLE_FILE")
-  endif()
-  target_link_libraries(binaryen_wasm PRIVATE "-sEXPORT_ES6")
-  target_link_libraries(binaryen_wasm PRIVATE "-sEXPORTED_RUNTIME_METHODS=stringToUTF8OnStack,stringToAscii")
-  # Explictly export _i32_load to ensure the binaryen-c.cpp is linked in.
-  # This is the file that contains all the EMSCRIPTEN_KEEPALIVE symbols which
-  # we want to exports, but enless we explictly reference a symbol from it
-  # the linker will ignore the whole library.
-  # TODO(sbc): Replace with `LINK_LIBRARY:WHOLE_ARCHIVE` once we bump the min
-  # cmake version 3.24.
-  target_link_libraries(binaryen_wasm PRIVATE "-sEXPORTED_FUNCTIONS=_malloc,_free,__i32_load")
-  target_link_libraries(binaryen_wasm PRIVATE "--post-js=${CMAKE_CURRENT_SOURCE_DIR}/src/js/binaryen.js-post.js")
-  target_link_libraries(binaryen_wasm PRIVATE optimized "--closure=1")
-  # TODO: Fix closure warnings! (#5062)
-  target_link_libraries(binaryen_wasm PRIVATE optimized "-Wno-error=closure")
-  target_link_libraries(binaryen_wasm PRIVATE debug "--profiling")
-  # Avoid catching exit as that can confuse error reporting in Node,
-  # see https://github.com/emscripten-core/emscripten/issues/17228
-  target_link_libraries(binaryen_wasm PRIVATE "-sNODEJS_CATCH_EXIT=0")
-  # Don't exit the process on a fatal error, instead throw, so that JS can
-  # catch.
-  add_compile_flag("-DTHROW_ON_FATAL")
-  # Add support for printing C++ exceptions from JS.
-  target_link_libraries(binaryen_wasm PRIVATE "-sEXPORT_EXCEPTION_HANDLING_HELPERS")
-  install(TARGETS binaryen_wasm DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-  # binaryen.js JavaScript variant
-  add_executable(binaryen_js ${binaryen_HEADERS})
   target_link_libraries(binaryen_js PRIVATE binaryen)
-  target_link_libraries(binaryen_js PRIVATE "-sWASM=0")
-  target_link_libraries(binaryen_js PRIVATE "-sWASM_ASYNC_COMPILATION=0")
-
-  if(${CMAKE_CXX_COMPILER_VERSION} STREQUAL "6.0.1")
-    # only valid with fastcomp and WASM=0
-    target_link_libraries(binaryen_js PRIVATE "-sELIMINATE_DUPLICATE_FUNCTIONS")
-  endif()
-  # Disabling filesystem and setting web environment for js_of_ocaml
-  # so it doesn't try to detect the "node" environment
-  if(JS_OF_OCAML)
-    target_link_libraries(binaryen_js PRIVATE "-sFILESYSTEM=0")
-    target_link_libraries(binaryen_js PRIVATE "-sENVIRONMENT=web,worker")
-  else()
-    target_link_libraries(binaryen_js PRIVATE "-sFILESYSTEM=1")
-  endif()
+  target_link_libraries(binaryen_js PRIVATE "-sFILESYSTEM")
+  target_link_libraries(binaryen_js PRIVATE "-sEXPORT_NAME=Binaryen")
   target_link_libraries(binaryen_js PRIVATE "-sNODERAWFS=0")
   # Do not error on the repeated NODERAWFS argument
   target_link_libraries(binaryen_js PRIVATE "-Wno-unused-command-line-argument")
+  # Emit a single file for convenience of people using binaryen.js as a library,
+  # so they only need to distribute a single file.
   if(EMSCRIPTEN_ENABLE_SINGLE_FILE)
     target_link_libraries(binaryen_js PRIVATE "-sSINGLE_FILE")
   endif()
-  target_link_libraries(binaryen_js PRIVATE "-sEXPORT_NAME=Binaryen")
-  # Currently, js_of_ocaml can only process ES5 code
   if(JS_OF_OCAML)
-    target_link_libraries(binaryen_js PRIVATE "-sEXPORT_ES6=0")
+    # js_of_ocaml needs a specified variable with special comment to provide the library to consumer
+    target_link_libraries(binaryen_js PRIVATE "--extern-pre-js=${CMAKE_CURRENT_SOURCE_DIR}/src/js/binaryen.jsoo-extern-pre.js")
+    # Currently, js_of_ocaml can only process ES5 code
+    target_link_libraries(binaryen_js PRIVATE optimized "--closure-args=\"--language_out=ECMASCRIPT5\"")
   else()
-    target_link_libraries(binaryen_js PRIVATE "-sEXPORT_ES6=1")
+    target_link_libraries(binaryen_js PRIVATE "-sEXPORT_ES6")
   endif()
   target_link_libraries(binaryen_js PRIVATE "-sEXPORTED_RUNTIME_METHODS=stringToUTF8OnStack,stringToAscii")
   target_link_libraries(binaryen_js PRIVATE "-sEXPORTED_FUNCTIONS=_malloc,_free,__i32_load")
   target_link_libraries(binaryen_js PRIVATE "--post-js=${CMAKE_CURRENT_SOURCE_DIR}/src/js/binaryen.js-post.js")
-  # js_of_ocaml needs a specified variable with special comment to provide the library to consumers
-  if(JS_OF_OCAML)
-    target_link_libraries(binaryen_js PRIVATE "--extern-pre-js=${CMAKE_CURRENT_SOURCE_DIR}/src/js/binaryen.jsoo-extern-pre.js")
-  endif()
   target_link_libraries(binaryen_js PRIVATE optimized "--closure=1")
-  # Currently, js_of_ocaml can only process ES5 code
-  if(JS_OF_OCAML)
-    target_link_libraries(binaryen_js PRIVATE optimized "--closure-args=\"--language_out=ECMASCRIPT5\"")
-  endif()
   # TODO: Fix closure warnings! (#5062)
   target_link_libraries(binaryen_js PRIVATE optimized "-Wno-error=closure")
   target_link_libraries(binaryen_js PRIVATE debug "--profiling")
-  target_link_libraries(binaryen_js PRIVATE debug "-sASSERTIONS")
   # Avoid catching exit as that can confuse error reporting in Node,
   # see https://github.com/emscripten-core/emscripten/issues/17228
   target_link_libraries(binaryen_js PRIVATE "-sNODEJS_CATCH_EXIT=0")
+  # Don't exit the process on a fatal error, instead throw, so that JS can
+  # catch.
   add_compile_flag("-DTHROW_ON_FATAL")
+  # Add support for printing C++ exceptions from JS.
   target_link_libraries(binaryen_js PRIVATE "-sEXPORT_EXCEPTION_HANDLING_HELPERS")
   install(TARGETS binaryen_js DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/check.py
+++ b/check.py
@@ -438,7 +438,6 @@ TEST_SUITES = OrderedDict([
     ('example', run_example_tests),
     ('unit', run_unittest),
     ('binaryenjs', binaryenjs.test_binaryen_js),
-    ('binaryenjs_wasm', binaryenjs.test_binaryen_wasm),
     ('lit', run_lit),
     ('gtest', run_gtest),
 ])
@@ -447,7 +446,7 @@ TEST_SUITES = OrderedDict([
 # Run all the tests
 def main():
     all_suites = TEST_SUITES.keys()
-    skip_by_default = ['binaryenjs', 'binaryenjs_wasm']
+    skip_by_default = ['binaryenjs']
 
     if shared.options.list_suites:
         for suite in all_suites:

--- a/scripts/emcc-tests.sh
+++ b/scripts/emcc-tests.sh
@@ -5,16 +5,17 @@ set -o pipefail
 
 SRCDIR="$(dirname $(dirname ${BASH_SOURCE[0]}))"
 
-mkdir -p emcc-build
-echo "emcc-tests: build:wasm"
-emcmake cmake -S $SRCDIR -B emcc-build -DCMAKE_BUILD_TYPE=Release -G Ninja
-ninja -C emcc-build binaryen_wasm
-echo "emcc-tests: test:wasm"
-$SRCDIR/check.py --binaryen-bin=emcc-build/bin binaryenjs_wasm
-echo "emcc-tests: done:wasm"
+mkdir -p emcc-build-dbg
+echo "emcc-tests: build dbg"
+emcmake cmake -S $SRCDIR -B emcc-build-dbg -DCMAKE_BUILD_TYPE=Debug -G Ninja
+ninja -C emcc-build-dbg binaryen_js
+echo "emcc-tests: test dbg"
+$SRCDIR/check.py --binaryen-bin=emcc-build-dbg/bin binaryenjs
 
-echo "emcc-tests: build:js"
-ninja -C emcc-build  binaryen_js
-echo "emcc-tests: test:js"
+mkdir -p emcc-build
+echo "emcc-tests: build"
+emcmake cmake -S $SRCDIR -B emcc-build -DCMAKE_BUILD_TYPE=Release -G Ninja
+ninja -C emcc-build binaryen_js
+echo "emcc-tests: test"
 $SRCDIR/check.py --binaryen-bin=emcc-build/bin binaryenjs
-echo "emcc-tests: done:js"
+echo "emcc-tests: done"

--- a/scripts/test/binaryenjs.py
+++ b/scripts/test/binaryenjs.py
@@ -44,18 +44,18 @@ def make_js_test(input_js_file, binaryen_js):
     return outname
 
 
-def do_test_binaryen_js_with(which):
+def test_binaryen_js():
     if not (shared.MOZJS or shared.NODEJS):
         shared.fail_with_error('no vm to run binaryen.js tests')
 
     node_has_wasm = shared.NODEJS and support.node_has_webassembly(shared.NODEJS)
-    if not os.path.exists(which):
-        shared.fail_with_error('no ' + which + ' build to test')
+    if not os.path.exists(shared.BINARYEN_JS):
+        shared.fail_with_error('no ' + shared.BINARYEN_JS + ' build to test')
 
-    print('\n[ checking binaryen.js testcases (' + which + ')... ]\n')
+    print('\n[ checking binaryen.js testcases (' + shared.BINARYEN_JS + ')... ]\n')
 
     for s in shared.get_tests(shared.get_test_dir('binaryen.js'), ['.js']):
-        outname = make_js_test(s, which)
+        outname = make_js_test(s, shared.BINARYEN_JS)
 
         def test(cmd):
             if 'fatal' not in s:
@@ -109,11 +109,3 @@ def update_binaryen_js_tests():
             update([shared.NODEJS, outname])
         else:
             print('Skipping ' + s + ' because WebAssembly might not be supported')
-
-
-def test_binaryen_js():
-    do_test_binaryen_js_with(shared.BINARYEN_JS)
-
-
-def test_binaryen_wasm():
-    do_test_binaryen_js_with(shared.BINARYEN_WASM)

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -207,7 +207,6 @@ WASM_METADCE = [os.path.join(options.binaryen_bin, 'wasm-metadce')]
 WASM_EMSCRIPTEN_FINALIZE = [os.path.join(options.binaryen_bin,
                                          'wasm-emscripten-finalize')]
 BINARYEN_JS = os.path.join(options.binaryen_bin, 'binaryen_js.js')
-BINARYEN_WASM = os.path.join(options.binaryen_bin, 'binaryen_wasm.js')
 
 
 def wrap_with_valgrind(cmd):

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -3262,13 +3262,17 @@ function handleFatalError(func) {
   try {
     return func();
   } catch (e) {
-    // C++ exceptions are thrown as pointers (numbers).
+    // Fatal errors begin with that prefix. Strip it out, and the newline.
+    // C++ exceptions are thrown as pointers (numbers) in release builds
+    // but CppException JS class in debug builds.
     if (typeof e === 'number') {
-      // Fatal errors begin with that prefix. Strip it out, and the newline.
       var [_, message] = getExceptionMessage(e);
       if (message?.startsWith('Fatal: ')) {
         throw new Error(message.substr(7).trim());
       }
+    } else  {
+      e.message = e.message.replace('Fatal:', '');
+      e.message = e.message.trim();
     }
     // Rethrow anything else.
     throw e;


### PR DESCRIPTION
There is now just one emscripten target called `binaryen_js`.  The settings for these two targets were almost identical except for.

1. Some JS_OF_OCAML specific stuff which is kept for the new unified target.
2. `-sASSERTIONS` was being forced (See #2507).  I dropped this in favor of doing a debug build in testing where this is enabled by default.

The changes to the post.js files are needed to get the binaryenjs tests to pass in debug mode.  We were simply not running any tests in debug mode before this change.
