### PR TITLE
Fuzzer: Fix handling of Rethrow and Try fixups

### DIFF
--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -2160,6 +2160,8 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
     void visitRethrow(Rethrow* curr) {
       if (!isValidTryRef(curr->target, curr)) {
         replace();
+      } else {
+        visitExpression(curr);
       }
     }
 
@@ -2167,6 +2169,8 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
       if (curr->delegateTarget.is() &&
           !isValidTryRef(curr->delegateTarget, curr)) {
         replace();
+      } else {
+        visitExpression(curr);
       }
     }
 
@@ -2203,8 +2207,7 @@ void TranslateToFuzzReader::fixAfterChanges(Function* func) {
         i--;
       }
     }
-  };
-  Fixer fixer(wasm, *this);
+  } fixer(wasm, *this);
   fixer.walk(func->body);
 
   // Refinalize at the end, after labels are all fixed up.


### PR DESCRIPTION
We need to call the super (`visitExpression`) if they do not entirely
replace the contents, as the super has general logic (like name
fixups for Try) that we need.