### PR TITLE
Fix mutated default argument in roundtrip tests

### DIFF
--- a/test/unit/utils.py
+++ b/test/unit/utils.py
@@ -9,7 +9,8 @@ class BinaryenTestCase(unittest.TestCase):
         return os.path.join(shared.options.binaryen_test, 'unit', 'input',
                             filename)
 
-    def roundtrip(self, filename, opts=[], debug=True):
+    def roundtrip(self, filename, opts=None, debug=True):
+        opts = opts if opts is not None else []
         opts = ['--mvp-features'] + opts
         if debug:
             opts.append('-g')


### PR DESCRIPTION
The test appends to `opts` which can refer to the default value of the function, causing future calls with the default value to be changed. e.g.

```py
**>>> def f(a=[]):
...     a.append(1)
...     print(a)
...
>>> f()
[1]
>>> f()
[1, 1]
```
This would cause `-g` to be added to the arguments even when `debug=False`.

There are other instances that use lists as a default argument, but I left them alone for now since they never mutate it.