### PR TITLE
feat: Implement `BinaryenModuleUpdateMaps` in js api.

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -2859,7 +2859,7 @@ function wrapModule(module, self = {}) {
    * Updates the internal name mapping logic in a module. This must be called
    * after renaming module elements.
    */
-  self['update_maps'] = function() {
+  self['updateMaps'] = function() {
     Module['_BinaryenModuleUpdateMaps'](module);
   };
   self['optimizeFunction'] = function(func) {


### PR DESCRIPTION
This implements `BinaryenModuleUpdateMaps` as `module.update_maps()` in the js api.

I might need some guidance on testing this. This is meant to be called after `setName` on a module in the c test suite it's called after `Table.setName` however I can't find any `setName` api's implemented in the js api so this might need to wait.

I am trying to update this so we can make our bindings symmetrical between our js and c bindings in [`binaryen.ml`](https://github.com/grain-lang/binaryen.ml/issues/266)