### PR TITLE
Fuzzer: Emit fewer null descriptors, which trap

### DIFF
--- a/src/tools/fuzzing.h
+++ b/src/tools/fuzzing.h
@@ -487,6 +487,7 @@ private:
   // used in a place that will trap on null. For example, the reference of a
   // struct.get or array.set would use this.
   Expression* makeTrappingRefUse(HeapType type);
+  Expression* makeTrappingRefUse(Type type);
 
   Expression* buildUnary(const UnaryArgs& args);
   Expression* makeUnary(Type type);

--- a/src/tools/fuzzing/fuzzing.cpp
+++ b/src/tools/fuzzing/fuzzing.cpp
@@ -3952,7 +3952,7 @@ Expression* TranslateToFuzzReader::makeCompoundRef(Type type) {
       }
       Expression* descriptor = nullptr;
       if (auto descType = heapType.getDescriptorType()) {
-        descriptor = make(Type(*descType, Nullable, Exact));
+        descriptor = makeTrappingRefUse(Type(*descType, Nullable, Exact));
       }
       return builder.makeStructNew(heapType, values, descriptor);
     }
@@ -4076,13 +4076,17 @@ Expression* TranslateToFuzzReader::makeStringGet(Type type) {
 }
 
 Expression* TranslateToFuzzReader::makeTrappingRefUse(HeapType type) {
+  return makeTrappingRefUse(Type(type, Nullable));
+}
+
+Expression* TranslateToFuzzReader::makeTrappingRefUse(Type type) {
   auto percent = upTo(100);
   // Only give a low probability to emit a nullable reference.
   if (percent < 5) {
-    return make(Type(type, Nullable));
+    return make(type.with(Nullable));
   }
   // Otherwise, usually emit a non-nullable one.
-  auto nonNull = Type(type, NonNullable);
+  auto nonNull = type.with(NonNullable);
   if (percent < 70 || !funcContext) {
     return make(nonNull);
   }


### PR DESCRIPTION
This was a major source of testcases failing in initialization.