### PR TITLE
Move ostream operators to wasm namespace

### DIFF
--- a/src/passes/Print.cpp
+++ b/src/passes/Print.cpp
@@ -3894,10 +3894,6 @@ printStackIR(std::ostream& o, Module* module, const PassOptions& options) {
   return o;
 }
 
-} // namespace wasm
-
-namespace std {
-
 std::ostream& operator<<(std::ostream& o, wasm::Module& module) {
   wasm::PassRunner runner(&module);
   wasm::Printer printer(&o);
@@ -3958,4 +3954,19 @@ std::ostream& operator<<(std::ostream& o,
   return o << importNames.module << "." << importNames.name;
 }
 
-} // namespace std
+std::ostream& operator<<(std::ostream& os, wasm::MemoryOrder mo) {
+  switch (mo) {
+    case wasm::MemoryOrder::Unordered:
+      os << "Unordered";
+      break;
+    case wasm::MemoryOrder::SeqCst:
+      os << "SeqCst";
+      break;
+    case wasm::MemoryOrder::AcqRel:
+      os << "AcqRel";
+      break;
+  }
+  return os;
+}
+
+} // namespace wasm

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -2654,15 +2654,6 @@ struct ShallowExpression {
   Module* module = nullptr;
 };
 
-} // namespace wasm
-
-namespace std {
-template<> struct hash<wasm::Address> {
-  size_t operator()(const wasm::Address a) const {
-    return std::hash<wasm::Address::address64_t>()(a.addr);
-  }
-};
-
 std::ostream& operator<<(std::ostream& o, wasm::Module& module);
 std::ostream& operator<<(std::ostream& o, wasm::Function& func);
 std::ostream& operator<<(std::ostream& o, wasm::Expression& expression);
@@ -2672,6 +2663,15 @@ std::ostream& operator<<(std::ostream& o, wasm::ModuleType pair);
 std::ostream& operator<<(std::ostream& o, wasm::ModuleHeapType pair);
 std::ostream& operator<<(std::ostream& os, wasm::MemoryOrder mo);
 std::ostream& operator<<(std::ostream& o, const wasm::ImportNames& importNames);
+
+} // namespace wasm
+
+namespace std {
+template<> struct hash<wasm::Address> {
+  size_t operator()(const wasm::Address a) const {
+    return std::hash<wasm::Address::address64_t>()(a.addr);
+  }
+};
 
 } // namespace std
 

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -2015,22 +2015,3 @@ void Module::clearDebugInfo() {
 }
 
 } // namespace wasm
-
-namespace std {
-
-std::ostream& operator<<(std::ostream& os, wasm::MemoryOrder mo) {
-  switch (mo) {
-    case wasm::MemoryOrder::Unordered:
-      os << "Unordered";
-      break;
-    case wasm::MemoryOrder::SeqCst:
-      os << "SeqCst";
-      break;
-    case wasm::MemoryOrder::AcqRel:
-      os << "AcqRel";
-      break;
-  }
-  return os;
-}
-
-} // namespace std


### PR DESCRIPTION
Extending std with ostream operators is UB: https://en.cppreference.com/w/cpp/language/extending_std.html. Including these definitions in wasm is just as good because argument-dependent lookup will look it up using the argument's namespace which is always wasm anyway.

Also move MemoryOrder ostream operator from wasm.cpp to Print.cpp to match others.