### PR TITLE
Use std::filesystem::path::preferred_separator. NFC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,8 @@
 # https://launchpad.net/ubuntu/focal/+source/cmake
 cmake_minimum_required(VERSION 3.16.3)
 
-# Needed for C++17 (std::variant)
-# TODO(https://github.com/WebAssembly/binaryen/issues/4299): We need
-# to reduce this for compatability with emsdk.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14" CACHE STRING "Minimum OS X deployment version")
+# Needed for C++17 (std::path)
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 
 project(binaryen LANGUAGES C CXX VERSION 125)
 include(GNUInstallDirs)

--- a/src/support/path.cpp
+++ b/src/support/path.cpp
@@ -18,6 +18,8 @@
 // Command line helpers.
 //
 
+#include <filesystem>
+
 #include "support/path.h"
 #ifdef USE_WSTRING_PATHS
 #include "windows.h"
@@ -52,15 +54,7 @@ std::string wstring_to_string(const std::wstring& s) {
 PathString to_path(const std::string& s) { return s; }
 #endif
 
-char getPathSeparator() {
-  // TODO: use c++17's path separator
-  //       http://en.cppreference.com/w/cpp/experimental/fs/path
-#if defined(WIN32) || defined(_WIN32)
-  return '\\';
-#else
-  return '/';
-#endif
-}
+char getPathSeparator() { return std::filesystem::path::preferred_separator; }
 
 static std::string getAllPathSeparators() {
   // The canonical separator on Windows is `\`, but it also accepts `/`.


### PR DESCRIPTION
The emsdk TODO is no longer necessary after: 
https://github.com/emscripten-core/emsdk/pull/1637
