### PR TITLE
Use _Exit instead of std::quick_exit to work around macOS bug

### DIFF
--- a/src/support/file.cpp
+++ b/src/support/file.cpp
@@ -158,6 +158,6 @@ void wasm::flush_and_quick_exit(int code) {
   // So instead use _Exit(); the only difference is that _Exit() does not call
   // handlers registered by at_quick_exit(). Currently Binaryen does not have
   // any of those.
-  _Exit();
+  _Exit(code);
 #endif
 }


### PR DESCRIPTION
Older versions of macOS are missing the libc symbol quick_exit, despite
the fact that libc++ implements std::quick_exit on top of it. The
result is that Binaryen will link but fail to load.
Switch to _Exit instead.
