### PR TITLE
Mark TypeFinalizing/Unfinalizing as requiring closed world

### DIFF
--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -2484,6 +2484,8 @@ requires_closed_world = {("--type-refining",),
                          ("--abstract-type-refining",),
                          ("--cfp",),
                          ("--cfp-reftest",),
+                         ("--type-finalizing",),
+                         ("--type-unfinalizing",),
                          ("--type-ssa",),
                          ("--type-merging",),
                          ("--unsubtyping",)}


### PR DESCRIPTION
They change the ABI, possibly making casts start to work/fail.