### PR TITLE
Remove unneeded python install step on alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,6 @@ jobs:
     name: alpine
     runs-on: ubuntu-24.04-arm
     steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
     - uses: actions/checkout@v4
       with:
         submodules: true


### PR DESCRIPTION
The alpine CI runs on a VM on ubuntu, and this install step installs python to the host ubuntu environment which isn't used. The later `install packages` step is what installs it to the VM (`./alpine.sh apk add build-base cmake git python3 py3-pip clang ninja util-linux`).