### PR TITLE
[NFC] Inlining: Avoid wasteful non-nullable local fixups

### DIFF
--- a/src/passes/Inlining.cpp
+++ b/src/passes/Inlining.cpp
@@ -1262,6 +1262,9 @@ struct Inlining : public Pass {
   // FIXME DWARF updating does not handle local changes yet.
   bool invalidatesDWARF() override { return true; }
 
+  // We do this only where we inline, inside updateAfterInlining().
+  bool requiresNonNullableLocalFixups() override { return false; }
+
   // whether to optimize where we inline
   bool optimize = false;
 


### PR DESCRIPTION
Mark the scanning and planning passes as not modifying the IR at all.

Mark the doInlining and Inlining passes as not needing non-nullable
fixups, as we apply those fixups when we inline (update the comment
there to clarify that).

This makes `--inlining` 8% faster on a Dart testcase I am looking at.
That is the result of avoiding 87% of the scans for non-nullable
fixups. The `--inlining-optimizing` pass, however, has a more modest
speedup (since it optimizes after each inlining anyhow, which is even
larger work): 10% fewer scans, and wall time is within noise. (Still,
this does avoid some wasted work even there, and marking sub-passes
that do not modify the IR as not doing so seems like a win for
readability.)