### PR TITLE
[NFC] Avoid imported (ref exn) in testcase

### DIFF
--- a/test/lit/passes/j2cl.wast
+++ b/test/lit/passes/j2cl.wast
@@ -352,9 +352,9 @@
   )
 )
 
-;; Imported globals are ignored
+;; Imported globals are ignored.
 (module
-  ;; CHECK:      (import "a" "b" (global $a.b (ref extern)))
-  (import "a" "b" (global $a.b (ref extern)))
+  ;; CHECK:      (import "a" "b" (global $a.b (ref func)))
+  (import "a" "b" (global $a.b (ref func)))
 )
 


### PR DESCRIPTION
That is harder for the fuzzer to handle, and isn't important in the test.

cc @mason-lgtm