### PR TITLE
Add relaxed atomics support for stores

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -1371,7 +1371,8 @@ BinaryenExpressionRef BinaryenAtomicStore(BinaryenModuleRef module,
                        (Expression*)ptr,
                        (Expression*)value,
                        Type(type),
-                       getMemoryName(module, memoryName)));
+                       getMemoryName(module, memoryName),
+                       MemoryOrder::SeqCst));
 }
 BinaryenExpressionRef BinaryenAtomicRMW(BinaryenModuleRef module,
                                         BinaryenOp op,

--- a/src/parser/contexts.h
+++ b/src/parser/contexts.h
@@ -565,7 +565,8 @@ struct NullInstrParserCtx {
                      int,
                      bool,
                      MemoryIdxT*,
-                     MemargT) {
+                     MemargT,
+                     MemoryOrder) {
     return Ok{};
   }
   Result<> makeAtomicRMW(Index,
@@ -2255,12 +2256,13 @@ struct ParseDefsCtx : TypeParserCtx<ParseDefsCtx>, AnnotationParserCtx {
                      int bytes,
                      bool isAtomic,
                      Name* mem,
-                     Memarg memarg) {
+                     Memarg memarg,
+                     MemoryOrder order) {
     auto m = getMemory(pos, mem);
     CHECK_ERR(m);
     if (isAtomic) {
-      return withLoc(pos,
-                     irBuilder.makeAtomicStore(bytes, memarg.offset, type, *m));
+      return withLoc(
+        pos, irBuilder.makeAtomicStore(bytes, memarg.offset, type, *m, order));
     }
     return withLoc(
       pos, irBuilder.makeStore(bytes, memarg.offset, memarg.align, type, *m));

--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -605,6 +605,7 @@ struct PrintExpressionContents
     }
     restoreNormalColor(o);
     printMemoryName(curr->memory, o, wasm);
+    printMemoryOrder(curr->order);
     if (curr->offset) {
       o << " offset=" << curr->offset;
     }

--- a/src/tools/wasm-split/instrumenter.cpp
+++ b/src/tools/wasm-split/instrumenter.cpp
@@ -151,7 +151,8 @@ void Instrumenter::instrumentFuncs() {
                                   builder.makeConstPtr(0, Type::i32),
                                   builder.makeConst(uint32_t(1)),
                                   Type::i32,
-                                  memoryName),
+                                  memoryName,
+                                  MemoryOrder::SeqCst),
           func->body,
           func->body->type);
         ++funcIdx;

--- a/src/wasm-builder.h
+++ b/src/wasm-builder.h
@@ -451,9 +451,13 @@ public:
                          Expression* ptr,
                          Expression* value,
                          Type type,
-                         Name memory) {
+                         Name memory,
+                         MemoryOrder order) {
+    assert(order != MemoryOrder::Unordered &&
+           "Atomic stores can't be unordered");
+
     Store* store = makeStore(bytes, offset, bytes, ptr, value, type, memory);
-    store->order = MemoryOrder::SeqCst;
+    store->order = order;
     return store;
   }
   AtomicRMW* makeAtomicRMW(AtomicRMWOp op,

--- a/src/wasm-ir-builder.h
+++ b/src/wasm-ir-builder.h
@@ -158,7 +158,8 @@ public:
     unsigned bytes, Address offset, unsigned align, Type type, Name mem);
   Result<> makeAtomicLoad(
     unsigned bytes, Address offset, Type type, Name mem, MemoryOrder order);
-  Result<> makeAtomicStore(unsigned bytes, Address offset, Type type, Name mem);
+  Result<> makeAtomicStore(
+    unsigned bytes, Address offset, Type type, Name mem, MemoryOrder order);
   Result<> makeAtomicRMW(
     AtomicRMWOp op, unsigned bytes, Address offset, Type type, Name mem);
   Result<>

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -3657,31 +3657,38 @@ Result<> WasmBinaryReader::readInst() {
         }
         case BinaryConsts::I32AtomicStore8: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(1, offset, Type::i32, mem);
+          return builder.makeAtomicStore(
+            1, offset, Type::i32, mem, memoryOrder);
         }
         case BinaryConsts::I32AtomicStore16: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(2, offset, Type::i32, mem);
+          return builder.makeAtomicStore(
+            2, offset, Type::i32, mem, memoryOrder);
         }
         case BinaryConsts::I32AtomicStore: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(4, offset, Type::i32, mem);
