### PR TITLE
Improve fuzzing of Two

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -1816,8 +1816,8 @@ class Two(TestCaseHandler):
 
     def handle(self, wasm):
         # Generate a second wasm file. (For fuzzing, we may be given one, but we
-        # still generate it to avoid changes to random numbers later; we just
-        # discard it after.)
+        # still do the work to prepare to generate it, as that consumes random
+        # values, and we don't want that to affect anything later.)
         second_wasm = abspath('second.wasm')
         second_input = abspath('second_input.dat')
         second_size = random_size()


### PR DESCRIPTION
I finally found out how to make this not horrible:

1. We must be careful to not use randomness differently when
  the second file is provided (or else reductions can fail weirdly).
2. Automatically fuzz the second wasm when `BINARYEN_FIRST_WASM`
  is provided (which means the first is to be kept fixed).
4. Add some docs.
