### PR TITLE
Increment failure count on exception in spec tests

### DIFF
--- a/check.py
+++ b/check.py
@@ -257,6 +257,7 @@ def run_spec_test_with_wrapped_stdout(wast: Path):
     try:
         run_one_spec_test(wast, stdout=out)
     except Exception as e:
+        shared.num_failures += 1
         # Serialize exceptions into the output string buffer
         # so they can be reported on the main thread.
         print(e, file=out)


### PR DESCRIPTION
It was previously covered by [these lines](https://github.com/WebAssembly/binaryen/blob/2f798880e456161bee4dc5d403777e1305db45eb/check.py#L219-L220) which were accidentally removed when changing the tests to be multithreaded.

Before: https://gist.github.com/stevenfontanella/377b3cd922ff0a4bb20205d4568ef912
After: https://gist.github.com/stevenfontanella/0c1c804451c405f241af52f0da815c11