+          return builder.makeAtomicStore(
+            4, offset, Type::i32, mem, memoryOrder);
         }
         case BinaryConsts::I64AtomicStore8: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(1, offset, Type::i64, mem);
+          return builder.makeAtomicStore(
+            1, offset, Type::i64, mem, memoryOrder);
         }
         case BinaryConsts::I64AtomicStore16: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(2, offset, Type::i64, mem);
+          return builder.makeAtomicStore(
+            2, offset, Type::i64, mem, memoryOrder);
         }
         case BinaryConsts::I64AtomicStore32: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(4, offset, Type::i64, mem);
+          return builder.makeAtomicStore(
+            4, offset, Type::i64, mem, memoryOrder);
         }
         case BinaryConsts::I64AtomicStore: {
           auto [mem, align, offset, memoryOrder] = getAtomicMemarg();
-          return builder.makeAtomicStore(8, offset, Type::i64, mem);
+          return builder.makeAtomicStore(
+            8, offset, Type::i64, mem, memoryOrder);
         }
 
 #define RMW(op)                                                                \

--- a/src/wasm/wasm-ir-builder.cpp
+++ b/src/wasm/wasm-ir-builder.cpp
@@ -1492,15 +1492,14 @@ Result<> IRBuilder::makeAtomicLoad(
   return Ok{};
 }
 
-Result<> IRBuilder::makeAtomicStore(unsigned bytes,
-                                    Address offset,
-                                    Type type,
-                                    Name mem) {
+Result<> IRBuilder::makeAtomicStore(
+  unsigned bytes, Address offset, Type type, Name mem, MemoryOrder order) {
   Store curr;
   curr.memory = mem;
   curr.valueType = type;
   CHECK_ERR(visitStore(&curr));
-  push(builder.makeAtomicStore(bytes, offset, curr.ptr, curr.value, type, mem));
+  push(builder.makeAtomicStore(
+    bytes, offset, curr.ptr, curr.value, type, mem, order));
   return Ok{};
 }
 

--- a/src/wasm/wasm-validator.cpp
+++ b/src/wasm/wasm-validator.cpp
@@ -1147,6 +1147,12 @@ void FunctionValidator::visitStore(Store* curr) {
                  curr,
                  "Atomic store should be i32 or i64");
   }
