### PR TITLE
[Custom Descriptors] Exact imports require CD

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -4159,7 +4159,12 @@ void FunctionValidator::visitFunction(Function* curr) {
                curr->name,
                "all used types should be allowed");
 
-  if (!curr->imported()) {
+  if (curr->imported()) {
+    shouldBeTrue(
+      curr->type.isInexact() || getModule()->features.hasCustomDescriptors(),
+      curr->name,
+      "exact imports require custom descriptors [--enable-custom-descriptors]");
+  } else {
     shouldBeTrue(
       curr->type.isExact(), curr->name, "defined function should be exact");
   }

--- a/test/lit/validation/exact-import.wast
+++ b/test/lit/validation/exact-import.wast
@@ -1,0 +1,9 @@
+;; Test that exact imports require custom descriptors.
+
+;; RUN: not wasm-opt %s -all --disable-custom-descriptors 2>&1 | filecheck %s
+
+;; CHECK: exact imports require custom descriptors [--enable-custom-descriptors]
+
+(module
+  (import "" "" (func $f (exact)))
+)


### PR DESCRIPTION
Validate that exact function imports require custom descriptors. An
alternative approach (that we may switch to in the future if necessary)
would be to always allow exact imports, but then strip them out in the
binary writer when custom descriptors are not enabled. For now take the
more explicit what-you-see-is-what-you-get approach.
