### PR TITLE
Inlining: Handle local dependencies when splitting

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1015,7 +1015,7 @@ struct FunctionSplitter {
     }
     // Finish the locals check mentioned above.
     if (finalItem) {
-      for (auto* get : FindAll<LocalSet>(finalItem).list) {
+      for (auto* get : FindAll<LocalGet>(finalItem).list) {
         if (writtenLocals.count(get->index)) {
           return InliningMode::Uninlineable;
         }


### PR DESCRIPTION
In pattern B there, we handle stuff like
```js
if (..) { .. }
return x;
```
We split out the `if` body if it is large-enough, which allows inlining the `if`
condition + the return (efficient if the condition rarely happens). This did
not handle local effects: imagine that the if body contains `x = 42`, then
after splitting it out to another function, that value is not picked up in
the return of x. Fix that by checking local dependencies.

More detailed example:
```js
function foo(x) {
  if (..) {
    work();
    x = 42;
  }
  return x;
}

function caller() {
  foo(1);
}

=> the incorrect optimization before =>

function caller() {
  // inlined call, but split: just the condition + return.
  var x = 1; // inlined value sent in call
  if (..) {
    outlinedCode();
  }
  x = x;
}

function outlinedCode() {
  // The setting of x to 42 is done here, and not picked up
  // in the caller.
  var x;
  work();
  x = 42;
}
```

After this PR, we do not do such split inlining.