### PR TITLE
[NFC] Used Mixed Arena in IString interning

### DIFF
--- a/src/support/istring.cpp
+++ b/src/support/istring.cpp
@@ -48,7 +48,7 @@ std::string_view IString::interned(std::string_view s, bool reuse) {
   // stable addresses.
   static MixedArena arena;
 
-  // Guards access to `globalStrings` and `arena`.
+  // Guards access to `globalStrings`. (note: `arena` is thread-safe anyhow)
   static std::mutex mutex;
 
   // A thread-local cache of strings to reduce contention.


### PR DESCRIPTION
Testing on a 50 MB Dart wasm file, this saves 12% (2 seconds) from the
wall time when just loading the file and doing nothing. It also saves 7%
from max RSS.