### PR TITLE
feat: Add `Binaryen.arrayref` and `module.arrayref.pop()` to js api

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -39,6 +39,7 @@ function initializeConstants() {
     ['eqref', 'Eqref'],
     ['i31ref', 'I31ref'],
     ['structref', 'Structref'],
+    ['arrayref', 'Arrayref'],
     ['stringref', 'Stringref'],
     ['nullref', 'Nullref'],
     ['nullexternref', 'NullExternref'],
@@ -2378,6 +2379,12 @@ function wrapModule(module, self = {}) {
   self['structref'] = {
     'pop'() {
       return Module['_BinaryenPop'](module, Module['structref']);
+    }
+  };
+
+  self['arrayref'] = {
+    'pop'() {
+      return Module['_BinaryenPop'](module, Module['arrayref']);
     }
   };
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -660,6 +660,7 @@ function test_core() {
     module.eqref.pop(),
     module.i31ref.pop(),
     module.structref.pop(),
+    module.arrayref.pop(),
     module.stringref.pop(),
 
     // Memory

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -2185,6 +2185,9 @@ getExpressionInfo(tuple[3])={"id":14,"type":5,"value":3.7}
        (pop structref)
       )
       (drop
+       (pop arrayref)
+      )
+      (drop
        (pop stringref)
       )
       (drop


### PR DESCRIPTION
This pr implements `Binaryen.arrayref` and `module.arrayref.pop()` in the js api following the same pattern I see used for the various other types.