+  if (curr->order == MemoryOrder::AcqRel) {
+    shouldBeTrue(getModule()->features.hasRelaxedAtomics(),
+                 curr,
+                 "Acquire/release operations require relaxed atomics "
+                 "[--enable-relaxed-atomics]");
+  }
   if (curr->valueType == Type::v128) {
     shouldBeTrue(getModule()->features.hasSIMD(),
                  curr,

--- a/test/lit/basic/relaxed-atomics.wast
+++ b/test/lit/basic/relaxed-atomics.wast
@@ -5,36 +5,56 @@
  ;; RTRIP:      (memory $0 23 256 shared)
  (memory $0 23 256 shared)
 
- ;; RTRIP:      (func $acqrel (type $0) (result i32)
- ;; RTRIP-NEXT:  (i32.atomic.load acqrel
+ ;; RTRIP:      (func $acqrel (type $0)
+ ;; RTRIP-NEXT:  (i32.atomic.store acqrel
+ ;; RTRIP-NEXT:   (i32.const 1)
  ;; RTRIP-NEXT:   (i32.const 1)
  ;; RTRIP-NEXT:  )
+ ;; RTRIP-NEXT:  (drop
+ ;; RTRIP-NEXT:   (i32.atomic.load acqrel
+ ;; RTRIP-NEXT:    (i32.const 1)
+ ;; RTRIP-NEXT:   )
+ ;; RTRIP-NEXT:  )
  ;; RTRIP-NEXT: )
- (func $acqrel (result i32)
-   (i32.atomic.load acqrel
-    (i32.const 1)
-   )
+ (func $acqrel
+   (i32.atomic.store acqrel (i32.const 1) (i32.const 1))
+   (drop
+    (i32.atomic.load acqrel
+     (i32.const 1)
+   ))
  )
 
  ;; Optional seqcst ordering is dropped in text output.
- ;; RTRIP:      (func $seqcst (type $0) (result i32)
+ ;; RTRIP:      (func $seqcst (type $0)
+ ;; RTRIP-NEXT:  (i32.atomic.store
+ ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:  )
+ ;; RTRIP-NEXT:  (i32.atomic.store
+ ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:  )
  ;; RTRIP-NEXT:  (drop
  ;; RTRIP-NEXT:   (i32.atomic.load
  ;; RTRIP-NEXT:    (i32.const 1)
  ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
- ;; RTRIP-NEXT:  (i32.atomic.load
- ;; RTRIP-NEXT:   (i32.const 1)
+ ;; RTRIP-NEXT:  (drop
+ ;; RTRIP-NEXT:   (i32.atomic.load
+ ;; RTRIP-NEXT:    (i32.const 1)
+ ;; RTRIP-NEXT:   )
  ;; RTRIP-NEXT:  )
  ;; RTRIP-NEXT: )
- (func $seqcst (result i32)
-   ;; seqcst may be omitted for atomic loads, it's the default
+ (func $seqcst
+   (i32.atomic.store seqcst (i32.const 1) (i32.const 1))
+   (i32.atomic.store 0 seqcst (i32.const 1) (i32.const 1))
    (drop (i32.atomic.load seqcst
     (i32.const 1)
    ))
    ;; allows memory index before memory ordering immediate
-   (i32.atomic.load 0 seqcst
+   (drop
+    (i32.atomic.load 0 seqcst
     (i32.const 1)
-   )
+   ))
  )
 )

--- a/test/lit/passes/safe-heap_enable-threads_enable-simd.wast
+++ b/test/lit/passes/safe-heap_enable-threads_enable-simd.wast
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_A
+ ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_SC
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
@@ -2502,47 +2502,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -2584,6 +2543,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -2620,56 +2620,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2720,6 +2670,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2816,56 +2816,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -2916,7 +2866,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -2934,7 +2884,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -2951,7 +2901,16 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2998,6 +2957,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3034,56 +3034,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3134,6 +3084,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3230,56 +3230,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3325,6 +3275,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3471,56 +3471,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3566,6 +3516,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9488,47 +9488,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9570,6 +9529,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9606,56 +9606,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9706,6 +9656,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9802,56 +9802,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9902,7 +9852,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -9920,7 +9870,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -9937,7 +9887,16 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9984,6 +9943,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10020,56 +10020,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10120,6 +10070,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10216,56 +10216,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10311,6 +10261,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10457,56 +10457,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10552,6 +10502,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_enable-threads_enable-simd64.wast
+++ b/test/lit/passes/safe-heap_enable-threads_enable-simd64.wast
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:   (i64.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_A
+ ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_SC
  ;; CHECK-NEXT:   (i64.const 1)
  ;; CHECK-NEXT:   (i64.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
@@ -2562,47 +2562,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -2644,6 +2603,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -2680,58 +2680,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2784,6 +2732,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2882,58 +2882,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -2986,7 +2934,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i64.add
@@ -3004,7 +2952,7 @@
 ;; CHECK-NEXT:     (i64.gt_u
 ;; CHECK-NEXT:      (i64.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:       (i64.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i64.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -3021,7 +2969,18 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3068,6 +3027,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3104,58 +3104,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3208,6 +3156,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3306,58 +3306,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3405,6 +3353,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3555,58 +3555,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3654,6 +3602,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9734,47 +9734,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -9816,6 +9775,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -9852,58 +9852,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9956,6 +9904,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10054,58 +10054,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -10158,7 +10106,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i64.add
@@ -10176,7 +10124,7 @@
 ;; CHECK-NEXT:     (i64.gt_u
 ;; CHECK-NEXT:      (i64.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:       (i64.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i64.load
 ;; CHECK-NEXT:       (call $foo)
@@ -10193,7 +10141,18 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10240,6 +10199,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -10276,58 +10276,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10380,6 +10328,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10478,58 +10478,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -10577,6 +10525,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10727,58 +10727,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -10826,6 +10774,58 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_enable-threads_enable-simd64_enable-relaxed-atomics.wast
+++ b/test/lit/passes/safe-heap_enable-threads_enable-simd64_enable-relaxed-atomics.wast
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:   (i64.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_A
+ ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_SC
  ;; CHECK-NEXT:   (i64.const 1)
  ;; CHECK-NEXT:   (i64.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
@@ -3160,47 +3160,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3242,6 +3201,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3278,58 +3319,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3382,6 +3371,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3480,58 +3573,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3584,7 +3625,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i64.add
@@ -3602,7 +3643,7 @@
 ;; CHECK-NEXT:     (i64.gt_u
 ;; CHECK-NEXT:      (i64.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:       (i64.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i64.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -3619,7 +3660,70 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3666,6 +3770,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -3702,58 +3888,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3806,6 +3940,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3904,58 +4142,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -4003,6 +4189,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4153,58 +4443,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -4252,6 +4490,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10930,47 +11272,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -11012,6 +11313,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -11048,58 +11431,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11152,6 +11483,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11250,58 +11685,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i64) (param $1 i64) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -11354,7 +11737,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i64) (param $1 i64) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i64.add
@@ -11372,7 +11755,7 @@
 ;; CHECK-NEXT:     (i64.gt_u
 ;; CHECK-NEXT:      (i64.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:       (i64.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i64.load
 ;; CHECK-NEXT:       (call $foo)
@@ -11389,7 +11772,70 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i64) (param $1 i64) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11436,6 +11882,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -11472,58 +12000,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11576,6 +12052,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11674,58 +12254,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -11773,6 +12301,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11923,58 +12555,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i64) (param $1 i64) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i64)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i64.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i64.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i64.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i64.gt_u
-;; CHECK-NEXT:      (i64.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i64.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i64.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i64.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (i32.wrap_i64
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i64) (param $1 i64) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i64)
 ;; CHECK-NEXT:  (local.set $3
@@ -12022,6 +12602,110 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i64) (param $1 i64) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i64)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i64.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i64.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i64.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i64.gt_u
+;; CHECK-NEXT:      (i64.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i64.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i64.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i64.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (i32.wrap_i64
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_enable-threads_enable-simd_enable-relaxed-atomics.wast
+++ b/test/lit/passes/safe-heap_enable-threads_enable-simd_enable-relaxed-atomics.wast
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_A
+ ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_SC
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
@@ -3084,47 +3084,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3166,6 +3125,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3202,56 +3243,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3302,6 +3293,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3398,56 +3489,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3498,7 +3539,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -3516,7 +3557,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -3533,7 +3574,66 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3580,6 +3680,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3616,56 +3798,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3716,6 +3848,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3812,56 +4044,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3907,6 +4089,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4053,56 +4335,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -4148,6 +4380,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10652,47 +10984,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10734,6 +11025,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10770,56 +11143,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10870,6 +11193,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10966,56 +11389,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11066,7 +11439,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -11084,7 +11457,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -11101,7 +11474,66 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11148,6 +11580,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11184,56 +11698,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11284,6 +11748,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11380,56 +11944,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11475,6 +11989,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11621,56 +12235,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.eq
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 0)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11716,6 +12280,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.eq
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 0)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.wast
+++ b/test/lit/passes/safe-heap_low-memory-unused_enable-threads_enable-simd.wast
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_A
+ ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_SC
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
@@ -2502,47 +2502,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -2584,6 +2543,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -2620,56 +2620,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2720,6 +2670,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2816,56 +2816,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -2916,7 +2866,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -2934,7 +2884,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -2951,7 +2901,16 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -2998,6 +2957,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3034,56 +3034,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3134,6 +3084,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3230,56 +3230,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3325,6 +3275,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3471,56 +3471,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3566,6 +3516,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9488,47 +9488,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9570,6 +9529,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9606,56 +9606,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9706,6 +9656,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9802,56 +9802,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -9902,7 +9852,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -9920,7 +9870,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $foo)
@@ -9937,7 +9887,16 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -9984,6 +9943,47 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10020,56 +10020,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10120,6 +10070,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10216,56 +10216,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10311,6 +10261,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10457,56 +10457,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10552,6 +10502,56 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/lit/passes/safe-heap_low-memory-unused_enable-threads_enable-simd_enable-relaxed-atomics.wast
+++ b/test/lit/passes/safe-heap_low-memory-unused_enable-threads_enable-simd_enable-relaxed-atomics.wast
@@ -152,7 +152,7 @@
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
  ;; CHECK-NEXT:  )
- ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_A
+ ;; CHECK-NEXT:  (call $SAFE_HEAP_STORE_i32_4_SC
  ;; CHECK-NEXT:   (i32.const 1)
  ;; CHECK-NEXT:   (i32.const 0)
  ;; CHECK-NEXT:   (i32.const 100)
@@ -3084,47 +3084,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3166,6 +3125,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3202,56 +3243,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3302,6 +3293,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3398,56 +3489,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3498,7 +3539,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -3516,7 +3557,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
@@ -3533,7 +3574,66 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3580,6 +3680,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3616,56 +3798,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3716,6 +3848,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -3812,56 +4044,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -3907,6 +4089,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -4053,56 +4335,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -4148,6 +4380,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $emscripten_get_sbrk_ptr)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10652,47 +10984,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store8
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10734,6 +11025,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_1_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_1 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -10770,56 +11143,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10870,6 +11193,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i32.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_AR (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_2_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -10966,56 +11389,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_A (param $0 i32) (param $1 i32) (param $2 i32)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i32.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_4 (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11066,7 +11439,7 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_A (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_AR (param $0 i32) (param $1 i32) (param $2 i32)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
 ;; CHECK-NEXT:   (i32.add
@@ -11084,7 +11457,7 @@
 ;; CHECK-NEXT:     (i32.gt_u
 ;; CHECK-NEXT:      (i32.add
 ;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:       (i32.const 4)
 ;; CHECK-NEXT:      )
 ;; CHECK-NEXT:      (i32.load
 ;; CHECK-NEXT:       (call $foo)
@@ -11101,7 +11474,66 @@
 ;; CHECK-NEXT:    (unreachable)
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i32_4_SC (param $0 i32) (param $1 i32) (param $2 i32)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i32.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11148,6 +11580,88 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_1_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 1)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store8
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_1 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11184,56 +11698,6 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16 align=1
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 2)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11284,6 +11748,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store16
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_2_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 2)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store16
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11380,56 +11944,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 4)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 3)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store32
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_4 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11475,6 +11989,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store32
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32 acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_4_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 4)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 3)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store32
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )
@@ -11621,56 +12235,6 @@
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT: )
 
-;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_A (param $0 i32) (param $1 i32) (param $2 i64)
-;; CHECK-NEXT:  (local $3 i32)
-;; CHECK-NEXT:  (local.set $3
-;; CHECK-NEXT:   (i32.add
-;; CHECK-NEXT:    (local.get $0)
-;; CHECK-NEXT:    (local.get $1)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.or
-;; CHECK-NEXT:    (i32.lt_u
-;; CHECK-NEXT:     (local.get $3)
-;; CHECK-NEXT:     (i32.const 1024)
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:    (i32.or
-;; CHECK-NEXT:     (i32.gt_u
-;; CHECK-NEXT:      (i32.add
-;; CHECK-NEXT:       (local.get $3)
-;; CHECK-NEXT:       (i32.const 8)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:      (i32.load
-;; CHECK-NEXT:       (call $foo)
-;; CHECK-NEXT:      )
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:     (i32.lt_u
-;; CHECK-NEXT:      (local.get $3)
-;; CHECK-NEXT:      (local.get $0)
-;; CHECK-NEXT:     )
-;; CHECK-NEXT:    )
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $segfault)
-;; CHECK-NEXT:    (unreachable)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (if
-;; CHECK-NEXT:   (i32.and
-;; CHECK-NEXT:    (local.get $3)
-;; CHECK-NEXT:    (i32.const 7)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:   (then
-;; CHECK-NEXT:    (call $alignfault)
-;; CHECK-NEXT:   )
-;; CHECK-NEXT:  )
-;; CHECK-NEXT:  (i64.atomic.store
-;; CHECK-NEXT:   (local.get $3)
-;; CHECK-NEXT:   (local.get $2)
-;; CHECK-NEXT:  )
-;; CHECK-NEXT: )
-
 ;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_8 (param $0 i32) (param $1 i32) (param $2 i64)
 ;; CHECK-NEXT:  (local $3 i32)
 ;; CHECK-NEXT:  (local.set $3
@@ -11716,6 +12280,106 @@
 ;; CHECK-NEXT:   )
 ;; CHECK-NEXT:  )
 ;; CHECK-NEXT:  (i64.store
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_AR (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store acqrel
+;; CHECK-NEXT:   (local.get $3)
+;; CHECK-NEXT:   (local.get $2)
+;; CHECK-NEXT:  )
+;; CHECK-NEXT: )
+
+;; CHECK:      (func $SAFE_HEAP_STORE_i64_8_SC (param $0 i32) (param $1 i32) (param $2 i64)
+;; CHECK-NEXT:  (local $3 i32)
+;; CHECK-NEXT:  (local.set $3
+;; CHECK-NEXT:   (i32.add
+;; CHECK-NEXT:    (local.get $0)
+;; CHECK-NEXT:    (local.get $1)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.or
+;; CHECK-NEXT:    (i32.lt_u
+;; CHECK-NEXT:     (local.get $3)
+;; CHECK-NEXT:     (i32.const 1024)
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:    (i32.or
+;; CHECK-NEXT:     (i32.gt_u
+;; CHECK-NEXT:      (i32.add
+;; CHECK-NEXT:       (local.get $3)
+;; CHECK-NEXT:       (i32.const 8)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:      (i32.load
+;; CHECK-NEXT:       (call $foo)
+;; CHECK-NEXT:      )
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:     (i32.lt_u
+;; CHECK-NEXT:      (local.get $3)
+;; CHECK-NEXT:      (local.get $0)
+;; CHECK-NEXT:     )
+;; CHECK-NEXT:    )
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $segfault)
+;; CHECK-NEXT:    (unreachable)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (if
+;; CHECK-NEXT:   (i32.and
+;; CHECK-NEXT:    (local.get $3)
+;; CHECK-NEXT:    (i32.const 7)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:   (then
+;; CHECK-NEXT:    (call $alignfault)
+;; CHECK-NEXT:   )
+;; CHECK-NEXT:  )
+;; CHECK-NEXT:  (i64.atomic.store
 ;; CHECK-NEXT:   (local.get $3)
 ;; CHECK-NEXT:   (local.get $2)
 ;; CHECK-NEXT:  )

--- a/test/spec/relaxed-atomics.wast
+++ b/test/spec/relaxed-atomics.wast
@@ -2,11 +2,13 @@
  (memory $0 23 256 shared)
 
  (func $acqrel (result i32)
+   (i32.atomic.store acqrel (i32.const 0) (i32.const 0))
    (i32.atomic.load acqrel
     (i32.const 1)
    )
  )
  (func $seqcst (result i32)
+   (i32.atomic.store 0 seqcst (i32.const 0) (i32.const 0))
    ;; seqcst may be omitted for atomic loads, it's the default
    (drop (i32.atomic.load seqcst
     (i32.const 1)
@@ -28,6 +30,55 @@
    ") "
  )
  "Memory ordering can only be provided for atomic loads."
+)
+
+;; Parses acquire-release immediate
+;; (module
+;;  (memory $0 23 256 shared)
+;;  (func $acqrel
+;;   (i32.atomic.store (i32.const 0) (i32.const 0))
+;;  )
+;; )
+(module binary
+ "\00asm\01\00\00\00"
+ "\01\04\01\60\00\00\03\02\01\00\05\05\01\03\17\80\02" ;; other sections
+ "\0a\0d\01" ;; code section
+   "\0b\00" ;; func $acqrel
+   "\41\00\41\00" ;; (i32.const 0) (i32.const 0)
+   "\fe\17" ;; i32.atomic.store
+   "\22" ;; 2 | (1<<5): Alignment of 2 (32-bit store), with bit 5 set indicating that then next byte is a memory ordering
+   "\01" ;; acqrel ordering
+   "\00" ;; offset
+   "\0b" ;; end
+)
+
+;; Parses optional seq-cst immediate
+(module binary
+ "\00asm\01\00\00\00"
+ "\01\04\01\60\00\00\03\02\01\00\05\05\01\03\17\80\02" ;; other sections
+ "\0a\0d\01" ;; code section
+   "\0b\00" ;; func $seqcst
+   "\41\00\41\00" ;; (i32.const 0) (i32.const 0)
+   "\fe\17" ;; i32.atomic.store
+   "\22" ;; 2 | (1<<5): Alignment of 2 (32-bit store), with bit 5 set indicating that then next byte is a memory ordering
+   "\00" ;; seqcst ordering
+   "\00" ;; offset
+   "\0b" ;; end
+)
+
+;; Parses optional seq-cst immediate with memory idx
+(module binary
+ "\00asm\01\00\00\00"
+ "\01\04\01\60\00\00\03\02\01\00\05\05\01\03\17\80\02" ;; other sections
+ "\0a\0e\01" ;; code section
+   "\0c\00" ;; func $seqcst
+   "\41\00\41\00" ;; (i32.const 0) (i32.const 0)
+   "\fe\17" ;; i32.atomic.store
+   "\62" ;; 2 | (1<<5): Alignment of 2 (32-bit store), with bit 5 set indicating that then next byte is a memory ordering
+   "\00" ;; memory index
+   "\00" ;; seqcst ordering
+   "\00" ;; offset
+   "\0b" ;; end
 )
 
 ;; Parses acquire-release immediate


### PR DESCRIPTION
Part of #8165. The unit tests are written manually for now, but I will compact the tests later once I have a script to generate them. C and JS apis will be updated later with all atomic instructions together.