### PR TITLE
RemoveUnusedModuleElements: Scan indirect calls once up front [NFC]

### DIFF
--- a/src/passes/RemoveUnusedModuleElements.cpp
+++ b/src/passes/RemoveUnusedModuleElements.cpp
@@ -286,7 +286,7 @@ struct Analyzer {
     // is, typeItemMap[foo] includes data for subtypes of foo, so that we just
     // need to read one place.
     std::unordered_map<HeapType, std::unordered_set<Name>> typeFuncs;
-    std::unordered_map<HeapType, std::unordered_set<Name>> typeSegments;
+    std::unordered_map<HeapType, std::unordered_set<Name>> typeElems;
   };
   std::unordered_map<Name, FlatTableInfo> flatTableInfoMap;
 
@@ -322,7 +322,7 @@ struct Analyzer {
           while (type) {
             flatTableInfo.typeFuncs[*type].insert(func->name);
             flatTableInfo.typeElems[*type].insert(elem->name);
-            type = type.getSuperType();
+            type = type->getSuperType();
           }
         }
       }


### PR DESCRIPTION
Before, for each call_indirect signature (type+table) we scanned the elems to
find the callable functions. We used caching here, so it seemed fairly fast.
Measuring on a large Dart testcase, however, just scanning the elems
multiple times (once per type) is a lot of overhead. This avoids that by
scanning elems up front and filling in a data structure with all the info for
fast querying later.

Note the real overhead is not the table scanning, but all the `HeapType::isSubType`
calls. If we could make those fast it would be good, but this PR avoids the
issue in this pass at least.

This PR may be slower if no indirect calls exist (in that case we'd never
scan the table), but I see no memory overhead and it makes this Dart
testcase almost **2.8x** faster on this pass, which runs more than once,
making the total `-O3` noticeably faster, 15%.

@tlively suggested this and I did not realize how big a win it could be!

cc #4165