### PR TITLE
Fix use-after-free when a partially-instantiated module writes a function to an imported table

### DIFF
--- a/src/shell-interface.h
+++ b/src/shell-interface.h
@@ -148,7 +148,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
       // Use a null instance because these are host functions.
       return Literal(
         std::make_shared<FuncData>(import->name,
-                                   nullptr,
+                                   /*self=*/0,
                                    [](const Literals& arguments) -> Flow {
                                      for (auto argument : arguments) {
                                        std::cout << argument << " : "
@@ -159,7 +159,7 @@ struct ShellExternalInterface : ModuleRunner::ExternalInterface {
         import->type);
     } else if (import->module == ENV && import->base == EXIT) {
       return Literal(std::make_shared<FuncData>(import->name,
-                                                nullptr,
+                                                /*self=*/0,
                                                 [](const Literals&) -> Flow {
                                                   // XXX hack for torture tests
                                                   std::cout << "exit()\n";

--- a/src/tools/execution-results.h
+++ b/src/tools/execution-results.h
@@ -210,7 +210,7 @@ public:
       return {};
     };
     // Use a null instance because this is a host function.
-    return Literal(std::make_shared<FuncData>(import->name, nullptr, f),
+    return Literal(std::make_shared<FuncData>(import->name, /*self=*/0, f),
                    import->type);
   }
 

--- a/test/spec/linking0.wast
+++ b/test/spec/linking0.wast
@@ -1,0 +1,30 @@
+;; adapted from test/spec/testsuite/linking0.wast, with some assertions removed
+
+(module $Mt
+  (type (func (result i32)))
+  (type (func))
+
+  (table (export "tab") 10 funcref)
+  (elem (i32.const 2) $g $g $g $g)
+  (func $g (result i32) (i32.const 4))
+  (func (export "h") (result i32) (i32.const -4))
+
+  (func (export "call") (param i32) (result i32)
+    (call_indirect (type 0) (local.get 0))
+  )
+)
+(register "Mt" $Mt)
+
+(assert_trap
+  (module
+    (table (import "Mt" "tab") 10 funcref)
+    (func $f (result i32) (i32.const 0))
+    (elem (i32.const 7) $f)
+    (memory 0)
+    (memory $m 1)
+    (memory 0)
+    (data $m (i32.const 0x10000) "d")  ;; out of bounds
+  )
+  "out of bounds memory access"
+)
+(assert_return (invoke $Mt "call" (i32.const 7)) (i32.const 0))


### PR DESCRIPTION
Fixes #8108.