### PR TITLE
Use relative paths for spec tests to skip to avoid ambiguity when two tests have the same basename

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -389,7 +389,7 @@ if options.spec_tests:
     non_existent_tests = [test_name for test_name in options.spec_tests if not os.path.isfile(test_name)]
     if non_existent_tests:
         raise ValueError(f"Supplied test files do not exist: {non_existent_tests}")
-    options.spec_tests = options.spec_tests
+    options.spec_tests = [os.path.abspath(t) for t in options.spec_tests]
 else:
     options.spec_tests = get_tests(get_test_dir('spec'), ['.wast'], recursive=True)
 


### PR DESCRIPTION
* Update SPEC_TESTS_TO_SKIP and SPEC_TESTSUITE_TESTS_TO_SKIP to use relative paths, which allows us to distinguish between tests with the same base name. This is useful since some future changes will fix test/spec/testsuite/memory.wast but not test/spec/testsuite/proposals/threads/memory.wast
* Check that the user-specified `--spec-test` paths exist. This is also done to avoid skipping rather than erroring when the user specifies a path relative to `test/` instead of relative to the repo root (since we drop the test/ prefix we can't tell the difference).

Test (after commenting the exclusion for  test/spec/testsuite/proposals/threads/memory.wast, which is currently failing): 
<img width="1093" height="785" alt="image" src="https://github.com/user-attachments/assets/07e2c927-d5a8-4d99-8540-c80d63d4b327" />
