### PR TITLE
Stop using operator[] only for default-insertion into maps

### DIFF
--- a/src/ir/LocalGraph.cpp
+++ b/src/ir/LocalGraph.cpp
@@ -426,12 +426,12 @@ struct LocalGraphFlower
     // Ensure empty entries for each set of this index, to mark them as
     // computed.
     for (auto* set : setsByIndex[index]) {
-      setInfluences[set];
+      setInfluences.try_emplace(set);
     }
 
     // Also ensure |set| itself, that we were originally asked about. It may be
     // in unreachable code, which means it is not listed in setsByIndex.
-    setInfluences[set];
+    setInfluences.try_emplace(set);
 
     // Apply the info from the gets to the sets.
     for (auto* get : getsByIndex[index]) {

--- a/src/ir/module-utils.h
+++ b/src/ir/module-utils.h
@@ -284,7 +284,7 @@ struct ParallelFunctionAnalysis {
     // Fill in the map as we operate on it in parallel (each function to its own
     // entry).
     for (auto& func : wasm.functions) {
-      map[func.get()];
+      map.insert({func.get(), {}});
     }
 
     doAnalysis(work);

--- a/src/ir/struct-utils.h
+++ b/src/ir/struct-utils.h
@@ -139,7 +139,7 @@ struct FunctionStructValuesMap
     // Initialize the data for each function in preparation for parallel
     // computation.
     for (auto& func : wasm.functions) {
-      (*this)[func.get()];
+      this->try_emplace(func.get());
     }
   }
 

--- a/src/ir/type-updating.h
+++ b/src/ir/type-updating.h
@@ -78,7 +78,7 @@ struct TypeUpdater
     } else {
       BranchUtils::operateOnScopeNameUses(curr, [&](Name& name) {
         // ensure info exists, discoverBreaks can then fill it
-        blockInfos[name];
+        blockInfos.try_emplace(name);
       });
     }
     // add a break to the info, for break and switch

--- a/src/passes/DeadArgumentElimination.cpp
+++ b/src/passes/DeadArgumentElimination.cpp
@@ -200,10 +200,10 @@ struct DAE : public Pass {
     // Ensure all entries exist so the parallel threads don't modify the data
     // structure.
     for (auto& func : module->functions) {
-      infoMap[func->name];
+      infoMap.try_emplace(func->name);
     }
     // The null name represents module-level code (not in a function).
-    infoMap[Name()];
+    infoMap.try_emplace(Name());
 
     numFunctions = module->functions.size();
 

--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1344,7 +1344,7 @@ struct Inlining : public Pass {
     // fill in info, as we operate on it in parallel (each function to its own
     // entry)
     for (auto& func : module->functions) {
-      infos[func->name];
+      infos.try_emplace(func->name);
     }
     {
       FunctionInfoScanner scanner(infos);
@@ -1388,7 +1388,7 @@ struct Inlining : public Pass {
     // without iterator invalidation.
     std::vector<Name> funcNames;
     for (auto& func : module->functions) {
-      state.actionsForFunction[func->name];
+      state.actionsForFunction.try_emplace(func->name);
       funcNames.push_back(func->name);
     }
 

--- a/src/passes/OnceReduction.cpp
+++ b/src/passes/OnceReduction.cpp
@@ -419,7 +419,7 @@ struct OnceReduction : public Pass {
       // Initialize all the items in the new data structure that will be
       // populated.
       for (auto& func : module->functions) {
-        optInfo.newOnceGlobalsSetInFuncs[func->name];
+        optInfo.newOnceGlobalsSetInFuncs.try_emplace(func->name);
       }
 
       Optimizer(optInfo).run(getPassRunner(), module);

--- a/src/passes/ReorderFunctions.cpp
+++ b/src/passes/ReorderFunctions.cpp
@@ -67,7 +67,7 @@ struct ReorderFunctions : public Pass {
     // fill in info, as we operate on it in parallel (each function to its own
     // entry)
     for (auto& func : module->functions) {
-      counts[func->name];
+      counts.try_emplace(func->name, 0);
     }
     // find counts on function calls
     CallCountScanner(&counts).run(getPassRunner(), module);

--- a/src/passes/ReorderGlobals.cpp
+++ b/src/passes/ReorderGlobals.cpp
@@ -100,7 +100,7 @@ struct ReorderGlobals : public Pass {
     AtomicNameCountMap atomicCounts;
     // Fill in info, as we'll operate on it in parallel.
     for (auto& global : globals) {
-      atomicCounts[global->name];
+      atomicCounts.try_emplace(global->name, 0);
     }
 
     // Count uses.

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -298,7 +298,7 @@ public:
   static void visitPreBlock(FunctionValidator* self, Expression** currp) {
     auto* curr = (*currp)->cast<Block>();
     if (curr->name.is()) {
-      self->breakTypes[curr->name];
+      self->breakTypes.try_emplace(curr->name);
     }
   }
 
@@ -309,7 +309,7 @@ public:
   static void visitPreLoop(FunctionValidator* self, Expression** currp) {
     auto* curr = (*currp)->cast<Loop>();
     if (curr->name.is()) {
-      self->breakTypes[curr->name];
+      self->breakTypes.try_emplace(curr->name);
     }
   }
 


### PR DESCRIPTION
Upstream libc++ recently added the [[nodiscard]] attribute to the return value
of operator[] on maps, meaning the compiler now warns on uses of this operator
that only want to insert rather than also use the result.

Switch to using try_emplace, which does not construct the value unless insertion
succeeds, and is IMO more readable than operator[] for this purpose.

Fixes #8124