### PR TITLE
Add initial (binary only) support for compact imports proposal. NFC.

### DIFF
--- a/src/binaryen-c.cpp
+++ b/src/binaryen-c.cpp
@@ -511,6 +511,9 @@ BinaryenFeatures BinaryenFeatureCustomPageSizes(void) {
 BinaryenFeatures BinaryenFeatureWideArithmetic(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::WideArithmetic);
 }
+BinaryenFeatures BinaryenFeatureCompactImports(void) {
+  return static_cast<BinaryenFeatures>(FeatureSet::CompactImports);
+}
 BinaryenFeatures BinaryenFeatureAll(void) {
   return static_cast<BinaryenFeatures>(FeatureSet::All);
 }

--- a/src/binaryen-c.h
+++ b/src/binaryen-c.h
@@ -249,6 +249,7 @@ BINARYEN_API BinaryenFeatures BinaryenFeatureRelaxedAtomics(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureMultibyte(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureCustomPageSizes(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureWideArithmetic(void);
+BINARYEN_API BinaryenFeatures BinaryenFeatureCompactImports(void);
 BINARYEN_API BinaryenFeatures BinaryenFeatureAll(void);
 
 // Modules

--- a/src/js/binaryen.js-post.js
+++ b/src/js/binaryen.js-post.js
@@ -195,6 +195,7 @@ function initializeConstants() {
     'RelaxedAtomics',
     'CustomPageSizes',
     'WideArithmetic',
+    'CompactImports',
     'All'
   ].forEach(name => {
     Module['Features'][name] = Module['_BinaryenFeature' + name]();

--- a/src/tools/tool-options.h
+++ b/src/tools/tool-options.h
@@ -113,6 +113,7 @@ struct ToolOptions : public Options {
                   "acquire/release atomic memory operations")
       .addFeature(FeatureSet::CustomPageSizes, "custom page sizes")
       .addFeature(FeatureSet::WideArithmetic, "wide arithmetic")
+      .addFeature(FeatureSet::CompactImports, "compact import section")
       .add("--enable-typed-function-references",
            "",
            "Deprecated compatibility flag",

--- a/src/wasm-binary.h
+++ b/src/wasm-binary.h
@@ -371,6 +371,10 @@ constexpr uint32_t HasMemoryIndexMask = 1 << 6;
 constexpr uint8_t HasTableInitializer = 0x40;
 constexpr uint8_t TableReservedByte = 0x00;
 
+// TODO(sbc): Use upstream names for these schemes if/when they are decided.
+constexpr uint8_t CompactImportsSharedModule = 0x7f;
+constexpr uint8_t CompactImportsSharedAll = 0x7e;
+
 enum EncodedType {
   // value types
   i32 = -0x1,  // 0x7f
@@ -475,6 +479,7 @@ extern const char* RelaxedAtomicsFeature;
 extern const char* MultibyteFeature;
 extern const char* CustomPageSizesFeature;
 extern const char* WideArithmeticFeature;
+extern const char* CompactImportsFeature;
 
 enum Subsection {
   NameModule = 0,
@@ -1692,6 +1697,9 @@ public:
   std::unique_ptr<Memory> readMemoryImport(Name module, Name base);
   std::unique_ptr<Global> readGlobalImport(Name module, Name base);
   std::unique_ptr<Tag> readTagImport(Name module, Name base);
+
+  template<typename T, typename ReadFunc>
+  void readCompactImportsShared(Name module, ReadFunc readFunc);
 
   // The signatures of each function, including imported functions, given in the
   // import and function sections. Store HeapTypes instead of Signatures because

--- a/src/wasm-features.h
+++ b/src/wasm-features.h
@@ -59,11 +59,12 @@ struct FeatureSet {
     CustomPageSizes = 1 << 23,
     Multibyte = 1 << 24,
     WideArithmetic = 1 << 25,
+    CompactImports = 1 << 26,
     MVP = None,
     // Keep in sync with llvm default features:
     // https://github.com/llvm/llvm-project/blob/c7576cb89d6c95f03968076e902d3adfd1996577/clang/lib/Basic/Targets/WebAssembly.cpp#L150-L153
     Default = SignExt | MutableGlobals,
-    All = (1 << 26) - 1,
+    All = (1 << 27) - 1,
   };
 
   static std::string toString(Feature f) {
@@ -120,6 +121,8 @@ struct FeatureSet {
         return "multibyte";
       case WideArithmetic:
         return "wide-arithmetic";
+      case CompactImports:
+        return "compact-imports";
       case MVP:
       case Default:
       case All:
@@ -184,6 +187,7 @@ struct FeatureSet {
   bool hasCustomPageSizes() const { return (features & CustomPageSizes) != 0; }
   bool hasMultibyte() const { return (features & Multibyte) != 0; }
   bool hasWideArithmetic() const { return (features & WideArithmetic) != 0; }
+  bool hasCompactImports() const { return (features & CompactImports) != 0; }
   bool hasAll() const { return (features & All) != 0; }
 
   void set(FeatureSet f, bool v = true) {
@@ -213,6 +217,7 @@ struct FeatureSet {
   void setRelaxedAtomics(bool v = true) { set(RelaxedAtomics, v); }
   void setMultibyte(bool v = true) { set(Multibyte, v); }
   void setWideArithmetic(bool v = true) { set(WideArithmetic, v); }
+  void setCompactImports(bool v = true) { set(CompactImports, v); }
   void setMVP() { features = MVP; }
   void setAll() { features = All; }
 

--- a/src/wasm/wasm-binary.cpp
+++ b/src/wasm/wasm-binary.cpp
@@ -1489,6 +1489,8 @@ void WasmBinaryWriter::writeFeaturesSection() {
         return BinaryConsts::CustomSections::CustomPageSizesFeature;
       case FeatureSet::WideArithmetic:
         return BinaryConsts::CustomSections::WideArithmeticFeature;
+      case FeatureSet::CompactImports:
+        return BinaryConsts::CustomSections::CompactImportsFeature;
       case FeatureSet::None:
       case FeatureSet::Default:
       case FeatureSet::All:
@@ -3156,6 +3158,18 @@ std::unique_ptr<Tag> WasmBinaryReader::readTagImport(Name module, Name base) {
   return curr;
 }
 
+template<typename T, typename ReadFunc>
+void WasmBinaryReader::readCompactImportsShared(Name module,
+                                                ReadFunc readBaseDetails) {
+  std::unique_ptr<T> baseDetails = readBaseDetails(Name());
+  size_t numCompactImports = getU32LEB();
+  while (numCompactImports--) {
+    auto details = std::make_unique<T>(*baseDetails);
+    details->base = getInlineString();
+    addImport(std::move(details));
+  }
+}
+
 void WasmBinaryReader::readImport(Name module, Name base, uint32_t kind) {
   switch (kind & ~BinaryConsts::ExactImport) {
     case ExternalKind::Function:
@@ -3183,8 +3197,52 @@ void WasmBinaryReader::readImports() {
   for (size_t i = 0; i < num; i++) {
     auto module = getInlineString();
     auto base = getInlineString();
-    auto kind = getU32LEB();
-    readImport(module, base, kind);
+    auto kind = getInt8();
+    if (base == "" && (kind == BinaryConsts::CompactImportsSharedModule ||
+                       kind == BinaryConsts::CompactImportsSharedAll)) {
+      if (!wasm.features.hasCompactImports()) {
+        throwError("compact imports not supported");
+      }
+      if (kind == BinaryConsts::CompactImportsSharedModule) {
+        size_t numCompactImports = getU32LEB();
+        while (numCompactImports--) {
+          base = getInlineString();
+          kind = getInt8();
+          readImport(module, base, kind);
+        }
+      } else {
+        kind = getInt8();
+        switch (kind & ~BinaryConsts::ExactImport) {
+          case ExternalKind::Function:
+            readCompactImportsShared<Function>(module, [&](Name base) {
+              return readFunctionImport(module, base, kind);
+            });
+            break;
+          case ExternalKind::Table:
+            readCompactImportsShared<Table>(
+              module, [&](Name base) { return readTableImport(module, base); });
+            break;
+          case ExternalKind::Memory:
+            readCompactImportsShared<Memory>(module, [&](Name base) {
+              return readMemoryImport(module, base);
+            });
+            break;
+          case ExternalKind::Global:
+            readCompactImportsShared<Global>(module, [&](Name base) {
+              return readGlobalImport(module, base);
+            });
+            break;
+          case ExternalKind::Tag:
+            readCompactImportsShared<Tag>(
+              module, [&](Name base) { return readTagImport(module, base); });
+            break;
+          default:
+            throwError("bad import kind");
+        }
+      }
+    } else {
+      readImport(module, base, kind);
+    }
   }
   numFuncImports = wasm.functions.size();
 }
@@ -5519,6 +5577,8 @@ void WasmBinaryReader::readFeatures(size_t sectionPos, size_t payloadLen) {
       feature = FeatureSet::CustomPageSizes;
     } else if (name == BinaryConsts::CustomSections::WideArithmeticFeature) {
       feature = FeatureSet::WideArithmetic;
+    } else if (name == BinaryConsts::CustomSections::CompactImportsFeature) {
+      feature = FeatureSet::CompactImports;
     } else {
       // Silently ignore unknown features (this may be and old binaryen running
       // on a new wasm).

--- a/src/wasm/wasm.cpp
+++ b/src/wasm/wasm.cpp
@@ -80,6 +80,7 @@ const char* RelaxedAtomicsFeature = "relaxed-atomics";
 const char* MultibyteFeature = "multibyte";
 const char* CustomPageSizesFeature = "custom-page-sizes";
 const char* WideArithmeticFeature = "wide-arithmetic";
+const char* CompactImportsFeature = "compact-imports";
 
 } // namespace BinaryConsts::CustomSections
 

--- a/test/binaryen.js/kitchen-sink.js
+++ b/test/binaryen.js/kitchen-sink.js
@@ -103,6 +103,7 @@ function test_features() {
   console.log("Features.RelaxedAtomics: " + binaryen.Features.RelaxedAtomics);
   console.log("Features.CustomPageSizes: " + binaryen.Features.CustomPageSizes);
   console.log("Features.WideArithmetic: " + binaryen.Features.WideArithmetic);
+  console.log("Features.CompactImports: " + binaryen.Features.CompactImports);
   console.log("Features.All: " + binaryen.Features.All);
 }
 

--- a/test/binaryen.js/kitchen-sink.js.txt
+++ b/test/binaryen.js/kitchen-sink.js.txt
@@ -36,7 +36,8 @@ Features.MultiMemory: 32768
 Features.RelaxedAtomics: 4194304
 Features.CustomPageSizes: 8388608
 Features.WideArithmetic: 33554432
-Features.All: 67108863
+Features.CompactImports: 67108864
+Features.All: 134217727
 InvalidId: 0
 BlockId: 1
 IfId: 2

--- a/test/example/c-api-kitchen-sink.c
+++ b/test/example/c-api-kitchen-sink.c
@@ -381,6 +381,8 @@ void test_features() {
   printf("BinaryenFeatureMultibyte: %d\n", BinaryenFeatureMultibyte());
   printf("BinaryenFeatureWideArithmetic: %d\n",
          BinaryenFeatureWideArithmetic());
+  printf("BinaryenFeatureCompactImports: %d\n",
+         BinaryenFeatureCompactImports());
   printf("BinaryenFeatureAll: %d\n", BinaryenFeatureAll());
 }
 

--- a/test/example/c-api-kitchen-sink.txt
+++ b/test/example/c-api-kitchen-sink.txt
@@ -51,7 +51,8 @@ BinaryenFeatureRelaxedAtomics: 4194304
 BinaryenFeatureCustomPageSizes: 8388608
 BinaryenFeatureMultibyte: 16777216
 BinaryenFeatureWideArithmetic: 33554432
-BinaryenFeatureAll: 67108863
+BinaryenFeatureCompactImports: 67108864
+BinaryenFeatureAll: 134217727
 (f32.neg
  (f32.const -33.61199951171875)
 )

--- a/test/lit/help/wasm-as.test
+++ b/test/lit/help/wasm-as.test
@@ -152,6 +152,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-ctor-eval.test
+++ b/test/lit/help/wasm-ctor-eval.test
@@ -159,6 +159,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-dis.test
+++ b/test/lit/help/wasm-dis.test
@@ -145,6 +145,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-emscripten-finalize.test
+++ b/test/lit/help/wasm-emscripten-finalize.test
@@ -187,6 +187,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-merge.test
+++ b/test/lit/help/wasm-merge.test
@@ -182,6 +182,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-metadce.test
+++ b/test/lit/help/wasm-metadce.test
@@ -825,6 +825,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic                     Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports                      Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports                     Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/lit/help/wasm-opt.test
+++ b/test/lit/help/wasm-opt.test
@@ -861,6 +861,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic                     Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports                      Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports                     Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/lit/help/wasm-reduce.test
+++ b/test/lit/help/wasm-reduce.test
@@ -235,6 +235,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm-split.test
+++ b/test/lit/help/wasm-split.test
@@ -296,6 +296,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic            Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports             Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports            Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references   Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references  Deprecated compatibility flag

--- a/test/lit/help/wasm2js.test
+++ b/test/lit/help/wasm2js.test
@@ -789,6 +789,10 @@
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-wide-arithmetic                     Disable wide arithmetic
 ;; CHECK-NEXT:
+;; CHECK-NEXT:   --enable-compact-imports                      Enable compact import section
+;; CHECK-NEXT:
+;; CHECK-NEXT:   --disable-compact-imports                     Disable compact import section
+;; CHECK-NEXT:
 ;; CHECK-NEXT:   --enable-typed-function-references            Deprecated compatibility flag
 ;; CHECK-NEXT:
 ;; CHECK-NEXT:   --disable-typed-function-references           Deprecated compatibility flag

--- a/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
+++ b/test/passes/strip-target-features_roundtrip_print-features_all-features.txt
@@ -24,6 +24,7 @@
 --enable-custom-page-sizes
 --enable-multibyte
 --enable-wide-arithmetic
+--enable-compact-imports
 (module
  (type $0 (func (result v128 externref)))
  (func $foo (type $0) (result v128 externref)

--- a/test/spec/compact-import-section/binary-compact-imports.wast
+++ b/test/spec/compact-import-section/binary-compact-imports.wast
@@ -1,0 +1,174 @@
+;; Auxiliary modules to import
+
+(module
+  (func (export "b") (result i32) (i32.const 0x0f))
+  (func (export "c") (result i32) (i32.const 0xf0))
+)
+(register "a")
+(module
+  (func (export "") (result i32) (i32.const 0xab))
+)
+(register "")
+
+
+;; Valid compact encodings
+
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\01\05\01\60\00\01\7f"     ;; Type section: (type (func (result i32)))
+  "\02\0e"                    ;; Import section
+  "\01"                       ;;   1 group
+  "\01a"                      ;;     "a"
+  "\00" "\7f"                 ;;     "" + 0x7f (compact encoding)
+  "\02"                       ;;     2 items
+  "\01b" "\00\00"             ;;       "b" (func (type 0))
+  "\01c" "\00\00"             ;;       "c" (func (type 0))
+  "\03\02" "\01"              ;; Function section, 1 func
+  "\00"                       ;;   func 2: type 0
+  "\07\08" "\01"              ;; Export section, 1 export
+  "\04test" "\00\02"          ;;   "test" func 2
+  "\0a\09" "\01"              ;; Code section, 1 func
+  "\07" "\00"                 ;;   len, 0 locals
+  "\10\00"                    ;;   call 0
+  "\10\01"                    ;;   call 1
+  "\6a"                       ;;   i32.add
+  "\0b"                       ;;   end
+)
+(assert_return (invoke "test") (i32.const 0xff))
+
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\01\05\01\60\00\01\7f"     ;; Type section: (type (func (result i32)))
+  "\02\0c"                    ;; Import section
+  "\01"                       ;;   1 group
+  "\01a"                      ;;     "a"
+  "\00" "\7e"                 ;;     "" + 0x7e (compact encoding)
+  "\00\00"                    ;;     (func (type 0))
+  "\02"                       ;;     2 items
+  "\01b"                      ;;       "b"
+  "\01c"                      ;;       "c"
+  "\03\02" "\01"              ;; Function section, 1 func
+  "\00"                       ;;   func 2: type 0
+  "\07\08" "\01"              ;; Export section, 1 export
+  "\04test" "\00\02"          ;;   "test" func 2
+  "\0a\09" "\01"              ;; Code section, 1 func
+  "\07" "\00"                 ;;   len, 0 locals
+  "\10\00"                    ;;   call 0
+  "\10\01"                    ;;   call 1
+  "\6a"                       ;;   i32.add
+  "\0b"                       ;;   end
+)
+(assert_return (invoke "test") (i32.const 0xff))
+
+
+;; Overly-long empty name encodings are valid
+
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\01\05\01\60\00\01\7f"     ;; Type section: (type (func (result i32)))
+  "\02\11"                    ;; Import section
+  "\01"                       ;;   1 group
+  "\01a"                      ;;     "a"
+  "\80\80\80\00" "\7f"        ;;     "" (long encoding) + 0x7f
+  "\02"                       ;;     2 items
+  "\01b" "\00\00"             ;;       "b" (func (type 0))
+  "\01c" "\00\00"             ;;       "c" (func (type 0))
+)
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\01\05\01\60\00\01\7f"     ;; Type section: (type (func (result i32)))
+  "\02\0f"                    ;; Import section
+  "\01"                       ;;   1 group
+  "\01a"                      ;;     "a"
+  "\80\80\80\00" "\7e"        ;;     "" (long encoding) + 0x7e
+  "\00\00"                    ;;     (func (type 0))
+  "\02"                       ;;     2 items
+  "\01b"                      ;;       "b"
+  "\01c"                      ;;       "c"
+)
+
+
+;; Discriminator is not valid except after empty names
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\05\01\60\00\01\7f"   ;; Type section: (type (func (result i32)))
+    "\02\12"                  ;; Import section
+    "\01"                     ;;   1 group
+    "\01a"                    ;;     "a"
+    "\01b" "\7f"              ;;     "b" + 0x7f
+    "\02"                     ;;     2 items
+    "\01b" "\00\00"           ;;       "b" (func (type 0))
+    "\01c" "\00\00"           ;;       "c" (func (type 0))
+  )
+  "malformed import kind"
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\05\01\60\00\01\7f"   ;; Type section: (type (func (result i32)))
+    "\02\10"                  ;; Import section
+    "\01"                     ;;   1 group
+    "\01a"                    ;;     "a"
+    "\01b" "\7e"              ;;     "" + 0x7e (long encoding)
+    "\00\00"                  ;;     (func (type 0))
+    "\02"                     ;;     2 items
+    "\01b"                    ;;       "b"
+    "\01c"                    ;;       "c"
+  )
+  "malformed import kind"
+)
+
+
+;; Discriminator is not to be interpreted as LEB128
+
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\05\01\60\00\01\7f"   ;; Type section: (type (func (result i32)))
+    "\02\11"                  ;; Import section
+    "\01"                     ;;   1 group
+    "\01a"                    ;;     "a"
+    "\00\ff\80\80\00"         ;;     "" + 0x7f (long encoding)
+    "\02"                     ;;     2 items
+    "\01b" "\00\00"           ;;       "b" (func (type 0))
+    "\01c" "\00\00"           ;;       "c" (func (type 0))
+  )
+  "malformed import kind"
+)
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\01\05\01\60\00\01\7f"   ;; Type section: (type (func (result i32)))
+    "\02\0f"                  ;; Import section
+    "\01"                     ;;   1 group
+    "\01a"                    ;;     "a"
+    "\00\fe\80\80\00"         ;;     "" + 0x7e (long encoding)
+    "\00\00"                  ;;     (func (type 0))
+    "\02"                     ;;     2 items
+    "\01b"                    ;;       "b"
+    "\01c"                    ;;       "c"
+  )
+  "malformed import kind"
+)
+
+
+;; Empty names are still valid if not followed by a discriminator
+
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\01\05\01\60\00\01\7f"     ;; Type section: (type (func (result i32)))
+  "\02\05"                    ;; Import section
+  "\01"                       ;;   1 group
+  "\00\00\00\00"              ;;     "" "" (func (type 0))
+  "\03\02" "\01"              ;; Function section, 1 func
+  "\00"                       ;;   func 1: type 0
+  "\07\08" "\01"              ;; Export section, 1 export
+  "\04test" "\00\01"          ;;   "test" func 1
+  "\0a\06" "\01"              ;; Code section, 1 func
+  "\04" "\00"                 ;;   len, 0 locals
+  "\10\00"                    ;;   call 0
+  "\0b"                       ;;   end
+)
+(assert_return (invoke "test") (i32.const 0xab))

--- a/test/unit/test_features.py
+++ b/test/unit/test_features.py
@@ -459,4 +459,5 @@ class TargetFeaturesSectionTest(utils.BinaryenTestCase):
             '--enable-relaxed-atomics',
             '--enable-custom-page-sizes',
             '--enable-wide-arithmetic',
+            '--enable-compact-imports',
         ], p2.stdout.splitlines())


### PR DESCRIPTION
See https://github.com/WebAssembly/compact-import-section

This change only adds binary support.  Luckily the upstream tests are devided in two seperate
files `binary-compact-imports.wast` and `compact-imports.wast` so this change only imports
one of them.

