### PR TITLE
[NFC] Fuzzer: Rename the misleading void-returning get() method

### DIFF
--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -311,9 +311,9 @@ struct ExecutionResults {
   // If set, we should ignore this and not compare it to anything.
   bool ignore = false;
 
-  // Get results of executing a module. Optionally, provide a second module to
-  // link with it (like fuzz_shell's second module).
-  void get(Module& wasm, Module* second = nullptr) {
+  // Execute a module and collect the results. Optionally, provide a second
+  // module to link with it (like fuzz_shell's second module).
+  void collect(Module& wasm, Module* second = nullptr) {
     try {
       // Instantiate the first module.
       LoggingExternalInterface interface(loggings, wasm);
@@ -427,7 +427,7 @@ struct ExecutionResults {
   // get current results and check them against previous ones
   void check(Module& wasm) {
     ExecutionResults optimizedResults;
-    optimizedResults.get(wasm);
+    optimizedResults.collect(wasm);
     if (optimizedResults != *this) {
       std::cout << "[fuzz-exec] optimization passes changed results\n";
       exit(1);

--- a/src/tools/wasm-opt.cpp
+++ b/src/tools/wasm-opt.cpp
@@ -367,14 +367,14 @@ For more on how to optimize effectively, see
   ExecutionResults results;
   if (fuzzExecBefore) {
     if (fuzzExecSecond.empty()) {
-      results.get(wasm);
+      results.collect(wasm);
     } else {
       // Add the second module.
       Module second;
       second.features = wasm.features;
       ModuleReader().read(fuzzExecSecond, second);
 
-      results.get(wasm, &second);
+      results.collect(wasm, &second);
     }
   }
 


### PR DESCRIPTION
@tlively you noticed this name was confusing.