### PR TITLE
Print failed test results at the end for the spec test suite

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -40,15 +40,10 @@ def parse_args(args):
         '--no-torture', dest='torture', action='store_false',
         help='Disables running the torture testcases.')
     parser.add_argument(
-        '--abort-on-first-failure', "--fail-fast", dest='abort_on_first_failure',
-        action='store_true', default=True,
+        '--abort-on-first-failure', '--fail-fast', dest='abort_on_first_failure',
+        action=argparse.BooleanOptionalAction, default=True,
         help=('Specifies whether to halt test suite execution on first test error.'
               ' Default: true.'))
-    parser.add_argument(
-        '--no-abort-on-first-failure', "--no-fail-fast", dest='abort_on_first_failure',
-        action='store_false',
-        help=('If set, the whole test suite will run to completion independent of'
-              ' earlier errors.'))
     parser.add_argument(
         '--binaryen-bin', dest='binaryen_bin', default='',
         help=('Specifies the path to the Binaryen executables in the CMake build'


### PR DESCRIPTION
* Print all failed test stdouts/stderrs at the end so that the output isn't lost among the successful tests
* Make `shared.options.abort_on_first_failure` work with the spec test suite and add aliases for --fail-fast and --no-fail-fast
* Re-raise in run_one_spec_test since fail_with_error may no longer throw an exception when abort_on_first_failure is false (the remaining code shouldn't execute because then `actual` isn't defined).

With `--no-fail-fast`:
<img width="1561" height="953" alt="image" src="https://github.com/user-attachments/assets/83ac23f5-c433-4b91-aaef-fef6958b4ab6" />

With `--fail-fast` (the default):
<img width="1561" height="953" alt="image" src="https://github.com/user-attachments/assets/1532a2f0-e2f1-4b1a-931c-1a057128874f" />
