### PR TITLE
[analysis] Add a ConeType lattice

### DIFF
--- a/src/analysis/lattices/conetype.h
+++ b/src/analysis/lattices/conetype.h
@@ -22,6 +22,11 @@
 
 namespace wasm::analysis {
 
+// The value type lattice augmented with subtyping depths on reference types. An
+// element {(ref $foo), 1}, for example, represents the set of values that are
+// exactly $foo or exactly one of $foo's immediate subtypes, but not any deeper
+// type. Non-reference types and bottom references types always have a depth of
+// 0.
 struct ConeType {
   struct Element {
     Type type;
@@ -34,7 +39,8 @@ struct ConeType {
     bool isTop() const { return type == Type::none; }
   };
 
-  std::unordered_map<HeapType, Index> typeDepths;
+  // Used only for initializing depths for new elements.
+  const std::unordered_map<HeapType, Index> typeDepths;
 
   ConeType(std::unordered_map<HeapType, Index>&& typeDepths)
     : typeDepths(std::move(typeDepths)) {}

--- a/test/gtest/lattices.cpp
+++ b/test/gtest/lattices.cpp
@@ -869,6 +869,8 @@ protected:
   Element top;
   Element i32;
   Element i64;
+
+  // The number at the end is the depth of the element.
   Element eqNull3;
   Element eqNonNull3;
   Element structNull2;
@@ -975,6 +977,8 @@ protected:
     CHECK_MEET(a, b, meet);
     switch (lattice.compare(a, b)) {
       case analysis::NO_RELATION:
+        // This first check looks redundant, but it's also checking the opposite
+        // direction.
         CHECK_UNRELATED(a, b);
         CHECK_LESS(a, join);
         CHECK_LESS(b, join);
@@ -1046,8 +1050,8 @@ private:
 
 std::unordered_map<HeapType, Index>
 ConeTypeLatticeTest::initTypes(ConeTypeLatticeTest* self) {
-  // 0  3
-  // |\
+  //   0  3
+  //  /|
   // 1 2
   TypeBuilder builder(4);
   builder.createRecGroup(0, 4);


### PR DESCRIPTION
ConeType is an important part of PossibleContents. Implement it as a
standalone lattice that can be combined into a larger lattice if we
rewrite PossibleContents in terms of the lattice framework.
