### PR TITLE
Fix assertion failure in unsubtyping

### DIFF
--- a/src/ir/subtype-exprs.h
+++ b/src/ir/subtype-exprs.h
@@ -133,7 +133,7 @@ struct SubtypingDiscoverer : public OverriddenVisitor<SubType> {
   void visitBreak(Break* curr) {
     if (curr->value) {
       self()->noteSubtype(curr->value, self()->findBreakTarget(curr->name));
-      if (curr->condition) {
+      if (curr->condition && curr->type != Type::unreachable) {
         self()->noteSubtype(curr->value, curr);
       }
     }


### PR DESCRIPTION
When noting a subtype relationship, Unsubtyping asserts that if the
subtype is a tuple, then the supertype must be a tuple as well. This
assertion was violated when SubtypingDiscoverer noted a subtyping
between an unreachable br_if's tuple value and the br_if's type. Fix the
problem by not noting this subtyping for unreachable br_ifs.
