### PR TITLE
feat(jsapi): Implement Table Bindings

### DIFF
--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -5263,6 +5263,130 @@ Module['Function'] = (() => {
   return Function;
 })();
 
+// Table wrapper
+Module['Table'] = (() => {
+  /** @constructor */
+  function Table(table) {
+    if (!(this instanceof Table)) {
+      if (!table) return null;
+      return new Table(table);
+    }
+    if (!table) throw Error("table reference must not be null");
+    this[thisPtr] = table;
+  }
+  /**
+   * Gets the name of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to get the name from.
+   * 
+   * @return {string} The name of the `Table`.
+   */
+  Table['getName'] = function(table) {
+    return UTF8ToString(Module['_BinaryenTableGetName'](table));
+  };
+
+  /**
+   * Sets the name of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to set the name for.
+   * @param {string} name - The new name for the `Table`.
+   * 
+   * @return {void}
+   */
+  Table['setName'] = function(table, name) {
+    preserveStack(() => {
+      Module['_BinaryenTableSetName'](table, strToStack(name));
+    });
+  };
+
+  /**
+   * Gets the initial number of pages of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to get the initial number of pages from.
+   * 
+   * @return {number} The initial number of pages of the `Table`.
+   */
+  Table['getInitial'] = function(table) {
+    return Module['_BinaryenTableGetInitial'](table);
+  };
+
+  /**
+   * Sets the initial number of pages of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to set the initial number of pages for.
+   * @param {number} initial - The new initial number of pages for the `Table`.
+   * 
+   * @return {void}
+   */
+  Table['setInitial'] = function(table, initial) {
+    Module['_BinaryenTableSetInitial'](table, initial);
+  };
+
+  /**
+   * Tests whether the specified `Table` has a maximum number of pages.
+   * 
+   * @param {Table} table - The `Table` to test.
+   * 
+   * @return {boolean} `true` if the `Table` has a maximum number of pages, `false` otherwise.
+   */
+  Table['hasMax'] = function(table) {
+    return Boolean(Module['_BinaryenTableHasMax'](table));
+  };
+
+  /**
+   * Gets the maximum number of pages of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to get the maximum number of pages from.
+   * 
+   * @return {number} The maximum number of pages of the `Table`.
+   */
+  Table['getMax'] = function(table) {
+    return Module['_BinaryenTableGetMax'](table);
+  };
+
+  /** 
+   * Sets the maximum number of pages of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to set the maximum number of pages for.
+   * @param {number} max - The new maximum number of pages for the `Table`.
+   * 
+   * @return {void}
+   */
+  Table['setMax'] = function(table, max) {
+    return Module['_BinaryenTableSetMax'](table, max);
+  };
+
+  /**
+   * Gets the table type of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to get the type from.
+   * 
+   * @return {number} The type of the `Table`.
+   */
+  Table['getType'] = function(table) {
+    return Module['_BinaryenTableGetType'](table);
+  };
+
+  /**
+   * Sets the table type of the specified `Table`.
+   * 
+   * @param {Table} table - The `Table` to set the type for.
+   * @param {Type} tableType - The new type for the `Table`.
+   * 
+   * @return {void}
+   */
+  Table['setType'] = function(table, tableType) {
+    return Module['_BinaryenTableSetType'](table, tableType);
+  };
+
+  deriveWrapperInstanceMembers(Table.prototype, Table);
+  Table.prototype['valueOf'] = function() {
+    return this[thisPtr];
+  };
+  return Table;
+})();
+
+
 // Additional customizations
 
 Module['exit'] = function(status) {

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -743,13 +743,6 @@ function test_core() {
   assert(tablePtr !== 0);
   assert(tablePtr === module.getTableByIndex(0));
 
-  var table = binaryen.getTableInfo(tablePtr);
-  assert(table.name === "t1");
-  assert(table.module === "");
-  assert(table.base === "");
-  assert(table.initial === 0);
-  assert(table.max === 2);
-
   module.removeTable("t1");
   assert(module.getNumTables() === 0);
 

--- a/test/binaryen.js/tables.js
+++ b/test/binaryen.js/tables.js
@@ -1,0 +1,52 @@
+const module = new binaryen.Module();
+
+// Test table
+const tableName = "a-table";
+const tableMin = 5;
+const tableMax = 15;
+const tablePtr = module.addTable(tableName, tableMin, tableMax);
+
+console.log("GetTable is equal: " + (tablePtr === module.getTable(tableName)));
+
+const tableInfo = binaryen.getTableInfo(tablePtr);
+console.log("getTableInfo=" + JSON.stringify(tableInfo));
+
+// Test Wrapper
+// get/set name
+assert(binaryen.Table.getName(tablePtr) === tableName);
+binaryen.Table.setName(tablePtr, "new-table-name");
+assert(binaryen.Table.getName(tablePtr) === "new-table-name");
+binaryen.Table.setName(tablePtr, tableName);
+
+// get/set initial
+assert(binaryen.Table.getInitial(tablePtr) === tableMin);
+binaryen.Table.setInitial(tablePtr, 10);
+assert(binaryen.Table.getInitial(tablePtr) === 10);
+binaryen.Table.setInitial(tablePtr, tableMin);
+
+// hasMax
+assert(binaryen.Table.hasMax(tablePtr) === true);
+
+// get/set max
+assert(binaryen.Table.getMax(tablePtr) === tableMax);
+binaryen.Table.setMax(tablePtr, 20);
+assert(binaryen.Table.getMax(tablePtr) === 20);
+binaryen.Table.setMax(tablePtr, tableMax);
+
+// get/set type
+assert(binaryen.Table.getType(tablePtr) === binaryen.funcref);
+binaryen.Table.setType(tablePtr, binaryen.anyref);
+assert(binaryen.Table.getType(tablePtr) === binaryen.anyref);
+binaryen.Table.setType(tablePtr, binaryen.funcref);
+
+const tableRef = binaryen.Table(tablePtr);
+assert(tableRef.name === tableName);
+assert(tableRef.initial === tableMin);
+assert(tableRef.max === tableMax);
+assert(tableRef.type === binaryen.funcref);
+
+// Cleanup
+assert(module.validate());
+console.log(module.emitText());
+
+module.dispose();

--- a/test/binaryen.js/tables.js.txt
+++ b/test/binaryen.js/tables.js.txt
@@ -1,0 +1,6 @@
+GetTable is equal: true
+getTableInfo={"name":"a-table","module":"","base":"","initial":5,"max":15}
+(module
+ (table $a-table 5 15 funcref)
+)
+


### PR DESCRIPTION
This pr implements the table bindings I wasn't quite sure what was meant by in parrellel to the memory stuff, so I put it after the function stuff like it is in the c api, happy to change this however.

Let me know if there are any changes that need to be made.

Closes: #8122

Notes:
* I removed the getInfo table tests in kitchen-sink and moved them here as it's more specific
* I added jsdoc which isn't something i've seen through the js api but it does however seem helpful.

I'm pretty sure that for adding the `Elem Segment Operations` it would be bassically the exact same patterns so I can probably do that as well once this is okay'd.