### PR TITLE
SubTypes: Ensure a depth for cont

### DIFF
--- a/src/ir/subtypes.h
+++ b/src/ir/subtypes.h
@@ -158,8 +158,9 @@ struct SubTypes {
       depths[HeapTypes::noexn.getBasic(share)] = 0;
 
       // func would appear already if we saw function types, but if not, ensure
-      // it exists here.
+      // it exists here. Ditto for cont.
       depths[HeapTypes::func.getBasic(share)];
+      depths[HeapTypes::cont.getBasic(share)];
     }
 
     return depths;

--- a/test/gtest/type-builder.cpp
+++ b/test/gtest/type-builder.cpp
@@ -1614,6 +1614,7 @@ TEST_F(TypeTest, TestMaxStructDepths) {
   EXPECT_EQ(maxDepths[HeapType::nocont], Index(0));
   EXPECT_EQ(maxDepths[HeapType::noexn], Index(0));
   EXPECT_EQ(maxDepths[HeapType::func], Index(0));
+  EXPECT_EQ(maxDepths[HeapType::cont], Index(0));
 }
 
 TEST_F(TypeTest, TestMaxArrayDepths) {


### PR DESCRIPTION
Like `func`, if no subtypes exist, we must still ensure an entry (with 0).