### PR TITLE
Fix unintentional macro shadowing in json.h

### DIFF
--- a/src/emscripten-optimizer/simple_ast.h
+++ b/src/emscripten-optimizer/simple_ast.h
@@ -310,13 +310,15 @@ struct Value {
   }
 
   char* parse(char* curr) {
-  /* space, tab, linefeed/newline, or return */
-#define is_json_space(x) (x == 32 || x == 9 || x == 10 || x == 13)
-#define skip()                                                                 \
-  {                                                                            \
-    while (*curr && is_json_space(*curr))                                      \
-      curr++;                                                                  \
-  }
+    /* space, tab, linefeed/newline, or return */
+    constexpr auto is_json_space = [](char x) {
+      return x == 32 || x == 9 || x == 10 || x == 13;
+    };
+    auto skip = [&curr, &is_json_space]() {
+      while (*curr && is_json_space(*curr)) {
+        curr++;
+      }
+    };
     skip();
     if (*curr == '"') {
       // String


### PR DESCRIPTION
json.h defines two lambdas with the same name [link](https://github.com/WebAssembly/binaryen/blob/c2e47d3bffdb66e237525da24d8c28f4b5402f20/src/support/json.h#L274-L283). From #8086, the calls in json.h are macro-expanded rather than using the lambdas defined there. This is coincidentally ok because they have the exact same definition, but results in an unused variable warning for the two lambdas. This happens in #8086 and not in main because that PR adds `#include "ir/memory-utils.h"` in wasm-interpreter.h which probably results in simple_ast.h being included before json.h which causes the shadowing.

[Without this PR](https://gist.github.com/stevenfontanella/16ea5cc5144db625e5b6194706e3617d). With this PR, compilation succeeds.