### PR TITLE
Fix a +200% Windows performance regression caused by PR #4897.

### DIFF
--- a/src/passes/pass.cpp
+++ b/src/passes/pass.cpp
@@ -867,9 +867,11 @@ void PassRunner::run() {
     for (auto& pass : passes) {
       // ignoring the time, save a printout of the module before, in case this
       // pass breaks it, so we can print the before and after
-      std::stringstream moduleBefore;
+      std::string moduleBefore;
       if (passDebug == 2 && !isNested) {
-        moduleBefore << *wasm << '\n';
+        std::stringstream ss;
+        ss << *wasm << '\n';
+        moduleBefore = ss.str();
       }
       // prepare to run
       std::cerr << "[PassRunner]   running pass: " << pass->name << "... ";
@@ -896,7 +898,7 @@ void PassRunner::run() {
           if (passDebug >= 2) {
             Fatal() << "Last pass (" << pass->name
                     << ") broke validation. Here is the module before: \n"
-                    << moduleBefore.str() << "\n";
+                    << moduleBefore << "\n";
           } else {
             Fatal() << "Last pass (" << pass->name
                     << ") broke validation. Run with BINARYEN_PASS_DEBUG=2 "
@@ -1026,9 +1028,12 @@ void PassRunner::runPassOnFunction(Pass* pass, Function* func) {
   // useful - leave it to the entire module to fail validation in that case.
   bool extraFunctionValidation =
     passDebug == 2 && options.validate && !pass->name.empty();
-  std::stringstream bodyBefore;
+
+  std::string bodyBefore;
   if (extraFunctionValidation) {
-    bodyBefore << *func->body << '\n';
+    std::stringstream ss;
+    ss << *func->body << '\n';
+    bodyBefore = ss.str();
   }
 
   // Function-parallel passes get a new instance per function
@@ -1042,7 +1047,7 @@ void PassRunner::runPassOnFunction(Pass* pass, Function* func) {
       Fatal() << "Last nested function-parallel pass (" << pass->name
               << ") broke validation of function " << func->name
               << ". Here is the function body before:\n"
-              << bodyBefore.str() << "\n\nAnd here it is now:\n"
+              << bodyBefore << "\n\nAnd here it is now:\n"
               << *func->body << '\n';
     }
   }


### PR DESCRIPTION
Fix a +200% Windows performance regression caused by PR #4897. On Windows with Visual Studio compiler, the constructor of a std::stringstream object is extremely slow, as it incurs a call to a std::locale ctor(), which in turn causes an access to some kind of process global locale mutex lock. (maybe to get the current system locale?).

Visual Studio profiler showed this hotspot as:

<img width="1527" height="791" alt="image" src="https://github.com/user-attachments/assets/23fc8de6-4b6f-4433-b081-b7f38688a9e8" />

And Markus Stange's fantastic [Samply profiler](https://github.com/mstange/samply) highlighted the size of the issue as

<img width="2557" height="1304" alt="image" src="https://github.com/user-attachments/assets/046aad57-f0da-41a8-ab1e-826301cba3ad" />

where 79% of total time in `wasm-opt` was taken by the `std::stringstream` constructor on Windows.

Live link to the above profile: https://share.firefox.dev/4a2wen8

The slow behavior occurred with at least the following command lines:

```
wasm-opt --strip-dwarf --post-emscripten -O3 --low-memory-unused --zero-filled-memory
--pass-arg=directize-initial-contents-immutable --strip-debug --strip-producers
build.wasm -o build2.wasm --mvp-features --enable-bulk-memory --enable-exception-handling
--enable-mutable-globals --enable-nontrapping-float-to-int --enable-sign-ext --enable-simd
```
and
```
wasm-opt --strip-target-features --post-emscripten -O2 --low-memory-unused --zero-filled-memory
--pass-arg=directize-initial-contents-immutable build.wasm -o build2.wasm --mvp-features
--enable-bulk-memory --enable-bulk-memory-opt --enable-call-indirect-overlong --enable-exception-handling
--enable-multivalue --enable-mutable-globals --enable-nontrapping-float-to-int --enable-reference-types
--enable-sign-ext --enable-simd
```

The main issue is on the very hot function PassRunner::runPassOnFunction() that increased wasm-opt link times from ~20 seconds to ~60 seconds after #4897 on Windows when `wasm-opt -O2` optimizing a large 33MB .wasm file. `std::string` ctor does not share this performance problem on Windows.

Searched through the codebase for other possible uses of `std::stringstream` that were "optional", and the function `PassRunner::run()` also had a similar usage pattern, so fixed that too for consistency (even though that call site did not show up in profiles as hot).

After this change, the wasm-opt time returned from ~60s to ~20s.