### PR TITLE
Fix uninitialized member

### DIFF
--- a/src/support/small_vector.h
+++ b/src/support/small_vector.h
@@ -230,14 +230,6 @@ struct ZeroInitSmallVector : public SmallVector<T, N> {
   }
 };
 
-#if defined(__aarch64__)
-#pragma GCC diagnostic pop
-#endif
-
-#if defined(__riscv) && __riscv_xlen == 64
-#pragma GCC diagnostic pop
-#endif
-
 } // namespace wasm
 
 #endif // wasm_support_small_vector_h


### PR DESCRIPTION
std::array is an aggregate type with a C array as a member so its default initialization is garbage. Change it to value initialization to ensure that it has a defined value which removes the need for disabling the warnings and fixes the Alpine CI build.