### PR TITLE
Use `capture_output` param when running python subprocesses. NFC

### DIFF
--- a/check.py
+++ b/check.py
@@ -60,7 +60,7 @@ def run_version_tests():
     changelog_version = get_changelog_version()
     for e in executables:
         print('.. %s --version' % e)
-        proc = subprocess.run([e, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        proc = subprocess.run([e, '--version'], capture_output=True, text=True)
         assert len(proc.stderr) == 0, 'Expected no stderr, got:\n%s' % proc.stderr
         out = proc.stdout
         assert os.path.basename(e).replace('.exe', '') in out, 'Expected version to contain program name, got:\n%s' % out

--- a/scripts/auto_update_tests.py
+++ b/scripts/auto_update_tests.py
@@ -60,7 +60,7 @@ def update_example_tests():
             print('link: ', ' '.join(cmd))
             subprocess.check_call(cmd)
             print('run...', output_file)
-            proc = subprocess.run([output_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            proc = subprocess.run([output_file], capture_output=True)
             assert proc.returncode == 0, [proc.returncode, proc.stderror, proc.stdout]
             actual = proc.stdout
             with open(expected, 'wb') as o:

--- a/scripts/fuzz_relooper.py
+++ b/scripts/fuzz_relooper.py
@@ -370,14 +370,10 @@ int main() {
     print('^')
     subprocess.check_call(['./fuzz'], stdout=open('fuzz.wast', 'w'))
     print('*')
-    fast_out = subprocess.run(['bin/wasm-shell', 'fuzz.wast'],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE).stdout
+    fast_out = subprocess.run(['bin/wasm-shell', 'fuzz.wast'], capture_output=True).stdout
     print('-')
     node = os.getenv('NODE', 'nodejs')
-    slow_out = subprocess.run([node, 'fuzz.slow.js'],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE).stdout
+    slow_out = subprocess.run([node, 'fuzz.slow.js'], capture_output=True).stdout
     print('_')
 
     if slow_out != fast_out:

--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -264,9 +264,7 @@ V8_OPTS = [
 
 try:
     if NODEJS is not None:
-        subprocess.check_call([NODEJS, '--version'],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+        subprocess.run([NODEJS, '--version'], check=True, capture_output=True)
 except (OSError, subprocess.CalledProcessError):
     NODEJS = None
 if NODEJS is None:
@@ -314,12 +312,9 @@ class Py2CalledProcessError(subprocess.CalledProcessError):
         self.stderr = stderr
 
 
-def run_process(cmd, check=True, input=None, capture_output=False, decode_output=True, *args, **kw):
+def run_process(cmd, check=True, input=None, decode_output=True, *args, **kw):
     if input and type(input) is str:
         input = bytes(input, 'utf-8')
-    if capture_output:
-        kw['stdout'] = subprocess.PIPE
-        kw['stderr'] = subprocess.PIPE
     ret = subprocess.run(cmd, check=check, input=input, *args, **kw)
     if decode_output and ret.stdout is not None:
         ret.stdout = ret.stdout.decode('utf-8')

--- a/scripts/test/wasm_opt.py
+++ b/scripts/test/wasm_opt.py
@@ -96,12 +96,12 @@ def test_wasm_opt():
         wasm = os.path.basename(t).replace('.wast', '')
         cmd = shared.WASM_OPT + [t, '--print', '-all']
         print('    ', ' '.join(cmd))
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        proc = subprocess.run(cmd, capture_output=True, text=True)
         expected_file = os.path.join(shared.get_test_dir('print'), wasm + '.txt')
         shared.fail_if_not_identical_to_file(proc.stdout, expected_file)
         cmd = shared.WASM_OPT + [os.path.join(shared.get_test_dir('print'), t), '--print-minified', '-all']
         print('    ', ' '.join(cmd))
-        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        proc = subprocess.run(cmd, capture_output=True, text=True)
         shared.fail_if_not_identical(proc.stdout.strip(), open(os.path.join(shared.get_test_dir('print'), wasm + '.minified.txt')).read().strip())
 
 

--- a/test/unit/test_asyncify.py
+++ b/test/unit/test_asyncify.py
@@ -15,7 +15,7 @@ class AsyncifyTest(utils.BinaryenTestCase):
             shared.run_process(shared.WASM_OPT + args + [self.input_path('asyncify-stackOverflow.wat'), '--asyncify', '-o', 'c.wasm'])
             print('  file size: %d' % os.path.getsize('a.wasm'))
             if shared.NODEJS:
-                shared.run_process([shared.NODEJS, self.input_path('asyncify.js')], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                shared.run_process([shared.NODEJS, self.input_path('asyncify.js')], capture_output=True)
 
         test(['-g'])
         test([])
@@ -55,7 +55,7 @@ class AsyncifyTest(utils.BinaryenTestCase):
             ('--pass-arg=asyncify-onlylist@DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)', None),
         ]:
             print(arg, warning)
-            err = shared.run_process(shared.WASM_OPT + ['-q', self.input_path('asyncify-pure.wat'), '--asyncify', arg], stdout=subprocess.PIPE, stderr=subprocess.PIPE).stderr.strip()
+            err = shared.run_process(shared.WASM_OPT + ['-q', self.input_path('asyncify-pure.wat'), '--asyncify', arg], capture_output=True).stderr.strip()
             if warning:
                 self.assertIn('warning', err)
                 self.assertIn(warning, err)

--- a/test/unit/test_cluster_fuzz.py
+++ b/test/unit/test_cluster_fuzz.py
@@ -71,8 +71,7 @@ class ClusterFuzz(utils.BinaryenTestCase):
                                f'--output_dir={testcase_dir}',
                                f'--no_of_files={N}'],
                               text=True,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE)
+                              capture_output=True)
         self.assertEqual(proc.returncode, 0)
 
         # We should have logged the creation of N testcases.
@@ -444,9 +443,7 @@ class ClusterFuzz(utils.BinaryenTestCase):
                        fuzz_file]
                 # Capture stderr even though we will not read it. It may
                 # contain warnings like us passing v8 experimental flags.
-                proc = subprocess.run(cmd,
-                                      stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE)
+                proc = subprocess.run(cmd, capture_output=True)
 
                 # An execution is valid if we exited without error, and if we
                 # managed to run some code before exiting (modules with no
@@ -487,7 +484,7 @@ class ClusterFuzz(utils.BinaryenTestCase):
 
         failed = False
         try:
-            subprocess.check_call(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.run(cmd, check=True, capture_output=True)
         except subprocess.CalledProcessError:
             # Expected error.
             failed = True


### PR DESCRIPTION
This param is exactly equivalent to `stdout=subprocess.PIPE` + `stderr=subprocess.PIPE`.

Followup to #8125