### PR TITLE
[test] Remove `decode_output` argument to `shared.run_process`. NFC

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -297,15 +297,11 @@ def delete_from_orbit(filename):
         pass
 
 
-def run_process(cmd, check=True, input=None, decode_output=True, *args, **kwargs):
-    if input and type(input) is str:
-        input = bytes(input, 'utf-8')
-    ret = subprocess.run(cmd, *args, check=check, input=input, **kwargs)
-    if decode_output and ret.stdout is not None:
-        ret.stdout = ret.stdout.decode('utf-8')
-    if ret.stderr is not None:
-        ret.stderr = ret.stderr.decode('utf-8')
-    return ret
+def run_process(cmd, check=True, text=True, *args, **kwargs):
+    """Trivial wrapper around subprocess.run that defaults to check=True and
+    text=True
+    """
+    return subprocess.run(cmd, *args, check=check, text=text, **kwargs)
 
 
 def fail_with_error(msg):

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -422,16 +422,19 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
                             opts=['-mvp', '--detect-features', '--enable-simd'])
 
     def test_emit_all_features(self):
+        # We use text=False in this test because we pass binary modules via
+        # stdin and stdout.
         p = shared.run_process(shared.WASM_OPT +
                                ['--emit-target-features', '-all', '-o', '-'],
-                               input="(module)", check=False,
-                               capture_output=True, decode_output=False)
+                               input=b"(module)", check=False, text=False,
+                               capture_output=True)
         self.assertEqual(p.returncode, 0)
         p2 = shared.run_process(shared.WASM_OPT +
                                 ['--print-features', '-o', os.devnull],
-                                input=p.stdout, check=False,
+                                input=p.stdout, text=False, check=False,
                                 capture_output=True)
         self.assertEqual(p2.returncode, 0)
+        output = p2.stdout.debug('utf-8')
         self.assertEqual([
             '--enable-threads',
             '--enable-mutable-globals',
@@ -457,4 +460,4 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
             '--enable-custom-descriptors',
             '--enable-relaxed-atomics',
             '--enable-custom-page-sizes',
-        ], p2.stdout.splitlines())
+        ], output.splitlines())


### PR DESCRIPTION
There was only a single user of this argument in the codebase.