### PR TITLE
Ignore build directory in .flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,4 +6,4 @@ ignore =
   E241,
   ; line break after binary operator
   W504
-exclude = third_party,./test/emscripten,./test/spec,./test/wasm-install,./test/lit,./_deps
+exclude = third_party,./test/emscripten,./test/spec,./test/wasm-install,./test/lit,./_deps,./build


### PR DESCRIPTION
Prevents spurious formatting errors from `./build/test/lit/lit.site.cfg.py`:

```sh
$ flake8
./build/test/lit/lit.site.cfg.py:3:1: F821 undefined name 'config'
./build/test/lit/lit.site.cfg.py:4:1: F821 undefined name 'config'
./build/test/lit/lit.site.cfg.py:6:1: F821 undefined name 'lit_config'
./build/test/lit/lit.site.cfg.py:7:5: F821 undefined name 'config'
./build/test/lit/lit.site.cfg.py:7:26: F821 undefined name 'config'
```