### PR TITLE
TypeRefining-GUFA: Fix bug with considering continuation fields empty

### DIFF
--- a/src/passes/TypeRefining.cpp
+++ b/src/passes/TypeRefining.cpp
@@ -210,9 +210,9 @@ struct TypeRefining : public Pass {
             gufaType = gufaType.withInexactIfNoCustomDescs(module->features);
           }
           // Do not use the GUFA type if it is a continuation, as we cannot add
-          // casts to fix up issues later.
+          // casts to fix up issues later. Instead, use the original type.
           if (gufaType.isContinuation()) {
-            continue;
+            gufaType = fields[i].type;
           }
           infos[i] = LUBFinder(gufaType);
         }


### PR DESCRIPTION
We must skip such fields and not refine them, as we can't use casts to fix
up refinement issues. But we were just not writing anything to GUFA's
tracking of that location, which meant it looked unwritten - hence any
reads would be unreachable, and trap. To fix this, just write the current
type there.