### PR TITLE
Check for end of input while reading expressions

### DIFF
--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -4733,11 +4733,14 @@ void WasmBinaryReader::readExports() {
 
 Expression* WasmBinaryReader::readExpression() {
   assert(builder.empty());
-  while (input[pos] != BinaryConsts::End) {
+  while (more() && input[pos] != BinaryConsts::End) {
     auto inst = readInst();
     if (auto* err = inst.getErr()) {
       throwError(err->msg);
     }
+  }
+  if (!more()) {
+    throwError("unexpected end of input");
   }
   ++pos;
   auto expr = builder.build();


### PR DESCRIPTION
If the input ends in an expression, we are missing at minimum the end
of the function, so it is definitely invalid.

Fixes #8089