### PR TITLE
[NFC] Avoid multiple scans in LUBFinder::getResultsLUB

### DIFF
--- a/src/ir/lubs.cpp
+++ b/src/ir/lubs.cpp
@@ -75,7 +75,7 @@ LUBFinder getResultsLUB(Function* func, Module& wasm) {
         if (!targetType.isSignature()) {
           return;
         }
-        lub.note(targetHeapType.getSignature().results);
+        lub.note(targetType.getHeapType().getSignature().results);
       }
     }
   } finder(wasm, lub);


### PR DESCRIPTION
Rather than FindAll multiple times, do a single scan with visitors.

This makes DAE 2% faster (and likely other passes that also use this utility).

Diff without whitespace is smaller.