### PR TITLE
[NFC] RemoveUnusedModuleElements: Optimize repeated table lookups

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -417,7 +417,7 @@ struct Analyzer {
     // Any function in the table of that signature may be called.
     for (auto& elemInfo : flatTableInfoMap[table]) {
       auto elemReferenced = false;
-      for (auto [func, funcType] : elemInfo.data) {
+      for (auto& [func, funcType] : elemInfo.data) {
         if (HeapType::isSubType(funcType.getHeapType(), type)) {
           use({ModuleElementKind::Function, func});
           elemReferenced = true;


### PR DESCRIPTION
Each time we see a new `call_indirect` form (a new combo of table + type that
is called), we scan the table to see which functions might be called. In a large
Dart testcase I am looking at, we have 500K items in a table (!), and the
constant scanning of items in the segment into RefFuncs and then looking up
their functions on the module is by far the slowest part of the pass. Reduce that
overhead by precomputing a "flat", friendly form of segments, which has the
function name and type on each element segment item.

This makes the slowest pass on that testcase over **2x faster**, from `16.05` to `6.85`
seconds. The pass runs 3 times in `-O3` so this lets us save almost `30`
seconds from the total time of `184`, making us overall **15% faster**.

After this, the slowest thing is `HeapType::isSubType`, which might also be
worth optimizing (but harder).