### PR TITLE
[NFC] DeadArgumentElimination: Compute callers once

### DIFF
--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -296,7 +296,7 @@ struct DAE : public Pass {
       callers.resize(numFunctions);
       for (Index i = 0; i < numFunctions; ++i) {
         auto& set = callersSets[i];
-        std::copy(set.begin(), set.end(), std::back_inserter(callers[i]));
+        callers[i] = std::vector<Name>(set.begin(), set.end());
       }
     }
 


### PR DESCRIPTION
This is an over-approximation, as later iterations may have fewer calls - if we
remove a call. Such removal is rare, however, and the cost of computing this
map is actually very high. Computing it once up front, and using that over-
approximation, turns out to be much faster, even if in theory it can lead to a
little wasted work (more scanning; but no optimizations are missed, as we do
not use this mapping to decide what/how to optimize).

This makes the pass 30-40% faster on several large testcases I tried, from
Dart, Java, and C++. I did see two testcases that benefited only by 10-20%,
from GraalVM and Rust, but I saw none that did not benefit significantly.

This was the slowest pass in some of those 30-40% cases.

Helps #4165