### PR TITLE
Check isBasic() before getBasic() in validator

### DIFF
--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -199,7 +199,7 @@ struct ValidationInfo {
                                 const char* text,
                                 Function* func = nullptr) {
     if (!ty.isBasic()) {
-      fail(std::string(text) + " (not basic)", curr, func);
+      fail(text, curr, func);
       return;
     }
     switch (ty.getBasic()) {


### PR DESCRIPTION
This avoids asserting.

Fixes #8097 