### PR TITLE
Ignore emcc-build in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,4 +6,4 @@ ignore =
   E241,
   ; line break after binary operator
   W504
-exclude = third_party,./test/emscripten,./test/spec,./test/wasm-install,./test/lit,./_deps,./build
+exclude = third_party,./test/emscripten,./test/spec,./test/wasm-install,./test/lit,./_deps,./build,./emcc-build


### PR DESCRIPTION
The directory is created by `./scripts/emcc-tests.sh` and contains python files that don't pass the formatting check

```sh
./emcc-build/test/lit/lit.site.cfg.py:3:1: F821 undefined name 'config'
./emcc-build/test/lit/lit.site.cfg.py:4:1: F821 undefined name 'config'
./emcc-build/test/lit/lit.site.cfg.py:6:1: F821 undefined name 'lit_config'
./emcc-build/test/lit/lit.site.cfg.py:7:5: F821 undefined name 'config'
./emcc-build/test/lit/lit.site.cfg.py:7:26: F821 undefined name 'config'
```