### PR TITLE
Properly hash and compare internalized strings

### DIFF
--- a/src/wasm/literal.cpp
+++ b/src/wasm/literal.cpp
@@ -493,12 +493,16 @@ bool Literal::operator==(const Literal& other) const {
     if (type.isData()) {
       return gcData == other.gcData;
     }
-    assert(type.getHeapType().isBasic());
-    if (type.getHeapType().isMaybeShared(HeapType::i31)) {
+    auto heapType = type.getHeapType();
+    assert(heapType.isBasic());
+    if (heapType.isMaybeShared(HeapType::i31)) {
       return i32 == other.i32;
     }
-    if (type.getHeapType().isMaybeShared(HeapType::ext)) {
+    if (heapType.isMaybeShared(HeapType::ext)) {
       return internalize() == other.internalize();
+    }
+    if (heapType.isMaybeShared(HeapType::any)) {
+      return externalize() == other.externalize();
     }
     WASM_UNREACHABLE("unexpected type");
   }

--- a/test/lit/passes/rse-gc.wast
+++ b/test/lit/passes/rse-gc.wast
@@ -303,4 +303,44 @@
     (local.get $s)
   )
  )
+
+ ;; CHECK:      (func $any-extern (type $3)
+ ;; CHECK-NEXT:  (local $any anyref)
+ ;; CHECK-NEXT:  (local.set $any
+ ;; CHECK-NEXT:   (any.convert_extern
+ ;; CHECK-NEXT:    (string.const "hello")
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (drop
+ ;; CHECK-NEXT:   (any.convert_extern
+ ;; CHECK-NEXT:    (string.const "hello")
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT:  (local.set $any
+ ;; CHECK-NEXT:   (any.convert_extern
+ ;; CHECK-NEXT:    (string.const "world")
+ ;; CHECK-NEXT:   )
+ ;; CHECK-NEXT:  )
+ ;; CHECK-NEXT: )
+ (func $any-extern
+  ;; Test internalized strings.
+  (local $any anyref)
+  (local.set $any
+   (any.convert_extern
+    (string.const "hello")
+   )
+  )
+  ;; This set can turn into a drop, as the value is already in the local.
+  (local.set $any
+   (any.convert_extern
+    (string.const "hello")
+   )
+  )
+  ;; This is a different string.
+  (local.set $any
+   (any.convert_extern
+    (string.const "world")
+   )
+  )
+ )
 )


### PR DESCRIPTION
Such Literals were not handled, crashing the RSE pass.