### PR TITLE
[NFC] Update the timer utility

### DIFF
--- a/src/tools/wasm-reduce/wasm-reduce.cpp
+++ b/src/tools/wasm-reduce/wasm-reduce.cpp
@@ -97,7 +97,6 @@ struct ProgramResult {
 #ifdef _WIN32
   void getFromExecution(std::string command) {
     Timer timer;
-    timer.start();
     SECURITY_ATTRIBUTES saAttr;
     saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
     saAttr.bInheritHandle = TRUE;
@@ -176,15 +175,13 @@ struct ProgramResult {
         output.append(chBuf);
       }
     }
-    timer.stop();
-    time = timer.getTotal();
+    time = timer.totalElapsed();
   }
 #else  // POSIX
   // runs the command and notes the output
   // TODO: also stderr, not just stdout?
   void getFromExecution(std::string command) {
     Timer timer;
-    timer.start();
     const int MAX_BUFFER = 1024;
     char buffer[MAX_BUFFER];
     FILE* stream = popen(
@@ -195,8 +192,7 @@ struct ProgramResult {
       output.append(buffer);
     }
     code = pclose(stream);
-    timer.stop();
-    time = timer.getTotal();
+    time = timer.totalElapsed();
   }
 #endif // _WIN32
 


### PR DESCRIPTION
Reduce verbosity by implicitly starting the timer when it is first
constructed. Separate concerns by removing printing functionality.
Add the ability to measure time elapsed since the last measurement to
better support the use case of measuring several subsequent steps of an
operation as well as the total elapsed time.
