### PR TITLE
[NFC] DeadArgumentElimination: Compute callers instead of Call origins

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -247,7 +247,7 @@ struct DAE : public Pass {
     std::vector<bool> hasUnseenCalls(numFunctions);
 
     // For each function, the set of callers.
-    std::vector<std::unordered_set<Name>> callers;
+    std::vector<std::unordered_set<Name>> callers(numFunctions);
 
     for (auto& [func, info] : infoMap) {
       for (auto& [name, calls] : info.calls) {


### PR DESCRIPTION
We had the list of Calls to each function, and used a map of Calls to
their origin functions to find all the callers of a function. Instead, just
track the set of callers directly, which avoids duplication and the extra
lookup table entry per Call (there can be many Calls from a source to a
target).

This makes a Dart testcase I am looking at run DAE 10% faster, and
DAE is the slowest pass by far.