### PR TITLE
Audit the dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install tools
@@ -41,10 +41,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -94,7 +94,7 @@ jobs:
       if: matrix.os != 'windows-latest'
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: build-${{ matrix.os }}
         path: out/install
@@ -109,10 +109,10 @@ jobs:
     name: clang (LTO)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install ninja
@@ -138,10 +138,10 @@ jobs:
       ASAN_OPTIONS: "symbolize=1"
       COMPILER_FLAGS: "-fsanitize=address"
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install ninja
@@ -164,10 +164,10 @@ jobs:
     name: alpine
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: start docker
@@ -204,10 +204,10 @@ jobs:
       CC: "clang"
       CXX: "clang++"
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install ninja
@@ -231,10 +231,10 @@ jobs:
       COMPILER_FLAGS: "-fsanitize=thread"
       LINKER_FLAGS: "-fsanitize=thread"
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install ninja
@@ -259,10 +259,10 @@ jobs:
       # Format: https://github.com/<fork>/emscripten/tree/<refspec>
       EMSCRIPTEN_REPO: ""
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install ninja
@@ -292,10 +292,10 @@ jobs:
     name: mingw
     runs-on: windows-latest
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: cmake
@@ -314,10 +314,10 @@ jobs:
       CC: "gcc"
       CXX: "g++"
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
     - name: install ninja
@@ -335,6 +335,6 @@ jobs:
         python check.py --binaryen-bin=out/bin lit
         python check.py --binaryen-bin=out/bin gtest
     - name: upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         gcov: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@
 
 # Install with `pip3 install -r requirements-dev.txt`
 
-flake8==3.7.8
-filecheck==0.0.22
-lit==0.11.0.post1
+flake8==7.1.2
+filecheck==1.0.1
+lit==18.1.8


### PR DESCRIPTION
- Update Python dev dependencies in requirements-dev.txt:
  - flake8: 3.7.8 -> 7.1.2
  - filecheck: 0.0.22 -> 1.0.1
  - lit: 0.11.0.post1 -> 18.1.8

- Update GitHub Actions to modern versions:
  - actions/setup-python: v1 -> v5
  - actions/checkout: v1 -> v4
  - actions/upload-artifact: v1 -> v4
  - codecov/codecov-action: v3 -> v4

The old action versions were deprecated and may stop working. The Python packages were severely outdated (some by 4+ years).