### PR TITLE
Replace subprocess.Popen usage. NFC

### DIFF
--- a/check.py
+++ b/check.py
@@ -60,12 +60,9 @@ def run_version_tests():
     changelog_version = get_changelog_version()
     for e in executables:
         print('.. %s --version' % e)
-        out, err = subprocess.Popen([e, '--version'],
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE).communicate()
-        out = out.decode('utf-8')
-        err = err.decode('utf-8')
-        assert len(err) == 0, 'Expected no stderr, got:\n%s' % err
+        proc = subprocess.run([e, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        assert len(proc.stderr) == 0, 'Expected no stderr, got:\n%s' % proc.stderr
+        out = proc.stdout
         assert os.path.basename(e).replace('.exe', '') in out, 'Expected version to contain program name, got:\n%s' % out
         assert len(out.strip().splitlines()) == 1, 'Expected only version info, got:\n%s' % out
         parts = out.split()

--- a/scripts/auto_update_tests.py
+++ b/scripts/auto_update_tests.py
@@ -60,9 +60,9 @@ def update_example_tests():
             print('link: ', ' '.join(cmd))
             subprocess.check_call(cmd)
             print('run...', output_file)
-            proc = subprocess.Popen([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            actual, err = proc.communicate()
-            assert proc.returncode == 0, [proc.returncode, actual, err]
+            proc = subprocess.run([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            assert proc.returncode == 0, [proc.returncode, proc.stderror, proc.stdout]
+            actual = proc.stdout
             with open(expected, 'wb') as o:
                 o.write(actual)
         finally:

--- a/scripts/fuzz_opt.py
+++ b/scripts/fuzz_opt.py
@@ -46,7 +46,7 @@ from test import shared
 from test import support
 
 
-assert sys.version_info.major == 3, 'requires Python 3!'
+assert sys.version_info >= (3, 10), 'requires Python 3.10'
 
 # parameters
 
@@ -102,7 +102,7 @@ def run(cmd, stderr=None, silent=False):
 
 def run_unchecked(cmd):
     print(' '.join(cmd))
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True).communicate()[0]
+    return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True).stdout
 
 
 def randomize_pass_debug():

--- a/scripts/fuzz_relooper.py
+++ b/scripts/fuzz_relooper.py
@@ -370,14 +370,14 @@ int main() {
     print('^')
     subprocess.check_call(['./fuzz'], stdout=open('fuzz.wast', 'w'))
     print('*')
-    fast_out = subprocess.Popen(['bin/wasm-shell', 'fuzz.wast'],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE).communicate()[0]
+    fast_out = subprocess.run(['bin/wasm-shell', 'fuzz.wast'],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE).stdout
     print('-')
     node = os.getenv('NODE', 'nodejs')
-    slow_out = subprocess.Popen([node, 'fuzz.slow.js'],
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE).communicate()[0]
+    slow_out = subprocess.run([node, 'fuzz.slow.js'],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE).stdout
     print('_')
 
     if slow_out != fast_out:

--- a/scripts/gen-s-parser.py
+++ b/scripts/gen-s-parser.py
@@ -16,6 +16,11 @@
 
 import sys
 
+if sys.version_info < (3, 10):
+    print("python 3.10 required")
+    sys.exit(1)
+
+
 instructions = [
     ("unreachable",    "makeUnreachable()"),
     ("nop",            "makeNop()"),
@@ -831,10 +836,6 @@ def print_footer():
 
 
 def main():
-    if sys.version_info.major != 3:
-        import datetime
-        print("It's " + str(datetime.datetime.now().year) + "! Use Python 3!")
-        sys.exit(1)
     print_header()
     instruction_parser()
     print_footer()

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -186,8 +186,8 @@ def write_wast(filename, wast, asserts=[]):
             o.write(wast + '\n'.join(asserts))
 
 
-# Hack to allow subprocess.Popen with stdout/stderr to StringIO, which doesn't have a fileno and doesn't work otherwise
-def _process_communicate(*args, **kwargs):
+# Hack to allow subprocess with stdout/stderr to StringIO, which doesn't have a fileno and doesn't work otherwise
+def _subprocess_run(*args, **kwargs):
     overwrite_stderr = "stderr" in kwargs and isinstance(kwargs["stderr"], io.StringIO)
     overwrite_stdout = "stdout" in kwargs and isinstance(kwargs["stdout"], io.StringIO)
 
@@ -198,15 +198,14 @@ def _process_communicate(*args, **kwargs):
         stderr_fd = kwargs["stderr"]
         kwargs["stderr"] = subprocess.PIPE
 
-    proc = subprocess.Popen(*args, **kwargs)
-    out, err = proc.communicate()
+    proc = subprocess.run(*args, **kwargs)
 
     if overwrite_stdout:
-        stdout_fd.write(out)
+        stdout_fd.write(proc.stdout)
     if overwrite_stderr:
-        stderr_fd.write(err)
+        stderr_fd.write(proc.stderr)
 
-    return out, err, proc.returncode
+    return proc.stdout, proc.stderr, proc.returncode
 
 
 def run_command(cmd, expected_status=0, stdout=None, stderr=None,
@@ -222,7 +221,7 @@ def run_command(cmd, expected_status=0, stdout=None, stderr=None,
         stderr = subprocess.PIPE
     print('executing: ', ' '.join(cmd), file=stdout)
 
-    out, err, code = _process_communicate(cmd, stdout=subprocess.PIPE, stderr=stderr, universal_newlines=True, encoding='UTF-8')
+    out, err, code = _subprocess_run(cmd, stdout=subprocess.PIPE, stderr=stderr, encoding='UTF-8')
 
     if expected_status is not None and code != expected_status:
         raise Exception(f"run_command `{' '.join(cmd)}` failed ({code}) {err or ''}")

--- a/scripts/test/wasm_opt.py
+++ b/scripts/test/wasm_opt.py
@@ -96,13 +96,13 @@ def test_wasm_opt():
         wasm = os.path.basename(t).replace('.wast', '')
         cmd = shared.WASM_OPT + [t, '--print', '-all']
         print('    ', ' '.join(cmd))
-        actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         expected_file = os.path.join(shared.get_test_dir('print'), wasm + '.txt')
-        shared.fail_if_not_identical_to_file(actual, expected_file)
+        shared.fail_if_not_identical_to_file(proc.stdout, expected_file)
         cmd = shared.WASM_OPT + [os.path.join(shared.get_test_dir('print'), t), '--print-minified', '-all']
         print('    ', ' '.join(cmd))
-        actual, err = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True).communicate()
-        shared.fail_if_not_identical(actual.strip(), open(os.path.join(shared.get_test_dir('print'), wasm + '.minified.txt')).read().strip())
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        shared.fail_if_not_identical(proc.stdout.strip(), open(os.path.join(shared.get_test_dir('print'), wasm + '.minified.txt')).read().strip())
 
 
 def update_wasm_opt_tests():


### PR DESCRIPTION
These days we can just use `subprocess.run`.  Also `universal_newlines` can now just be written as `text=True`.