### PR TITLE
J2CLOpts - Avoid an error when handling imported globals by checking for/ignoring them in GlobalAssignmentCollector

### DIFF
--- a/src/passes/J2CLOpts.cpp
+++ b/src/passes/J2CLOpts.cpp
@@ -88,6 +88,10 @@ public:
     : assignmentCounts(assignmentCounts) {}
 
   void visitGlobal(Global* curr) {
+    // Ignore imported globals, e.g., JS prototypes.
+    if (curr->imported()) {
+      return;
+    }
     if (isInitialValue(curr->init)) {
       return;
     }

--- a/test/lit/passes/j2cl.wast
+++ b/test/lit/passes/j2cl.wast
@@ -351,3 +351,10 @@
     )
   )
 )
+
+;; Imported globals are ignored
+(module
+  ;; CHECK:      (import "a" "b" (global $a.b (ref extern)))
+  (import "a" "b" (global $a.b (ref extern)))
+)
+


### PR DESCRIPTION
This pass was failing because it is trying to access `curr->init`, where `curr` is a `Global*`. `init` is null when the global is imported.