### PR TITLE
Fix Unsubtyping on extern.convert_any

### DIFF
--- a/src/ir/subtype-exprs.h
+++ b/src/ir/subtype-exprs.h
@@ -445,8 +445,19 @@ struct SubtypingDiscoverer : public OverriddenVisitor<SubType> {
     self()->noteSubtype(curr->replacement, type);
   }
   void visitRefAs(RefAs* curr) {
-    if (curr->op == RefAsNonNull) {
-      self()->noteCast(curr->value, curr);
+    switch (curr->op) {
+      case RefAsNonNull:
+        self()->noteCast(curr->value, curr);
+        return;
+      case AnyConvertExtern:
+        return;
+      case ExternConvertAny:
+        if (curr->type != Type::unreachable) {
+          auto any =
+            HeapTypes::any.getBasic(curr->type.getHeapType().getShared());
+          self()->noteSubtype(curr->value, Type(any, Nullable));
+        }
+        return;
     }
   }
   void visitStringNew(StringNew* curr) {}


### PR DESCRIPTION
We were not previously recording that the input to extern.convert_any
has to be a subtype of anyref. This meant that it was possible for
Unsubtyping to optimize too aggressively and break casts.
