### PR TITLE
Fix UB in SIMD dot product arithmetic

### DIFF
--- a/scripts/test/shared.py
+++ b/scripts/test/shared.py
@@ -462,9 +462,6 @@ SPEC_TESTSUITE_TESTS_TO_SKIP = [
     'simd_f64x2.wast',            # Min of 0 and NaN should give a canonical NaN
     'simd_f64x2_arith.wast',      # Adding inf and -inf should give a canonical NaN
     'simd_f64x2_rounding.wast',   # Ceil of NaN should give a canonical NaN
-    'simd_i32x4_cmp.wast',        # UBSan error on integer overflow
-    'simd_i32x4_arith2.wast',     # UBSan error on integer overflow
-    'simd_i32x4_dot_i16x8.wast',  # UBSan error on integer overflow
     'token.wast',                 # Lexer should require spaces between strings and non-paren tokens
 ]
 

--- a/test/lit/exec/simd.wast
+++ b/test/lit/exec/simd.wast
@@ -23,6 +23,15 @@
    (i64.const -4611686018427387904)
   )
  )
+
+ ;; CHECK:      [fuzz-exec] calling i8x16.avgr_u
+ ;; CHECK-NEXT: [fuzz-exec] note result: i8x16.avgr_u => i32x4 0x80808080 0x80808080 0x80808080 0x80808080
+ (func $i8x16.avgr_u (export "i8x16.avgr_u") (result v128)
+  (i8x16.avgr_u
+   (v128.const i8x16 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128)
+   (v128.const i8x16 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128 -128)
+  )
+ )
 )
 
 ;; CHECK:      [fuzz-exec] calling load8x8_s
@@ -30,5 +39,9 @@
 
 ;; CHECK:      [fuzz-exec] calling load32x2_u
 ;; CHECK-NEXT: [trap final > memory: 13835058055282163712 > 1048576]
+
+;; CHECK:      [fuzz-exec] calling i8x16.avgr_u
+;; CHECK-NEXT: [fuzz-exec] note result: i8x16.avgr_u => i32x4 0x80808080 0x80808080 0x80808080 0x80808080
+;; CHECK-NEXT: [fuzz-exec] comparing i8x16.avgr_u
 ;; CHECK-NEXT: [fuzz-exec] comparing load32x2_u
 ;; CHECK-NEXT: [fuzz-exec] comparing load8x8_s


### PR DESCRIPTION
* Use Literal::add and Literal::mul to avoid overflow of signed arithmetic. These do the right thing by casting to unsigned first.
* Use bit_cast instead of a C-style cast to convey the intent better when converting between signed and unsigned.
* Also add a unit test for i8x16.avgr_u to demonstrate that it doesn't overflow.

From reading the code, most other arithmetic in Literal.cpp shouldn't invoke UB. There are some spec tests that are disabled due to float/nan behavior that I'll look at in future PRs.