### PR TITLE
Make lit tests work with filter argument

### DIFF
--- a/check.py
+++ b/check.py
@@ -382,9 +382,9 @@ def run_unittest():
 def run_lit():
     def run():
         lit_script = os.path.join(shared.options.binaryen_bin, 'binaryen-lit')
-        lit_tests = os.path.join(shared.options.binaryen_root, 'test', 'lit')
+        lit_tests = shared.get_tests(shared.get_test_dir('lit'), extensions=support.LIT_TEST_SUFFIXES, recursive=True)
         # lit expects to be run as its own executable
-        cmd = [sys.executable, lit_script, lit_tests, '-vv']
+        cmd = [sys.executable, lit_script, '-vv'] + lit_tests
         result = subprocess.run(cmd)
         if result.returncode != 0:
             shared.num_failures += 1

--- a/scripts/test/support.py
+++ b/scripts/test/support.py
@@ -174,6 +174,9 @@ def split_wast(wastFile):
     return ret
 
 
+LIT_TEST_SUFFIXES = frozenset({'.wat', '.wast', '.test'})
+
+
 # write a split wast from split_wast. the wast may be binary if the original
 # file was binary
 def write_wast(filename, wast, asserts=[]):

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -2,10 +2,13 @@ import os
 import sys
 import lit.formats
 
+sys.path.append(config.binaryen_src_root)
+from scripts.test.support import LIT_TEST_SUFFIXES
+
 config.name = "Binaryen lit tests"
 config.test_format = lit.formats.ShTest()
 
-config.suffixes = ['.wat', '.wast', '.test']
+config.suffixes = LIT_TEST_SUFFIXES
 
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.binaryen_build_root, 'out', 'test')


### PR DESCRIPTION
Example:

```sh
$ python3 check.py lit --filter='*gc-atomics*'
ninja: no work to do.
-- Testing: 6 tests, 6 workers --
PASS: Binaryen lit tests :: passes/optimize-instructions-gc-atomics.wast (1 of 6)
PASS: Binaryen lit tests :: passes/precompute-gc-atomics.wast (2 of 6)
PASS: Binaryen lit tests :: passes/vacuum-gc-atomics.wast (3 of 6)
PASS: Binaryen lit tests :: validation/gc-atomics.wast (4 of 6)
PASS: Binaryen lit tests :: basic/gc-atomics-null-refs.wast (5 of 6)
PASS: Binaryen lit tests :: basic/gc-atomics.wast (6 of 6)

Testing Time: 0.15s
  Passed: 6

[ success! ]
```

```sh
python3 check.py lit
ninja: no work to do.
-- Testing: 797 tests, 128 workers --
PASS: Binaryen lit tests :: binary/component-error.test (1 of 797)
PASS: Binaryen lit tests :: binary/bad-datacount.test (2 of 797)
...
```