### PR TITLE
Remove the use of microsoft STL extension in file.cpp

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -125,13 +125,13 @@ wasm::Output::Output(const std::string& filename, Flags::BinaryOption binary)
     }()) {}
 
 void wasm::copy_file(std::string input, std::string output) {
-  std::ifstream src(wasm::Path::to_path(input), std::ios::binary);
-  std::ofstream dst(wasm::Path::to_path(output), std::ios::binary);
+  std::ifstream src(wasm::Path::to_path(input).c_str(), std::ios::binary);
+  std::ofstream dst(wasm::Path::to_path(output).c_str(), std::ios::binary);
   dst << src.rdbuf();
 }
 
 size_t wasm::file_size(std::string filename) {
-  std::ifstream infile(wasm::Path::to_path(filename),
+  std::ifstream infile(wasm::Path::to_path(filename).c_str(),
                        std::ifstream::ate | std::ifstream::binary);
   return infile.tellg();
 }


### PR DESCRIPTION
Standard std::[io]fstream does not have a constructor from `std::wstring`, but from `std::string` or `const wchar_t*`. Microsoft STL has an extension that supports a `std::wstring` constructor, which the current code depends on. However, that extension does not exist in libc++ and therefore fails when trying to use libc++ with clang-cl on Windows.

This patch uses the standard-compliant constructor and builds with libc++.

https://en.cppreference.com/w/cpp/io/basic_ifstream/basic_ifstream.html
https://en.cppreference.com/w/cpp/io/basic_ifstream/basic_ofstream.html